### PR TITLE
[#4298] Fix 'created_at' in ParsedMetric to allow recalculating metrics depends_on refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 - Avoid error when missing column in YAML description ([#4151](https://github.com/dbt-labs/dbt-core/issues/4151), [#4285](https://github.com/dbt-labs/dbt-core/pull/4285))
 
+### Fixes
+- Correct definition of 'created_at' in ParsedMetric nodes ([#4298](http://github.com/dbt-labs/dbt-core/issues/4298), [#4299](https://github.com/dbt-labs/dbt-core/pull/4299))
+
 ### Under the hood
 Add --indirect-selection parameter to profiles.yml and builtin DBT_ env vars; stringified parameter to enable multi-modal use ([#3997](https://github.com/dbt-labs/dbt-core/issues/3997), [PR #4270](https://github.com/dbt-labs/dbt-core/pull/4270))
 - Fix filesystem searcher test failure on Python 3.9 ([#3689](https://github.com/dbt-labs/dbt-core/issues/3689), [#4271](https://github.com/dbt-labs/dbt-core/pull/4271))

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -800,7 +800,7 @@ class ParsedMetric(UnparsedBaseNode, HasUniqueID, HasFqn):
     sources: List[List[str]] = field(default_factory=list)
     depends_on: DependsOn = field(default_factory=DependsOn)
     refs: List[List[str]] = field(default_factory=list)
-    created_at: int = field(default_factory=lambda: int(time.time()))
+    created_at: float = field(default_factory=lambda: time.time())
 
     @property
     def depends_on_nodes(self):

--- a/test/integration/068_partial_parsing_tests/test_pp_metrics.py
+++ b/test/integration/068_partial_parsing_tests/test_pp_metrics.py
@@ -74,6 +74,8 @@ class MetricsTest(BasePPTest):
         self.assertEqual(metric_people.meta, expected_meta)
         self.assertEqual(metric_people.refs, [['people']])
         self.assertEqual(metric_tenure.refs, [['people']])
+        expected_depends_on_nodes = ['model.test.people']
+        self.assertEqual(metric_people.depends_on.nodes, expected_depends_on_nodes)
 
         # Change metrics yaml files
         self.copy_file('test-files/people_metrics2.yml', 'models/people_metrics.yml')
@@ -83,3 +85,6 @@ class MetricsTest(BasePPTest):
         metric_people = manifest.metrics[metric_people_id]
         expected_meta = {'my_meta': 'replaced'}
         self.assertEqual(metric_people.meta, expected_meta)
+        expected_depends_on_nodes = ['model.test.people']
+        self.assertEqual(metric_people.depends_on.nodes, expected_depends_on_nodes)
+


### PR DESCRIPTION

resolves #4298

### Description

The definition of the created_at field had changed from an int to a float while the metrics feature was being developed. Change metrics node 'created_at' to match so that depends_on.nodes is recalculated with partial parsing.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
