### PR TITLE
structured logging: add data attributes to json log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Avoid error when missing column in YAML description ([#4151](https://github.com/dbt-labs/dbt-core/issues/4151), [#4285](https://github.com/dbt-labs/dbt-core/pull/4285))
 - Allow `--defer` flag to `dbt snapshot` ([#4110](https://github.com/dbt-labs/dbt-core/issues/4110), [#4296](https://github.com/dbt-labs/dbt-core/pull/4296))
 - Install prerelease packages when `version` explicitly references a prerelease version, regardless of `install-prerelease` status ([#4243](https://github.com/dbt-labs/dbt-core/issues/4243), [#4295](https://github.com/dbt-labs/dbt-core/pull/4295))
+- Add data attributes to json log messages[#4301](https://github.com/dbt-labs/dbt-core/pull/4301)
 
 ### Fixes
 - Fix serialization error with missing quotes in metrics model ref ([#4252](https://github.com/dbt-labs/dbt-core/issues/4252), [#4287](https://github.com/dbt-labs/dbt-core/pull/4289))

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -2,8 +2,7 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 import os
-from typing import Any, Optional
-
+from typing import Any, Dict, Optional
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -83,7 +83,6 @@ class Event(metaclass=ABCMeta):
         return self.pid
 
 
-
 class File(Event, metaclass=ABCMeta):
     # Solely the human readable message. Timestamps and formatting will be added by the logger.
     def file_msg(self) -> str:

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -5,6 +5,7 @@ import os
 from typing import Any, Optional
 
 
+
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # These base types define the _required structure_ for the concrete event #
 # types defined in types.py                                               #
@@ -80,6 +81,7 @@ class Event(metaclass=ABCMeta):
         if not self.pid:
             self.pid = os.getpid()
         return self.pid
+
 
 
 class File(Event, metaclass=ABCMeta):

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -2,7 +2,7 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -14,7 +14,7 @@ import logging
 from logging import Logger
 from logging.handlers import RotatingFileHandler
 import os
-from typing import Callable, List, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 from dataclasses import _FIELD_BASE  # type: ignore[attr-defined]
 
 
@@ -121,7 +121,9 @@ def event_to_dict(e: T_Event, msg_fn: Callable[[T_Event], str]) -> dict:
         'ts': e.get_ts(),
         'pid': e.get_pid(),
         'msg': msg_fn(e),
-        'level': level
+        'level': level,
+        'data': Optional[Dict[str, Any]],
+        'event_data_serialized': True
     }
 
 
@@ -161,9 +163,10 @@ def create_json_log_line(e: T_Event, msg_fn: Callable[[T_Event], str]) -> str:
     except TypeError:
         # the only key currently throwing errors is 'data'.  Expand this list
         # as needed if new issues pop up
-        safe_values = {k: v for (k, v) in values.items() if k not in ('data')}
+        values['data'] = None
+        values['event_data_serialized'] = False
         log_line = json.dumps(
-            {k: scrub_secrets(v, env_secrets()) for (k, v) in safe_values.items()},
+            {k: scrub_secrets(v, env_secrets()) for (k, v) in values.items()},
             sort_keys=True
         )
     return log_line

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -141,6 +141,7 @@ def create_text_log_line(e: T_Event, msg_fn: Callable[[T_Event], str]) -> str:
 def create_json_log_line(e: T_Event, msg_fn: Callable[[T_Event], str]) -> str:
     values = event_to_dict(e, lambda x: scrub_secrets(msg_fn(x), env_secrets()))
     values['ts'] = e.get_ts().isoformat()
+    values['data'] = {k: scrub_secrets(str(v), env_secrets()) for (k, v) in e.__dict__.items()}
     log_line = json.dumps(values, sort_keys=True)
     return log_line
 

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -141,7 +141,7 @@ def create_text_log_line(e: T_Event, msg_fn: Callable[[T_Event], str]) -> str:
 def create_json_log_line(e: T_Event, msg_fn: Callable[[T_Event], str]) -> str:
     values = event_to_dict(e, lambda x: scrub_secrets(msg_fn(x), env_secrets()))
     values['ts'] = e.get_ts().isoformat()
-    values['data'] = {k: scrub_secrets(str(v), env_secrets()) for (k, v) in e.__dict__.items()}
+    values['data'] = {k: scrub_secrets(str(v), env_secrets()) for (k, v) in vars(e).items()}
     log_line = json.dumps(values, sort_keys=True)
     return log_line
 

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -15,6 +15,7 @@ from logging import Logger
 from logging.handlers import RotatingFileHandler
 import os
 from typing import Callable, List, Union
+from dataclasses import _FIELD_BASE  # type: ignore[attr-defined]
 
 
 # create the global file logger with no configuration
@@ -136,13 +137,33 @@ def create_text_log_line(e: T_Event, msg_fn: Callable[[T_Event], str]) -> str:
     return log_line
 
 
+# classes and sets are returned that cannot be natively encoded to json
+def set_default(obj):
+    if hasattr(obj, '__dict__'):
+        return obj.__dict__
+    if isinstance(obj, set):
+        return list(obj)
+    return str(obj)
+
+
 # translates an Event to a completely formatted json log line
 # you have to specify which message you want. (i.e. - e.message, e.cli_msg(), e.file_msg())
 def create_json_log_line(e: T_Event, msg_fn: Callable[[T_Event], str]) -> str:
     values = event_to_dict(e, lambda x: scrub_secrets(msg_fn(x), env_secrets()))
     values['ts'] = e.get_ts().isoformat()
-    values['data'] = {k: scrub_secrets(str(v), env_secrets()) for (k, v) in vars(e).items()}
-    log_line = json.dumps(values, sort_keys=True)
+    if hasattr(e, '__dataclass_fields__'):
+        values['data'] = {
+            x: getattr(e, x) for x, y
+            in e.__dataclass_fields__.items()  # type: ignore[attr-defined]
+            if type(y._field_type) == _FIELD_BASE
+        }
+    else:
+        values['data'] = None
+    log_line = json.dumps(
+        {k: scrub_secrets(v, env_secrets()) for (k, v) in values.items()},
+        default=lambda x: set_default(x),
+        sort_keys=True
+    )
     return log_line
 
 


### PR DESCRIPTION
### Description

Add the dataclass attributes to a data key in the json log output.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
