### PR TITLE
Remove redundant $() in setup_db.sh

### DIFF
--- a/test/setup_db.sh
+++ b/test/setup_db.sh
@@ -30,7 +30,7 @@ if [[ -n $CIRCLECI ]]; then
 fi
 
 for i in {1..10}; do
-	if $(pg_isready -h "${PGHOST}" -p "${PGPORT}" -U "${PGUSER}") ; then
+	if pg_isready -h "${PGHOST}" -p "${PGPORT}" -U "${PGUSER}" ; then
 		break
 	fi
 


### PR DESCRIPTION
This executes the command (on mac OSX at least) thus creating an error. See PR #3908

No need for a mention in the CHANGELOG for this.

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] ~~have updated the `CHANGELOG.md` and added information about my change~~
