### PR TITLE
Provide function to set the invocation_id

### DIFF
--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -324,3 +324,10 @@ def get_invocation_id() -> str:
     if invocation_id is None:
         invocation_id = str(uuid.uuid4())
     return invocation_id
+
+
+def set_invocation_id() -> None:
+    # This is primarily for setting the invocation_id for separate
+    # commands in the dbt servers. It shouldn't be necessary for the CLI.
+    global invocation_id
+    invocation_id = str(uuid.uuid4())


### PR DESCRIPTION
resolves #4337


### Description

This adds a 'set_invocation_id' function for use of the dbt rpc server.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
