### PR TITLE
Add extra graph edges for `build` only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Contributors:
 - Added support for tests on databases that lack real boolean types. ([#4084](https://github.com/dbt-labs/dbt-core/issues/4084))
 - Scrub secrets coming from `CommandError`s so they don't get exposed in logs. ([#4138](https://github.com/dbt-labs/dbt-core/pull/4138))
 - Syntax fix in `alter_relation_add_remove_columns` if only removing columns in `on_schema_change: sync_all_columns` ([#4147](https://github.com/dbt-labs/dbt-core/issues/4147))
+- Add downstream test edges for `build` task _only_. Restore previous graph construction, compilation performance, and node selection behavior (`test+`) for all other tasks ([#4135](https://github.com/dbt-labs/dbt-core/issues/4135), [#4143](https://github.com/dbt-labs/dbt-core/pull/4143))
 
 Contributors:
 - [@ljhopkins2](https://github.com/ljhopkins2) ([#4077](https://github.com/dbt-labs/dbt-core/pull/4077))

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -418,7 +418,7 @@ class Compiler:
             else:
                 dependency_not_found(node, dependency)
 
-    def link_graph(self, linker: Linker, manifest: Manifest):
+    def link_graph(self, linker: Linker, manifest: Manifest, resolve: bool):
         for source in manifest.sources.values():
             linker.add_node(source.unique_id)
         for node in manifest.nodes.values():
@@ -431,9 +431,9 @@ class Compiler:
         if cycle:
             raise RuntimeError("Found a cycle: {}".format(cycle))
 
-        manifest.build_parent_and_child_maps()
-
-        self.resolve_graph(linker, manifest)
+        if resolve:
+            manifest.build_parent_and_child_maps()
+            self.resolve_graph(linker, manifest)
 
     def resolve_graph(self, linker: Linker, manifest: Manifest) -> None:
         """ This method adds additional edges to the DAG. For a given non-test
@@ -501,11 +501,11 @@ class Compiler:
                             node_id
                         )
 
-    def compile(self, manifest: Manifest, write=True) -> Graph:
+    def compile(self, manifest: Manifest, resolve=False, write=True) -> Graph:
         self.initialize()
         linker = Linker()
 
-        self.link_graph(linker, manifest)
+        self.link_graph(linker, manifest, resolve)
 
         stats = _generate_stats(manifest)
 

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -418,7 +418,7 @@ class Compiler:
             else:
                 dependency_not_found(node, dependency)
 
-    def link_graph(self, linker: Linker, manifest: Manifest, resolve: bool):
+    def link_graph(self, linker: Linker, manifest: Manifest, add_test_edges: bool = False):
         for source in manifest.sources.values():
             linker.add_node(source.unique_id)
         for node in manifest.nodes.values():
@@ -431,11 +431,11 @@ class Compiler:
         if cycle:
             raise RuntimeError("Found a cycle: {}".format(cycle))
 
-        if resolve:
+        if add_test_edges:
             manifest.build_parent_and_child_maps()
-            self.resolve_graph(linker, manifest)
+            self.add_test_edges(linker, manifest)
 
-    def resolve_graph(self, linker: Linker, manifest: Manifest) -> None:
+    def add_test_edges(self, linker: Linker, manifest: Manifest) -> None:
         """ This method adds additional edges to the DAG. For a given non-test
         executable node, add an edge from an upstream test to the given node if
         the set of nodes the test depends on is a proper/strict subset of the
@@ -501,11 +501,11 @@ class Compiler:
                             node_id
                         )
 
-    def compile(self, manifest: Manifest, resolve=False, write=True) -> Graph:
+    def compile(self, manifest: Manifest, write=True, add_test_edges=False) -> Graph:
         self.initialize()
         linker = Linker()
 
-        self.link_graph(linker, manifest, resolve)
+        self.link_graph(linker, manifest, add_test_edges)
 
         stats = _generate_stats(manifest)
 

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -73,4 +73,4 @@ class BuildTask(RunTask):
             )
         adapter = get_adapter(self.config)
         compiler = adapter.get_compiler()
-        self.graph = compiler.compile(self.manifest, resolve=True)
+        self.graph = compiler.compile(self.manifest, add_test_edges=True)

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -3,6 +3,7 @@ from .snapshot import SnapshotRunner as snapshot_model_runner
 from .seed import SeedRunner as seed_runner
 from .test import TestRunner as test_runner
 
+from dbt.adapters.factory import get_adapter
 from dbt.contracts.results import NodeStatus
 from dbt.exceptions import InternalException
 from dbt.graph import ResourceTypeSelector
@@ -64,3 +65,12 @@ class BuildTask(RunTask):
 
     def get_runner_type(self, node):
         return self.RUNNER_MAP.get(node.resource_type)
+        
+    def compile_manifest(self):
+        if self.manifest is None:
+            raise InternalException(
+                'compile_manifest called before manifest was loaded'
+            )
+        adapter = get_adapter(self.config)
+        compiler = adapter.get_compiler()
+        self.graph = compiler.compile(self.manifest, resolve=True)

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -65,7 +65,7 @@ class BuildTask(RunTask):
 
     def get_runner_type(self, node):
         return self.RUNNER_MAP.get(node.resource_type)
-        
+
     def compile_manifest(self):
         if self.manifest is None:
             raise InternalException(

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -87,7 +87,7 @@ class ManifestTask(ConfiguredTask):
             )
         adapter = get_adapter(self.config)
         compiler = adapter.get_compiler()
-        self.graph = compiler.compile(self.manifest, resolve=False)
+        self.graph = compiler.compile(self.manifest)
 
     def _runtime_initialize(self):
         self.load_manifest()

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -87,7 +87,7 @@ class ManifestTask(ConfiguredTask):
             )
         adapter = get_adapter(self.config)
         compiler = adapter.get_compiler()
-        self.graph = compiler.compile(self.manifest)
+        self.graph = compiler.compile(self.manifest, resolve=False)
 
     def _runtime_initialize(self):
         self.load_manifest()

--- a/test/integration/062_defer_state_test/test_run_results_state.py
+++ b/test/integration/062_defer_state_test/test_run_results_state.py
@@ -184,8 +184,8 @@ class TestRunResultsState(DBTIntegrationTest):
         assert nodes == {'table_model', 'unique_view_model_id'}
 
         results = self.run_dbt(['ls', '--select', 'result:fail+', '--state', './state'])
-        assert len(results) == 2
-        assert set(results) == {'test.table_model', 'test.unique_view_model_id'}
+        assert len(results) == 1
+        assert set(results) == {'test.unique_view_model_id'}
 
         # change the unique test severity from error to warn and reuse the same view_model.sql changes above
         f = open('models/schema.yml', 'r')
@@ -212,8 +212,8 @@ class TestRunResultsState(DBTIntegrationTest):
         assert nodes == {'table_model', 'unique_view_model_id'}
 
         results = self.run_dbt(['ls', '--select', 'result:warn+', '--state', './state'])
-        assert len(results) == 2
-        assert set(results) == {'test.table_model', 'test.unique_view_model_id'}
+        assert len(results) == 1
+        assert set(results) == {'test.unique_view_model_id'}
 
     @use_profile('postgres')
     def test_postgres_run_run_results_state(self):


### PR DESCRIPTION
Short-term resolution for #4135. My hope is that, with a change this simple, we can backport it to `0.21.latest` for last-minute inclusion in v0.21.1

In order to enable desirable test-blocking behavior for `dbt build`, we add graph edges between upstream tests and downstream models. In very large projects, this has performance implications, since we're passing a much larger graph into `networkx` methods. Let's only add those extra edges for `build`, where they really get us something, and restore previous performance for other tasks, which don't use them.

The long-term resolution to this issue could look like:
- Reusing previously compiled graph (as in partial parsing)
- Cleverly constructing a partial graph, based on ancestors and descendents of actually selected nodes, to significantly speed up `dbt build -s one_model`
- Reworking our execution queue to obviate the need for transitive closure

I realized, counterintuitively, that in many cases, preserving transitive edges doesn't really change the result of a dbt operation. That said, the rigor of dbt's DAG is one of its most important conceptual features, so I don't think we can remove this right now.

In the process of using snakeviz, I saw a lot of opportunity for performance work beyond our tight focus this year (project parsing / manifest construction). There are methods in graph compilation and node selection that take multiple seconds in large projects, and (no surprise) I added at least one of them in #3235. Let's swing back for more after v1.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
