### PR TITLE
ignore epic and discussion issues during stale check

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,4 +12,7 @@ jobs:
         with:
           stale-issue-message: "This issue has been marked as Stale because it has been open for 180 days with no activity. If you would like the issue to remain open, please remove the stale label or comment on the issue, or it will be closed in 7 days."
           stale-pr-message: "This PR has been marked as Stale because it has been open for 180 days with no activity. If you would like the PR to remain open, please remove the stale label or comment on the PR, or it will be closed in 7 days."
+          # mark issues/PRs stale when they haven't seen activity in 180 days
           days-before-stale: 180
+          # ignore checking issues with the following labels
+          exempt-issue-labels: "epic,discussion"


### PR DESCRIPTION
### Description

Adds config to ignore checking issues with `discussion` and `epic` labels.

This came up when this epic was marked as stale: https://github.com/dbt-labs/dbt-core/issues/3199

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
