### PR TITLE
updated DepsStartPackageInstall event to use package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Fixes
 - Fix wrong url in the dbt docs overview homepage ([#4442](https://github.com/dbt-labs/dbt-core/pull/4442))
-- Fix redefined status param of SQLQueryStatus to typecheck the string which passes on `._message` value of `AdapterResponse` or the `str` value sent by adapter plugin.  ([#4463](https://github.com/dbt-labs/dbt-core/pull/4463#issuecomment-990174166)) 
+- Fix redefined status param of SQLQueryStatus to typecheck the string which passes on `._message` value of `AdapterResponse` or the `str` value sent by adapter plugin.  ([#4463](https://github.com/dbt-labs/dbt-core/pull/4463#issuecomment-990174166))
+- Fix `DepsStartPackageInstall` event to use package name instead of version number. ([#4482](https://github.com/dbt-labs/dbt-core/pull/4482))
 
 Contributors:
 - [remoyson](https://github.com/remoyson) ([#4442](https://github.com/dbt-labs/dbt-core/pull/4442))

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1414,11 +1414,11 @@ class DepsNoPackagesFound(InfoLevel, Cli, File):
 
 @dataclass
 class DepsStartPackageInstall(InfoLevel, Cli, File):
-    package: str
+    package_name: str
     code: str = "M014"
 
     def message(self) -> str:
-        return f"Installing {self.package}"
+        return f"Installing {self.package_name}"
 
 
 @dataclass
@@ -2589,7 +2589,7 @@ if 1 == 0:
     FinishedCleanPaths()
     OpenCommand(open_cmd='', profiles_dir='')
     DepsNoPackagesFound()
-    DepsStartPackageInstall(package='')
+    DepsStartPackageInstall(package_name='')
     DepsInstallInfo(version_name='')
     DepsUpdateAvailable(version_latest='')
     DepsListSubdirectory(subdirectory='')

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -63,7 +63,7 @@ class DepsTask(BaseTask):
                 source_type = package.source_type()
                 version = package.get_version()
 
-                fire_event(DepsStartPackageInstall(package=package.nice_version_name()))
+                fire_event(DepsStartPackageInstall(package_name=package_name))
                 package.install(self.config, renderer)
                 fire_event(DepsInstallInfo(version_name=package.nice_version_name()))
                 if source_type == 'hub':

--- a/test/unit/test_events.py
+++ b/test/unit/test_events.py
@@ -294,7 +294,7 @@ sample_values = [
     FinishedCleanPaths(),
     OpenCommand(open_cmd='', profiles_dir=''),
     DepsNoPackagesFound(),
-    DepsStartPackageInstall(package=''),
+    DepsStartPackageInstall(package_name=''),
     DepsInstallInfo(version_name=''),
     DepsUpdateAvailable(version_latest=''),
     DepsListSubdirectory(subdirectory=''),


### PR DESCRIPTION
resolves #4461 

### Description

Updated `DepsStartPackageInstall` to use package name instead of version number.  Log output is now

```
(env) emily@Emily-Rockman jaffle-shop % dbt deps
12:53:38  Running with dbt=1.0.0
12:53:39  Installing dbt-labs/dbt_utils
12:53:39    Installed from version 0.8.0
12:53:39    Up to date!
```

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
