### PR TITLE
set invocation id when generating psuedo config

### DIFF
--- a/core/dbt/lib.py
+++ b/core/dbt/lib.py
@@ -12,6 +12,7 @@ RuntimeArgs = namedtuple(
 def get_dbt_config(project_dir, single_threaded=False):
     from dbt.config.runtime import RuntimeConfig
     import dbt.adapters.factory
+    import dbt.events.functions
 
     if os.getenv('DBT_PROFILES_DIR'):
         profiles_dir = os.getenv('DBT_PROFILES_DIR')
@@ -28,6 +29,8 @@ def get_dbt_config(project_dir, single_threaded=False):
     dbt.adapters.factory.reset_adapters()
     # Load the relevant adapter
     dbt.adapters.factory.register_adapter(config)
+    # Set invocation id
+    dbt.events.functions.set_invocation_id()
 
     return config
 


### PR DESCRIPTION
resolves #4337

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Set invocation id in lib.py whenever we create a new config for task. Will likely be refactored, but necessary for unique invocation id per task executed.
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
