### PR TITLE
Make `read_files` behave functional and let `filesystem_search` accept multiple extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@
 - Use more augmented assignment statements ([#4315](https://github.com/dbt-labs/dbt-core/issues/4315)), ([#4311](https://github.com/dbt-labs/dbt-core/pull/4331))
 - Adjust logic when finding approximate matches for models and tests ([#3835](https://github.com/dbt-labs/dbt-core/issues/3835)), [#4076](https://github.com/dbt-labs/dbt-core/pull/4076))
 - Restore small previous behaviors for logging: JSON formatting for first few events; `WARN`-level stdout for `list` task; include tracking events in `dbt.log` ([#4341](https://github.com/dbt-labs/dbt-core/pull/4341))
+- Refactor `read_files` to be functional and let `filesystem_search` accept multiple file extensions ([#4348](https://github.com/dbt-labs/dbt-core/pull/4348))
 
 Contributors:
 - [@sarah-weatherbee](https://github.com/sarah-weatherbee) ([#4331](https://github.com/dbt-labs/dbt-core/pull/4331))
 - [@emilieschario](https://github.com/emilieschario) ([#4076](https://github.com/dbt-labs/dbt-core/pull/4076))
 - [@sneznaj](https://github.com/sneznaj) ([#4349](https://github.com/dbt-labs/dbt-core/pull/4349))
+- [@JCZuurmond](https://github.com/jczuurmond) ([#4348](https://github.com/dbt-labs/dbt-core/pull/4348))
 
 ## dbt-core 1.0.0rc2 (November 22, 2021)
 

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -220,12 +220,23 @@ class ManifestLoader:
         # of parsers to lists of file strings. The file strings are
         # used to get the SourceFiles from the manifest files.
         start_read_files = time.perf_counter()
-        project_parser_files = {}
         saved_files = {}
         if self.saved_manifest:
             saved_files = self.saved_manifest.files
-        for project in self.all_projects.values():
-            read_files(project, self.manifest.files, project_parser_files, saved_files)
+
+        project_parser_files = {
+            project.project_name: read_files(project, saved_files)
+            for project in self.all_projects.values()
+        }
+
+        for files in project_parser_files.values():
+            for file in files:
+                saved_files[file.file_id] = file
+        project_parser_files = {
+            project_name: list(map(lambda file: file.file_id, files))
+            for project_name, files in project_parser_files.items()
+        }
+
         orig_project_parser_files = project_parser_files
         self._perf_info.path_count = len(self.manifest.files)
         self._perf_info.read_files_elapsed = (time.perf_counter() - start_read_files)

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -229,10 +229,13 @@ class ManifestLoader:
             for project in self.all_projects.values()
         }
 
-        for project_files in project_parser_files.values():
-            for files in project_files.values():
-                for file in files:
-                    self.manifest.files[file.file_id] = file
+        all_files = {
+            file.file_id: file
+            for project_files in project_parser_files.values()
+            for files in project_files.values()
+            for file in files
+        }
+        self.manifest.files.update(all_files)
 
         project_parser_files = {
             project_name: {

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -229,12 +229,17 @@ class ManifestLoader:
             for project in self.all_projects.values()
         }
 
-        for files in project_parser_files.values():
-            for file in files:
-                saved_files[file.file_id] = file
+        for project_files in project_parser_files.values():
+            for files in project_files.values():
+                for file in files:
+                    self.manifest.files[file.file_id] = file
+
         project_parser_files = {
-            project_name: list(map(lambda file: file.file_id, files))
-            for project_name, files in project_parser_files.items()
+            project_name: {
+                parser_name: list(map(lambda file: file.file_id, files))
+                for parser_name, files in project_files.items()
+            }
+            for project_name, project_files in project_parser_files.items()
         }
 
         orig_project_parser_files = project_parser_files

--- a/core/dbt/parser/read_files.py
+++ b/core/dbt/parser/read_files.py
@@ -123,7 +123,7 @@ def get_source_files(project, paths, extension, parse_file_type, saved_files):
 # non-root projects need to be done separately in order?
 def read_files(
     project: Project, saved_files: dict[str, SourceFile]
-) -> dict[str, SourceFile]:
+) -> dict[str, list[SourceFile]]:
     """
     Read files all files within a project.
 
@@ -136,7 +136,7 @@ def read_files(
 
     Returns
     -------
-    dict[str, List[SourceFile]]
+    dict[str, list[SourceFile]]
         All files within a project mached for each parser type.
     """
     parser_file_types_with_paths = [

--- a/core/dbt/parser/read_files.py
+++ b/core/dbt/parser/read_files.py
@@ -114,22 +114,11 @@ def get_source_files(project, paths, extension, parse_file_type, saved_files):
     return fb_list
 
 
-def read_files_for_parser(project, files, dirs, extension, parse_ft, saved_files):
-    parser_files = []
-    source_files = get_source_files(
-        project, dirs, extension, parse_ft, saved_files
-    )
-    for sf in source_files:
-        files[sf.file_id] = sf
-        parser_files.append(sf.file_id)
-    return parser_files
-
-
 # This needs to read files for multiple projects, so the 'files'
 # dictionary needs to be passed in. What determines the order of
 # the various projects? Is the root project always last? Do the
 # non-root projects need to be done separately in order?
-def read_files(project, files, parser_files, saved_files):
+def read_files(project, parser_files, saved_files):
 
     parser_file_types_with_paths = [
         (ParseFileType.Macro, project.macro_paths, ".sql"),
@@ -143,8 +132,8 @@ def read_files(project, files, parser_files, saved_files):
         (ParseFileType.Schema, project.all_source_paths, [".yml", ".yaml"]),
     ]
     project_files = {
-        parse_file_type_to_parser[parser_file_type]: read_files_for_parser(
-            project, files, dirs, extension, parser_file_type, saved_files
+        parse_file_type_to_parser[parser_file_type]: get_source_files(
+            project, dirs, extension, parser_file_type, saved_files
         )
         for parser_file_type, dirs, extension in parser_file_types_with_paths
     }

--- a/core/dbt/parser/read_files.py
+++ b/core/dbt/parser/read_files.py
@@ -142,19 +142,12 @@ def read_files(project, files, parser_files, saved_files):
         (ParseFileType.GenericTest, project.generic_test_paths, ".sql"),
         (ParseFileType.Seed, project.seed_paths, ".csv"),
         (ParseFileType.Documentation, project.docs_paths, ".md"),
-        (ParseFileType.Schema, project.all_source_paths, ".yml"),
+        (ParseFileType.Schema, project.all_source_paths, [".yml", ".yaml"]),
     ]
     for parser_file_type, dirs, extension in parser_file_types_with_paths:
         project_files[parse_file_type_to_parser[parser_file_type]] = read_files_for_parser(
             project, files, dirs, extension, parser_file_type, saved_files
         )
-
-    # Also read .yaml files for schema files. Might be better to change
-    # 'read_files_for_parser' accept an array in the future.
-    yaml_files = read_files_for_parser(
-        project, files, project.all_source_paths, '.yaml', ParseFileType.Schema, saved_files
-    )
-    project_files['SchemaParser'].extend(yaml_files)
 
     # Store the parser files for this particular project
     parser_files[project.project_name] = project_files

--- a/core/dbt/parser/read_files.py
+++ b/core/dbt/parser/read_files.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 import pathlib
+from typing import Dict, List
+
 from dbt.config import Project
 from dbt.clients.system import load_file_contents
 from dbt.contracts.files import (
@@ -122,8 +122,8 @@ def get_source_files(project, paths, extension, parse_file_type, saved_files):
 # the various projects? Is the root project always last? Do the
 # non-root projects need to be done separately in order?
 def read_files(
-    project: Project, saved_files: dict[str, SourceFile]
-) -> dict[str, list[SourceFile]]:
+    project: Project, saved_files: Dict[str, SourceFile]
+) -> Dict[str, List[SourceFile]]:
     """
     Read files all files within a project.
 
@@ -131,12 +131,12 @@ def read_files(
     ----------
     project : Project
         A project.
-    saved_files : dict[str, SourceFile]
+    saved_files : Dict[str, SourceFile]
         The saved files. Functions as a cache for already loaded files.
 
     Returns
     -------
-    dict[str, list[SourceFile]]
+    Dict[str, List[SourceFile]]
         All files within a project mached for each parser type.
     """
     parser_file_types_with_paths = [

--- a/core/dbt/parser/read_files.py
+++ b/core/dbt/parser/read_files.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import pathlib
+from dbt.config import Project
 from dbt.clients.system import load_file_contents
 from dbt.contracts.files import (
     FilePath,
@@ -118,8 +121,24 @@ def get_source_files(project, paths, extension, parse_file_type, saved_files):
 # dictionary needs to be passed in. What determines the order of
 # the various projects? Is the root project always last? Do the
 # non-root projects need to be done separately in order?
-def read_files(project, parser_files, saved_files):
+def read_files(
+    project: Project, saved_files: dict[str, SourceFile]
+) -> dict[str, SourceFile]:
+    """
+    Read files all files within a project.
 
+    Parameters
+    ----------
+    project : Project
+        A project.
+    saved_files : dict[str, SourceFile]
+        The saved files. Functions as a cache for already loaded files.
+
+    Returns
+    -------
+    dict[str, List[SourceFile]]
+        All files within a project mached for each parser type.
+    """
     parser_file_types_with_paths = [
         (ParseFileType.Macro, project.macro_paths, ".sql"),
         (ParseFileType.Model, project.model_paths, ".sql"),
@@ -138,5 +157,4 @@ def read_files(project, parser_files, saved_files):
         for parser_file_type, dirs, extension in parser_file_types_with_paths
     }
 
-    # Store the parser files for this particular project
-    parser_files[project.project_name] = project_files
+    return project_files

--- a/core/dbt/parser/read_files.py
+++ b/core/dbt/parser/read_files.py
@@ -131,8 +131,6 @@ def read_files_for_parser(project, files, dirs, extension, parse_ft, saved_files
 # non-root projects need to be done separately in order?
 def read_files(project, files, parser_files, saved_files):
 
-    project_files = {}
-
     parser_file_types_with_paths = [
         (ParseFileType.Macro, project.macro_paths, ".sql"),
         (ParseFileType.Model, project.model_paths, ".sql"),
@@ -144,10 +142,12 @@ def read_files(project, files, parser_files, saved_files):
         (ParseFileType.Documentation, project.docs_paths, ".md"),
         (ParseFileType.Schema, project.all_source_paths, [".yml", ".yaml"]),
     ]
-    for parser_file_type, dirs, extension in parser_file_types_with_paths:
-        project_files[parse_file_type_to_parser[parser_file_type]] = read_files_for_parser(
+    project_files = {
+        parse_file_type_to_parser[parser_file_type]: read_files_for_parser(
             project, files, dirs, extension, parser_file_type, saved_files
         )
+        for parser_file_type, dirs, extension in parser_file_types_with_paths
+    }
 
     # Store the parser files for this particular project
     parser_files[project.project_name] = project_files

--- a/core/dbt/parser/search.py
+++ b/core/dbt/parser/search.py
@@ -63,22 +63,47 @@ class FullBlock(FileBlock):
         return self.block.full_block
 
 
-def filesystem_search(project: Project, relative_dirs: List[str], extension: str):
-    ext = "[!.#~]*" + extension
-    root = project.project_root
+def filesystem_search(
+    project: Project,
+    relative_dirs: List[str],
+    extension: Union[str, List[str]],
+) -> List[FilePath]:
+    """
+    Search for files in the project.
+
+    Parameters
+    ----------
+    project : Project
+        The project to search in.
+    relative_dirs : List[str]
+        The directories in which is searched, relative to the project root.
+    extension : Union[str, List[str]]
+        The extension(s) of the files to include.
+
+    Returns
+    -------
+    List[FilePath] :
+        The found file paths.
+    """
+    if isinstance(extension, str):
+        extension = [extension]
+
     file_path_list = []
-    for result in find_matching(root, relative_dirs, ext):
-        if 'searched_path' not in result or 'relative_path' not in result:
-            raise InternalException(
-                'Invalid result from find_matching: {}'.format(result)
+    for ext in extension:
+        ext = "[!.#~]*" + ext  # https://docs.python.org/3/library/fnmatch.html
+        root = project.project_root
+        for result in find_matching(root, relative_dirs, ext):
+            if "searched_path" not in result or "relative_path" not in result:
+                raise InternalException(
+                    "Invalid result from find_matching: {}".format(result)
+                )
+            file_match = FilePath(
+                searched_path=result["searched_path"],
+                relative_path=result["relative_path"],
+                modification_time=result["modification_time"],
+                project_root=root,
             )
-        file_match = FilePath(
-            searched_path=result['searched_path'],
-            relative_path=result['relative_path'],
-            modification_time=result['modification_time'],
-            project_root=root,
-        )
-        file_path_list.append(file_match)
+            file_path_list.append(file_match)
 
     return file_path_list
 


### PR DESCRIPTION
resolves #4343

### Description

Make `read_files` behave functional and let `filesystem_search` accept multiple extensions.

### Why am I working on this?

I would like to build a tool to test dbt macros. The tool should use `dbt-core` to retrieve macros, I think, it should use the `Manifest` class for this. Therefore, I started what the `ManifestBuilder` does, and was puzzled about what state  - like which files are read when - is added where to the `Manifest`. This rewrite pushes some of the building logic back into the `ManifestBuilder` class so that it is explicit where state is added to the manifest, instead of implicit in a function external to the `ManifestBuilder` class.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] ~I have run this code in development and it appears to resolve the stated issue~ NA, it's a refactor
- [x] ~This PR includes tests, or tests are not required/relevant for this PR~ NA, it's a refactor
- [x] I have updated the `CHANGELOG.md` and added information about my change
