### PR TITLE
Env var shim to enable legacy logger

### DIFF
--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -4,7 +4,7 @@ import dbt.events.functions as this  # don't worry I hate it too.
 from dbt.events.types import Cli, Event, File, ShowException
 import dbt.flags as flags
 # TODO this will need to move eventually
-from dbt.logger import SECRET_ENV_PREFIX, make_log_dir_if_missing
+from dbt.logger import SECRET_ENV_PREFIX, make_log_dir_if_missing, GLOBAL_LOGGER
 import io
 from io import StringIO
 import json
@@ -205,6 +205,24 @@ def fire_event(e: Event) -> None:
     # TODO manage history in phase 2:  EVENT_HISTORY.append(e)
     # explicitly checking the debug flag here so that potentially expensive-to-construct
     # log messages are not constructed if debug messages are never shown.
+
+    # backwards compatibility for plugins that require old logger (dbt-rpc)
+    if flags.USE_LEGACY_LOGGER:
+        log_line = create_log_line(e, json_fmt=this.format_json, cli_dest=False)
+        level_tag = e.level_tag()
+        if level_tag == 'debug':
+            GLOBAL_LOGGER.debug(log_line)
+        elif level_tag == 'info':
+            GLOBAL_LOGGER.info(log_line)
+        elif level_tag == 'warn':
+            GLOBAL_LOGGER.warn(log_line)
+        elif level_tag == 'error':
+            GLOBAL_LOGGER.error(log_line)
+        else:
+            raise AssertionError(
+                f"While attempting to log {log_line}, encountered the unhandled level: {level_tag}"
+            )
+        return
 
     # always logs debug level regardless of user input
     if isinstance(e, File):

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -207,7 +207,7 @@ def fire_event(e: Event) -> None:
     # log messages are not constructed if debug messages are never shown.
 
     # backwards compatibility for plugins that require old logger (dbt-rpc)
-    if flags.USE_LEGACY_LOGGER:
+    if flags.ENABLE_LEGACY_LOGGER:
         log_line = create_log_line(e, json_fmt=this.format_json, cli_dest=False)
         level_tag = e.level_tag()
         if level_tag == 'debug':

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -81,6 +81,7 @@ def env_set_path(key: str) -> Optional[Path]:
 MACRO_DEBUGGING = env_set_truthy('DBT_MACRO_DEBUGGING')
 DEFER_MODE = env_set_truthy('DBT_DEFER_TO_STATE')
 ARTIFACT_STATE_PATH = env_set_path('DBT_ARTIFACT_STATE_PATH')
+USE_LEGACY_LOGGER = env_set_truthy('DBT_USE_LEGACY_LOGGER')
 
 
 def _get_context():

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -81,7 +81,7 @@ def env_set_path(key: str) -> Optional[Path]:
 MACRO_DEBUGGING = env_set_truthy('DBT_MACRO_DEBUGGING')
 DEFER_MODE = env_set_truthy('DBT_DEFER_TO_STATE')
 ARTIFACT_STATE_PATH = env_set_path('DBT_ARTIFACT_STATE_PATH')
-USE_LEGACY_LOGGER = env_set_truthy('DBT_USE_LEGACY_LOGGER')
+ENABLE_LEGACY_LOGGER = env_set_truthy('DBT_ENABLE_LEGACY_LOGGER')
 
 
 def _get_context():

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -576,7 +576,7 @@ def log_cache_events(flag):
     CACHE_LOGGER.disabled = not flag
 
 
-if not dbt.flags.USE_LEGACY_LOGGER:
+if not dbt.flags.ENABLE_LEGACY_LOGGER:
     logger.disable()
 GLOBAL_LOGGER = logger
 

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -576,7 +576,8 @@ def log_cache_events(flag):
     CACHE_LOGGER.disabled = not flag
 
 
-logger.disable()
+if not dbt.flags.USE_LEGACY_LOGGER:
+    logger.disable()
 GLOBAL_LOGGER = logger
 
 


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-rpc/issues/60

### Description

We need an escape hatch to use the legacy logger instead, for plugins with complex integrations that aren't worth cutting over (namely, `dbt-rpc`).

I coded this up using an env var, but I think the best version probably looks like an on/off switch (function) in the `logger` module that can be flipped by packages importing `dbt-core` (namely, `dbt-rpc`).

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- ~This PR includes tests, or tests are not required/relevant for this PR~
- ~I have updated the `CHANGELOG.md` and added information about my change~
