### PR TITLE
Rm py36 support

### DIFF
--- a/.github/scripts/integration-test-matrix.js
+++ b/.github/scripts/integration-test-matrix.js
@@ -1,6 +1,6 @@
 module.exports = ({ context }) => {
   const defaultPythonVersion = "3.8";
-  const supportedPythonVersions = ["3.6", "3.7", "3.8", "3.9"];
+  const supportedPythonVersions = ["3.7", "3.8", "3.9"];
   const supportedAdapters = ["postgres"];
 
   // if PR, generate matrix based on files changed and PR labels

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8] # TODO: support unit testing for python 3.9 (https://github.com/dbt-labs/dbt/issues/3689)
+        python-version: [3.7, 3.8] # TODO: support unit testing for python 3.9 (https://github.com/dbt-labs/dbt/issues/3689)
 
     env:
       TOXENV: "unit"
@@ -167,7 +167,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Speed up node selection by skipping `incorporate_indirect_nodes` if not needed ([#4213](https://github.com/dbt-labs/dbt-core/issues/4213), [#4214](https://github.com/dbt-labs/dbt-core/issues/4214))
 - When on_schema_change is set, pass common columns as dest_columns in incremental merge macros ([#4144](https://github.com/dbt-labs/dbt-core/issues/4144), [#4170](https://github.com/dbt-labs/dbt-core/pull/4170))
 - Clear adapters before registering in lib module config generation ([#4218](https://github.com/dbt-labs/dbt-core/pull/4218))
+- Remove official support for python 3.6, which is reaching end of life on December 23, 2021 ([#4134](https://github.com/dbt-labs/dbt-core/issues/4134), [#4223](https://github.com/dbt-labs/dbt-core/pull/4223))
 
 Contributors:
 - [@kadero](https://github.com/kadero) ([#3955](https://github.com/dbt-labs/dbt-core/pull/3955))

--- a/core/setup.py
+++ b/core/setup.py
@@ -2,9 +2,9 @@
 import os
 import sys
 
-if sys.version_info < (3, 6):
+if sys.version_info < (3, 7):
     print('Error: dbt does not support this version of Python.')
-    print('Please upgrade to Python 3.6 or higher.')
+    print('Please upgrade to Python 3.7 or higher.')
     sys.exit(1)
 
 
@@ -55,7 +55,6 @@ setup(
         'agate>=1.6,<1.6.4',
         'click>=8,<9',
         'colorama>=0.3.9,<0.4.5',
-        'dataclasses>=0.6,<0.9;python_version<"3.7"',
         'hologram==0.0.14',
         'isodate>=0.6,<0.7',
         'logbook>=1.5,<1.6',
@@ -82,10 +81,9 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX :: Linux',
 
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
-    python_requires=">=3.6.3",
+    python_requires=">=3.7",
 )

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -2,9 +2,9 @@
 import os
 import sys
 
-if sys.version_info < (3, 6):
+if sys.version_info < (3, 7):
     print('Error: dbt does not support this version of Python.')
-    print('Please upgrade to Python 3.6 or higher.')
+    print('Please upgrade to Python 3.7 or higher.')
     sys.exit(1)
 
 
@@ -82,10 +82,9 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX :: Linux',
 
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
-    python_requires=">=3.6.2",
+    python_requires=">=3.7",
 )

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ if 'sdist' not in sys.argv:
     sys.exit(1)
 
 
-if sys.version_info < (3, 6):
+if sys.version_info < (3, 7):
     print('Error: dbt does not support this version of Python.')
-    print('Please upgrade to Python 3.6 or higher.')
+    print('Please upgrade to Python 3.7 or higher.')
     sys.exit(1)
 
 
@@ -62,10 +62,9 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX :: Linux',
 
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
-    python_requires=">=3.6.2",
+    python_requires=">=3.7",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py36,py37,py38,py39,flake8,mypy
+envlist = py37,py38,py39,flake8,mypy
 
 [testenv:flake8]
 description = flake8 code checks
@@ -21,7 +21,7 @@ deps =
   -rdev-requirements.txt
   -reditable-requirements.txt
 
-[testenv:{unit,py36,py37,py38,py39,py}]
+[testenv:{unit,py37,py38,py39,py}]
 description = unit testing
 skip_install = true
 passenv = DBT_* PYTEST_ADDOPTS
@@ -30,7 +30,7 @@ deps =
   -rdev-requirements.txt
   -reditable-requirements.txt
 
-[testenv:{integration,py36,py37,py38,py39,py}-{postgres}]
+[testenv:{integration,py37,py38,py39,py}-{postgres}]
 description = adapter plugin integration testing
 skip_install = true
 passenv = DBT_* POSTGRES_TEST_* PYTEST_ADDOPTS


### PR DESCRIPTION
resolves #4134

### Description

- Remove `py36` tests
- Remove py36 support from package metadata
- Bump `sys.version_info` and `python_requires`
- Leave in `dataclasses` backport + associated cruft for now

Adapter PRs:
- https://github.com/dbt-labs/dbt-redshift/pull/38
- https://github.com/dbt-labs/dbt-snowflake/pull/45
- https://github.com/dbt-labs/dbt-bigquery/pull/59
- spark TK

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- ~I have run this code in development and it appears to resolve the stated issue~
- ~This PR includes tests, or tests are not required/relevant for this PR~
- [x] I have updated the `CHANGELOG.md` and added information about my change
