### PR TITLE
[#4337] Always create an invocation_id, even when not tracking

### DIFF
--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -15,7 +15,7 @@ from dbt.exceptions import (
     raise_compiler_error, MacroReturn, raise_parsing_error, disallow_secret_env_var
 )
 from dbt.logger import SECRET_ENV_PREFIX
-from dbt.events.functions import fire_event
+from dbt.events.functions import fire_event, get_invocation_id
 from dbt.events.types import MacroEventInfo, MacroEventDebug
 from dbt.version import __version__ as dbt_version
 
@@ -526,10 +526,7 @@ class BaseContext(metaclass=ContextMeta):
         """invocation_id outputs a UUID generated for this dbt run (useful for
         auditing)
         """
-        if tracking.active_user is not None:
-            return tracking.active_user.invocation_id
-        else:
-            return None
+        return get_invocation_id()
 
     @contextproperty
     def modules(self) -> Dict[str, Any]:

--- a/core/dbt/contracts/util.py
+++ b/core/dbt/contracts/util.py
@@ -11,7 +11,7 @@ from dbt.exceptions import (
     RuntimeException,
 )
 from dbt.version import __version__
-from dbt.tracking import get_invocation_id
+from dbt.events.functions import get_invocation_id
 from dbt.dataclass_schema import dbtClassMixin
 
 SourceKey = Tuple[str, str]

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -88,6 +88,11 @@ class Event(metaclass=ABCMeta):
             self.pid = os.getpid()
         return self.pid
 
+    @classmethod
+    def get_invocation_id(cls) -> str:
+        from dbt.events.functions import get_invocation_id
+        return get_invocation_id()
+
 
 class File(Event, metaclass=ABCMeta):
     # Solely the human readable message. Timestamps and formatting will be added by the logger.

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -15,6 +15,7 @@ from logging import Logger
 from logging.handlers import RotatingFileHandler
 import numbers
 import os
+import uuid
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 from dataclasses import _FIELD_BASE  # type: ignore[attr-defined]
 
@@ -36,6 +37,7 @@ STDOUT_LOG.addHandler(stdout_handler)
 
 format_color = True
 format_json = False
+invocation_id: Optional[str] = None
 
 
 def setup_event_logger(log_path):
@@ -151,7 +153,8 @@ def event_to_dict(e: T_Event, msg_fn: Callable[[T_Event], str]) -> dict:
         'msg': msg_fn(e),
         'level': level,
         'data': Optional[Dict[str, Any]],
-        'event_data_serialized': True
+        'event_data_serialized': True,
+        'invocation_id': e.get_invocation_id()
     }
 
 
@@ -314,3 +317,10 @@ def fire_event(e: Event) -> None:
                 stack_info=e.stack_info,
                 extra=e.extra
             )
+
+
+def get_invocation_id() -> str:
+    global invocation_id
+    if invocation_id is None:
+        invocation_id = str(uuid.uuid4())
+    return invocation_id

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -19,7 +19,7 @@ from dbt.adapters.factory import (
     get_adapter_package_names,
 )
 from dbt.helper_types import PathSet
-from dbt.events.functions import fire_event
+from dbt.events.functions import fire_event, get_invocation_id
 from dbt.events.types import (
     PartialParsingFullReparseBecauseOfError, PartialParsingExceptionFile, PartialParsingFile,
     PartialParsingException, PartialParsingSkipParsing, PartialParsingMacroChangeStartFullParse,
@@ -629,10 +629,7 @@ class ManifestLoader:
                     # We don't want to have stale generated_at dates
                     manifest.metadata.generated_at = datetime.utcnow()
                     # or invocation_ids
-                    if dbt.tracking.active_user:
-                        manifest.metadata.invocation_id = dbt.tracking.active_user.invocation_id
-                    else:
-                        manifest.metadata.invocation_id = None
+                    manifest.metadata.invocation_id = get_invocation_id()
                     return manifest
             except Exception as exc:
                 fire_event(ParsedFileLoadFailed(path=path, exc=exc))
@@ -772,7 +769,7 @@ class ManifestLoader:
 
     # Create tracking event for saving performance info
     def track_project_load(self):
-        invocation_id = dbt.tracking.active_user.invocation_id
+        invocation_id = get_invocation_id()
         dbt.tracking.track_project_load({
             "invocation_id": invocation_id,
             "project_id": self.root_project.hashed_name(),

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -28,7 +28,7 @@ from dbt.exceptions import (
     RuntimeException,
     missing_materialization,
 )
-from dbt.events.functions import fire_event
+from dbt.events.functions import fire_event, get_invocation_id
 from dbt.events.types import (
     DatabaseErrorRunning, EmptyLine, HooksRunning, HookFinished,
     PrintModelErrorResultLine, PrintModelResultLine, PrintStartLine,
@@ -102,7 +102,7 @@ def get_hook(source, index):
 def track_model_run(index, num_nodes, run_model_result):
     if tracking.active_user is None:
         raise InternalException('cannot track model run with no active user')
-    invocation_id = tracking.active_user.invocation_id
+    invocation_id = get_invocation_id()
     tracking.track_model_run({
         "invocation_id": invocation_id,
         "index": index,

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -32,6 +32,7 @@ from dbt.contracts.graph.unparsed import (
 )
 
 from dbt.contracts.graph.compiled import CompiledModelNode
+from dbt.events.functions import get_invocation_id
 from dbt.node_types import NodeType
 import freezegun
 
@@ -295,6 +296,8 @@ class ManifestTest(unittest.TestCase):
             exposures={}, metrics={}, selectors={},
             metadata=ManifestMetadata(generated_at=datetime.utcnow()),
         )
+
+        invocation_id = dbt.events.functions.invocation_id
         self.assertEqual(
             manifest.writable_manifest().to_dict(omit_none=True),
             {
@@ -311,7 +314,7 @@ class ManifestTest(unittest.TestCase):
                     'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v4.json',
                     'dbt_version': dbt.version.__version__,
                     'env': {ENV_KEY_NAME: 'value'},
-                    # invocation_id is None, so it will not be present
+                    'invocation_id': invocation_id,
                 },
                 'docs': {},
                 'disabled': {},
@@ -411,7 +414,7 @@ class ManifestTest(unittest.TestCase):
     @mock.patch.object(tracking, 'active_user')
     def test_metadata(self, mock_user):
         mock_user.id = 'cfc9500f-dc7f-4c83-9ea7-2c581c1b38cf'
-        mock_user.invocation_id = '01234567-0123-0123-0123-0123456789ab'
+        dbt.events.functions.invocation_id = '01234567-0123-0123-0123-0123456789ab'
         dbt.flags.SEND_ANONYMOUS_USAGE_STATS = False
         now = datetime.utcnow()
         self.assertEqual(
@@ -434,7 +437,7 @@ class ManifestTest(unittest.TestCase):
     @freezegun.freeze_time('2018-02-14T09:15:13Z')
     def test_no_nodes_with_metadata(self, mock_user):
         mock_user.id = 'cfc9500f-dc7f-4c83-9ea7-2c581c1b38cf'
-        mock_user.invocation_id = '01234567-0123-0123-0123-0123456789ab'
+        dbt.events.functions.invocation_id = '01234567-0123-0123-0123-0123456789ab'
         dbt.flags.SEND_ANONYMOUS_USAGE_STATS = False
         metadata = ManifestMetadata(
             project_id='098f6bcd4621d373cade4e832627b4f6',

--- a/test/unit/test_tracking.py
+++ b/test/unit/test_tracking.py
@@ -35,7 +35,7 @@ class TestTracking(unittest.TestCase):
         assert dbt.tracking.active_user.invocation_id == invocation_id
         assert dbt.tracking.active_user.run_started_at == run_started_at
 
-        # this should generate a whole new user object -> new invocation_id/run_started_at
+        # this should generate a whole new user object -> new run_started_at
         dbt.tracking.do_not_track()
         assert isinstance(dbt.tracking.active_user, dbt.tracking.User)
 
@@ -43,7 +43,8 @@ class TestTracking(unittest.TestCase):
         assert dbt.tracking.active_user.id is None
         assert isinstance(dbt.tracking.active_user.invocation_id, str)
         assert isinstance(dbt.tracking.active_user.run_started_at, datetime.datetime)
-        assert dbt.tracking.active_user.invocation_id != invocation_id
+        # invocation_id no longer only linked to active_user so it doesn't change
+        assert dbt.tracking.active_user.invocation_id == invocation_id
         # if you use `!=`, you might hit a race condition (especially on windows)
         assert dbt.tracking.active_user.run_started_at is not run_started_at
 


### PR DESCRIPTION
resolves #4337

### Description

For logging purposes we always want an invocation_id, even when we're not tracking. This pull request decouples the invocation_id from dbt.tracking.active_user.

I've added a 'get_invocation_id' class method to the base Event class, but I put the generic 'get_invocation_id' and the global variable invocation_id in dbt.events.functions, because that felt more appropriate and I don't think we want to import the base_types file everywhere that we're setting the invocation_id. That meant that I had to do the import of get_invocation_id in the Event.get_invocation_id function to avoid circular imports. Let me know if you see a better way of doing that.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
