### PR TITLE
make json serialization overridable for events

### DIFF
--- a/core/dbt/adapters/sql/connections.py
+++ b/core/dbt/adapters/sql/connections.py
@@ -75,7 +75,7 @@ class SQLConnectionManager(BaseConnectionManager):
 
             fire_event(
                 SQLQueryStatus(
-                    status=self.get_response(cursor), elapsed=round((time.time() - pre), 2)
+                    status=str(self.get_response(cursor)), elapsed=round((time.time() - pre), 2)
                 )
             )
 

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -1,14 +1,19 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
 from dataclasses import dataclass
 from datetime import datetime
+import json
 import os
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional, Union
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # These base types define the _required structure_ for the concrete event #
 # types defined in types.py                                               #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+
+JSONValue = Union[str, int, float, bool, None]
+JSONType = Union[JSONValue, Dict[str, JSONValue], List[JSONValue]]
 
 
 # in preparation for #3977
@@ -75,6 +80,17 @@ class Event(metaclass=ABCMeta):
     @abstractmethod
     def message(self) -> str:
         raise Exception("msg not implemented for Event")
+
+    # Default implementation for turning an event into json.
+    # Should be overridden by concrete event types whose attributes are not serializable to json.
+    def to_json(self) -> str:
+        try:
+            json.dumps(self, sort_keys=True)
+        except TypeError:
+            raise Exception(
+                f"{type(self).__name__} is not serializable to json."
+                " Please override Event::to_json."
+            )
 
     # exactly one time stamp per concrete event
     def get_ts(self) -> datetime:

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -1,7 +1,6 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
 from dataclasses import dataclass
 from datetime import datetime
-from dbt.events.functions import JSONType
 import json
 import os
 from typing import Any, Optional
@@ -84,7 +83,7 @@ class Event(metaclass=ABCMeta):
     # there is no type-level mechanism to have mypy enforce json serializability, so we just try
     # to serialize and raise an exception at runtime when that fails. This safety mechanism
     # only works if we have attempted to serialized every concrete event type in our tests.
-    def fields_to_json(self, field_value: Any) -> JSONType:
+    def fields_to_json(self, field_value: Any) -> Any:
         try:
             json.dumps(field_value, sort_keys=True)
             return field_value

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -82,7 +82,7 @@ class Event(metaclass=ABCMeta):
     #
     # there is no type-level mechanism to have mypy enforce json serializability, so we just try
     # to serialize and raise an exception at runtime when that fails. This safety mechanism
-    # only works if we have attempted to serialized every concrete event type in our tests.
+    # only works if we have attempted to serialize every concrete event type in our tests.
     def fields_to_json(self, field_value: Any) -> Any:
         try:
             json.dumps(field_value, sort_keys=True)
@@ -90,7 +90,7 @@ class Event(metaclass=ABCMeta):
         except TypeError:
             val_type = type(field_value).__name__
             event_type = type(self).__name__
-            raise Exception(
+            return Exception(
                 f"type {val_type} is not serializable to json."
                 f" First make sure that the call sites for {event_type} match the type hints"
                 f" and if they do, you can override Event::fields_to_json in {event_type} in"

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -8,7 +8,6 @@ import dbt.flags as flags
 from dbt.logger import SECRET_ENV_PREFIX, make_log_dir_if_missing, GLOBAL_LOGGER
 import io
 from io import StringIO, TextIOWrapper
-import json
 import logbook
 import logging
 from logging import Logger
@@ -155,7 +154,7 @@ def create_json_log_line(e: T_Event, msg_fn: Callable[[T_Event], str]) -> str:
     else:
         values['data'] = None
 
-    raw_log_line = json.dumps(values, sort_keys=True)
+    raw_log_line = values.to_json()
     return scrub_secrets(raw_log_line, env_secrets())
 
 

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -16,7 +16,7 @@ from logging import Logger
 from logging.handlers import RotatingFileHandler
 import os
 import uuid
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 from dataclasses import _FIELD_BASE  # type: ignore[attr-defined]
 
 

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -113,11 +113,6 @@ def scrub_secrets(msg: str, secrets: List[str]) -> str:
     return scrubbed
 
 
-# types that represent json serializable values
-JSONValue = Union[str, int, float, bool, None]
-JSONType = Union[JSONValue, Dict[str, JSONValue], List[JSONValue]]
-
-
 # returns a dictionary representation of the event fields. You must specify which of the
 # available messages you would like to use (i.e. - e.message, e.cli_msg(), e.file_msg())
 # used for constructing json formatted events. includes secrets which must be scrubbed at
@@ -125,7 +120,7 @@ JSONType = Union[JSONValue, Dict[str, JSONValue], List[JSONValue]]
 def event_to_serializable_dict(
     e: T_Event, ts_fn: Callable[[datetime], str],
     msg_fn: Callable[[T_Event], str]
-) -> Dict[str, JSONType]:
+) -> Dict[str, Any]:
     data: Optional[dict] = None
     if hasattr(e, '__dataclass_fields__'):
         data = {

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -112,6 +112,7 @@ def scrub_secrets(msg: str, secrets: List[str]) -> str:
 
     return scrubbed
 
+
 # returns a dictionary representation of the event fields. You must specify which of the
 # available messages you would like to use (i.e. - e.message, e.cli_msg(), e.file_msg())
 # used for constructing json formatted events. includes secrets which must be scrubbed at
@@ -122,14 +123,14 @@ def event_to_serializable_dict(
 ) -> Dict[str, Any]:
     data = dict()
     if hasattr(e, '__dataclass_fields__'):
-        for field, value in e.__dataclass_fields__.items():
+        for field, value in e.__dataclass_fields__.items():  # type: ignore[attr-defined]
             if type(value._field_type) != _FIELD_BASE:
                 _json_value = e.fields_to_json(value)
 
                 if not isinstance(_json_value, Exception):
                     data[field] = _json_value
                 else:
-                    data[field] = f"JSON_SERIALIZE_FAILED: {type(value).__name__, 'NA'}" 
+                    data[field] = f"JSON_SERIALIZE_FAILED: {type(value).__name__, 'NA'}"
 
     return {
         'log_version': e.log_version,

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -112,7 +112,6 @@ def scrub_secrets(msg: str, secrets: List[str]) -> str:
 
     return scrubbed
 
-
 # returns a dictionary representation of the event fields. You must specify which of the
 # available messages you would like to use (i.e. - e.message, e.cli_msg(), e.file_msg())
 # used for constructing json formatted events. includes secrets which must be scrubbed at
@@ -121,13 +120,16 @@ def event_to_serializable_dict(
     e: T_Event, ts_fn: Callable[[datetime], str],
     msg_fn: Callable[[T_Event], str]
 ) -> Dict[str, Any]:
-    data: Optional[dict] = None
+    data = dict()
     if hasattr(e, '__dataclass_fields__'):
-        data = {
-            x: e.fields_to_json(getattr(e, x)) for x, y
-            in e.__dataclass_fields__.items()  # type: ignore[attr-defined]
-            if type(y._field_type) == _FIELD_BASE
-        }
+        for field, value in e.__dataclass_fields__.items():
+            if type(value._field_type) != _FIELD_BASE:
+                _json_value = e.fields_to_json(value)
+
+                if not isinstance(_json_value, Exception):
+                    data[field] = _json_value
+                else:
+                    data[field] = f"JSON_SERIALIZE_FAILED: {type(value).__name__, 'NA'}" 
 
     return {
         'log_version': e.log_version,

--- a/core/dbt/events/stubs.py
+++ b/core/dbt/events/stubs.py
@@ -26,11 +26,6 @@ class _CachedRelation:
     inner: Any
 
 
-class AdapterResponse:
-    code: Optional[str]
-    rows_affected: Optional[int]
-
-
 class BaseRelation:
     path: Any
     type: Optional[Any]

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -440,7 +440,7 @@ class MacroEventDebug(DebugLevel, Cli, File):
 class NewConnection(DebugLevel, Cli, File):
     conn_type: str
     conn_name: str
-    code: str = "E001"
+    code: str = "E005"
 
     def message(self) -> str:
         return f'Acquiring new {self.conn_type} connection "{self.conn_name}"'
@@ -449,7 +449,7 @@ class NewConnection(DebugLevel, Cli, File):
 @dataclass
 class ConnectionReused(DebugLevel, Cli, File):
     conn_name: str
-    code: str = "E002"
+    code: str = "E006"
 
     def message(self) -> str:
         return f"Re-using an available connection from the pool (formerly {self.conn_name})"
@@ -458,7 +458,7 @@ class ConnectionReused(DebugLevel, Cli, File):
 @dataclass
 class ConnectionLeftOpen(DebugLevel, Cli, File):
     conn_name: Optional[str]
-    code: str = "E003"
+    code: str = "E007"
 
     def message(self) -> str:
         return f"Connection '{self.conn_name}' was left open."
@@ -467,7 +467,7 @@ class ConnectionLeftOpen(DebugLevel, Cli, File):
 @dataclass
 class ConnectionClosed(DebugLevel, Cli, File):
     conn_name: Optional[str]
-    code: str = "E004"
+    code: str = "E008"
 
     def message(self) -> str:
         return f"Connection '{self.conn_name}' was properly closed."
@@ -476,7 +476,7 @@ class ConnectionClosed(DebugLevel, Cli, File):
 @dataclass
 class RollbackFailed(ShowException, DebugLevel, Cli, File):
     conn_name: Optional[str]
-    code: str = "E005"
+    code: str = "E009"
 
     def message(self) -> str:
         return f"Failed to rollback '{self.conn_name}'"
@@ -486,7 +486,7 @@ class RollbackFailed(ShowException, DebugLevel, Cli, File):
 @dataclass
 class ConnectionClosed2(DebugLevel, Cli, File):
     conn_name: Optional[str]
-    code: str = "E038"
+    code: str = "E010"
 
     def message(self) -> str:
         return f"On {self.conn_name}: Close"
@@ -496,7 +496,7 @@ class ConnectionClosed2(DebugLevel, Cli, File):
 @dataclass
 class ConnectionLeftOpen2(DebugLevel, Cli, File):
     conn_name: Optional[str]
-    code: str = "E006"
+    code: str = "E011"
 
     def message(self) -> str:
         return f"On {self.conn_name}: No close available on handle"
@@ -505,7 +505,7 @@ class ConnectionLeftOpen2(DebugLevel, Cli, File):
 @dataclass
 class Rollback(DebugLevel, Cli, File):
     conn_name: Optional[str]
-    code: str = "E007"
+    code: str = "E012"
 
     def message(self) -> str:
         return f"On {self.conn_name}: ROLLBACK"
@@ -516,7 +516,7 @@ class CacheMiss(DebugLevel, Cli, File):
     conn_name: Any  # TODO mypy says this is `Callable[[], str]`??  ¯\_(ツ)_/¯
     database: Optional[str]
     schema: str
-    code: str = "E008"
+    code: str = "E013"
 
     def message(self) -> str:
         return (
@@ -530,7 +530,7 @@ class ListRelations(DebugLevel, Cli, File):
     database: Optional[str]
     schema: str
     relations: List[BaseRelation]
-    code: str = "E009"
+    code: str = "E014"
 
     def message(self) -> str:
         return f"with database={self.database}, schema={self.schema}, relations={self.relations}"
@@ -540,7 +540,7 @@ class ListRelations(DebugLevel, Cli, File):
 class ConnectionUsed(DebugLevel, Cli, File):
     conn_type: str
     conn_name: Optional[str]
-    code: str = "E010"
+    code: str = "E015"
 
     def message(self) -> str:
         return f'Using {self.conn_type} connection "{self.conn_name}"'
@@ -550,7 +550,7 @@ class ConnectionUsed(DebugLevel, Cli, File):
 class SQLQuery(DebugLevel, Cli, File):
     conn_name: Optional[str]
     sql: str
-    code: str = "E011"
+    code: str = "E016"
 
     def message(self) -> str:
         return f"On {self.conn_name}: {self.sql}"
@@ -560,7 +560,7 @@ class SQLQuery(DebugLevel, Cli, File):
 class SQLQueryStatus(DebugLevel, Cli, File):
     status: Union[AdapterResponse, str]
     elapsed: float
-    code: str = "E012"
+    code: str = "E017"
 
     def message(self) -> str:
         return f"SQL status: {self.status} in {self.elapsed} seconds"
@@ -569,7 +569,7 @@ class SQLQueryStatus(DebugLevel, Cli, File):
 @dataclass
 class SQLCommit(DebugLevel, Cli, File):
     conn_name: str
-    code: str = "E013"
+    code: str = "E018"
 
     def message(self) -> str:
         return f"On {self.conn_name}: COMMIT"
@@ -580,7 +580,7 @@ class ColTypeChange(DebugLevel, Cli, File):
     orig_type: str
     new_type: str
     table: str
-    code: str = "E014"
+    code: str = "E019"
 
     def message(self) -> str:
         return f"Changing col type from {self.orig_type} to {self.new_type} in table {self.table}"
@@ -589,7 +589,7 @@ class ColTypeChange(DebugLevel, Cli, File):
 @dataclass
 class SchemaCreation(DebugLevel, Cli, File):
     relation: BaseRelation
-    code: str = "E015"
+    code: str = "E020"
 
     def message(self) -> str:
         return f'Creating schema "{self.relation}"'
@@ -598,7 +598,7 @@ class SchemaCreation(DebugLevel, Cli, File):
 @dataclass
 class SchemaDrop(DebugLevel, Cli, File):
     relation: BaseRelation
-    code: str = "E016"
+    code: str = "E021"
 
     def message(self) -> str:
         return f'Dropping schema "{self.relation}".'
@@ -610,7 +610,7 @@ class SchemaDrop(DebugLevel, Cli, File):
 class UncachedRelation(DebugLevel, Cli, File):
     dep_key: _ReferenceKey
     ref_key: _ReferenceKey
-    code: str = "E017"
+    code: str = "E022"
 
     def message(self) -> str:
         return (
@@ -624,7 +624,7 @@ class UncachedRelation(DebugLevel, Cli, File):
 class AddLink(DebugLevel, Cli, File):
     dep_key: _ReferenceKey
     ref_key: _ReferenceKey
-    code: str = "E018"
+    code: str = "E023"
 
     def message(self) -> str:
         return f"adding link, {self.dep_key} references {self.ref_key}"
@@ -633,7 +633,7 @@ class AddLink(DebugLevel, Cli, File):
 @dataclass
 class AddRelation(DebugLevel, Cli, File):
     relation: _CachedRelation
-    code: str = "E019"
+    code: str = "E024"
 
     def message(self) -> str:
         return f"Adding relation: {str(self.relation)}"
@@ -642,7 +642,7 @@ class AddRelation(DebugLevel, Cli, File):
 @dataclass
 class DropMissingRelation(DebugLevel, Cli, File):
     relation: _ReferenceKey
-    code: str = "E039"
+    code: str = "E025"
 
     def message(self) -> str:
         return f"dropped a nonexistent relationship: {str(self.relation)}"
@@ -652,7 +652,7 @@ class DropMissingRelation(DebugLevel, Cli, File):
 class DropCascade(DebugLevel, Cli, File):
     dropped: _ReferenceKey
     consequences: Set[_ReferenceKey]
-    code: str = "E020"
+    code: str = "E026"
 
     def message(self) -> str:
         return f"drop {self.dropped} is cascading to {self.consequences}"
@@ -661,7 +661,7 @@ class DropCascade(DebugLevel, Cli, File):
 @dataclass
 class DropRelation(DebugLevel, Cli, File):
     dropped: _ReferenceKey
-    code: str = "E021"
+    code: str = "E027"
 
     def message(self) -> str:
         return f"Dropping relation: {self.dropped}"
@@ -672,7 +672,7 @@ class UpdateReference(DebugLevel, Cli, File):
     old_key: _ReferenceKey
     new_key: _ReferenceKey
     cached_key: _ReferenceKey
-    code: str = "E022"
+    code: str = "E028"
 
     def message(self) -> str:
         return f"updated reference from {self.old_key} -> {self.cached_key} to "\
@@ -682,7 +682,7 @@ class UpdateReference(DebugLevel, Cli, File):
 @dataclass
 class TemporaryRelation(DebugLevel, Cli, File):
     key: _ReferenceKey
-    code: str = "E023"
+    code: str = "E029"
 
     def message(self) -> str:
         return f"old key {self.key} not found in self.relations, assuming temporary"
@@ -692,7 +692,7 @@ class TemporaryRelation(DebugLevel, Cli, File):
 class RenameSchema(DebugLevel, Cli, File):
     old_key: _ReferenceKey
     new_key: _ReferenceKey
-    code: str = "E024"
+    code: str = "E030"
 
     def message(self) -> str:
         return f"Renaming relation {self.old_key} to {self.new_key}"
@@ -701,7 +701,7 @@ class RenameSchema(DebugLevel, Cli, File):
 @dataclass
 class DumpBeforeAddGraph(DebugLevel, Cli, File):
     graph_func: Callable[[], Dict[str, List[str]]]
-    code: str = "E025"
+    code: str = "E031"
 
     def message(self) -> str:
         # workaround for https://github.com/python/mypy/issues/6910
@@ -713,7 +713,7 @@ class DumpBeforeAddGraph(DebugLevel, Cli, File):
 @dataclass
 class DumpAfterAddGraph(DebugLevel, Cli, File):
     graph_func: Callable[[], Dict[str, List[str]]]
-    code: str = "E026"
+    code: str = "E032"
 
     def message(self) -> str:
         # workaround for https://github.com/python/mypy/issues/6910
@@ -724,7 +724,7 @@ class DumpAfterAddGraph(DebugLevel, Cli, File):
 @dataclass
 class DumpBeforeRenameSchema(DebugLevel, Cli, File):
     graph_func: Callable[[], Dict[str, List[str]]]
-    code: str = "E027"
+    code: str = "E033"
 
     def message(self) -> str:
         # workaround for https://github.com/python/mypy/issues/6910
@@ -735,7 +735,7 @@ class DumpBeforeRenameSchema(DebugLevel, Cli, File):
 @dataclass
 class DumpAfterRenameSchema(DebugLevel, Cli, File):
     graph_func: Callable[[], Dict[str, List[str]]]
-    code: str = "E028"
+    code: str = "E034"
 
     def message(self) -> str:
         # workaround for https://github.com/python/mypy/issues/6910
@@ -746,7 +746,7 @@ class DumpAfterRenameSchema(DebugLevel, Cli, File):
 @dataclass
 class AdapterImportError(InfoLevel, Cli, File):
     exc: ModuleNotFoundError
-    code: str = "E029"
+    code: str = "E035"
 
     def message(self) -> str:
         return f"Error importing adapter: {self.exc}"
@@ -754,7 +754,7 @@ class AdapterImportError(InfoLevel, Cli, File):
 
 @dataclass
 class PluginLoadError(ShowException, DebugLevel, Cli, File):
-    code: str = "E030"
+    code: str = "E036"
 
     def message(self):
         pass
@@ -763,7 +763,7 @@ class PluginLoadError(ShowException, DebugLevel, Cli, File):
 @dataclass
 class NewConnectionOpening(DebugLevel, Cli, File):
     connection_state: str
-    code: str = "E031"
+    code: str = "E037"
 
     def message(self) -> str:
         return f"Opening a new connection, currently in state {self.connection_state}"
@@ -1266,7 +1266,7 @@ class RunningOperationCaughtError(ErrorLevel, Cli, File):
 @dataclass
 class RunningOperationUncaughtError(ErrorLevel, Cli, File):
     exc: Exception
-    code: str = "W001"
+    code: str = "FF01"
 
     def message(self) -> str:
         return f'Encountered an error while running operation: {self.exc}'
@@ -1531,7 +1531,7 @@ class DepsNotifyUpdatesAvailable(InfoLevel, Cli, File):
 @dataclass
 class DatabaseErrorRunning(InfoLevel, Cli, File):
     hook_type: str
-    code: str = "E040"
+    code: str = "E038"
 
     def message(self) -> str:
         return f"Database error while running {self.hook_type}"
@@ -1549,7 +1549,7 @@ class EmptyLine(InfoLevel, Cli, File):
 class HooksRunning(InfoLevel, Cli, File):
     num_hooks: int
     hook_type: str
-    code: str = "E032"
+    code: str = "E039"
 
     def message(self) -> str:
         plural = 'hook' if self.num_hooks == 1 else 'hooks'
@@ -1560,7 +1560,7 @@ class HooksRunning(InfoLevel, Cli, File):
 class HookFinished(InfoLevel, Cli, File):
     stat_line: str
     execution: str
-    code: str = "E033"
+    code: str = "E040"
 
     def message(self) -> str:
         return f"Finished running {self.stat_line}{self.execution}."
@@ -1569,7 +1569,7 @@ class HookFinished(InfoLevel, Cli, File):
 @dataclass
 class WriteCatalogFailure(ErrorLevel, Cli, File):
     num_exceptions: int
-    code: str = "E034"
+    code: str = "E041"
 
     def message(self) -> str:
         return (f"dbt encountered {self.num_exceptions} failure{(self.num_exceptions != 1) * 's'} "
@@ -1579,7 +1579,7 @@ class WriteCatalogFailure(ErrorLevel, Cli, File):
 @dataclass
 class CatalogWritten(InfoLevel, Cli, File):
     path: str
-    code: str = "E035"
+    code: str = "E042"
 
     def message(self) -> str:
         return f"Catalog written to {self.path}"
@@ -1587,7 +1587,7 @@ class CatalogWritten(InfoLevel, Cli, File):
 
 @dataclass
 class CannotGenerateDocs(InfoLevel, Cli, File):
-    code: str = "E036"
+    code: str = "E043"
 
     def message(self) -> str:
         return "compile failed, cannot generate docs"
@@ -1595,7 +1595,7 @@ class CannotGenerateDocs(InfoLevel, Cli, File):
 
 @dataclass
 class BuildingCatalog(InfoLevel, Cli, File):
-    code: str = "E037"
+    code: str = "E044"
 
     def message(self) -> str:
         return "Building catalog"
@@ -1839,7 +1839,7 @@ class SkippingDetails(InfoLevel, Cli, File):
     node_name: str
     index: int
     total: int
-    code: str = "Z034"
+    code: str = "Z033"
 
     def message(self) -> str:
         if self.resource_type in NodeType.refable():
@@ -1932,7 +1932,7 @@ class PrintSkipBecauseError(ErrorLevel, Cli, File):
     relation: str
     index: int
     total: int
-    code: str = "Z035"
+    code: str = "Z034"
 
     def message(self) -> str:
         msg = f'SKIP relation {self.schema}.{self.relation} due to ephemeral model error'
@@ -1949,7 +1949,7 @@ class PrintModelErrorResultLine(ErrorLevel, Cli, File):
     index: int
     total: int
     execution_time: int
-    code: str = "Z036"
+    code: str = "Z035"
 
     def message(self) -> str:
         info = "ERROR creating"
@@ -2305,7 +2305,7 @@ class DepsSetDownloadDirectory(DebugLevel, Cli, File):
 
 @dataclass
 class EnsureGitInstalled(ErrorLevel, Cli, File):
-    code: str = "Z037"
+    code: str = "Z036"
 
     def message(self) -> str:
         return ('Make sure git is installed on your machine. More '
@@ -2315,7 +2315,7 @@ class EnsureGitInstalled(ErrorLevel, Cli, File):
 
 @dataclass
 class DepsCreatingLocalSymlink(DebugLevel, Cli, File):
-    code: str = "Z038"
+    code: str = "Z037"
 
     def message(self) -> str:
         return '  Creating symlink to local dependency.'
@@ -2323,7 +2323,7 @@ class DepsCreatingLocalSymlink(DebugLevel, Cli, File):
 
 @dataclass
 class DepsSymlinkNotAvailable(DebugLevel, Cli, File):
-    code: str = "Z039"
+    code: str = "Z038"
 
     def message(self) -> str:
         return '  Symlinks are not available on this OS, copying dependency.'
@@ -2358,7 +2358,7 @@ class WritingInjectedSQLForNode(DebugLevel, Cli, File):
 
 @dataclass
 class DisableTracking(WarnLevel, Cli, File):
-    code: str = "Z040"
+    code: str = "Z039"
 
     def message(self) -> str:
         return "Error sending message, disabling tracking"
@@ -2367,7 +2367,7 @@ class DisableTracking(WarnLevel, Cli, File):
 @dataclass
 class SendingEvent(DebugLevel, Cli):
     kwargs: str
-    code: str = "Z041"
+    code: str = "Z040"
 
     def message(self) -> str:
         return f"Sending event: {self.kwargs}"
@@ -2375,7 +2375,7 @@ class SendingEvent(DebugLevel, Cli):
 
 @dataclass
 class SendEventFailure(DebugLevel, Cli, File):
-    code: str = "Z042"
+    code: str = "Z041"
 
     def message(self) -> str:
         return "An error was encountered while trying to send an event"
@@ -2383,7 +2383,7 @@ class SendEventFailure(DebugLevel, Cli, File):
 
 @dataclass
 class FlushEvents(DebugLevel, Cli):
-    code: str = "Z043"
+    code: str = "Z042"
 
     def message(self) -> str:
         return "Flushing usage events"
@@ -2391,7 +2391,7 @@ class FlushEvents(DebugLevel, Cli):
 
 @dataclass
 class FlushEventsFailure(DebugLevel, Cli):
-    code: str = "Z044"
+    code: str = "Z043"
 
     def message(self) -> str:
         return "An error was encountered while trying to flush usage events"
@@ -2399,7 +2399,7 @@ class FlushEventsFailure(DebugLevel, Cli):
 
 @dataclass
 class TrackingInitializeFailure(ShowException, DebugLevel, Cli, File):
-    code: str = "Z045"
+    code: str = "Z044"
 
     def message(self) -> str:
         return "Got an exception trying to initialize tracking"
@@ -2409,7 +2409,7 @@ class TrackingInitializeFailure(ShowException, DebugLevel, Cli, File):
 class RetryExternalCall(DebugLevel, Cli, File):
     attempt: int
     max: int
-    code: str = "Z046"
+    code: str = "Z045"
 
     def message(self) -> str:
         return f"Retrying external call. Attempt: {self.attempt} Max attempts: {self.max}"
@@ -2419,7 +2419,7 @@ class RetryExternalCall(DebugLevel, Cli, File):
 class GeneralWarningMsg(WarnLevel, Cli, File):
     msg: str
     log_fmt: str
-    code: str = "Z047"
+    code: str = "Z046"
 
     def message(self) -> str:
         if self.log_fmt is not None:
@@ -2431,7 +2431,7 @@ class GeneralWarningMsg(WarnLevel, Cli, File):
 class GeneralWarningException(WarnLevel, Cli, File):
     exc: Exception
     log_fmt: str
-    code: str = "Z048"
+    code: str = "Z047"
 
     def message(self) -> str:
         if self.log_fmt is not None:
@@ -2453,7 +2453,6 @@ if 1 == 0:
     MainKeyboardInterrupt()
     MainEncounteredError(BaseException(''))
     MainStackTrace('')
-    MainReportVersion('')
     MainTrackingUserState('')
     ParsingStart()
     ParsingCompiling()
@@ -2529,25 +2528,9 @@ if 1 == 0:
     DumpAfterRenameSchema(dump_callable)
     AdapterImportError(ModuleNotFoundError())
     PluginLoadError()
-    ReportPerformancePath(path='')
-    GitSparseCheckoutSubdirectory(subdir='')
-    GitProgressCheckoutRevision(revision='')
-    GitProgressUpdatingExistingDependency(dir='')
-    GitProgressPullingNewDependency(dir='')
-    GitNothingToDo(sha='')
-    GitProgressUpdatedCheckoutRange(start_sha='', end_sha='')
-    GitProgressCheckedOutAt(end_sha='')
-    SystemErrorRetrievingModTime(path='')
-    SystemCouldNotWrite(path='', reason='', exc=Exception(''))
-    SystemExecutingCmd(cmd=[''])
-    SystemStdOutMsg(bmsg=b'')
-    SystemStdErrMsg(bmsg=b'')
     SystemReportReturnCode(returncode=0)
     SelectorAlertUpto3UnusedNodes(node_names=[])
     SelectorAlertAllUnusedNodes(node_names=[])
-    SelectorReportInvalidSelector(selector_methods={'': ''}, spec_method='', raw_spec='')
-    MacroEventInfo(msg='')
-    MacroEventDebug(msg='')
     NewConnectionOpening(connection_state='')
     TimingInfoCollected()
     MergedFromState(nbr_merged=0, sample=[])
@@ -2559,6 +2542,7 @@ if 1 == 0:
     MacroFileParse(path='')
     PartialParsingFullReparseBecauseOfError()
     PartialParsingFile(file_dict={})
+    PartialParsingExceptionFile(file='')
     PartialParsingException(exc_info={})
     PartialParsingSkipParsing()
     PartialParsingMacroChangeStartFullParse()

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -751,6 +751,16 @@ class DumpAfterAddGraph(DebugLevel, Cli, File):
         func_returns = cast(Callable[[], Dict[str, List[str]]], getattr(self, "graph_func"))
         return f"after adding: {func_returns}"
 
+    # TODO should we manually cache the graph here so it doesn't get called for the message
+    # and serialization separately??
+    #
+    # overriding default json serialization for this event
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.graph_func:  # type: ignore
+            return str(val())
+
+        return val
+
 
 @dataclass
 class DumpBeforeRenameSchema(DebugLevel, Cli, File):

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -572,6 +572,13 @@ class SQLQueryStatus(DebugLevel, Cli, File):
     def message(self) -> str:
         return f"SQL status: {self.status} in {self.elapsed} seconds"
 
+    # overriding default json serialization for this event
+    def fields_to_json(self, val: Any) -> Any:
+        if isinstance(val, AdapterResponse):
+            return str(val)  # the AdapterResponse class overrides __str__ so this is a good choice
+
+        return val
+
 
 @dataclass
 class SQLCommit(DebugLevel, Cli, File):

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -654,7 +654,7 @@ class AddRelation(DebugLevel, Cli, File):
 
     # overriding default json serialization for this event
     def fields_to_json(self, val: Any) -> Any:
-        if val == self.e:
+        if val == self.relation:
             return str(val)
 
         return val
@@ -729,6 +729,16 @@ class DumpBeforeAddGraph(DebugLevel, Cli, File):
         # TODO remove when we've upgraded to a mypy version without that bug
         func_returns = cast(Callable[[], Dict[str, List[str]]], getattr(self, "graph_func"))
         return f"before adding : {func_returns}"
+
+    # TODO should we manually cache the graph here so it doesn't get called for the message
+    # and serialization separately??
+    #
+    # overriding default json serialization for this event
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.graph_func:  # type: ignore
+            return str(val())
+
+        return val
 
 
 @dataclass

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1,13 +1,13 @@
 import argparse
 from dataclasses import dataclass
-from dbt.events.stubs import _CachedRelation, AdapterResponse, BaseRelation, _ReferenceKey
+from dbt.events.stubs import _CachedRelation, BaseRelation, _ReferenceKey
 from dbt import ui
 from dbt.events.base_types import (
     Cli, Event, File, DebugLevel, InfoLevel, WarnLevel, ErrorLevel, ShowException
 )
 from dbt.events.format import format_fancy_output_line, pluralize
 from dbt.node_types import NodeType
-from typing import Any, Callable, cast, Dict, List, Optional, Set, Tuple, TypeVar, Union
+from typing import Any, Callable, cast, Dict, List, Optional, Set, Tuple, TypeVar
 
 
 # The classes in this file represent the data necessary to describe a

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -652,6 +652,13 @@ class AddRelation(DebugLevel, Cli, File):
     def message(self) -> str:
         return f"Adding relation: {str(self.relation)}"
 
+    # overriding default json serialization for this event
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.e:
+            return str(val)
+
+        return val
+
 
 @dataclass
 class DropMissingRelation(DebugLevel, Cli, File):

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -6,7 +6,6 @@ from dbt.events.base_types import (
     Cli, Event, File, DebugLevel, InfoLevel, WarnLevel, ErrorLevel, ShowException
 )
 from dbt.events.format import format_fancy_output_line, pluralize
-from dbt.events.functions import JSONType
 from dbt.node_types import NodeType
 from typing import Any, Callable, cast, Dict, List, Optional, Set, Tuple, TypeVar, Union
 
@@ -137,7 +136,7 @@ class MainReportArgs(DebugLevel, Cli, File):
         return f"running dbt with arguments {str(self.args)}"
 
     # overriding default json serialization for this event
-    def fields_to_json(self, val: Any) -> JSONType:
+    def fields_to_json(self, val: Any) -> Any:
         if isinstance(val, argparse.Namespace):
             return str(val)
 

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -6,6 +6,7 @@ from dbt.events.base_types import (
     Cli, Event, File, DebugLevel, InfoLevel, WarnLevel, ErrorLevel, ShowException
 )
 from dbt.events.format import format_fancy_output_line, pluralize
+from dbt.events.functions import JSONType
 from dbt.node_types import NodeType
 from typing import Any, Callable, cast, Dict, List, Optional, Set, Tuple, TypeVar, Union
 
@@ -134,6 +135,13 @@ class MainReportArgs(DebugLevel, Cli, File):
 
     def message(self):
         return f"running dbt with arguments {str(self.args)}"
+
+    # overriding default json serialization for this event
+    def fields_to_json(self, val: Any) -> JSONType:
+        if isinstance(val, argparse.Namespace):
+            return str(val)
+
+        return val
 
 
 @dataclass

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -108,6 +108,13 @@ class MainEncounteredError(ErrorLevel, Cli):
     def message(self) -> str:
         return f"Encountered an error:\n{str(self.e)}"
 
+    # overriding default json serialization for this event
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.e:
+            return str(val)
+
+        return val
+
 
 @dataclass
 class MainStackTrace(DebugLevel, Cli):

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -565,19 +565,12 @@ class SQLQuery(DebugLevel, Cli, File):
 
 @dataclass
 class SQLQueryStatus(DebugLevel, Cli, File):
-    status: Union[AdapterResponse, str]
+    status: str  # could include AdapterResponse if we resolve circular imports
     elapsed: float
     code: str = "E017"
 
     def message(self) -> str:
         return f"SQL status: {self.status} in {self.elapsed} seconds"
-
-    # overriding default json serialization for this event
-    def fields_to_json(self, val: Any) -> Any:
-        if isinstance(val, AdapterResponse):
-            return str(val)  # the AdapterResponse class overrides __str__ so this is a good choice
-
-        return val
 
 
 @dataclass

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -346,6 +346,13 @@ class SystemCouldNotWrite(DebugLevel, Cli, File):
             f"{self.reason}\nexception: {self.exc}"
         )
 
+    # overriding default json serialization for this event
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
+
 
 @dataclass
 class SystemExecutingCmd(DebugLevel, Cli, File):
@@ -772,6 +779,12 @@ class DumpBeforeRenameSchema(DebugLevel, Cli, File):
         func_returns = cast(Callable[[], Dict[str, List[str]]], getattr(self, "graph_func"))
         return f"before rename: {func_returns}"
 
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.graph_func:  # type: ignore
+            return str(val())
+
+        return val
+
 
 @dataclass
 class DumpAfterRenameSchema(DebugLevel, Cli, File):
@@ -783,6 +796,12 @@ class DumpAfterRenameSchema(DebugLevel, Cli, File):
         func_returns = cast(Callable[[], Dict[str, List[str]]], getattr(self, "graph_func"))
         return f"after rename: {func_returns}"
 
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.graph_func:  # type: ignore
+            return str(val())
+
+        return val
+
 
 @dataclass
 class AdapterImportError(InfoLevel, Cli, File):
@@ -791,6 +810,12 @@ class AdapterImportError(InfoLevel, Cli, File):
 
     def message(self) -> str:
         return f"Error importing adapter: {self.exc}"
+
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val())
+
+        return val
 
 
 @dataclass
@@ -846,6 +871,12 @@ class ProfileLoadError(ShowException, DebugLevel, Cli, File):
     def message(self) -> str:
         return f"Profile not loaded due to error: {self.exc}"
 
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
+
 
 @dataclass
 class ProfileNotFound(InfoLevel, Cli, File):
@@ -883,6 +914,12 @@ class CatchRunException(ShowException, DebugLevel, Cli, File):
         )
         return error
 
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
+
 
 # TODO: Remove? (appears to be uncalled)
 @dataclass
@@ -892,6 +929,12 @@ class HandleInternalException(ShowException, DebugLevel, Cli, File):
 
     def message(self) -> str:
         return str(self.exc)
+
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
 
 # TODO: Remove? (appears to be uncalled)
 
@@ -912,6 +955,12 @@ class MessageHandleGenericException(ErrorLevel, Cli, File):
             prefix=ui.red(prefix),
             error=str(self.exc).strip()
         )
+
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
 
 # TODO: Remove? (appears to be uncalled)
 
@@ -1089,6 +1138,12 @@ class ParsedFileLoadFailed(ShowException, DebugLevel, Cli, File):
 
     def message(self) -> str:
         return f"Failed to load parsed file from disk at {self.path}: {self.exc}"
+
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
 
 
 @dataclass
@@ -1303,6 +1358,12 @@ class RunningOperationCaughtError(ErrorLevel, Cli, File):
     def message(self) -> str:
         return f'Encountered an error while running operation: {self.exc}'
 
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
+
 
 @dataclass
 class RunningOperationUncaughtError(ErrorLevel, Cli, File):
@@ -1311,6 +1372,12 @@ class RunningOperationUncaughtError(ErrorLevel, Cli, File):
 
     def message(self) -> str:
         return f'Encountered an error while running operation: {self.exc}'
+
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
 
 
 @dataclass
@@ -1329,6 +1396,12 @@ class DbtProjectErrorException(ErrorLevel, Cli, File):
     def message(self) -> str:
         return f"  ERROR: {str(self.exc)}"
 
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
+
 
 @dataclass
 class DbtProfileError(ErrorLevel, Cli, File):
@@ -1345,6 +1418,12 @@ class DbtProfileErrorException(ErrorLevel, Cli, File):
 
     def message(self) -> str:
         return f"  ERROR: {str(self.exc)}"
+
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
 
 
 @dataclass
@@ -1393,6 +1472,12 @@ class CatchableExceptionOnRun(ShowException, DebugLevel, Cli, File):
     def message(self) -> str:
         return str(self.exc)
 
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
+
 
 @dataclass
 class InternalExceptionOnRun(DebugLevel, Cli, File):
@@ -1412,6 +1497,12 @@ the error persists, open an issue at https://github.com/dbt-labs/dbt-core
             error=str(self.exc).strip(),
             note=INTERNAL_ERROR_STRING
         )
+
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
 
 
 # This prints the stack trace at the debug level while allowing just the nice exception message
@@ -1441,6 +1532,12 @@ class GenericExceptionOnRun(ErrorLevel, Cli, File):
             error=str(self.exc).strip()
         )
 
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
+
 
 @dataclass
 class NodeConnectionReleaseError(ShowException, DebugLevel, Cli, File):
@@ -1451,6 +1548,12 @@ class NodeConnectionReleaseError(ShowException, DebugLevel, Cli, File):
     def message(self) -> str:
         return ('Error releasing connection for node {}: {!s}'
                 .format(self.node_name, self.exc))
+
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
 
 
 @dataclass
@@ -1771,6 +1874,12 @@ class SQlRunnerException(ShowException, DebugLevel, Cli, File):
 
     def message(self) -> str:
         return f"Got an exception: {self.exc}"
+
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
 
 
 @dataclass
@@ -2478,6 +2587,12 @@ class GeneralWarningException(WarnLevel, Cli, File):
         if self.log_fmt is not None:
             return self.log_fmt.format(str(self.exc))
         return str(self.exc)
+
+    def fields_to_json(self, val: Any) -> Any:
+        if val == self.exc:
+            return str(val)
+
+        return val
 
 
 # since mypy doesn't run on every file we need to suggest to mypy that every

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -225,7 +225,7 @@ def run_from_args(parsed):
     # set log_format in the logger
     parsed.cls.pre_init_hook(parsed)
 
-    fire_event(MainReportVersion(v=dbt.version.installed))
+    fire_event(MainReportVersion(v=str(dbt.version.installed)))
 
     # this will convert DbtConfigErrors into RuntimeExceptions
     # task could be any one of the task objects

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -189,6 +189,8 @@ class GraphRunnableTask(ManifestTask):
 
     def get_runner(self, node):
         adapter = get_adapter(self.config)
+        run_count: int = 0
+        num_nodes: int = 0
 
         if node.is_ephemeral_model:
             run_count = 0
@@ -209,7 +211,7 @@ class GraphRunnableTask(ManifestTask):
             extended_metadata = ModelMetadata(runner.node, index)
             with startctx, extended_metadata:
                 fire_event(NodeStart(unique_id=runner.node.unique_id))
-            status: Dict[str, str]
+            status: Dict[str, str] = {}
             try:
                 result = runner.run_with_hooks(self.manifest)
                 status = runner.get_result_status(result)

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -262,7 +262,7 @@ def track(user, *args, **kwargs):
     if user.do_not_track:
         return
     else:
-        fire_event(SendingEvent(kwargs=kwargs))
+        fire_event(SendingEvent(kwargs=str(kwargs)))
         try:
             tracker.track_struct_event(*args, **kwargs)
         except Exception:

--- a/test/unit/test_events.py
+++ b/test/unit/test_events.py
@@ -1,7 +1,8 @@
 from dbt.events import AdapterLogger
 from dbt.events.types import AdapterEventDebug
+from dbt.events.base_types import Event
+import inspect
 from unittest import TestCase
-
 
 class TestAdapterLogger(TestCase):
 
@@ -45,3 +46,28 @@ class TestAdapterLogger(TestCase):
         # were no args passed after the initial message
         event = AdapterEventDebug(name="dbt_tests", base_msg="boop{x}boop", args=())
         self.assertTrue("boop{x}boop" in event.message())
+
+class TestEventCodes(TestCase):
+
+    # takes in a class and finds any subclasses for it
+    def get_all_subclasses(self, cls):
+        all_subclasses = []
+        for subclass in cls.__subclasses__():
+            all_subclasses.append(subclass)
+            all_subclasses.extend(self.get_all_subclasses(subclass))
+        return set(all_subclasses)
+
+    # checks to see if event codes are duplicated to keep codes singluar and clear.
+    # also checks that event codes follow correct namming convention ex. E001
+    def test_event_codes(self):
+        all_concrete = self.get_all_subclasses(Event)
+        all_codes = set()
+
+        for event in all_concrete:
+            if not inspect.isabstract(event):
+                # must be in the form 1 capital letter, 3 digits
+                self.assertTrue('^[A-Z][0-9]{3}', event.code)
+                # cannot have been used already
+                self.assertFalse(event.code in all_codes, f'{event.code} is assigned more than once. Check types.py for duplicates.')
+                all_codes.add(event.code)
+                

--- a/test/unit/test_events.py
+++ b/test/unit/test_events.py
@@ -1,8 +1,19 @@
 from dbt.events import AdapterLogger
-from dbt.events.types import AdapterEventDebug
+from dbt.events.types import *
 from dbt.events.base_types import Event
+from dbt.events.stubs import _CachedRelation, BaseRelation, _ReferenceKey
 import inspect
 from unittest import TestCase
+
+
+# takes in a class and finds any subclasses for it
+def get_all_subclasses(cls):
+    all_subclasses = []
+    for subclass in cls.__subclasses__():
+        all_subclasses.append(subclass)
+        all_subclasses.extend(get_all_subclasses(subclass))
+    return set(all_subclasses)
+
 
 class TestAdapterLogger(TestCase):
 
@@ -49,18 +60,10 @@ class TestAdapterLogger(TestCase):
 
 class TestEventCodes(TestCase):
 
-    # takes in a class and finds any subclasses for it
-    def get_all_subclasses(self, cls):
-        all_subclasses = []
-        for subclass in cls.__subclasses__():
-            all_subclasses.append(subclass)
-            all_subclasses.extend(self.get_all_subclasses(subclass))
-        return set(all_subclasses)
-
     # checks to see if event codes are duplicated to keep codes singluar and clear.
     # also checks that event codes follow correct namming convention ex. E001
     def test_event_codes(self):
-        all_concrete = self.get_all_subclasses(Event)
+        all_concrete = get_all_subclasses(Event)
         all_codes = set()
 
         for event in all_concrete:
@@ -70,4 +73,266 @@ class TestEventCodes(TestCase):
                 # cannot have been used already
                 self.assertFalse(event.code in all_codes, f'{event.code} is assigned more than once. Check types.py for duplicates.')
                 all_codes.add(event.code)
+
+
+def dump_callable():
+    return dict()
+
+
+sample_values = [
+    MainReportVersion(''),
+    MainKeyboardInterrupt(),
+    MainEncounteredError(BaseException('')),
+    MainStackTrace(''),
+    MainTrackingUserState(''),
+    ParsingStart(),
+    ParsingCompiling(),
+    ParsingWritingManifest(),
+    ParsingDone(),
+    ManifestDependenciesLoaded(),
+    ManifestLoaderCreated(),
+    ManifestLoaded(),
+    ManifestChecked(),
+    ManifestFlatGraphBuilt(),
+    ReportPerformancePath(path=""),
+    GitSparseCheckoutSubdirectory(subdir=""),
+    GitProgressCheckoutRevision(revision=""),
+    GitProgressUpdatingExistingDependency(dir=""),
+    GitProgressPullingNewDependency(dir=""),
+    GitNothingToDo(sha=""),
+    GitProgressUpdatedCheckoutRange(start_sha="", end_sha=""),
+    GitProgressCheckedOutAt(end_sha=""),
+    SystemErrorRetrievingModTime(path=""),
+    SystemCouldNotWrite(path="", reason="", exc=Exception("")),
+    SystemExecutingCmd(cmd=[""]),
+    SystemStdOutMsg(bmsg=b""),
+    SystemStdErrMsg(bmsg=b""),
+    SelectorReportInvalidSelector(
+        selector_methods={"": ""}, spec_method="", raw_spec=""
+    ),
+    MacroEventInfo(msg=""),
+    MacroEventDebug(msg=""),
+    NewConnection(conn_type="", conn_name=""),
+    ConnectionReused(conn_name=""),
+    ConnectionLeftOpen(conn_name=""),
+    ConnectionClosed(conn_name=""),
+    RollbackFailed(conn_name=""),
+    ConnectionClosed2(conn_name=""),
+    ConnectionLeftOpen2(conn_name=""),
+    Rollback(conn_name=""),
+    CacheMiss(conn_name="", database="", schema=""),
+    ListRelations(database="", schema="", relations=[]),
+    ConnectionUsed(conn_type="", conn_name=""),
+    SQLQuery(conn_name="", sql=""),
+    SQLQueryStatus(status="", elapsed=0.1),
+    SQLCommit(conn_name=""),
+    ColTypeChange(orig_type="", new_type="", table=""),
+    SchemaCreation(relation=BaseRelation()),
+    SchemaDrop(relation=BaseRelation()),
+    UncachedRelation(
+        dep_key=_ReferenceKey(database="", schema="", identifier=""),
+        ref_key=_ReferenceKey(database="", schema="", identifier=""),
+    ),
+    AddLink(
+        dep_key=_ReferenceKey(database="", schema="", identifier=""),
+        ref_key=_ReferenceKey(database="", schema="", identifier=""),
+    ),
+    AddRelation(relation=_CachedRelation()),
+    DropMissingRelation(relation=_ReferenceKey(database="", schema="", identifier="")),
+    DropCascade(
+        dropped=_ReferenceKey(database="", schema="", identifier=""),
+        consequences={_ReferenceKey(database="", schema="", identifier="")},
+    ),
+    UpdateReference(
+        old_key=_ReferenceKey(database="", schema="", identifier=""),
+        new_key=_ReferenceKey(database="", schema="", identifier=""),
+        cached_key=_ReferenceKey(database="", schema="", identifier=""),
+    ),
+    TemporaryRelation(key=_ReferenceKey(database="", schema="", identifier="")),
+    RenameSchema(
+        old_key=_ReferenceKey(database="", schema="", identifier=""),
+        new_key=_ReferenceKey(database="", schema="", identifier="")
+    ),
+    DumpBeforeAddGraph(dump_callable),
+    DumpAfterAddGraph(dump_callable),
+    DumpBeforeRenameSchema(dump_callable),
+    DumpAfterRenameSchema(dump_callable),
+    AdapterImportError(ModuleNotFoundError()),
+    PluginLoadError(),
+    SystemReportReturnCode(returncode=0),
+    SelectorAlertUpto3UnusedNodes(node_names=[]),
+    SelectorAlertAllUnusedNodes(node_names=[]),
+    NewConnectionOpening(connection_state=''),
+    TimingInfoCollected(),
+    MergedFromState(nbr_merged=0, sample=[]),
+    MissingProfileTarget(profile_name='', target_name=''),
+    ProfileLoadError(exc=Exception('')),
+    ProfileNotFound(profile_name=''),
+    InvalidVarsYAML(),
+    GenericTestFileParse(path=''),
+    MacroFileParse(path=''),
+    PartialParsingFullReparseBecauseOfError(),
+    PartialParsingFile(file_dict={}),
+    PartialParsingExceptionFile(file=''),
+    PartialParsingException(exc_info={}),
+    PartialParsingSkipParsing(),
+    PartialParsingMacroChangeStartFullParse(),
+    ManifestWrongMetadataVersion(version=''),
+    PartialParsingVersionMismatch(saved_version='', current_version=''),
+    PartialParsingFailedBecauseConfigChange(),
+    PartialParsingFailedBecauseProfileChange(),
+    PartialParsingFailedBecauseNewProjectDependency(),
+    PartialParsingFailedBecauseHashChanged(),
+    PartialParsingDeletedMetric(''),
+    ParsedFileLoadFailed(path='', exc=Exception('')),
+    PartialParseSaveFileNotFound(),
+    StaticParserCausedJinjaRendering(path=''),
+    UsingExperimentalParser(path=''),
+    SampleFullJinjaRendering(path=''),
+    StaticParserFallbackJinjaRendering(path=''),
+    StaticParsingMacroOverrideDetected(path=''),
+    StaticParserSuccess(path=''),
+    StaticParserFailure(path=''),
+    ExperimentalParserSuccess(path=''),
+    ExperimentalParserFailure(path=''),
+    PartialParsingEnabled(deleted=0, added=0, changed=0),
+    PartialParsingAddedFile(file_id=''),
+    PartialParsingDeletedFile(file_id=''),
+    PartialParsingUpdatedFile(file_id=''),
+    PartialParsingNodeMissingInSourceFile(source_file=''),
+    PartialParsingMissingNodes(file_id=''),
+    PartialParsingChildMapMissingUniqueID(unique_id=''),
+    PartialParsingUpdateSchemaFile(file_id=''),
+    PartialParsingDeletedSource(unique_id=''),
+    PartialParsingDeletedExposure(unique_id=''),
+    InvalidDisabledSourceInTestNode(msg=''),
+    InvalidRefInTestNode(msg=''),
+    MessageHandleGenericException(build_path='', unique_id='', exc=Exception('')),
+    DetailsHandleGenericException(),
+    RunningOperationCaughtError(exc=Exception('')),
+    RunningOperationUncaughtError(exc=Exception('')),
+    DbtProjectError(),
+    DbtProjectErrorException(exc=Exception('')),
+    DbtProfileError(),
+    DbtProfileErrorException(exc=Exception('')),
+    ProfileListTitle(),
+    ListSingleProfile(profile=''),
+    NoDefinedProfiles(),
+    ProfileHelpMessage(),
+    CatchableExceptionOnRun(exc=Exception('')),
+    InternalExceptionOnRun(build_path='', exc=Exception('')),
+    GenericExceptionOnRun(build_path='', unique_id='', exc=Exception('')),
+    NodeConnectionReleaseError(node_name='', exc=Exception('')),
+    CheckCleanPath(path=''),
+    ConfirmCleanPath(path=''),
+    ProtectedCleanPath(path=''),
+    FinishedCleanPaths(),
+    OpenCommand(open_cmd='', profiles_dir=''),
+    DepsNoPackagesFound(),
+    DepsStartPackageInstall(package=''),
+    DepsInstallInfo(version_name=''),
+    DepsUpdateAvailable(version_latest=''),
+    DepsListSubdirectory(subdirectory=''),
+    DepsNotifyUpdatesAvailable(packages=[]),
+    DatabaseErrorRunning(hook_type=''),
+    EmptyLine(),
+    HooksRunning(num_hooks=0, hook_type=''),
+    HookFinished(stat_line='', execution=''),
+    WriteCatalogFailure(num_exceptions=0),
+    CatalogWritten(path=''),
+    CannotGenerateDocs(),
+    BuildingCatalog(),
+    CompileComplete(),
+    FreshnessCheckComplete(),
+    ServingDocsPort(address='', port=0),
+    ServingDocsAccessInfo(port=''),
+    ServingDocsExitInfo(),
+    SeedHeader(header=''),
+    SeedHeaderSeperator(len_header=0),
+    RunResultWarning(resource_type='', node_name='', path=''),
+    RunResultFailure(resource_type='', node_name='', path=''),
+    StatsLine(stats={}),
+    RunResultError(msg=''),
+    RunResultErrorNoMessage(status=''),
+    SQLCompiledPath(path=''),
+    CheckNodeTestFailure(relation_name=''),
+    FirstRunResultError(msg=''),
+    AfterFirstRunResultError(msg=''),
+    EndOfRunSummary(num_errors=0, num_warnings=0, keyboard_interrupt=False),
+    PrintStartLine(description='', index=0, total=0),
+    PrintHookStartLine(statement='', index=0, total=0, truncate=False),
+    PrintHookEndLine(statement='', status='', index=0, total=0, execution_time=0, truncate=False),
+    SkippingDetails(resource_type='', schema='', node_name='', index=0, total=0),
+    PrintErrorTestResult(name='', index=0, num_models=0, execution_time=0),
+    PrintPassTestResult(name='', index=0, num_models=0, execution_time=0),
+    PrintWarnTestResult(name='', index=0, num_models=0, execution_time=0, failures=[]),
+    PrintFailureTestResult(name='', index=0, num_models=0, execution_time=0, failures=[]),
+    PrintSkipBecauseError(schema='', relation='', index=0, total=0),
+    PrintModelErrorResultLine(description='', status='', index=0, total=0, execution_time=0),
+    PrintModelResultLine(description='', status='', index=0, total=0, execution_time=0),
+    PrintSnapshotErrorResultLine(status='',
+                                 description='',
+                                 cfg={},
+                                 index=0,
+                                 total=0,
+                                 execution_time=0),
+    PrintSnapshotResultLine(status='', description='', cfg={}, index=0, total=0, execution_time=0),
+    PrintSeedErrorResultLine(status='', index=0, total=0, execution_time=0, schema='', relation=''),
+    PrintSeedResultLine(status='', index=0, total=0, execution_time=0, schema='', relation=''),
+    PrintHookEndErrorLine(source_name='', table_name='', index=0, total=0, execution_time=0),
+    PrintHookEndErrorStaleLine(source_name='', table_name='', index=0, total=0, execution_time=0),
+    PrintHookEndWarnLine(source_name='', table_name='', index=0, total=0, execution_time=0),
+    PrintHookEndPassLine(source_name='', table_name='', index=0, total=0, execution_time=0),
+    PrintCancelLine(conn_name=''),
+    DefaultSelector(name=''),
+    NodeStart(unique_id=''),
+    NodeFinished(unique_id=''),
+    QueryCancelationUnsupported(type=''),
+    ConcurrencyLine(concurrency_line=''),
+    StarterProjectPath(dir=''),
+    ConfigFolderDirectory(dir=''),
+    NoSampleProfileFound(adapter=''),
+    ProfileWrittenWithSample(name='', path=''),
+    ProfileWrittenWithTargetTemplateYAML(name='', path=''),
+    ProfileWrittenWithProjectTemplateYAML(name='', path=''),
+    SettingUpProfile(),
+    InvalidProfileTemplateYAML(),
+    ProjectNameAlreadyExists(name=''),
+    GetAddendum(msg=''),
+    DepsSetDownloadDirectory(path=''),
+    EnsureGitInstalled(),
+    DepsCreatingLocalSymlink(),
+    DepsSymlinkNotAvailable(),
+    FoundStats(stat_line=''),
+    CompilingNode(unique_id=''),
+    WritingInjectedSQLForNode(unique_id=''),
+    DisableTracking(),
+    SendingEvent(kwargs=''),
+    SendEventFailure(),
+    FlushEvents(),
+    FlushEventsFailure(),
+    TrackingInitializeFailure(),
+    RetryExternalCall(attempt=0, max=0),
+    GeneralWarningMsg(msg='', log_fmt=''),
+    GeneralWarningException(exc=Exception(''), log_fmt='')
+]
+
+
+class TestEventJSONSerialization(TestCase):
+
+    # attempts to test that every event is serializable to json.
+    # event types that take `Any` are not possible to test in this way since some will serialize
+    # just fine and others won't.
+    def test_all_serializable(self):
+        all_events = get_all_subclasses(Event)
+        all_event_values = set(map(lambda x: x.__class__, sample_values))
+        diff = all_events.difference(all_event_values)
+        self.assertFalse(diff, f"test is missing concrete values in `sample_values`. Please add the missing values for the following event classes: {diff}")
+
+        # if we have everything we need to test, try to serialize everything
+        for event in all_event_values:
+            try:
+                json.dumps(event_to_serializable_dict(event))
+            except TypeError as e:
+                raise Exception(f"Event is not serializable to json. Originating exception: {e}")
                 


### PR DESCRIPTION
### Description

This PR does three things:

1. Instead of inspecting the Python dictionary values for scrubability before converting to a string, convert the whole log line to a json string and scrub the string.

which requires

2. More graceful handling of events with non json serializable field types, by making the serialization function overridable.

which implies the need for

3. A test that attempts to serialize one instance of each concrete event type into JSON. This is not a perfect test becuase some of these events are annotated with the `Any` type so mypy nor this test will catch if some instances of that class that we make somewhere in the code base are not serializable. However, in that case instead of exploding or hanging, users will see something like `{ ... "some_key": "JSON_SERIALIZE_FAILED: MyClass", ... }`.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
