### PR TITLE
Misc logging cleanup + commentary

### DIFF
--- a/core/dbt/deps/git.py
+++ b/core/dbt/deps/git.py
@@ -94,7 +94,7 @@ class GitPinnedPackage(GitPackageMixin, PinnedPackage):
                 'The git package "{}" \n\tis {}.\n\tThis can introduce '
                 'breaking changes into your project without warning!\n\nSee {}'
                 .format(self.git, self.unpinned_msg(), PIN_PACKAGE_URL),
-                log_fmt=ui.yellow('WARNING: {}')
+                log_fmt=ui.warning_tag('{}')
             )
         loaded = Project.from_project_root(path, renderer)
         return ProjectPackageMetadata.from_project(loaded)

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -223,7 +223,11 @@ def fire_event(e: Event) -> None:
 
     # always logs debug level regardless of user input
     if isinstance(e, File):
-        log_line = create_json_log_line(e, msg_fn=lambda x: x.file_msg())
+        log_line = (
+            create_json_log_line(e, msg_fn=lambda x: x.file_msg())
+            if this.format_json else
+            create_text_log_line(e, msg_fn=lambda x: x.file_msg())
+        )
         # doesn't send exceptions to exception logger
         send_to_logger(FILE_LOG, level_tag=e.level_tag(), log_line=log_line)
 
@@ -233,7 +237,11 @@ def fire_event(e: Event) -> None:
         if e.level_tag() == 'debug' and not flags.DEBUG:
             return  # eat the message in case it was one of the expensive ones
 
-        log_line = create_json_log_line(e, msg_fn=lambda x: x.cli_msg())
+        log_line = (
+            create_json_log_line(e, msg_fn=lambda x: x.cli_msg())
+            if this.format_json else
+            create_text_log_line(e, msg_fn=lambda x: x.cli_msg())
+        )
         if not isinstance(e, ShowException):
             send_to_logger(STDOUT_LOG, level_tag=e.level_tag(), log_line=log_line)
         # CliEventABC and ShowException

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -652,7 +652,7 @@ class ProfileNotFound(InfoLevel, Cli, File):
 
 class InvalidVarsYAML(ErrorLevel, Cli, File):
     def message(self) -> str:
-        return "The YAML provided in the --vars argument is not valid.\n"
+        return "The YAML provided in the --vars argument is not valid."
 
 
 @dataclass
@@ -1237,7 +1237,7 @@ class DepsNotifyUpdatesAvailable(InfoLevel, Cli, File):
     packages: List[str]
 
     def message(self) -> str:
-        return ('\nUpdates available for packages: {} \
+        return ('Updates available for packages: {} \
                 \nUpdate your versions in packages.yml, then run dbt deps'.format(self.packages))
 
 
@@ -1249,7 +1249,9 @@ class DatabaseErrorRunning(InfoLevel, Cli, File):
         return f"Database error while running {self.hook_type}"
 
 
-class EmptyLine(InfoLevel, Cli, File):
+class EmptyLine(InfoLevel, Cli):
+    # ignore in file
+    # TODO: ignore if JSON formatted?
     def message(self) -> str:
         return ''
 
@@ -1329,7 +1331,7 @@ class ServingDocsAccessInfo(InfoLevel, Cli, File):
 
 class ServingDocsExitInfo(InfoLevel, Cli, File):
     def message(self) -> str:
-        return "Press Ctrl+C to exit.\n\n"
+        return "Press Ctrl+C to exit."
 
 
 @dataclass
@@ -1375,7 +1377,7 @@ class StatsLine(InfoLevel, Cli, File):
     stats: Dict
 
     def message(self) -> str:
-        stats_line = ("\nDone. PASS={pass} WARN={warn} ERROR={error} SKIP={skip} TOTAL={total}")
+        stats_line = ("Done. PASS={pass} WARN={warn} ERROR={error} SKIP={skip} TOTAL={total}")
         return stats_line.format(**self.stats)
 
 

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -283,34 +283,6 @@ class SystemReportReturnCode(DebugLevel, Cli, File):
 
 
 @dataclass
-class SelectorAlertUpto3UnusedNodes(InfoLevel, Cli, File):
-    node_names: List[str]
-
-    def message(self) -> str:
-        summary_nodes_str = ("\n  - ").join(self.node_names[:3])
-        and_more_str = (
-            f"\n  - and {len(self.node_names) - 3} more" if len(self.node_names) > 4 else ""
-        )
-        return (
-            f"\nSome tests were excluded because at least one parent is not selected. "
-            f"Use the --greedy flag to include them."
-            f"\n  - {summary_nodes_str}{and_more_str}"
-        )
-
-
-@dataclass
-class SelectorAlertAllUnusedNodes(DebugLevel, Cli, File):
-    node_names: List[str]
-
-    def message(self) -> str:
-        debug_nodes_str = ("\n  - ").join(self.node_names)
-        return (
-            f"Full list of tests that were excluded:"
-            f"\n  - {debug_nodes_str}"
-        )
-
-
-@dataclass
 class SelectorReportInvalidSelector(InfoLevel, Cli, File):
     selector_methods: dict
     spec_method: str
@@ -2176,8 +2148,6 @@ if 1 == 0:
     SystemStdOutMsg(bmsg=b'')
     SystemStdErrMsg(bmsg=b'')
     SystemReportReturnCode(code=0)
-    SelectorAlertUpto3UnusedNodes(node_names=[])
-    SelectorAlertAllUnusedNodes(node_names=[])
     SelectorReportInvalidSelector(selector_methods={'': ''}, spec_method='', raw_spec='')
     MacroEventInfo(msg='')
     MacroEventDebug(msg='')

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1841,10 +1841,11 @@ class QueryCancelationUnsupported(InfoLevel, Cli, File):
 
 @dataclass
 class ConcurrencyLine(InfoLevel, Cli, File):
-    concurrency_line: str
+    num_threads: int
+    target_name: str
 
     def message(self) -> str:
-        return self.concurrency_line
+        return f"Concurrency: {self.num_threads} threads (target='{self.target_name}')"
 
 
 @dataclass
@@ -2276,7 +2277,7 @@ if 1 == 0:
     NodeStart(unique_id='')
     NodeFinished(unique_id='')
     QueryCancelationUnsupported(type='')
-    ConcurrencyLine(concurrency_line='')
+    ConcurrencyLine(num_threads=0, target_name='')
     StarterProjectPath(dir='')
     ConfigFolderDirectory(dir='')
     NoSampleProfileFound(adapter='')

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -961,7 +961,7 @@ class MacroPatchParser(NonSourceParser[UnparsedMacroUpdate, ParsedMacroPatch]):
         macro = self.manifest.macros.get(unique_id)
         if not macro:
             warn_or_error(
-                f'WARNING: Found patch for macro "{patch.name}" '
+                f'Found patch for macro "{patch.name}" '
                 f'which was not found'
             )
             return

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -10,7 +10,7 @@ from dbt.deps.resolver import resolve_packages
 from dbt.events.functions import fire_event
 from dbt.events.types import (
     DepsNoPackagesFound, DepsStartPackageInstall, DepsUpdateAvailable, DepsUTD,
-    DepsInstallInfo, DepsListSubdirectory, DepsNotifyUpdatesAvailable
+    DepsInstallInfo, DepsListSubdirectory, DepsNotifyUpdatesAvailable, EmptyLine
 )
 from dbt.clients import system
 
@@ -81,6 +81,7 @@ class DepsTask(BaseTask):
                     source_type=source_type,
                     version=version)
             if packages_to_upgrade:
+                fire_event(EmptyLine())
                 fire_event(DepsNotifyUpdatesAvailable(packages=packages_to_upgrade))
 
     @classmethod

--- a/core/dbt/task/printer.py
+++ b/core/dbt/task/printer.py
@@ -65,6 +65,8 @@ def print_run_status_line(results) -> None:
         stats[result_type] += 1
         stats['total'] += 1
 
+    with TextOnly():
+        fire_event(EmptyLine())
     fire_event(StatsLine(stats=stats))
 
 

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -353,10 +353,8 @@ class GraphRunnableTask(ManifestTask):
         num_threads = self.config.threads
         target_name = self.config.target_name
 
-        text = "Concurrency: {} threads (target='{}')"
-        concurrency_line = text.format(num_threads, target_name)
         with NodeCount(self.num_nodes):
-            fire_event(ConcurrencyLine(concurrency_line=concurrency_line))
+            fire_event(ConcurrencyLine(num_threads=num_threads, target_name=target_name))
         with TextOnly():
             fire_event(EmptyLine())
 

--- a/core/dbt/task/serve.py
+++ b/core/dbt/task/serve.py
@@ -6,7 +6,7 @@ from dbt.include.global_project import DOCS_INDEX_FILE_PATH
 from http.server import SimpleHTTPRequestHandler
 from socketserver import TCPServer
 from dbt.events.functions import fire_event
-from dbt.events.types import ServingDocsPort, ServingDocsAccessInfo, ServingDocsExitInfo
+from dbt.events.types import ServingDocsPort, ServingDocsAccessInfo, ServingDocsExitInfo, EmptyLine
 
 from dbt.task.base import ConfiguredTask
 
@@ -22,6 +22,8 @@ class ServeTask(ConfiguredTask):
 
         fire_event(ServingDocsPort(address=address, port=port))
         fire_event(ServingDocsAccessInfo(port=port))
+        fire_event(EmptyLine())
+        fire_event(EmptyLine())
         fire_event(ServingDocsExitInfo())
 
         # mypy doesn't think SimpleHTTPRequestHandler is ok here, but it is

--- a/core/dbt/ui.py
+++ b/core/dbt/ui.py
@@ -66,4 +66,6 @@ def line_wrap_message(
 
 
 def warning_tag(msg: str) -> str:
-    return f'[{yellow("WARNING")}]: {msg}'
+    # duplicative now that new structured logs include levels
+    # return f'[{yellow("WARNING")}]: {msg}'
+    return msg


### PR DESCRIPTION
I played around with the logging module this morning from an end-user perspective. It was a lot of fun! There are some fixes we should definitely merge; some questions are open for discussion. I tried to keep the commits separate + clean, so we could split up and cherry-pick accordingly. This is all in the interest of making dbt look + feel "like dbt" by v1 final.

### Critical fixes
- #4266 turned on JSON-formatted logging everywhere all the time, _except_ for the legacy logger. Re-enable the choice between `create_json_log_line` and `create_text_log_line` based on `this.format_json`

### Touch-ups + cosmetic fixes
- For events whose messages were prefixed with `\n`, instead precede them with `fire_event(EmptyLine())`. This is much cleaner to look at, since all (non-wrapped) log lines get the same frontmatter (timestamp + log level)
- I happened to notice that `ConcurrencyLine` could be more structured (unless there's a good reason why it wasn't)
- If we're going to include log levels on the CLI (more on this below), disable duplicative `WARNING` prefixes in messages / formatted via `warning_tag`

### Commentary
- **Log levels:** These are amazing to have in the File. I find they add a bit too much noise on the CLI. I'd be happy with either (a) turning them off for CLI logging, or (b) colorizing `warn`/yellow + `error`/red to raise the signal from the noise. (Also, I believe #4266 removed width-fixing for log levels, so I added that back in.)
- **Colorization:** Ideally, we'd have a way to turn this off for both File + JSON-formatted logging. This would require a little bit of plumbing: `dbt.ui.color` would need information from the `events` module, beyond just `flags.USE_COLORS`. Since color methods are mostly called in messages defined on event classes, I wonder if this could work by adding a `use_color(self) -> bool` method to the `File` + `Cli` base types, and reimplementing the color methods to check `self.use_color` (where self = event class).
- **EmptyLine:** Just like colorization, this is great for CLI + text formatting, but we'd ideally have a way to turn it off for File or JSON logging. (This is what `logbook` accomplished via the `TextOnly()` wrapper; I realize I was a bit inconsistent in whether I used this.)

Broadly, I find that I want:
- color, concision, clean spacing on the CLI
- colorless + compact verbosity in the File + JSON-formatted

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
