### PR TITLE
[#4006] replace `logger.warning` with `warn_or_error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Enable cataloging of unlogged Postgres tables ([3961](https://github.com/dbt-labs/dbt/issues/3961), [#3993](https://github.com/dbt-labs/dbt/pull/3993))
 - Fix multiple disabled nodes ([#4013](https://github.com/dbt-labs/dbt/issues/4013), [#4018](https://github.com/dbt-labs/dbt/pull/4018))
 - Fix multiple partial parsing errors ([#3996](https://github.com/dbt-labs/dbt/issues/3006), [#4020](https://github.com/dbt-labs/dbt/pull/4018))
+- Return an error instead of a warning when runing with `--warn-error` and no models are selected ([#4006](https://github.com/dbt-labs/dbt/issues/4006), [#4019](https://github.com/dbt-labs/dbt/pull/4019))
 
 ### Under the hood
 
@@ -38,6 +39,7 @@ Contributors:
 - [@kadero](https://github.com/kadero) ([#3952](https://github.com/dbt-labs/dbt/pull/3953))
 - [@samlader](https://github.com/samlader) ([#3993](https://github.com/dbt-labs/dbt/pull/3993))
 - [@yu-iskw](https://github.com/yu-iskw) ([#3967](https://github.com/dbt-labs/dbt/pull/3967))
+- [@laxjesse](https://github.com/laxjesse) ([#4019](https://github.com/dbt-labs/dbt/pull/4019))
 
 ## dbt 0.21.0 (October 04, 2021)
 

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -8,8 +8,8 @@ from dbt.graph import ResourceTypeSelector
 from dbt.task.runnable import GraphRunnableTask, ManifestTask
 from dbt.task.test import TestSelector
 from dbt.node_types import NodeType
-from dbt.exceptions import RuntimeException, InternalException
-from dbt.logger import log_manager, GLOBAL_LOGGER as logger
+from dbt.exceptions import RuntimeException, InternalException, warn_or_error
+from dbt.logger import log_manager
 
 
 class ListTask(GraphRunnableTask):
@@ -61,7 +61,7 @@ class ListTask(GraphRunnableTask):
         spec = self.get_selection_spec()
         nodes = sorted(selector.get_selected(spec))
         if not nodes:
-            logger.warning('No nodes selected!')
+            warn_or_error('No nodes selected!')
             return
         if self.manifest is None:
             raise InternalException(

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -41,6 +41,7 @@ from dbt.exceptions import (
     NotImplementedException,
     RuntimeException,
     FailFastException,
+    warn_or_error,
 )
 
 from dbt.graph import (
@@ -443,8 +444,8 @@ class GraphRunnableTask(ManifestTask):
             )
 
         if len(self._flattened_nodes) == 0:
-            logger.warning("\nWARNING: Nothing to do. Try checking your model "
-                           "configs and model specification args")
+            warn_or_error("\nWARNING: Nothing to do. Try checking your model "
+                          "configs and model specification args")
             result = self.get_result(
                 results=[],
                 generated_at=datetime.utcnow(),


### PR DESCRIPTION
resolves #4006

### Description

Uses `warn_or_error` to log _or_ raise errors depending on arguments passed. 

It wasn't 100% clear to me if there should be a test for this or not but I'm happy to add if there should be.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
