### PR TITLE
Upgrade to python3-pip

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -27,7 +27,7 @@ RUN apt-get update \
     && apt-get install -y \
     python \
     python-dev \
-    python-pip \
+    python3-pip \
     python3.6 \
     python3.6-dev \
     python3-pip \


### PR DESCRIPTION
resolves #4078

### Description

Upgrades Dockerfile to use `python3-pip` instead of the no-longer-available `python-pip`.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
