### PR TITLE
Add `--event-buffer-size` flag, recreate `EVENT_HISTORY` once configured

### DIFF
--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -23,8 +23,9 @@ import dataclasses
 from collections import deque
 
 
-# create the global event history buffer with a max size of 100k records
+# create the global event history buffer with the default max size (10k)
 # python 3.7 doesn't support type hints on globals, but mypy requires them. hence the ignore.
+# TODO the flags module has not yet been resolved when this is created
 global EVENT_HISTORY
 EVENT_HISTORY = deque(maxlen=flags.EVENT_BUFFER_SIZE)  # type: ignore
 
@@ -49,6 +50,10 @@ invocation_id: Optional[str] = None
 
 
 def setup_event_logger(log_path, level_override=None):
+    # flags have been resolved, and log_path is known
+    global EVENT_HISTORY
+    EVENT_HISTORY = deque(maxlen=flags.EVENT_BUFFER_SIZE)  # type: ignore
+
     make_log_dir_if_missing(log_path)
     this.format_json = flags.LOG_FORMAT == 'json'
     # USE_COLORS can be None if the app just started and the cli flags

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -1076,6 +1076,14 @@ def parse_args(args, cls=DBTArgumentParser):
         '''
     )
 
+    p.add_argument(
+        '--event-buffer-size',
+        dest='event_buffer_size',
+        help='''
+        Sets the max number of events to buffer in EVENT_HISTORY
+        '''
+    )
+
     subs = p.add_subparsers(title="Available sub-commands")
 
     base_subparser = _build_base_subparser()


### PR DESCRIPTION
Follow-on to #4411

- Add `--event-buffer-size` flag to `main.py`
- When `GLOBAL_HISTORY` is being created right now, `flags` have not yet been resolved, so it's just using the default value set in the `flags` module (10k). We need to recreate global `EVENT_HISTORY` once all configs are available.

**The downside:** We might lose 1-2 events that are fired before we call `setup_event_logger()`. Currently, this is just deprecation warnings for renamed configs in `dbt_project.yml`.

**The problem:** Currently, `setup_event_logger` is being called much later than it should be from `main.py`, because it needs to wait for `log_path` to be resolved (based on config in `dbt_project.yml`).

Flags are resolved earlier than that, so we should refactor this to either:
- Split `setup_event_logger` into different functions for setting up global `EVENT_HISTORY` + `STDOUT_LOG` vs. global `FILE_LOG`, since only the latter needs to know `log_path`
- Set up `FILE_LOG` to use `RotatingFileHandler` with `delay` + `emit`, i.e. buffer events until it knows where `log_path` is, then drop them in the file. This is the approach we used to take with the legacy logger.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- ~This PR includes tests, or tests are not required/relevant for this PR~
- ~I have updated the `CHANGELOG.md` and added information about my change~