### PR TITLE
Get prerelease packages when specifically requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 - Avoid error when missing column in YAML description ([#4151](https://github.com/dbt-labs/dbt-core/issues/4151), [#4285](https://github.com/dbt-labs/dbt-core/pull/4285))
 - Allow `--defer` flag to `dbt snapshot` ([#4110](https://github.com/dbt-labs/dbt-core/issues/4110), [#4296](https://github.com/dbt-labs/dbt-core/pull/4296))
+- Install prerelease packages when `version` explicitly references a prerelease version, regardless of `install-prerelease` status ([#4243](https://github.com/dbt-labs/dbt-core/issues/4243), [#4295](https://github.com/dbt-labs/dbt-core/pull/4295))
 
 ### Under the hood
 - Add --indirect-selection parameter to profiles.yml and builtin DBT_ env vars; stringified parameter to enable multi-modal use ([#3997](https://github.com/dbt-labs/dbt-core/issues/3997), [#4270](https://github.com/dbt-labs/dbt-core/pull/4270))
@@ -11,6 +12,7 @@
 
 Contributors:
 - [@kadero](https://github.com/kadero) ([#4285](https://github.com/dbt-labs/dbt-core/pull/4285), [#4296](https://github.com/dbt-labs/dbt-core/pull/4296))
+- [@joellabes](https://github.com/joellabes) ([#4295](https://github.com/dbt-labs/dbt-core/pull/4295))
 
 ## dbt-core 1.0.0rc1 (November 10, 2021)
 

--- a/core/dbt/deps/registry.py
+++ b/core/dbt/deps/registry.py
@@ -127,9 +127,12 @@ class RegistryUnpinnedPackage(
             raise DependencyException(new_msg) from e
 
         available = registry.get_available_versions(self.package)
+        prerelease_version_specified = any(
+            bool(version.prerelease) for version in self.versions
+        )
         installable = semver.filter_installable(
             available,
-            self.install_prerelease
+            self.install_prerelease or prerelease_version_specified
         )
         available_latest = installable[-1]
 

--- a/test/unit/test_deps.py
+++ b/test/unit/test_deps.py
@@ -472,6 +472,36 @@ class TestHubPackage(unittest.TestCase):
         self.assertEqual(c_pinned.get_version_latest(), '0.1.3')
         self.assertEqual(c_pinned.source_type(), 'hub')
 
+    def test_get_version_prerelease_explicitly_requested(self):
+        a_contract = RegistryPackage(
+            package='dbt-labs-test/a',
+            version='0.1.4a1',
+            install_prerelease=None
+        )
+
+        a = RegistryUnpinnedPackage.from_contract(a_contract)
+
+        self.assertEqual(a.package, 'dbt-labs-test/a')
+        self.assertEqual(
+            a.versions,
+            [
+                VersionSpecifier(
+                    build=None,
+                    major='0',
+                    matcher='=',
+                    minor='1',
+                    patch='4',
+                    prerelease='a1',
+                ),
+            ]
+        )
+
+        a_pinned = a.resolved()
+        self.assertEqual(a_pinned.package, 'dbt-labs-test/a')
+        self.assertEqual(a_pinned.version, '0.1.4a1')
+        self.assertEqual(a_pinned.get_version_latest(), '0.1.4a1')
+        self.assertEqual(a_pinned.source_type(), 'hub')
+
 class MockRegistry:
     def __init__(self, packages):
         self.packages = packages


### PR DESCRIPTION
resolves #4243 

### Description
Trying to install a prerelease version of dbt utils without the install-prerelease: True setting, e.g:
```yml
packages:
  - package: dbt-labs/dbt_utils
    version: 0.7.4-b1 
```
fails. Requesting a prerelease package by name should be enough to trigger its installation.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
