### PR TITLE
Handle exec info

### DIFF
--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -1,7 +1,7 @@
 
 import dbt.logger as logger  # type: ignore # TODO eventually remove dependency on this logger
 from dbt.events.history import EVENT_HISTORY
-from dbt.events.types import CliEventABC, Event
+from dbt.events.types import CliEventABC, Event, ShowException
 
 
 # top-level method for accessing the new eventing system
@@ -11,17 +11,53 @@ from dbt.events.types import CliEventABC, Event
 def fire_event(e: Event) -> None:
     EVENT_HISTORY.append(e)
     if isinstance(e, CliEventABC):
-        if e.level_tag() == 'test':
+        if e.level_tag() == 'test' and not isinstance(e, ShowException):
             # TODO after implmenting #3977 send to new test level
             logger.GLOBAL_LOGGER.debug(logger.timestamped_line(e.cli_msg()))
-        elif e.level_tag() == 'debug':
+        elif e.level_tag() == 'test' and isinstance(e, ShowException):
+            # TODO after implmenting #3977 send to new test level
+            logger.GLOBAL_LOGGER.debug(
+                logger.timestamped_line(e.cli_msg()),
+                exc_info=e.exc_info,
+                stack_info=e.stack_info,
+                extra=e.extra
+            )
+        elif e.level_tag() == 'debug' and not isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.debug(logger.timestamped_line(e.cli_msg()))
-        elif e.level_tag() == 'info':
+        elif e.level_tag() == 'debug' and isinstance(e, ShowException):
+            logger.GLOBAL_LOGGER.debug(
+                logger.timestamped_line(e.cli_msg()),
+                exc_info=e.exc_info,
+                stack_info=e.stack_info,
+                extra=e.extra
+            )
+        elif e.level_tag() == 'info' and not isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.info(logger.timestamped_line(e.cli_msg()))
-        elif e.level_tag() == 'warn':
+        elif e.level_tag() == 'info' and isinstance(e, ShowException):
+            logger.GLOBAL_LOGGER.info(
+                logger.timestamped_line(e.cli_msg()),
+                exc_info=e.exc_info,
+                stack_info=e.stack_info,
+                extra=e.extra
+            )
+        elif e.level_tag() == 'warn' and not isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.warning()(logger.timestamped_line(e.cli_msg()))
-        elif e.level_tag() == 'error':
+        elif e.level_tag() == 'warn' and isinstance(e, ShowException):
+            logger.GLOBAL_LOGGER.warning(
+                logger.timestamped_line(e.cli_msg()),
+                exc_info=e.exc_info,
+                stack_info=e.stack_info,
+                extra=e.extra
+            )
+        elif e.level_tag() == 'error' and not isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.error(logger.timestamped_line(e.cli_msg()))
+        elif e.level_tag() == 'error' and isinstance(e, ShowException):
+            logger.GLOBAL_LOGGER.error(
+                logger.timestamped_line(e.cli_msg()),
+                exc_info=e.exc_info,
+                stack_info=e.stack_info,
+                extra=e.extra
+            )
         else:
             raise AssertionError(
                 f"Event type {type(e).__name__} has unhandled level: {e.level_tag()}"

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -41,7 +41,7 @@ def fire_event(e: Event) -> None:
                 extra=e.extra
             )
         elif e.level_tag() == 'warn' and not isinstance(e, ShowException):
-            logger.GLOBAL_LOGGER.warning()(logger.timestamped_line(e.cli_msg()))
+            logger.GLOBAL_LOGGER.warning(logger.timestamped_line(e.cli_msg()))
         elif e.level_tag() == 'warn' and isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.warning(
                 logger.timestamped_line(e.cli_msg()),

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
+from typing import Any
 
 
 # types to represent log levels
@@ -28,6 +29,13 @@ class WarnLevel():
 class ErrorLevel():
     def level_tag(self) -> str:
         return "error"
+
+
+@dataclass
+class ShowException():
+    exc_info: Any = None
+    stack_info: Any = None
+    extra: Any = None
 
 
 # The following classes represent the data necessary to describe a


### PR DESCRIPTION
### Description

Allows for events to pass through exec information to be displayed by the underlying logger by extending `ShowException` and overriding the defaulted fields.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
