### PR TITLE
[#4272] Move validator keyword argument in jinja 'config.get' to after default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 - Avoid error when missing column in YAML description ([#4151](https://github.com/dbt-labs/dbt-core/issues/4151), [#4285](https://github.com/dbt-labs/dbt-core/pull/4285))
 
+### Fixes
+- Allow specifying default in Jinja config.get with default keyword ([#4273](https://github.com/dbt-labs/dbt-core/issues/4273), [#4297](https://github.com/dbt-labs/dbt-core/pull/4297))
+
 ### Under the hood
 Add --indirect-selection parameter to profiles.yml and builtin DBT_ env vars; stringified parameter to enable multi-modal use ([#3997](https://github.com/dbt-labs/dbt-core/issues/3997), [PR #4270](https://github.com/dbt-labs/dbt-core/pull/4270))
 - Fix filesystem searcher test failure on Python 3.9 ([#3689](https://github.com/dbt-labs/dbt-core/issues/3689), [#4271](https://github.com/dbt-labs/dbt-core/pull/4271))

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -325,7 +325,7 @@ class ParseConfigObject(Config):
     def require(self, name, validator=None):
         return ''
 
-    def get(self, name, validator=None, default=None):
+    def get(self, name, default=None, validator=None):
         return ''
 
     def persist_relation_docs(self) -> bool:
@@ -369,7 +369,7 @@ class RuntimeConfigObject(Config):
 
         return to_return
 
-    def get(self, name, validator=None, default=None):
+    def get(self, name, default=None, validator=None):
         to_return = self._lookup(name, default)
 
         if validator is not None and default is not None:

--- a/test/integration/039_config_test/models-get/any_model.sql
+++ b/test/integration/039_config_test/models-get/any_model.sql
@@ -1,0 +1,2 @@
+-- models/any_model.sql
+select {{ config.get('made_up_nonexistent_key', 'default_value') }} as col_value

--- a/test/integration/039_config_test/test_configs.py
+++ b/test/integration/039_config_test/test_configs.py
@@ -296,3 +296,23 @@ class TestConfigIndivTests(DBTIntegrationTest):
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0].status, 'fail')
         self.assertEqual(results[1].status, 'fail')
+
+
+
+class TestConfigGetDefault(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "config_039"
+
+    @property
+    def models(self):
+        return "models-get"
+
+    @use_profile('postgres')
+    def test_postgres_config_with_get_default(self):
+        # This test runs a model with a config.get(key, default)
+        # The default value is 'default_value' and causes an error
+        results = self.run_dbt(['run'], expect_pass=False)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(str(results[0].status), 'error')
+        self.assertIn('column "default_value" does not exist', results[0].message)


### PR DESCRIPTION

resolves #4272

### Description

The context provider code was wrapping the 'config.get' call in Jinja so that a default in the code required specifying the 'default=" keyword. This moves the order of the get validator param to after default so it's not necessary to specify the keyword.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
