### PR TITLE
Tiny touchups for deps, clean

### DIFF
--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -545,8 +545,12 @@ class UnsetProfileConfig(RuntimeConfig):
                 args, profile_renderer, profile_name
             )
         except (DbtProjectError, DbtProfileError) as exc:
+            selected_profile_name = Profile.pick_profile_name(
+                args_profile_name=getattr(args, 'profile', None),
+                project_profile_name=profile_name
+            )
             fire_event(ProfileLoadError(exc=exc))
-            fire_event(ProfileNotFound(profile_name=profile_name))
+            fire_event(ProfileNotFound(profile_name=selected_profile_name))
             # return the poisoned form
             profile = UnsetProfile()
             # disable anonymous usage statistics

--- a/core/dbt/task/clean.py
+++ b/core/dbt/task/clean.py
@@ -38,7 +38,7 @@ class CleanTask(BaseTask):
         """
         move_to_nearest_project_dir(self.args)
         if ('dbt_modules' in self.config.clean_targets and
-           self.config.packages_install_path != 'dbt_modules'):
+           self.config.packages_install_path not in self.config.clean_targets):
             deprecations.warn('install-packages-path')
         for path in self.config.clean_targets:
             fire_event(CheckCleanPath(path=path))


### PR DESCRIPTION
Resolved teensy bugs uncovered during the bug bash!

### Avoid deprecation warning if irrelevant

This is a reasonable thing many users will do:
- finding out that `dbt_modules` has been renamed to `dbt_packages`
- adding `dbt_packages` to `clean-targets` (but leaving `dbt_modules` in there still)

Let's consider the deprecation warning "addressed" by that change, and stop raising it. Alternatively, if they _do_ want to keep using `dbt_modules` and configure `packages-install-path: "dbt_modules"`, we shouldn't raise the warning. 

### Use actual (bad) profile name

`dbt clean` + `dbt deps` are supposed to work even with an invalid database connection (profile). One easy way to test this is by running with, e.g., `dbt clean --profile badprof`.

@joellabes and I noticed that dbt uses the profile name specified in `dbt_project.yml` instead of the one specified in the CLI arg:
```
$ dbt clean --profile bad
18:22:44 | [ info  ] | Running with dbt=1.0.0-rc3
18:22:44 | [ info  ] | No profile "garage-postgres" found, continuing with no target
```

This PR would have us use `Profile.pick_profile_name` to find the right profile name for the log message. Voila:
```
$ dbt clean --profile bad
18:29:02 | [ info  ] | Running with dbt=1.0.0-rc2
18:29:03 | [ info  ] | No profile "bad" found, continuing with no target
```