### PR TITLE
[#4218] Create more specific tests to debug partial parsing generic tests test

### DIFF
--- a/test/integration/068_partial_parsing_tests/test_partial_parsing.py
+++ b/test/integration/068_partial_parsing_tests/test_partial_parsing.py
@@ -523,6 +523,9 @@ class TestTests(BasePPTest):
         self.copy_file('test-files/generic_schema.yml', 'models/schema.yml')
         results = self.run_dbt()
         self.assertEqual(len(results), 1)
+        manifest = get_manifest()
+        expected_nodes = ['model.test.orders', 'test.test.unique_orders_id.1360ecc70e']
+        self.assertCountEqual(expected_nodes, list(manifest.nodes.keys()))
 
         # add generic test in test-path
         self.copy_file('test-files/generic_test.sql', 'tests/generic/generic_test.sql')
@@ -532,7 +535,8 @@ class TestTests(BasePPTest):
         manifest = get_manifest()
         test_id = 'test.test.is_odd_orders_id.82834fdc5b'
         self.assertIn(test_id, manifest.nodes)
-        self.assertEqual(len(manifest.nodes), 3)
+        expected_nodes = ['model.test.orders', 'test.test.unique_orders_id.1360ecc70e', 'test.test.is_odd_orders_id.82834fdc5b']
+        self.assertCountEqual(expected_nodes, list(manifest.nodes.keys()))
 
         # edit generic test in test-path
         self.copy_file('test-files/generic_test_edited.sql', 'tests/generic/generic_test.sql')
@@ -541,4 +545,5 @@ class TestTests(BasePPTest):
         manifest = get_manifest()
         test_id = 'test.test.is_odd_orders_id.82834fdc5b'
         self.assertIn(test_id, manifest.nodes)
-        self.assertEqual(len(manifest.nodes), 3)
+        expected_nodes = ['model.test.orders', 'test.test.unique_orders_id.1360ecc70e', 'test.test.is_odd_orders_id.82834fdc5b']
+        self.assertCountEqual(expected_nodes, list(manifest.nodes.keys()))


### PR DESCRIPTION
resolves #4128


### Description

A partial parsing test is only failing in main branch CI tests. This PR does more granular tests to enable us to better identify the underlying source of the error.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x]  This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
