### PR TITLE
point latest version check to dbt-core package

### DIFF
--- a/core/dbt/version.py
+++ b/core/dbt/version.py
@@ -11,7 +11,7 @@ import dbt.exceptions
 import dbt.semver
 
 
-PYPI_VERSION_URL = 'https://pypi.org/pypi/dbt/json'
+PYPI_VERSION_URL = 'https://pypi.org/pypi/dbt-core/json'
 
 
 def get_latest_version():


### PR DESCRIPTION
### Description

Because we renamed our package from `dbt` to `dbt-core` when we split out the adapters, our latest version check is wrong. Users will see this in the following message for v1.0.0:

```
% dbt --version
installed version: 1.0.0
   latest version: 0.21.1

Your version of dbt is ahead of the latest release!

Plugins:
  - snowflake: 1.0.0
```

You can manually check that this change works with the following python shell commands:
```
>>> import requests
>>> requests.get("https://pypi.org/pypi/dbt/json").json()['info']['version']
'0.21.1'
>>> requests.get("https://pypi.org/pypi/dbt-core/json").json()['info']['version']
'1.0.0'
```

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
