### PR TITLE
Revert "Bump freezegun from 0.3.12 to 1.1.0"

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 bumpversion
 flake8
 flaky
-freezegun==1.1.0
+freezegun==0.3.12
 ipdb
 mypy==0.782
 pip-tools


### PR DESCRIPTION
Reverts dbt-labs/dbt#3206

This change causes Postgres integration tests to hang, created https://github.com/dbt-labs/dbt/issues/3817 to address.