### PR TITLE
Info vs debug text formatting

### DIFF
--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -176,7 +176,7 @@ def event_to_serializable_dict(
 # translates an Event to a completely formatted text-based log line
 # you have to specify which message you want. (i.e. - e.message, e.cli_msg(), e.file_msg())
 # type hinting everything as strings so we don't get any unintentional string conversions via str()
-def create_stdout_text_log_line(e: T_Event, msg_fn: Callable[[T_Event], str]) -> str:
+def create_info_text_log_line(e: T_Event, msg_fn: Callable[[T_Event], str]) -> str:
     color_tag: str = '' if this.format_color else Style.RESET_ALL
     ts: str = e.get_ts().strftime("%H:%M:%S")
     scrubbed_msg: str = scrub_secrets(msg_fn(e), env_secrets())
@@ -184,7 +184,7 @@ def create_stdout_text_log_line(e: T_Event, msg_fn: Callable[[T_Event], str]) ->
     return log_line
 
 
-def create_file_text_log_line(e: T_Event, msg_fn: Callable[[T_Event], str]) -> str:
+def create_debug_text_log_line(e: T_Event, msg_fn: Callable[[T_Event], str]) -> str:
     log_line: str = ''
     # Create a separator if this is the beginning of an invocation
     if type(e) == MainReportVersion:
@@ -223,10 +223,10 @@ def create_log_line(
 ) -> Optional[str]:
     if this.format_json:
         return create_json_log_line(e, msg_fn)  # json output, both console and file
-    elif file_output is True:
-        return create_file_text_log_line(e, msg_fn)  # default file output
+    elif file_output is True or flags.DEBUG:
+        return create_debug_text_log_line(e, msg_fn)  # default file output
     else:
-        return create_stdout_text_log_line(e, msg_fn)  # console output
+        return create_info_text_log_line(e, msg_fn)  # console output
 
 
 # allows for resuse of this obnoxious if else tree.


### PR DESCRIPTION
**cosmetic only!**

One last bit of parity with the old logger: When the `--debug` flag is provided, and text-formatted logs are used, I think that should mean both:
- Print `debug`-level messages to stdout
- Use "debug" formatting, i.e. include longer timestamp + thread name

In this sense, the operative distinction is less CLI vs. File, and more Info vs. Debug style of text formatting. This lets the user see the exact same thing in `logs/dbt.log` and in stdout when they pass the `--debug` flag

### Legacy
```
$ dbt --debug run
2021-12-03 13:00:23.366679 (MainThread): Running with dbt=0.21.1
2021-12-03 13:00:23.463368 (MainThread): running dbt with arguments Namespace(cls=<class 'dbt.task.run.RunTask'>, debug=True, defer=None, exclude=None, fail_fast=False, full_refresh=False, log_cache_events=False, log_format='default', partial_parse=None, profile=None, profiles_dir='/Users/jerco/.dbt', project_dir=None, record_timing_info=None, rpc_method='run', select=None, selector_name=None, single_threaded=False, state=None, strict=False, target=None, test_new_parser=False, threads=None, use_cache=True, use_colors=None, use_experimental_parser=False, vars='{}', version_check=True, warn_error=False, which='run', write_json=True)
```
### Before (current)
```
$ dbt --debug run
13:01:19  Running with dbt=1.0.0-rc3
13:01:19  running dbt with arguments Namespace(cls=<class 'dbt.task.run.RunTask'>, debug=True, defer=None, exclude=None, fail_fast=None, full_refresh=False, log_cache_events=False, log_format=None, partial_parse=None, printer_width=None, profile=None, profiles_dir='/Users/jerco/.dbt', project_dir=None, record_timing_info=None, rpc_method='run', select=None, selector_name=None, send_anonymous_usage_stats=None, single_threaded=False, state=None, static_parser=None, target=None, threads=None, use_colors=None, use_experimental_parser=None, vars='{}', version_check=None, warn_error=None, which='run', write_json=None)
```
### After (this change)
```
$ dbt --debug run


============================== 2021-12-03 13:00:54.558606 | 31ffd57a-af02-4834-86ee-51202abb8832 ==============================
13:00:54.558606 [info ] [MainThread]: Running with dbt=1.0.0-rc3
13:00:54.559303 [debug] [MainThread]: running dbt with arguments Namespace(cls=<class 'dbt.task.run.RunTask'>, debug=True, defer=None, exclude=None, fail_fast=None, full_refresh=False, log_cache_events=False, log_format=None, partial_parse=None, printer_width=None, profile=None, profiles_dir='/Users/jerco/.dbt', project_dir=None, record_timing_info=None, rpc_method='run', select=None, selector_name=None, send_anonymous_usage_stats=None, single_threaded=False, state=None, static_parser=None, target=None, threads=None, use_colors=None, use_experimental_parser=None, vars='{}', version_check=None, warn_error=None, which='run', write_json=None)
```

I don't mind the separator :)