### PR TITLE
Allow to overwrite the default test selection

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ description = adapter plugin integration testing
 skip_install = true
 passenv = DBT_* POSTGRES_TEST_* PYTEST_ADDOPTS
 commands =
-  postgres: {envpython} -m pytest {posargs} -m profile_postgres test/integration
+  postgres: {envpython} -m pytest  -m profile_postgres {posargs:test/integration}
 deps =
   -rdev-requirements.txt
   -e./core


### PR DESCRIPTION
It was not possible to overwrite the default test selection for the tox integration env.

The following command did not select the test like I would expect it to:

``` bash
tox -e integration-postgres -- test/integration/016_macro_tests/test_macros.py::TestMacroOverridePackage::test_postgres_overrides
```

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] ~~I have updated the `CHANGELOG.md` and added information about my change~~
