### PR TITLE
test_postgres_profile_env_vars: change user env var instead of pass

### DIFF
--- a/test/integration/068_partial_parsing_tests/test_pp_vars.py
+++ b/test/integration/068_partial_parsing_tests/test_pp_vars.py
@@ -327,8 +327,8 @@ class ProfileEnvVarTest(BasePPTest):
         manifest = get_manifest()
         env_vars_checksum = manifest.state_check.profile_env_vars_hash.checksum
 
-        # Change env_vars
-        os.environ['ENV_VAR_PASS'] = 'my_pass'
+        # Change env_vars, the user doesn't exist, this should fail
+        os.environ['ENV_VAR_USER'] = 'fake_user'
         (results, log_output) = self.run_dbt_and_capture(["run"], expect_pass=False)
         self.assertTrue('env vars used in profiles.yml have changed' in log_output)
         manifest = get_manifest()


### PR DESCRIPTION
Fix failing test on macOS: [`ProfileEnvVarTest::test_postgres_profile_env_vars`](https://github.com/dbt-labs/dbt-core/runs/4150327832?check_suite_focus=true)

This test is passing when we expect it ought to fail. Currently, it tries to break the run by switching the password for authenticating to Postgres. I _believe_ that the Postgres `root` user doesn't require password-based authentication. I don't know enough of the details of how we set up the Postgres db on different OS to know why this is only failing on macOS.

If instead of changing `ENV_VAR_PASS`, I change `ENV_VAR_USER` to `fake_user`, dbt appropriately catches the env var change (what we're actually testing here), tries to connect with `fake_user`, and fails.

Testing on both macOS + Windows to be sure.