### PR TITLE
remove len check from integration test

### DIFF
--- a/test/integration/068_partial_parsing_tests/test_partial_parsing.py
+++ b/test/integration/068_partial_parsing_tests/test_partial_parsing.py
@@ -532,7 +532,6 @@ class TestTests(BasePPTest):
         manifest = get_manifest()
         test_id = 'test.test.is_odd_orders_id.82834fdc5b'
         self.assertIn(test_id, manifest.nodes)
-        self.assertEqual(len(manifest.nodes), 3)
 
         # edit generic test in test-path
         self.copy_file('test-files/generic_test_edited.sql', 'tests/generic/generic_test.sql')
@@ -541,4 +540,3 @@ class TestTests(BasePPTest):
         manifest = get_manifest()
         test_id = 'test.test.is_odd_orders_id.82834fdc5b'
         self.assertIn(test_id, manifest.nodes)
-        self.assertEqual(len(manifest.nodes), 3)


### PR DESCRIPTION
resolves #4052

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

len() check was causing an error where, when run in CI, there were 4 manifest nodes, but there should have only been three (1 model and 2 tests).

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
