### PR TITLE
[#4254] Change some CompilationExceptions to ParsingExceptions in the parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-core 1.0.0 (Release TBD)
 
+### Under the hood
+
+- Change some CompilationExceptions to ParsingExceptions ([#4254](http://github.com/dbt-labs/dbt-core/issues/4254), [#4328](https://github.com/dbt-core/pull/4328))
+
 ## dbt-core 1.0.0rc2 (November 22, 2021)
 
 ### Breaking changes

--- a/core/dbt/parser/base.py
+++ b/core/dbt/parser/base.py
@@ -23,7 +23,7 @@ from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.parsed import HasUniqueID, ManifestNodes
 from dbt.contracts.graph.unparsed import UnparsedNode
 from dbt.exceptions import (
-    CompilationException, validator_error_message, InternalException
+    ParsingException, validator_error_message, InternalException
 )
 from dbt import hooks
 from dbt.node_types import NodeType
@@ -247,7 +247,7 @@ class ConfiguredParser(
                 original_file_path=block.path.original_file_path,
                 raw_sql=block.contents,
             )
-            raise CompilationException(msg, node=node)
+            raise ParsingException(msg, node=node)
 
     def _context_for(
         self, parsed_node: IntermediateNode, config: ContextConfig
@@ -378,7 +378,7 @@ class ConfiguredParser(
         except ValidationError as exc:
             # we got a ValidationError - probably bad types in config()
             msg = validator_error_message(exc)
-            raise CompilationException(msg, node=node) from exc
+            raise ParsingException(msg, node=node) from exc
 
     def add_result_node(self, block: FileBlock, node: ManifestNodes):
         if node.config.enabled:

--- a/core/dbt/parser/generic_test.py
+++ b/core/dbt/parser/generic_test.py
@@ -2,7 +2,7 @@ from typing import Iterable, List
 
 import jinja2
 
-from dbt.exceptions import CompilationException
+from dbt.exceptions import ParsingException
 from dbt.clients import jinja
 from dbt.contracts.graph.parsed import ParsedGenericTestNode
 from dbt.contracts.graph.unparsed import UnparsedMacro
@@ -55,14 +55,14 @@ class GenericTestParser(BaseParser[ParsedGenericTestNode]):
                 )
                 if isinstance(t, jinja.BlockTag)
             ]
-        except CompilationException as exc:
+        except ParsingException as exc:
             exc.add_node(base_node)
             raise
 
         for block in blocks:
             try:
                 ast = jinja.parse(block.full_block)
-            except CompilationException as e:
+            except ParsingException as e:
                 e.add_node(base_node)
                 raise
 
@@ -72,7 +72,7 @@ class GenericTestParser(BaseParser[ParsedGenericTestNode]):
             if len(generic_test_nodes) != 1:
                 # things have gone disastrously wrong, we thought we only
                 # parsed one block!
-                raise CompilationException(
+                raise ParsingException(
                     f'Found multiple generic tests in {block.full_block}, expected 1',
                     node=base_node
                 )

--- a/core/dbt/parser/macros.py
+++ b/core/dbt/parser/macros.py
@@ -6,7 +6,7 @@ from dbt.clients import jinja
 from dbt.contracts.graph.unparsed import UnparsedMacro
 from dbt.contracts.graph.parsed import ParsedMacro
 from dbt.contracts.files import FilePath, SourceFile
-from dbt.exceptions import CompilationException
+from dbt.exceptions import ParsingException
 from dbt.events.functions import fire_event
 from dbt.events.types import MacroFileParse
 from dbt.node_types import NodeType
@@ -62,14 +62,14 @@ class MacroParser(BaseParser[ParsedMacro]):
                 )
                 if isinstance(t, jinja.BlockTag)
             ]
-        except CompilationException as exc:
+        except ParsingException as exc:
             exc.add_node(base_node)
             raise
 
         for block in blocks:
             try:
                 ast = jinja.parse(block.full_block)
-            except CompilationException as e:
+            except ParsingException as e:
                 e.add_node(base_node)
                 raise
 
@@ -78,7 +78,7 @@ class MacroParser(BaseParser[ParsedMacro]):
             if len(macro_nodes) != 1:
                 # things have gone disastrously wrong, we thought we only
                 # parsed one block!
-                raise CompilationException(
+                raise ParsingException(
                     f'Found multiple macros in {block.full_block}, expected 1',
                     node=base_node
                 )

--- a/core/dbt/parser/read_files.py
+++ b/core/dbt/parser/read_files.py
@@ -5,7 +5,7 @@ from dbt.contracts.files import (
 )
 
 from dbt.parser.schemas import yaml_from_file, schema_file_keys, check_format_version
-from dbt.exceptions import CompilationException
+from dbt.exceptions import ParsingException
 from dbt.parser.search import filesystem_search
 from typing import Optional
 
@@ -54,17 +54,17 @@ def validate_yaml(file_path, dct):
             if not isinstance(dct[key], list):
                 msg = (f"The schema file at {file_path} is "
                        f"invalid because the value of '{key}' is not a list")
-                raise CompilationException(msg)
+                raise ParsingException(msg)
             for element in dct[key]:
                 if not isinstance(element, dict):
                     msg = (f"The schema file at {file_path} is "
                            f"invalid because a list element for '{key}' is not a dictionary")
-                    raise CompilationException(msg)
+                    raise ParsingException(msg)
                 if 'name' not in element:
                     msg = (f"The schema file at {file_path} is "
                            f"invalid because a list element for '{key}' does not have a "
                            "name attribute.")
-                    raise CompilationException(msg)
+                    raise ParsingException(msg)
 
 
 # Special processing for big seed files

--- a/core/dbt/parser/search.py
+++ b/core/dbt/parser/search.py
@@ -8,7 +8,7 @@ from dbt.clients.jinja import extract_toplevel_blocks, BlockTag
 from dbt.clients.system import find_matching
 from dbt.config import Project
 from dbt.contracts.files import FilePath, AnySourceFile
-from dbt.exceptions import CompilationException, InternalException
+from dbt.exceptions import ParsingException, InternalException
 
 
 # What's the point of wrapping a SourceFile with this class?
@@ -113,7 +113,7 @@ class BlockSearcher(Generic[BlockSearchResult], Iterable[BlockSearchResult]):
                 assert isinstance(block, BlockTag)
                 yield block
 
-        except CompilationException as exc:
+        except ParsingException as exc:
             if exc.node is None:
                 exc.add_node(source_file)
             raise

--- a/core/dbt/parser/snapshots.py
+++ b/core/dbt/parser/snapshots.py
@@ -7,7 +7,7 @@ from dbt.contracts.graph.parsed import (
     IntermediateSnapshotNode, ParsedSnapshotNode
 )
 from dbt.exceptions import (
-    CompilationException, validator_error_message
+    ParsingException, validator_error_message
 )
 from dbt.node_types import NodeType
 from dbt.parser.base import SQLParser
@@ -68,7 +68,7 @@ class SnapshotParser(
             self.set_snapshot_attributes(parsed_node)
             return parsed_node
         except ValidationError as exc:
-            raise CompilationException(validator_error_message(exc), node)
+            raise ParsingException(validator_error_message(exc), node)
 
     def parse_file(self, file_block: FileBlock) -> None:
         blocks = BlockSearcher(

--- a/test/integration/004_simple_snapshot_test/test_simple_snapshot.py
+++ b/test/integration/004_simple_snapshot_test/test_simple_snapshot.py
@@ -344,7 +344,7 @@ class TestBadSnapshot(DBTIntegrationTest):
 
     @use_profile('postgres')
     def test__postgres__invalid(self):
-        with self.assertRaises(dbt.exceptions.CompilationException) as exc:
+        with self.assertRaises(dbt.exceptions.ParsingException) as exc:
             self.run_dbt(['compile'], expect_pass=False)
 
         self.assertIn('Snapshots must be configured with a \'strategy\'', str(exc.exception))

--- a/test/integration/008_schema_tests_test/test_schema_v2_tests.py
+++ b/test/integration/008_schema_tests_test/test_schema_v2_tests.py
@@ -2,7 +2,7 @@ from test.integration.base import DBTIntegrationTest, FakeArgs, use_profile
 import os
 
 from dbt.task.test import TestTask
-from dbt.exceptions import CompilationException, ParsingException
+from dbt.exceptions import ParsingException
 from dbt.contracts.results import TestStatus
 
 
@@ -772,7 +772,7 @@ class TestInvalidSchema(DBTIntegrationTest):
 
     @use_profile('postgres')
     def test_postgres_invalid_schema_file(self):
-        with self.assertRaises(CompilationException) as exc:
+        with self.assertRaises(ParsingException) as exc:
             results = self.run_dbt()
         self.assertRegex(str(exc.exception), r"'models' is not a list")
 


### PR DESCRIPTION

resolves #4254

### Description

We've recently added a ParsingException class. This pull request changes existing CompilationExceptions in the parser files to ParsingExceptions. We will still get CompilationExceptions when parsing from the rendering code, but that's more complicated to change because rendering is done both at parsing and at compilation time. Ideally we will straighten those out in a future effort.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
