### PR TITLE
Avoid errors when missing column in yaml doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 ## dbt-core 1.0.0rc2 (TBD)
 
+### Features
+- Avoid error when missing column in YAML description ([#4151](https://github.com/dbt-labs/dbt-core/issues/4151), [#4285](https://github.com/dbt-labs/dbt-core/pull/4285))
+
 ### Under the hood
 Add --indirect-selection parameter to profiles.yml and builtin DBT_ env vars; stringified parameter to enable multi-modal use ([#3997](https://github.com/dbt-labs/dbt-core/issues/3997), [PR #4270](https://github.com/dbt-labs/dbt-core/pull/4270))
 - Fix filesystem searcher test failure on Python 3.9 ([#3689](https://github.com/dbt-labs/dbt-core/issues/3689), [#4271](https://github.com/dbt-labs/dbt-core/pull/4271))
 
+Contributors:
+- [@kadero](https://github.com/kadero) ([#4285](https://github.com/dbt-labs/dbt-core/pull/4285))
 
 ## dbt-core 1.0.0rc1 (November 10, 2021)
 

--- a/plugins/postgres/dbt/include/postgres/macros/adapters.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/adapters.sql
@@ -180,7 +180,8 @@
 
 
 {% macro postgres__alter_column_comment(relation, column_dict) %}
-  {% for column_name in column_dict %}
+  {% set existing_columns = adapter.get_columns_in_relation(relation) | map(attribute="name") | list %}
+  {% for column_name in column_dict if (column_name in existing_columns) %}
     {% set comment = column_dict[column_name]['description'] %}
     {% set escaped_comment = postgres_escape_comment(comment) %}
     comment on column {{ relation }}.{{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }} is {{ escaped_comment }};

--- a/test/integration/060_persist_docs_tests/models-column-missing/missing_column.sql
+++ b/test/integration/060_persist_docs_tests/models-column-missing/missing_column.sql
@@ -1,0 +1,2 @@
+{{ config(materialized='table') }}
+select 1 as id, 'Ed' as name

--- a/test/integration/060_persist_docs_tests/models-column-missing/schema.yaml
+++ b/test/integration/060_persist_docs_tests/models-column-missing/schema.yaml
@@ -1,0 +1,8 @@
+version: 2
+models:
+  - name: missing_column
+    columns:
+      - name: id
+        description: "test id column description"
+      - name: column_that_does_not_exist
+        description: "comment that cannot be created"


### PR DESCRIPTION
resolves #4151 

### Description
As described in the issue, we just need to update the postgres/redshift adapter.


I reproduced the issue described in the issue:
![image](https://user-images.githubusercontent.com/14804907/141972594-31f43d1c-2264-43d1-a5cd-cef9dfe55d2d.png)


With the fix, the `dbt run` pass:
![image](https://user-images.githubusercontent.com/14804907/141972666-b2972db4-060e-4845-947c-19a77121b3c9.png)

And the wrong fiied is not persisted:

![image](https://user-images.githubusercontent.com/14804907/141972715-b03e961d-3d1e-411a-b7fb-1abd324f4a17.png)



### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
