### PR TITLE
relax version specifier for dbt-extractor

### DIFF
--- a/docker/requirements/requirements.txt
+++ b/docker/requirements/requirements.txt
@@ -7,7 +7,7 @@ charset-normalizer==2.0.8
 click==8.0.3
 colorama==0.4.4
 dbt-core==1.0.0rc3
-dbt-extractor==0.4.0
+dbt-extractor~=0.4.0
 dbt-postgres==1.0.0rc3
 future==0.18.2
 hologram==0.0.14


### PR DESCRIPTION
### Description

Uses the [compatible release](https://www.python.org/dev/peps/pep-0440/#compatible-release) version specifier so that if we need to release dbt-extractor v0.4.1 for whatever reason, existing instances of dbt v1.0 will automatically be able to use them.

This change is in preparation for the dbt-extractor to be built and distributed for the M1 architecture which it is currently not. PR for supporting the M1 arch is in dbt-labs/dbt-extractor#41.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
