### PR TITLE
add log_var macro

### DIFF
--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -447,6 +447,31 @@ class BaseContext(metaclass=ContextMeta):
         else:
             logger.debug(msg)
         return ''
+    
+    @contextmember
+    @staticmethod
+    def log_var(var: str, sep = ': ', info: bool = False) -> str:
+        """Given a variable,
+        logs the variable name and value separated by sep
+
+        :param var: The variable to log
+        :param sep: how name and value are concatenated
+        :param info: If `False`, write to the log file. If `True`, write to
+            both the log file and stdout.
+
+        > macros/my_log_var_macro.sql
+
+            {% macro some_macro(arg1) %}
+              {{ log(arg1) }}
+            {% endmacro %}"
+        """
+        msg = f'{var=}' # py3.8+ only
+
+        if info:
+            logger.info(msg)
+        else:
+            logger.debug(msg)
+        return ''
 
     @contextproperty
     def run_started_at(self) -> Optional[datetime.datetime]:


### PR DESCRIPTION
resolves #3911

### Description

Add a new `log_var` dbt-jinja macro. My implementation only works for Python 3.8 and above. getting a variable's name in python<=3.7 is way trickier. my initial idea for the PR would be jinja instead of python like `msg = 'drop_script: ' ~ drop_script`, but not sure how I'd do that.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
