### PR TITLE
Clears adapters before registering to fix dbt-server cacheing behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Under the hood
 - Bump artifact schema versions for 1.0.0: manifest v4, run results v4, sources v3. Notable changes: schema test + data test nodes are renamed to generic test + singular test nodes; freshness threshold default values ([#4191](https://github.com/dbt-labs/dbt-core/pull/4191))
 - Speed up node selection by skipping `incorporate_indirect_nodes` if not needed ([#4213](https://github.com/dbt-labs/dbt-core/issues/4213), [#4214](https://github.com/dbt-labs/dbt-core/issues/4214))
+- Clear adapters before registering in lib module config generation
+([#4218](https://github.com/dbt-labs/dbt-core/pull/4218))
 
 Contributors:
 - [@kadero](https://github.com/kadero) ([3955](https://github.com/dbt-labs/dbt-core/pull/3955))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@
 ### Under the hood
 - Bump artifact schema versions for 1.0.0: manifest v4, run results v4, sources v3. Notable changes: schema test + data test nodes are renamed to generic test + singular test nodes; freshness threshold default values ([#4191](https://github.com/dbt-labs/dbt-core/pull/4191))
 - Speed up node selection by skipping `incorporate_indirect_nodes` if not needed ([#4213](https://github.com/dbt-labs/dbt-core/issues/4213), [#4214](https://github.com/dbt-labs/dbt-core/issues/4214))
-- Clear adapters before registering in lib module config generation
-([#4218](https://github.com/dbt-labs/dbt-core/pull/4218))
+- Clear adapters before registering in lib module config generation ([#4218](https://github.com/dbt-labs/dbt-core/pull/4218))
 
 Contributors:
 - [@kadero](https://github.com/kadero) ([3955](https://github.com/dbt-labs/dbt-core/pull/3955))

--- a/core/dbt/lib.py
+++ b/core/dbt/lib.py
@@ -21,6 +21,9 @@ def get_dbt_config(project_dir, single_threaded=False):
     config = RuntimeConfig.from_args(RuntimeArgs(
         project_dir, profiles_dir, single_threaded
     ))
+    # Clear previously registered adapters--
+    # this fixes cacheing behavior on the dbt-server
+    dbt.adapters.factory.reset_adapters()
     # Load the relevant adapter
     dbt.adapters.factory.register_adapter(config)
 


### PR DESCRIPTION
resolves #TIGER-28

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

In implementing `dbt deps` logic in the new client/server, it became clear that running deps in the server results in cacheing of adapters-- such that the server needed to be stopped if additional packages needed to be added. This PR resets adapters in `dbt.lib.get_dbt_config` before registration. 

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
