### PR TITLE
Logging: restore previous (small) behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Under the hood
 - Change some CompilationExceptions to ParsingExceptions ([#4254](http://github.com/dbt-labs/dbt-core/issues/4254), [#4328](https://github.com/dbt-core/pull/4328))
 - Reorder logic for static parser sampling to speed up model parsing ([#4332](https://github.com/dbt-labs/dbt-core/pull/4332))
+- Restore small previous behaviors for logging: JSON formatting for first few events; `WARN`-level stdout for `list` task; include tracking events in `dbt.log` ([#4341](https://github.com/dbt-labs/dbt-core/pull/4341))
 
 
 ## dbt-core 1.0.0rc2 (November 22, 2021)

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -48,7 +48,7 @@ def setup_event_logger(log_path):
     this.format_color = True if flags.USE_COLORS else False
     # TODO this default should live somewhere better
     log_dest = os.path.join(log_path, 'dbt.log')
-    level = logging.DEBUG if flags.DEBUG else logging.INFO
+    level = logging.DEBUG if flags.DEBUG else this.STDOUT_LOG.level
 
     # overwrite the STDOUT_LOG logger with the configured one
     this.STDOUT_LOG = logging.getLogger('configured_std_out')

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -40,7 +40,7 @@ format_json = False
 invocation_id: Optional[str] = None
 
 
-def setup_event_logger(log_path):
+def setup_event_logger(log_path, level_override=None):
     make_log_dir_if_missing(log_path)
     this.format_json = flags.LOG_FORMAT == 'json'
     # USE_COLORS can be None if the app just started and the cli flags
@@ -48,7 +48,7 @@ def setup_event_logger(log_path):
     this.format_color = True if flags.USE_COLORS else False
     # TODO this default should live somewhere better
     log_dest = os.path.join(log_path, 'dbt.log')
-    level = logging.DEBUG if flags.DEBUG else this.STDOUT_LOG.level
+    level = level_override or (logging.DEBUG if flags.DEBUG else logging.INFO)
 
     # overwrite the STDOUT_LOG logger with the configured one
     this.STDOUT_LOG = logging.getLogger('configured_std_out')

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -137,7 +137,7 @@ class MainReportArgs(DebugLevel, Cli, File):
 
 
 @dataclass
-class MainTrackingUserState(DebugLevel, Cli):
+class MainTrackingUserState(DebugLevel, Cli, File):
     user_state: str
     code: str = "A003"
 
@@ -2365,7 +2365,7 @@ class DisableTracking(WarnLevel, Cli, File):
 
 
 @dataclass
-class SendingEvent(DebugLevel, Cli):
+class SendingEvent(DebugLevel, Cli, File):
     kwargs: str
     code: str = "Z040"
 

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -223,6 +223,7 @@ def run_from_args(parsed):
 
     # we can now use the logger for stdout
     # set log_format in the logger
+    # if 'list' task: set stdout to WARN instead of INFO
     level_override = parsed.cls.pre_init_hook(parsed)
 
     fire_event(MainReportVersion(v=dbt.version.installed))

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -223,7 +223,7 @@ def run_from_args(parsed):
 
     # we can now use the logger for stdout
     # set log_format in the logger
-    parsed.cls.pre_init_hook(parsed)
+    level_override = parsed.cls.pre_init_hook(parsed)
 
     fire_event(MainReportVersion(v=dbt.version.installed))
 
@@ -237,7 +237,7 @@ def run_from_args(parsed):
         log_path = getattr(task.config, 'log_path', None)
     # we can finally set the file logger up
     log_manager.set_path(log_path)
-    setup_event_logger(log_path or 'logs')
+    setup_event_logger(log_path or 'logs', level_override)
     if dbt.tracking.active_user is not None:  # mypy appeasement, always true
         fire_event(MainTrackingUserState(dbt.tracking.active_user.state()))
 

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -15,6 +15,7 @@ from dbt.exceptions import (
     InternalException
 )
 from dbt.logger import log_manager
+import dbt.events.functions as event_logger
 from dbt.events.functions import fire_event
 from dbt.events.types import (
     DbtProjectError, DbtProjectErrorException, DbtProfileError, DbtProfileErrorException,
@@ -64,6 +65,7 @@ class BaseTask(metaclass=ABCMeta):
         """A hook called before the task is initialized."""
         if args.log_format == 'json':
             log_manager.format_json()
+            event_logger.format_json = True
         else:
             log_manager.format_text()
 
@@ -71,6 +73,7 @@ class BaseTask(metaclass=ABCMeta):
     def set_log_format(cls):
         if flags.LOG_FORMAT == 'json':
             log_manager.format_json()
+            event_logger.format_json = True
         else:
             log_manager.format_text()
 

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -15,6 +15,7 @@ from dbt.exceptions import (
     InternalException
 )
 from dbt.logger import log_manager
+import logging
 import dbt.events.functions as event_logger
 from dbt.events.functions import fire_event
 from dbt.events.types import (
@@ -63,6 +64,9 @@ class BaseTask(metaclass=ABCMeta):
     @classmethod
     def pre_init_hook(cls, args):
         """A hook called before the task is initialized."""
+        # the event logger has been initialized, but it has not yet been configured
+        # TODO refactor
+        event_logger.STDOUT_LOG.level = logging.DEBUG if args.debug else logging.INFO
         if args.log_format == 'json':
             log_manager.format_json()
             event_logger.format_json = True
@@ -71,6 +75,9 @@ class BaseTask(metaclass=ABCMeta):
 
     @classmethod
     def set_log_format(cls):
+        # the event logger has been initialized, but it has not yet been configured
+        # TODO refactor
+        event_logger.STDOUT_LOG.level = logging.DEBUG if flags.DEBUG else logging.INFO
         if flags.LOG_FORMAT == 'json':
             log_manager.format_json()
             event_logger.format_json = True

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -65,6 +65,8 @@ class BaseTask(metaclass=ABCMeta):
         """A hook called before the task is initialized."""
         if args.log_format == 'json':
             log_manager.format_json()
+            # we're mutating the initialized, but not-yet-configured event logger
+            # because it's being configured too late -- bad! TODO refactor!
             event_logger.format_json = True
         else:
             log_manager.format_text()
@@ -73,6 +75,8 @@ class BaseTask(metaclass=ABCMeta):
     def set_log_format(cls):
         if flags.LOG_FORMAT == 'json':
             log_manager.format_json()
+            # we're mutating the initialized, but not-yet-configured event logger
+            # because it's being configured too late -- bad! TODO refactor!
             event_logger.format_json = True
         else:
             log_manager.format_text()

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -15,7 +15,6 @@ from dbt.exceptions import (
     InternalException
 )
 from dbt.logger import log_manager
-import logging
 import dbt.events.functions as event_logger
 from dbt.events.functions import fire_event
 from dbt.events.types import (
@@ -64,9 +63,6 @@ class BaseTask(metaclass=ABCMeta):
     @classmethod
     def pre_init_hook(cls, args):
         """A hook called before the task is initialized."""
-        # the event logger has been initialized, but it has not yet been configured
-        # TODO refactor
-        event_logger.STDOUT_LOG.level = logging.DEBUG if args.debug else logging.INFO
         if args.log_format == 'json':
             log_manager.format_json()
             event_logger.format_json = True
@@ -75,9 +71,6 @@ class BaseTask(metaclass=ABCMeta):
 
     @classmethod
     def set_log_format(cls):
-        # the event logger has been initialized, but it has not yet been configured
-        # TODO refactor
-        event_logger.STDOUT_LOG.level = logging.DEBUG if flags.DEBUG else logging.INFO
         if flags.LOG_FORMAT == 'json':
             log_manager.format_json()
             event_logger.format_json = True

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -11,6 +11,8 @@ from dbt.task.test import TestSelector
 from dbt.node_types import NodeType
 from dbt.exceptions import RuntimeException, InternalException, warn_or_error
 from dbt.logger import log_manager
+import logging
+import dbt.events.functions as event_logger
 
 
 class ListTask(GraphRunnableTask):
@@ -56,6 +58,7 @@ class ListTask(GraphRunnableTask):
     def pre_init_hook(cls, args):
         """A hook called before the task is initialized."""
         log_manager.stderr_console()
+        event_logger.STDOUT_LOG.level = logging.WARN
         super().pre_init_hook(args)
 
     def _iterate_selected_nodes(self):

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -57,9 +57,17 @@ class ListTask(GraphRunnableTask):
     @classmethod
     def pre_init_hook(cls, args):
         """A hook called before the task is initialized."""
+        # Filter out all INFO-level logging to allow piping ls output to jq, etc
+        # WARN level will still include all warnings + errors
+        # Do this by:
+        #  - returning the log level so that we can pass it into the 'level_override'
+        #    arg of events.functions.setup_event_logger() -- good!
+        #  - mutating the initialized, not-yet-configured STDOUT event logger
+        #    because it's being configured too late -- bad! TODO refactor!
         log_manager.stderr_console()
         event_logger.STDOUT_LOG.level = logging.WARN
         super().pre_init_hook(args)
+        return logging.WARN
 
     def _iterate_selected_nodes(self):
         selector = self.get_node_selector()

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -57,14 +57,9 @@ class ListTask(GraphRunnableTask):
     @classmethod
     def pre_init_hook(cls, args):
         """A hook called before the task is initialized."""
-        super().pre_init_hook(args)
         log_manager.stderr_console()
-        # filter out all INFO-level logging to allow piping ls output to jq, etc
-        # WARN level will still include all warnings + errors
-        # if user has specified DEBUG level (dbt --debug), don't override
-        # TODO refactor!
-        if event_logger.STDOUT_LOG.level == logging.INFO:
-            event_logger.STDOUT_LOG.level = logging.WARN
+        event_logger.STDOUT_LOG.level = logging.WARN
+        super().pre_init_hook(args)
 
     def _iterate_selected_nodes(self):
         selector = self.get_node_selector()

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -57,9 +57,14 @@ class ListTask(GraphRunnableTask):
     @classmethod
     def pre_init_hook(cls, args):
         """A hook called before the task is initialized."""
-        log_manager.stderr_console()
-        event_logger.STDOUT_LOG.level = logging.WARN
         super().pre_init_hook(args)
+        log_manager.stderr_console()
+        # filter out all INFO-level logging to allow piping ls output to jq, etc
+        # WARN level will still include all warnings + errors
+        # if user has specified DEBUG level (dbt --debug), don't override
+        # TODO refactor!
+        if event_logger.STDOUT_LOG.level == logging.INFO:
+            event_logger.STDOUT_LOG.level = logging.WARN
 
     def _iterate_selected_nodes(self):
         selector = self.get_node_selector()


### PR DESCRIPTION
From #4260:

> - [ ] (size: S) Find a way to configure logger _before_ firing any events, e.g. avoid text logs preceding JSON logs

```
$ dbt --log-format json run
{"data": null, "event_data_serialized": false, "invocation_id": "455dcb72-fcb5-41dd-bc64-4e0279a45a7c", "level": "info", "log_version": 1, "msg": "Running with dbt=1.0.0-rc2", "pid": 81044, "ts": "2021-11-25T14:56:50.296716"}
{"data": {"code": "Z046", "log_fmt": null, "msg": "* Deprecation Warning:\nThe `source-paths` config has been deprecated in favor of `model-paths`. Please\nupdate your `dbt_project.yml` configuration to reflect this change."}, "event_data_serialized": true, "invocation_id": "455dcb72-fcb5-41dd-bc64-4e0279a45a7c", "level": "warn", "log_version": 1, "msg": "* Deprecation Warning:\nThe `source-paths` config has been deprecated in favor of `model-paths`. Please\nupdate your `dbt_project.yml` configuration to reflect this change.", "pid": 81044, "ts": "2021-11-25T14:56:50.358948"}
{"data": {"code": "Z046", "log_fmt": null, "msg": "* Deprecation Warning:\nThe `data-paths` config has been deprecated in favor of `seed-paths`. Please\nupdate your `dbt_project.yml` configuration to reflect this change."}, "event_data_serialized": true, "invocation_id": "455dcb72-fcb5-41dd-bc64-4e0279a45a7c", "level": "warn", "log_version": 1, "msg": "* Deprecation Warning:\nThe `data-paths` config has been deprecated in favor of `seed-paths`. Please\nupdate your `dbt_project.yml` configuration to reflect this change.", "pid": 81044, "ts": "2021-11-25T14:56:50.360507"}
{"data": {"code": "W006", "stat_line": "2 models, 1 test, 0 snapshots, 0 analyses, 355 macros, 0 operations, 0 seed files, 0 sources, 0 exposures, 1 metric"}, "event_data_serialized": true, "invocation_id": "455dcb72-fcb5-41dd-bc64-4e0279a45a7c", "level": "info", "log_version": 1, "msg": "Found 2 models, 1 test, 0 snapshots, 0 analyses, 355 macros, 0 operations, 0 seed files, 0 sources, 0 exposures, 1 metric", "pid": 81044, "ts": "2021-11-25T14:56:50.485785"}
```

> - [ ] (size: S) feature parity for `dbt ls` + workflow automation: set stdout logger to WARN level instead of INFO (see [here](https://github.com/dbt-labs/dbt-core/blob/22416980d19888d7bbbcfcda639c16d37a80b948/core/dbt/logger.py#L517-L521) + [here](https://github.com/dbt-labs/dbt-core/blob/22416980d19888d7bbbcfcda639c16d37a80b948/core/dbt/task/list.py#L55-L59)), or better yet replace [`print()` 
here](https://github.com/dbt-labs/dbt-core/blob/22416980d19888d7bbbcfcda639c16d37a80b948/core/dbt/task/list.py#L151) with an actual fired event that can be filtered on + piped out (??)

```
$ dbt ls
14:57:26 | [ warn  ] | * Deprecation Warning:
The `source-paths` config has been deprecated in favor of `model-paths`. Please
update your `dbt_project.yml` configuration to reflect this change.
14:57:26 | [ warn  ] | * Deprecation Warning:
The `data-paths` config has been deprecated in favor of `seed-paths`. Please
update your `dbt_project.yml` configuration to reflect this change.
testy.ephemeral_model
testy.my_model
```

For both of these, I took the goal as providing exact parity with legacy logging behavior, with as small a lift as possible. That means, if we hook into legacy logger methods from `main.py` by way of task methods in a few subtle ways (`pre_init_hook`, `set_log_format`), we should set the same configs for the new event logger. If we hate this and want to keep config centralized, we can take up a more serious refactor.

> - [ ] (size: S) include snowplow tracking events in file logging (not cli) when available (i.e. without breaking `dbt clean`)

This was just a matter of adding `File` back to tracking events. I'm able to `dbt clean`, with `logs/` as a clean target, without dbt throwing up an error that it can't find the file it expects to write to. If I had to guess, the switch from `WatchedFileHandler` to `RotatingFileHandler` may have fixed this?

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
