### PR TITLE
Address unexpected cancelled CI workflows and stop blocking Postgres integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,7 +40,7 @@ permissions: read-all
 
 # will cancel previous workflows triggered by the same event and for the same ref
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
   cancel-in-progress: true
 
 # sets default shell to bash, for all operating systems


### PR DESCRIPTION
### Description

This resolves 2 issues:
- PRs pointing at `develop` are cancelling tests that run on pushes to `develop`
- Postgres integration test jobs were being blocked by other Postgres integration test jobs, no need to block these as we are running Postgres locally

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
