### PR TITLE
[#4012] Performance: Use child_map to find tests for nodes in resolve_graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix multiple disabled nodes ([#4013](https://github.com/dbt-labs/dbt/issues/4013), [#4018](https://github.com/dbt-labs/dbt/pull/4018))
 - Fix multiple partial parsing errors ([#3996](https://github.com/dbt-labs/dbt/issues/3006), [#4020](https://github.com/dbt-labs/dbt/pull/4018))
 - Return an error instead of a warning when runing with `--warn-error` and no models are selected ([#4006](https://github.com/dbt-labs/dbt/issues/4006), [#4019](https://github.com/dbt-labs/dbt/pull/4019))
+- Performance: Use child_map to find tests for nodes in resolve_graph ([#4012](https://github.com/dbt-labs/dbt/issues/4012), [#4022](https://github.com/dbt-labs/dbt/pull/4022))
 
 ### Under the hood
 

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -111,12 +111,13 @@ def _get_tests_for_node(manifest: Manifest, unique_id: UniqueID) -> List[UniqueI
     """ Get a list of tests that depend on the node with the
     provided unique id """
 
-    return [
-        node.unique_id
-        for _, node in manifest.nodes.items()
-        if node.resource_type == NodeType.Test and
-        unique_id in node.depends_on_nodes
-    ]
+    tests = []
+    if unique_id in manifest.child_map:
+        for child_unique_id in manifest.child_map[unique_id]:
+            if child_unique_id.startswith('test.'):
+                tests.append(child_unique_id)
+
+    return tests
 
 
 class Linker:
@@ -429,6 +430,8 @@ class Compiler:
 
         if cycle:
             raise RuntimeError("Found a cycle: {}".format(cycle))
+
+        manifest.build_parent_and_child_maps()
 
         self.resolve_graph(linker, manifest)
 

--- a/test/integration/069_build_test/models-interdependent/model_a.sql
+++ b/test/integration/069_build_test/models-interdependent/model_a.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/test/integration/069_build_test/models-interdependent/model_c.sql
+++ b/test/integration/069_build_test/models-interdependent/model_c.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('model_b') }}

--- a/test/integration/069_build_test/models-interdependent/schema.yml
+++ b/test/integration/069_build_test/models-interdependent/schema.yml
@@ -1,0 +1,41 @@
+version: 2
+
+models:
+  - name: model_a
+    columns:
+      - name: id
+        tests:
+          - unique
+          - not_null
+          - relationships:
+              to: ref('model_b')
+              field: id
+          - relationships:
+              to: ref('model_c')
+              field: id
+
+  - name: model_b
+    columns:
+      - name: id
+        tests:
+          - unique
+          - not_null
+          - relationships:
+              to: ref('model_a')
+              field: id
+          - relationships:
+              to: ref('model_c')
+              field: id
+
+  - name: model_c
+    columns:
+      - name: id
+        tests:
+          - unique
+          - not_null
+          - relationships:
+              to: ref('model_a')
+              field: id
+          - relationships:
+              to: ref('model_b')
+              field: id

--- a/test/integration/069_build_test/test-files/model_b.sql
+++ b/test/integration/069_build_test/test-files/model_b.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('model_a') }} 

--- a/test/integration/069_build_test/test-files/model_b_null.sql
+++ b/test/integration/069_build_test/test-files/model_b_null.sql
@@ -1,0 +1,1 @@
+select null from {{ ref('model_a') }} 


### PR DESCRIPTION

resolves #4012

### Description

The resolve_graph method that was implemented to support the build command caused a performance regression. This pull request switches to using the child_map to find tests for nodes.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
