### PR TITLE
Fix static parser tracking logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Under the hood
 - Change some CompilationExceptions to ParsingExceptions ([#4254](http://github.com/dbt-labs/dbt-core/issues/4254), [#4328](https://github.com/dbt-core/pull/4328))
+- Reorder logic for static parser sampling to speed up model parsing ([#4332](https://github.com/dbt-labs/dbt-core/pull/4332))
 
 
 ## dbt-core 1.0.0rc2 (November 22, 2021)


### PR DESCRIPTION
### Background

I noticed a few weird things this morning:
- We have _way_ too many `cannot_parse` results in anonymous usage tracking for v1 — many more than I'd expect if we're only sampling one out of every 50k models
- Using latest v1, `dbt --no-partial-parse parse` ("cold parse") in our internal analytics project is taking 15-16 seconds, instead of 7-8 seconds. Indeed, that extra time is spent in _tracking_:

<img width="1007" alt="Screenshot 2021-11-24 at 12 23 28" src="https://user-images.githubusercontent.com/13897643/143233184-3669485e-6c67-4781-ad57-7c4c8c2ccaa9.png">

### Fix

We're firing a tracking event _every single time_ the stable parser `cannot_parse` (or `has_banned_macro`). Instead, we should only populate the tracking result if we're sampling. When I make this change, a "cold parse" of our internal analytics project takes 7-8 seconds again. Hooray!

While here:
- Consolidated the logic, so this check + result population happens as part of the "fall back to jinja" conditional branch
- We should be checking `experimental_sample`, too, and firing a differently coded event depending (`0x`vs. `8x`)

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
