### PR TITLE
test/integration call sites

### DIFF
--- a/core/dbt/events/test_types.py
+++ b/core/dbt/events/test_types.py
@@ -16,7 +16,7 @@ class IntegrationTestInfo(InfoLevel, CliEventABC):
     msg: str
 
     def cli_msg(self) -> str:
-        return self.msg
+        return f"Integration Test: {self.msg}"
 
 
 @dataclass
@@ -24,7 +24,7 @@ class IntegrationTestDebug(DebugLevel, CliEventABC):
     msg: str
 
     def cli_msg(self) -> str:
-        return self.msg
+        return f"Integration Test: {self.msg}"
 
 
 @dataclass
@@ -32,7 +32,7 @@ class IntegrationTestException(ShowException, ErrorLevel, CliEventABC):
     msg: str
 
     def cli_msg(self) -> str:
-        return self.msg
+        return f"Integration Test: {self.msg}"
 
 
 # since mypy doesn't run on every file we need to suggest to mypy that every

--- a/core/dbt/events/test_types.py
+++ b/core/dbt/events/test_types.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from .types import (
+    InfoLevel,
+    DebugLevel,
+    ErrorLevel,
+    ShowException,
+    CliEventABC
+)
+
+
+# Keeping log messages for testing separate since they are used for debugging.
+# Reuse the existing messages when adding logs to tests.
+
+@dataclass
+class IntegrationTestInfo(InfoLevel, CliEventABC):
+    msg: str
+
+    def cli_msg(self) -> str:
+        return self.msg
+
+
+@dataclass
+class IntegrationTestDebug(DebugLevel, CliEventABC):
+    msg: str
+
+    def cli_msg(self) -> str:
+        return self.msg
+
+
+@dataclass
+class IntegrationTestException(ShowException, ErrorLevel, CliEventABC):
+    msg: str
+
+    def cli_msg(self) -> str:
+        return self.msg
+
+
+# since mypy doesn't run on every file we need to suggest to mypy that every
+# class gets instantiated. But we don't actually want to run this code.
+# making the conditional `if False` causes mypy to skip it as dead code so
+# we need to skirt around that by computing something it doesn't check statically.
+#
+# TODO remove these lines once we run mypy everywhere.
+if 1 == 0:
+    IntegrationTestInfo(msg='')
+    IntegrationTestDebug(msg='')
+    IntegrationTestException(msg='')

--- a/core/dbt/events/test_types.py
+++ b/core/dbt/events/test_types.py
@@ -28,6 +28,22 @@ class IntegrationTestDebug(DebugLevel, CliEventABC):
 
 
 @dataclass
+class IntegrationTestWarn(WarnLevel, CliEventABC):
+    msg: str
+
+    def cli_msg(self) -> str:
+        return f"Integration Test: {self.msg}"
+
+
+@dataclass
+class IntegrationTestError(ErrorLevel, CliEventABC):
+    msg: str
+
+    def cli_msg(self) -> str:
+        return f"Integration Test: {self.msg}"
+
+
+@dataclass
 class IntegrationTestException(ShowException, ErrorLevel, CliEventABC):
     msg: str
 
@@ -44,4 +60,6 @@ class IntegrationTestException(ShowException, ErrorLevel, CliEventABC):
 if 1 == 0:
     IntegrationTestInfo(msg='')
     IntegrationTestDebug(msg='')
+    IntegrationTestWarn(msg='')
+    IntegrationTestError(msg='')
     IntegrationTestException(msg='')

--- a/core/dbt/events/test_types.py
+++ b/core/dbt/events/test_types.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from .types import (
     InfoLevel,
     DebugLevel,
+    WarnLevel,
     ErrorLevel,
     ShowException,
     CliEventABC

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1722,36 +1722,11 @@ class GeneralWarningException(WarnLevel, CliEventABC):
 
 
 @dataclass
-class IntegrationTestSetupFailure(ShowException, ErrorLevel, CliEventABC):
+class IntegrationTestMessage(ShowException, ErrorLevel, CliEventABC):
     msg: str
 
     def cli_msg(self) -> str:
         return self.msg
-
-
-@dataclass
-class IntegrationTestTearDownFailure(ShowException, ErrorLevel, CliEventABC):
-    dir: str
-
-    def cli_msg(self) -> str:
-        return f"Could not clean up after test - {self.dir} not removable"
-
-
-@dataclass
-class IntegrationTestInvokingWithArgs(InfoLevel, CliEventABC):
-    final_args: List[str]
-
-    def cli_msg(self) -> str:
-        return f"Invoking dbt with {self.final_args}"
-
-
-@dataclass
-class IntegrationTestTestConnection(DebugLevel, CliEventABC):
-    conn_name: str
-    sql: str
-
-    def cli_msg(self) -> str:
-        return f'test connection "{self.conn_name}" executing: {self.sql}'
 
 
 # since mypy doesn't run on every file we need to suggest to mypy that every
@@ -1940,7 +1915,4 @@ if 1 == 0:
     RetryExternalCall(attempt=0, max=0)
     GeneralWarningMsg(msg='', log_fmt='')
     GeneralWarningException(exc=Exception(''), log_fmt='')
-    IntegrationTestSetupFailure(msg='')
-    IntegrationTestTearDownFailure(dir='')
-    IntegrationTestInvokingWithArgs(final_args=[])
-    IntegrationTestTestConnection(conn_name='', sql='')
+    IntegrationTestMessage(msg='')

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1109,6 +1109,7 @@ class FirstRunResultError(ErrorLevel, CliEventABC):
 
 @dataclass
 class AfterFirstRunResultError(ErrorLevel, CliEventABC):
+class IntegrationTestSetupFailure(ShowException, ErrorLevel, CliEventABC):
     msg: str
 
     def cli_msg(self) -> str:
@@ -1719,6 +1720,28 @@ class GeneralWarningException(WarnLevel, CliEventABC):
         if self.log_fmt is not None:
             return self.log_fmt.format(str(self.exc))
         return str(self.exc)
+class IntegrationTestTearDownFailure(ShowException, ErrorLevel, CliEventABC):
+    dir: str
+
+    def cli_msg(self) -> str:
+        return f"Could not clean up after test - {self.dir} not removable"
+
+
+@dataclass
+class IntegrationTestInvokingWithArgs(InfoLevel, CliEventABC):
+    final_args: List[str]
+
+    def cli_msg(self) -> str:
+        return f"Invoking dbt with {self.final_args}"
+
+
+@dataclass
+class IntegrationTestTestConnection(DebugLevel, CliEventABC):
+    conn_name: str
+    sql: str
+
+    def cli_msg(self) -> str:
+        return f'test connection "{self.conn_name}" executing: {self.sql}'
 
 
 # since mypy doesn't run on every file we need to suggest to mypy that every
@@ -1907,3 +1930,6 @@ if 1 == 0:
     RetryExternalCall(attempt=0, max=0)
     GeneralWarningMsg(msg='', log_fmt='')
     GeneralWarningException(exc=Exception(''), log_fmt='')
+    IntegrationTestSetupFailure(msg='')
+    IntegrationTestTearDownFailure(dir='')
+    IntegrationTestInvokingWithArgs(final_args=[])

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1109,7 +1109,6 @@ class FirstRunResultError(ErrorLevel, CliEventABC):
 
 @dataclass
 class AfterFirstRunResultError(ErrorLevel, CliEventABC):
-class IntegrationTestSetupFailure(ShowException, ErrorLevel, CliEventABC):
     msg: str
 
     def cli_msg(self) -> str:
@@ -1720,6 +1719,17 @@ class GeneralWarningException(WarnLevel, CliEventABC):
         if self.log_fmt is not None:
             return self.log_fmt.format(str(self.exc))
         return str(self.exc)
+
+
+@dataclass
+class IntegrationTestSetupFailure(ShowException, ErrorLevel, CliEventABC):
+    msg: str
+
+    def cli_msg(self) -> str:
+        return self.msg
+
+
+@dataclass
 class IntegrationTestTearDownFailure(ShowException, ErrorLevel, CliEventABC):
     dir: str
 
@@ -1933,3 +1943,4 @@ if 1 == 0:
     IntegrationTestSetupFailure(msg='')
     IntegrationTestTearDownFailure(dir='')
     IntegrationTestInvokingWithArgs(final_args=[])
+    IntegrationTestTestConnection(conn_name='', sql='')

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1721,14 +1721,6 @@ class GeneralWarningException(WarnLevel, CliEventABC):
         return str(self.exc)
 
 
-@dataclass
-class IntegrationTestMessage(ShowException, ErrorLevel, CliEventABC):
-    msg: str
-
-    def cli_msg(self) -> str:
-        return self.msg
-
-
 # since mypy doesn't run on every file we need to suggest to mypy that every
 # class gets instantiated. But we don't actually want to run this code.
 # making the conditional `if False` causes mypy to skip it as dead code so
@@ -1915,4 +1907,3 @@ if 1 == 0:
     RetryExternalCall(attempt=0, max=0)
     GeneralWarningMsg(msg='', log_fmt='')
     GeneralWarningException(exc=Exception(''), log_fmt='')
-    IntegrationTestMessage(msg='')

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -25,7 +25,11 @@ from dbt.config import RuntimeConfig
 from dbt.context import providers
 from dbt.logger import log_manager
 from dbt.events.functions import fire_event
-from dbt.events.types import IntegrationTestMessage
+from dbt.events.test_types import (
+    IntegrationTestInfo,
+    IntegrationTestDebug,
+    IntegrationTestException
+)
 from dbt.contracts.graph.manifest import Manifest
 
 
@@ -324,7 +328,7 @@ class DBTIntegrationTest(unittest.TestCase):
                 'test_original_source_path={0.test_original_source_path}',
                 'test_root_dir={0.test_root_dir}'
             )).format(self)
-            fire_event(IntegrationTestMessage(msg=msg))
+            fire_event(IntegrationTestException(msg=msg))
 
             # if logging isn't set up, I still really want this message.
             print(msg)
@@ -435,7 +439,7 @@ class DBTIntegrationTest(unittest.TestCase):
             shutil.rmtree(self.test_root_dir)
         except EnvironmentError:
             msg = f"Could not clean up after test - {self.test_root_dir} not removable"
-            fire_event(IntegrationTestMessage(msg=msg))
+            fire_event(IntegrationTestException(msg=msg))
 
     def _get_schema_fqn(self, database, schema):
         schema_fqn = self.quote_as_configured(schema, 'schema')
@@ -549,7 +553,7 @@ class DBTIntegrationTest(unittest.TestCase):
             final_args.extend(['--profiles-dir', self.test_root_dir])
         final_args.append('--log-cache-events')
         msg = f"Invoking dbt with {final_args}"
-        fire_event(IntegrationTestMessage(msg=msg))
+        fire_event(IntegrationTestInfo(msg=msg))
         return dbt.handle_and_check(final_args)
 
     def run_sql_file(self, path, kwargs=None):
@@ -629,7 +633,7 @@ class DBTIntegrationTest(unittest.TestCase):
 
         with self.get_connection(connection_name) as conn:
             msg = f'test connection "{conn.name}" executing: {sql}'
-            fire_event(IntegrationTestMessage(msg=msg))
+            fire_event(IntegrationTestDebug(msg=msg))
             if self.adapter_type == 'presto':
                 return self.run_sql_presto(sql, fetch, conn)
             else:

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -23,7 +23,12 @@ from dbt.adapters.factory import get_adapter, reset_adapters, register_adapter
 from dbt.clients.jinja import template_cache
 from dbt.config import RuntimeConfig
 from dbt.context import providers
-from dbt.logger import GLOBAL_LOGGER as logger, log_manager
+from dbt.logger import log_manager
+from dbt.events.functions import fire_event
+from dbt.events.types import (
+    IntegrationTestSetupFailure, IntegrationTestTearDownFailure,
+    IntegrationTestInvokingWithArgs, IntegrationTestTestConnection
+)
 from dbt.contracts.graph.manifest import Manifest
 
 
@@ -322,7 +327,7 @@ class DBTIntegrationTest(unittest.TestCase):
                 'test_original_source_path={0.test_original_source_path}',
                 'test_root_dir={0.test_root_dir}'
             )).format(self)
-            logger.exception(msg)
+            fire_event(IntegrationTestSetupFailure(msg=msg))
 
             # if logging isn't set up, I still really want this message.
             print(msg)
@@ -432,8 +437,7 @@ class DBTIntegrationTest(unittest.TestCase):
         try:
             shutil.rmtree(self.test_root_dir)
         except EnvironmentError:
-            logger.exception('Could not clean up after test - {} not removable'
-                             .format(self.test_root_dir))
+            fire_event(IntegrationTestTearDownFailure(dir=self.test_root_dir))
 
     def _get_schema_fqn(self, database, schema):
         schema_fqn = self.quote_as_configured(schema, 'schema')
@@ -547,7 +551,7 @@ class DBTIntegrationTest(unittest.TestCase):
             final_args.extend(['--profiles-dir', self.test_root_dir])
         final_args.append('--log-cache-events')
 
-        logger.info("Invoking dbt with {}".format(final_args))
+        fire_event(IntegrationTestInvokingWithArgs(final_args=final_args))
         return dbt.handle_and_check(final_args)
 
     def run_sql_file(self, path, kwargs=None):
@@ -626,7 +630,7 @@ class DBTIntegrationTest(unittest.TestCase):
         sql = self.transform_sql(query, kwargs=kwargs)
 
         with self.get_connection(connection_name) as conn:
-            logger.debug('test connection "{}" executing: {}'.format(conn.name, sql))
+            fire_event(IntegrationTestTestConnection(conn_name=conn.name, sql=sql))
             if self.adapter_type == 'presto':
                 return self.run_sql_presto(sql, fetch, conn)
             else:


### PR DESCRIPTION
### Description

Modifying call sites for structured logging in test/integration

Only `base.py` actually produces logs and those are all this PR touches.  log_manager still appears in multiple places.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
