### PR TITLE
removing get_missing_var from ParseVar class

### DIFF
--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -570,9 +570,7 @@ class ModelConfiguredVar(Var):
 
 
 class ParseVar(ModelConfiguredVar):
-    def get_missing_var(self, var_name):
-        # in the parser, just always return None.
-        return None
+    pass
 
 
 class RuntimeVar(ModelConfiguredVar):


### PR DESCRIPTION
resolves https://github.com/fishtown-analytics/dbt/issues/3320

### Description

Gets rid of a function that only returned `None` that appears to be causing the compiler having issues raising descriptive exceptions when loops and vars are involved.

Getting rid of this _seems_ to get everything working for me (ie. get more verbose errors showing up - I have tested this in jaffle_shop). I have no context as to why this odd return None function was added here so there might be an some conditional logic to make sure that the original case isn't being blown out of the water here.

### Checklist
 - [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
