### PR TITLE
Lean on mypy more

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ flake8
 flaky
 freezegun==0.3.12
 ipdb
-mypy==0.782
+mypy==0.910
 pip-tools
 pytest
 pytest-dotenv

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
 description = mypy static type checking
 basepython = python3.8
 skip_install = true
-commands = mypy core/dbt
+commands = mypy --strict --warn-unreachable ./ 
 deps =
   -rdev-requirements.txt
   -reditable-requirements.txt


### PR DESCRIPTION
resolves #4089, #3203

### Description

- updates mypy to latest
- runs with `--strict` and `--warn-unreachable` flags

`Found 2869 errors in 73 files (checked 52 source files)`

This PR will either fix these errors or explicitly ignore them in the code.

### Development

In case anyone wants to work on this in parallel, I will be treating this as the feature branch and make merges into it. Incremental merges into main are not an option because this PR will fail CI until all 2869 errors are addressed.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
