### PR TITLE
[#4253] Support partial parsing of env_vars in metrics definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## dbt-core 1.0.0 (Release TBD)
 
-### Under the hood
+### Fixes
+- Support partial parsing of env_vars in metrics ([#4253](https://github.com/dbt-labs/dbt-core/issues/4293), [#4322](https://github.com/dbt-labs/dbt-core/pull/4322))
 
+### Under the hood
 - Change some CompilationExceptions to ParsingExceptions ([#4254](http://github.com/dbt-labs/dbt-core/issues/4254), [#4328](https://github.com/dbt-core/pull/4328))
+
 
 ## dbt-core 1.0.0rc2 (November 22, 2021)
 
@@ -20,6 +23,11 @@
 ### Fixes
 - Fix serialization error with missing quotes in metrics model ref ([#4252](https://github.com/dbt-labs/dbt-core/issues/4252), [#4287](https://github.com/dbt-labs/dbt-core/pull/4289))
 - Correct definition of 'created_at' in ParsedMetric nodes ([#4298](http://github.com/dbt-labs/dbt-core/issues/4298), [#4299](https://github.com/dbt-labs/dbt-core/pull/4299))
+
+### Fixes
+- Allow specifying default in Jinja config.get with default keyword ([#4273](https://github.com/dbt-labs/dbt-core/issues/4273), [#4297](https://github.com/dbt-labs/dbt-core/pull/4297))
+- Fix serialization error with missing quotes in metrics model ref ([#4252](https://github.com/dbt-labs/dbt-core/issues/4252), [#4287](https://github.com/dbt-labs/dbt-core/pull/4289))
+- Correct definition of 'created_at' in ParsedMetric nodes ([#4298](https://github.com/dbt-labs/dbt-core/issues/4298), [#4299](https://github.com/dbt-labs/dbt-core/pull/4299))
 
 ### Under the hood
 - Add --indirect-selection parameter to profiles.yml and builtin DBT_ env vars; stringified parameter to enable multi-modal use ([#3997](https://github.com/dbt-labs/dbt-core/issues/3997), [#4270](https://github.com/dbt-labs/dbt-core/pull/4270))

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -693,21 +693,31 @@ class PartialParsing:
                     continue
                 elem = self.get_schema_element(new_yaml_dict[dict_key], name)
                 if elem:
-                    self.delete_schema_exposure(schema_file, exposure)
-                    self.merge_patch(schema_file, dict_key, exposure)
+                    self.delete_schema_exposure(schema_file, elem)
+                    self.merge_patch(schema_file, dict_key, elem)
 
         # metrics
+        dict_key = 'metrics'
         metric_diff = self.get_diff_for('metrics', saved_yaml_dict, new_yaml_dict)
         if metric_diff['changed']:
             for metric in metric_diff['changed']:
                 self.delete_schema_metric(schema_file, metric)
-                self.merge_patch(schema_file, 'metrics', metric)
+                self.merge_patch(schema_file, dict_key, metric)
         if metric_diff['deleted']:
             for metric in metric_diff['deleted']:
                 self.delete_schema_metric(schema_file, metric)
         if metric_diff['added']:
             for metric in metric_diff['added']:
-                self.merge_patch(schema_file, 'metrics', metric)
+                self.merge_patch(schema_file, dict_key, metric)
+        # Handle schema file updates due to env_var changes
+        if dict_key in env_var_changes and dict_key in new_yaml_dict:
+            for name in env_var_changes[dict_key]:
+                if name in metric_diff['changed_or_deleted_names']:
+                    continue
+                elem = self.get_schema_element(new_yaml_dict[dict_key], name)
+                if elem:
+                    self.delete_schema_metric(schema_file, elem)
+                    self.merge_patch(schema_file, dict_key, elem)
 
     # Take a "section" of the schema file yaml dictionary from saved and new schema files
     # and determine which parts have changed

--- a/test/integration/068_partial_parsing_tests/test-files/env_var_metrics.yml
+++ b/test/integration/068_partial_parsing_tests/test-files/env_var_metrics.yml
@@ -1,0 +1,30 @@
+version: 2
+
+metrics:
+
+  - model: "ref('people')"
+    name: number_of_people
+    description: Total count of people
+    label: "Number of people"
+    type: count
+    sql: "*"
+    timestamp: created_at
+    time_grains: [day, week, month]
+    dimensions:
+      - favorite_color
+      - loves_dbt
+    meta:
+        my_meta: '{{ env_var("ENV_VAR_METRICS") }}'
+
+  - model: "ref('people')"
+    name: collective_tenure
+    description: Total number of years of team experience
+    label: "Collective tenure"
+    type: sum
+    sql: tenure
+    timestamp: created_at
+    time_grains: [day]
+    filters:
+      - field: loves_dbt
+        operator: is
+        value: 'true'


### PR DESCRIPTION
resolves #4253

### Description

Because of parallel development of the metrics feature and partial parsing with environment variables, some code was missing to support re-parsing metrics when env_vars change.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
