### PR TITLE
[#4252] Serialization error when missing quotes in metrics model ref() call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 - Avoid error when missing column in YAML description ([#4151](https://github.com/dbt-labs/dbt-core/issues/4151), [#4285](https://github.com/dbt-labs/dbt-core/pull/4285))
 
+### Fixes
+- Fix serialization error with missing quotes in metrics model ref ([#4252](https://github.com/dbt-labs/dbt-core/issues/4252), [#4287](https://github.com/dbt-labs/dbt-core/pull/4289))
+
 ### Under the hood
 Add --indirect-selection parameter to profiles.yml and builtin DBT_ env vars; stringified parameter to enable multi-modal use ([#3997](https://github.com/dbt-labs/dbt-core/issues/3997), [PR #4270](https://github.com/dbt-labs/dbt-core/pull/4270))
 - Fix filesystem searcher test failure on Python 3.9 ([#3689](https://github.com/dbt-labs/dbt-core/issues/3689), [#4271](https://github.com/dbt-labs/dbt-core/pull/4271))

--- a/test/integration/075_metrics_tests/invalid-models/people.sql
+++ b/test/integration/075_metrics_tests/invalid-models/people.sql
@@ -1,0 +1,3 @@
+select 1 as id, 'Drew' as first_name, 'Banin' as last_name, 'yellow' as favorite_color, true as loves_dbt, 5 as tenure, current_timestamp as created_at
+union all
+select 1 as id, 'Jeremy' as first_name, 'Cohen' as last_name, 'indigo' as favorite_color, true as loves_dbt, 4 as tenure, current_timestamp as created_at

--- a/test/integration/075_metrics_tests/invalid-models/people_metrics.yml
+++ b/test/integration/075_metrics_tests/invalid-models/people_metrics.yml
@@ -1,0 +1,30 @@
+version: 2
+
+metrics:
+
+  - model: "ref(people)"
+    name: number_of_people
+    description: Total count of people
+    label: "Number of people"
+    type: count
+    sql: "*"
+    timestamp: created_at
+    time_grains: [day, week, month]
+    dimensions:
+      - favorite_color
+      - loves_dbt
+    meta:
+        my_meta: 'testing'
+
+  - model: "ref(people)"
+    name: collective_tenure
+    description: Total number of years of team experience
+    label: "Collective tenure"
+    type: sum
+    sql: tenure
+    timestamp: created_at
+    time_grains: [day]
+    filters:
+      - field: loves_dbt
+        operator: is
+        value: 'true'

--- a/test/integration/075_metrics_tests/models/people.sql
+++ b/test/integration/075_metrics_tests/models/people.sql
@@ -1,0 +1,3 @@
+select 1 as id, 'Drew' as first_name, 'Banin' as last_name, 'yellow' as favorite_color, true as loves_dbt, 5 as tenure, current_timestamp as created_at
+union all
+select 1 as id, 'Jeremy' as first_name, 'Cohen' as last_name, 'indigo' as favorite_color, true as loves_dbt, 4 as tenure, current_timestamp as created_at

--- a/test/integration/075_metrics_tests/models/people_metrics.yml
+++ b/test/integration/075_metrics_tests/models/people_metrics.yml
@@ -1,0 +1,30 @@
+version: 2
+
+metrics:
+
+  - model: "ref('people')"
+    name: number_of_people
+    description: Total count of people
+    label: "Number of people"
+    type: count
+    sql: "*"
+    timestamp: created_at
+    time_grains: [day, week, month]
+    dimensions:
+      - favorite_color
+      - loves_dbt
+    meta:
+        my_meta: 'testing'
+
+  - model: "ref('people')"
+    name: collective_tenure
+    description: Total number of years of team experience
+    label: "Collective tenure"
+    type: sum
+    sql: tenure
+    timestamp: created_at
+    time_grains: [day]
+    filters:
+      - field: loves_dbt
+        operator: is
+        value: 'true'

--- a/test/integration/075_metrics_tests/test_metrics.py
+++ b/test/integration/075_metrics_tests/test_metrics.py
@@ -1,0 +1,59 @@
+from test.integration.base import DBTIntegrationTest, use_profile, normalize, get_manifest
+from dbt.exceptions import ParsingException
+
+class BaseMetricTest(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "test_075"
+
+    @property
+    def models(self):
+        return "models"
+
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'seed-paths': ['seeds'],
+            'seeds': {
+                'quote_columns': False,
+            },
+        }
+
+    @use_profile('postgres')
+    def test_postgres_simple_metric(self):
+        # initial run
+        results = self.run_dbt(["run"])
+        self.assertEqual(len(results), 1)
+        manifest = get_manifest()
+        metric_ids = list(manifest.metrics.keys())
+        expected_metric_ids = ['metric.test.number_of_people', 'metric.test.collective_tenure']
+        self.assertEqual(metric_ids, expected_metric_ids)
+
+class InvalidRefMetricTest(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "test_075"
+
+    @property
+    def models(self):
+        return "invalid-models"
+
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'seed-paths': ['seeds'],
+            'seeds': {
+                'quote_columns': False,
+            },
+        }
+
+    @use_profile('postgres')
+    def test_postgres_simple_metric(self):
+        # initial run
+        with self.assertRaises(ParsingException):
+            results = self.run_dbt(["run"])
+


### PR DESCRIPTION

resolves #4252

### Description

Add validation of metrics model ref call to ensure it contains a string.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
