### PR TITLE
Update workflow concurrency

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,7 +28,6 @@ on:
       - "develop"
       - "*.latest"
       - "releases/*"
-      - "github-actions" # testing!
   # all PRs, important to note that `pull_request_target` workflows
   # will run in the context of the target branch of a PR
   pull_request_target:
@@ -38,9 +37,9 @@ on:
 # explicitly turn off permissions for `GITHUB_TOKEN`
 permissions: read-all
 
-# will cancel previous workflows triggered by the same event and for the same ref
+# will cancel previous workflows triggered by the same event and for the same ref for PRs or same SHA otherwise
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.ref || github.sha }}
   cancel-in-progress: true
 
 # sets default shell to bash, for all operating systems
@@ -132,11 +131,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     needs: test-metadata
-
-    # only block on non-postgres jobs, this is an attempt to decrease amount of concurrent jobs running against a warehouse
-    concurrency:
-      group: ${{ matrix.adapter != 'postgres' && matrix.adapter || github.run_id }}-${{ matrix.python-version }}-${{ matrix.os }}
-      cancel-in-progress: false
 
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,14 +21,14 @@ on:
       - "develop"
       - "*.latest"
       - "releases/*"
-      - "github-actions"
   pull_request:
   workflow_dispatch:
 
 permissions: read-all
 
+# will cancel previous workflows triggered by the same event and for the same ref for PRs or same SHA otherwise
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.ref || github.sha }}
   cancel-in-progress: true
 
 defaults:


### PR DESCRIPTION
### Description
Last concurrency change, took a little trial and error.

This PR flips `ref` and `sha`
`ref` = branch or tag
`sha` = commit SHA

The intention here is for workflows to run on every push event, for each unique `sha` aka commit. I think it is useful to have info on each commit to a release branch about whether or not all tests pass or not for auditing and debugging reasons. This change will ensure that workflows run on the latest event for PRs. So if you push changes to a PR and there is already workflows running, it will cancel the previous workflows and you will be left with a running workflow with your latest changes. There is no need to waste resources on each commit of a PR, only the latest _really_ matters. This also removes the attempt to decrease amount of concurrent jobs running against a warehouse. We are unable to to this because in GHA docs it mentions "Any previously pending job or workflow in the concurrency group will be canceled." ([source](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency)) This might lead to unexpected job cancellations 😞 

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
