### PR TITLE
SecretContext for secret env vars, profiles + packages only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 ## dbt-core 1.0.0rc2 (TBD)
 
+### Breaking changes
+- Restrict secret env vars (prefixed `DBT_ENV_SECRET_`) to `profiles.yml` + `packages.yml` _only_. Raise an exception if a secret env var is used elsewhere ([#4310](https://github.com/dbt-labs/dbt-core/issues/4310), [#4311](https://github.com/dbt-labs/dbt-core/pull/4311))
+- Reorder arguments to `config.get()` so that `default` is second ([#4273](https://github.com/dbt-labs/dbt-core/issues/4273), [#4297](https://github.com/dbt-labs/dbt-core/pull/4297))
+
 ### Features
 - Avoid error when missing column in YAML description ([#4151](https://github.com/dbt-labs/dbt-core/issues/4151), [#4285](https://github.com/dbt-labs/dbt-core/pull/4285))
 - Allow `--defer` flag to `dbt snapshot` ([#4110](https://github.com/dbt-labs/dbt-core/issues/4110), [#4296](https://github.com/dbt-labs/dbt-core/pull/4296))
 - Install prerelease packages when `version` explicitly references a prerelease version, regardless of `install-prerelease` status ([#4243](https://github.com/dbt-labs/dbt-core/issues/4243), [#4295](https://github.com/dbt-labs/dbt-core/pull/4295))
-
-### Fixes
-- Allow specifying default in Jinja config.get with default keyword ([#4273](https://github.com/dbt-labs/dbt-core/issues/4273), [#4297](https://github.com/dbt-labs/dbt-core/pull/4297))
 
 ### Fixes
 - Fix serialization error with missing quotes in metrics model ref ([#4252](https://github.com/dbt-labs/dbt-core/issues/4252), [#4287](https://github.com/dbt-labs/dbt-core/pull/4289))

--- a/core/dbt/config/renderer.py
+++ b/core/dbt/config/renderer.py
@@ -2,6 +2,7 @@ from typing import Dict, Any, Tuple, Optional, Union, Callable
 
 from dbt.clients.jinja import get_rendered, catch_jinja
 from dbt.context.target import TargetContext
+from dbt.context.secret import SecretContext
 from dbt.context.base import BaseContext
 from dbt.contracts.connection import HasCredentials
 from dbt.exceptions import (
@@ -175,8 +176,7 @@ class DbtProjectYamlRenderer(BaseRenderer):
         return True
 
 
-class ProfileRenderer(BaseRenderer):
-
+class SecretRenderer(BaseRenderer):
     def __init__(
         self, cli_vars: Optional[Dict[str, Any]] = None
     ) -> None:
@@ -184,16 +184,22 @@ class ProfileRenderer(BaseRenderer):
         # object in order to retrieve the env_vars.
         if cli_vars is None:
             cli_vars = {}
-        self.ctx_obj = BaseContext(cli_vars)
+        self.ctx_obj = SecretContext(cli_vars)
         context = self.ctx_obj.to_dict()
         super().__init__(context)
+        
+    @property
+    def name(self):
+        'Secret'
 
+
+class ProfileRenderer(SecretRenderer):
     @property
     def name(self):
         'Profile'
 
 
-class PackageRenderer(BaseRenderer):
+class PackageRenderer(SecretRenderer):
     @property
     def name(self):
         return 'Packages config'

--- a/core/dbt/config/renderer.py
+++ b/core/dbt/config/renderer.py
@@ -176,6 +176,12 @@ class DbtProjectYamlRenderer(BaseRenderer):
         return True
 
 
+class SelectorRenderer(BaseRenderer):
+    @property
+    def name(self):
+        return 'Selector config'
+
+
 class SecretRenderer(BaseRenderer):
     def __init__(
         self, cli_vars: Optional[Dict[str, Any]] = None
@@ -187,25 +193,19 @@ class SecretRenderer(BaseRenderer):
         self.ctx_obj = SecretContext(cli_vars)
         context = self.ctx_obj.to_dict()
         super().__init__(context)
-        
+
     @property
     def name(self):
-        'Secret'
+        return 'Secret'
 
 
 class ProfileRenderer(SecretRenderer):
     @property
     def name(self):
-        'Profile'
+        return 'Profile'
 
 
 class PackageRenderer(SecretRenderer):
     @property
     def name(self):
         return 'Packages config'
-
-
-class SelectorRenderer(BaseRenderer):
-    @property
-    def name(self):
-        return 'Selector config'

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -313,6 +313,8 @@ class BaseContext(metaclass=ContextMeta):
         If the default is None, raise an exception for an undefined variable.
         """
         return_value = None
+        if var.startswith(SECRET_ENV_PREFIX):
+            raise_parsing_error("You can't do that here!")
         if var in os.environ:
             return_value = os.environ[var]
         elif default is not None:

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -11,7 +11,10 @@ from dbt.clients.yaml_helper import (  # noqa: F401
     yaml, safe_load, SafeLoader, Loader, Dumper
 )
 from dbt.contracts.graph.compiled import CompiledResource
-from dbt.exceptions import raise_compiler_error, MacroReturn, raise_parsing_error
+from dbt.exceptions import (
+    raise_compiler_error, MacroReturn, raise_parsing_error, disallow_secret_env_var
+)
+from dbt.logger import SECRET_ENV_PREFIX
 from dbt.events.functions import fire_event
 from dbt.events.types import MacroEventInfo, MacroEventDebug
 from dbt.version import __version__ as dbt_version
@@ -42,6 +45,7 @@ import re
 # Context class hierarchy
 #
 #   BaseContext -- core/dbt/context/base.py
+#     SecretContext -- core/dbt/context/secret.py
 #     TargetContext -- core/dbt/context/target.py
 #       ConfiguredContext -- core/dbt/context/configured.py
 #         SchemaYamlContext -- core/dbt/context/configured.py
@@ -314,7 +318,7 @@ class BaseContext(metaclass=ContextMeta):
         """
         return_value = None
         if var.startswith(SECRET_ENV_PREFIX):
-            raise_parsing_error("You can't do that here!")
+            disallow_secret_env_var(var)
         if var in os.environ:
             return_value = os.environ[var]
         elif default is not None:

--- a/core/dbt/context/configured.py
+++ b/core/dbt/context/configured.py
@@ -89,6 +89,8 @@ class SchemaYamlContext(ConfiguredContext):
     @contextmember
     def env_var(self, var: str, default: Optional[str] = None) -> str:
         return_value = None
+        if var.startswith(SECRET_ENV_PREFIX):
+            raise_parsing_error(f"You can't do that here!")
         if var in os.environ:
             return_value = os.environ[var]
         elif default is not None:

--- a/core/dbt/context/configured.py
+++ b/core/dbt/context/configured.py
@@ -8,7 +8,7 @@ from dbt.utils import MultiDict
 
 from dbt.context.base import contextproperty, contextmember, Var
 from dbt.context.target import TargetContext
-from dbt.exceptions import raise_parsing_error
+from dbt.exceptions import raise_parsing_error, disallow_secret_env_var
 
 
 class ConfiguredContext(TargetContext):
@@ -90,14 +90,14 @@ class SchemaYamlContext(ConfiguredContext):
     def env_var(self, var: str, default: Optional[str] = None) -> str:
         return_value = None
         if var.startswith(SECRET_ENV_PREFIX):
-            raise_parsing_error(f"You can't do that here!")
+            disallow_secret_env_var(var)
         if var in os.environ:
             return_value = os.environ[var]
         elif default is not None:
             return_value = default
 
         if return_value is not None:
-            if not var.startswith(SECRET_ENV_PREFIX) and self.schema_yaml_vars:
+            if self.schema_yaml_vars:
                 self.schema_yaml_vars.env_vars[var] = return_value
             return return_value
         else:

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1172,7 +1172,10 @@ class ProviderContext(ManifestContext):
 
         If the default is None, raise an exception for an undefined variable.
         """
+        import ipdb; ipdb.set_trace()
         return_value = None
+        if var.startswith(SECRET_ENV_PREFIX):
+            raise_parsing_error("You can't do that here!")
         if var in os.environ:
             return_value = os.environ[var]
         elif default is not None:
@@ -1481,6 +1484,8 @@ class TestContext(ProviderContext):
     @contextmember
     def env_var(self, var: str, default: Optional[str] = None) -> str:
         return_value = None
+        if var.startswith(SECRET_ENV_PREFIX):
+            raise_parsing_error("You can't do that here!")
         if var in os.environ:
             return_value = os.environ[var]
         elif default is not None:

--- a/core/dbt/context/secret.py
+++ b/core/dbt/context/secret.py
@@ -1,0 +1,40 @@
+import os
+from typing import Any, Dict, Optional
+
+from dbt.contracts.connection import HasCredentials
+
+from .base import (
+    BaseContext, contextproperty, contextmember
+)
+
+from dbt.exceptions import raise_parsing_error
+
+
+class SecretContext(BaseContext):
+    # the only thing this does is reimplement env_var to return actual secret values
+
+    @contextmember
+    def env_var(self, var: str, default: Optional[str] = None) -> str:
+        """The env_var() function. Return the environment variable named 'var'.
+        If there is no such environment variable set, return the default.
+
+        If the default is None, raise an exception for an undefined variable.
+        """
+        return_value = None
+        if var in os.environ:
+            return_value = os.environ[var]
+        elif default is not None:
+            return_value = default
+
+        if return_value is not None:
+            self.env_vars[var] = return_value
+            return return_value
+        else:
+            msg = f"Env var required but not provided: '{var}'"
+            raise_parsing_error(msg)
+
+
+def generate_secret_context(cli_vars: Dict[str, Any]) -> Dict[str, Any]:
+    ctx = SecretContext(cli_vars)
+    # This is not a Mashumaro to_dict call
+    return ctx.to_dict()

--- a/core/dbt/context/secret.py
+++ b/core/dbt/context/secret.py
@@ -1,17 +1,14 @@
 import os
 from typing import Any, Dict, Optional
 
-from dbt.contracts.connection import HasCredentials
-
-from .base import (
-    BaseContext, contextproperty, contextmember
-)
+from .base import BaseContext, contextmember
 
 from dbt.exceptions import raise_parsing_error
 
 
 class SecretContext(BaseContext):
-    # the only thing this does is reimplement env_var to return actual secret values
+    """This context is used in profiles.yml + packages.yml. It can render secret
+    env vars that aren't usable elsewhere"""
 
     @contextmember
     def env_var(self, var: str, default: Optional[str] = None) -> str:
@@ -19,6 +16,9 @@ class SecretContext(BaseContext):
         If there is no such environment variable set, return the default.
 
         If the default is None, raise an exception for an undefined variable.
+
+        In this context *only*, env_var will return the actual values of
+        env vars prefixed with DBT_ENV_SECRET_
         """
         return_value = None
         if var in os.environ:

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -469,6 +469,14 @@ def raise_dependency_error(msg) -> NoReturn:
     raise DependencyException(msg)
 
 
+def disallow_secret_env_var(env_var_name) -> NoReturn:
+    """Raise an error when a secret env var is referenced outside allowed
+    rendering contexts"""
+    msg = ("Secret env vars are allowed only in profiles.yml or packages.yml. "
+           "Found '{env_var_name}' referenced elsewhere.")
+    raise_parsing_error(msg.format(env_var_name=env_var_name))
+
+
 def invalid_type_error(method_name, arg_name, got_value, expected_type,
                        version='0.13.0') -> NoReturn:
     """Raise a CompilationException when an adapter method available to macros

--- a/test/integration/013_context_var_tests/models-with-secret-bad/context.sql
+++ b/test/integration/013_context_var_tests/models-with-secret-bad/context.sql
@@ -1,0 +1,12 @@
+
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+select
+
+    '{{ env_var("DBT_TEST_013_ENV_VAR") }}' as env_var,
+    '{{ env_var("DBT_ENV_SECRET_013_SECRET") }}' as env_var_secret, -- this should raise an error!
+    '{{ env_var("DBT_TEST_013_NOT_SECRET") }}' as env_var_not_secret

--- a/test/integration/013_context_var_tests/models/context.sql
+++ b/test/integration/013_context_var_tests/models/context.sql
@@ -28,5 +28,5 @@ select
     '{{ invocation_id }}'  as invocation_id,
 
     '{{ env_var("DBT_TEST_013_ENV_VAR") }}' as env_var,
-    '{{ env_var("DBT_ENV_SECRET_013_SECRET") }}' as env_var_secret,
+    'secret_variable' as env_var_secret, -- make sure the value itself is scrubbed from the logs
     '{{ env_var("DBT_TEST_013_NOT_SECRET") }}' as env_var_not_secret


### PR DESCRIPTION
resolves #4310

### Description
- Adds `SecretContext` for use by the `ProfileRenderer` (`profiles.yml`) + `PackageRenderer` (`packages.yml`)
- In all other rendering contexts, the `env_var` context member will raise an exception (`disallow_secret_env_var`) if it encounters a var prefixed with `DBT_ENV_SECRET_`

Adjust integration tests accordingly:
- check for `ParsingException` if secret env var is used in a model
- ensure that secret env vars _can_ be used in `profiles.yml` + `packages.yml`
- ensure that the value of a secret env var is scrubbed from the logs (even if defined as a string literal, not via `env_var()`)

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
