### PR TITLE
add node type codes to more events + more hook log data

### DIFF
--- a/core/dbt/adapters/sql/connections.py
+++ b/core/dbt/adapters/sql/connections.py
@@ -75,7 +75,7 @@ class SQLConnectionManager(BaseConnectionManager):
 
             fire_event(
                 SQLQueryStatus(
-                    status=str(self.get_response(cursor)), elapsed=round((time.time() - pre), 2)
+                    status=self.get_response(cursor)._message, elapsed=round((time.time() - pre), 2)
                 )
             )
 

--- a/core/dbt/adapters/sql/connections.py
+++ b/core/dbt/adapters/sql/connections.py
@@ -75,7 +75,8 @@ class SQLConnectionManager(BaseConnectionManager):
 
             fire_event(
                 SQLQueryStatus(
-                    status=self.get_response(cursor)._message, elapsed=round((time.time() - pre), 2)
+                    status=self.get_response(cursor)._message,
+                    elapsed=round((time.time() - pre), 2)
                 )
             )
 

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -4,8 +4,8 @@ from dbt.adapters.reference_keys import _make_key, _ReferenceKey
 from dbt.events.stubs import (
     _CachedRelation,
     BaseRelation,
-    ParsedModelNode,
     ParsedHookNode,
+    ParsedModelNode,
     RunResult
 )
 from dbt import ui
@@ -1745,7 +1745,7 @@ class PrintHookStartLine(InfoLevel, Cli, File, NodeInfo):
     index: int
     total: int
     truncate: bool
-    report_node_data: ParsedHookNode
+    report_node_data: Any  # TODO: resolve ParsedHookNode circular import
     code: str = "Q032"
 
     def message(self) -> str:
@@ -1765,7 +1765,7 @@ class PrintHookEndLine(InfoLevel, Cli, File, NodeInfo):
     total: int
     execution_time: int
     truncate: bool
-    report_node_data: ParsedHookNode
+    report_node_data: Any  # TODO: resolve ParsedHookNode circular import
     code: str = "Q007"
 
     def message(self) -> str:

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1727,7 +1727,7 @@ class PrintStartLine(InfoLevel, Cli, File, NodeInfo):
     index: int
     total: int
     report_node_data: ParsedModelNode
-    code: str = "Z031"
+    code: str = "Q033"
 
     def message(self) -> str:
         msg = f"START {self.description}"
@@ -1745,8 +1745,8 @@ class PrintHookStartLine(InfoLevel, Cli, File, NodeInfo):
     index: int
     total: int
     truncate: bool
-    report_node_data: Any  # TODO use ParsedHookNode here
-    code: str = "Z032"
+    report_node_data: ParsedHookNode
+    code: str = "Q032"
 
     def message(self) -> str:
         msg = f"START hook: {self.statement}"
@@ -1765,7 +1765,7 @@ class PrintHookEndLine(InfoLevel, Cli, File, NodeInfo):
     total: int
     execution_time: int
     truncate: bool
-    report_node_data: Any  # TODO use ParsedHookNode here
+    report_node_data: ParsedHookNode
     code: str = "Q007"
 
     def message(self) -> str:
@@ -1786,7 +1786,7 @@ class SkippingDetails(InfoLevel, Cli, File, NodeInfo):
     index: int
     total: int
     report_node_data: ParsedModelNode
-    code: str = "Z033"
+    code: str = "Q034"
 
     def message(self) -> str:
         if self.resource_type in NodeType.refable():
@@ -1901,7 +1901,7 @@ class PrintModelErrorResultLine(ErrorLevel, Cli, File, NodeInfo):
     total: int
     execution_time: int
     report_node_data: ParsedModelNode
-    code: str = "Z035"
+    code: str = "Q035"
 
     def message(self) -> str:
         info = "ERROR creating"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -543,7 +543,7 @@ class SQLQuery(DebugLevel, Cli, File):
 
 @dataclass
 class SQLQueryStatus(DebugLevel, Cli, File):
-    status: str  # could include AdapterResponse if we resolve circular imports
+    status: str
     elapsed: float
     code: str = "E017"
 

--- a/core/dbt/task/freshness.py
+++ b/core/dbt/task/freshness.py
@@ -59,8 +59,7 @@ class FreshnessRunner(BaseRunner):
                     table_name=table_name,
                     index=self.node_index,
                     total=self.num_nodes,
-                    execution_time=result.execution_time,
-                    report_node_data=self.node
+                    execution_time=result.execution_time
                 )
             )
         elif result.status == FreshnessStatus.Error:
@@ -70,8 +69,7 @@ class FreshnessRunner(BaseRunner):
                     table_name=table_name,
                     index=self.node_index,
                     total=self.num_nodes,
-                    execution_time=result.execution_time,
-                    report_node_data=self.node
+                    execution_time=result.execution_time
                 )
             )
         elif result.status == FreshnessStatus.Warn:
@@ -81,8 +79,7 @@ class FreshnessRunner(BaseRunner):
                     table_name=table_name,
                     index=self.node_index,
                     total=self.num_nodes,
-                    execution_time=result.execution_time,
-                    report_node_data=self.node
+                    execution_time=result.execution_time
                 )
             )
         else:
@@ -92,8 +89,7 @@ class FreshnessRunner(BaseRunner):
                     table_name=table_name,
                     index=self.node_index,
                     total=self.num_nodes,
-                    execution_time=result.execution_time,
-                    report_node_data=self.node
+                    execution_time=result.execution_time
                 )
             )
 

--- a/core/dbt/task/freshness.py
+++ b/core/dbt/task/freshness.py
@@ -59,7 +59,8 @@ class FreshnessRunner(BaseRunner):
                     table_name=table_name,
                     index=self.node_index,
                     total=self.num_nodes,
-                    execution_time=result.execution_time
+                    execution_time=result.execution_time,
+                    report_node_data=self.node
                 )
             )
         elif result.status == FreshnessStatus.Error:
@@ -69,7 +70,8 @@ class FreshnessRunner(BaseRunner):
                     table_name=table_name,
                     index=self.node_index,
                     total=self.num_nodes,
-                    execution_time=result.execution_time
+                    execution_time=result.execution_time,
+                    report_node_data=self.node
                 )
             )
         elif result.status == FreshnessStatus.Warn:
@@ -79,7 +81,8 @@ class FreshnessRunner(BaseRunner):
                     table_name=table_name,
                     index=self.node_index,
                     total=self.num_nodes,
-                    execution_time=result.execution_time
+                    execution_time=result.execution_time,
+                    report_node_data=self.node
                 )
             )
         else:
@@ -89,7 +92,8 @@ class FreshnessRunner(BaseRunner):
                     table_name=table_name,
                     index=self.node_index,
                     total=self.num_nodes,
-                    execution_time=result.execution_time
+                    execution_time=result.execution_time,
+                    report_node_data=self.node
                 )
             )
 

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -362,12 +362,13 @@ class RunTask(CompileTask):
                         )
                     )
 
-                status = 'OK'
-
                 with Timer() as timer:
                     if len(sql.strip()) > 0:
-                        status, _ = adapter.execute(sql, auto_begin=False,
+                        response, _ = adapter.execute(sql, auto_begin=False,
                                                     fetch=False)
+                        status = response._message
+                    else:
+                        status = 'OK'
 
                 self.ran_hooks.append(hook)
                 hook._event_status['finished_at'] = datetime.utcnow().isoformat()
@@ -376,7 +377,7 @@ class RunTask(CompileTask):
                     fire_event(
                         PrintHookEndLine(
                             statement=hook_text,
-                            status=str(status),
+                            status=status,
                             index=idx,
                             total=num_hooks,
                             execution_time=timer.elapsed,

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -364,15 +364,15 @@ class RunTask(CompileTask):
 
                 status = 'OK'
 
-                
                 with Timer() as timer:
                     if len(sql.strip()) > 0:
                         status, _ = adapter.execute(sql, auto_begin=False,
                                                     fetch=False)
+
                 self.ran_hooks.append(hook)
                 hook._event_status['dbt_internal__finished_at'] = datetime.utcnow().isoformat()
                 with finishctx, DbtModelState({'node_status': 'passed'}):
-                    hook._event_status['node_status'] = NodeStatus.Pass
+                    hook._event_status['node_status'] = RunStatus.Success
                     fire_event(
                         PrintHookEndLine(
                             statement=hook_text,

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -342,7 +342,7 @@ class RunTask(CompileTask):
         finishctx = TimestampNamed('node_finished_at')
 
         for idx, hook in enumerate(ordered_hooks, start=1):
-            hook._event_status['dbt_internal__started_at'] = datetime.utcnow().isoformat()
+            hook._event_status['started_at'] = datetime.utcnow().isoformat()
             hook._event_status['node_status'] = RunningStatus.Started
             sql = self.get_hook_sql(adapter, hook, idx, num_hooks,
                                     extra_context)
@@ -370,7 +370,7 @@ class RunTask(CompileTask):
                                                     fetch=False)
 
                 self.ran_hooks.append(hook)
-                hook._event_status['dbt_internal__finished_at'] = datetime.utcnow().isoformat()
+                hook._event_status['finished_at'] = datetime.utcnow().isoformat()
                 with finishctx, DbtModelState({'node_status': 'passed'}):
                     hook._event_status['node_status'] = RunStatus.Success
                     fire_event(
@@ -386,8 +386,8 @@ class RunTask(CompileTask):
                     )
             # `_event_status` dict is only used for logging.  Make sure
             # it gets deleted when we're done with it
-            del hook._event_status["dbt_internal__started_at"]
-            del hook._event_status["dbt_internal__finished_at"]
+            del hook._event_status["started_at"]
+            del hook._event_status["finished_at"]
             del hook._event_status["node_status"]
 
         self._total_executed += len(ordered_hooks)

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -364,8 +364,7 @@ class RunTask(CompileTask):
 
                 with Timer() as timer:
                     if len(sql.strip()) > 0:
-                        response, _ = adapter.execute(sql, auto_begin=False,
-                                                    fetch=False)
+                        response, _ = adapter.execute(sql, auto_begin=False, fetch=False)
                         status = response._message
                     else:
                         status = 'OK'

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -11,7 +11,7 @@ from .printer import (
     print_run_end_messages,
     get_counts,
 )
-
+from datetime import datetime
 from dbt import tracking
 from dbt import utils
 from dbt.adapters.base import BaseRelation
@@ -21,7 +21,7 @@ from dbt.contracts.graph.compiled import CompileResultNode
 from dbt.contracts.graph.manifest import WritableManifest
 from dbt.contracts.graph.model_config import Hook
 from dbt.contracts.graph.parsed import ParsedHookNode
-from dbt.contracts.results import NodeStatus, RunResult, RunStatus
+from dbt.contracts.results import NodeStatus, RunResult, RunStatus, RunningStatus
 from dbt.exceptions import (
     CompilationException,
     InternalException,
@@ -342,6 +342,8 @@ class RunTask(CompileTask):
         finishctx = TimestampNamed('node_finished_at')
 
         for idx, hook in enumerate(ordered_hooks, start=1):
+            hook._event_status['dbt_internal__started_at'] = datetime.utcnow().isoformat()
+            hook._event_status['node_status'] = RunningStatus.Started
             sql = self.get_hook_sql(adapter, hook, idx, num_hooks,
                                     extra_context)
 
@@ -362,13 +364,15 @@ class RunTask(CompileTask):
 
                 status = 'OK'
 
+                
                 with Timer() as timer:
                     if len(sql.strip()) > 0:
                         status, _ = adapter.execute(sql, auto_begin=False,
                                                     fetch=False)
                 self.ran_hooks.append(hook)
-
+                hook._event_status['dbt_internal__finished_at'] = datetime.utcnow().isoformat()
                 with finishctx, DbtModelState({'node_status': 'passed'}):
+                    hook._event_status['node_status'] = NodeStatus.Pass
                     fire_event(
                         PrintHookEndLine(
                             statement=hook_text,
@@ -380,6 +384,11 @@ class RunTask(CompileTask):
                             report_node_data=hook
                         )
                     )
+            # `_event_status` dict is only used for logging.  Make sure
+            # it gets deleted when we're done with it
+            del hook._event_status["dbt_internal__started_at"]
+            del hook._event_status["dbt_internal__finished_at"]
+            del hook._event_status["node_status"]
 
         self._total_executed += len(ordered_hooks)
 

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -209,7 +209,7 @@ class GraphRunnableTask(ManifestTask):
         with RUNNING_STATE, uid_context:
             startctx = TimestampNamed('node_started_at')
             index = self.index_offset(runner.node_index)
-            runner.node._event_status['dbt_internal__started_at'] = datetime.utcnow().isoformat()
+            runner.node._event_status['started_at'] = datetime.utcnow().isoformat()
             runner.node._event_status['node_status'] = RunningStatus.Started
             extended_metadata = ModelMetadata(runner.node, index)
 
@@ -225,8 +225,7 @@ class GraphRunnableTask(ManifestTask):
                 result = runner.run_with_hooks(self.manifest)
                 status = runner.get_result_status(result)
                 runner.node._event_status['node_status'] = result.status
-                runner.node._event_status['dbt_internal__finished_at'] = \
-                    datetime.utcnow().isoformat()
+                runner.node._event_status['finished_at'] = datetime.utcnow().isoformat()
             finally:
                 finishctx = TimestampNamed('finished_at')
                 with finishctx, DbtModelState(status):
@@ -239,8 +238,8 @@ class GraphRunnableTask(ManifestTask):
                     )
             # `_event_status` dict is only used for logging.  Make sure
             # it gets deleted when we're done with it
-            del runner.node._event_status["dbt_internal__started_at"]
-            del runner.node._event_status["dbt_internal__finished_at"]
+            del runner.node._event_status["started_at"]
+            del runner.node._event_status["finished_at"]
             del runner.node._event_status["node_status"]
 
         fail_fast = flags.FAIL_FAST


### PR DESCRIPTION
on-run-start/end hooks were not getting `node_status`, `node_started_at`, `node_finished_at` populated in `node_status` of logs.  Fixed.

Made it a little more clear when we use the `_message` method in `AdapterResponse` for logging purposes.  

Fixed up a few logging codes to point to nodes.


