### PR TITLE
Fix/dbt deps retry none answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Contributors:
 - [@Kayrnt](https://github.com/Kayrnt) ([#4136](https://github.com/dbt-labs/dbt-core/pull/4170))
 - [@VersusFacit](https://github.com/VersusFacit) ([#4104](https://github.com/dbt-labs/dbt-core/pull/4104))
 - [@joellabes](https://github.com/joellabes) ([#4104](https://github.com/dbt-labs/dbt-core/pull/4104))
-- [@b-per](https://github.com/b-per)
+- [@b-per](https://github.com/b-per) ([#4225](https://github.com/dbt-labs/dbt-core/pull/4225))
 
 
 ## dbt-core 1.0.0b2 (October 25, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 - Changes unit tests using `assertRaisesRegexp` to `assertRaisesRegex` ([#4136](https://github.com/dbt-labs/dbt-core/issues/4132), [#4136](https://github.com/dbt-labs/dbt-core/pull/4136))
+- Allow retries when the answer from a `dbt deps` is `None` ([#4178](https://github.com/dbt-labs/dbt-core/issues/4178))
 
 ### Under the hood
 - Bump artifact schema versions for 1.0.0: manifest v4, run results v4, sources v3. Notable changes: schema test + data test nodes are renamed to generic test + singular test nodes; freshness threshold default values ([#4191](https://github.com/dbt-labs/dbt-core/pull/4191))
@@ -23,6 +24,7 @@ Contributors:
 - [@Kayrnt](https://github.com/Kayrnt) ([#4136](https://github.com/dbt-labs/dbt-core/pull/4170))
 - [@VersusFacit](https://github.com/VersusFacit) ([#4104](https://github.com/dbt-labs/dbt-core/pull/4104))
 - [@joellabes](https://github.com/joellabes) ([#4104](https://github.com/dbt-labs/dbt-core/pull/4104))
+- [@b-per](https://github.com/b-per)
 
 
 ## dbt-core 1.0.0b2 (October 25, 2021)

--- a/core/dbt/clients/registry.py
+++ b/core/dbt/clients/registry.py
@@ -30,6 +30,8 @@ def _get(path, registry_base_url=None):
     logger.debug('Response from registry: GET {} {}'.format(url,
                                                             resp.status_code))
     resp.raise_for_status()
+    if resp is None:
+        raise requests.exceptions.InvalidJSONError('Request error: The response is None', response=resp)
     return resp.json()
 
 

--- a/core/dbt/clients/registry.py
+++ b/core/dbt/clients/registry.py
@@ -31,7 +31,9 @@ def _get(path, registry_base_url=None):
                                                             resp.status_code))
     resp.raise_for_status()
     if resp is None:
-        raise requests.exceptions.InvalidJSONError('Request error: The response is None', response=resp)
+        raise requests.exceptions.ContentDecodingError(
+            'Request error: The response is None', response=resp
+        )
     return resp.json()
 
 

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -615,7 +615,11 @@ def _connection_exception_retry(fn, max_attempts: int, attempt: int = 0):
     """
     try:
         return fn()
-    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout, requests.exceptions.InvalidJSONError) as exc:
+    except (
+        requests.exceptions.ConnectionError,
+        requests.exceptions.Timeout,
+        requests.exceptions.ContentDecodingError,
+    ) as exc:
         if attempt <= max_attempts - 1:
             logger.debug('Retrying external call. Attempt: ' +
                          f'{attempt} Max attempts: {max_attempts}')

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -615,7 +615,7 @@ def _connection_exception_retry(fn, max_attempts: int, attempt: int = 0):
     """
     try:
         return fn()
-    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout, requests.exceptions.InvalidJSONError) as exc:
         if attempt <= max_attempts - 1:
             logger.debug('Retrying external call. Attempt: ' +
                          f'{attempt} Max attempts: {max_attempts}')

--- a/test/unit/test_core_dbt_utils.py
+++ b/test/unit/test_core_dbt_utils.py
@@ -22,6 +22,11 @@ class TestCoreDbtUtils(unittest.TestCase):
         connection_exception_retry(lambda: Counter._add_with_limited_exception(), 5)
         self.assertEqual(2, counter) # 2 = original attempt plus 1 retry
 
+    def test_connection_exception_retry_success_none_response(self):
+        Counter._reset()
+        connection_exception_retry(lambda: Counter._add_with_none_exception(), 5)
+        self.assertEqual(2, counter) # 2 = original attempt returned None, plus 1 retry
+
 
 counter:int = 0 
 class Counter():
@@ -37,6 +42,11 @@ class Counter():
         counter+=1
         if counter < 2:
             raise requests.exceptions.ConnectionError
+    def _add_with_none_exception():
+        global counter
+        counter+=1
+        if counter < 2:
+            raise requests.exceptions.ContentDecodingError
     def _reset():
         global counter
         counter = 0


### PR DESCRIPTION
Allow retries when the answer received after a `dbt deps` is `None`

resolves #4178

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

Add the logic to handle the case when the answer received is `None`.  
I picked the `requests` exception `InvalidJSONError` to handle the situation but I am not sure if another one would be more suitable.

I didn't add tests and wouldn't be too sure where to start if a test would need to be created. Happy to add one if it is required.

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have updated the `CHANGELOG.md` and added information about my change
