### PR TITLE
Add windows OS error suppressing for temp dir cleanups

### DIFF
--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -41,9 +41,17 @@ def temporary_working_directory() -> str:
     out : str
         The temporary working directory.
     """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with change_working_directory(tmpdir):
-            yield tmpdir
+    # N.B: supressing the OSError is necessary for older (pre 3.10) versions of python 
+    # which do not support the `ignore_cleanup_errors` in tempfile::TemporaryDirectory.
+    # See: https://github.com/python/cpython/pull/24793
+    #
+    # In our case the cleanup is redundent since windows handles clearing 
+    # Appdata/Local/Temp at the os level anyway.
+
+    with contextlib.suppress(OSError):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with change_working_directory(tmpdir):
+                yield tmpdir
 
 
 def get_custom_profiles_config(database_host, custom_schema):


### PR DESCRIPTION
resolves # 4261

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Our new logging keeps files open in such a way that causes a problem for a test when executed in a windows-based env.  It's apparently "a thing" involving the builtin `tempfile::TemporaryDirectory` and has a work-around in python 3.10.  This PR replicates that behavior for all python versions we support.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
