### PR TITLE
Clean up project config rename deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 - Avoid error when missing column in YAML description ([#4151](https://github.com/dbt-labs/dbt-core/issues/4151), [#4285](https://github.com/dbt-labs/dbt-core/pull/4285))
 
 ### Under the hood
-Add --indirect-selection parameter to profiles.yml and builtin DBT_ env vars; stringified parameter to enable multi-modal use ([#3997](https://github.com/dbt-labs/dbt-core/issues/3997), [PR #4270](https://github.com/dbt-labs/dbt-core/pull/4270))
+- Add --indirect-selection parameter to profiles.yml and builtin DBT_ env vars; stringified parameter to enable multi-modal use ([#3997](https://github.com/dbt-labs/dbt-core/issues/3997), [#4270](https://github.com/dbt-labs/dbt-core/pull/4270))
 - Fix filesystem searcher test failure on Python 3.9 ([#3689](https://github.com/dbt-labs/dbt-core/issues/3689), [#4271](https://github.com/dbt-labs/dbt-core/pull/4271))
+- Clean up deprecation warnings shown for `dbt_project.yml` config renames ([#4276](https://github.com/dbt-labs/dbt-core/issues/4276), [#4291](https://github.com/dbt-labs/dbt-core/pull/4291))
 
 Contributors:
 - [@kadero](https://github.com/kadero) ([#4285](https://github.com/dbt-labs/dbt-core/pull/4285))

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -305,7 +305,7 @@ class PartialProject(RenderComponents):
                 )
                 raise DbtProjectError(msg.format(deprecated_path=deprecated_path,
                                                  exp_path=exp_path))
-            deprecations.warn('project_config_path',
+            deprecations.warn(f'project-config-{deprecated_path}',
                               deprecated_path=deprecated_path,
                               exp_path=exp_path)
 

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -36,7 +36,7 @@ class DBTDeprecation:
         if self.name not in active_deprecations:
             desc = self.description.format(**kwargs)
             msg = ui.line_wrap_message(
-                desc, prefix='* Deprecation Warning: '
+                desc, prefix='* Deprecation Warning:\n\n'
             )
             dbt.exceptions.warn_or_error(msg)
             self.track_deprecation_warn()
@@ -61,11 +61,18 @@ class PackageInstallPathDeprecation(DBTDeprecation):
 
 
 class ConfigPathDeprecation(DBTDeprecation):
-    _name = 'project_config_path'
     _description = '''\
     The `{deprecated_path}` config has been deprecated in favor of `{exp_path}`.
     Please update your `dbt_project.yml` configuration to reflect this change.
     '''
+
+
+class ConfigSourcePathDeprecation(ConfigPathDeprecation):
+    _name = 'project-config-source-paths'
+
+
+class ConfigDataPathDeprecation(ConfigPathDeprecation):
+    _name = 'project-config-data-paths'
 
 
 _adapter_renamed_description = """\
@@ -106,7 +113,8 @@ def warn(name, *args, **kwargs):
 active_deprecations: Set[str] = set()
 
 deprecations_list: List[DBTDeprecation] = [
-    ConfigPathDeprecation(),
+    ConfigSourcePathDeprecation(),
+    ConfigDataPathDeprecation(),
     PackageInstallPathDeprecation(),
     PackageRedirectDeprecation()
 ]

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -19,6 +19,8 @@ from typing import Callable, List, TypeVar, Union
 # create the global file logger with no configuration
 global FILE_LOG
 FILE_LOG = logging.getLogger('default_file')
+null_handler = logging.NullHandler()
+FILE_LOG.addHandler(null_handler)
 
 # set up logger to go to stdout with defaults
 # setup_event_logger will be called once args have been parsed

--- a/core/dbt/ui.py
+++ b/core/dbt/ui.py
@@ -62,8 +62,10 @@ def line_wrap_message(
     # (we'll turn it into a single line soon). Support windows, too.
     splitter = '\r\n\r\n' if '\r\n\r\n' in msg else '\n\n'
     chunks = msg.split(splitter)
-    return '\n'.join(textwrap.fill(chunk, width=width) for chunk in chunks)
+    return '\n'.join(textwrap.fill(chunk, width=width, break_on_hyphens=False) for chunk in chunks)
 
 
 def warning_tag(msg: str) -> str:
-    return f'[{yellow("WARNING")}]: {msg}'
+    # no longer needed, since new logging includes colorized log level
+    # return f'[{yellow("WARNING")}]: {msg}'
+    return msg

--- a/test/integration/012_deprecation_tests/test_deprecations.py
+++ b/test/integration/012_deprecation_tests/test_deprecations.py
@@ -34,7 +34,7 @@ class TestConfigPathDeprecation(BaseTestDeprecations):
     def test_postgres_data_path(self):
         self.assertEqual(deprecations.active_deprecations, set())
         self.run_dbt(['debug'])
-        expected = {'project_config_path'}
+        expected = {'project-config-data-paths'}
         self.assertEqual(expected, deprecations.active_deprecations)
 
     @use_profile('postgres')


### PR DESCRIPTION
resolves #4276

- Create different deprecation warnings for each of `source-paths` and `data-paths` being renamed, so that both will display for users newly upgraded to v1
- Add a null handler to the global `FILE_LOG` when it's first instantiated, to prevent the un-configured `FILE_LOG` and `STDOUT_LOG` from _both_ writing to stdout. This shouldn't have any functional impact, since the file logger isn't meant to be doing anything until it's configured, anyway

Also:
- Add `\n\n` to deprecation warning. `ui.line_wrap_message()` doesn't work perfectly with the new logging format just yet (it doesn't account for space taken up by timestamp + log level), so I'd prefer a cleaner break.
- In `ui.line_wrap_message()`, prevent `textwrap.fill()` from breaking on hyphens. This is awkward for `PackageRedirectDeprecation`, which includes hyphen-bearing package names.

Before:
```
$ dbt test
07:16:14 | [ info  ] | Running with dbt=1.0.0-rc1
07:16:14 | [ warn  ] | * Deprecation Warning: The `source-paths` config has been deprecated in favor of
`model-paths`. Please update your `dbt_project.yml` configuration to reflect
this change.
07:16:14 | [ warn  ] | * Deprecation Warning: The `source-paths` config has been deprecated in favor of
`model-paths`. Please update your `dbt_project.yml` configuration to reflect
this change.
```

After:
```
$ dbt test
06:50:56 | [ info  ] | Running with dbt=1.0.0-rc1
06:50:56 | [ warn  ] | * Deprecation Warning:
The `source-paths` config has been deprecated in favor of `model-paths`. Please
update your `dbt_project.yml` configuration to reflect this change.
06:50:56 | [ warn  ] | * Deprecation Warning:
The `data-paths` config has been deprecated in favor of `seed-paths`. Please
update your `dbt_project.yml` configuration to reflect this change.
```

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
