### PR TITLE
Rollover + backup for `dbt.log`

### DIFF
--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -82,7 +82,12 @@ def setup_event_logger(log_path, level_override=None):
 
     file_passthrough_formatter = logging.Formatter(fmt=FORMAT)
 
-    file_handler = RotatingFileHandler(filename=log_dest, encoding='utf8')
+    file_handler = RotatingFileHandler(
+        filename=log_dest,
+        encoding='utf8',
+        maxBytes=10 * 1024 * 1024,  # 10 mb
+        backupCount=5
+    )
     file_handler.setFormatter(file_passthrough_formatter)
     file_handler.setLevel(logging.DEBUG)  # always debug regardless of user input
     this.FILE_LOG.handlers.clear()


### PR DESCRIPTION
resolves #4404

- Configs available from the good ol' built-in `RotatingFileHandler`. Match [the old values](https://github.com/dbt-labs/dbt-core/blob/74fbaa18cd7522161b8e0db97393c73d869a0498/core/dbt/logger.py#L386-L387) exactly
- We also used to mess with `delay` + `emit`, to buffer events before the log file location was known/ready. It all makes sense! The way we're doing it now forces us to be much more intentional about when configuration happens, which is a net positive
- Confirmed this worked locally by setting `maxSize=1000` + `dbt run` :)