### PR TITLE
change json override strategy

### DIFF
--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -291,7 +291,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         if (database, schema) not in self.cache:
             fire_event(
                 CacheMiss(
-                    conn_name=self.nice_connection_name,
+                    conn_name=self.nice_connection_name(),
                     database=database,
                     schema=schema
                 )

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -66,17 +66,6 @@ class ShowException():
         self.stack_info: Any = None
         self.extra: Any = None
 
-    def asdict(self):
-        d = dict()
-
-        for k, v in self.__dict__.items():
-            if isinstance(v, Exception):
-                d[k] = str(v)
-            else:
-                d[k] = v
-
-        return d
-
 
 # TODO add exhaustiveness checking for subclasses
 # can't use ABCs with @dataclass because of https://github.com/python/mypy/issues/5374
@@ -135,6 +124,17 @@ class Event(metaclass=ABCMeta):
     def get_invocation_id(cls) -> str:
         from dbt.events.functions import get_invocation_id
         return get_invocation_id()
+
+    # default dict factory for all events. can override on concrete classes.
+    @classmethod
+    def asdict(cls, data: list) -> dict:
+        d = dict()
+        for k, v in data:
+            if isinstance(v, Exception):
+                d[k] = str(v)
+            else:
+                d[k] = v
+        return d
 
 
 @dataclass  # type: ignore

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -130,8 +130,12 @@ class Event(metaclass=ABCMeta):
     def asdict(cls, data: list) -> dict:
         d = dict()
         for k, v in data:
-            if isinstance(v, Exception):
+            # stringify all exceptions
+            if isinstance(v, Exception) or isinstance(v, BaseException):
                 d[k] = str(v)
+            # skip all binary data
+            elif isinstance(v, bytes):
+                continue
             else:
                 d[k] = v
         return d

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -1,7 +1,6 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
 from dataclasses import dataclass
 from datetime import datetime
-import json
 import os
 import threading
 from typing import Any, Optional
@@ -67,6 +66,17 @@ class ShowException():
         self.stack_info: Any = None
         self.extra: Any = None
 
+    def asdict(self):
+        d = dict()
+
+        for k, v in self.__dict__.items():
+            if isinstance(v, Exception):
+                d[k] = str(v)
+            else:
+                d[k] = v
+
+        return d
+
 
 # TODO add exhaustiveness checking for subclasses
 # can't use ABCs with @dataclass because of https://github.com/python/mypy/issues/5374
@@ -96,26 +106,6 @@ class Event(metaclass=ABCMeta):
     @abstractmethod
     def message(self) -> str:
         raise Exception("msg not implemented for Event")
-
-    # override this method to convert non-json serializable fields to json.
-    # for override examples, see existing concrete types.
-    #
-    # there is no type-level mechanism to have mypy enforce json serializability, so we just try
-    # to serialize and raise an exception at runtime when that fails. This safety mechanism
-    # only works if we have attempted to serialize every concrete event type in our tests.
-    def fields_to_json(self, field_value: Any) -> Any:
-        try:
-            json.dumps(field_value, sort_keys=True)
-            return field_value
-        except TypeError:
-            val_type = type(field_value).__name__
-            event_type = type(self).__name__
-            return Exception(
-                f"type {val_type} is not serializable to json."
-                f" First make sure that the call sites for {event_type} match the type hints"
-                f" and if they do, you can override Event::fields_to_json in {event_type} in"
-                " types.py to define your own serialization function to any valid json type"
-            )
 
     # exactly one time stamp per concrete event
     def get_ts(self) -> datetime:

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -132,18 +132,26 @@ def event_to_serializable_dict(
 ) -> Dict[str, Any]:
     data = dict()
     node_info = dict()
-    if hasattr(e, '__dataclass_fields__'):
-        if isinstance(e, NodeInfo):
-            node_info = dataclasses.asdict(e.get_node_info())
+    log_line = dict()
+    try:
+        log_line = dataclasses.asdict(e)
+        json.dumps(log_line)  # throwing away unprocessed result, just to make sure it works
+    except AttributeError:
+        event_type = type(e).__name__
+        raise Exception(
+            f"type {event_type} is not serializable to json."
+            f" First make sure that the call sites for {event_type} match the type hints"
+            f" and if they do, you can override the dataclass method `asdict` in {event_type} in"
+            " types.py to define your own serialization function to a dictionary of valid json"
+            " types"
+        )
 
-        for field, value in dataclasses.asdict(e).items():  # type: ignore[attr-defined]
-            if field not in ["code", "report_node_data"]:
-                _json_value = e.fields_to_json(value)
+    if isinstance(e, NodeInfo):
+        node_info = dataclasses.asdict(e.get_node_info())
 
-                if not isinstance(_json_value, Exception):
-                    data[field] = _json_value
-                else:
-                    data[field] = f"JSON_SERIALIZE_FAILED: {type(value).__name__, 'NA'}"
+    for field, value in log_line.items():  # type: ignore[attr-defined]
+        if field not in ["code", "report_node_data"]:
+            data[field] = e
 
     event_dict = {
         'type': 'log_line',

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -134,10 +134,7 @@ def event_to_serializable_dict(
     node_info = dict()
     log_line = dict()
     try:
-        if hasattr(e, 'asdict'):
-            log_line = dataclasses.asdict(e, dict_factory=type(e).asdict)  # type: ignore
-        else:
-            log_line = dataclasses.asdict(e)
+        log_line = dataclasses.asdict(e, dict_factory=type(e).asdict)
     except AttributeError:
         event_type = type(e).__name__
         raise Exception(  # TODO this may hang async threads

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -878,7 +878,7 @@ class HandleInternalException(ShowException, DebugLevel, Cli, File):
 
 
 @dataclass
-class MessageHandleGenericException(ShowException, ErrorLevel, Cli, File):
+class MessageHandleGenericException(ErrorLevel, Cli, File):
     build_path: str
     unique_id: str
     exc: Exception
@@ -1277,7 +1277,7 @@ class InvalidRefInTestNode(WarnLevel, Cli, File):
 
 
 @dataclass
-class RunningOperationCaughtError(ShowException, ErrorLevel, Cli, File):
+class RunningOperationCaughtError(ErrorLevel, Cli, File):
     exc: Exception
     code: str = "Q001"
 
@@ -1286,7 +1286,7 @@ class RunningOperationCaughtError(ShowException, ErrorLevel, Cli, File):
 
 
 @dataclass
-class RunningOperationUncaughtError(ShowException, ErrorLevel, Cli, File):
+class RunningOperationUncaughtError(ErrorLevel, Cli, File):
     exc: Exception
     code: str = "FF01"
 
@@ -1303,7 +1303,7 @@ class DbtProjectError(ErrorLevel, Cli, File):
 
 
 @dataclass
-class DbtProjectErrorException(ShowException, ErrorLevel, Cli, File):
+class DbtProjectErrorException(ErrorLevel, Cli, File):
     exc: Exception
     code: str = "A010"
 
@@ -1320,7 +1320,7 @@ class DbtProfileError(ErrorLevel, Cli, File):
 
 
 @dataclass
-class DbtProfileErrorException(ShowException, ErrorLevel, Cli, File):
+class DbtProfileErrorException(ErrorLevel, Cli, File):
     exc: Exception
     code: str = "A012"
 
@@ -1376,7 +1376,7 @@ class CatchableExceptionOnRun(ShowException, DebugLevel, Cli, File):
 
 
 @dataclass
-class InternalExceptionOnRun(ShowException, DebugLevel, Cli, File):
+class InternalExceptionOnRun(DebugLevel, Cli, File):
     build_path: str
     exc: Exception
     code: str = "W003"
@@ -1406,7 +1406,7 @@ class PrintDebugStackTrace(ShowException, DebugLevel, Cli, File):
 
 
 @dataclass
-class GenericExceptionOnRun(ShowException, ErrorLevel, Cli, File):
+class GenericExceptionOnRun(ErrorLevel, Cli, File):
     build_path: str
     unique_id: str
     exc: Exception
@@ -2501,7 +2501,7 @@ class GeneralWarningMsg(WarnLevel, Cli, File):
 
 
 @dataclass
-class GeneralWarningException(ShowException, WarnLevel, Cli, File):
+class GeneralWarningException(WarnLevel, Cli, File):
     exc: Exception
     log_fmt: str
     code: str = "Z047"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -617,6 +617,7 @@ class SchemaCreation(DebugLevel, Cli, File):
     def asdict(cls, data: list) -> dict:
         return dict((k, str(v)) for k, v in data)
 
+
 @dataclass
 class SchemaDrop(DebugLevel, Cli, File):
     relation: BaseRelation
@@ -694,8 +695,9 @@ class DropCascade(DebugLevel, Cli, File, Cache):
             if isinstance(v, list):
                 d[k] = [str(x) for x in v]
             else:
-                d[k] = str(v)
+                d[k] = str(v)  # type: ignore
         return d
+
 
 @dataclass
 class DropRelation(DebugLevel, Cli, File, Cache):

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -613,6 +613,9 @@ class SchemaCreation(DebugLevel, Cli, File):
     def message(self) -> str:
         return f'Creating schema "{self.relation}"'
 
+    @classmethod
+    def asdict(cls, data: list) -> dict:
+        return dict((k, str(v)) for k, v in data)
 
 @dataclass
 class SchemaDrop(DebugLevel, Cli, File):
@@ -621,6 +624,10 @@ class SchemaDrop(DebugLevel, Cli, File):
 
     def message(self) -> str:
         return f'Dropping schema "{self.relation}".'
+
+    @classmethod
+    def asdict(cls, data: list) -> dict:
+        return dict((k, str(v)) for k, v in data)
 
 
 # TODO pretty sure this is only ever called in dead code
@@ -680,6 +687,15 @@ class DropCascade(DebugLevel, Cli, File, Cache):
     def message(self) -> str:
         return f"drop {self.dropped} is cascading to {self.consequences}"
 
+    @classmethod
+    def asdict(cls, data: list) -> dict:
+        d = dict()
+        for k, v in data:
+            if isinstance(v, list):
+                d[k] = [str(x) for x in v]
+            else:
+                d[k] = str(v)
+        return d
 
 @dataclass
 class DropRelation(DebugLevel, Cli, File, Cache):

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -142,11 +142,9 @@ class MainReportArgs(DebugLevel, Cli, File):
     def message(self):
         return f"running dbt with arguments {str(self.args)}"
 
-    def asdict(self) -> dict:
-        return {
-            'code': self.code,
-            'args': str(self.args)
-        }
+    @classmethod
+    def asdict(cls, data: list) -> dict:
+        return dict((k, str(v)) for k, v in data)
 
 
 @dataclass
@@ -526,7 +524,7 @@ class Rollback(DebugLevel, Cli, File):
 
 @dataclass
 class CacheMiss(DebugLevel, Cli, File):
-    conn_name: Any  # TODO mypy says this is `Callable[[], str]`??  ¯\_(ツ)_/¯
+    conn_name: str
     database: Optional[str]
     schema: str
     code: str = "E013"
@@ -547,6 +545,14 @@ class ListRelations(DebugLevel, Cli, File):
 
     def message(self) -> str:
         return f"with database={self.database}, schema={self.schema}, relations={self.relations}"
+
+    @classmethod
+    def asdict(cls, data: list) -> dict:
+        d = dict()
+        for k, v in data:
+            if type(v) == list:
+                d[k] = [str(x) for x in v]
+        return d
 
 
 @dataclass
@@ -651,11 +657,9 @@ class AddRelation(DebugLevel, Cli, File, Cache):
     def message(self) -> str:
         return f"Adding relation: {str(self.relation)}"
 
-    def asdict(self) -> dict:
-        return {
-            'code': self.code,
-            'relation': str(self.relation)
-        }
+    @classmethod
+    def asdict(cls, data: list) -> dict:
+        return dict((k, str(v)) for k, v in data)
 
 
 @dataclass
@@ -765,11 +769,9 @@ class AdapterImportError(InfoLevel, Cli, File):
     def message(self) -> str:
         return f"Error importing adapter: {self.exc}"
 
-    def asdict(self) -> dict:
-        return {
-            'code': self.code,
-            'exc': str(self.exc)
-        }
+    @classmethod
+    def asdict(cls, data: list) -> dict:
+        return dict((k, str(v)) for k, v in data)
 
 
 @dataclass
@@ -2220,6 +2222,10 @@ class NodeFinished(DebugLevel, Cli, File, NodeInfo):
 
     def message(self) -> str:
         return f"Finished running node {self.unique_id}"
+
+    @classmethod
+    def asdict(cls, data: list) -> dict:
+        return dict((k, str(v)) for k, v in data)
 
 
 @dataclass

--- a/test/unit/test_events.py
+++ b/test/unit/test_events.py
@@ -108,10 +108,6 @@ class TestEventBuffer(TestCase):
     #         EVENT_HISTORY.count(UnitTestInfo(msg='Test Event 1', code='T006')) == 0
     #     )
 
-def dump_callable():
-    return dict()
-    
-
 def MockNode():
     return ParsedModelNode(
         alias='model_one',
@@ -221,10 +217,10 @@ sample_values = [
         old_key=_ReferenceKey(database="", schema="", identifier=""),
         new_key=_ReferenceKey(database="", schema="", identifier="")
     ),
-    DumpBeforeAddGraph(dump_callable),
-    DumpAfterAddGraph(dump_callable),
-    DumpBeforeRenameSchema(dump_callable),
-    DumpAfterRenameSchema(dump_callable),
+    DumpBeforeAddGraph(dict()),
+    DumpAfterAddGraph(dict()),
+    DumpBeforeRenameSchema(dict()),
+    DumpAfterRenameSchema(dict()),
     AdapterImportError(ModuleNotFoundError()),
     PluginLoadError(),
     SystemReportReturnCode(returncode=0),
@@ -429,7 +425,7 @@ class TestEventJSONSerialization(TestCase):
 
         # if we have everything we need to test, try to serialize everything
         for event in sample_values:
-            d = event_to_serializable_dict(event, lambda dt: dt.isoformat(), lambda x: x.message())
+            d = event_to_serializable_dict(event, lambda _: event.get_ts_rfc3339(), lambda x: x.message())
             try:
                 json.dumps(d)
             except TypeError as e:


### PR DESCRIPTION
resolves #4392 

### Description

Previously we were overriding on a per field basis. However, some of the serialization problems came one step earlier when we called `asdict.` This allows concrete classes to define their own dict factory methods to override the serialization strategy earlier in the pipeline.

This is very manual and definitely not optimized, so we may want to explore using something like mashumaro instead after the initial release.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
