### PR TITLE
Feature/incremental predicate support

### DIFF
--- a/core/dbt/contracts/graph/model_config.py
+++ b/core/dbt/contracts/graph/model_config.py
@@ -406,7 +406,7 @@ class NodeConfig(BaseConfig):
     )
     full_refresh: Optional[bool] = None
     on_schema_change: Optional[str] = 'ignore'
-    incremental_predicates: Optional[List[str]] = None
+    incremental_predicates: Optional[List[Dict[str, Any]]] = None
 
     @classmethod
     def __pre_deserialize__(cls, data):

--- a/core/dbt/contracts/graph/model_config.py
+++ b/core/dbt/contracts/graph/model_config.py
@@ -406,6 +406,7 @@ class NodeConfig(BaseConfig):
     )
     full_refresh: Optional[bool] = None
     on_schema_change: Optional[str] = 'ignore'
+    incremental_predicates: Optional[list] = None
 
     @classmethod
     def __pre_deserialize__(cls, data):

--- a/core/dbt/contracts/graph/model_config.py
+++ b/core/dbt/contracts/graph/model_config.py
@@ -406,7 +406,7 @@ class NodeConfig(BaseConfig):
     )
     full_refresh: Optional[bool] = None
     on_schema_change: Optional[str] = 'ignore'
-    incremental_predicates: Optional[list] = None
+    incremental_predicates: Optional[List[str]] = None
 
     @classmethod
     def __pre_deserialize__(cls, data):

--- a/core/dbt/include/global_project/macros/materializations/common/get_incremental_predicates.sql
+++ b/core/dbt/include/global_project/macros/materializations/common/get_incremental_predicates.sql
@@ -1,8 +1,17 @@
-{% macro get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates) %}
-    {{ adapter.dispatch('get_incremental_predicates')(target_relation, incremental_strategy, unique_key, user_predicates) }}
+{#
+
+    These macros will compile the proper join predicates for incremental models,
+    merging default behavior with the optional, user-supplied incremental_predicates
+    config. 
+
+#}
+
+
+{% macro get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates, partitions=none) %}
+    {{ adapter.dispatch('get_incremental_predicates')(target_relation, incremental_strategy, unique_key, user_predicates, partitions) }}
 {% endmacro %}
 
-{% macro default__get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates) %}
+{% macro default__get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates=none, partitions=none) %}
     {# this should be the default added to the `delete from` syntax in the basic strategy#}
     {% if user_predicates %}
         {%- set predicates -%}
@@ -16,7 +25,7 @@
 
 {% endmacro %}
 
-{%- macro snowflake__get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates=none) %}
+{%- macro snowflake__get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates=none, partitions=none) %}
 
     {%- if incremental_strategy == 'merge'%}
         {%- if unique_key -%}
@@ -51,6 +60,55 @@
 
 {%- endmacro -%}
 
-{% macro bigquery__get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates=none) %}
-    {{ return('bigquery') }}
-{% endmacro %}
+{% macro bigquery__get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates=none, partitions=none) %}
+    
+    {%- if incremental_strategy == 'insert_overwrite'%}
+        {% if partitions is not none and partitions != [] %} {# static #}
+            {%- set match_criteria %}
+                {{ partition_by.render(alias='DBT_INTERNAL_DEST') }} in (
+                    {{ partitions | join (', ') }}
+                )
+            {%- endset -%}
+        {% else %}
+            {%- set match_criteria %} {# dynamic #}
+                {{ partition_by.render(alias='DBT_INTERNAL_DEST') }} in unnest(dbt_partitions_for_replacement)
+            {%- endset -%}
+        {% endif %}
+    
+        {%- if user_predicates -%}
+            {%- set filter_criteria %}
+                {%- for condition in user_predicates -%}
+                    and DBT_INTERNAL_DEST.{{ condition.source_col }} {{ condition.expression }}
+                {%- endfor -%}
+            {%- endset -%}
+        {% endif %}
+
+        {{ match_criteria | join(' and ') }}
+        {{ filter_criteria }}
+
+
+    {%- elif incremental_strategy == 'merge' %}
+        {%- if unique_key -%}
+            {%- set match_criteria %}
+                DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}  
+            {%- endset -%}
+        {% else %}
+            {%- set match_criteria %}
+                FALSE
+            {%- endset -%}
+        {% endif %}
+    
+        {%- if user_predicates -%}
+            {%- set filter_criteria %}
+                {%- for condition in user_predicates -%}
+                    and DBT_INTERNAL_DEST.{{ condition.source_col }} {{ condition.expression }}
+                {%- endfor -%}
+            {%- endset -%}
+        {% endif %}
+
+        {{ match_criteria }}
+        {{ filter_criteria }}
+
+    {%- endif -%}
+
+{%- endmacro -%}

--- a/core/dbt/include/global_project/macros/materializations/common/get_incremental_predicates.sql
+++ b/core/dbt/include/global_project/macros/materializations/common/get_incremental_predicates.sql
@@ -3,7 +3,7 @@
 {% endmacro %}
 
 {% macro default__get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates) %}
-
+    {# this should be the default added to the `delete from` syntax in the basic strategy#}
     {% if user_predicates %}
         {%- set predicates -%}
             {%- for condition in user_predicates %}
@@ -16,9 +16,40 @@
 
 {% endmacro %}
 
-{% macro snowflake__get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates=none) %}
-    {{ return('snowflake') }}
-{% endmacro %}
+{%- macro snowflake__get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates=none) %}
+
+    {%- if incremental_strategy == 'merge'%}
+        {%- if unique_key -%}
+            {%- set match_criteria %}
+                DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}  
+            {%- endset -%}
+        {% else %}
+            {%- set match_criteria %}
+                FALSE
+            {%- endset -%}
+        {% endif %}
+    
+        {%- if user_predicates -%}
+            {%- set filter_criteria %}
+                {%- for condition in user_predicates -%}
+                    and DBT_INTERNAL_DEST.{{ condition.source_col }} {{ condition.expression }}
+                {%- endfor -%}
+            {%- endset -%}
+        {% endif %}
+    {%- elif incremental_strategy == 'delete+insert' %}
+        {%- if user_predicates -%}
+            {%- set filter_criteria %}
+                {%- for condition in user_predicates -%}
+                    and {{ target_relation.name }}.{{ condition.source_col }} {{ condition.expression }}
+                {%- endfor -%}
+            {%- endset -%}
+        {% endif %}
+    {%- endif -%}
+
+    {{ match_criteria }}
+    {{ filter_criteria }}
+
+{%- endmacro -%}
 
 {% macro bigquery__get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates=none) %}
     {{ return('bigquery') }}

--- a/core/dbt/include/global_project/macros/materializations/common/get_incremental_predicates.sql
+++ b/core/dbt/include/global_project/macros/materializations/common/get_incremental_predicates.sql
@@ -1,0 +1,25 @@
+{% macro get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates) %}
+    {{ adapter.dispatch('get_incremental_predicates')(target_relation, incremental_strategy, unique_key, user_predicates) }}
+{% endmacro %}
+
+{% macro default__get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates) %}
+
+    {% if user_predicates %}
+        {%- set predicates -%}
+            {%- for condition in user_predicates %}
+                and {{ target_relation.name }}.{{ condition.source_col }} {{ condition.expression }}
+            {%- endfor %} 
+        {%- endset -%}
+    {% endif %}
+
+    {{ return(predicates) }}
+
+{% endmacro %}
+
+{% macro snowflake__get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates=none) %}
+    {{ return('snowflake') }}
+{% endmacro %}
+
+{% macro bigquery__get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates=none) %}
+    {{ return('bigquery') }}
+{% endmacro %}

--- a/core/dbt/include/global_project/macros/materializations/common/merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/common/merge.sql
@@ -15,7 +15,7 @@
 {%- endmacro %}
 
 
-{% macro default__get_merge_sql(target, source, unique_key, dest_columns, predicates, incremental_predicates=none) -%}
+{% macro default__get_merge_sql(target, source, unique_key, dest_columns, predicates=none, incremental_predicates=none) -%}
     {%- set predicates = [] if predicates is none else [] + predicates -%}
     {%- set incremental_predicates = [] if incremental_predicates is none else [] + incremental_predicates -%}
     {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}

--- a/core/dbt/include/global_project/macros/materializations/common/merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/common/merge.sql
@@ -116,13 +116,12 @@
 
     when not matched by source
         {% if predicates %} and {{ predicates | join(' and ') }} {% endif %}
+        {% if incremental_predicates %} and {{ target.name }}.{{ condition.source_col }} {{ condition.expression }} {% endif %}
         then delete
 
     when not matched then insert
         ({{ dest_cols_csv }})
     values
         ({{ dest_cols_csv }})
-
-     {% if incremental_predicates %} where {{ incremental_predicates | join(' and ') }} {% endif %}
 
 {% endmacro %}

--- a/core/dbt/include/global_project/macros/materializations/common/merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/common/merge.sql
@@ -116,7 +116,11 @@
 
     when not matched by source
         {% if predicates %} and {{ predicates | join(' and ') }} {% endif %}
-        {% if incremental_predicates %} and {{ target.name }}.{{ condition.source_col }} {{ condition.expression }} {% endif %}
+        {% if incremental_predicates %} 
+            {% for condition in incremental_predicates %}
+            and DBT_INTERNAL_DEST.{{ condition.source_col }} {{ condition.expression }} 
+            {% endfor %}
+        {% endif %}        
         then delete
 
     when not matched then insert

--- a/core/dbt/include/global_project/macros/materializations/common/merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/common/merge.sql
@@ -1,22 +1,23 @@
 
 
-{% macro get_merge_sql(target, source, unique_key, dest_columns, predicates=none) -%}
-  {{ adapter.dispatch('get_merge_sql')(target, source, unique_key, dest_columns, predicates) }}
+{% macro get_merge_sql(target, source, unique_key, dest_columns, predicates=none, incremental_predicates=none) -%}
+  {{ adapter.dispatch('get_merge_sql')(target, source, unique_key, dest_columns, predicates, incremental_predicates) }}
 {%- endmacro %}
 
 
-{% macro get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}
-  {{ adapter.dispatch('get_delete_insert_merge_sql')(target, source, unique_key, dest_columns) }}
+{% macro get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) -%}
+  {{ adapter.dispatch('get_delete_insert_merge_sql')(target, source, unique_key, dest_columns, incremental_predicates) }}
 {%- endmacro %}
 
 
-{% macro get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header=false) -%}
-  {{ adapter.dispatch('get_insert_overwrite_merge_sql')(target, source, dest_columns, predicates, include_sql_header) }}
+{% macro get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header=false, incremental_predicates=none) -%}
+  {{ adapter.dispatch('get_insert_overwrite_merge_sql')(target, source, dest_columns, predicates, include_sql_header, incremental_predicates) }}
 {%- endmacro %}
 
 
-{% macro default__get_merge_sql(target, source, unique_key, dest_columns, predicates) -%}
+{% macro default__get_merge_sql(target, source, unique_key, dest_columns, predicates, incremental_predicates=none) -%}
     {%- set predicates = [] if predicates is none else [] + predicates -%}
+    {%- set incremental_predicates = [] if incremental_predicates is none else [] + incremental_predicates -%}
     {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
     {%- set update_columns = config.get('merge_update_columns', default = dest_columns | map(attribute="quoted") | list) -%}
     {%- set sql_header = config.get('sql_header', none) -%}
@@ -49,6 +50,8 @@
     values
         ({{ dest_cols_csv }})
 
+    {% if incremental_predicates %} where {{ incremental_predicates | join(' and ') }} {% endif %}
+
 {% endmacro %}
 
 
@@ -63,7 +66,7 @@
 {% endmacro %}
 
 
-{% macro common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}
+{% macro common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) -%}
 
     {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
 
@@ -72,7 +75,11 @@
     where ({{ unique_key }}) in (
         select ({{ unique_key }})
         from {{ source }}
-    );
+    )
+
+    {% if incremental_predicates %} and {{ incremental_predicates | join(' and ') }} {% endif %}
+
+    ;
     {% endif %}
 
     insert into {{ target }} ({{ dest_cols_csv }})
@@ -83,13 +90,14 @@
 
 {%- endmacro %}
 
-{% macro default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}
-    {{ common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns) }}
+{% macro default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) -%}
+    {{ common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) }}
 {% endmacro %}
 
 
-{% macro default__get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header) -%}
+{% macro default__get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header, incremental_predicates=none) -%}
     {%- set predicates = [] if predicates is none else [] + predicates -%}
+    {%- set incremental_predicates = [] if incremental_predicates is none else [] + incremental_predicates -%}
     {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
     {%- set sql_header = config.get('sql_header', none) -%}
 
@@ -107,5 +115,7 @@
         ({{ dest_cols_csv }})
     values
         ({{ dest_cols_csv }})
+
+     {% if incremental_predicates %} where {{ incremental_predicates | join(' and ') }} {% endif %}
 
 {% endmacro %}

--- a/core/dbt/include/global_project/macros/materializations/incremental/helpers.sql
+++ b/core/dbt/include/global_project/macros/materializations/incremental/helpers.sql
@@ -13,7 +13,7 @@
     )
     {%- if incremental_predicates %}
         {%- for condition in incremental_predicates %}
-            and {{ target.name }}.{{ condition.source_col }} {{ condition.expression }}
+            and {{ target_relation.name }}.{{ condition.source_col }} {{ condition.expression }}
         {% endfor %}
     {%- endif %};
     {%- endif %}

--- a/core/dbt/include/global_project/macros/materializations/incremental/helpers.sql
+++ b/core/dbt/include/global_project/macros/materializations/incremental/helpers.sql
@@ -1,5 +1,5 @@
 
-{% macro incremental_upsert(tmp_relation, target_relation, unique_key=none, statement_name="main", incremental_predicates=none) %}
+{% macro incremental_upsert(tmp_relation, target_relation, unique_key=none, statement_name="main", predicates=none) %}
     
     {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
     {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
@@ -11,10 +11,8 @@
         select ({{ unique_key }})
         from {{ tmp_relation }}
     )
-    {%- if incremental_predicates %}
-        {%- for condition in incremental_predicates %}
-            and {{ target_relation.name }}.{{ condition.source_col }} {{ condition.expression }}
-        {% endfor %}
+    {%- if predicates %}
+        {{ predicates }}
     {%- endif %};
     {%- endif %}
 

--- a/core/dbt/include/global_project/macros/materializations/incremental/helpers.sql
+++ b/core/dbt/include/global_project/macros/materializations/incremental/helpers.sql
@@ -1,5 +1,5 @@
 
-{% macro incremental_upsert(tmp_relation, target_relation, unique_key=none, statement_name="main") %}
+{% macro incremental_upsert(tmp_relation, target_relation, unique_key=none, statement_name="main", incremental_predicates=none) %}
     
     {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
     {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
@@ -10,7 +10,8 @@
     where ({{ unique_key }}) in (
         select ({{ unique_key }})
         from {{ tmp_relation }}
-    );
+    )
+    {% if incremental_predicates %} and {{ incremental_predicates | join(' and ') }} {% endif %};
     {%- endif %}
 
     insert into {{ target_relation }} ({{ dest_cols_csv }})

--- a/core/dbt/include/global_project/macros/materializations/incremental/helpers.sql
+++ b/core/dbt/include/global_project/macros/materializations/incremental/helpers.sql
@@ -11,7 +11,11 @@
         select ({{ unique_key }})
         from {{ tmp_relation }}
     )
-    {% if incremental_predicates %} and {{ incremental_predicates | join(' and ') }} {% endif %};
+    {%- if incremental_predicates %}
+        {%- for condition in incremental_predicates %}
+            and {{ target.name }}.{{ condition.source_col }} {{ condition.expression }}
+        {% endfor %}
+    {%- endif %};
     {%- endif %}
 
     insert into {{ target_relation }} ({{ dest_cols_csv }})

--- a/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
+++ b/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
@@ -9,7 +9,7 @@
   {%- set full_refresh_mode = (should_full_refresh()) -%}
 
   {% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}
-  {% set incremental_predicates = config.get('incremental_predicates'), default=None) %}
+  {% set incremental_predicates = config.get('incremental_predicates', default=None) %}
 
   {% set tmp_identifier = model['name'] + '__dbt_tmp' %}
   {% set backup_identifier = model['name'] + "__dbt_backup" %}

--- a/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
+++ b/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
@@ -9,8 +9,10 @@
   {%- set full_refresh_mode = (should_full_refresh()) -%}
 
   {% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}
-  {% set incremental_predicates = config.get('incremental_predicates', default=None) %}
+  {% set user_predicates = config.get('incremental_predicates', default=None) %}
+  {% set incremental_strategy = config.get('incremental_strategy') %}
 
+  {% set predicates = get_incremental_predicates(target_relation,incremental_strategy,unique_key,user_predicates) %}
   {% set tmp_identifier = model['name'] + '__dbt_tmp' %}
   {% set backup_identifier = model['name'] + "__dbt_backup" %}
 
@@ -59,7 +61,7 @@
         tmp_relation, 
         target_relation, 
         unique_key=unique_key,
-        incremental_predicates=incremental_predicates) %}  
+        predicates=predicates) %}  
   {% endif %}
 
   {% call statement("main") %}

--- a/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
+++ b/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
@@ -9,6 +9,7 @@
   {%- set full_refresh_mode = (should_full_refresh()) -%}
 
   {% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}
+  {% set incremental_predicates = config.get('incremental_predicates'), default=None) %}
 
   {% set tmp_identifier = model['name'] + '__dbt_tmp' %}
   {% set backup_identifier = model['name'] + "__dbt_backup" %}
@@ -54,8 +55,11 @@
              from_relation=tmp_relation,
              to_relation=target_relation) %}
     {% do process_schema_changes(on_schema_change, tmp_relation, existing_relation) %}
-    {% set build_sql = incremental_upsert(tmp_relation, target_relation, unique_key=unique_key) %}
-  
+    {% set build_sql = incremental_upsert(
+        tmp_relation, 
+        target_relation, 
+        unique_key=unique_key,
+        incremental_predicates=incremental_predicates) %}  
   {% endif %}
 
   {% call statement("main") %}

--- a/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -33,7 +33,7 @@
         )
       {%- endset -%}
 
-      {{ get_insert_overwrite_merge_sql(target_relation, source_sql, dest_columns, [predicate], include_sql_header=true, incremental_predicates) }}
+      {{ get_insert_overwrite_merge_sql(target_relation, source_sql, dest_columns, [predicate], include_sql_header=true, incremental_predicates=incremental_predicates) }}
 
   {% else %} {# dynamic #}
 
@@ -74,7 +74,7 @@
               the sql_header at the materialization-level instead
       #}
       -- 3. run the merge statement
-      {{ get_insert_overwrite_merge_sql(target_relation, source_sql, dest_columns, [predicate], include_sql_header=false, incremental_predicates) }};
+      {{ get_insert_overwrite_merge_sql(target_relation, source_sql, dest_columns, [predicate], include_sql_header=false, incremental_predicates=incremental_predicates) }};
 
       -- 4. clean up the temp table
       drop table if exists {{ tmp_relation }}

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
@@ -61,7 +61,7 @@
            to_relation=target_relation) %}
     {% do process_schema_changes(on_schema_change, tmp_relation, existing_relation) %}
     {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}
-    {% set build_sql = dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns, incremental_predicates) %}
+    {% set build_sql = dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns, incremental_predicates=incremental_predicates) %}
   
   {% endif %}
 

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
@@ -14,11 +14,11 @@
   {% do return(strategy) %}
 {% endmacro %}
 
-{% macro dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns, predicates=none, incremental_predicates=none) %}
+{% macro dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns, predicates) %}
   {% if strategy == 'merge' %}
-    {% do return(get_merge_sql(target_relation, tmp_relation, unique_key, dest_columns, predicates, incremental_predicates)) %}
+    {% do return(get_merge_sql(target_relation, tmp_relation, unique_key, dest_columns, predicates)) %}
   {% elif strategy == 'delete+insert' %}
-    {% do return(get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns, incremental_predicates)) %}
+    {% do return(get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns, predicates)) %}
   {% else %}
     {% do exceptions.raise_compiler_error('invalid strategy: ' ~ strategy) %}
   {% endif %}
@@ -30,7 +30,7 @@
 
   {%- set unique_key = config.get('unique_key') -%}
   {%- set full_refresh_mode = (should_full_refresh()) -%}
-  {% set incremental_predicates = config.get('incremental_predicates', default = None) %}
+  {% set user_predicates = config.get('incremental_predicates', default = None) %}
 
   {% set target_relation = this %}
   {% set existing_relation = load_relation(this) %}
@@ -39,6 +39,7 @@
   {#-- Validate early so we don't run SQL if the strategy is invalid --#}
   {% set strategy = dbt_snowflake_validate_get_incremental_strategy(config) -%}
   {% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}
+  {% set predicates = get_incremental_predicates(target_relation=target_relation, incremental_strategy=strategy, unique_key=unique_key, user_predicates=user_predicates) %}
 
   {{ run_hooks(pre_hooks) }}
 
@@ -61,7 +62,7 @@
            to_relation=target_relation) %}
     {% do process_schema_changes(on_schema_change, tmp_relation, existing_relation) %}
     {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}
-    {% set build_sql = dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns, incremental_predicates=incremental_predicates) %}
+    {% set build_sql = dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns, predicates=predicates) %}
   
   {% endif %}
 

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/merge.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/merge.sql
@@ -1,4 +1,4 @@
-{% macro snowflake__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates=none, incremental_predicates=none) -%}
+{% macro snowflake__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates) -%}
 
     {#
        Workaround for Snowflake not being happy with a merge on a constant-false predicate.
@@ -22,7 +22,7 @@
 
     {%- else -%}
 
-        {{ default__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates, incremental_predicates) }}
+        {{ default__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates) }}
 
     {%- endif -%}
     {%- endset -%}

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/merge.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/merge.sql
@@ -32,8 +32,8 @@
 {% endmacro %}
 
 
-{% macro snowflake__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) %}
-    {% set dml = default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) %}
+{% macro snowflake__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, predicates) %}
+    {% set dml = default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, predicates) %}
     {% do return(snowflake_dml_explicit_transaction(dml)) %}
 {% endmacro %}
 

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/merge.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/merge.sql
@@ -1,4 +1,4 @@
-{% macro snowflake__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates) -%}
+{% macro snowflake__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates=none, incremental_predicates=none) -%}
 
     {#
        Workaround for Snowflake not being happy with a merge on a constant-false predicate.
@@ -22,7 +22,7 @@
 
     {%- else -%}
 
-        {{ default__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates) }}
+        {{ default__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates, incremental_predicates) }}
 
     {%- endif -%}
     {%- endset -%}
@@ -32,8 +32,8 @@
 {% endmacro %}
 
 
-{% macro snowflake__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) %}
-    {% set dml = default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) %}
+{% macro snowflake__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) %}
+    {% set dml = default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) %}
     {% do return(snowflake_dml_explicit_transaction(dml)) %}
 {% endmacro %}
 


### PR DESCRIPTION
resolves [#3923](https://github.com/dbt-labs/dbt/issues/3293)

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->


### Description

This PR adds an optional configuration to incremental models that allows the user to supply an arbitrary filter expression to merge/delete statements to reduce the amount of data scanned while performing those operations. 

V1 of this logic allows the user to pass a dictionary to the new `incremental predicates` config to supply a column and expression to evaluate at runtime. The dictionary format allows proper table aliasing in these statements. 

Example:
```
{{
    config(
        materialized='incremental',
        unique_key = 'customerorderid',
        incremental_predicates = [{
            'source_col' : 'customerorderid',
            'expression' : '> 1'
        }]
        
    )
}}
```

TODO:
- [ ] consolidate `predicates` and `incremental_predicates` (if possible!)
- [ ] add integration tests
- [ ] incorporate macro formatting standards


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
