### PR TITLE
made change to test of str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 - Fix wrong url in the dbt docs overview homepage ([#4442](https://github.com/dbt-labs/dbt-core/pull/4442))
+- Fix redefined status param of SQLQueryStatus to typecheck the string which passes on `._message` value of `AdapterResponse` or the `str` value sent by adapter plugin.  ([#4463](https://github.com/dbt-labs/dbt-core/pull/4463#issuecomment-990174166)) 
 
 Contributors:
 - [remoyson](https://github.com/remoyson) ([#4442](https://github.com/dbt-labs/dbt-core/pull/4442))

--- a/core/dbt/adapters/sql/connections.py
+++ b/core/dbt/adapters/sql/connections.py
@@ -75,7 +75,7 @@ class SQLConnectionManager(BaseConnectionManager):
 
             fire_event(
                 SQLQueryStatus(
-                    status=self.get_response(cursor)._message,
+                    status=str(self.get_response(cursor)),
                     elapsed=round((time.time() - pre), 2)
                 )
             )


### PR DESCRIPTION
resolves #4433 

### Description
redefined status param of SQLQueryStatus to typecheck. string which passes on ._message value of AdapterResponse or the str value sent by adapter plugin.

Worked with Nate going through process of dealing with issues as they come in with minimal context, talked through several potential ways to solve the issue and even found some that would cause a bigger change than currently needed so had to take into account what might be worth time investment of task. 

-- Co Author @nathaniel-may 

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
