### PR TITLE
Try to fix failing tests for node_info additions

### DIFF
--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -2,7 +2,7 @@
 from colorama import Style
 from datetime import datetime
 import dbt.events.functions as this  # don't worry I hate it too.
-from dbt.events.base_types import Cli, Event, File, ShowException
+from dbt.events.base_types import Cli, Event, File, ShowException, NodeInfo
 from dbt.events.types import T_Event
 import dbt.flags as flags
 # TODO this will need to move eventually
@@ -125,7 +125,7 @@ def event_to_serializable_dict(
     node_info = dict()
     if hasattr(e, '__dataclass_fields__'):
         for field, value in e.__dataclass_fields__.items():  # type: ignore[attr-defined]
-            if field == 'report_node_data':
+            if isinstance(e, NodeInfo):
                 node_info = asdict(e.get_node_info())
             if type(value._field_type) != _FIELD_BASE:
                 _json_value = e.fields_to_json(value)
@@ -133,7 +133,7 @@ def event_to_serializable_dict(
                 if not isinstance(_json_value, Exception):
                     data[field] = _json_value
                 else:
-                    data[field] = f"JSON_SERIALIZE_FAILED: {type(value).__name__, 'NA'}"            
+                    data[field] = f"JSON_SERIALIZE_FAILED: {type(value).__name__, 'NA'}"
 
     event_dict = {
         'type': 'log_line',

--- a/core/dbt/events/stubs.py
+++ b/core/dbt/events/stubs.py
@@ -3,6 +3,7 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    Dict,
 )
 
 # N.B.:
@@ -53,3 +54,19 @@ class CompiledModelNode(CompiledNode):
 
 class ParsedModelNode():
     resource_type: Any
+
+
+class ParsedHookNode():
+    resource_type: Any
+    index: Optional[int]
+
+
+class RunResult():
+    status: str
+    timing: List[Any]
+    thread_id: str
+    execution_time: float
+    adapter_response: Dict[str, Any]
+    message: Optional[str]
+    failures: Optional[int]
+    node: Any

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -4,7 +4,9 @@ from dbt.events.stubs import (
     _CachedRelation,
     BaseRelation,
     ParsedModelNode,
-    _ReferenceKey
+    ParsedHookNode,
+    _ReferenceKey,
+    RunResult
 )
 from dbt import ui
 from dbt.events.base_types import (
@@ -1943,7 +1945,7 @@ class PrintStartLine(InfoLevel, Cli, File, NodeInfo):
     description: str
     index: int
     total: int
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedModelNode
     code: str = "Z031"
 
     def message(self) -> str:
@@ -1962,7 +1964,7 @@ class PrintHookStartLine(InfoLevel, Cli, File, NodeInfo):
     index: int
     total: int
     truncate: bool
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: Any  # TODO use ParsedHookNode here
     code: str = "Z032"
 
     def message(self) -> str:
@@ -1982,7 +1984,7 @@ class PrintHookEndLine(InfoLevel, Cli, File, NodeInfo):
     total: int
     execution_time: int
     truncate: bool
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: Any  # TODO use ParsedHookNode here
     code: str = "Q007"
 
     def message(self) -> str:
@@ -2002,7 +2004,7 @@ class SkippingDetails(InfoLevel, Cli, File, NodeInfo):
     node_name: str
     index: int
     total: int
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedModelNode
     code: str = "Z033"
 
     def message(self) -> str:
@@ -2022,7 +2024,7 @@ class PrintErrorTestResult(ErrorLevel, Cli, File, NodeInfo):
     index: int
     num_models: int
     execution_time: int
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedModelNode
     code: str = "Q008"
 
     def message(self) -> str:
@@ -2041,7 +2043,7 @@ class PrintPassTestResult(InfoLevel, Cli, File, NodeInfo):
     index: int
     num_models: int
     execution_time: int
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedModelNode
     code: str = "Q009"
 
     def message(self) -> str:
@@ -2061,7 +2063,7 @@ class PrintWarnTestResult(WarnLevel, Cli, File, NodeInfo):
     num_models: int
     execution_time: int
     failures: List[str]
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedModelNode
     code: str = "Q010"
 
     def message(self) -> str:
@@ -2081,7 +2083,7 @@ class PrintFailureTestResult(ErrorLevel, Cli, File, NodeInfo):
     num_models: int
     execution_time: int
     failures: List[str]
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedModelNode
     code: str = "Q011"
 
     def message(self) -> str:
@@ -2117,7 +2119,7 @@ class PrintModelErrorResultLine(ErrorLevel, Cli, File, NodeInfo):
     index: int
     total: int
     execution_time: int
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedModelNode
     code: str = "Z035"
 
     def message(self) -> str:
@@ -2137,7 +2139,7 @@ class PrintModelResultLine(InfoLevel, Cli, File, NodeInfo):
     index: int
     total: int
     execution_time: int
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedModelNode
     code: str = "Q012"
 
     def message(self) -> str:
@@ -2158,7 +2160,7 @@ class PrintSnapshotErrorResultLine(ErrorLevel, Cli, File, NodeInfo):
     index: int
     total: int
     execution_time: int
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedModelNode
     code: str = "Q013"
 
     def message(self) -> str:
@@ -2179,7 +2181,7 @@ class PrintSnapshotResultLine(InfoLevel, Cli, File, NodeInfo):
     index: int
     total: int
     execution_time: int
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedModelNode
     code: str = "Q014"
 
     def message(self) -> str:
@@ -2200,7 +2202,7 @@ class PrintSeedErrorResultLine(ErrorLevel, Cli, File, NodeInfo):
     execution_time: int
     schema: str
     relation: str
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedModelNode
     code: str = "Q015"
 
     def message(self) -> str:
@@ -2221,7 +2223,7 @@ class PrintSeedResultLine(InfoLevel, Cli, File, NodeInfo):
     execution_time: int
     schema: str
     relation: str
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedModelNode
     code: str = "Q016"
 
     def message(self) -> str:
@@ -2241,7 +2243,7 @@ class PrintHookEndErrorLine(ErrorLevel, Cli, File, NodeInfo):
     index: int
     total: int
     execution_time: int
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedHookNode
     code: str = "Q017"
 
     def message(self) -> str:
@@ -2261,7 +2263,7 @@ class PrintHookEndErrorStaleLine(ErrorLevel, Cli, File, NodeInfo):
     index: int
     total: int
     execution_time: int
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedHookNode
     code: str = "Q018"
 
     def message(self) -> str:
@@ -2281,7 +2283,7 @@ class PrintHookEndWarnLine(WarnLevel, Cli, File, NodeInfo):
     index: int
     total: int
     execution_time: int
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedHookNode
     code: str = "Q019"
 
     def message(self) -> str:
@@ -2301,7 +2303,7 @@ class PrintHookEndPassLine(InfoLevel, Cli, File, NodeInfo):
     index: int
     total: int
     execution_time: int
-    report_node_data: Any  # TODO: be explicit
+    report_node_data: ParsedHookNode
     code: str = "Q020"
 
     def message(self) -> str:
@@ -2350,7 +2352,7 @@ class NodeStart(DebugLevel, Cli, File, NodeInfo):
 class NodeFinished(DebugLevel, Cli, File, NodeInfo):
     unique_id: str
     report_node_data: ParsedModelNode
-    run_result: Any  # RunResult
+    run_result: RunResult
     code: str = "Q024"
 
     def message(self) -> str:
@@ -2836,8 +2838,14 @@ if 1 == 0:
     FirstRunResultError(msg='')
     AfterFirstRunResultError(msg='')
     EndOfRunSummary(num_errors=0, num_warnings=0, keyboard_interrupt=False)
-    PrintStartLine(description='', index=0, total=0, report_node_data='')
-    PrintHookStartLine(statement='', index=0, total=0, truncate=False, report_node_data='')
+    PrintStartLine(description='', index=0, total=0, report_node_data=ParsedModelNode())
+    PrintHookStartLine(
+        statement='',
+        index=0,
+        total=0,
+        truncate=False,
+        report_node_data=ParsedHookNode()
+    )
     PrintHookEndLine(
         statement='',
         status='',
@@ -2845,7 +2853,7 @@ if 1 == 0:
         total=0,
         execution_time=0,
         truncate=False,
-        report_node_data=''
+        report_node_data=ParsedHookNode()
     )
     SkippingDetails(
         resource_type='',
@@ -2853,17 +2861,29 @@ if 1 == 0:
         node_name='',
         index=0,
         total=0,
-        report_node_data=''
+        report_node_data=ParsedModelNode()
     )
-    PrintErrorTestResult(name='', index=0, num_models=0, execution_time=0, report_node_data='')
-    PrintPassTestResult(name='', index=0, num_models=0, execution_time=0, report_node_data='')
+    PrintErrorTestResult(
+        name='',
+        index=0,
+        num_models=0,
+        execution_time=0,
+        report_node_data=ParsedModelNode()
+    )
+    PrintPassTestResult(
+        name='',
+        index=0,
+        num_models=0,
+        execution_time=0,
+        report_node_data=ParsedModelNode()
+    )
     PrintWarnTestResult(
         name='',
         index=0,
         num_models=0,
         execution_time=0,
         failures=[],
-        report_node_data=''
+        report_node_data=ParsedModelNode()
     )
     PrintFailureTestResult(
         name='',
@@ -2871,7 +2891,7 @@ if 1 == 0:
         num_models=0,
         execution_time=0,
         failures=[],
-        report_node_data=''
+        report_node_data=ParsedModelNode()
     )
     PrintSkipBecauseError(schema='', relation='', index=0, total=0)
     PrintModelErrorResultLine(
@@ -2880,7 +2900,7 @@ if 1 == 0:
         index=0,
         total=0,
         execution_time=0,
-        report_node_data=''
+        report_node_data=ParsedModelNode()
     )
     PrintModelResultLine(
         description='',
@@ -2888,7 +2908,7 @@ if 1 == 0:
         index=0,
         total=0,
         execution_time=0,
-        report_node_data=''
+        report_node_data=ParsedModelNode()
     )
     PrintSnapshotErrorResultLine(
         status='',
@@ -2897,7 +2917,7 @@ if 1 == 0:
         index=0,
         total=0,
         execution_time=0,
-        report_node_data=''
+        report_node_data=ParsedModelNode()
     )
     PrintSnapshotResultLine(
         status='',
@@ -2906,7 +2926,7 @@ if 1 == 0:
         index=0,
         total=0,
         execution_time=0,
-        report_node_data=''
+        report_node_data=ParsedModelNode()
     )
     PrintSeedErrorResultLine(
         status='',
@@ -2915,7 +2935,7 @@ if 1 == 0:
         execution_time=0,
         schema='',
         relation='',
-        report_node_data=''
+        report_node_data=ParsedModelNode()
     )
     PrintSeedResultLine(
         status='',
@@ -2924,7 +2944,7 @@ if 1 == 0:
         execution_time=0,
         schema='',
         relation='',
-        report_node_data=''
+        report_node_data=ParsedModelNode()
     )
     PrintHookEndErrorLine(
         source_name='',
@@ -2932,7 +2952,7 @@ if 1 == 0:
         index=0,
         total=0,
         execution_time=0,
-        report_node_data=''
+        report_node_data=ParsedHookNode()
     )
     PrintHookEndErrorStaleLine(
         source_name='',
@@ -2940,7 +2960,7 @@ if 1 == 0:
         index=0,
         total=0,
         execution_time=0,
-        report_node_data=''
+        report_node_data=ParsedHookNode()
     )
     PrintHookEndWarnLine(
         source_name='',
@@ -2948,7 +2968,7 @@ if 1 == 0:
         index=0,
         total=0,
         execution_time=0,
-        report_node_data=''
+        report_node_data=ParsedHookNode()
     )
     PrintHookEndPassLine(
         source_name='',
@@ -2956,12 +2976,12 @@ if 1 == 0:
         index=0,
         total=0,
         execution_time=0,
-        report_node_data=''
+        report_node_data=ParsedHookNode()
     )
     PrintCancelLine(conn_name='')
     DefaultSelector(name='')
     NodeStart(report_node_data=ParsedModelNode(), unique_id='')
-    NodeFinished(report_node_data=ParsedModelNode(), unique_id='', run_result='')
+    NodeFinished(report_node_data=ParsedModelNode(), unique_id='', run_result=RunResult())
     QueryCancelationUnsupported(type='')
     ConcurrencyLine(concurrency_line='')
     NodeCompiling(report_node_data=ParsedModelNode(), unique_id='')

--- a/test/unit/test_events.py
+++ b/test/unit/test_events.py
@@ -2,12 +2,16 @@ from argparse import Namespace
 from dbt.events import AdapterLogger
 from dbt.events.functions import event_to_serializable_dict
 from dbt.events.types import *
-from dbt.events.base_types import Event
-from dbt.events.stubs import _CachedRelation, BaseRelation, _ReferenceKey
+from dbt.events.base_types import Event, Node
+from dbt.events.stubs import _CachedRelation, BaseRelation, _ReferenceKey, ParsedModelNode
 import inspect
 import json
+import datetime
 from unittest import TestCase
-
+from dbt.contracts.graph.parsed import (
+    ParsedModelNode, NodeConfig, DependsOn, ParsedMacro
+)
+from dbt.contracts.files import FileHash
 
 # takes in a class and finds any subclasses for it
 def get_all_subclasses(cls):
@@ -80,6 +84,41 @@ class TestEventCodes(TestCase):
 
 def dump_callable():
     return dict()
+    
+
+def MockNode():
+    return ParsedModelNode(
+        alias='model_one',
+        name='model_one',
+        database='dbt',
+        schema='analytics',
+        resource_type=NodeType.Model,
+        unique_id='model.root.model_one',
+        fqn=['root', 'model_one'],
+        package_name='root',
+        original_file_path='model_one.sql',
+        root_path='/usr/src/app',
+        refs=[],
+        sources=[],
+        depends_on=DependsOn(),
+        config=NodeConfig.from_dict({
+            'enabled': True,
+            'materialized': 'view',
+            'persist_docs': {},
+            'post-hook': [],
+            'pre-hook': [],
+            'vars': {},
+            'quoting': {},
+            'column_types': {},
+            'tags': [],
+        }),
+        tags=[],
+        path='model_one.sql',
+        raw_sql='',
+        description='',
+        columns={},
+        checksum=FileHash.from_contents(''),
+    )
 
 
 sample_values = [
@@ -262,34 +301,37 @@ sample_values = [
     FirstRunResultError(msg=''),
     AfterFirstRunResultError(msg=''),
     EndOfRunSummary(num_errors=0, num_warnings=0, keyboard_interrupt=False),
-    PrintStartLine(description='', index=0, total=0, report_node_data=''),
-    PrintHookStartLine(statement='', index=0, total=0, truncate=False),
-    PrintHookEndLine(statement='', status='', index=0, total=0, execution_time=0, truncate=False),
-    SkippingDetails(resource_type='', schema='', node_name='', index=0, total=0),
-    PrintErrorTestResult(name='', index=0, num_models=0, execution_time=0),
-    PrintPassTestResult(name='', index=0, num_models=0, execution_time=0),
-    PrintWarnTestResult(name='', index=0, num_models=0, execution_time=0, failures=[]),
-    PrintFailureTestResult(name='', index=0, num_models=0, execution_time=0, failures=[]),
+    PrintStartLine(description='', index=0, total=0, report_node_data=MockNode()),
+    PrintHookStartLine(statement='', index=0, total=0, truncate=False, report_node_data=MockNode()),
+    PrintHookEndLine(statement='', status='', index=0, total=0, execution_time=0, truncate=False, report_node_data=MockNode()),
+    SkippingDetails(resource_type='', schema='', node_name='', index=0, total=0, report_node_data=MockNode()),
+    PrintErrorTestResult(name='', index=0, num_models=0, execution_time=0, report_node_data=MockNode()),
+    PrintPassTestResult(name='', index=0, num_models=0, execution_time=0, report_node_data=MockNode()),
+    PrintWarnTestResult(name='', index=0, num_models=0, execution_time=0, failures=[], report_node_data=MockNode()),
+    PrintFailureTestResult(name='', index=0, num_models=0, execution_time=0, failures=[], report_node_data=MockNode()),
     PrintSkipBecauseError(schema='', relation='', index=0, total=0),
-    PrintModelErrorResultLine(description='', status='', index=0, total=0, execution_time=0),
-    PrintModelResultLine(description='', status='', index=0, total=0, execution_time=0),
+    PrintModelErrorResultLine(description='', status='', index=0, total=0, execution_time=0, report_node_data=MockNode()),
+    PrintModelResultLine(description='', status='', index=0, total=0, execution_time=0, report_node_data=MockNode()),
     PrintSnapshotErrorResultLine(status='',
                                  description='',
                                  cfg={},
                                  index=0,
                                  total=0,
-                                 execution_time=0),
-    PrintSnapshotResultLine(status='', description='', cfg={}, index=0, total=0, execution_time=0),
-    PrintSeedErrorResultLine(status='', index=0, total=0, execution_time=0, schema='', relation=''),
-    PrintSeedResultLine(status='', index=0, total=0, execution_time=0, schema='', relation=''),
-    PrintHookEndErrorLine(source_name='', table_name='', index=0, total=0, execution_time=0),
-    PrintHookEndErrorStaleLine(source_name='', table_name='', index=0, total=0, execution_time=0),
-    PrintHookEndWarnLine(source_name='', table_name='', index=0, total=0, execution_time=0),
-    PrintHookEndPassLine(source_name='', table_name='', index=0, total=0, execution_time=0),
+                                 execution_time=0,
+                                 report_node_data=MockNode()),
+    PrintSnapshotResultLine(status='', description='', cfg={}, index=0, total=0, execution_time=0, report_node_data=MockNode()),
+    PrintSeedErrorResultLine(status='', index=0, total=0, execution_time=0, schema='', relation='', report_node_data=MockNode()),
+    PrintSeedResultLine(status='', index=0, total=0, execution_time=0, schema='', relation='', report_node_data=MockNode()),
+    PrintHookEndErrorLine(source_name='', table_name='', index=0, total=0, execution_time=0, report_node_data=MockNode()),
+    PrintHookEndErrorStaleLine(source_name='', table_name='', index=0, total=0, execution_time=0, report_node_data=MockNode()),
+    PrintHookEndWarnLine(source_name='', table_name='', index=0, total=0, execution_time=0, report_node_data=MockNode()),
+    PrintHookEndPassLine(source_name='', table_name='', index=0, total=0, execution_time=0, report_node_data=MockNode()),
     PrintCancelLine(conn_name=''),
     DefaultSelector(name=''),
-    NodeStart(unique_id=''),
-    NodeFinished(unique_id=''),
+    NodeStart(unique_id='', report_node_data=MockNode()),
+    NodeCompiling(unique_id='', report_node_data=MockNode()),
+    NodeExecuting(unique_id='', report_node_data=MockNode()),
+    NodeFinished(unique_id='', report_node_data=MockNode(), run_result=''),
     QueryCancelationUnsupported(type=''),
     ConcurrencyLine(concurrency_line=''),
     StarterProjectPath(dir=''),


### PR DESCRIPTION
Try to fix failing tests in https://github.com/dbt-labs/dbt-core/pull/4336. I see that PR has some conflicts with `main` that will also need sorting.

### unit tests
Tries to fix failing unit tests by:
- adding `NodeCompiling` + `NodeExecuting` to `sample_values`
- mocking a model node, and calling it in `sample_values`. I copied the mocked node from `test/unit/test_context.py`. I realize we should do the same for a hook node as well.

### mypy

Tries to fix mypy errors by:
- checking if an event is an instance of `NodeInfo` before calling `e.get_node_info()`, rather than checking to see if `field == 'report_node_data'`
- adding stubbed types for `report_data_node` (`ParsedModelNode`, `ParsedHookNode`) and `run_results` (`RunResult`). I couldn't manage to correctly stub `ParsedHookNode` for the hook events, though, so I've cheated with `Any` and left a `TODO`:
```
$ mypy core/dbt
core/dbt/task/run.py:359: error: Argument "report_node_data" to "PrintHookStartLine" has incompatible type "dbt.contracts.graph.parsed.ParsedHookNode"; expected "dbt.events.stubs.ParsedHookNode"
core/dbt/task/run.py:380: error: Argument "report_node_data" to "PrintHookEndLine" has incompatible type "dbt.contracts.graph.parsed.ParsedHookNode"; expected "dbt.events.stubs.ParsedHookNode"
````

