### PR TITLE
[Backport] #3716 to v0.20.2, too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt 0.20.2 (Release TBD)
 
+### Fixes
+- Avoid caching schemas for tests when `store_failures` is not enabled ([#3715](https://github.com/dbt-labs/dbt/issues/3715), [#3716](https://github.com/dbt-labs/dbt/pull/3716))
+
 ### Under the hood
 - Get more information on partial parsing version mismatches ([#3757](https://github.com/dbt-labs/dbt/issues/3757), [#3758](https://github.com/dbt-labs/dbt/pull/3758))
 - Use GitHub Actions for CI ([#3688](https://github.com/dbt-labs/dbt/issues/3688), [#3669](https://github.com/dbt-labs/dbt/pull/3669))

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -31,7 +31,6 @@ from dbt.contracts.graph.compiled import (
 from dbt.contracts.graph.manifest import Manifest, MacroManifest
 from dbt.contracts.graph.parsed import ParsedSeedNode
 from dbt.exceptions import warn_or_error
-from dbt.node_types import NodeType
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.utils import filter_null_values, executor
 
@@ -310,8 +309,7 @@ class BaseAdapter(metaclass=AdapterMeta):
             self.Relation.create_from(self.config, node).without_identifier()
             for node in manifest.nodes.values()
             if (
-                node.resource_type in NodeType.executable() and
-                not node.is_ephemeral_model
+                node.is_relational and not node.is_ephemeral_model
             )
         }
 


### PR DESCRIPTION
As initially reported, #3715 was a cosmetic issue that resulted in some failed Snowflake queries, but no failed dbt runs. I've now heard reports from some users of other databases that don't have handling when dbt tries to cache (grab metadata for) a nonexistent schema (main [Slack thread here](https://getdbt.slack.com/archives/CNNPBQ24R/p1629130625017800)).

This is definitely a fix for something v0.20-related. Now that I understand the bug is functional, not just cosmetic, I think it belongs in v0.20.2. The question if whether we'd want some extra testing and validation before final release—i.e. a second release candidate, v0.20.2-rc2, now that we've got a handful of changes since the last one.