### PR TITLE
Fix adapter failures due to string formatting issues

### DIFF
--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -35,7 +35,13 @@ class AdapterEventBase(Cli, File):
                 'attempted to create a message for AdapterEventBase which cannot be created'
             )
 
-        msg = self.base_msg.format(*self.args)
+        # only apply formatting if there are arguments to format.
+        # avoids issues like "dict: {k: v}".format() which results in `KeyError 'k'`
+        msg = (
+            self.base_msg
+            if len(self.args) == 0 else
+            self.base_msg.format(*self.args)
+        )
         return f"{self.name} adapter: {msg}"
 
 

--- a/test/unit/test_events.py
+++ b/test/unit/test_events.py
@@ -1,4 +1,5 @@
 from dbt.events import AdapterLogger
+from dbt.events.types import AdapterEventDebug
 from unittest import TestCase
 
 
@@ -9,11 +10,38 @@ class TestAdapterLogger(TestCase):
 
     # this interface is documented for adapter maintainers to plug into
     # so we should test that it at the very least doesn't explode.
-    def test_adapter_logging_interface(self):
+    def test_basic_adapter_logging_interface(self):
         logger = AdapterLogger("dbt_tests")
         logger.debug("debug message")
         logger.info("info message")
         logger.warning("warning message")
         logger.error("error message")
         logger.exception("exception message")
+        logger.critical("exception message")
         self.assertTrue(True)
+
+    # python loggers allow deferring string formatting via this signature:
+    def test_formatting(self):
+        logger = AdapterLogger("dbt_tests")
+        # tests that it doesn't throw
+        logger.debug("hello {}", 'world')
+
+        # enters lower in the call stack to test that it formats correctly
+        event = AdapterEventDebug(name="dbt_tests", base_msg="hello {}", args=('world',))
+        self.assertTrue("hello world" in event.message())
+
+        # tests that it doesn't throw
+        logger.debug("1 2 {}", 3)
+
+        # enters lower in the call stack to test that it formats correctly
+        event = AdapterEventDebug(name="dbt_tests", base_msg="1 2 {}", args=(3,))
+        self.assertTrue("1 2 3" in event.message())
+
+        # tests that it doesn't throw
+        logger.debug("boop{x}boop")
+
+        # enters lower in the call stack to test that it formats correctly
+        # in this case it's that we didn't attempt to replace anything since there
+        # were no args passed after the initial message
+        event = AdapterEventDebug(name="dbt_tests", base_msg="boop{x}boop", args=())
+        self.assertTrue("boop{x}boop" in event.message())


### PR DESCRIPTION
### Description

This is an alternative solution to dbt-redshift#43. Prior to this change, log messages passed to the AdapterLogger that had brackets in them would trigger a KeyError when we tried to format with an empty set of arguments. This solution is preferred to dbt-redshift#43 because it fixes an existing interface problem.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
