### PR TITLE
Add get_where_subquery to test namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@ Contributors:
 ## dbt 0.21.1 (Release TBD)
 
 ### Fixes
+- Add `get_where_subquery` to test macro namespace, fixing tests  
+
+## dbt 0.21.1rc1 (November 03, 2021)
+
+### Fixes
 - Performance: Use child_map to find tests for nodes in resolve_graph ([#4012](https://github.com/dbt-labs/dbt/issues/4012), [#4022](https://github.com/dbt-labs/dbt/pull/4022))
 - Switch `unique_field` from abstractproperty to optional property. Add docstring ([#4025](https://github.com/dbt-labs/dbt/issues/4025), [#4028](https://github.com/dbt-labs/dbt/pull/4028))
 - Include only relational nodes in `database_schema_set` ([#4063](https://github.com/dbt-labs/dbt-core/issues/4063), [#4077](https://github.com/dbt-labs/dbt-core/pull/4077))

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1413,7 +1413,10 @@ class TestContext(ProviderContext):
     # This only provides a namespace with macros in the test node
     # 'depends_on.macros' by using the TestMacroNamespace
     def _build_test_namespace(self):
-        depends_on_macros = ['macro.dbt.get_where_subquery']
+        # all generic tests use a macro named 'get_where_subquery' to wrap 'model' arg
+        # see generic_test_builders.build_model_str
+        get_where_subquery = self.macro_resolver.macros_by_name.get('get_where_subquery')
+        depends_on_macros = [get_where_subquery.unique_id]
         if self.model.depends_on and self.model.depends_on.macros:
             depends_on_macros.extend(self.model.depends_on.macros)
         lookup_macros = depends_on_macros.copy()

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1413,10 +1413,12 @@ class TestContext(ProviderContext):
     # This only provides a namespace with macros in the test node
     # 'depends_on.macros' by using the TestMacroNamespace
     def _build_test_namespace(self):
+        depends_on_macros = []
         # all generic tests use a macro named 'get_where_subquery' to wrap 'model' arg
         # see generic_test_builders.build_model_str
         get_where_subquery = self.macro_resolver.macros_by_name.get('get_where_subquery')
-        depends_on_macros = [get_where_subquery.unique_id]
+        if get_where_subquery:
+            depends_on_macros.append(get_where_subquery.unique_id)
         if self.model.depends_on and self.model.depends_on.macros:
             depends_on_macros.extend(self.model.depends_on.macros)
         lookup_macros = depends_on_macros.copy()

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1413,9 +1413,9 @@ class TestContext(ProviderContext):
     # This only provides a namespace with macros in the test node
     # 'depends_on.macros' by using the TestMacroNamespace
     def _build_test_namespace(self):
-        depends_on_macros = []
+        depends_on_macros = ['macro.dbt.get_where_subquery']
         if self.model.depends_on and self.model.depends_on.macros:
-            depends_on_macros = self.model.depends_on.macros
+            depends_on_macros.extend(self.model.depends_on.macros)
         lookup_macros = depends_on_macros.copy()
         for macro_unique_id in lookup_macros:
             lookup_macro = self.macro_resolver.macros.get(macro_unique_id)

--- a/core/dbt/include/global_project/macros/etc/where_subquery.sql
+++ b/core/dbt/include/global_project/macros/etc/where_subquery.sql
@@ -1,5 +1,5 @@
 {% macro get_where_subquery(relation) -%}
-    {% do return(adapter.dispatch('get_where_subquery')(relation)) %}
+    {% do return(adapter.dispatch('get_where_subquery', 'dbt')(relation)) %}
 {%- endmacro %}
 
 {% macro default__get_where_subquery(relation) -%}

--- a/test/integration/008_schema_tests_test/test-context-models/schema.yml
+++ b/test/integration/008_schema_tests_test/test-context-models/schema.yml
@@ -6,6 +6,7 @@ models:
       tests:
         - type_one
         - type_two
+        - type_three
     - name: model_c
       tests:
         - call_pkg_macro

--- a/test/integration/008_schema_tests_test/test-context-models/schema.yml
+++ b/test/integration/008_schema_tests_test/test-context-models/schema.yml
@@ -6,7 +6,6 @@ models:
       tests:
         - type_one
         - type_two
-        - type_three
     - name: model_c
       tests:
         - call_pkg_macro

--- a/test/integration/008_schema_tests_test/test-context-where-subq-macros/custom_generic_test.sql
+++ b/test/integration/008_schema_tests_test/test-context-where-subq-macros/custom_generic_test.sql
@@ -1,0 +1,12 @@
+/*{# This test will fail if get_where_subquery() is missing from TestContext + TestMacroNamespace #}*/
+
+{% test self_referential(model) %}
+
+    {%- set relation = api.Relation.create(schema=model.schema, identifier=model.table) -%}
+    {%- set columns = adapter.get_columns_in_relation(relation) -%}
+    {%- set columns_csv = columns | map(attribute='name') | list | join(', ') -%}
+
+    select {{ columns_csv }} from {{ model }}
+    limit 0
+
+{% endtest %}

--- a/test/integration/008_schema_tests_test/test-context-where-subq-models/model_a.sql
+++ b/test/integration/008_schema_tests_test/test-context-where-subq-models/model_a.sql
@@ -1,0 +1,1 @@
+select 1 as fun

--- a/test/integration/008_schema_tests_test/test-context-where-subq-models/schema.yml
+++ b/test/integration/008_schema_tests_test/test-context-where-subq-models/schema.yml
@@ -1,0 +1,6 @@
+version: 2
+
+models:
+  - name: model_a
+    tests:
+      - self_referential

--- a/test/integration/008_schema_tests_test/test_schema_v2_tests.py
+++ b/test/integration/008_schema_tests_test/test_schema_v2_tests.py
@@ -793,3 +793,30 @@ class TestWrongSpecificationBlock(DBTIntegrationTest):
 
         assert len(results) == 1
         assert results[0] == '{"name": "some_seed", "description": ""}'
+
+
+class TestSchemaTestContextWhereSubq(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "schema_tests_008"
+
+    @property
+    def models(self):
+        return "test-context-where-subq-models"
+
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            "macro-paths": ["test-context-where-subq-macros"],
+        }
+
+    @use_profile('postgres')
+    def test_postgres_test_context_tests(self):
+        # This test tests that get_where_subquery() is included in TestContext + TestMacroNamespace,
+        # otherwise api.Relation.create() will return an error
+        results = self.run_dbt()
+        self.assertEqual(len(results), 1)
+
+        results = self.run_dbt(['test'])
+        self.assertEqual(len(results), 1)


### PR DESCRIPTION
resolves #4195, naively

I'm definitely open to better ideas for how to go about this!

- https://github.com/dbt-labs/dbt-core/pull/3859 added a macro, `get_where_subquery`, to use when constructing generic tests. Now, the `model` object in tests is set to the output of `get_where_subquery(ref(...))` or `get_where_subquery(source(..., ...))`, instead of a very ugly Jinja string.
- Therefore, `get_where_subquery` needs to be present in the test context / macro namespace in order for particular generic tests to work, if they introspect `model` / expect it to be a relation. I added a test case that demonstrates this behavior.

In a sense, all generic tests _do_ depend on `get_where_subquery`, in the similar way to how they depend on `ref()` or `source()`. Should we _actually_ add `get_where_subquery` to the `depends_on.macros` for these generic test macros? If a user provided a custom (override) version of `get_where_subquery`, with partial parsing enabled, would we need to re-parse all those tests? 99% of the time, no; with generic tests like the ones that raise this issue, _technically yes_. It's a quite narrow edge case.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
