### PR TITLE
scrub the secrets

### DIFF
--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -2,6 +2,24 @@
 import dbt.logger as logger  # type: ignore # TODO eventually remove dependency on this logger
 from dbt.events.history import EVENT_HISTORY
 from dbt.events.types import CliEventABC, Event, ShowException
+import os
+from typing import List
+
+
+def env_secrets() -> List[str]:
+    return [
+        v for k, v in os.environ.items()
+        if k.startswith('DBT_ENV_SECRET_')
+    ]
+
+
+def scrub_secrets(msg: str, secrets: List[str]) -> str:
+    scrubbed = msg
+
+    for secret in secrets:
+        scrubbed = scrubbed.replace(secret, "*****")
+
+    return scrubbed
 
 
 # top-level method for accessing the new eventing system
@@ -11,49 +29,50 @@ from dbt.events.types import CliEventABC, Event, ShowException
 def fire_event(e: Event) -> None:
     EVENT_HISTORY.append(e)
     if isinstance(e, CliEventABC):
+        msg = scrub_secrets(e.cli_msg(), env_secrets())
         if e.level_tag() == 'test' and not isinstance(e, ShowException):
             # TODO after implmenting #3977 send to new test level
-            logger.GLOBAL_LOGGER.debug(logger.timestamped_line(e.cli_msg()))
+            logger.GLOBAL_LOGGER.debug(logger.timestamped_line(msg))
         elif e.level_tag() == 'test' and isinstance(e, ShowException):
             # TODO after implmenting #3977 send to new test level
             logger.GLOBAL_LOGGER.debug(
-                logger.timestamped_line(e.cli_msg()),
+                logger.timestamped_line(msg),
                 exc_info=e.exc_info,
                 stack_info=e.stack_info,
                 extra=e.extra
             )
         elif e.level_tag() == 'debug' and not isinstance(e, ShowException):
-            logger.GLOBAL_LOGGER.debug(logger.timestamped_line(e.cli_msg()))
+            logger.GLOBAL_LOGGER.debug(logger.timestamped_line(msg))
         elif e.level_tag() == 'debug' and isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.debug(
-                logger.timestamped_line(e.cli_msg()),
+                logger.timestamped_line(msg),
                 exc_info=e.exc_info,
                 stack_info=e.stack_info,
                 extra=e.extra
             )
         elif e.level_tag() == 'info' and not isinstance(e, ShowException):
-            logger.GLOBAL_LOGGER.info(logger.timestamped_line(e.cli_msg()))
+            logger.GLOBAL_LOGGER.info(logger.timestamped_line(msg))
         elif e.level_tag() == 'info' and isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.info(
-                logger.timestamped_line(e.cli_msg()),
+                logger.timestamped_line(msg),
                 exc_info=e.exc_info,
                 stack_info=e.stack_info,
                 extra=e.extra
             )
         elif e.level_tag() == 'warn' and not isinstance(e, ShowException):
-            logger.GLOBAL_LOGGER.warning(logger.timestamped_line(e.cli_msg()))
+            logger.GLOBAL_LOGGER.warning(logger.timestamped_line(msg))
         elif e.level_tag() == 'warn' and isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.warning(
-                logger.timestamped_line(e.cli_msg()),
+                logger.timestamped_line(msg),
                 exc_info=e.exc_info,
                 stack_info=e.stack_info,
                 extra=e.extra
             )
         elif e.level_tag() == 'error' and not isinstance(e, ShowException):
-            logger.GLOBAL_LOGGER.error(logger.timestamped_line(e.cli_msg()))
+            logger.GLOBAL_LOGGER.error(logger.timestamped_line(msg))
         elif e.level_tag() == 'error' and isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.error(
-                logger.timestamped_line(e.cli_msg()),
+                logger.timestamped_line(msg),
                 exc_info=e.exc_info,
                 stack_info=e.stack_info,
                 extra=e.extra

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -9,7 +9,7 @@ from typing import List
 def env_secrets() -> List[str]:
     return [
         v for k, v in os.environ.items()
-        if k.startswith('DBT_ENV_SECRET_')
+        if k.startswith(logger.SECRET_ENV_PREFIX)
     ]
 
 


### PR DESCRIPTION
### Description

Uses the same strategy that we use today via LogBook just via a simple function call. I decided not to use the built-in scrubbing from structlog because it's made to scrub named fields, which we are not doing here. We only have the values.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
