### PR TITLE
BQ partition configs support

### DIFF
--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -794,7 +794,7 @@ class BigQueryAdapter(BaseAdapter):
             labels = config.get('labels', {})
             opts['labels'] = list(labels.items())
 
-        if config.get('require_partition_filter'):
+        if config.get('require_partition_filter') and not temporary:
             opts['require_partition_filter'] = config.get(
                 'require_partition_filter')
 

--- a/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -122,26 +122,26 @@
                 {% do exceptions.raise_compiler_error(missing_partition_msg) %}
             {% endif %}
 
-        {% set build_sql = bq_insert_overwrite(
-            tmp_relation,
-            target_relation,
-            sql,
-            unique_key,
-            partition_by,
-            partitions,
-            dest_columns) %}
+            {% set build_sql = bq_insert_overwrite(
+                tmp_relation,
+                target_relation,
+                sql,
+                unique_key,
+                partition_by,
+                partitions,
+                dest_columns) %}
 
-    {% else %}
-        {#-- wrap sql in parens to make it a subquery --#}
-        {%- set source_sql -%}
-            (
-                {{sql}}
-            )
-        {%- endset -%}
+        {% else %}
+            {#-- wrap sql in parens to make it a subquery --#}
+            {%- set source_sql -%}
+                (
+                    {{sql}}
+                )
+            {%- endset -%}
 
-    {% set build_sql = get_merge_sql(target_relation, source_sql, unique_key, dest_columns) %}
+            {% set build_sql = get_merge_sql(target_relation, source_sql, unique_key, dest_columns) %}
 
-    {% endif %}
+        {% endif %}
 
     {% endif %}
 

--- a/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -1,126 +1,126 @@
 
 {% macro dbt_bigquery_validate_get_incremental_strategy(config) %}
-  {#-- Find and validate the incremental strategy #}
-  {%- set strategy = config.get("incremental_strategy", default="merge") -%}
+    {#-- Find and validate the incremental strategy #}
+    {%- set strategy = config.get("incremental_strategy", default="merge") -%}
 
-  {% set invalid_strategy_msg -%}
-    Invalid incremental strategy provided: {{ strategy }}
-    Expected one of: 'merge', 'insert_overwrite'
-  {%- endset %}
-  {% if strategy not in ['merge', 'insert_overwrite'] %}
-    {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
-  {% endif %}
+    {% set invalid_strategy_msg -%}
+        Invalid incremental strategy provided: {{ strategy }}
+        Expected one of: 'merge', 'insert_overwrite'
+    {%- endset %}
+    {% if strategy not in ['merge', 'insert_overwrite'] %}
+        {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
+    {% endif %}
 
-  {% do return(strategy) %}
+    {% do return(strategy) %}
 {% endmacro %}
 
 
 {% macro bq_insert_overwrite(tmp_relation, target_relation, sql, unique_key, partition_by, partitions, dest_columns) %}
 
-  {% if partitions is not none and partitions != [] %} {# static #}
+    {% if partitions is not none and partitions != [] %} {# static #}
 
-      {% set predicate -%}
-          {{ partition_by.render(alias='DBT_INTERNAL_DEST') }} in (
-              {{ partitions | join (', ') }}
-          )
-      {%- endset %}
+        {% set predicate -%}
+            {{ partition_by.render(alias='DBT_INTERNAL_DEST') }} in (
+                {{ partitions | join (', ') }}
+            )
+        {%- endset %}
 
-      {%- set source_sql -%}
-        (
-          {{sql}}
-        )
-      {%- endset -%}
+        {%- set source_sql -%}
+            (
+                {{sql}}
+            )
+        {%- endset -%}
 
-      {{ get_insert_overwrite_merge_sql(target_relation, source_sql, dest_columns, [predicate], include_sql_header=true) }}
+        {{ get_insert_overwrite_merge_sql(target_relation, source_sql, dest_columns, [predicate], include_sql_header=true) }}
 
-  {% else %} {# dynamic #}
+    {% else %} {# dynamic #}
 
-      {% set predicate -%}
-          {{ partition_by.render(alias='DBT_INTERNAL_DEST') }} in unnest(dbt_partitions_for_replacement)
-      {%- endset %}
+        {% set predicate -%}
+            {{ partition_by.render(alias='DBT_INTERNAL_DEST') }} in unnest(dbt_partitions_for_replacement)
+        {%- endset %}
 
-      {%- set source_sql -%}
-      (
-        select * from {{ tmp_relation }}
-      )
-      {%- endset -%}
+        {%- set source_sql -%}
+            (
+                select * from {{ tmp_relation }}
+            )
+        {%- endset -%}
 
-      -- generated script to merge partitions into {{ target_relation }}
-      declare dbt_partitions_for_replacement array<{{ partition_by.data_type }}>;
-      declare _dbt_max_partition {{ partition_by.data_type }} default (
-          select max({{ partition_by.field }}) from {{ this }}
-          where {{ partition_by.field }} is not null
-      );
+        -- generated script to merge partitions into {{ target_relation }}
+        declare dbt_partitions_for_replacement array<{{ partition_by.data_type }}>;
+        declare _dbt_max_partition {{ partition_by.data_type }} default (
+            select max({{ partition_by.field }}) from {{ this }}
+            where {{ partition_by.field }} is not null
+        );
 
-      -- 1. create a temp table
-      {{ create_table_as(True, tmp_relation, sql) }}
+        -- 1. create a temp table
+        {{ create_table_as(True, tmp_relation, sql) }}
 
-      -- 2. define partitions to update
-      set (dbt_partitions_for_replacement) = (
-          select as struct
-              array_agg(distinct {{ partition_by.render() }})
-          from {{ tmp_relation }}
-      );
+        -- 2. define partitions to update
+        set (dbt_partitions_for_replacement) = (
+            select as struct
+                array_agg(distinct {{ partition_by.render() }})
+            from {{ tmp_relation }}
+        );
 
-      {#
-        TODO: include_sql_header is a hack; consider a better approach that includes
-              the sql_header at the materialization-level instead
-      #}
-      -- 3. run the merge statement
-      {{ get_insert_overwrite_merge_sql(target_relation, source_sql, dest_columns, [predicate], include_sql_header=false) }};
+        {#
+            TODO: include_sql_header is a hack; consider a better approach that includes
+            the sql_header at the materialization-level instead
+        #}
+        -- 3. run the merge statement
+        {{ get_insert_overwrite_merge_sql(target_relation, source_sql, dest_columns, [predicate], include_sql_header=false) }};
 
-      -- 4. clean up the temp table
-      drop table if exists {{ tmp_relation }}
+        -- 4. clean up the temp table
+        drop table if exists {{ tmp_relation }}
 
-  {% endif %}
+    {% endif %}
 
 {% endmacro %}
 
 
 {% materialization incremental, adapter='bigquery' -%}
 
-  {%- set unique_key = config.get('unique_key') -%}
-  {%- set full_refresh_mode = (should_full_refresh()) -%}
+    {%- set unique_key = config.get('unique_key') -%}
+    {%- set full_refresh_mode = (should_full_refresh()) -%}
 
-  {%- set target_relation = this %}
-  {%- set existing_relation = load_relation(this) %}
-  {%- set tmp_relation = make_temp_relation(this) %}
+    {%- set target_relation = this %}
+    {%- set existing_relation = load_relation(this) %}
+    {%- set tmp_relation = make_temp_relation(this) %}
 
-  {#-- Validate early so we don't run SQL if the strategy is invalid --#}
-  {% set strategy = dbt_bigquery_validate_get_incremental_strategy(config) -%}
+    {#-- Validate early so we don't run SQL if the strategy is invalid --#}
+    {% set strategy = dbt_bigquery_validate_get_incremental_strategy(config) -%}
 
-  {%- set raw_partition_by = config.get('partition_by', none) -%}
-  {%- set partition_by = adapter.parse_partition_by(raw_partition_by) -%}
-  {%- set partitions = config.get('partitions', none) -%}
-  {%- set cluster_by = config.get('cluster_by', none) -%}
+    {%- set raw_partition_by = config.get('partition_by', none) -%}
+    {%- set partition_by = adapter.parse_partition_by(raw_partition_by) -%}
+    {%- set partitions = config.get('partitions', none) -%}
+    {%- set cluster_by = config.get('cluster_by', none) -%}
 
-  {{ run_hooks(pre_hooks) }}
+    {{ run_hooks(pre_hooks) }}
 
-  {% if existing_relation is none %}
-      {% set build_sql = create_table_as(False, target_relation, sql) %}
-  {% elif existing_relation.is_view %}
-      {#-- There's no way to atomically replace a view with a table on BQ --#}
-      {{ adapter.drop_relation(existing_relation) }}
-      {% set build_sql = create_table_as(False, target_relation, sql) %}
-  {% elif full_refresh_mode %}
-      {#-- If the partition/cluster config has changed, then we must drop and recreate --#}
-      {% if not adapter.is_replaceable(existing_relation, partition_by, cluster_by) %}
-          {% do log("Hard refreshing " ~ existing_relation ~ " because it is not replaceable") %}
-          {{ adapter.drop_relation(existing_relation) }}
-      {% endif %}
-      {% set build_sql = create_table_as(False, target_relation, sql) %}
-  {% else %}
-     {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}
-
-     {#-- if partitioned, use BQ scripting to get the range of partition values to be updated --#}
-     {% if strategy == 'insert_overwrite' %}
-
-        {% set missing_partition_msg -%}
-          The 'insert_overwrite' strategy requires the `partition_by` config.
-        {%- endset %}
-        {% if partition_by is none %}
-          {% do exceptions.raise_compiler_error(missing_partition_msg) %}
+    {% if existing_relation is none %}
+        {% set build_sql = create_table_as(False, target_relation, sql) %}
+    {% elif existing_relation.is_view %}
+        {#-- There's no way to atomically replace a view with a table on BQ --#}
+        {{ adapter.drop_relation(existing_relation) }}
+        {% set build_sql = create_table_as(False, target_relation, sql) %}
+    {% elif full_refresh_mode %}
+        {#-- If the partition/cluster config has changed, then we must drop and recreate --#}
+        {% if not adapter.is_replaceable(existing_relation, partition_by, cluster_by) %}
+            {% do log("Hard refreshing " ~ existing_relation ~ " because it is not replaceable") %}
+            {{ adapter.drop_relation(existing_relation) }}
         {% endif %}
+        {% set build_sql = create_table_as(False, target_relation, sql) %}
+    {% else %}
+        {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}
+
+        {#-- if partitioned, use BQ scripting to get the range of partition values to be updated --#}
+        {% if strategy == 'insert_overwrite' %}
+
+            {% set missing_partition_msg -%}
+                The 'insert_overwrite' strategy requires the `partition_by` config.
+            {%- endset %}
+            {% if partition_by is none %}
+                {% do exceptions.raise_compiler_error(missing_partition_msg) %}
+            {% endif %}
 
         {% set build_sql = bq_insert_overwrite(
             tmp_relation,
@@ -131,30 +131,30 @@
             partitions,
             dest_columns) %}
 
-     {% else %}
-       {#-- wrap sql in parens to make it a subquery --#}
-       {%- set source_sql -%}
-         (
-           {{sql}}
-         )
-       {%- endset -%}
+    {% else %}
+        {#-- wrap sql in parens to make it a subquery --#}
+        {%- set source_sql -%}
+            (
+                {{sql}}
+            )
+        {%- endset -%}
 
-       {% set build_sql = get_merge_sql(target_relation, source_sql, unique_key, dest_columns) %}
+    {% set build_sql = get_merge_sql(target_relation, source_sql, unique_key, dest_columns) %}
 
-     {% endif %}
+    {% endif %}
 
-  {% endif %}
+    {% endif %}
 
-  {%- call statement('main') -%}
-    {{ build_sql }}
-  {% endcall %}
+    {%- call statement('main') -%}
+        {{ build_sql }}
+    {% endcall %}
 
-  {{ run_hooks(post_hooks) }}
+    {{ run_hooks(post_hooks) }}
 
-  {% set target_relation = this.incorporate(type='table') %}
+    {% set target_relation = this.incorporate(type='table') %}
 
-  {% do persist_docs(target_relation, model) %}
+    {% do persist_docs(target_relation, model) %}
 
-  {{ return({'relations': [target_relation]}) }}
+    {{ return({'relations': [target_relation]}) }}
 
 {%- endmaterialization %}

--- a/test/integration/022_bigquery_test/incremental-strategy-models/incremental_merge_range.sql
+++ b/test/integration/022_bigquery_test/incremental-strategy-models/incremental_merge_range.sql
@@ -18,23 +18,23 @@
 
 
 with data as (
-    
+
     {% if not is_incremental() %}
-    
+
         select 1 as id, cast('2020-01-01' as datetime) as date_time union all
         select 2 as id, cast('2020-01-01' as datetime) as date_time union all
         select 3 as id, cast('2020-01-01' as datetime) as date_time union all
         select 4 as id, cast('2020-01-01' as datetime) as date_time
-    
+
     {% else %}
-    
+
         select 1 as id, cast('2020-01-01' as datetime) as date_time union all
         select 2 as id, cast('2020-01-01' as datetime) as date_time union all
         select 3 as id, cast('2020-01-01' as datetime) as date_time union all
         select 4 as id, cast('2020-01-02' as datetime) as date_time union all
         select 5 as id, cast('2020-01-02' as datetime) as date_time union all
         select 6 as id, cast('2020-01-02' as datetime) as date_time
-    
+
     {% endif %}
 
 )
@@ -42,5 +42,6 @@ with data as (
 select * from data
 
 {% if is_incremental() %}
-where id >= (select max(id) from {{ this }})
+{% set most_recent = get_most_recent_record(this, 'id', True) %}
+where id >= {{ most_recent }}
 {% endif %}

--- a/test/integration/022_bigquery_test/incremental-strategy-models/incremental_merge_time.sql
+++ b/test/integration/022_bigquery_test/incremental-strategy-models/incremental_merge_time.sql
@@ -14,23 +14,23 @@
 
 
 with data as (
-    
+
     {% if not is_incremental() %}
-    
+
         select 1 as id, cast('2020-01-01' as datetime) as date_time union all
         select 2 as id, cast('2020-01-01' as datetime) as date_time union all
         select 3 as id, cast('2020-01-01' as datetime) as date_time union all
         select 4 as id, cast('2020-01-01' as datetime) as date_time
-    
+
     {% else %}
-    
+
         select 1 as id, cast('2020-01-01' as datetime) as date_time union all
         select 2 as id, cast('2020-01-01' as datetime) as date_time union all
         select 3 as id, cast('2020-01-01' as datetime) as date_time union all
         select 4 as id, cast('2020-01-02' as datetime) as date_time union all
         select 5 as id, cast('2020-01-02' as datetime) as date_time union all
         select 6 as id, cast('2020-01-02' as datetime) as date_time
-    
+
     {% endif %}
 
 )
@@ -38,5 +38,6 @@ with data as (
 select * from data
 
 {% if is_incremental() %}
-where date_time > (select max(date_time) from {{ this }})
+{% set most_recent = get_most_recent_record(this, 'date_time', True) %}
+where date_time > '{{ most_recent }}'
 {% endif %}

--- a/test/integration/022_bigquery_test/macros/get_most_recent_record.sql
+++ b/test/integration/022_bigquery_test/macros/get_most_recent_record.sql
@@ -1,0 +1,25 @@
+
+{%- macro get_max_sql(relation, field, require_partition_filter=False) -%}
+
+    select max({{ field }}) as start_ts
+    from {{ relation }}
+    {% if require_partition_filter -%}
+    where {{ field }} is null or {{ field }} is not null
+    {%- endif %}
+
+{%- endmacro -%}
+
+
+{%- macro get_most_recent_record(relation, field, require_partition_filter=False) -%}
+
+    {%- set result = run_query(get_max_sql(relation, field, require_partition_filter)) -%}
+
+    {% if execute %}
+        {% set start_ts = result.columns['start_ts'].values()[0] %}
+    {% else %}
+        {% set start_ts = '' %}
+    {% endif %}
+
+    {{ return(start_ts) }}
+
+{%- endmacro -%}

--- a/test/integration/022_bigquery_test/test_incremental_strategies.py
+++ b/test/integration/022_bigquery_test/test_incremental_strategies.py
@@ -10,6 +10,18 @@ class TestBigQueryScripting(DBTIntegrationTest):
     def models(self):
         return "incremental-strategy-models"
 
+    @property
+    def project_config(self):
+        return {
+            "config_version": 2,
+            "seeds": {
+                "+quote_columns": False
+            },
+            "models": {
+                "require_partition_filter": True
+            }
+        }
+
     @use_profile('bigquery')
     def test__bigquery_assert_incrementals(self):
         results = self.run_dbt()

--- a/test/integration/022_bigquery_test/test_incremental_strategies.py
+++ b/test/integration/022_bigquery_test/test_incremental_strategies.py
@@ -13,7 +13,6 @@ class TestBigQueryScripting(DBTIntegrationTest):
     @property
     def project_config(self):
         return {
-            "config_version": 2,
             "seeds": {
                 "+quote_columns": False
             },

--- a/test/integration/022_bigquery_test/test_incremental_strategies.py
+++ b/test/integration/022_bigquery_test/test_incremental_strategies.py
@@ -3,6 +3,12 @@ from test.integration.base import DBTIntegrationTest, FakeArgs, use_profile
 class TestBigQueryScripting(DBTIntegrationTest):
 
     @property
+    def project_config(self):
+        return {
+            'macro-paths': ['macros']
+        }
+
+    @property
     def schema(self):
         return "bigquery_test_022"
 
@@ -34,6 +40,7 @@ class TestBigQueryPartitionFilterScripting(TestBigQueryScripting):
     @property
     def project_config(self):
         return {
+            'macro-paths': ['macros'],
             "seeds": {
                 "+quote_columns": False
             },

--- a/test/integration/022_bigquery_test/test_incremental_strategies.py
+++ b/test/integration/022_bigquery_test/test_incremental_strategies.py
@@ -10,17 +10,6 @@ class TestBigQueryScripting(DBTIntegrationTest):
     def models(self):
         return "incremental-strategy-models"
 
-    @property
-    def project_config(self):
-        return {
-            "seeds": {
-                "+quote_columns": False
-            },
-            "models": {
-                "require_partition_filter": True
-            }
-        }
-
     @use_profile('bigquery')
     def test__bigquery_assert_incrementals(self):
         results = self.run_dbt()
@@ -38,3 +27,17 @@ class TestBigQueryScripting(DBTIntegrationTest):
         self.assertTablesEqual('incremental_overwrite_partitions', 'incremental_overwrite_date_expected')
         self.assertTablesEqual('incremental_overwrite_day', 'incremental_overwrite_day_expected')
         self.assertTablesEqual('incremental_overwrite_range', 'incremental_overwrite_range_expected')
+
+
+class TestBigQueryPartitionFilterScripting(TestBigQueryScripting):
+
+    @property
+    def project_config(self):
+        return {
+            "seeds": {
+                "+quote_columns": False
+            },
+            "models": {
+                "require_partition_filter": True
+            }
+        }


### PR DESCRIPTION
resolves #3016 


### Description

#2928 added support for `require_partition_filter` and `partition_expiration_days` in the BigQuery adapter. As outlined in #3016, this PR ensure that the new config options work with all incremental strategies available for BigQuery today.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
