### PR TITLE
Add error surfacing for git cloning errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Contributors:
 - Update the default project paths to be `analysis-paths = ['analyses']` and `test-paths = ['tests]`. Also have starter project set `analysis-paths: ['analyses']` from now on.  ([#2659](https://github.com/dbt-labs/dbt-core/issues/2659))
 - Define the data type of `sources` as an array of arrays of string in the manifest artifacts. ([#3966](https://github.com/dbt-labs/dbt-core/issues/3966), [#3967](https://github.com/dbt-labs/dbt-core/pull/3967))
 - Marked `source-paths` and `data-paths` as deprecated keys in `dbt_project.yml` in favor of `model-paths` and `seed-paths` respectively.([#1607](https://github.com/dbt-labs/dbt-core/issues/1607))
+- Surface git errors to `stdout` when cloning dbt packages from Github. ([#3167](https://github.com/dbt-labs/dbt-core/issues/3167))
 
 Contributors:
 
@@ -61,6 +62,7 @@ Contributors:
 - [@samlader](https://github.com/samlader) ([#3993](https://github.com/dbt-labs/dbt-core/pull/3993))
 - [@yu-iskw](https://github.com/yu-iskw) ([#3967](https://github.com/dbt-labs/dbt-core/pull/3967))
 - [@laxjesse](https://github.com/laxjesse) ([#4019](https://github.com/dbt-labs/dbt-core/pull/4019))
+- [@gitznik](https://github.com/Gitznik) ([#4124](https://github.com/dbt-labs/dbt-core/pull/4124))
 
 ## dbt 0.21.1 (Release TBD)
 

--- a/core/dbt/clients/git.py
+++ b/core/dbt/clients/git.py
@@ -11,12 +11,14 @@ def _is_commit(revision: str) -> bool:
     # match SHA-1 git commit
     return bool(re.match(r"\b[0-9a-f]{40}\b", revision))
 
+
 def _raise_git_cloning_error(repo, revision, error):
     stderr = error.stderr.decode('utf-8').strip()
     if 'usage: git' in stderr:
         stderr = stderr.split('\nusage: git')[0]
 
     dbt.exceptions.bad_package_spec(repo, revision, stderr)
+
 
 def clone(repo, cwd, dirname=None, remove_git_dir=False, revision=None, subdirectory=None):
     has_revision = revision is not None
@@ -46,8 +48,6 @@ def clone(repo, cwd, dirname=None, remove_git_dir=False, revision=None, subdirec
         result = run_cmd(cwd, clone_cmd, env={'LC_ALL': 'C'})
     except dbt.exceptions.CommandResultError as exc:
         _raise_git_cloning_error(repo, revision, exc)
-    except:
-        raise
 
     if subdirectory:
         cwd_subdir = os.path.join(cwd, dirname or '')
@@ -56,8 +56,6 @@ def clone(repo, cwd, dirname=None, remove_git_dir=False, revision=None, subdirec
             run_cmd(cwd_subdir, clone_cmd_subdir)
         except dbt.exceptions.CommandResultError as exc:
             _raise_git_cloning_error(repo, revision, exc)
-        except:
-            raise
 
     if remove_git_dir:
         rmdir(os.path.join(dirname, '.git'))

--- a/core/dbt/clients/git.py
+++ b/core/dbt/clients/git.py
@@ -11,6 +11,12 @@ def _is_commit(revision: str) -> bool:
     # match SHA-1 git commit
     return bool(re.match(r"\b[0-9a-f]{40}\b", revision))
 
+def _raise_git_cloning_error(repo, revision, error):
+    stderr = error.stderr.decode('utf-8').strip()
+    if 'usage: git' in stderr:
+        stderr = stderr.split('\nusage: git')[0]
+
+    dbt.exceptions.bad_package_spec(repo, revision, stderr)
 
 def clone(repo, cwd, dirname=None, remove_git_dir=False, revision=None, subdirectory=None):
     has_revision = revision is not None
@@ -36,10 +42,22 @@ def clone(repo, cwd, dirname=None, remove_git_dir=False, revision=None, subdirec
 
     if dirname is not None:
         clone_cmd.append(dirname)
-    result = run_cmd(cwd, clone_cmd, env={'LC_ALL': 'C'})
+    try:
+        result = run_cmd(cwd, clone_cmd, env={'LC_ALL': 'C'})
+    except dbt.exceptions.CommandResultError as exc:
+        _raise_git_cloning_error(repo, revision, exc)
+    except:
+        raise
 
     if subdirectory:
-        run_cmd(os.path.join(cwd, dirname or ''), ['git', 'sparse-checkout', 'set', subdirectory])
+        cwd_subdir = os.path.join(cwd, dirname or '')
+        clone_cmd_subdir = ['git', 'sparse-checkout', 'set', subdirectory]
+        try:
+            run_cmd(cwd_subdir, clone_cmd_subdir)
+        except dbt.exceptions.CommandResultError as exc:
+            _raise_git_cloning_error(repo, revision, exc)
+        except:
+            raise
 
     if remove_git_dir:
         rmdir(os.path.join(dirname, '.git'))
@@ -111,7 +129,10 @@ def clone_and_checkout(repo, cwd, dirname=None, remove_git_dir=False,
     except dbt.exceptions.CommandResultError as exc:
         err = exc.stderr.decode('utf-8')
         exists = re.match("fatal: destination path '(.+)' already exists", err)
-        if not exists:  # something else is wrong, raise it
+        if not exists:
+            print(
+                '\nSomething went wrong while cloning {}'.format(repo) +
+                '\nCheck the debug logs for more information')
             raise
 
     directory = None

--- a/core/dbt/clients/git.py
+++ b/core/dbt/clients/git.py
@@ -16,6 +16,8 @@ def _raise_git_cloning_error(repo, revision, error):
     stderr = error.stderr.decode('utf-8').strip()
     if 'usage: git' in stderr:
         stderr = stderr.split('\nusage: git')[0]
+    if re.match("fatal: destination path '(.+)' already exists", stderr):
+        raise error
 
     dbt.exceptions.bad_package_spec(repo, revision, stderr)
 


### PR DESCRIPTION
resolves #3167

### Description

1. Use the existing `dbt.exceptions.bad_package_spec()` function to raise the git error and print the content to stdout.
_Decided to do this in the clone method as that is where it is done for the checkout part.
If git returns the `usage: git` string with the error, I remove it from the message as it is very verbose and probably not helpful._
2. On an unknown error during cloning, the user is now advised to take a look at the debug logs for more information on the error

This handled the errors I managed to test fine:
- Invalid Repo Name
- Too many arguments as described by @tpilewicz 
- Invalid revision (still works as it did before)

I did not test:
- A bad installation of git. Let me know if you know of a way to test this.

I think this works well enough for surfacing the error messages git provides, without any more contextual error handling. `OSErrors` should be raised as they were before.

If you think I should add unit tests for this, let me know which file/test class would be appropriate to add them. I could only find `test_deps.py` which did not seem to test any git functionality. 

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
