### PR TITLE
Table-level freshness should inherit from schema-level freshness when table-level is missing and schema-level is null

### DIFF
--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -364,9 +364,9 @@ def merge_freshness(
         merged_freshness.error_after = merged_error_after
         merged_freshness.warn_after = merged_warn_after
         return merged_freshness
-    elif base is None and update is not None:
-        return update
     elif base is None and not update:
         return None
+    elif base is None and update is not None:
+        return update
     else:
         return None

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -364,7 +364,9 @@ def merge_freshness(
         merged_freshness.error_after = merged_error_after
         merged_freshness.warn_after = merged_warn_after
         return merged_freshness
-    elif base is None and not update:
+    elif base is None and update is not None:
         return update
+    elif base is None and not update:
+        return None
     else:
         return None

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -364,7 +364,7 @@ def merge_freshness(
         merged_freshness.error_after = merged_error_after
         merged_freshness.warn_after = merged_warn_after
         return merged_freshness
-    elif base is None and update is not None:
+    elif base is None and not update:
         return update
     else:
         return None


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/4245

### Description

Currently, when schema-level (base) freshness is set to `null` and table-level freshness is missing (i.e. set to default), merge_freshness returns `{'warn_after': None, 'error_after': None, 'filter': None}`, which is the default value when freshness is missing.

In this case, the source's freshness should equal `None`, as it should inherit from the schema-level freshness, which is set to `null`

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
