### PR TITLE
add thread_name to structured logging

### DIFF
--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -2,6 +2,7 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 from dataclasses import dataclass
 from datetime import datetime
 import os
+import threading
 from typing import Any, Optional
 
 
@@ -87,6 +88,10 @@ class Event(metaclass=ABCMeta):
         if not self.pid:
             self.pid = os.getpid()
         return self.pid
+
+    # in theory threads can change so we don't cache them.
+    def get_thread_name(self) -> str:
+        return threading.current_thread().getName()
 
     @classmethod
     def get_invocation_id(cls) -> str:

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -154,7 +154,8 @@ def event_to_dict(e: T_Event, msg_fn: Callable[[T_Event], str]) -> dict:
         'level': level,
         'data': Optional[Dict[str, Any]],
         'event_data_serialized': True,
-        'invocation_id': e.get_invocation_id()
+        'invocation_id': e.get_invocation_id(),
+        'thread_name': e.get_thread_name()
     }
 
 


### PR DESCRIPTION
### Description

Adds the following field that was present in pre-1.0 json logging.

```
{ ... "thread_name": "MainThread", ... }
```

This uses the python-native thread name instead of the kernel assigned `thread_id` or `ident` for two reasons: 1 - it's what dbt used before, and 2 - kernel ids are OS specific (there are some cases where fetching these from linux doesn't get the right long value) and they can be reused by the kernel within the same running dbt process.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
