### PR TITLE
v0 - new dbt deps type: tarball url

### DIFF
--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -495,6 +495,24 @@ def untar_package(
         dbt.clients.system.rename(downloaded_path, desired_path, force=True)
 
 
+def resolve_tar_dir_name(TarFile: tarfile.TarFile):
+    tarfile_dir_list = [x.name for x in TarFile.getmembers() if x.isdir()]
+    tar_dir_name = os.path.commonpath(tarfile_dir_list)
+    return convert_path(tar_dir_name)
+
+
+def untar_tarfile(
+    TarFile: tarfile.TarFile, dest_dir: str, rename_to: Optional[str] = None
+) -> None:
+    tar_dir_name = dbt.clients.system.resolve_tar_dir_name(TarFile)
+    TarFile.extractall(path=dest_dir)
+
+    if rename_to:
+        downloaded_path = os.path.join(dest_dir, tar_dir_name)
+        desired_path = os.path.join(dest_dir, rename_to)
+        dbt.clients.system.rename(downloaded_path, desired_path, force=True)
+
+
 def chmod_and_retry(func, path, exc_info):
     """Define an error handler to pass to shutil.rmtree.
     On Windows, when a file is marked read-only as git likes to do, rmtree will

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -62,6 +62,8 @@ class LocalPackage(Package):
 @dataclass
 class TarballPackage(Package):
     tarball: str
+    subdirectory: Optional[str] = None
+    sha1: Optional[str] = None
 
 
 # `float` also allows `int`, according to PEP484 (and jsonschema!)

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -59,6 +59,11 @@ class LocalPackage(Package):
     local: str
 
 
+@dataclass
+class TarballPackage(Package):
+    tarball: str
+
+
 # `float` also allows `int`, according to PEP484 (and jsonschema!)
 RawVersion = Union[str, float]
 
@@ -90,7 +95,7 @@ class RegistryPackage(Package):
             return [str(self.version)]
 
 
-PackageSpec = Union[LocalPackage, GitPackage, RegistryPackage]
+PackageSpec = Union[LocalPackage, TarballPackage, GitPackage, RegistryPackage]
 
 
 @dataclass

--- a/core/dbt/deps/resolver.py
+++ b/core/dbt/deps/resolver.py
@@ -8,16 +8,19 @@ from dbt.config import Project, RuntimeConfig
 from dbt.config.renderer import DbtProjectYamlRenderer
 from dbt.deps.base import BasePackage, PinnedPackage, UnpinnedPackage
 from dbt.deps.local import LocalUnpinnedPackage
+from dbt.deps.tarball import TarballUnpinnedPackage
 from dbt.deps.git import GitUnpinnedPackage
 from dbt.deps.registry import RegistryUnpinnedPackage
 
 from dbt.contracts.project import (
     LocalPackage,
+    TarballPackage,
     GitPackage,
     RegistryPackage,
 )
 
-PackageContract = Union[LocalPackage, GitPackage, RegistryPackage]
+PackageContract = Union[LocalPackage, TarballPackage, 
+                        GitPackage, RegistryPackage]
 
 
 @dataclass
@@ -72,6 +75,8 @@ class PackageListing:
         for contract in src:
             if isinstance(contract, LocalPackage):
                 pkg = LocalUnpinnedPackage.from_contract(contract)
+            elif isinstance(contract, TarballPackage):
+                pkg = TarballUnpinnedPackage.from_contract(contract)
             elif isinstance(contract, GitPackage):
                 pkg = GitUnpinnedPackage.from_contract(contract)
             elif isinstance(contract, RegistryPackage):

--- a/core/dbt/deps/resolver.py
+++ b/core/dbt/deps/resolver.py
@@ -19,7 +19,7 @@ from dbt.contracts.project import (
     RegistryPackage,
 )
 
-PackageContract = Union[LocalPackage, TarballPackage, 
+PackageContract = Union[LocalPackage, TarballPackage,
                         GitPackage, RegistryPackage]
 
 

--- a/core/dbt/deps/tarball.py
+++ b/core/dbt/deps/tarball.py
@@ -12,7 +12,7 @@ from dbt.contracts.project import (
     ProjectPackageMetadata,
     TarballPackage,
 )
-# from dbt.logger import GLOBAL_LOGGER as logger
+
 from dbt.logger import GLOBAL_LOGGER as logger
 
 TARFILE_MAX_SIZE = 1 * 1e+6  # limit tarfiles to 1mb
@@ -32,14 +32,23 @@ class TarballPackageMixin:
 
 
 class TarballPinnedPackage(TarballPackageMixin, PinnedPackage):
+    def __init__(
+        self, 
+        tarball: str,
+        sha1: Optional[str] = None,
+        subdirectory: Optional[str] = None,
+    ) -> None:
         super().__init__(tarball)
+        self.sha1 = sha1
+        self.subdirectory = subdirectory
         self.tarfile = self.get_tarfile()
         # init tarfile in class, and use tarfile as cache
         # simpler for tempfile handling, and prevent multiple hits to
         # url (one for metadata, one for intall)
-        self.tar_dir_name = self.validate_tarfile()
+        self.tar_dir_name = self.resolve_tar_dir()
         # assumed structure is that tarfile has a root dir (package name)
         # but we don't know what it is. will scan file for best candidate
+        # todo implement subdirectory like in git package
 
     def get_version(self):
         return None
@@ -48,41 +57,58 @@ class TarballPinnedPackage(TarballPackageMixin, PinnedPackage):
         return '<tarball @ {}>'.format(self.tarball)
 
     def get_tarfile(self):
-        from tempfile import NamedTemporaryFile
-        import tarfile
         def get_tar_size(TarFile: tarfile.TarFile):
             return sum(x.size for x in TarFile.getmembers())
+
+        def file_sha1(fp: str):
+            with open(named_temp_file.name, 'rb') as fp:
+                return hashlib.sha1(fp.read()).hexdigest()
 
         with NamedTemporaryFile(dir=get_downloads_path()) as named_temp_file:
             # NamedTemporaryFile on top of get_downloads_path
             # can mean NamedTemporaryFile in TemporaryFile, but works fine
-            print('\n\nHAI - tempfile?')
-            print(named_temp_file.name)
-
+            logger.debug(f"Using NamedTemporaryFile {named_temp_file.name}")
             download_url = self.tarball
             system.download_with_retries(download_url, named_temp_file.name)
 
-            print('\n\nHAI - got a file now?')
-
-            assert tarfile.is_tarfile(named_temp_file.name), "xxx not TAR!"
-            print('\n\nHAI - file looks good')
+            msg = f"{download_url} is not a valid tarfile."
+            assert tarfile.is_tarfile(named_temp_file.name), msg
 
             tar = tarfile.open(named_temp_file.name, "r:gz")
 
             msg = (f"{named_temp_file.name} size is larger than limit "
                    "of {TARFILE_MAX_SIZE}.")
             assert get_tar_size(tar) <= TARFILE_MAX_SIZE, msg
+
+            if self.sha1:
+                checksum = file_sha1(named_temp_file.name)
+                msg = ("sha1 mismatch for downloaded file. "
+                       f"Actual: [{checksum}], expected: [{self.sha1}]. ")
+                assert checksum == self.sha1, msg
+                logger.debug(f"sha1 checksum passes ({self.sha1})")
+
         return tar
 
-    def validate_tarfile(self):
+    def resolve_tar_dir(self):
         ''' assumed structure is that tarfile has a root dir (package name)
         but we don't know what it is. will look for lone dir on root and
-        use that, error if multiple dirs on root (better way?)
-          todo? optional tarball root_dir arg (e.g. '.', 'mything', 'whatever) 
-          in package file?'''
-        tar_dir_name = system.resolve_tar_dir_name(self.tarfile)
+        use that.
+        optional - use subdirectory arg to manually specify, like used in git 
+        package'''
+        if not self.subdirectory:
+            tar_dir_name = system.resolve_tar_dir_name(self.tarfile)
+            debug_txt = 'resolved '
+            msg = ("Package structure malformed. Expected one parent folder in"
+                   " tar root. Try using the subdirectory setting to specify"
+                   " path to package dir, or rebuilding the package "
+                   "structure.")
+            assert tar_dir_name != '', msg
+        else:
+            tar_dir_name = self.subdirectory
+            debug_txt = 'specified '
 
-        assert tar_dir_name != '', "package structure malformed"
+        logger.debug(f"Using {debug_txt} {tar_dir_name}/ directory as "
+                     "project root in tarfile.")
 
         return tar_dir_name
 
@@ -125,16 +151,35 @@ class TarballPinnedPackage(TarballPackageMixin, PinnedPackage):
 class TarballUnpinnedPackage(
     TarballPackageMixin, UnpinnedPackage[TarballPinnedPackage]
 ):
+    def __init__(
+        self, 
+        tarball: str,
+        sha1: Optional[str] = None,
+        subdirectory: Optional[str] = None,
+    ) -> None:
+        super().__init__(tarball)
+        self.sha1 = sha1
+        self.subdirectory = subdirectory
+
     @classmethod
     def from_contract(
         cls, contract: TarballPackage
-    ) -> 'TarballPinnedPackage':
-        return cls(tarball=contract.tarball)
+    ) -> 'TarballUnpinnedPackage':
+        return cls(
+            tarball=contract.tarball, sha1=contract.sha1,
+            subdirectory=contract.subdirectory
+        )
 
     def incorporate(
         self, other: 'TarballUnpinnedPackage'
     ) -> 'TarballUnpinnedPackage':
-        return TarballUnpinnedPackage(tarball=self.tarball)
+        return TarballUnpinnedPackage(
+            tarball=self.tarball, sha1=self.sha1,
+            subdirectory=self.subdirectory
+        )
 
     def resolved(self) -> TarballPinnedPackage:
-        return TarballPinnedPackage(tarball=self.tarball)
+        return TarballPinnedPackage(
+            tarball=self.tarball, sha1=self.sha1,
+            subdirectory=self.subdirectory
+        )

--- a/core/dbt/deps/tarball.py
+++ b/core/dbt/deps/tarball.py
@@ -1,0 +1,130 @@
+import os
+# import shutil
+
+from dbt.clients import system
+from dbt.deps.base import PinnedPackage, UnpinnedPackage, get_downloads_path
+from dbt.config import Project
+from dbt.contracts.project import (
+    ProjectPackageMetadata,
+    TarballPackage,
+)
+from dbt.logger import GLOBAL_LOGGER as logger
+
+
+class TarballPackageMixin:
+    def __init__(self, tarball: str) -> None:
+        super().__init__()
+        self.tarball = tarball
+
+    @property
+    def name(self):
+        return self.tarball
+
+    def source_type(self):
+        return 'tarball'
+
+
+class TarballPinnedPackage(TarballPackageMixin, PinnedPackage):
+    def __init__(self, tarball: str) -> None:
+        super().__init__(tarball)
+        self.tarfile = self.get_tarfile()
+        # init tarfile in class, and use tarfile as cache
+        # simpler for tempfile handling, and prevent multiple hits to 
+        # url (one for metadata, one for intall)
+        self.tar_dir_name = self.validate_tarfile()
+        # assumed structure is that tarfile has a root dir (package name)
+        # but we don't know what it is. will scan file for best candidate
+
+    def get_version(self):
+        return None
+
+    def nice_version_name(self):
+        return '<tarball @ {}>'.format(self.tarball)
+
+    def get_tarfile(self):
+        from tempfile import NamedTemporaryFile
+        import tarfile
+
+        with NamedTemporaryFile(dir=get_downloads_path()) as named_temp_file:
+            # NamedTemporaryFile on top of get_downloads_path
+            # can mean NamedTemporaryFile in TemporaryFile, but works fine
+            print('\n\nHAI - tempfile?')
+            print(named_temp_file.name)
+
+            download_url = self.tarball
+            system.download_with_retries(download_url, named_temp_file.name)
+
+            print('\n\nHAI - got a file now?')
+
+            assert tarfile.is_tarfile(named_temp_file.name), "xxx not TAR!"
+            print('\n\nHAI - file looks good')
+
+            tar = tarfile.open(named_temp_file.name, "r:gz")
+
+        return tar
+
+    def validate_tarfile(self):
+        # assumed structure is that tarfile has a root dir (package name)
+        # but we don't know what it is. will look for lone dir on root and 
+        # use that, error if multiple dirs on root (better way?)
+        #  todo? optional tarball root_dir arg (e.g. '.', 'mything', 'whatever) 
+        #  in package file?
+        tar_dir_name = system.resolve_tar_dir_name(self.tarfile)
+
+        assert tar_dir_name != '', "package structure malformed"
+
+        return tar_dir_name
+
+    def _fetch_metadata(self, project, renderer):
+        
+        tarfile = self.tarfile
+        tar_dir_name = self.tar_dir_name
+
+        tar_path = os.path.realpath(
+            os.path.join(get_downloads_path(), tar_dir_name)
+        )
+        system.make_directory(os.path.dirname(tar_path))
+
+        tarfile.extractall(path=tar_path)
+
+        tar_extracted_root = os.path.join(tar_path, tar_dir_name)
+
+        loaded = Project.from_project_root(tar_extracted_root, renderer)
+
+        return ProjectPackageMetadata.from_project(loaded)
+
+    def install(self, project, renderer):
+        tar_dir_name = self.tar_dir_name
+
+        tar_path = os.path.realpath(
+            os.path.join(get_downloads_path(), tar_dir_name)
+        )
+        system.make_directory(os.path.dirname(tar_path))
+        # tar_extracted_root = os.path.join(tar_path, tar_dir_name)
+
+        # loaded = Project.from_project_root(tar_extracted_root, renderer)
+
+        deps_path = project.packages_install_path
+        package_name = self.get_project_name(project, renderer)
+        # tarfile.extractall(path=deps_path)
+
+        system.untar_tarfile(TarFile=self.tarfile, dest_dir=deps_path, 
+                             rename_to=package_name)
+
+
+class TarballUnpinnedPackage(
+    TarballPackageMixin, UnpinnedPackage[TarballPinnedPackage]
+):
+    @classmethod
+    def from_contract(
+        cls, contract: TarballPackage
+    ) -> 'TarballPinnedPackage':
+        return cls(tarball=contract.tarball)
+
+    def incorporate(
+        self, other: 'TarballUnpinnedPackage'
+    ) -> 'TarballUnpinnedPackage':
+        return TarballUnpinnedPackage(tarball=self.tarball)
+
+    def resolved(self) -> TarballPinnedPackage:
+        return TarballPinnedPackage(tarball=self.tarball)

--- a/core/dbt/deps/tarball.py
+++ b/core/dbt/deps/tarball.py
@@ -1,5 +1,9 @@
 import os
 # import shutil
+import hashlib
+import tarfile
+from tempfile import NamedTemporaryFile
+from typing import Optional
 
 from dbt.clients import system
 from dbt.deps.base import PinnedPackage, UnpinnedPackage, get_downloads_path
@@ -9,6 +13,8 @@ from dbt.contracts.project import (
     TarballPackage,
 )
 # from dbt.logger import GLOBAL_LOGGER as logger
+from dbt.logger import GLOBAL_LOGGER as logger
+
 TARFILE_MAX_SIZE = 1 * 1e+6  # limit tarfiles to 1mb
 
 

--- a/core/dbt/deps/tarball.py
+++ b/core/dbt/deps/tarball.py
@@ -27,12 +27,11 @@ class TarballPackageMixin:
     def name(self):
         return self.tarball
 
-    def source_type(self):
+    def source_type(self) -> str:
         return 'tarball'
 
 
 class TarballPinnedPackage(TarballPackageMixin, PinnedPackage):
-    def __init__(self, tarball: str) -> None:
         super().__init__(tarball)
         self.tarfile = self.get_tarfile()
         # init tarfile in class, and use tarfile as cache

--- a/core/dbt/deps/tarball.py
+++ b/core/dbt/deps/tarball.py
@@ -33,7 +33,7 @@ class TarballPackageMixin:
 
 class TarballPinnedPackage(TarballPackageMixin, PinnedPackage):
     def __init__(
-        self, 
+        self,
         tarball: str,
         sha1: Optional[str] = None,
         subdirectory: Optional[str] = None,
@@ -93,7 +93,7 @@ class TarballPinnedPackage(TarballPackageMixin, PinnedPackage):
         ''' assumed structure is that tarfile has a root dir (package name)
         but we don't know what it is. will look for lone dir on root and
         use that.
-        optional - use subdirectory arg to manually specify, like used in git 
+        optional - use subdirectory arg to manually specify, like used in git
         package'''
         if not self.subdirectory:
             tar_dir_name = system.resolve_tar_dir_name(self.tarfile)
@@ -152,7 +152,7 @@ class TarballUnpinnedPackage(
     TarballPackageMixin, UnpinnedPackage[TarballPinnedPackage]
 ):
     def __init__(
-        self, 
+        self,
         tarball: str,
         sha1: Optional[str] = None,
         subdirectory: Optional[str] = None,

--- a/core/dbt/deps/tarball.py
+++ b/core/dbt/deps/tarball.py
@@ -8,7 +8,7 @@ from dbt.contracts.project import (
     ProjectPackageMetadata,
     TarballPackage,
 )
-from dbt.logger import GLOBAL_LOGGER as logger
+# from dbt.logger import GLOBAL_LOGGER as logger
 
 
 class TarballPackageMixin:
@@ -29,7 +29,7 @@ class TarballPinnedPackage(TarballPackageMixin, PinnedPackage):
         super().__init__(tarball)
         self.tarfile = self.get_tarfile()
         # init tarfile in class, and use tarfile as cache
-        # simpler for tempfile handling, and prevent multiple hits to 
+        # simpler for tempfile handling, and prevent multiple hits to
         # url (one for metadata, one for intall)
         self.tar_dir_name = self.validate_tarfile()
         # assumed structure is that tarfile has a root dir (package name)
@@ -64,11 +64,11 @@ class TarballPinnedPackage(TarballPackageMixin, PinnedPackage):
         return tar
 
     def validate_tarfile(self):
-        # assumed structure is that tarfile has a root dir (package name)
-        # but we don't know what it is. will look for lone dir on root and 
-        # use that, error if multiple dirs on root (better way?)
-        #  todo? optional tarball root_dir arg (e.g. '.', 'mything', 'whatever) 
-        #  in package file?
+        ''' assumed structure is that tarfile has a root dir (package name)
+        but we don't know what it is. will look for lone dir on root and
+        use that, error if multiple dirs on root (better way?)
+          todo? optional tarball root_dir arg (e.g. '.', 'mything', 'whatever) 
+          in package file?'''
         tar_dir_name = system.resolve_tar_dir_name(self.tarfile)
 
         assert tar_dir_name != '', "package structure malformed"
@@ -76,7 +76,6 @@ class TarballPinnedPackage(TarballPackageMixin, PinnedPackage):
         return tar_dir_name
 
     def _fetch_metadata(self, project, renderer):
-        
         tarfile = self.tarfile
         tar_dir_name = self.tar_dir_name
 
@@ -108,7 +107,7 @@ class TarballPinnedPackage(TarballPackageMixin, PinnedPackage):
         package_name = self.get_project_name(project, renderer)
         # tarfile.extractall(path=deps_path)
 
-        system.untar_tarfile(TarFile=self.tarfile, dest_dir=deps_path, 
+        system.untar_tarfile(TarFile=self.tarfile, dest_dir=deps_path,
                              rename_to=package_name)
 
 

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -24,10 +24,13 @@ class DepsTask(BaseTask):
         self, package_name: str, source_type: str, version: str
     ) -> None:
         # Hub packages do not need to be hashed, as they are public
-        # Use the string 'local' for local package versions
+        # Use the string 'local' for local and 'tarball' package versions
         if source_type == 'local':
             package_name = dbt.utils.md5(package_name)
             version = 'local'
+        elif source_type == 'tarball':
+            package_name = dbt.utils.md5(package_name)
+            version = 'tarball'
         elif source_type != 'hub':
             package_name = dbt.utils.md5(package_name)
             version = dbt.utils.md5(version)

--- a/test/unit/test_deps.py
+++ b/test/unit/test_deps.py
@@ -5,10 +5,12 @@ import dbt.deps
 import dbt.exceptions
 from dbt.deps.git import GitUnpinnedPackage
 from dbt.deps.local import LocalUnpinnedPackage
+from dbt.deps.tarball import TarballUnpinnedPackage
 from dbt.deps.registry import RegistryUnpinnedPackage
 from dbt.deps.resolver import resolve_packages
 from dbt.contracts.project import (
     LocalPackage,
+    TarballPackage,
     GitPackage,
     RegistryPackage,
 )
@@ -28,6 +30,39 @@ class TestLocalPackage(unittest.TestCase):
         a_pinned = a.resolved()
         self.assertEqual(a_pinned.local, '/path/to/package')
         self.assertEqual(str(a_pinned), '/path/to/package')
+
+
+class TestTarballPackage(unittest.TestCase):
+    def test_init(self):
+        a_contract = TarballPackage.from_dict({'tarball': '/path/to/package'})
+        self.assertEqual(a_contract.tarball, '/path/to/package')
+        a = TarballUnpinnedPackage.from_contract(a_contract)
+        self.assertEqual(a.tarball, '/path/to/package')
+        a_pinned = a.resolved()
+        self.assertEqual(a_pinned.tarball, '/path/to/package')
+        self.assertEqual(str(a_pinned), '/path/to/package')
+
+        # test optional args
+        a_contract = TarballPackage.from_dict(
+            {'tarball': '/path/to/package', 'sha1': '123'
+             , 'subdirectory': 'subdir'}
+        )
+        self.assertEqual(a_contract.tarball, '/path/to/package')
+        self.assertEqual(a_contract.sha1, '123')
+        self.assertEqual(a_contract.subdirectory, 'subdir')
+
+        a = TarballUnpinnedPackage.from_contract(a_contract)
+        self.assertEqual(a.tarball, '/path/to/package')
+        self.assertEqual(a.sha1, '123')
+        self.assertEqual(a.subdirectory, 'subdir')
+        a_pinned = a.resolved()
+        self.assertEqual(a_pinned.tarball, '/path/to/package')
+        self.assertEqual(a_pinned.sha1, '123')
+        self.assertEqual(a_pinned.subdirectory, 'subdir')
+        self.assertEqual(a_pinned.resolve_tar_dir(), 'subdir')
+        self.assertEqual(str(a_pinned), '/path/to/package')
+
+        # mock a tarinfo list?
 
 
 class TestGitPackage(unittest.TestCase):


### PR DESCRIPTION
in support of
https://github.com/dbt-labs/dbt-core/issues/4205

resolves #

na

### Description

Enable direct linking to tarball urls in `packages.yml`, for example:
```
# packages.yml
packages:
  - tarball: https://codeload.github.com/dbt-labs/dbt-utils/tar.gz/0.6.6
  - sha1: 549db5560efccbadc7ec7834c03cf13579199a66
# sha1 is optional. if specified, will only install package if downloaded tar matches. 
  - subdirectory: dbt-utils-0.6.6
# subdirectory is optional. By default will look for single parent folder in tarfile and use as package root. Subdirectory can be used to override (like subdirectory arg in git package).
```
Use case is for dbt projects that want to host internal private packages without relying on git package install option. (public tarball used here as example only). 

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [IN PROGRESS ] I have run this code in development and it appears to resolve the stated issue
- [IN PROGRESS ] This PR includes tests, or tests are not required/relevant for this PR
- [TODO ] I have updated the `CHANGELOG.md` and added information about my change
- [TODO ] PR for updates to documentation