### PR TITLE
Bump version to 1.0.0a1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.21.0rc1
+current_version = 1.0.0a1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
@@ -35,4 +35,3 @@ first_value = 1
 [bumpversion:file:plugins/postgres/setup.py]
 
 [bumpversion:file:plugins/postgres/dbt/adapters/postgres/__version__.py]
-

--- a/core/dbt/version.py
+++ b/core/dbt/version.py
@@ -96,5 +96,5 @@ def _get_dbt_plugins_info():
         yield plugin_name, mod.version
 
 
-__version__ = '0.21.0rc1'
+__version__ = '1.0.0a1'
 installed = get_installed_version()

--- a/core/scripts/create_adapter_plugins.py
+++ b/core/scripts/create_adapter_plugins.py
@@ -284,12 +284,12 @@ def parse_args(argv=None):
     parser.add_argument('adapter')
     parser.add_argument('--title-case', '-t', default=None)
     parser.add_argument('--dependency', action='append')
-    parser.add_argument('--dbt-core-version', default='0.21.0rc1')
+    parser.add_argument('--dbt-core-version', default='1.0.0a1')
     parser.add_argument('--email')
     parser.add_argument('--author')
     parser.add_argument('--url')
     parser.add_argument('--sql', action='store_true')
-    parser.add_argument('--package-version', default='0.21.0rc1')
+    parser.add_argument('--package-version', default='1.0.0a1')
     parser.add_argument('--project-version', default='1.0')
     parser.add_argument(
         '--no-dependency', action='store_false', dest='set_dependency'

--- a/core/setup.py
+++ b/core/setup.py
@@ -24,7 +24,7 @@ def read(fname):
 
 
 package_name = "dbt-core"
-package_version = "0.21.0rc1"
+package_version = "1.0.0a1"
 description = """dbt (data build tool) is a command line tool that helps \
 analysts and engineers transform data in their warehouse more effectively"""
 

--- a/plugins/postgres/dbt/adapters/postgres/__version__.py
+++ b/plugins/postgres/dbt/adapters/postgres/__version__.py
@@ -1,1 +1,1 @@
-version = '0.21.0rc1'
+version = '1.0.0a1'

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -41,7 +41,7 @@ def _dbt_psycopg2_name():
 
 
 package_name = "dbt-postgres"
-package_version = "0.21.0rc1"
+package_version = "1.0.0a1"
 description = """The postgres adpter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
 
 
 package_name = "dbt"
-package_version = "0.21.0rc1"
+package_version = "1.0.0a1"
 description = """With dbt, data analysts and engineers can build analytics \
 the way engineers build applications."""
 


### PR DESCRIPTION
We're planning to cut `1.0.0b1` on Monday. Any reason not to do this now?

(Otherwise, it is confusing for users why `develop` is behind `0.21.latest`)