### PR TITLE
[#4013] Fix multiple disabled models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add generic tests defined on sources to the manifest once, not twice ([#3347](https://github.com/dbt-labs/dbt/issues/3347), [#3880](https://github.com/dbt-labs/dbt/pull/3880))
 - Skip partial parsing if certain macros have changed ([#3810](https://github.com/dbt-labs/dbt/issues/3810), [#3982](https://github.com/dbt-labs/dbt/pull/3892))
 - Enable cataloging of unlogged Postgres tables ([3961](https://github.com/dbt-labs/dbt/issues/3961), [#3993](https://github.com/dbt-labs/dbt/pull/3993))
+- Fix multiple disabled nodes ([#4013](https://github.com/dbt-labs/dbt/issues/4013), [#4018](https://github.com/dbt-labs/dbt/pull/4018))
 
 ### Under the hood
 

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -6,6 +6,7 @@ import traceback
 from typing import (
     Dict, Optional, Mapping, Callable, Any, List, Type, Union, Tuple
 )
+from itertools import chain
 import time
 
 import dbt.exceptions
@@ -893,7 +894,9 @@ def _warn_for_unused_resource_config_paths(
     manifest: Manifest, config: RuntimeConfig
 ) -> None:
     resource_fqns: Mapping[str, PathSet] = manifest.get_resource_fqns()
-    disabled_fqns: PathSet = frozenset(tuple(n.fqn) for n in manifest.disabled.values())
+    disabled_fqns: PathSet = frozenset(
+        tuple(n.fqn) for n in list(chain.from_iterable(manifest.disabled.values()))
+    )
     config.warn_for_unused_resource_config_paths(resource_fqns, disabled_fqns)
 
 

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -827,8 +827,17 @@ class NodePatchParser(
                 f'file {source_file.path.original_file_path}'
             )
         if unique_id is None:
-            # This will usually happen when a node is disabled
-            return
+            # Node might be disabled. Following call returns first matching node encountered.
+            found_node = self.manifest.find_disabled_by_name(patch.package_name, patch.name)
+            if found_node:
+                # There might be multiple disabled nodes for this model
+                for node in self.manifest.disabled[found_node.unique_id]:
+                    # We're saving the patch_path because we need to schedule
+                    # re-application of the patch in partial parsing.
+                    node.patch_path = source_file.file_id
+            else:
+                # Should we issue a warning message here?
+                return
 
         # patches can't be overwritten
         node = self.manifest.nodes.get(unique_id)

--- a/test/integration/025_duplicate_model_test/models-5/subdir1/model_alt.sql
+++ b/test/integration/025_duplicate_model_test/models-5/subdir1/model_alt.sql
@@ -1,0 +1,1 @@
+select 100 as somevalue

--- a/test/integration/025_duplicate_model_test/models-5/subdir2/model_alt.sql
+++ b/test/integration/025_duplicate_model_test/models-5/subdir2/model_alt.sql
@@ -1,0 +1,4 @@
+{{
+  config(enabled = False)
+}}
+select 100 as altvalue

--- a/test/integration/025_duplicate_model_test/models-5/subdir3/model_alt.sql
+++ b/test/integration/025_duplicate_model_test/models-5/subdir3/model_alt.sql
@@ -1,0 +1,5 @@
+{{
+  config(enabled = False)
+}}
+
+select 100 as thirdvalue

--- a/test/integration/025_duplicate_model_test/test_duplicate_model.py
+++ b/test/integration/025_duplicate_model_test/test_duplicate_model.py
@@ -1,5 +1,5 @@
 from dbt.exceptions import CompilationException
-from test.integration.base import DBTIntegrationTest, use_profile
+from test.integration.base import DBTIntegrationTest, use_profile, get_manifest
 
 
 class TestDuplicateModelEnabled(DBTIntegrationTest):
@@ -150,3 +150,21 @@ class TestModelTestOverlap(DBTIntegrationTest):
         self.run_dbt(['compile'])
         self.run_dbt(['--partial-parse', 'compile'])
         self.run_dbt(['--partial-parse', 'compile'])
+
+
+class TestMultipleDisabledModels(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "duplicate_model_025"
+
+    @property
+    def models(self):
+        return "models-5"
+
+    @use_profile('postgres')
+    def test_postgres_multiple_disabled_models(self):
+        self.run_dbt(['run'])
+        manifest = get_manifest()
+        model_id = 'model.test.model_alt'
+        self.assertIn(model_id, manifest.nodes)


### PR DESCRIPTION
resolves #4013

### Description

We recently switched to a dictionary with a unique_id key and a single node value for the disabled attribute, but this doesn't support multiple disabled nodes. This changes the value in the disabled dictionary to a list of nodes. In addition, this pull request sets the 'patch_path' in all of the disabled nodes, because it's needed in partial parsing in order to schedule the patch for parsing when the node associated with the SQL file is updated.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
