### PR TITLE
Bumping artifact versions for v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@
 ### Features
 - Allow nullable `error_after` in source freshness ([#3874](https://github.com/dbt-labs/dbt-core/issues/3874), [#3955](https://github.com/dbt-labs/dbt-core/pull/3955))
 - Increase performance of graph subset selection ([#4135](https://github.com/dbt-labs/dbt-core/issues/4135),[#4155](https://github.com/dbt-labs/dbt-core/pull/4155))
+
 ### Fixes
 - Changes unit tests using `assertRaisesRegexp` to `assertRaisesRegex`
+
+### Under the hood
+Bump artifact schema versions for 1.0.0
 
 Contributors:
 - [@kadero](https://github.com/kadero) ([3955](https://github.com/dbt-labs/dbt-core/pull/3955))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Changes unit tests using `assertRaisesRegexp` to `assertRaisesRegex`
 
 ### Under the hood
-Bump artifact schema versions for 1.0.0
+- Bump artifact schema versions (manifest to v4, run-results to v4, sources to v3) for 1.0.0 ([#4191](https://github.com/dbt-labs/dbt-core/pull/4191))
 
 Contributors:
 - [@kadero](https://github.com/kadero) ([3955](https://github.com/dbt-labs/dbt-core/pull/3955))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Changes unit tests using `assertRaisesRegexp` to `assertRaisesRegex`
 
 ### Under the hood
-- Bump artifact schema versions (manifest to v4, run-results to v4, sources to v3) for 1.0.0 ([#4191](https://github.com/dbt-labs/dbt-core/pull/4191))
+- Bump artifact schema versions (main changes to CompiledSingularTestNode, CompiledSqlNode, CompiledRPCNode, CompiledGenericTestNode, ParsedSingularTestNode, ParsedSqlNode, ParsedGenericTestNode) for 1.0.0 ([#4191](https://github.com/dbt-labs/dbt-core/pull/4191))
 
 Contributors:
 - [@kadero](https://github.com/kadero) ([3955](https://github.com/dbt-labs/dbt-core/pull/3955))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Changes unit tests using `assertRaisesRegexp` to `assertRaisesRegex`
 
 ### Under the hood
-- Bump artifact schema versions (main changes to CompiledSingularTestNode, CompiledSqlNode, CompiledRPCNode, CompiledGenericTestNode, ParsedSingularTestNode, ParsedSqlNode, ParsedGenericTestNode) for 1.0.0 ([#4191](https://github.com/dbt-labs/dbt-core/pull/4191))
+- Bump artifact schema versions for 1.0.0: manifest v4, run results v4, sources v3. Notable changes: schema test + data test nodes are renamed to generic test + singular test nodes; freshness threshold default values ([#4191](https://github.com/dbt-labs/dbt-core/pull/4191))
 
 Contributors:
 - [@kadero](https://github.com/kadero) ([3955](https://github.com/dbt-labs/dbt-core/pull/3955))

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1072,7 +1072,7 @@ AnyManifest = Union[Manifest, MacroManifest]
 
 
 @dataclass
-@schema_version('manifest', 3)
+@schema_version('manifest', 4)
 class WritableManifest(ArtifactMixin):
     nodes: Mapping[UniqueID, ManifestNode] = field(
         metadata=dict(description=(

--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -185,7 +185,7 @@ class RunExecutionResult(
 
 
 @dataclass
-@schema_version('run-results', 3)
+@schema_version('run-results', 4)
 class RunResultsArtifact(ExecutionResult, ArtifactMixin):
     results: Sequence[RunResultOutput]
     args: Dict[str, Any] = field(default_factory=dict)
@@ -369,7 +369,7 @@ class FreshnessResult(ExecutionResult):
 
 
 @dataclass
-@schema_version('sources', 2)
+@schema_version('sources', 3)
 class FreshnessExecutionResultArtifact(
     ArtifactMixin,
     VersionedSchema,

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -644,7 +644,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         )
 
         return {
-            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v3.json',
+            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v4.json',
             'dbt_version': dbt.version.__version__,
             'nodes': {
                 'model.test.model': {
@@ -1231,7 +1231,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         snapshot_path = self.dir('snapshot/snapshot_seed.sql')
 
         return {
-            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v3.json',
+            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v4.json',
             'dbt_version': dbt.version.__version__,
             'nodes': {
                 'model.test.ephemeral_copy': {
@@ -1812,7 +1812,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             elif key == 'metadata':
                 metadata = manifest['metadata']
                 self.verify_metadata(
-                    metadata, 'https://schemas.getdbt.com/dbt/manifest/v3.json')
+                    metadata, 'https://schemas.getdbt.com/dbt/manifest/v4.json')
                 assert 'project_id' in metadata and metadata[
                     'project_id'] == '098f6bcd4621d373cade4e832627b4f6'
                 assert 'send_anonymous_usage_stats' in metadata and metadata[
@@ -1952,7 +1952,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         run_results = _read_json('./target/run_results.json')
         assert 'metadata' in run_results
         self.verify_metadata(
-            run_results['metadata'], 'https://schemas.getdbt.com/dbt/run-results/v3.json')
+            run_results['metadata'], 'https://schemas.getdbt.com/dbt/run-results/v4.json')
         self.assertIn('elapsed_time', run_results)
         self.assertGreater(run_results['elapsed_time'], 0)
         self.assertTrue(

--- a/test/integration/042_sources_test/test_sources.py
+++ b/test/integration/042_sources_test/test_sources.py
@@ -248,7 +248,7 @@ class TestSourceFreshness(SuccessfulSourcesTest):
         assert isinstance(data['elapsed_time'], float)
         self.assertBetween(data['metadata']['generated_at'],
                            self.freshness_start_time)
-        assert data['metadata']['dbt_schema_version'] == 'https://schemas.getdbt.com/dbt/sources/v2.json'
+        assert data['metadata']['dbt_schema_version'] == 'https://schemas.getdbt.com/dbt/sources/v3.json'
         assert data['metadata']['dbt_version'] == dbt.version.__version__
         assert data['metadata']['invocation_id'] == dbt.tracking.active_user.invocation_id
         key = 'key'

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -272,7 +272,7 @@ class ManifestTest(unittest.TestCase):
                 'child_map': {},
                 'metadata': {
                     'generated_at': '2018-02-14T09:15:13Z',
-                    'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v3.json',
+                    'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v4.json',
                     'dbt_version': dbt.version.__version__,
                     'env': {ENV_KEY_NAME: 'value'},
                     # invocation_id is None, so it will not be present
@@ -418,7 +418,7 @@ class ManifestTest(unittest.TestCase):
                 'docs': {},
                 'metadata': {
                     'generated_at': '2018-02-14T09:15:13Z',
-                    'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v3.json',
+                    'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v4.json',
                     'dbt_version': dbt.version.__version__,
                     'project_id': '098f6bcd4621d373cade4e832627b4f6',
                     'user_id': 'cfc9500f-dc7f-4c83-9ea7-2c581c1b38cf',
@@ -659,7 +659,7 @@ class MixedManifestTest(unittest.TestCase):
                 'child_map': {},
                 'metadata': {
                     'generated_at': '2018-02-14T09:15:13Z',
-                    'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v3.json',
+                    'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v4.json',
                     'dbt_version': dbt.version.__version__,
                     'invocation_id': '01234567-0123-0123-0123-0123456789ab',
                     'env': {ENV_KEY_NAME: 'value'},


### PR DESCRIPTION
### Description
Before releasing the v1.0.0RC1, we need to bump our schema versions for changes that were made

Related PR for schema bump: https://github.com/dbt-labs/schemas.getdbt.com/pull/6

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
