### PR TITLE
Dataclass compatibility

### DIFF
--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -33,9 +33,10 @@ class ErrorLevel():
 
 @dataclass
 class ShowException():
-    exc_info: Any = None
-    stack_info: Any = None
-    extra: Any = None
+    def __post_init__(self):
+        self.exc_info: Any = None
+        self.stack_info: Any = None
+        self.extra: Any = None
 
 
 # The following classes represent the data necessary to describe a

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -33,6 +33,10 @@ class ErrorLevel():
 
 @dataclass
 class ShowException():
+    # N.B.:
+    # As long as we stick with the current convention of setting the member vars in the
+    # `cli_msg` method of subclasses, this is a safe operation.
+    # If that ever changes we'll want to reassess.
     def __post_init__(self):
         self.exc_info: Any = None
         self.stack_info: Any = None


### PR DESCRIPTION
The `dataclass` library we're using for 3.6 compatibility causes mypy/pylance errors when a subclass doesn't have default values  for a member var, but the parent class does.

Switched to using `__post_init__()` instead.

