### PR TITLE
adjust level length for text only

### DIFF
--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -73,11 +73,10 @@ class Event(metaclass=ABCMeta):
     # used for constructing json formatted events. includes secrets which must be scrubbed at
     # the usage site.
     def to_dict(self, msg: str) -> dict:
-        level = self.level_tag()
         return {
             'pid': self.pid,
             'msg': msg,
-            'level': level if len(level) == 5 else f"{level} "
+            'level': self.level_tag()
         }
 
 

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -119,7 +119,7 @@ def create_text_log_line(e: T_Event, msg_fn: Callable[[T_Event], str]) -> str:
     color_tag: str = '' if this.format_color else Style.RESET_ALL
     ts: str = e.ts.strftime("%H:%M:%S")
     scrubbed_msg: str = scrub_secrets(msg_fn(e), env_secrets())
-    level: str = e.level_tag() if len(e.level_tag()) == 5 else f"{level} "
+    level: str = e.level_tag() if len(e.level_tag()) == 5 else f"{e.level_tag()} "
     log_line: str = f"{color_tag}{ts} | [ {level} ] | {scrubbed_msg}"
     return log_line
 

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -119,7 +119,7 @@ def create_text_log_line(e: T_Event, msg_fn: Callable[[T_Event], str]) -> str:
     color_tag: str = '' if this.format_color else Style.RESET_ALL
     ts: str = e.ts.strftime("%H:%M:%S")
     scrubbed_msg: str = scrub_secrets(msg_fn(e), env_secrets())
-    level: str = e.level_tag()
+    level: str = e.level_tag() if len(e.level_tag()) == 5 else f"{level} "
     log_line: str = f"{color_tag}{ts} | [ {level} ] | {scrubbed_msg}"
     return log_line
 


### PR DESCRIPTION
### Description

level lengths need to line up in stdout but explicitly shouldn't for json outputs.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
