### PR TITLE
lazy logging in event module

### DIFF
--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -41,7 +41,6 @@ def gen_msg(e: CliEventABC) -> Generator[str, None, None]:
 # to files, etc.)
 def fire_event(e: Event) -> None:
     EVENT_HISTORY.append(e)
-    debug = flags.DEBUG
     if isinstance(e, CliEventABC):
         msg = gen_msg(e)
         if e.level_tag() == 'test' and not isinstance(e, ShowException):
@@ -57,7 +56,7 @@ def fire_event(e: Event) -> None:
             )
         # explicitly checking the debug flag here so that potentially expensive-to-construct
         # log messages are not constructed if debug messages are never shown.
-        elif e.level_tag() == 'debug' and not debug:
+        elif e.level_tag() == 'debug' and not flags.DEBUG:
             return  # eat the message in case it was one of the expensive ones
         elif e.level_tag() == 'debug' and not isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.debug(next(msg))

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -2,8 +2,9 @@
 import dbt.logger as logger  # type: ignore # TODO eventually remove dependency on this logger
 from dbt.events.history import EVENT_HISTORY
 from dbt.events.types import CliEventABC, Event, ShowException
+import dbt.flags as flags
 import os
-from typing import Callable, List
+from typing import Generator, List
 
 
 def env_secrets() -> List[str]:
@@ -26,8 +27,12 @@ def scrub_secrets(msg: str, secrets: List[str]) -> str:
 # for example, many debug messages call `dump_graph()` and we don't want to
 # do that in the event that those messages are never going to be sent to
 # the user because we are only logging info-level events.
-def lazy_log_msg(e: CliEventABC) -> Callable[[], str]:
-    return lambda: scrub_secrets(e.cli_msg(), env_secrets())
+def gen_msg(e: CliEventABC) -> Generator[str, None, None]:
+    msg = None
+    if not msg:
+        msg = scrub_secrets(e.cli_msg(), env_secrets())
+    while True:
+        yield msg
 
 
 # top-level method for accessing the new eventing system
@@ -36,51 +41,56 @@ def lazy_log_msg(e: CliEventABC) -> Callable[[], str]:
 # to files, etc.)
 def fire_event(e: Event) -> None:
     EVENT_HISTORY.append(e)
+    debug = flags.DEBUG
     if isinstance(e, CliEventABC):
-        msg: Callable[[], str] = lazy_log_msg(e)
+        msg = gen_msg(e)
         if e.level_tag() == 'test' and not isinstance(e, ShowException):
             # TODO after implmenting #3977 send to new test level
-            logger.GLOBAL_LOGGER.debug(logger.timestamped_line(msg()))
+            logger.GLOBAL_LOGGER.debug(next(msg))
         elif e.level_tag() == 'test' and isinstance(e, ShowException):
             # TODO after implmenting #3977 send to new test level
             logger.GLOBAL_LOGGER.debug(
-                logger.timestamped_line(msg()),
+                next(msg),
                 exc_info=e.exc_info,
                 stack_info=e.stack_info,
                 extra=e.extra
             )
+        # explicitly checking the debug flag here so that potentially expensive-to-construct
+        # log messages are not constructed if debug messages are never shown.
+        elif e.level_tag() == 'debug' and not debug:
+            return  # eat the message in case it was one of the expensive ones
         elif e.level_tag() == 'debug' and not isinstance(e, ShowException):
-            logger.GLOBAL_LOGGER.debug(logger.timestamped_line(msg()))
+            logger.GLOBAL_LOGGER.debug(next(msg))
         elif e.level_tag() == 'debug' and isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.debug(
-                logger.timestamped_line(msg()),
+                next(msg),
                 exc_info=e.exc_info,
                 stack_info=e.stack_info,
                 extra=e.extra
             )
         elif e.level_tag() == 'info' and not isinstance(e, ShowException):
-            logger.GLOBAL_LOGGER.info(logger.timestamped_line(msg()))
+            logger.GLOBAL_LOGGER.info(next(msg))
         elif e.level_tag() == 'info' and isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.info(
-                logger.timestamped_line(msg()),
+                next(msg),
                 exc_info=e.exc_info,
                 stack_info=e.stack_info,
                 extra=e.extra
             )
         elif e.level_tag() == 'warn' and not isinstance(e, ShowException):
-            logger.GLOBAL_LOGGER.warning(logger.timestamped_line(msg()))
+            logger.GLOBAL_LOGGER.warning(next(msg))
         elif e.level_tag() == 'warn' and isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.warning(
-                logger.timestamped_line(msg()),
+                next(msg),
                 exc_info=e.exc_info,
                 stack_info=e.stack_info,
                 extra=e.extra
             )
         elif e.level_tag() == 'error' and not isinstance(e, ShowException):
-            logger.GLOBAL_LOGGER.error(logger.timestamped_line(msg()))
+            logger.GLOBAL_LOGGER.error(next(msg))
         elif e.level_tag() == 'error' and isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.error(
-                logger.timestamped_line(msg()),
+                next(msg),
                 exc_info=e.exc_info,
                 stack_info=e.stack_info,
                 extra=e.extra

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -3,7 +3,7 @@ import dbt.logger as logger  # type: ignore # TODO eventually remove dependency 
 from dbt.events.history import EVENT_HISTORY
 from dbt.events.types import CliEventABC, Event, ShowException
 import os
-from typing import List
+from typing import Callable, List
 
 
 def env_secrets() -> List[str]:
@@ -22,6 +22,14 @@ def scrub_secrets(msg: str, secrets: List[str]) -> str:
     return scrubbed
 
 
+# this exists because some log messages are actually expensive to build.
+# for example, many debug messages call `dump_graph()` and we don't want to
+# do that in the event that those messages are never going to be sent to
+# the user because we are only logging info-level events.
+def lazy_log_msg(e: CliEventABC) -> Callable[[], str]:
+    return lambda: scrub_secrets(e.cli_msg(), env_secrets())
+
+
 # top-level method for accessing the new eventing system
 # this is where all the side effects happen branched by event type
 # (i.e. - mutating the event history, printing to stdout, logging
@@ -29,50 +37,50 @@ def scrub_secrets(msg: str, secrets: List[str]) -> str:
 def fire_event(e: Event) -> None:
     EVENT_HISTORY.append(e)
     if isinstance(e, CliEventABC):
-        msg = scrub_secrets(e.cli_msg(), env_secrets())
+        msg: Callable[[], str] = lazy_log_msg(e)
         if e.level_tag() == 'test' and not isinstance(e, ShowException):
             # TODO after implmenting #3977 send to new test level
-            logger.GLOBAL_LOGGER.debug(logger.timestamped_line(msg))
+            logger.GLOBAL_LOGGER.debug(logger.timestamped_line(msg()))
         elif e.level_tag() == 'test' and isinstance(e, ShowException):
             # TODO after implmenting #3977 send to new test level
             logger.GLOBAL_LOGGER.debug(
-                logger.timestamped_line(msg),
+                logger.timestamped_line(msg()),
                 exc_info=e.exc_info,
                 stack_info=e.stack_info,
                 extra=e.extra
             )
         elif e.level_tag() == 'debug' and not isinstance(e, ShowException):
-            logger.GLOBAL_LOGGER.debug(logger.timestamped_line(msg))
+            logger.GLOBAL_LOGGER.debug(logger.timestamped_line(msg()))
         elif e.level_tag() == 'debug' and isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.debug(
-                logger.timestamped_line(msg),
+                logger.timestamped_line(msg()),
                 exc_info=e.exc_info,
                 stack_info=e.stack_info,
                 extra=e.extra
             )
         elif e.level_tag() == 'info' and not isinstance(e, ShowException):
-            logger.GLOBAL_LOGGER.info(logger.timestamped_line(msg))
+            logger.GLOBAL_LOGGER.info(logger.timestamped_line(msg()))
         elif e.level_tag() == 'info' and isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.info(
-                logger.timestamped_line(msg),
+                logger.timestamped_line(msg()),
                 exc_info=e.exc_info,
                 stack_info=e.stack_info,
                 extra=e.extra
             )
         elif e.level_tag() == 'warn' and not isinstance(e, ShowException):
-            logger.GLOBAL_LOGGER.warning(logger.timestamped_line(msg))
+            logger.GLOBAL_LOGGER.warning(logger.timestamped_line(msg()))
         elif e.level_tag() == 'warn' and isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.warning(
-                logger.timestamped_line(msg),
+                logger.timestamped_line(msg()),
                 exc_info=e.exc_info,
                 stack_info=e.stack_info,
                 extra=e.extra
             )
         elif e.level_tag() == 'error' and not isinstance(e, ShowException):
-            logger.GLOBAL_LOGGER.error(logger.timestamped_line(msg))
+            logger.GLOBAL_LOGGER.error(logger.timestamped_line(msg()))
         elif e.level_tag() == 'error' and isinstance(e, ShowException):
             logger.GLOBAL_LOGGER.error(
-                logger.timestamped_line(msg),
+                logger.timestamped_line(msg()),
                 exc_info=e.exc_info,
                 stack_info=e.stack_info,
                 extra=e.extra


### PR DESCRIPTION
### Description

#4189 ran into a lazy logging function we previously didn't understand. Now we understand it has a pretty significant purpose, and we need to plumb laziness through the event module to prevent rendering huge messages that will never be written to a user.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
