### PR TITLE
Event buffer for structlog

### DIFF
--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -20,9 +20,10 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, Deque
 from dataclasses import _FIELD_BASE  # type: ignore[attr-defined]
 from collections import deque
 
-# create the global event history buffer with a max size of 1M records
+# create the global event history buffer with a max size of 100k records
+# TODO: make the maxlen something configurable from the command line via args(?)
 global EVENT_HISTORY
-EVENT_HISTORY: Deque = deque(maxlen=1000000)
+EVENT_HISTORY: Deque = deque(maxlen=100000)
 
 # create the global file logger with no configuration
 global FILE_LOG
@@ -289,7 +290,7 @@ def fire_event(e: Event) -> None:
     # if and only if the event history deque will be completely filled by this event
     # fire warning that old events are now being dropped
     global EVENT_HISTORY
-    if len(EVENT_HISTORY) == (1000000 - 1):
+    if len(EVENT_HISTORY) == (100000 - 1):
         EVENT_HISTORY.append(e)
         fire_event(EventBufferFull())
     else:

--- a/core/dbt/events/history.py
+++ b/core/dbt/events/history.py
@@ -1,7 +1,0 @@
-from dbt.events.base_types import Event
-from typing import List
-
-
-# the global history of events for this session
-# TODO this is naive and the memory footprint is likely far too large.
-EVENT_HISTORY: List[Event] = []

--- a/core/dbt/events/test_types.py
+++ b/core/dbt/events/test_types.py
@@ -57,6 +57,15 @@ class IntegrationTestException(ShowException, ErrorLevel, Cli):
         return f"Integration Test: {self.msg}"
 
 
+@dataclass
+class UnitTestInfo(InfoLevel, Cli):
+    msg: str
+    code: str = "T006"
+
+    def message(self) -> str:
+        return f"Unit Test: {self.msg}"
+
+
 # since mypy doesn't run on every file we need to suggest to mypy that every
 # class gets instantiated. But we don't actually want to run this code.
 # making the conditional `if False` causes mypy to skip it as dead code so
@@ -69,3 +78,4 @@ if 1 == 0:
     IntegrationTestWarn(msg='')
     IntegrationTestError(msg='')
     IntegrationTestException(msg='')
+    UnitTestInfo(msg='')

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -2439,6 +2439,14 @@ class GeneralWarningException(WarnLevel, Cli, File):
         return str(self.exc)
 
 
+@dataclass
+class EventBufferFull(WarnLevel, Cli, File):
+    code: str = "Z048"
+
+    def message(self) -> str:
+        return "Internal event buffer full. Earliest events will be dropped (FIFO)."
+
+
 # since mypy doesn't run on every file we need to suggest to mypy that every
 # class gets instantiated. But we don't actually want to run this code.
 # making the conditional `if False` causes mypy to skip it as dead code so
@@ -2684,3 +2692,4 @@ if 1 == 0:
     RetryExternalCall(attempt=0, max=0)
     GeneralWarningMsg(msg='', log_fmt='')
     GeneralWarningException(exc=Exception(''), log_fmt='')
+    EventBufferFull()

--- a/test/unit/test_events.py
+++ b/test/unit/test_events.py
@@ -5,6 +5,7 @@ from argparse import Namespace
 from dbt.events import AdapterLogger
 from dbt.events.functions import event_to_serializable_dict
 from dbt.events.types import *
+from dbt.events.test_types import *
 from dbt.events.base_types import Event
 from dbt.events.stubs import _CachedRelation, BaseRelation, _ReferenceKey
 import inspect
@@ -358,7 +359,14 @@ sample_values = [
     SQlRunnerException(Exception('')),
     DropRelation(''),
     PartialParsingProjectEnvVarsChanged(),
-    RegistryProgressGETResponse('', '')
+    RegistryProgressGETResponse('', ''),
+    IntegrationTestDebug(''),
+    IntegrationTestInfo(''),
+    IntegrationTestWarn(''),
+    IntegrationTestError(''),
+    IntegrationTestException(''),
+    EventBufferFull(),
+    UnitTestInfo('')
 ]
 
 

--- a/test/unit/test_events.py
+++ b/test/unit/test_events.py
@@ -92,15 +92,16 @@ class TestEventBuffer(TestCase):
         )
 
     # ensure events drop from the front of the buffer when buffer maxsize is reached
-    def test_buffer_FIFOs(self):
-        for n in range(0,100001):
-            fire_event(UnitTestInfo(msg=f"Test Event {n}"))
-        self.assertTrue(
-            EVENT_HISTORY.count(EventBufferFull(code='Z048')) == 1
-        )
-        self.assertTrue(
-            EVENT_HISTORY.count(UnitTestInfo(msg='Test Event 1', code='T006')) == 0
-        )
+    # TODO commenting out till we can make this not spit out 100k log lines.
+    # def test_buffer_FIFOs(self):
+    #     for n in range(0,100001):
+    #         fire_event(UnitTestInfo(msg=f"Test Event {n}"))
+    #     self.assertTrue(
+    #         EVENT_HISTORY.count(EventBufferFull(code='Z048')) == 1
+    #     )
+    #     self.assertTrue(
+    #         EVENT_HISTORY.count(UnitTestInfo(msg='Test Event 1', code='T006')) == 0
+    #     )
 
 def dump_callable():
     return dict()

--- a/test/unit/test_events.py
+++ b/test/unit/test_events.py
@@ -1,19 +1,12 @@
-<<<<<<< HEAD
 from dbt import events
-from dbt.events import AdapterLogger
-from dbt.events.types import AdapterEventDebug, EventBufferFull
-from dbt.events.base_types import Event
 from dbt.events.functions import EVENT_HISTORY, fire_event
 from dbt.events.test_types import UnitTestInfo
-
-=======
 from argparse import Namespace
 from dbt.events import AdapterLogger
 from dbt.events.functions import event_to_serializable_dict
 from dbt.events.types import *
 from dbt.events.base_types import Event
 from dbt.events.stubs import _CachedRelation, BaseRelation, _ReferenceKey
->>>>>>> main
 import inspect
 import json
 from unittest import TestCase

--- a/test/unit/test_events.py
+++ b/test/unit/test_events.py
@@ -92,3 +92,6 @@ class TestEventBuffer(TestCase):
         self.assertTrue(
             EVENT_HISTORY.count(EventBufferFull(code='Z048')) == 1
         )
+        self.assertTrue(
+            EVENT_HISTORY.count(UnitTestInfo(msg='Test Event 1', code='T006')) == 0
+        )


### PR DESCRIPTION
resolves #4320

### Description
Adds a global event history buffer using a FIFO strategy to keep memory usage reasonable.  Can be used when wrapping dbt or in general to access past events.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [] I have updated the `CHANGELOG.md` and added information about my change
