### PR TITLE
Minor Cleanup of Structured Logging Module

### DIFF
--- a/core/dbt/events/adapter_endpoint.py
+++ b/core/dbt/events/adapter_endpoint.py
@@ -17,7 +17,7 @@ class AdapterLogger():
         stack_info: Any = None,
         extra: Any = None
     ):
-        event = AdapterEventDebug(name=self.name, raw_msg=msg)
+        event = AdapterEventDebug(self.name, msg)
 
         event.exc_info = exc_info
         event.stack_info = stack_info
@@ -32,7 +32,7 @@ class AdapterLogger():
         stack_info: Any = None,
         extra: Any = None
     ):
-        event = AdapterEventInfo(name=self.name, raw_msg=msg)
+        event = AdapterEventInfo(self.name, msg)
 
         event.exc_info = exc_info
         event.stack_info = stack_info
@@ -47,7 +47,7 @@ class AdapterLogger():
         stack_info: Any = None,
         extra: Any = None
     ):
-        event = AdapterEventWarning(name=self.name, raw_msg=msg)
+        event = AdapterEventWarning(self.name, msg)
 
         event.exc_info = exc_info
         event.stack_info = stack_info
@@ -62,7 +62,7 @@ class AdapterLogger():
         stack_info: Any = None,
         extra: Any = None
     ):
-        event = AdapterEventError(name=self.name, raw_msg=msg)
+        event = AdapterEventError(self.name, msg)
 
         event.exc_info = exc_info
         event.stack_info = stack_info
@@ -77,7 +77,7 @@ class AdapterLogger():
         stack_info: Any = None,
         extra: Any = None
     ):
-        event = AdapterEventError(name=self.name, raw_msg=msg)
+        event = AdapterEventError(self.name, msg)
 
         event.exc_info = exc_info
         event.stack_info = stack_info

--- a/core/dbt/events/adapter_endpoint.py
+++ b/core/dbt/events/adapter_endpoint.py
@@ -11,7 +11,7 @@ class AdapterLogger():
     name: str
 
     def debug(self, *args, **kwargs):
-        event = AdapterEventDebug(self.name, *args, **kwargs)
+        event = AdapterEventDebug(self.name, args, kwargs)
 
         event.exc_info = or_none(kwargs, 'exc_info')
         event.stack_info = or_none(kwargs, 'stack_info')
@@ -20,7 +20,7 @@ class AdapterLogger():
         fire_event(event)
 
     def info(self, *args, **kwargs):
-        event = AdapterEventInfo(self.name, *args, **kwargs)
+        event = AdapterEventInfo(self.name, args, kwargs)
 
         event.exc_info = or_none(kwargs, 'exc_info')
         event.stack_info = or_none(kwargs, 'stack_info')
@@ -29,7 +29,7 @@ class AdapterLogger():
         fire_event(event)
 
     def warning(self, *args, **kwargs):
-        event = AdapterEventWarning(self.name, *args, **kwargs)
+        event = AdapterEventWarning(self.name, args, kwargs)
 
         event.exc_info = or_none(kwargs, 'exc_info')
         event.stack_info = or_none(kwargs, 'stack_info')
@@ -38,7 +38,7 @@ class AdapterLogger():
         fire_event(event)
 
     def error(self, *args, **kwargs):
-        event = AdapterEventError(self.name, *args, **kwargs)
+        event = AdapterEventError(self.name, args, kwargs)
 
         event.exc_info = or_none(kwargs, 'exc_info')
         event.stack_info = or_none(kwargs, 'stack_info')
@@ -47,7 +47,7 @@ class AdapterLogger():
         fire_event(event)
 
     def exception(self, *args, **kwargs):
-        event = AdapterEventError(self.name, *args, **kwargs)
+        event = AdapterEventError(self.name, args, kwargs)
 
         # defaulting exc_info=True if it is empty is what makes this method different
         x = or_none(kwargs, 'exc_info')

--- a/core/dbt/events/adapter_endpoint.py
+++ b/core/dbt/events/adapter_endpoint.py
@@ -3,84 +3,63 @@ from dbt.events.functions import fire_event
 from dbt.events.types import (
     AdapterEventDebug, AdapterEventInfo, AdapterEventWarning, AdapterEventError
 )
-from typing import Any
+from typing import Any, Optional
 
 
 @dataclass
 class AdapterLogger():
     name: str
 
-    def debug(
-        self,
-        msg: str,
-        exc_info: Any = None,
-        stack_info: Any = None,
-        extra: Any = None
-    ):
-        event = AdapterEventDebug(self.name, msg)
+    def debug(self, *args, **kwargs):
+        event = AdapterEventDebug(self.name, *args, **kwargs)
 
-        event.exc_info = exc_info
-        event.stack_info = stack_info
-        event.extra = extra
+        event.exc_info = or_none(kwargs, 'exc_info')
+        event.stack_info = or_none(kwargs, 'stack_info')
+        event.extra = or_none(kwargs, 'extra')
 
         fire_event(event)
 
-    def info(
-        self,
-        msg: str,
-        exc_info: Any = None,
-        stack_info: Any = None,
-        extra: Any = None
-    ):
-        event = AdapterEventInfo(self.name, msg)
+    def info(self, *args, **kwargs):
+        event = AdapterEventInfo(self.name, *args, **kwargs)
 
-        event.exc_info = exc_info
-        event.stack_info = stack_info
-        event.extra = extra
+        event.exc_info = or_none(kwargs, 'exc_info')
+        event.stack_info = or_none(kwargs, 'stack_info')
+        event.extra = or_none(kwargs, 'extra')
 
         fire_event(event)
 
-    def warning(
-        self,
-        msg: str,
-        exc_info: Any = None,
-        stack_info: Any = None,
-        extra: Any = None
-    ):
-        event = AdapterEventWarning(self.name, msg)
+    def warning(self, *args, **kwargs):
+        event = AdapterEventWarning(self.name, *args, **kwargs)
 
-        event.exc_info = exc_info
-        event.stack_info = stack_info
-        event.extra = extra
+        event.exc_info = or_none(kwargs, 'exc_info')
+        event.stack_info = or_none(kwargs, 'stack_info')
+        event.extra = or_none(kwargs, 'extra')
 
         fire_event(event)
 
-    def error(
-        self,
-        msg: str,
-        exc_info: Any = None,
-        stack_info: Any = None,
-        extra: Any = None
-    ):
-        event = AdapterEventError(self.name, msg)
+    def error(self, *args, **kwargs):
+        event = AdapterEventError(self.name, *args, **kwargs)
 
-        event.exc_info = exc_info
-        event.stack_info = stack_info
-        event.extra = extra
+        event.exc_info = or_none(kwargs, 'exc_info')
+        event.stack_info = or_none(kwargs, 'stack_info')
+        event.extra = or_none(kwargs, 'extra')
 
         fire_event(event)
 
-    def exception(
-        self,
-        msg: str,
-        exc_info: Any = True,  # this default is what makes this method different
-        stack_info: Any = None,
-        extra: Any = None
-    ):
-        event = AdapterEventError(self.name, msg)
+    def exception(self, *args, **kwargs):
+        event = AdapterEventError(self.name, *args, **kwargs)
 
-        event.exc_info = exc_info
-        event.stack_info = stack_info
-        event.extra = extra
+        # defaulting exc_info=True if it is empty is what makes this method different
+        x = or_none(kwargs, 'exc_info')
+        event.exc_info = x if x else True
+        event.stack_info = or_none(kwargs, 'stack_info')
+        event.extra = or_none(kwargs, 'extra')
 
         fire_event(event)
+
+
+def or_none(x: dict, key: str) -> Optional[Any]:
+    try:
+        return x[key]
+    except KeyError:
+        return None

--- a/core/dbt/events/adapter_endpoint.py
+++ b/core/dbt/events/adapter_endpoint.py
@@ -3,7 +3,6 @@ from dbt.events.functions import fire_event
 from dbt.events.types import (
     AdapterEventDebug, AdapterEventInfo, AdapterEventWarning, AdapterEventError
 )
-from typing import Any, Optional
 
 
 @dataclass
@@ -13,36 +12,36 @@ class AdapterLogger():
     def debug(self, *args, **kwargs):
         event = AdapterEventDebug(self.name, args, kwargs)
 
-        event.exc_info = or_none(kwargs, 'exc_info')
-        event.stack_info = or_none(kwargs, 'stack_info')
-        event.extra = or_none(kwargs, 'extra')
+        event.exc_info = kwargs.get('exc_info')
+        event.stack_info = kwargs.get('stack_info')
+        event.extra = kwargs.get('extra')
 
         fire_event(event)
 
     def info(self, *args, **kwargs):
         event = AdapterEventInfo(self.name, args, kwargs)
 
-        event.exc_info = or_none(kwargs, 'exc_info')
-        event.stack_info = or_none(kwargs, 'stack_info')
-        event.extra = or_none(kwargs, 'extra')
+        event.exc_info = kwargs.get('exc_info')
+        event.stack_info = kwargs.get('stack_info')
+        event.extra = kwargs.get('extra')
 
         fire_event(event)
 
     def warning(self, *args, **kwargs):
         event = AdapterEventWarning(self.name, args, kwargs)
 
-        event.exc_info = or_none(kwargs, 'exc_info')
-        event.stack_info = or_none(kwargs, 'stack_info')
-        event.extra = or_none(kwargs, 'extra')
+        event.exc_info = kwargs.get('exc_info')
+        event.stack_info = kwargs.get('stack_info')
+        event.extra = kwargs.get('extra')
 
         fire_event(event)
 
     def error(self, *args, **kwargs):
         event = AdapterEventError(self.name, args, kwargs)
 
-        event.exc_info = or_none(kwargs, 'exc_info')
-        event.stack_info = or_none(kwargs, 'stack_info')
-        event.extra = or_none(kwargs, 'extra')
+        event.exc_info = kwargs.get('exc_info')
+        event.stack_info = kwargs.get('stack_info')
+        event.extra = kwargs.get('extra')
 
         fire_event(event)
 
@@ -50,16 +49,9 @@ class AdapterLogger():
         event = AdapterEventError(self.name, args, kwargs)
 
         # defaulting exc_info=True if it is empty is what makes this method different
-        x = or_none(kwargs, 'exc_info')
+        x = kwargs.get('exc_info')
         event.exc_info = x if x else True
-        event.stack_info = or_none(kwargs, 'stack_info')
-        event.extra = or_none(kwargs, 'extra')
+        event.stack_info = kwargs.get('stack_info')
+        event.extra = kwargs.get('extra')
 
         fire_event(event)
-
-
-def or_none(x: dict, key: str) -> Optional[Any]:
-    try:
-        return x[key]
-    except KeyError:
-        return None

--- a/core/dbt/events/adapter_endpoint.py
+++ b/core/dbt/events/adapter_endpoint.py
@@ -9,49 +9,57 @@ from dbt.events.types import (
 class AdapterLogger():
     name: str
 
-    def debug(self, *args, **kwargs):
-        event = AdapterEventDebug(self.name, args, kwargs)
+    def debug(self, msg, *args, exc_info=None, extra=None, stack_info=False):
+        event = AdapterEventDebug(name=self.name, base_msg=msg, args=args)
 
-        event.exc_info = kwargs.get('exc_info')
-        event.stack_info = kwargs.get('stack_info')
-        event.extra = kwargs.get('extra')
-
-        fire_event(event)
-
-    def info(self, *args, **kwargs):
-        event = AdapterEventInfo(self.name, args, kwargs)
-
-        event.exc_info = kwargs.get('exc_info')
-        event.stack_info = kwargs.get('stack_info')
-        event.extra = kwargs.get('extra')
+        event.exc_info = exc_info
+        event.extra = extra
+        event.stack_info = stack_info
 
         fire_event(event)
 
-    def warning(self, *args, **kwargs):
-        event = AdapterEventWarning(self.name, args, kwargs)
+    def info(self, msg, *args, exc_info=None, extra=None, stack_info=False):
+        event = AdapterEventInfo(name=self.name, base_msg=msg, args=args)
 
-        event.exc_info = kwargs.get('exc_info')
-        event.stack_info = kwargs.get('stack_info')
-        event.extra = kwargs.get('extra')
-
-        fire_event(event)
-
-    def error(self, *args, **kwargs):
-        event = AdapterEventError(self.name, args, kwargs)
-
-        event.exc_info = kwargs.get('exc_info')
-        event.stack_info = kwargs.get('stack_info')
-        event.extra = kwargs.get('extra')
+        event.exc_info = exc_info
+        event.extra = extra
+        event.stack_info = stack_info
 
         fire_event(event)
 
-    def exception(self, *args, **kwargs):
-        event = AdapterEventError(self.name, args, kwargs)
+    def warning(self, msg, *args, exc_info=None, extra=None, stack_info=False):
+        event = AdapterEventWarning(name=self.name, base_msg=msg, args=args)
 
-        # defaulting exc_info=True if it is empty is what makes this method different
-        x = kwargs.get('exc_info')
-        event.exc_info = x if x else True
-        event.stack_info = kwargs.get('stack_info')
-        event.extra = kwargs.get('extra')
+        event.exc_info = exc_info
+        event.extra = extra
+        event.stack_info = stack_info
+
+        fire_event(event)
+
+    def error(self, msg, *args, exc_info=None, extra=None, stack_info=False):
+        event = AdapterEventError(name=self.name, base_msg=msg, args=args)
+
+        event.exc_info = exc_info
+        event.extra = extra
+        event.stack_info = stack_info
+
+        fire_event(event)
+
+    # The default exc_info=True is what makes this method different
+    def exception(self, msg, *args, exc_info=True, extra=None, stack_info=False):
+        event = AdapterEventError(name=self.name, base_msg=msg, args=args)
+
+        event.exc_info = exc_info
+        event.extra = extra
+        event.stack_info = stack_info
+
+        fire_event(event)
+
+    def critical(self, msg, *args, exc_info=False, extra=None, stack_info=False):
+        event = AdapterEventError(name=self.name, base_msg=msg, args=args)
+
+        event.exc_info = exc_info
+        event.extra = extra
+        event.stack_info = stack_info
 
         fire_event(event)

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
-from datetime import datetime
 from dataclasses import dataclass
+from datetime import datetime
 import os
 from typing import Any
 

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -5,7 +5,11 @@ import os
 from typing import Any
 
 
-# types to represent log levels
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# These base types define the _required structure_ for the concrete event #
+# types defined in types.py                                               #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
 
 # in preparation for #3977
 class TestLevel():

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -1,0 +1,85 @@
+from abc import ABCMeta, abstractmethod
+from datetime import datetime
+from dataclasses import dataclass
+import os
+from typing import Any
+
+
+# types to represent log levels
+
+# in preparation for #3977
+class TestLevel():
+    def level_tag(self) -> str:
+        return "test"
+
+
+class DebugLevel():
+    def level_tag(self) -> str:
+        return "debug"
+
+
+class InfoLevel():
+    def level_tag(self) -> str:
+        return "info"
+
+
+class WarnLevel():
+    def level_tag(self) -> str:
+        return "warn"
+
+
+class ErrorLevel():
+    def level_tag(self) -> str:
+        return "error"
+
+
+@dataclass
+class ShowException():
+    # N.B.:
+    # As long as we stick with the current convention of setting the member vars in the
+    # `message` method of subclasses, this is a safe operation.
+    # If that ever changes we'll want to reassess.
+    def __post_init__(self):
+        self.exc_info: Any = True
+        self.stack_info: Any = None
+        self.extra: Any = None
+
+
+# The following classes represent the data necessary to describe a
+# particular event to both human readable logs, and machine reliable
+# event streams. classes extend superclasses that indicate what
+# destinations they are intended for, which mypy uses to enforce
+# that the necessary methods are defined.
+
+
+# top-level superclass for all events
+class Event(metaclass=ABCMeta):
+    # fields that should be on all events with their default implementations
+    ts: datetime = datetime.now()
+    pid: int = os.getpid()
+    # code: int
+
+    # do not define this yourself. inherit it from one of the above level types.
+    @abstractmethod
+    def level_tag(self) -> str:
+        raise Exception("level_tag not implemented for event")
+
+    # Solely the human readable message. Timestamps and formatting will be added by the logger.
+    # Must override yourself
+    @abstractmethod
+    def message(self) -> str:
+        raise Exception("msg not implemented for cli event")
+
+
+class File(Event, metaclass=ABCMeta):
+    # Solely the human readable message. Timestamps and formatting will be added by the logger.
+    def file_msg(self) -> str:
+        # returns the event msg unless overriden in the concrete class
+        return self.message()
+
+
+class Cli(Event, metaclass=ABCMeta):
+    # Solely the human readable message. Timestamps and formatting will be added by the logger.
+    def cli_msg(self) -> str:
+        # returns the event msg unless overriden in the concrete class
+        return self.message()

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -49,6 +49,7 @@ class ShowException():
         self.extra: Any = None
 
 
+# TODO add exhaustiveness checking for subclasses
 # top-level superclass for all events
 class Event(metaclass=ABCMeta):
     # fields that should be on all events with their default implementations

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -49,6 +49,7 @@ class ShowException():
         self.extra: Any = None
 
 
+# TODO move this in a later commit
 # The following classes represent the data necessary to describe a
 # particular event to both human readable logs, and machine reliable
 # event streams. classes extend superclasses that indicate what
@@ -73,6 +74,18 @@ class Event(metaclass=ABCMeta):
     @abstractmethod
     def message(self) -> str:
         raise Exception("msg not implemented for cli event")
+
+    # returns a dictionary representation of the event fields. You must specify which of the
+    # available messages you would like to use (i.e. - e.message, e.cli_msg(), e.file_msg())
+    # used for constructing json formatted events. includes secrets which must be scrubbed at
+    # the usage site.
+    def to_dict(self, msg: str) -> dict:
+        level = self.level_tag()
+        return {
+            'pid': self.pid,
+            'msg': msg,
+            'level': level if len(level) == 5 else f"{level} "
+        }
 
 
 class File(Event, metaclass=ABCMeta):

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -49,14 +49,6 @@ class ShowException():
         self.extra: Any = None
 
 
-# TODO move this in a later commit
-# The following classes represent the data necessary to describe a
-# particular event to both human readable logs, and machine reliable
-# event streams. classes extend superclasses that indicate what
-# destinations they are intended for, which mypy uses to enforce
-# that the necessary methods are defined.
-
-
 # top-level superclass for all events
 class Event(metaclass=ABCMeta):
     # fields that should be on all events with their default implementations

--- a/core/dbt/events/format.py
+++ b/core/dbt/events/format.py
@@ -1,6 +1,6 @@
 from dbt import ui
-from typing import Optional, Union
 from dbt.node_types import NodeType
+from typing import Optional, Union
 
 
 def format_fancy_output_line(

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -210,8 +210,6 @@ def send_exc_to_logger(
 # to files, etc.)
 def fire_event(e: Event) -> None:
     # TODO manage history in phase 2:  EVENT_HISTORY.append(e)
-    # explicitly checking the debug flag here so that potentially expensive-to-construct
-    # log messages are not constructed if debug messages are never shown.
 
     # backwards compatibility for plugins that require old logger (dbt-rpc)
     if flags.ENABLE_LEGACY_LOGGER:
@@ -226,8 +224,11 @@ def fire_event(e: Event) -> None:
         send_to_logger(FILE_LOG, level_tag=e.level_tag(), log_line=log_line)
 
     if isinstance(e, Cli):
+        # explicitly checking the debug flag here so that potentially expensive-to-construct
+        # log messages are not constructed if debug messages are never shown.
         if e.level_tag() == 'debug' and not flags.DEBUG:
             return  # eat the message in case it was one of the expensive ones
+
         log_line = create_log_line(e, json_fmt=this.format_json, cli_dest=True)
         if not isinstance(e, ShowException):
             send_to_logger(STDOUT_LOG, level_tag=e.level_tag(), log_line=log_line)

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -1,7 +1,7 @@
 
 from colorama import Style
 import dbt.events.functions as this  # don't worry I hate it too.
-from dbt.events.types import Cli, Event, File, ShowException
+from dbt.events.base_types import Cli, Event, File, ShowException
 import dbt.flags as flags
 # TODO this will need to move eventually
 from dbt.logger import SECRET_ENV_PREFIX, make_log_dir_if_missing, GLOBAL_LOGGER

--- a/core/dbt/events/history.py
+++ b/core/dbt/events/history.py
@@ -1,4 +1,4 @@
-from dbt.events.types import Event
+from dbt.events.base_types import Event
 from typing import List
 
 

--- a/core/dbt/events/stubs.py
+++ b/core/dbt/events/stubs.py
@@ -1,7 +1,7 @@
 from typing import (
     Any,
-    Optional,
     NamedTuple,
+    Optional,
 )
 
 # N.B.:

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1,13 +1,13 @@
 import argparse
 from dataclasses import dataclass
-from typing import Any, Callable, cast, Dict, List, Optional, Set, Union
 from dbt.events.stubs import _CachedRelation, AdapterResponse, BaseRelation, _ReferenceKey
 from dbt import ui
-from dbt.node_types import NodeType
 from dbt.events.base_types import (
     Cli, File, DebugLevel, InfoLevel, WarnLevel, ErrorLevel, ShowException
 )
 from dbt.events.format import format_fancy_output_line, pluralize
+from dbt.node_types import NodeType
+from typing import Any, Callable, cast, Dict, List, Optional, Set, Union
 
 
 @dataclass

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1,3 +1,4 @@
+from abc import ABCMeta
 import argparse
 from dataclasses import dataclass
 from dbt.events.stubs import _CachedRelation, AdapterResponse, BaseRelation, _ReferenceKey
@@ -17,28 +18,30 @@ from typing import Any, Callable, cast, Dict, List, Optional, Set, Union
 # that the necessary methods are defined.
 
 
-@dataclass
-class AdapterEventBase():
-    name: str
-    raw_msg: str
+# can't use @dataclass because of https://github.com/python/mypy/issues/5374
+class AdapterEventBase(Cli, File, metaclass=ABCMeta):
+
+    def __init__(self, name: str, raw_msg: str):
+        self.name = name
+        self.raw_msg = raw_msg
 
     def message(self) -> str:
         return f"{self.name} adapter: {self.raw_msg}"
 
 
-class AdapterEventDebug(DebugLevel, AdapterEventBase, Cli, File, ShowException):
+class AdapterEventDebug(DebugLevel, ShowException, AdapterEventBase):
     pass
 
 
-class AdapterEventInfo(InfoLevel, AdapterEventBase, Cli, File, ShowException):
+class AdapterEventInfo(InfoLevel, ShowException, AdapterEventBase):
     pass
 
 
-class AdapterEventWarning(WarnLevel, AdapterEventBase, Cli, File, ShowException):
+class AdapterEventWarning(WarnLevel, ShowException, AdapterEventBase):
     pass
 
 
-class AdapterEventError(ErrorLevel, AdapterEventBase, Cli, File, ShowException):
+class AdapterEventError(ErrorLevel, ShowException, AdapterEventBase):
     pass
 
 

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -28,7 +28,7 @@ class AdapterEventBase(Cli, File):
 
     # instead of having this inherit from one of the level classes
     def level_tag(self) -> str:
-        raise Exception("level_tag not implemented for AdapterEventBase")
+        raise Exception("level_tag should never be called on AdapterEventBase")
 
     def message(self) -> str:
         # this class shouldn't be createable, but we can't make it an ABC because of a mypy bug
@@ -53,19 +53,19 @@ class AdapterEventBase(Cli, File):
         return f"{self.name} adapter: {msg}"
 
 
-class AdapterEventDebug(DebugLevel, ShowException, AdapterEventBase):
+class AdapterEventDebug(DebugLevel, AdapterEventBase, ShowException):
     pass
 
 
-class AdapterEventInfo(InfoLevel, ShowException, AdapterEventBase):
+class AdapterEventInfo(InfoLevel, AdapterEventBase, ShowException):
     pass
 
 
-class AdapterEventWarning(WarnLevel, ShowException, AdapterEventBase):
+class AdapterEventWarning(WarnLevel, AdapterEventBase, ShowException):
     pass
 
 
-class AdapterEventError(ErrorLevel, ShowException, AdapterEventBase):
+class AdapterEventError(ErrorLevel, AdapterEventBase, ShowException):
     pass
 
 

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1,93 +1,13 @@
-from abc import ABCMeta, abstractmethod
 import argparse
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Any, Callable, cast, Dict, List, Optional, Set, Union
 from dbt.events.stubs import _CachedRelation, AdapterResponse, BaseRelation, _ReferenceKey
 from dbt import ui
 from dbt.node_types import NodeType
+from dbt.events.base_types import (
+    Cli, File, DebugLevel, InfoLevel, WarnLevel, ErrorLevel, ShowException
+)
 from dbt.events.format import format_fancy_output_line, pluralize
-import os
-
-
-# types to represent log levels
-
-# in preparation for #3977
-class TestLevel():
-    def level_tag(self) -> str:
-        return "test"
-
-
-class DebugLevel():
-    def level_tag(self) -> str:
-        return "debug"
-
-
-class InfoLevel():
-    def level_tag(self) -> str:
-        return "info"
-
-
-class WarnLevel():
-    def level_tag(self) -> str:
-        return "warn"
-
-
-class ErrorLevel():
-    def level_tag(self) -> str:
-        return "error"
-
-
-@dataclass
-class ShowException():
-    # N.B.:
-    # As long as we stick with the current convention of setting the member vars in the
-    # `message` method of subclasses, this is a safe operation.
-    # If that ever changes we'll want to reassess.
-    def __post_init__(self):
-        self.exc_info: Any = True
-        self.stack_info: Any = None
-        self.extra: Any = None
-
-
-# The following classes represent the data necessary to describe a
-# particular event to both human readable logs, and machine reliable
-# event streams. classes extend superclasses that indicate what
-# destinations they are intended for, which mypy uses to enforce
-# that the necessary methods are defined.
-
-
-# top-level superclass for all events
-class Event(metaclass=ABCMeta):
-    # fields that should be on all events with their default implementations
-    ts: datetime = datetime.now()
-    pid: int = os.getpid()
-    # code: int
-
-    # do not define this yourself. inherit it from one of the above level types.
-    @abstractmethod
-    def level_tag(self) -> str:
-        raise Exception("level_tag not implemented for event")
-
-    # Solely the human readable message. Timestamps and formatting will be added by the logger.
-    # Must override yourself
-    @abstractmethod
-    def message(self) -> str:
-        raise Exception("msg not implemented for cli event")
-
-
-class File(Event, metaclass=ABCMeta):
-    # Solely the human readable message. Timestamps and formatting will be added by the logger.
-    def file_msg(self) -> str:
-        # returns the event msg unless overriden in the concrete class
-        return self.message()
-
-
-class Cli(Event, metaclass=ABCMeta):
-    # Solely the human readable message. Timestamps and formatting will be added by the logger.
-    def cli_msg(self) -> str:
-        # returns the event msg unless overriden in the concrete class
-        return self.message()
 
 
 @dataclass

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -10,6 +10,13 @@ from dbt.node_types import NodeType
 from typing import Any, Callable, cast, Dict, List, Optional, Set, Union
 
 
+# The classes in this file represent the data necessary to describe a
+# particular event to both human readable logs, and machine reliable
+# event streams. classes extend superclasses that indicate what
+# destinations they are intended for, which mypy uses to enforce
+# that the necessary methods are defined.
+
+
 @dataclass
 class AdapterEventBase():
     name: str

--- a/test/unit/test_events.py
+++ b/test/unit/test_events.py
@@ -1,0 +1,19 @@
+from dbt.events import AdapterLogger
+from unittest import TestCase
+
+
+class TestAdapterLogger(TestCase):
+
+    def setUp(self):
+        pass
+
+    # this interface is documented for adapter maintainers to plug into
+    # so we should test that it at the very least doesn't explode.
+    def test_adapter_logging_interface(self):
+        logger = AdapterLogger("dbt_tests")
+        logger.debug("debug message")
+        logger.info("info message")
+        logger.warning("warning message")
+        logger.error("error message")
+        logger.exception("exception message")
+        self.assertTrue(True)


### PR DESCRIPTION
### Description

1 - Cleaned up some of the code.

2- Fixed the adapter interface in here since post-cleanup it wasn't type checking. In the new system, the following logger call would have thrown a runtime exception before this change but is almost certainly present in the wild since it was found in our adapter tests:
`logger.info("ran this sql: {}", sql)`

~Rather than re-implement every way a python logger could be called, I just make the std lib logger construct the message component of the log line and hand it back with a stringio buffer.~ <- this strategy did not work because the std lib logger does not use new-style string formatting, only old-style.

I dug into some logger libraries and found that this string formatting is really the only thing that `*args` is doing. Python prefers it this way so it can be done lazily which we are already doing via a function. I apply these arguments with new-style formatting via `str::format` to maintain compatibility with the former logbook logger.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
