### PR TITLE
Run postgres integration tests when dev dependency changes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -91,6 +91,7 @@ jobs:
             postgres:
               - 'core/**'
               - 'plugins/postgres/**'
+              - 'dev-requirements.txt'
             snowflake:
               - 'core/**'
               - 'plugins/snowflake/**'


### PR DESCRIPTION
### Description
This PR runs Postgres integration tests when a dev dependency changes. This would of caught https://github.com/dbt-labs/dbt/pull/3206 and will help prevent breaking development environments.


### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
