### PR TITLE
Basic local FS functionality, pt 2

### DIFF
--- a/core/dbt/adapters/internal_storage/local_filesystem.py
+++ b/core/dbt/adapters/internal_storage/local_filesystem.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from shutil import rmtree
 from stat import S_IRUSR, S_IWUSR
 from sys import platform
-from typing import Any, Union
+from typing import Union
 from typing_extensions import Literal
 
 from dbt.logger import GLOBAL_LOGGER as logger

--- a/core/dbt/adapters/internal_storage/local_filesystem.py
+++ b/core/dbt/adapters/internal_storage/local_filesystem.py
@@ -64,7 +64,7 @@ def read(
 def write(
     path: str,
     content: Union[str, bytes, None],
-    overwrite: bool = False,
+    overwrite: bool = True,
 ) -> bool:
     """Writes the given content out to a resource on the filesystem.
 
@@ -90,8 +90,6 @@ def write(
         `True` for success, `False` otherwise.
 
     """
-    # TODO: double check I hit all possible permutations here! (IK)
-
     # create a concrete path object
     path: Path = Path(path)
 
@@ -152,6 +150,9 @@ def delete(path: str) -> bool:
     Args:
         path: Full path of resource to be deleted
 
+    Returns:
+        `True` for success, `False` otherwise.
+
     """
     # create concrete path object
     path: Path = Path(path)
@@ -177,10 +178,6 @@ def delete(path: str) -> bool:
             rmtree(path)
 
     return True
-
-
-def find():
-    pass
 
 
 def info(path: str) -> Union[dict, Literal[False]]:

--- a/core/dbt/adapters/internal_storage/local_filesystem.py
+++ b/core/dbt/adapters/internal_storage/local_filesystem.py
@@ -42,7 +42,7 @@ def read(
     """Reads the content of a file on the filesystem.
 
     Args:
-        path: Full path of file to be read.
+        path: Path of resource to be read (full path or relative to cwd).
         strip: Wether or not to strip whitespace.
 
     Returns:
@@ -81,13 +81,16 @@ def write(
     All logical cases outside those outlined above will result in failure
 
     Args:
-        path: Full path of resource to be written.
+        path: Path of resource to be written (full path or relative to cwd).
         content: Data to be written.
         overwrite: Wether or not to overwrite if a file already exists at this path.
         parser: A parser to apply to file data.
 
     Returns:
         `True` for success, `False` otherwise.
+
+    Raises:
+        Some sort of file write error depending on platform.  See TODO regarding exceptions
 
     """
     # create a concrete path object

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -1,6 +1,6 @@
 import errno
 import fnmatch
-import json
+#import json
 import os
 import os.path
 import re
@@ -11,7 +11,7 @@ import tarfile
 import requests
 import stat
 from typing import (
-    Type, NoReturn, List, Optional, Dict, Any, Tuple, Callable, Union
+    Type, NoReturn, List, Optional, Dict, Any, Tuple, Union
 )
 
 import dbt.exceptions
@@ -71,116 +71,6 @@ def find_matching(
     return matching
 
 
-def load_file_contents(path: str, strip: bool = True) -> str:
-    path = convert_path(path)
-    with open(path, 'rb') as handle:
-        to_return = handle.read().decode('utf-8')
-
-    if strip:
-        to_return = to_return.strip()
-
-    return to_return
-
-
-def make_directory(path: str) -> None:
-    """
-    Make a directory and any intermediate directories that don't already
-    exist. This function handles the case where two threads try to create
-    a directory at once.
-    """
-    path = convert_path(path)
-    if not os.path.exists(path):
-        # concurrent writes that try to create the same dir can fail
-        try:
-            os.makedirs(path)
-
-        except OSError as e:
-            if e.errno == errno.EEXIST:
-                pass
-            else:
-                raise e
-
-
-def make_file(path: str, contents: str = '', overwrite: bool = False) -> bool:
-    """
-    Make a file at `path` assuming that the directory it resides in already
-    exists. The file is saved with contents `contents`
-    """
-    if overwrite or not os.path.exists(path):
-        path = convert_path(path)
-        with open(path, 'w') as fh:
-            fh.write(contents)
-        return True
-
-    return False
-
-
-def make_symlink(source: str, link_path: str) -> None:
-    """
-    Create a symlink at `link_path` referring to `source`.
-    """
-    if not supports_symlinks():
-        dbt.exceptions.system_error('create a symbolic link')
-
-    os.symlink(source, link_path)
-
-
-def supports_symlinks() -> bool:
-    return getattr(os, "symlink", None) is not None
-
-
-def write_file(path: str, contents: str = '') -> bool:
-    path = convert_path(path)
-    try:
-        make_directory(os.path.dirname(path))
-        with open(path, 'w', encoding='utf-8') as f:
-            f.write(str(contents))
-    except Exception as exc:
-        # note that you can't just catch FileNotFound, because sometimes
-        # windows apparently raises something else.
-        # It's also not sufficient to look at the path length, because
-        # sometimes windows fails to write paths that are less than the length
-        # limit. So on windows, suppress all errors that happen from writing
-        # to disk.
-        if os.name == 'nt':
-            # sometimes we get a winerror of 3 which means the path was
-            # definitely too long, but other times we don't and it means the
-            # path was just probably too long. This is probably based on the
-            # windows/python version.
-            if getattr(exc, 'winerror', 0) == 3:
-                reason = 'Path was too long'
-            else:
-                reason = 'Path was possibly too long'
-            # all our hard work and the path was still too long. Log and
-            # continue.
-            logger.debug(
-                f'Could not write to path {path}({len(path)} characters): '
-                f'{reason}\nexception: {exc}'
-            )
-        else:
-            raise
-    return True
-
-
-def read_json(path: str) -> Dict[str, Any]:
-    return json.loads(load_file_contents(path))
-
-
-def write_json(path: str, data: Dict[str, Any]) -> bool:
-    return write_file(path, json.dumps(data, cls=dbt.utils.JSONEncoder))
-
-
-def _windows_rmdir_readonly(
-    func: Callable[[str], Any], path: str, exc: Tuple[Any, OSError, Any]
-):
-    exception_val = exc[1]
-    if exception_val.errno == errno.EACCES:
-        os.chmod(path, stat.S_IWUSR)
-        func(path)
-    else:
-        raise
-
-
 def resolve_path_from_base(path_to_resolve: str, base_path: str) -> str:
     """
     If path-to_resolve is a relative path, create an absolute path
@@ -193,108 +83,6 @@ def resolve_path_from_base(path_to_resolve: str, base_path: str) -> str:
         os.path.join(
             base_path,
             os.path.expanduser(path_to_resolve)))
-
-
-def rmdir(path: str) -> None:
-    """
-    Recursively deletes a directory. Includes an error handler to retry with
-    different permissions on Windows. Otherwise, removing directories (eg.
-    cloned via git) can cause rmtree to throw a PermissionError exception
-    """
-    path = convert_path(path)
-    if sys.platform == 'win32':
-        onerror = _windows_rmdir_readonly
-    else:
-        onerror = None
-
-    shutil.rmtree(path, onerror=onerror)
-
-
-def _win_prepare_path(path: str) -> str:
-    """Given a windows path, prepare it for use by making sure it is absolute
-    and normalized.
-    """
-    path = os.path.normpath(path)
-
-    # if a path starts with '\', splitdrive() on it will return '' for the
-    # drive, but the prefix requires a drive letter. So let's add the drive
-    # letter back in.
-    # Unless it starts with '\\'. In that case, the path is a UNC mount point
-    # and splitdrive will be fine.
-    if not path.startswith('\\\\') and path.startswith('\\'):
-        curdrive = os.path.splitdrive(os.getcwd())[0]
-        path = curdrive + path
-
-    # now our path is either an absolute UNC path or relative to the current
-    # directory. If it's relative, we need to make it absolute or the prefix
-    # won't work. `ntpath.abspath` allegedly doesn't always play nice with long
-    # paths, so do this instead.
-    if not os.path.splitdrive(path)[0]:
-        path = os.path.join(os.getcwd(), path)
-
-    return path
-
-
-def _supports_long_paths() -> bool:
-    if sys.platform != 'win32':
-        return True
-    # Eryk Sun says to use `WinDLL('ntdll')` instead of `windll.ntdll` because
-    # of pointer caching in a comment here:
-    # https://stackoverflow.com/a/35097999/11262881
-    # I don't know exaclty what he means, but I am inclined to believe him as
-    # he's pretty active on Python windows bugs!
-    try:
-        dll = WinDLL('ntdll')
-    except OSError:  # I don't think this happens? you need ntdll to run python
-        return False
-    # not all windows versions have it at all
-    if not hasattr(dll, 'RtlAreLongPathsEnabled'):
-        return False
-    # tell windows we want to get back a single unsigned byte (a bool).
-    dll.RtlAreLongPathsEnabled.restype = c_bool
-    return dll.RtlAreLongPathsEnabled()
-
-
-def convert_path(path: str) -> str:
-    """Convert a path that dbt has, which might be >260 characters long, to one
-    that will be writable/readable on Windows.
-
-    On other platforms, this is a no-op.
-    """
-    # some parts of python seem to append '\*.*' to strings, better safe than
-    # sorry.
-    if len(path) < 250:
-        return path
-    if _supports_long_paths():
-        return path
-
-    prefix = '\\\\?\\'
-    # Nothing to do
-    if path.startswith(prefix):
-        return path
-
-    path = _win_prepare_path(path)
-
-    # add the prefix. The check is just in case os.getcwd() does something
-    # unexpected - I believe this if-state should always be True though!
-    if not path.startswith(prefix):
-        path = prefix + path
-    return path
-
-
-def remove_file(path: str) -> None:
-    path = convert_path(path)
-    os.remove(path)
-
-
-def path_exists(path: str) -> bool:
-    path = convert_path(path)
-    return os.path.lexists(path)
-
-
-def path_is_symlink(path: str) -> bool:
-    path = convert_path(path)
-    return os.path.islink(path)
 
 
 def open_dir_cmd() -> str:
@@ -444,7 +232,6 @@ def run_cmd(
 def download(
     url: str, path: str, timeout: Optional[Union[float, tuple]] = None
 ) -> None:
-    path = convert_path(path)
     connection_timeout = timeout or float(os.getenv('DBT_HTTP_TIMEOUT', 10))
     response = requests.get(url, timeout=connection_timeout)
     with open(path, 'wb') as handle:
@@ -452,24 +239,9 @@ def download(
             handle.write(block)
 
 
-def rename(from_path: str, to_path: str, force: bool = False) -> None:
-    from_path = convert_path(from_path)
-    to_path = convert_path(to_path)
-    is_symlink = path_is_symlink(to_path)
-
-    if os.path.exists(to_path) and force:
-        if is_symlink:
-            remove_file(to_path)
-        else:
-            rmdir(to_path)
-
-    shutil.move(from_path, to_path)
-
-
 def untar_package(
     tar_path: str, dest_dir: str, rename_to: Optional[str] = None
 ) -> None:
-    tar_path = convert_path(tar_path)
     tar_dir_name = None
     with tarfile.open(tar_path, 'r') as tarball:
         tarball.extractall(dest_dir)
@@ -478,69 +250,3 @@ def untar_package(
         downloaded_path = os.path.join(dest_dir, tar_dir_name)
         desired_path = os.path.join(dest_dir, rename_to)
         dbt.clients.system.rename(downloaded_path, desired_path, force=True)
-
-
-def chmod_and_retry(func, path, exc_info):
-    """Define an error handler to pass to shutil.rmtree.
-    On Windows, when a file is marked read-only as git likes to do, rmtree will
-    fail. To handle that, on errors try to make the file writable.
-    We want to retry most operations here, but listdir is one that we know will
-    be useless.
-    """
-    if func is os.listdir or os.name != 'nt':
-        raise
-    os.chmod(path, stat.S_IREAD | stat.S_IWRITE)
-    # on error,this will raise.
-    func(path)
-
-
-def _absnorm(path):
-    return os.path.normcase(os.path.abspath(path))
-
-
-def move(src, dst):
-    """A re-implementation of shutil.move that properly removes the source
-    directory on windows when it has read-only files in it and the move is
-    between two drives.
-
-    This is almost identical to the real shutil.move, except it uses our rmtree
-    and skips handling non-windows OSes since the existing one works ok there.
-    """
-    src = convert_path(src)
-    dst = convert_path(dst)
-    if os.name != 'nt':
-        return shutil.move(src, dst)
-
-    if os.path.isdir(dst):
-        if _absnorm(src) == _absnorm(dst):
-            os.rename(src, dst)
-            return
-
-        dst = os.path.join(dst, os.path.basename(src.rstrip('/\\')))
-        if os.path.exists(dst):
-            raise EnvironmentError("Path '{}' already exists".format(dst))
-
-    try:
-        os.rename(src, dst)
-    except OSError:
-        # probably different drives
-        if os.path.isdir(src):
-            if _absnorm(dst + '\\').startswith(_absnorm(src + '\\')):
-                # dst is inside src
-                raise EnvironmentError(
-                    "Cannot move a directory '{}' into itself '{}'"
-                    .format(src, dst)
-                )
-            shutil.copytree(src, dst, symlinks=True)
-            rmtree(src)
-        else:
-            shutil.copy2(src, dst)
-            os.unlink(src)
-
-
-def rmtree(path):
-    """Recursively remove path. On permissions errors on windows, try to remove
-    the read-only flag and try again.
-    """
-    path = convert_path(path)
-    return shutil.rmtree(path, onerror=chmod_and_retry)

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -1,6 +1,5 @@
 import errno
 import fnmatch
-#import json
 import os
 import os.path
 import re
@@ -9,7 +8,7 @@ import subprocess
 import sys
 import tarfile
 import requests
-import stat
+from pathlib import Path
 from typing import (
     Type, NoReturn, List, Optional, Dict, Any, Tuple, Union
 )
@@ -18,7 +17,6 @@ import dbt.exceptions
 import dbt.utils
 
 from dbt.logger import GLOBAL_LOGGER as logger
-
 if sys.platform == 'win32':
     from ctypes import WinDLL, c_bool
 else:
@@ -247,6 +245,6 @@ def untar_package(
         tarball.extractall(dest_dir)
         tar_dir_name = os.path.commonprefix(tarball.getnames())
     if rename_to:
-        downloaded_path = os.path.join(dest_dir, tar_dir_name)
-        desired_path = os.path.join(dest_dir, rename_to)
-        dbt.clients.system.rename(downloaded_path, desired_path, force=True)
+        downloaded_path = Path(os.path.join(dest_dir, tar_dir_name))
+        desired_path = Path(os.path.join(dest_dir, rename_to))
+        downloaded_path.rename(desired_path)

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -19,7 +19,7 @@ from dbt.dataclass_schema import (
     dbtClassMixin, ExtensibleDbtClassMixin
 )
 
-from dbt.clients.system import write_file
+from dbt.clients.storage import adapter as SA
 from dbt.contracts.files import FileHash, MAXIMUM_SEED_SIZE_NAME
 from dbt.contracts.graph.unparsed import (
     UnparsedNode, UnparsedDocumentation, Quoting, Docs,
@@ -216,7 +216,7 @@ class ParsedNodeDefaults(ParsedNodeMandatory):
             target_path, subdirectory, self.package_name, path
         )
 
-        write_file(full_path, payload)
+        SA.write(full_path, payload)
         return full_path
 
 

--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -31,7 +31,6 @@ from typing import (
 )
 
 
-
 @dataclass
 class TimingInfo(dbtClassMixin):
     name: str

--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -20,6 +20,9 @@ from dbt.utils import lowercase
 from dbt.dataclass_schema import dbtClassMixin, StrEnum
 
 import agate
+import json
+import dbt.utils
+from dbt.clients.storage import adapter as SA
 
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -27,7 +30,6 @@ from typing import (
     Union, Dict, List, Optional, Any, NamedTuple, Sequence,
 )
 
-from dbt.clients.system import write_json
 
 
 @dataclass
@@ -211,7 +213,8 @@ class RunResultsArtifact(ExecutionResult, ArtifactMixin):
         )
 
     def write(self, path: str):
-        write_json(path, self.to_dict(omit_none=False))
+        content = json.dumps(self.to_dict(omit_none=False), cls=dbt.utils.JSONEncoder)
+        SA.write(path, content)
 
 
 @dataclass

--- a/core/dbt/contracts/util.py
+++ b/core/dbt/contracts/util.py
@@ -59,10 +59,10 @@ class Mergeable(Replaceable):
 class Writable:
     def write(self, path: str):
         content = json.dumps(
-            self.to_dict(omit_none=False),
+            self.to_dict(omit_none=False),  # type: ignore
             cls=dbt.utils.JSONEncoder
         )
-        
+
         SA.write(path, content)
 
 

--- a/core/dbt/deps/git.py
+++ b/core/dbt/deps/git.py
@@ -3,7 +3,7 @@ import hashlib
 from pathlib import Path
 from typing import List, Optional
 
-from dbt.clients import git, system
+from dbt.clients import git
 import dbt.adapters.internal_storage.local_filesystem as local_SA
 from dbt.config import Project
 from dbt.contracts.project import (
@@ -109,6 +109,7 @@ class GitPinnedPackage(GitPackageMixin, PinnedPackage):
         local_SA.delete(dest_path)
         checkout_path = Path(self._checkout())
         checkout_path.rename(dest_path)
+
 
 class GitUnpinnedPackage(GitPackageMixin, UnpinnedPackage[GitPinnedPackage]):
     def __init__(

--- a/core/dbt/deps/git.py
+++ b/core/dbt/deps/git.py
@@ -1,8 +1,10 @@
 import os
 import hashlib
+from pathlib import Path
 from typing import List, Optional
 
 from dbt.clients import git, system
+import dbt.adapters.internal_storage.local_filesystem as local_SA
 from dbt.config import Project
 from dbt.contracts.project import (
     ProjectPackageMetadata,
@@ -104,14 +106,9 @@ class GitPinnedPackage(GitPackageMixin, PinnedPackage):
 
     def install(self, project, renderer):
         dest_path = self.get_installation_path(project, renderer)
-        if os.path.exists(dest_path):
-            if system.path_is_symlink(dest_path):
-                system.remove_file(dest_path)
-            else:
-                system.rmdir(dest_path)
-
-        system.move(self._checkout(), dest_path)
-
+        local_SA.delete(dest_path)
+        checkout_path = Path(self._checkout())
+        checkout_path.rename(dest_path)
 
 class GitUnpinnedPackage(GitPackageMixin, UnpinnedPackage[GitPinnedPackage]):
     def __init__(

--- a/core/dbt/deps/local.py
+++ b/core/dbt/deps/local.py
@@ -7,7 +7,6 @@ from dbt.contracts.project import (
     ProjectPackageMetadata,
     LocalPackage,
 )
-from dbt.logger import GLOBAL_LOGGER as logger
 
 
 class LocalPackageMixin:
@@ -47,11 +46,12 @@ class LocalPinnedPackage(LocalPackageMixin, PinnedPackage):
 
     def install(self, project, renderer):
         src_path = Path(self.resolve_path(project))
-        dest_path = self.get_installation_path(project, renderer)        
+        dest_path = self.get_installation_path(project, renderer)
         local_SA.delete(dest_path)
         src_path.rename(dest_path)
-        # TODO: is it ok to remove symlinking?  
+        # TODO: is it ok to remove symlinking?
         # Symlinks aren't really a thing outside of filesystems and will be hard to model in SAs
+
 
 class LocalUnpinnedPackage(
     LocalPackageMixin, UnpinnedPackage[LocalPinnedPackage]

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -9,6 +9,7 @@ import time
 import warnings
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Optional, List, ContextManager, Callable, Dict, Any, Set
 
 import colorama
@@ -360,8 +361,8 @@ initialized = False
 
 
 def make_log_dir_if_missing(log_dir):
-    import dbt.clients.system
-    dbt.clients.system.make_directory(log_dir)
+    # N.B:  Storage adapters can't be used in the logger (circular imports)
+    Path(log_dir).mkdir(parents=True, exist_ok=True)
 
 
 class DebugWarnings(logbook.compat.redirected_warnings):

--- a/core/dbt/task/parse.py
+++ b/core/dbt/task/parse.py
@@ -38,8 +38,14 @@ class ParseTask(ConfiguredTask):
 
     def write_perf_info(self):
         path = os.path.join(self.config.target_path, PERF_INFO_FILE_NAME)
-        SA.write(path, json.dumps(self.loader._perf_info,
-                                    cls=dbt.utils.JSONEncoder, indent=4))
+        SA.write(
+            path,
+            json.dumps(
+                self.loader._perf_info,
+                cls=dbt.utils.JSONEncoder,
+                indent=4
+            )
+        )
         print_timestamped_line(f"Performance info: {path}")
 
     # This method takes code that normally exists in other files

--- a/core/dbt/task/parse.py
+++ b/core/dbt/task/parse.py
@@ -12,7 +12,7 @@ from dbt.parser.manifest import (
     Manifest, ManifestLoader, _check_manifest
 )
 from dbt.logger import DbtProcessState, print_timestamped_line
-from dbt.clients.system import write_file
+from dbt.clients.storage import adapter as SA
 from dbt.graph import Graph
 import time
 from typing import Optional
@@ -38,7 +38,7 @@ class ParseTask(ConfiguredTask):
 
     def write_perf_info(self):
         path = os.path.join(self.config.target_path, PERF_INFO_FILE_NAME)
-        write_file(path, json.dumps(self.loader._perf_info,
+        SA.write(path, json.dumps(self.loader._perf_info,
                                     cls=dbt.utils.JSONEncoder, indent=4))
         print_timestamped_line(f"Performance info: {path}")
 

--- a/scripts/collect-artifact-schema.py
+++ b/scripts/collect-artifact-schema.py
@@ -10,7 +10,7 @@ from dbt.contracts.results import (
     CatalogArtifact, RunResultsArtifact, FreshnessExecutionResultArtifact
 )
 from dbt.contracts.util import VersionedSchema
-from dbt.clients.system import write_file
+from dbt.adapters.internal_storage import local_filesystem as local_SA
 
 
 @dataclass
@@ -31,7 +31,7 @@ class ArtifactInfo:
         )
 
     def write_schema(self, dest_dir: Path):
-        write_file(
+        local_SA.write(
             str(dest_dir / self.path),
             json.dumps(self.json_schema, indent=2)
         )

--- a/test/unit/test_system_client.py
+++ b/test/unit/test_system_client.py
@@ -8,47 +8,6 @@ from dbt.exceptions import ExecutableError, WorkingDirectoryError
 import dbt.clients.system
 
 
-class SystemClient(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.tmp_dir = mkdtemp()
-        self.profiles_path = '{}/profiles.yml'.format(self.tmp_dir)
-
-    def set_up_profile(self):
-        with open(self.profiles_path, 'w') as f:
-            f.write('ORIGINAL_TEXT')
-
-    def get_profile_text(self):
-        with open(self.profiles_path, 'r') as f:
-            return f.read()
-
-    def tearDown(self):
-        try:
-            shutil.rmtree(self.tmp_dir)
-        except:
-            pass
-
-    def test__make_file_when_exists(self):
-        self.set_up_profile()
-        written = dbt.clients.system.make_file(self.profiles_path, contents='NEW_TEXT')
-
-        self.assertFalse(written)
-        self.assertEqual(self.get_profile_text(), 'ORIGINAL_TEXT')
-
-    def test__make_file_when_not_exists(self):
-        written = dbt.clients.system.make_file(self.profiles_path, contents='NEW_TEXT')
-
-        self.assertTrue(written)
-        self.assertEqual(self.get_profile_text(), 'NEW_TEXT')
-
-    def test__make_file_with_overwrite(self):
-        self.set_up_profile()
-        written = dbt.clients.system.make_file(self.profiles_path, contents='NEW_TEXT', overwrite=True)
-
-        self.assertTrue(written)
-        self.assertEqual(self.get_profile_text(), 'NEW_TEXT')
-
-
 class TestRunCmd(unittest.TestCase):
     """Test `run_cmd`.
 


### PR DESCRIPTION
PR for second segment of local FS storage adapter.
Contains:

- Cleaned up `dbt.clients.system` module
- More/better integration with the rest of the codebase-- 100% of `system` module's file system functions have been swapped with the SA ones (excepting `find_matching`)
- Re-worked `write` method params to match previous system
- Removed many `os.path` refs replacing with `Pathlib` 

This breaks a few tests (unit and integration). The unit test failures are utilizing MagicMocks which don't seem to play nice as file paths for some reason. The integration test failures are mostly from the cli test suite and need further investigation.