### PR TITLE
Show Exception should trigger a stack trace

### DIFF
--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -39,7 +39,7 @@ class ShowException():
     # `cli_msg` method of subclasses, this is a safe operation.
     # If that ever changes we'll want to reassess.
     def __post_init__(self):
-        self.exc_info: Any = None
+        self.exc_info: Any = True
         self.stack_info: Any = None
         self.extra: Any = None
 


### PR DESCRIPTION
### Description

When we see a logline with just `exc_info=True` we're just Extending `ShowException` which I think is good because it's the most common form. Without this change we really should be setting `exc_info=True` in the concrete types which this change makes unnecessary.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
