### PR TITLE
Use `cls` in classmethod

### DIFF
--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -195,7 +195,7 @@ class ManifestLoader:
             start_load_all = time.perf_counter()
 
             projects = config.load_dependencies()
-            loader = ManifestLoader(config, projects, macro_hook)
+            loader = cls(config, projects, macro_hook)
 
             manifest = loader.load()
 


### PR DESCRIPTION
Instead of calling the class explicitly, use the `cls` variable instead.

resolves #4344 

### Description

Minor change: use the `cls` variable inside a class method. When I read this class method, I read it like it was instantiating another class, where the same class is expected.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] ~I have run this code in development and it appears to resolve the stated issue~ NA minor change
- [x] This PR includes tests, or tests are not required/relevant for this PR 
- [x] ~I have updated the `CHANGELOG.md` and added information about my change~ Not needed, minor change
