### PR TITLE
Alow snapshot defer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ### Features
 - Avoid error when missing column in YAML description ([#4151](https://github.com/dbt-labs/dbt-core/issues/4151), [#4285](https://github.com/dbt-labs/dbt-core/pull/4285))
+- Allow `--defer` flag to `dbt snapshot` ([#4110](https://github.com/dbt-labs/dbt-core/issues/4110), [#4296](https://github.com/dbt-labs/dbt-core/pull/4296))
 
 ### Under the hood
 Add --indirect-selection parameter to profiles.yml and builtin DBT_ env vars; stringified parameter to enable multi-modal use ([#3997](https://github.com/dbt-labs/dbt-core/issues/3997), [PR #4270](https://github.com/dbt-labs/dbt-core/pull/4270))
 - Fix filesystem searcher test failure on Python 3.9 ([#3689](https://github.com/dbt-labs/dbt-core/issues/3689), [#4271](https://github.com/dbt-labs/dbt-core/pull/4271))
 
 Contributors:
-- [@kadero](https://github.com/kadero) ([#4285](https://github.com/dbt-labs/dbt-core/pull/4285))
+- [@kadero](https://github.com/kadero) ([#4285](https://github.com/dbt-labs/dbt-core/pull/4285), [#4296](https://github.com/dbt-labs/dbt-core/pull/4296))
 
 ## dbt-core 1.0.0rc1 (November 10, 2021)
 

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -1109,7 +1109,7 @@ def parse_args(args, cls=DBTArgumentParser):
     _add_selection_arguments(
         run_sub, compile_sub, generate_sub, test_sub, snapshot_sub, seed_sub)
     # --defer
-    _add_defer_argument(run_sub, test_sub, build_sub)
+    _add_defer_argument(run_sub, test_sub, build_sub, snapshot_sub)
     # --full-refresh
     _add_table_mutability_arguments(run_sub, compile_sub, build_sub)
 

--- a/core/dbt/task/snapshot.py
+++ b/core/dbt/task/snapshot.py
@@ -43,10 +43,6 @@ class SnapshotTask(RunTask):
     def raise_on_first_error(self):
         return False
 
-    def defer_to_manifest(self, adapter, selected_uids):
-        # snapshots don't defer
-        return
-
     def get_node_selector(self):
         if self.manifest is None or self.graph is None:
             raise InternalException(


### PR DESCRIPTION
resolves #4110

### Description

Allow `--defer` to `dbt snapshot`. Following implementation plan described [here](https://github.com/dbt-labs/dbt-core/issues/4110#issuecomment-948845375) :slightly_smiling_face: .

Tested in dev:
![image](https://user-images.githubusercontent.com/14804907/142177869-0b678c68-db55-4e21-a218-5130d91c9d6c.png)





:warning:  Not in scope of this PR and can be done later in another PR:
-  Add the --defer flag to the compile and docs subparsers, too
- Move defer_to_manifest up from RunTask into CompileTask (its parent)


### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
