### PR TITLE
Raise parsing error instead of compilation when extracting test args

### DIFF
--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -456,8 +456,8 @@ def raise_compiler_error(msg, node=None) -> NoReturn:
     raise CompilationException(msg, node)
 
 
-def raise_parsing_error(msg) -> NoReturn:
-    raise ParsingException(msg)
+def raise_parsing_error(msg, node=None) -> NoReturn:
+    raise ParsingException(msg, node)
 
 
 def raise_database_error(msg, node=None) -> NoReturn:

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -15,7 +15,7 @@ from dbt.contracts.graph.unparsed import (
     UnparsedNodeUpdate,
     UnparsedExposure,
 )
-from dbt.exceptions import raise_compiler_error
+from dbt.exceptions import raise_compiler_error, raise_parsing_error
 from dbt.parser.search import FileBlock
 
 
@@ -266,7 +266,7 @@ class TestBuilder(Generic[Testable]):
     @staticmethod
     def extract_test_args(test, name=None) -> Tuple[str, Dict[str, Any]]:
         if not isinstance(test, dict):
-            raise_compiler_error(
+            raise_parsing_error(
                 'test must be dict or str, got {} (value {})'.format(
                     type(test), test
                 )
@@ -274,20 +274,20 @@ class TestBuilder(Generic[Testable]):
 
         test = list(test.items())
         if len(test) != 1:
-            raise_compiler_error(
+            raise_parsing_error(
                 'test definition dictionary must have exactly one key, got'
                 ' {} instead ({} keys)'.format(test, len(test))
             )
         test_name, test_args = test[0]
 
         if not isinstance(test_args, dict):
-            raise_compiler_error(
+            raise_parsing_error(
                 'test arguments must be dict, got {} (value {})'.format(
                     type(test_args), test_args
                 )
             )
         if not isinstance(test_name, str):
-            raise_compiler_error(
+            raise_parsing_error(
                 'test name must be a str, got {} (value {})'.format(
                     type(test_name), test_name
                 )

--- a/test/integration/042_sources_test/test_sources.py
+++ b/test/integration/042_sources_test/test_sources.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 import yaml
 
-from dbt.exceptions import CompilationException
+from dbt.exceptions import ParsingException
 import dbt.tracking
 import dbt.version
 from test.integration.base import DBTIntegrationTest, use_profile, AnyFloat, \
@@ -523,7 +523,7 @@ class TestMalformedSources(BaseSourcesTest):
 
     @use_profile('postgres')
     def test_postgres_malformed_schema_will_break_run(self):
-        with self.assertRaises(CompilationException):
+        with self.assertRaises(ParsingException):
             self.run_dbt_with_vars(['seed'])
 
 


### PR DESCRIPTION
### Description
Raise a parsing error instead of a compilation error that gets caught and turned into useful message when using test builder.

https://github.com/dbt-labs/dbt-core/blob/0f57b36b402e4e7e267b754550556e8e6e6829f6/core/dbt/parser/schemas.py#L298-L305

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
