### PR TITLE
Issue message instead of exception when patch does not have a matching node

### DIFF
--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -57,6 +57,7 @@ from dbt.parser.generic_test_builders import (
     TestBuilder, GenericTestBlock, TargetBlock, YamlBlock,
     TestBlock, Testable
 )
+from dbt.ui import warning_tag
 from dbt.utils import (
     get_pseudo_test_path, coerce_dict_str
 )
@@ -886,11 +887,13 @@ class NodePatchParser(
                     # re-application of the patch in partial parsing.
                     node.patch_path = source_file.file_id
             else:
-                raise ParsingException(
+                msg = (
                     f"Did not find matching node for patch with name '{patch.name}' "
                     f"in the '{patch.yaml_key}' section of "
                     f"file '{source_file.path.original_file_path}'"
                 )
+                warn_or_error(msg, log_fmt=warning_tag('{}'))
+                return
 
         # patches can't be overwritten
         node = self.manifest.nodes.get(unique_id)

--- a/test/integration/068_partial_parsing_tests/test_partial_parsing.py
+++ b/test/integration/068_partial_parsing_tests/test_partial_parsing.py
@@ -143,7 +143,7 @@ class ModelTest(BasePPTest):
         # referred to in schema file
         self.copy_file('test-files/models-schema2.yml', 'models/schema.yml')
         self.rm_file('models/model_three.sql')
-        with self.assertRaises(ParsingException):
+        with self.assertRaises(CompilationException):
             results = self.run_dbt(["--partial-parse", "--warn-error", "run"])
 
         # Put model back again
@@ -312,7 +312,7 @@ class TestSources(BasePPTest):
 
         # Change seed name to wrong name
         self.copy_file('test-files/schema-sources5.yml', 'models/sources.yml')
-        with self.assertRaises(ParsingException):
+        with self.assertRaises(CompilationException):
             results = self.run_dbt(["--partial-parse", "--warn-error", "run"])
 
         # Put back seed name to right name


### PR DESCRIPTION

resolves #3885

### Description

Implementation of the env var partial parsing code included a change to throw an exception when there is no matching node for a patch. This reverts that and switches to issuing a message.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
