### PR TITLE
`incorporate_indirect_nodes` should pass if not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 ### Features
 - Allow nullable `error_after` in source freshness ([#3874](https://github.com/dbt-labs/dbt-core/issues/3874), [#3955](https://github.com/dbt-labs/dbt-core/pull/3955))
 - Increase performance of graph subset selection ([#4135](https://github.com/dbt-labs/dbt-core/issues/4135),[#4155](https://github.com/dbt-labs/dbt-core/pull/4155))
+- Speed up node selection by skipping indirect node incorporation when not needed ([#4213](https://github.com/dbt-labs/dbt-core/issues/4213),[#4214](https://github.com/dbt-labs/dbt-core/pull/4214))
 
 ### Fixes
 - Changes unit tests using `assertRaisesRegexp` to `assertRaisesRegex`
 
 ### Under the hood
 - Bump artifact schema versions for 1.0.0: manifest v4, run results v4, sources v3. Notable changes: schema test + data test nodes are renamed to generic test + singular test nodes; freshness threshold default values ([#4191](https://github.com/dbt-labs/dbt-core/pull/4191))
+- Speed up node selection by skipping `incorporate_indirect_nodes` if not needed ([#4213](https://github.com/dbt-labs/dbt-core/issues/4213), [#4214](https://github.com/dbt-labs/dbt-core/issues/4214))
 
 Contributors:
 - [@kadero](https://github.com/kadero) ([3955](https://github.com/dbt-labs/dbt-core/pull/3955))

--- a/core/dbt/graph/selector.py
+++ b/core/dbt/graph/selector.py
@@ -254,6 +254,10 @@ class NodeSelector(MethodManager):
     ) -> Set[UniqueId]:
         # Check tests previously selected indirectly to see if ALL their
         # parents are now present.
+        
+        # performance: if identical, skip the processing below
+        if set(direct_nodes) == set(indirect_nodes):
+            return direct_nodes
 
         selected = set(direct_nodes)
 

--- a/core/dbt/graph/selector.py
+++ b/core/dbt/graph/selector.py
@@ -254,7 +254,7 @@ class NodeSelector(MethodManager):
     ) -> Set[UniqueId]:
         # Check tests previously selected indirectly to see if ALL their
         # parents are now present.
-        
+
         # performance: if identical, skip the processing below
         if set(direct_nodes) == set(indirect_nodes):
             return direct_nodes


### PR DESCRIPTION
resolves #4213

Quick opportunistic performance boost! Adjusts a method that I was responsible for adding, way back in v0.20...

### Before

<img width="1393" alt="Screenshot 2021-11-05 at 08 38 36" src="https://user-images.githubusercontent.com/13897643/140476347-65b6c71d-db52-473c-a547-fc7e21d40ad3.png">


### After

<img width="1406" alt="Screenshot 2021-11-05 at 08 42 45" src="https://user-images.githubusercontent.com/13897643/140476342-5089f9f3-3aa3-4772-a78c-6cfe451e4e76.png">

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
