### PR TITLE
[#3885] Skip partial parsing if project env vars change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Contributors:
 - Dependency updates ([#4079](https://github.com/dbt-labs/dbt-core/pull/4079)), ([#3532](https://github.com/dbt-labs/dbt-core/pull/3532)
 - Schedule partial parsing for SQL files with env_var changes ([#3885](https://github.com/dbt-labs/dbt-core/issues/3885), [#4101](https://github.com/dbt-labs/dbt-core/pull/4101))
 - Schedule partial parsing for schema files with env_var changes ([#3885](https://github.com/dbt-labs/dbt-core/issues/3885), [#4162](https://github.com/dbt-labs/dbt-core/pull/4162))
+- Skip partial parsing when env_vars change in dbt_project or profile ([#3885](https://github.com/dbt-labs/dbt-core/issues/3885), [#4212](https://github.com/dbt-labs/dbt-core/pull/4212))
 
 Contributors:
 - [@sungchun12](https://github.com/sungchun12) ([#4017](https://github.com/dbt-labs/dbt/pull/4017))

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -91,6 +91,7 @@ class Profile(HasCredentials):
     user_config: UserConfig
     threads: int
     credentials: Credentials
+    profile_env_vars: Dict[str, Any]
 
     def __init__(
         self,
@@ -108,6 +109,7 @@ class Profile(HasCredentials):
         self.user_config = user_config
         self.threads = threads
         self.credentials = credentials
+        self.profile_env_vars = {}  # never available on init
 
     def to_profile_info(
         self, serialize_credentials: bool = False

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -284,6 +284,7 @@ class PartialProject(RenderComponents):
             selectors_dict=rendered_selectors,
         )
 
+    # Called by 'collect_parts' in RuntimeConfig
     def render(self, renderer: DbtProjectYamlRenderer) -> 'Project':
         try:
             rendered = self.get_rendered(renderer)
@@ -397,6 +398,8 @@ class PartialProject(RenderComponents):
             vars_dict = cfg.vars
 
         vars_value = VarProvider(vars_dict)
+        # There will never be any project_env_vars when it's first created
+        project_env_vars: Dict[str, Any] = {}
         on_run_start: List[str] = value_or(cfg.on_run_start, [])
         on_run_end: List[str] = value_or(cfg.on_run_end, [])
 
@@ -444,6 +447,7 @@ class PartialProject(RenderComponents):
             vars=vars_value,
             config_version=cfg.config_version,
             unrendered=unrendered,
+            project_env_vars=project_env_vars,
         )
         # sanity check - this means an internal issue
         project.validate()
@@ -556,6 +560,7 @@ class Project:
     query_comment: QueryComment
     config_version: int
     unrendered: RenderComponents
+    project_env_vars: Dict[str, Any]
 
     @property
     def all_source_paths(self) -> List[str]:
@@ -644,26 +649,6 @@ class Project:
             project_root,
             verify_version=verify_version,
         )
-
-    @classmethod
-    def render_from_dict(
-        cls,
-        project_root: str,
-        project_dict: Dict[str, Any],
-        packages_dict: Dict[str, Any],
-        selectors_dict: Dict[str, Any],
-        renderer: DbtProjectYamlRenderer,
-        *,
-        verify_version: bool = False
-    ) -> 'Project':
-        partial = PartialProject.from_dicts(
-            project_root=project_root,
-            project_dict=project_dict,
-            packages_dict=packages_dict,
-            selectors_dict=selectors_dict,
-            verify_version=verify_version,
-        )
-        return partial.render(renderer)
 
     @classmethod
     def from_project_root(

--- a/core/dbt/config/renderer.py
+++ b/core/dbt/config/renderer.py
@@ -176,6 +176,18 @@ class DbtProjectYamlRenderer(BaseRenderer):
 
 
 class ProfileRenderer(BaseRenderer):
+
+    def __init__(
+        self, cli_vars: Optional[Dict[str, Any]] = None
+    ) -> None:
+        # Generate contexts here because we want to save the context
+        # object in order to retrieve the env_vars.
+        if cli_vars is None:
+            cli_vars = {}
+        self.ctx_obj = BaseContext(cli_vars)
+        context = self.ctx_obj.to_dict()
+        super().__init__(context)
+
     @property
     def name(self):
         'Profile'

--- a/core/dbt/config/renderer.py
+++ b/core/dbt/config/renderer.py
@@ -1,7 +1,9 @@
 from typing import Dict, Any, Tuple, Optional, Union, Callable
 
 from dbt.clients.jinja import get_rendered, catch_jinja
-
+from dbt.context.target import TargetContext
+from dbt.context.base import BaseContext
+from dbt.contracts.connection import HasCredentials
 from dbt.exceptions import (
     DbtProjectError, CompilationException, RecursionException
 )
@@ -97,6 +99,23 @@ class ProjectPostprocessor(Dict[Keypath, Callable[[Any], Any]]):
 
 class DbtProjectYamlRenderer(BaseRenderer):
     _KEYPATH_HANDLERS = ProjectPostprocessor()
+
+    def __init__(
+        self, profile: Optional[HasCredentials] = None,
+        cli_vars: Optional[Dict[str, Any]] = None
+    ) -> None:
+        # Generate contexts here because we want to save the context
+        # object in order to retrieve the env_vars. This is almost always
+        # a TargetContext, but in the debug task we want a project
+        # even when we don't have a profile.
+        if cli_vars is None:
+            cli_vars = {}
+        if profile:
+            self.ctx_obj = TargetContext(profile, cli_vars)
+        else:
+            self.ctx_obj = BaseContext(cli_vars)  # type:ignore
+        context = self.ctx_obj.to_dict()
+        super().__init__(context)
 
     @property
     def name(self):

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -196,6 +196,7 @@ class BaseContext(metaclass=ContextMeta):
     def __init__(self, cli_vars):
         self._ctx = {}
         self.cli_vars = cli_vars
+        self.env_vars = {}
 
     def generate_builtins(self):
         builtins: Dict[str, Any] = {}
@@ -317,6 +318,7 @@ class BaseContext(metaclass=ContextMeta):
             return_value = default
 
         if return_value is not None:
+            self.env_vars[var] = return_value
             return return_value
         else:
             msg = f"Env var required but not provided: '{var}'"

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -546,6 +546,7 @@ class ParsingInfo:
 @dataclass
 class ManifestStateCheck(dbtClassMixin):
     vars_hash: FileHash = field(default_factory=FileHash.empty)
+    env_vars_hash: FileHash = field(default_factory=FileHash.empty)
     profile_hash: FileHash = field(default_factory=FileHash.empty)
     project_hashes: MutableMapping[str, FileHash] = field(default_factory=dict)
 

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -546,7 +546,8 @@ class ParsingInfo:
 @dataclass
 class ManifestStateCheck(dbtClassMixin):
     vars_hash: FileHash = field(default_factory=FileHash.empty)
-    env_vars_hash: FileHash = field(default_factory=FileHash.empty)
+    project_env_vars_hash: FileHash = field(default_factory=FileHash.empty)
+    profile_env_vars_hash: FileHash = field(default_factory=FileHash.empty)
     profile_hash: FileHash = field(default_factory=FileHash.empty)
     project_hashes: MutableMapping[str, FileHash] = field(default_factory=dict)
 

--- a/core/dbt/deps/resolver.py
+++ b/core/dbt/deps/resolver.py
@@ -3,7 +3,6 @@ from typing import Dict, List, NoReturn, Union, Type, Iterator, Set
 
 from dbt.exceptions import raise_dependency_error, InternalException
 
-from dbt.context.target import generate_target_context
 from dbt.config import Project, RuntimeConfig
 from dbt.config.renderer import DbtProjectYamlRenderer
 from dbt.deps.base import BasePackage, PinnedPackage, UnpinnedPackage
@@ -126,8 +125,7 @@ def resolve_packages(
     pending = PackageListing.from_contracts(packages)
     final = PackageListing()
 
-    ctx = generate_target_context(config, config.cli_vars)
-    renderer = DbtProjectYamlRenderer(ctx)
+    renderer = DbtProjectYamlRenderer(config, config.cli_vars)
 
     while pending:
         next_pending = PackageListing()

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -78,6 +78,7 @@ class ReparseReason(StrEnum):
     project_config_changed = '06_project_config_changed'
     load_file_failure = '07_load_file_failure'
     exception = '08_exception'
+    env_vars_changed = '09_env_vars_changed'
 
 
 # Part of saved performance info
@@ -553,6 +554,10 @@ class ManifestLoader:
             logger.info("Unable to do partial parsing because profile has changed")
             valid = False
             reparse_reason = ReparseReason.profile_changed
+        if self.manifest.state_check.env_vars_hash != manifest.state_check.env_vars_hash:
+            logger.info("Unable to do partial parsing because env vars have changed")
+            valid = False
+            reparse_reason = ReparseReason.env_vars_changed
 
         missing_keys = {
             k for k in self.manifest.state_check.project_hashes
@@ -605,8 +610,8 @@ class ManifestLoader:
                 # keep this check inside the try/except in case something about
                 # the file has changed in weird ways, perhaps due to being a
                 # different version of dbt
-                is_partial_parseable, reparse_reason = self.is_partial_parsable(manifest)
-                if is_partial_parseable:
+                is_partial_parsable, reparse_reason = self.is_partial_parsable(manifest)
+                if is_partial_parsable:
                     # We don't want to have stale generated_at dates
                     manifest.metadata.generated_at = datetime.utcnow()
                     # or invocation_ids
@@ -664,6 +669,14 @@ class ManifestLoader:
             ])
         )
 
+        # Create a hash of the env_vars in the project
+        key_list = list(config.project_env_vars.keys())
+        key_list.sort()
+        env_var_str = ''
+        for key in key_list:
+            env_var_str = env_var_str + f'{key}:{config.project_env_vars[key]}|'
+        env_vars_hash = FileHash.from_contents(env_var_str)
+
         profile_path = os.path.join(flags.PROFILES_DIR, 'profiles.yml')
         with open(profile_path) as fp:
             profile_hash = FileHash.from_contents(fp.read())
@@ -675,6 +688,7 @@ class ManifestLoader:
                 project_hashes[name] = FileHash.from_contents(fp.read())
 
         state_check = ManifestStateCheck(
+            env_vars_hash=env_vars_hash,
             vars_hash=vars_hash,
             profile_hash=profile_hash,
             project_hashes=project_hashes,
@@ -921,20 +935,6 @@ def _warn_for_unused_resource_config_paths(
 def _check_manifest(manifest: Manifest, config: RuntimeConfig) -> None:
     _check_resource_uniqueness(manifest, config)
     _warn_for_unused_resource_config_paths(manifest, config)
-
-
-# This is just used in test cases
-def _load_projects(config, paths):
-    for path in paths:
-        try:
-            project = config.new_project(path)
-        except dbt.exceptions.DbtProjectError as e:
-            raise dbt.exceptions.DbtProjectError(
-                'Failed to read package at {}: {}'
-                .format(path, e)
-            )
-        else:
-            yield project.project_name, project
 
 
 def _get_node_column(node, column_name):

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -80,6 +80,8 @@ class BaseTask(metaclass=ABCMeta):
     @classmethod
     def from_args(cls, args):
         try:
+            # This is usually RuntimeConfig but will be UnsetProfileConfig
+            # for the clean or deps tasks
             config = cls.ConfigType.from_args(args)
         except dbt.exceptions.DbtProjectError as exc:
             logger.error("Encountered an error while reading the project:")

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -13,7 +13,6 @@ from dbt.config import Project, Profile
 from dbt.config.renderer import DbtProjectYamlRenderer, ProfileRenderer
 from dbt.config.utils import parse_cli_vars
 from dbt.context.base import generate_base_context
-from dbt.context.target import generate_target_context
 from dbt.clients.yaml_helper import load_yaml_text
 from dbt.links import ProfileConfigDocs
 from dbt.ui import green, red
@@ -146,12 +145,7 @@ class DebugTask(BaseTask):
             self.project_fail_details = FILE_NOT_FOUND
             return red('ERROR not found')
 
-        if self.profile is None:
-            ctx = generate_base_context(self.cli_vars)
-        else:
-            ctx = generate_target_context(self.profile, self.cli_vars)
-
-        renderer = DbtProjectYamlRenderer(ctx)
+        renderer = DbtProjectYamlRenderer(self.profile, self.cli_vars)
 
         try:
             self.project = Project.from_project_root(
@@ -198,9 +192,7 @@ class DebugTask(BaseTask):
                     os.path.dirname(self.project_path),
                     verify_version=bool(flags.VERSION_CHECK),
                 )
-                renderer = DbtProjectYamlRenderer(
-                    generate_base_context(self.cli_vars)
-                )
+                renderer = DbtProjectYamlRenderer(None, self.cli_vars)
                 project_profile = partial.render_profile_name(renderer)
             except dbt.exceptions.DbtProjectError:
                 pass

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -12,7 +12,6 @@ from dbt.adapters.factory import get_adapter, register_adapter
 from dbt.config import Project, Profile
 from dbt.config.renderer import DbtProjectYamlRenderer, ProfileRenderer
 from dbt.config.utils import parse_cli_vars
-from dbt.context.base import generate_base_context
 from dbt.clients.yaml_helper import load_yaml_text
 from dbt.links import ProfileConfigDocs
 from dbt.ui import green, red
@@ -233,7 +232,7 @@ class DebugTask(BaseTask):
         assert self.raw_profile_data is not None
         raw_profile = self.raw_profile_data[profile_name]
 
-        renderer = ProfileRenderer(generate_base_context(self.cli_vars))
+        renderer = ProfileRenderer(self.cli_vars)
 
         target_name, _ = Profile.render_profile(
             raw_profile=raw_profile,
@@ -264,7 +263,7 @@ class DebugTask(BaseTask):
 
         profile_errors = []
         profile_names = self._choose_profile_names()
-        renderer = ProfileRenderer(generate_base_context(self.cli_vars))
+        renderer = ProfileRenderer(self.cli_vars)
         for profile_name in profile_names:
             try:
                 profile: Profile = QueryCommentedProfile.render_from_args(
@@ -392,7 +391,7 @@ class DebugTask(BaseTask):
             raw_profile=profile_data,
             profile_name='',
             target_override=target_name,
-            renderer=ProfileRenderer(generate_base_context({})),
+            renderer=ProfileRenderer({}),
         )
         result = cls.attempt_connection(profile)
         if result is not None:

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -4,7 +4,6 @@ import dbt.exceptions
 
 from dbt.config import UnsetProfileConfig
 from dbt.config.renderer import DbtProjectYamlRenderer
-from dbt.context.target import generate_target_context
 from dbt.deps.base import downloads_directory
 from dbt.deps.resolver import resolve_packages
 
@@ -52,9 +51,7 @@ class DepsTask(BaseTask):
         with downloads_directory():
             final_deps = resolve_packages(packages, self.config)
 
-            renderer = DbtProjectYamlRenderer(generate_target_context(
-                self.config, self.config.cli_vars
-            ))
+            renderer = DbtProjectYamlRenderer(self.config, self.config.cli_vars)
 
             packages_to_upgrade = []
             for package in final_deps:

--- a/test/integration/068_partial_parsing_tests/test_pp_vars.py
+++ b/test/integration/068_partial_parsing_tests/test_pp_vars.py
@@ -268,7 +268,7 @@ class ProjectEnvVarTest(BasePPTest):
         model_id = 'model.test.model_one'
         model = manifest.nodes[model_id]
         self.assertEqual(model.config.meta['meta_name'], 'Jane Smith')
-        env_vars_hash_checksum = state_check.env_vars_hash.checksum
+        env_vars_hash_checksum = state_check.project_env_vars_hash.checksum
 
         # Change the environment variable
         os.environ['ENV_VAR_NAME'] = "Jane Doe"
@@ -277,7 +277,60 @@ class ProjectEnvVarTest(BasePPTest):
         manifest = get_manifest()
         model = manifest.nodes[model_id]
         self.assertEqual(model.config.meta['meta_name'], 'Jane Doe')
-        self.assertNotEqual(env_vars_hash_checksum, manifest.state_check.env_vars_hash.checksum)
+        self.assertNotEqual(env_vars_hash_checksum, manifest.state_check.project_env_vars_hash.checksum)
 
         # cleanup
         del os.environ['ENV_VAR_NAME']
+
+class ProfileEnvVarTest(BasePPTest):
+
+    @property
+    def profile_config(self):
+        # Need to set these here because the base integration test class
+        # calls 'load_config' before the tests are run.
+        # Note: only the specified profile is rendered, so there's no
+        # point it setting env_vars in non-used profiles.
+        os.environ['ENV_VAR_USER'] = 'root'
+        os.environ['ENV_VAR_PASS'] = 'password'
+        return {
+            'config': {
+                'send_anonymous_usage_stats': False
+            },
+            'test': {
+                'outputs': {
+                    'dev': {
+                        'type': 'postgres',
+                        'threads': 1,
+                        'host': self.database_host,
+                        'port': 5432,
+                        'user': "root",
+                        'pass': "password",
+                        'user': "{{ env_var('ENV_VAR_USER') }}",
+                        'pass': "{{ env_var('ENV_VAR_PASS') }}",
+                        'dbname': 'dbt',
+                        'schema': self.unique_schema()
+                    },
+                },
+                'target': 'dev'
+            }
+        }
+
+    @use_profile('postgres')
+    def test_postgres_profile_env_vars(self):
+
+        # Initial run
+        os.environ['ENV_VAR_USER'] = 'root'
+        os.environ['ENV_VAR_PASS'] = 'password'
+        self.setup_directories()
+        self.copy_file('test-files/model_one.sql', 'models/model_one.sql')
+        results = self.run_dbt(["run"])
+        manifest = get_manifest()
+        env_vars_checksum = manifest.state_check.profile_env_vars_hash.checksum
+
+        # Change env_vars
+        os.environ['ENV_VAR_PASS'] = 'my_pass'
+        (results, log_output) = self.run_dbt_and_capture(["run"], expect_pass=False)
+        self.assertTrue('env vars used in profiles.yml have changed' in log_output)
+        manifest = get_manifest()
+        self.assertNotEqual(env_vars_checksum, manifest.state_check.profile_env_vars_hash.checksum)
+

--- a/test/integration/068_partial_parsing_tests/test_pp_vars.py
+++ b/test/integration/068_partial_parsing_tests/test_pp_vars.py
@@ -229,4 +229,55 @@ class EnvVarTest(BasePPTest):
         del os.environ['TEST_SCHEMA_VAR']
         del os.environ['ENV_VAR_COLOR']
         del os.environ['ENV_VAR_SOME_KEY']
+        del os.environ['ENV_VAR_OWNER']
 
+
+class ProjectEnvVarTest(BasePPTest):
+
+    @property
+    def project_config(self):
+        # Need to set the environment variable here initially because
+        # the unittest setup does a load_config.
+        os.environ['ENV_VAR_NAME'] = "Jane Smith"
+        return {
+            'config-version': 2,
+            'seed-paths': ['seeds'],
+            'test-paths': ['tests'],
+            'macro-paths': ['macros'],
+            'seeds': {
+                'quote_columns': False,
+            },
+            'models': {
+                '+meta': {
+                    'meta_name': "{{ env_var('ENV_VAR_NAME') }}"
+                }
+            }
+        }
+
+    @use_profile('postgres')
+    def test_postgres_project_env_vars(self):
+
+        # Initial run
+        self.setup_directories()
+        self.copy_file('test-files/model_one.sql', 'models/model_one.sql')
+        self.run_dbt(['clean'])
+        results = self.run_dbt(["run"])
+        self.assertEqual(len(results), 1)
+        manifest = get_manifest()
+        state_check = manifest.state_check
+        model_id = 'model.test.model_one'
+        model = manifest.nodes[model_id]
+        self.assertEqual(model.config.meta['meta_name'], 'Jane Smith')
+        env_vars_hash_checksum = state_check.env_vars_hash.checksum
+
+        # Change the environment variable
+        os.environ['ENV_VAR_NAME'] = "Jane Doe"
+        results = self.run_dbt(["run"])
+        self.assertEqual(len(results), 1)
+        manifest = get_manifest()
+        model = manifest.nodes[model_id]
+        self.assertEqual(model.config.meta['meta_name'], 'Jane Doe')
+        self.assertNotEqual(env_vars_hash_checksum, manifest.state_check.env_vars_hash.checksum)
+
+        # cleanup
+        del os.environ['ENV_VAR_NAME']

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -47,7 +47,7 @@ def empty_profile_renderer():
 
 
 def empty_project_renderer():
-    return dbt.config.renderer.DbtProjectYamlRenderer(generate_base_context({}))
+    return dbt.config.renderer.DbtProjectYamlRenderer()
 
 
 model_config = {
@@ -943,13 +943,14 @@ class TestVariableProjectFile(BaseFileTest):
         self.default_project_data['project-root'] = self.project_dir
 
     def test_cli_and_env_vars(self):
-        renderer = dbt.config.renderer.DbtProjectYamlRenderer(generate_base_context({'cli_version': '0.1.2'}))
+        renderer = dbt.config.renderer.DbtProjectYamlRenderer(None, {'cli_version': '0.1.2'})
         with mock.patch.dict(os.environ, self.env_override):
             project = dbt.config.Project.from_project_root(
                 self.project_dir,
                 renderer,
             )
 
+        self.assertEqual(renderer.ctx_obj.env_vars, {'env_value_profile': 'default'})
         self.assertEqual(project.version, "0.1.2")
         self.assertEqual(project.project_name, 'blah')
         self.assertEqual(project.profile_name, 'default')

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -43,7 +43,7 @@ def raises_nothing():
 
 
 def empty_profile_renderer():
-    return dbt.config.renderer.ProfileRenderer(generate_base_context({}))
+    return dbt.config.renderer.ProfileRenderer({})
 
 
 def empty_project_renderer():
@@ -509,7 +509,7 @@ class TestProfileFile(BaseFileTest):
     def test_cli_and_env_vars(self):
         self.args.target = 'cli-and-env-vars'
         self.args.vars = '{"cli_value_host": "cli-postgres-host"}'
-        renderer = dbt.config.renderer.ProfileRenderer(generate_base_context({'cli_value_host': 'cli-postgres-host'}))
+        renderer = dbt.config.renderer.ProfileRenderer({'cli_value_host': 'cli-postgres-host'})
         with mock.patch.dict(os.environ, self.env_override):
             profile = self.from_args(renderer=renderer)
             from_raw = self.from_raw_profile_info(

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -31,7 +31,6 @@ class GraphTest(unittest.TestCase):
 
     def tearDown(self):
         self.write_gpickle_patcher.stop()
-        self.load_projects_patcher.stop()
         self.file_system_patcher.stop()
         self.mock_filesystem_constructor.stop()
         self.mock_hook_constructor.stop()
@@ -97,19 +96,13 @@ class GraphTest(unittest.TestCase):
         self.mock_hook_constructor = self.hook_patcher.start()
         self.mock_hook_constructor.side_effect = create_hook_patcher
 
-        # Create load_projects patcher
-        self.load_projects_patcher = patch('dbt.parser.manifest._load_projects')
-        self.mock_load_projects = self.load_projects_patcher.start()
-        def _load_projects(config, paths):
-            yield config.project_name, config
-        self.mock_load_projects.side_effect = _load_projects
-
         # Create the Manifest.state_check patcher
         @patch('dbt.parser.manifest.ManifestLoader.build_manifest_state_check')
         def _mock_state_check(self):
             config = self.root_project
             all_projects = self.all_projects
             return ManifestStateCheck(
+                env_vars_hash=FileHash.from_contents(''),
                 vars_hash=FileHash.from_contents('vars'),
                 project_hashes={name: FileHash.from_contents(name) for name in all_projects},
                 profile_hash=FileHash.from_contents('profile'),

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -102,7 +102,8 @@ class GraphTest(unittest.TestCase):
             config = self.root_project
             all_projects = self.all_projects
             return ManifestStateCheck(
-                env_vars_hash=FileHash.from_contents(''),
+                project_env_vars_hash=FileHash.from_contents(''),
+                profile_env_vars_hash=FileHash.from_contents(''),
                 vars_hash=FileHash.from_contents('vars'),
                 project_hashes={name: FileHash.from_contents(name) for name in all_projects},
                 profile_hash=FileHash.from_contents('profile'),

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -11,6 +11,7 @@ from unittest import TestCase
 import agate
 import pytest
 from dbt.dataclass_schema import ValidationError
+from dbt.config.project import PartialProject
 
 
 def normalize(path):
@@ -62,13 +63,18 @@ def project_from_dict(project, profile, packages=None, selectors=None, cli_vars=
     if not isinstance(cli_vars, dict):
         cli_vars = parse_cli_vars(cli_vars)
 
-    renderer = DbtProjectYamlRenderer(generate_target_context(profile, cli_vars))
+    renderer = DbtProjectYamlRenderer(profile, cli_vars)
 
     project_root = project.pop('project-root', os.getcwd())
 
-    return Project.render_from_dict(
-            project_root, project, packages, selectors, renderer
-        )
+    partial = PartialProject.from_dicts(
+        project_root=project_root,
+        project_dict=project,
+        packages_dict=packages,
+        selectors_dict=selectors,
+    )
+    return partial.render(renderer)
+
 
 
 def config_from_parts_or_dicts(project, profile, packages=None, selectors=None, cli_vars='{}'):

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -47,7 +47,7 @@ def profile_from_dict(profile, profile_name, cli_vars='{}'):
     if not isinstance(cli_vars, dict):
         cli_vars = parse_cli_vars(cli_vars)
 
-    renderer = ProfileRenderer(generate_base_context(cli_vars))
+    renderer = ProfileRenderer(cli_vars)
     return Profile.from_raw_profile_info(
         profile,
         profile_name,


### PR DESCRIPTION
resolves #3885

### Description

This pull request captures the env vars when the dbt_project.yml file is rendered and saves a checksum of them in the manifest.state_check. When partial parsing is attempted it will compare the checksums and skip partial parsing if they have changed.

Profile env vars have also been handled. Note: only the specified profile is actually rendered.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
