### PR TITLE
Simplify Log Destinations

### DIFF
--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -11,32 +11,6 @@ from typing import Any, Optional
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 
-# in preparation for #3977
-class TestLevel():
-    def level_tag(self) -> str:
-        return "test"
-
-
-class DebugLevel():
-    def level_tag(self) -> str:
-        return "debug"
-
-
-class InfoLevel():
-    def level_tag(self) -> str:
-        return "info"
-
-
-class WarnLevel():
-    def level_tag(self) -> str:
-        return "warn"
-
-
-class ErrorLevel():
-    def level_tag(self) -> str:
-        return "error"
-
-
 class Cache():
     # Events with this class will only be logged when the `--log-cache-events` flag is passed
     pass
@@ -139,6 +113,32 @@ class Event(metaclass=ABCMeta):
             else:
                 d[k] = v
         return d
+
+
+# in preparation for #3977
+class TestLevel(Event):
+    def level_tag(self) -> str:
+        return "test"
+
+
+class DebugLevel(Event):
+    def level_tag(self) -> str:
+        return "debug"
+
+
+class InfoLevel(Event):
+    def level_tag(self) -> str:
+        return "info"
+
+
+class WarnLevel(Event):
+    def level_tag(self) -> str:
+        return "warn"
+
+
+class ErrorLevel(Event):
+    def level_tag(self) -> str:
+        return "error"
 
 
 @dataclass  # type: ignore

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -159,15 +159,11 @@ class NodeInfo(Event, metaclass=ABCMeta):
         return node_info
 
 
-class File(Event, metaclass=ABCMeta):
-    # Solely the human readable message. Timestamps and formatting will be added by the logger.
-    def file_msg(self) -> str:
-        # returns the event msg unless overriden in the concrete class
-        return self.message()
+# prevents an event from going to the file
+class NoFile():
+    pass
 
 
-class Cli(Event, metaclass=ABCMeta):
-    # Solely the human readable message. Timestamps and formatting will be added by the logger.
-    def cli_msg(self) -> str:
-        # returns the event msg unless overriden in the concrete class
-        return self.message()
+# prevents an event from going to stdout
+class NoStdOut():
+    pass

--- a/core/dbt/events/test_types.py
+++ b/core/dbt/events/test_types.py
@@ -5,7 +5,7 @@ from .types import (
     WarnLevel,
     ErrorLevel,
     ShowException,
-    Cli
+    NoFile
 )
 
 
@@ -13,7 +13,7 @@ from .types import (
 # Reuse the existing messages when adding logs to tests.
 
 @dataclass
-class IntegrationTestInfo(InfoLevel, Cli):
+class IntegrationTestInfo(InfoLevel, NoFile):
     msg: str
     code: str = "T001"
 
@@ -22,7 +22,7 @@ class IntegrationTestInfo(InfoLevel, Cli):
 
 
 @dataclass
-class IntegrationTestDebug(DebugLevel, Cli):
+class IntegrationTestDebug(DebugLevel, NoFile):
     msg: str
     code: str = "T002"
 
@@ -31,7 +31,7 @@ class IntegrationTestDebug(DebugLevel, Cli):
 
 
 @dataclass
-class IntegrationTestWarn(WarnLevel, Cli):
+class IntegrationTestWarn(WarnLevel, NoFile):
     msg: str
     code: str = "T003"
 
@@ -40,7 +40,7 @@ class IntegrationTestWarn(WarnLevel, Cli):
 
 
 @dataclass
-class IntegrationTestError(ErrorLevel, Cli):
+class IntegrationTestError(ErrorLevel, NoFile):
     msg: str
     code: str = "T004"
 
@@ -49,7 +49,7 @@ class IntegrationTestError(ErrorLevel, Cli):
 
 
 @dataclass
-class IntegrationTestException(ShowException, ErrorLevel, Cli):
+class IntegrationTestException(ShowException, ErrorLevel, NoFile):
     msg: str
     code: str = "T005"
 
@@ -58,7 +58,7 @@ class IntegrationTestException(ShowException, ErrorLevel, Cli):
 
 
 @dataclass
-class UnitTestInfo(InfoLevel, Cli):
+class UnitTestInfo(InfoLevel, NoFile):
     msg: str
     code: str = "T006"
 

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -49,7 +49,7 @@ T_Event = TypeVar('T_Event', bound=Event)
 # https://github.com/python/mypy/issues/5374
 
 @dataclass  # type: ignore
-class AdapterEventBase():
+class AdapterEventBase(Event):
     name: str
     base_msg: str
     args: Tuple[Any, ...]

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -10,7 +10,7 @@ from dbt.events.stubs import (
 )
 from dbt import ui
 from dbt.events.base_types import (
-    Cli, Event, File, DebugLevel, InfoLevel, WarnLevel, ErrorLevel, ShowException, NodeInfo, Cache
+    NoStdOut, Event, NoFile, DebugLevel, InfoLevel, WarnLevel, ErrorLevel, ShowException, NodeInfo, Cache
 )
 from dbt.events.format import format_fancy_output_line, pluralize
 from dbt.node_types import NodeType

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -10,7 +10,8 @@ from dbt.events.stubs import (
 )
 from dbt import ui
 from dbt.events.base_types import (
-    NoStdOut, Event, NoFile, DebugLevel, InfoLevel, WarnLevel, ErrorLevel, ShowException, NodeInfo, Cache
+    Event, NoFile, DebugLevel, InfoLevel, WarnLevel, ErrorLevel, ShowException,
+    NodeInfo, Cache
 )
 from dbt.events.format import format_fancy_output_line, pluralize
 from dbt.node_types import NodeType
@@ -48,7 +49,7 @@ T_Event = TypeVar('T_Event', bound=Event)
 # https://github.com/python/mypy/issues/5374
 
 @dataclass  # type: ignore
-class AdapterEventBase(Cli, File):
+class AdapterEventBase():
     name: str
     base_msg: str
     args: Tuple[Any, ...]
@@ -99,16 +100,15 @@ class AdapterEventError(ErrorLevel, AdapterEventBase, ShowException):
 
 
 @dataclass
-class MainKeyboardInterrupt(InfoLevel, Cli):
+class MainKeyboardInterrupt(InfoLevel, NoFile):
     code: str = "Z001"
 
     def message(self) -> str:
         return "ctrl-c"
 
 
-# will log to a file if the file logger is configured
 @dataclass
-class MainEncounteredError(ErrorLevel, Cli):
+class MainEncounteredError(ErrorLevel, NoFile):
     e: BaseException
     code: str = "Z002"
 
@@ -117,7 +117,7 @@ class MainEncounteredError(ErrorLevel, Cli):
 
 
 @dataclass
-class MainStackTrace(DebugLevel, Cli):
+class MainStackTrace(DebugLevel, NoFile):
     stack_trace: str
     code: str = "Z003"
 
@@ -126,7 +126,7 @@ class MainStackTrace(DebugLevel, Cli):
 
 
 @dataclass
-class MainReportVersion(InfoLevel, Cli, File):
+class MainReportVersion(InfoLevel):
     v: str  # could be VersionSpecifier instead if we resolved some circular imports
     code: str = "A001"
 
@@ -135,7 +135,7 @@ class MainReportVersion(InfoLevel, Cli, File):
 
 
 @dataclass
-class MainReportArgs(DebugLevel, Cli, File):
+class MainReportArgs(DebugLevel):
     args: argparse.Namespace
     code: str = "A002"
 
@@ -148,7 +148,7 @@ class MainReportArgs(DebugLevel, Cli, File):
 
 
 @dataclass
-class MainTrackingUserState(DebugLevel, Cli, File):
+class MainTrackingUserState(DebugLevel):
     user_state: str
     code: str = "A003"
 
@@ -157,7 +157,7 @@ class MainTrackingUserState(DebugLevel, Cli, File):
 
 
 @dataclass
-class ParsingStart(InfoLevel, Cli, File):
+class ParsingStart(InfoLevel):
     code: str = "I001"
 
     def message(self) -> str:
@@ -165,7 +165,7 @@ class ParsingStart(InfoLevel, Cli, File):
 
 
 @dataclass
-class ParsingCompiling(InfoLevel, Cli, File):
+class ParsingCompiling(InfoLevel):
     code: str = "I002"
 
     def message(self) -> str:
@@ -173,7 +173,7 @@ class ParsingCompiling(InfoLevel, Cli, File):
 
 
 @dataclass
-class ParsingWritingManifest(InfoLevel, Cli, File):
+class ParsingWritingManifest(InfoLevel):
     code: str = "I003"
 
     def message(self) -> str:
@@ -181,7 +181,7 @@ class ParsingWritingManifest(InfoLevel, Cli, File):
 
 
 @dataclass
-class ParsingDone(InfoLevel, Cli, File):
+class ParsingDone(InfoLevel):
     code: str = "I004"
 
     def message(self) -> str:
@@ -189,7 +189,7 @@ class ParsingDone(InfoLevel, Cli, File):
 
 
 @dataclass
-class ManifestDependenciesLoaded(InfoLevel, Cli, File):
+class ManifestDependenciesLoaded(InfoLevel):
     code: str = "I005"
 
     def message(self) -> str:
@@ -197,7 +197,7 @@ class ManifestDependenciesLoaded(InfoLevel, Cli, File):
 
 
 @dataclass
-class ManifestLoaderCreated(InfoLevel, Cli, File):
+class ManifestLoaderCreated(InfoLevel):
     code: str = "I006"
 
     def message(self) -> str:
@@ -205,7 +205,7 @@ class ManifestLoaderCreated(InfoLevel, Cli, File):
 
 
 @dataclass
-class ManifestLoaded(InfoLevel, Cli, File):
+class ManifestLoaded(InfoLevel):
     code: str = "I007"
 
     def message(self) -> str:
@@ -213,7 +213,7 @@ class ManifestLoaded(InfoLevel, Cli, File):
 
 
 @dataclass
-class ManifestChecked(InfoLevel, Cli, File):
+class ManifestChecked(InfoLevel):
     code: str = "I008"
 
     def message(self) -> str:
@@ -221,7 +221,7 @@ class ManifestChecked(InfoLevel, Cli, File):
 
 
 @dataclass
-class ManifestFlatGraphBuilt(InfoLevel, Cli, File):
+class ManifestFlatGraphBuilt(InfoLevel):
     code: str = "I009"
 
     def message(self) -> str:
@@ -229,7 +229,7 @@ class ManifestFlatGraphBuilt(InfoLevel, Cli, File):
 
 
 @dataclass
-class ReportPerformancePath(InfoLevel, Cli, File):
+class ReportPerformancePath(InfoLevel):
     path: str
     code: str = "I010"
 
@@ -238,7 +238,7 @@ class ReportPerformancePath(InfoLevel, Cli, File):
 
 
 @dataclass
-class GitSparseCheckoutSubdirectory(DebugLevel, Cli, File):
+class GitSparseCheckoutSubdirectory(DebugLevel):
     subdir: str
     code: str = "M001"
 
@@ -247,7 +247,7 @@ class GitSparseCheckoutSubdirectory(DebugLevel, Cli, File):
 
 
 @dataclass
-class GitProgressCheckoutRevision(DebugLevel, Cli, File):
+class GitProgressCheckoutRevision(DebugLevel):
     revision: str
     code: str = "M002"
 
@@ -256,7 +256,7 @@ class GitProgressCheckoutRevision(DebugLevel, Cli, File):
 
 
 @dataclass
-class GitProgressUpdatingExistingDependency(DebugLevel, Cli, File):
+class GitProgressUpdatingExistingDependency(DebugLevel):
     dir: str
     code: str = "M003"
 
@@ -265,7 +265,7 @@ class GitProgressUpdatingExistingDependency(DebugLevel, Cli, File):
 
 
 @dataclass
-class GitProgressPullingNewDependency(DebugLevel, Cli, File):
+class GitProgressPullingNewDependency(DebugLevel):
     dir: str
     code: str = "M004"
 
@@ -274,7 +274,7 @@ class GitProgressPullingNewDependency(DebugLevel, Cli, File):
 
 
 @dataclass
-class GitNothingToDo(DebugLevel, Cli, File):
+class GitNothingToDo(DebugLevel):
     sha: str
     code: str = "M005"
 
@@ -283,7 +283,7 @@ class GitNothingToDo(DebugLevel, Cli, File):
 
 
 @dataclass
-class GitProgressUpdatedCheckoutRange(DebugLevel, Cli, File):
+class GitProgressUpdatedCheckoutRange(DebugLevel):
     start_sha: str
     end_sha: str
     code: str = "M006"
@@ -293,7 +293,7 @@ class GitProgressUpdatedCheckoutRange(DebugLevel, Cli, File):
 
 
 @dataclass
-class GitProgressCheckedOutAt(DebugLevel, Cli, File):
+class GitProgressCheckedOutAt(DebugLevel):
     end_sha: str
     code: str = "M007"
 
@@ -302,7 +302,7 @@ class GitProgressCheckedOutAt(DebugLevel, Cli, File):
 
 
 @dataclass
-class RegistryProgressMakingGETRequest(DebugLevel, Cli, File):
+class RegistryProgressMakingGETRequest(DebugLevel):
     url: str
     code: str = "M008"
 
@@ -311,7 +311,7 @@ class RegistryProgressMakingGETRequest(DebugLevel, Cli, File):
 
 
 @dataclass
-class RegistryProgressGETResponse(DebugLevel, Cli, File):
+class RegistryProgressGETResponse(DebugLevel):
     url: str
     resp_code: int
     code: str = "M009"
@@ -322,7 +322,7 @@ class RegistryProgressGETResponse(DebugLevel, Cli, File):
 
 # TODO this was actually `logger.exception(...)` not `logger.error(...)`
 @dataclass
-class SystemErrorRetrievingModTime(ErrorLevel, Cli, File):
+class SystemErrorRetrievingModTime(ErrorLevel):
     path: str
     code: str = "Z004"
 
@@ -331,7 +331,7 @@ class SystemErrorRetrievingModTime(ErrorLevel, Cli, File):
 
 
 @dataclass
-class SystemCouldNotWrite(DebugLevel, Cli, File):
+class SystemCouldNotWrite(DebugLevel):
     path: str
     reason: str
     exc: Exception
@@ -345,7 +345,7 @@ class SystemCouldNotWrite(DebugLevel, Cli, File):
 
 
 @dataclass
-class SystemExecutingCmd(DebugLevel, Cli, File):
+class SystemExecutingCmd(DebugLevel):
     cmd: List[str]
     code: str = "Z006"
 
@@ -354,7 +354,7 @@ class SystemExecutingCmd(DebugLevel, Cli, File):
 
 
 @dataclass
-class SystemStdOutMsg(DebugLevel, Cli, File):
+class SystemStdOutMsg(DebugLevel):
     bmsg: bytes
     code: str = "Z007"
 
@@ -363,7 +363,7 @@ class SystemStdOutMsg(DebugLevel, Cli, File):
 
 
 @dataclass
-class SystemStdErrMsg(DebugLevel, Cli, File):
+class SystemStdErrMsg(DebugLevel):
     bmsg: bytes
     code: str = "Z008"
 
@@ -372,7 +372,7 @@ class SystemStdErrMsg(DebugLevel, Cli, File):
 
 
 @dataclass
-class SystemReportReturnCode(DebugLevel, Cli, File):
+class SystemReportReturnCode(DebugLevel):
     returncode: int
     code: str = "Z009"
 
@@ -381,7 +381,7 @@ class SystemReportReturnCode(DebugLevel, Cli, File):
 
 
 @dataclass
-class SelectorReportInvalidSelector(InfoLevel, Cli, File):
+class SelectorReportInvalidSelector(InfoLevel):
     selector_methods: dict
     spec_method: str
     raw_spec: str
@@ -396,7 +396,7 @@ class SelectorReportInvalidSelector(InfoLevel, Cli, File):
 
 
 @dataclass
-class MacroEventInfo(InfoLevel, Cli, File):
+class MacroEventInfo(InfoLevel):
     msg: str
     code: str = "M011"
 
@@ -405,7 +405,7 @@ class MacroEventInfo(InfoLevel, Cli, File):
 
 
 @dataclass
-class MacroEventDebug(DebugLevel, Cli, File):
+class MacroEventDebug(DebugLevel):
     msg: str
     code: str = "M012"
 
@@ -414,7 +414,7 @@ class MacroEventDebug(DebugLevel, Cli, File):
 
 
 @dataclass
-class NewConnection(DebugLevel, Cli, File):
+class NewConnection(DebugLevel):
     conn_type: str
     conn_name: str
     code: str = "E005"
@@ -424,7 +424,7 @@ class NewConnection(DebugLevel, Cli, File):
 
 
 @dataclass
-class ConnectionReused(DebugLevel, Cli, File):
+class ConnectionReused(DebugLevel):
     conn_name: str
     code: str = "E006"
 
@@ -433,7 +433,7 @@ class ConnectionReused(DebugLevel, Cli, File):
 
 
 @dataclass
-class ConnectionLeftOpen(DebugLevel, Cli, File):
+class ConnectionLeftOpen(DebugLevel):
     conn_name: Optional[str]
     code: str = "E007"
 
@@ -442,7 +442,7 @@ class ConnectionLeftOpen(DebugLevel, Cli, File):
 
 
 @dataclass
-class ConnectionClosed(DebugLevel, Cli, File):
+class ConnectionClosed(DebugLevel):
     conn_name: Optional[str]
     code: str = "E008"
 
@@ -451,7 +451,7 @@ class ConnectionClosed(DebugLevel, Cli, File):
 
 
 @dataclass
-class RollbackFailed(ShowException, DebugLevel, Cli, File):
+class RollbackFailed(ShowException, DebugLevel):
     conn_name: Optional[str]
     code: str = "E009"
 
@@ -461,7 +461,7 @@ class RollbackFailed(ShowException, DebugLevel, Cli, File):
 
 # TODO: can we combine this with ConnectionClosed?
 @dataclass
-class ConnectionClosed2(DebugLevel, Cli, File):
+class ConnectionClosed2(DebugLevel):
     conn_name: Optional[str]
     code: str = "E010"
 
@@ -471,7 +471,7 @@ class ConnectionClosed2(DebugLevel, Cli, File):
 
 # TODO: can we combine this with ConnectionLeftOpen?
 @dataclass
-class ConnectionLeftOpen2(DebugLevel, Cli, File):
+class ConnectionLeftOpen2(DebugLevel):
     conn_name: Optional[str]
     code: str = "E011"
 
@@ -480,7 +480,7 @@ class ConnectionLeftOpen2(DebugLevel, Cli, File):
 
 
 @dataclass
-class Rollback(DebugLevel, Cli, File):
+class Rollback(DebugLevel):
     conn_name: Optional[str]
     code: str = "E012"
 
@@ -489,7 +489,7 @@ class Rollback(DebugLevel, Cli, File):
 
 
 @dataclass
-class CacheMiss(DebugLevel, Cli, File):
+class CacheMiss(DebugLevel):
     conn_name: str
     database: Optional[str]
     schema: str
@@ -503,7 +503,7 @@ class CacheMiss(DebugLevel, Cli, File):
 
 
 @dataclass
-class ListRelations(DebugLevel, Cli, File):
+class ListRelations(DebugLevel):
     database: Optional[str]
     schema: str
     relations: List[_ReferenceKey]
@@ -522,7 +522,7 @@ class ListRelations(DebugLevel, Cli, File):
 
 
 @dataclass
-class ConnectionUsed(DebugLevel, Cli, File):
+class ConnectionUsed(DebugLevel):
     conn_type: str
     conn_name: Optional[str]
     code: str = "E015"
@@ -532,7 +532,7 @@ class ConnectionUsed(DebugLevel, Cli, File):
 
 
 @dataclass
-class SQLQuery(DebugLevel, Cli, File):
+class SQLQuery(DebugLevel):
     conn_name: Optional[str]
     sql: str
     code: str = "E016"
@@ -542,7 +542,7 @@ class SQLQuery(DebugLevel, Cli, File):
 
 
 @dataclass
-class SQLQueryStatus(DebugLevel, Cli, File):
+class SQLQueryStatus(DebugLevel):
     status: str
     elapsed: float
     code: str = "E017"
@@ -552,7 +552,7 @@ class SQLQueryStatus(DebugLevel, Cli, File):
 
 
 @dataclass
-class SQLCommit(DebugLevel, Cli, File):
+class SQLCommit(DebugLevel):
     conn_name: str
     code: str = "E018"
 
@@ -561,7 +561,7 @@ class SQLCommit(DebugLevel, Cli, File):
 
 
 @dataclass
-class ColTypeChange(DebugLevel, Cli, File):
+class ColTypeChange(DebugLevel):
     orig_type: str
     new_type: str
     table: str
@@ -572,7 +572,7 @@ class ColTypeChange(DebugLevel, Cli, File):
 
 
 @dataclass
-class SchemaCreation(DebugLevel, Cli, File):
+class SchemaCreation(DebugLevel):
     relation: _ReferenceKey
     code: str = "E020"
 
@@ -581,7 +581,7 @@ class SchemaCreation(DebugLevel, Cli, File):
 
 
 @dataclass
-class SchemaDrop(DebugLevel, Cli, File):
+class SchemaDrop(DebugLevel):
     relation: _ReferenceKey
     code: str = "E021"
 
@@ -596,7 +596,7 @@ class SchemaDrop(DebugLevel, Cli, File):
 # TODO pretty sure this is only ever called in dead code
 # see: core/dbt/adapters/cache.py _add_link vs add_link
 @dataclass
-class UncachedRelation(DebugLevel, Cli, File, Cache):
+class UncachedRelation(DebugLevel, Cache):
     dep_key: _ReferenceKey
     ref_key: _ReferenceKey
     code: str = "E022"
@@ -610,7 +610,7 @@ class UncachedRelation(DebugLevel, Cli, File, Cache):
 
 
 @dataclass
-class AddLink(DebugLevel, Cli, File, Cache):
+class AddLink(DebugLevel, Cache):
     dep_key: _ReferenceKey
     ref_key: _ReferenceKey
     code: str = "E023"
@@ -620,7 +620,7 @@ class AddLink(DebugLevel, Cli, File, Cache):
 
 
 @dataclass
-class AddRelation(DebugLevel, Cli, File, Cache):
+class AddRelation(DebugLevel, Cache):
     relation: _ReferenceKey
     code: str = "E024"
 
@@ -629,7 +629,7 @@ class AddRelation(DebugLevel, Cli, File, Cache):
 
 
 @dataclass
-class DropMissingRelation(DebugLevel, Cli, File, Cache):
+class DropMissingRelation(DebugLevel, Cache):
     relation: _ReferenceKey
     code: str = "E025"
 
@@ -638,7 +638,7 @@ class DropMissingRelation(DebugLevel, Cli, File, Cache):
 
 
 @dataclass
-class DropCascade(DebugLevel, Cli, File, Cache):
+class DropCascade(DebugLevel, Cache):
     dropped: _ReferenceKey
     consequences: Set[_ReferenceKey]
     code: str = "E026"
@@ -658,7 +658,7 @@ class DropCascade(DebugLevel, Cli, File, Cache):
 
 
 @dataclass
-class DropRelation(DebugLevel, Cli, File, Cache):
+class DropRelation(DebugLevel, Cache):
     dropped: _ReferenceKey
     code: str = "E027"
 
@@ -667,7 +667,7 @@ class DropRelation(DebugLevel, Cli, File, Cache):
 
 
 @dataclass
-class UpdateReference(DebugLevel, Cli, File, Cache):
+class UpdateReference(DebugLevel, Cache):
     old_key: _ReferenceKey
     new_key: _ReferenceKey
     cached_key: _ReferenceKey
@@ -679,7 +679,7 @@ class UpdateReference(DebugLevel, Cli, File, Cache):
 
 
 @dataclass
-class TemporaryRelation(DebugLevel, Cli, File, Cache):
+class TemporaryRelation(DebugLevel, Cache):
     key: _ReferenceKey
     code: str = "E029"
 
@@ -688,7 +688,7 @@ class TemporaryRelation(DebugLevel, Cli, File, Cache):
 
 
 @dataclass
-class RenameSchema(DebugLevel, Cli, File, Cache):
+class RenameSchema(DebugLevel, Cache):
     old_key: _ReferenceKey
     new_key: _ReferenceKey
     code: str = "E030"
@@ -698,7 +698,7 @@ class RenameSchema(DebugLevel, Cli, File, Cache):
 
 
 @dataclass
-class DumpBeforeAddGraph(DebugLevel, Cli, File, Cache):
+class DumpBeforeAddGraph(DebugLevel, Cache):
     # large value. delay not necessary since every debug level message is logged anyway.
     dump: Dict[str, List[str]]
     code: str = "E031"
@@ -708,7 +708,7 @@ class DumpBeforeAddGraph(DebugLevel, Cli, File, Cache):
 
 
 @dataclass
-class DumpAfterAddGraph(DebugLevel, Cli, File, Cache):
+class DumpAfterAddGraph(DebugLevel, Cache):
     # large value. delay not necessary since every debug level message is logged anyway.
     dump: Dict[str, List[str]]
     code: str = "E032"
@@ -718,7 +718,7 @@ class DumpAfterAddGraph(DebugLevel, Cli, File, Cache):
 
 
 @dataclass
-class DumpBeforeRenameSchema(DebugLevel, Cli, File, Cache):
+class DumpBeforeRenameSchema(DebugLevel, Cache):
     # large value. delay not necessary since every debug level message is logged anyway.
     dump: Dict[str, List[str]]
     code: str = "E033"
@@ -728,7 +728,7 @@ class DumpBeforeRenameSchema(DebugLevel, Cli, File, Cache):
 
 
 @dataclass
-class DumpAfterRenameSchema(DebugLevel, Cli, File, Cache):
+class DumpAfterRenameSchema(DebugLevel, Cache):
     # large value. delay not necessary since every debug level message is logged anyway.
     dump: Dict[str, List[str]]
     code: str = "E034"
@@ -738,7 +738,7 @@ class DumpAfterRenameSchema(DebugLevel, Cli, File, Cache):
 
 
 @dataclass
-class AdapterImportError(InfoLevel, Cli, File):
+class AdapterImportError(InfoLevel):
     exc: ModuleNotFoundError
     code: str = "E035"
 
@@ -751,7 +751,7 @@ class AdapterImportError(InfoLevel, Cli, File):
 
 
 @dataclass
-class PluginLoadError(ShowException, DebugLevel, Cli, File):
+class PluginLoadError(ShowException, DebugLevel):
     code: str = "E036"
 
     def message(self):
@@ -759,7 +759,7 @@ class PluginLoadError(ShowException, DebugLevel, Cli, File):
 
 
 @dataclass
-class NewConnectionOpening(DebugLevel, Cli, File):
+class NewConnectionOpening(DebugLevel):
     connection_state: str
     code: str = "E037"
 
@@ -768,7 +768,7 @@ class NewConnectionOpening(DebugLevel, Cli, File):
 
 
 @dataclass
-class TimingInfoCollected(DebugLevel, Cli, File):
+class TimingInfoCollected(DebugLevel):
     code: str = "Z010"
 
     def message(self) -> str:
@@ -776,7 +776,7 @@ class TimingInfoCollected(DebugLevel, Cli, File):
 
 
 @dataclass
-class MergedFromState(DebugLevel, Cli, File):
+class MergedFromState(DebugLevel):
     nbr_merged: int
     sample: List
     code: str = "A004"
@@ -786,7 +786,7 @@ class MergedFromState(DebugLevel, Cli, File):
 
 
 @dataclass
-class MissingProfileTarget(InfoLevel, Cli, File):
+class MissingProfileTarget(InfoLevel):
     profile_name: str
     target_name: str
     code: str = "A005"
@@ -796,7 +796,7 @@ class MissingProfileTarget(InfoLevel, Cli, File):
 
 
 @dataclass
-class ProfileLoadError(ShowException, DebugLevel, Cli, File):
+class ProfileLoadError(ShowException, DebugLevel):
     exc: Exception
     code: str = "A006"
 
@@ -805,7 +805,7 @@ class ProfileLoadError(ShowException, DebugLevel, Cli, File):
 
 
 @dataclass
-class ProfileNotFound(InfoLevel, Cli, File):
+class ProfileNotFound(InfoLevel):
     profile_name: Optional[str]
     code: str = "A007"
 
@@ -814,7 +814,7 @@ class ProfileNotFound(InfoLevel, Cli, File):
 
 
 @dataclass
-class InvalidVarsYAML(ErrorLevel, Cli, File):
+class InvalidVarsYAML(ErrorLevel):
     code: str = "A008"
 
     def message(self) -> str:
@@ -822,7 +822,7 @@ class InvalidVarsYAML(ErrorLevel, Cli, File):
 
 
 @dataclass
-class GenericTestFileParse(DebugLevel, Cli, File):
+class GenericTestFileParse(DebugLevel):
     path: str
     code: str = "I011"
 
@@ -831,7 +831,7 @@ class GenericTestFileParse(DebugLevel, Cli, File):
 
 
 @dataclass
-class MacroFileParse(DebugLevel, Cli, File):
+class MacroFileParse(DebugLevel):
     path: str
     code: str = "I012"
 
@@ -840,7 +840,7 @@ class MacroFileParse(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingFullReparseBecauseOfError(InfoLevel, Cli, File):
+class PartialParsingFullReparseBecauseOfError(InfoLevel):
     code: str = "I013"
 
     def message(self) -> str:
@@ -848,7 +848,7 @@ class PartialParsingFullReparseBecauseOfError(InfoLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingExceptionFile(DebugLevel, Cli, File):
+class PartialParsingExceptionFile(DebugLevel):
     file: str
     code: str = "I014"
 
@@ -857,7 +857,7 @@ class PartialParsingExceptionFile(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingFile(DebugLevel, Cli, File):
+class PartialParsingFile(DebugLevel):
     file_dict: Dict
     code: str = "I015"
 
@@ -866,7 +866,7 @@ class PartialParsingFile(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingException(DebugLevel, Cli, File):
+class PartialParsingException(DebugLevel):
     exc_info: Dict
     code: str = "I016"
 
@@ -875,7 +875,7 @@ class PartialParsingException(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingSkipParsing(DebugLevel, Cli, File):
+class PartialParsingSkipParsing(DebugLevel):
     code: str = "I017"
 
     def message(self) -> str:
@@ -883,7 +883,7 @@ class PartialParsingSkipParsing(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingMacroChangeStartFullParse(InfoLevel, Cli, File):
+class PartialParsingMacroChangeStartFullParse(InfoLevel):
     code: str = "I018"
 
     def message(self) -> str:
@@ -891,7 +891,7 @@ class PartialParsingMacroChangeStartFullParse(InfoLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingProjectEnvVarsChanged(InfoLevel, Cli, File):
+class PartialParsingProjectEnvVarsChanged(InfoLevel):
     code: str = "I019"
 
     def message(self) -> str:
@@ -899,7 +899,7 @@ class PartialParsingProjectEnvVarsChanged(InfoLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingProfileEnvVarsChanged(InfoLevel, Cli, File):
+class PartialParsingProfileEnvVarsChanged(InfoLevel):
     code: str = "I020"
 
     def message(self) -> str:
@@ -907,7 +907,7 @@ class PartialParsingProfileEnvVarsChanged(InfoLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingDeletedMetric(DebugLevel, Cli, File):
+class PartialParsingDeletedMetric(DebugLevel):
     id: str
     code: str = "I021"
 
@@ -916,7 +916,7 @@ class PartialParsingDeletedMetric(DebugLevel, Cli, File):
 
 
 @dataclass
-class ManifestWrongMetadataVersion(DebugLevel, Cli, File):
+class ManifestWrongMetadataVersion(DebugLevel):
     version: str
     code: str = "I022"
 
@@ -926,7 +926,7 @@ class ManifestWrongMetadataVersion(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingVersionMismatch(InfoLevel, Cli, File):
+class PartialParsingVersionMismatch(InfoLevel):
     saved_version: str
     current_version: str
     code: str = "I023"
@@ -938,7 +938,7 @@ class PartialParsingVersionMismatch(InfoLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingFailedBecauseConfigChange(InfoLevel, Cli, File):
+class PartialParsingFailedBecauseConfigChange(InfoLevel):
     code: str = "I024"
 
     def message(self) -> str:
@@ -947,7 +947,7 @@ class PartialParsingFailedBecauseConfigChange(InfoLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingFailedBecauseProfileChange(InfoLevel, Cli, File):
+class PartialParsingFailedBecauseProfileChange(InfoLevel):
     code: str = "I025"
 
     def message(self) -> str:
@@ -955,7 +955,7 @@ class PartialParsingFailedBecauseProfileChange(InfoLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingFailedBecauseNewProjectDependency(InfoLevel, Cli, File):
+class PartialParsingFailedBecauseNewProjectDependency(InfoLevel):
     code: str = "I026"
 
     def message(self) -> str:
@@ -963,7 +963,7 @@ class PartialParsingFailedBecauseNewProjectDependency(InfoLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingFailedBecauseHashChanged(InfoLevel, Cli, File):
+class PartialParsingFailedBecauseHashChanged(InfoLevel):
     code: str = "I027"
 
     def message(self) -> str:
@@ -971,7 +971,7 @@ class PartialParsingFailedBecauseHashChanged(InfoLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingNotEnabled(DebugLevel, Cli, File):
+class PartialParsingNotEnabled(DebugLevel):
     code: str = "I028"
 
     def message(self) -> str:
@@ -979,7 +979,7 @@ class PartialParsingNotEnabled(DebugLevel, Cli, File):
 
 
 @dataclass
-class ParsedFileLoadFailed(ShowException, DebugLevel, Cli, File):
+class ParsedFileLoadFailed(ShowException, DebugLevel):
     path: str
     exc: Exception
     code: str = "I029"
@@ -989,7 +989,7 @@ class ParsedFileLoadFailed(ShowException, DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParseSaveFileNotFound(InfoLevel, Cli, File):
+class PartialParseSaveFileNotFound(InfoLevel):
     code: str = "I030"
 
     def message(self) -> str:
@@ -997,7 +997,7 @@ class PartialParseSaveFileNotFound(InfoLevel, Cli, File):
 
 
 @dataclass
-class StaticParserCausedJinjaRendering(DebugLevel, Cli, File):
+class StaticParserCausedJinjaRendering(DebugLevel):
     path: str
     code: str = "I031"
 
@@ -1008,7 +1008,7 @@ class StaticParserCausedJinjaRendering(DebugLevel, Cli, File):
 # TODO: Experimental/static parser uses these for testing and some may be a good use case for
 #       the `TestLevel` logger once we implement it.  Some will probably stay `DebugLevel`.
 @dataclass
-class UsingExperimentalParser(DebugLevel, Cli, File):
+class UsingExperimentalParser(DebugLevel):
     path: str
     code: str = "I032"
 
@@ -1017,7 +1017,7 @@ class UsingExperimentalParser(DebugLevel, Cli, File):
 
 
 @dataclass
-class SampleFullJinjaRendering(DebugLevel, Cli, File):
+class SampleFullJinjaRendering(DebugLevel):
     path: str
     code: str = "I033"
 
@@ -1026,7 +1026,7 @@ class SampleFullJinjaRendering(DebugLevel, Cli, File):
 
 
 @dataclass
-class StaticParserFallbackJinjaRendering(DebugLevel, Cli, File):
+class StaticParserFallbackJinjaRendering(DebugLevel):
     path: str
     code: str = "I034"
 
@@ -1035,7 +1035,7 @@ class StaticParserFallbackJinjaRendering(DebugLevel, Cli, File):
 
 
 @dataclass
-class StaticParsingMacroOverrideDetected(DebugLevel, Cli, File):
+class StaticParsingMacroOverrideDetected(DebugLevel):
     path: str
     code: str = "I035"
 
@@ -1044,7 +1044,7 @@ class StaticParsingMacroOverrideDetected(DebugLevel, Cli, File):
 
 
 @dataclass
-class StaticParserSuccess(DebugLevel, Cli, File):
+class StaticParserSuccess(DebugLevel):
     path: str
     code: str = "I036"
 
@@ -1053,7 +1053,7 @@ class StaticParserSuccess(DebugLevel, Cli, File):
 
 
 @dataclass
-class StaticParserFailure(DebugLevel, Cli, File):
+class StaticParserFailure(DebugLevel):
     path: str
     code: str = "I037"
 
@@ -1062,7 +1062,7 @@ class StaticParserFailure(DebugLevel, Cli, File):
 
 
 @dataclass
-class ExperimentalParserSuccess(DebugLevel, Cli, File):
+class ExperimentalParserSuccess(DebugLevel):
     path: str
     code: str = "I038"
 
@@ -1071,7 +1071,7 @@ class ExperimentalParserSuccess(DebugLevel, Cli, File):
 
 
 @dataclass
-class ExperimentalParserFailure(DebugLevel, Cli, File):
+class ExperimentalParserFailure(DebugLevel):
     path: str
     code: str = "I039"
 
@@ -1080,7 +1080,7 @@ class ExperimentalParserFailure(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingEnabled(DebugLevel, Cli, File):
+class PartialParsingEnabled(DebugLevel):
     deleted: int
     added: int
     changed: int
@@ -1094,7 +1094,7 @@ class PartialParsingEnabled(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingAddedFile(DebugLevel, Cli, File):
+class PartialParsingAddedFile(DebugLevel):
     file_id: str
     code: str = "I041"
 
@@ -1103,7 +1103,7 @@ class PartialParsingAddedFile(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingDeletedFile(DebugLevel, Cli, File):
+class PartialParsingDeletedFile(DebugLevel):
     file_id: str
     code: str = "I042"
 
@@ -1112,7 +1112,7 @@ class PartialParsingDeletedFile(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingUpdatedFile(DebugLevel, Cli, File):
+class PartialParsingUpdatedFile(DebugLevel):
     file_id: str
     code: str = "I043"
 
@@ -1121,7 +1121,7 @@ class PartialParsingUpdatedFile(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingNodeMissingInSourceFile(DebugLevel, Cli, File):
+class PartialParsingNodeMissingInSourceFile(DebugLevel):
     source_file: str
     code: str = "I044"
 
@@ -1130,7 +1130,7 @@ class PartialParsingNodeMissingInSourceFile(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingMissingNodes(DebugLevel, Cli, File):
+class PartialParsingMissingNodes(DebugLevel):
     file_id: str
     code: str = "I045"
 
@@ -1139,7 +1139,7 @@ class PartialParsingMissingNodes(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingChildMapMissingUniqueID(DebugLevel, Cli, File):
+class PartialParsingChildMapMissingUniqueID(DebugLevel):
     unique_id: str
     code: str = "I046"
 
@@ -1148,7 +1148,7 @@ class PartialParsingChildMapMissingUniqueID(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingUpdateSchemaFile(DebugLevel, Cli, File):
+class PartialParsingUpdateSchemaFile(DebugLevel):
     file_id: str
     code: str = "I047"
 
@@ -1157,7 +1157,7 @@ class PartialParsingUpdateSchemaFile(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingDeletedSource(DebugLevel, Cli, File):
+class PartialParsingDeletedSource(DebugLevel):
     unique_id: str
     code: str = "I048"
 
@@ -1166,7 +1166,7 @@ class PartialParsingDeletedSource(DebugLevel, Cli, File):
 
 
 @dataclass
-class PartialParsingDeletedExposure(DebugLevel, Cli, File):
+class PartialParsingDeletedExposure(DebugLevel):
     unique_id: str
     code: str = "I049"
 
@@ -1175,7 +1175,7 @@ class PartialParsingDeletedExposure(DebugLevel, Cli, File):
 
 
 @dataclass
-class InvalidDisabledSourceInTestNode(WarnLevel, Cli, File):
+class InvalidDisabledSourceInTestNode(WarnLevel):
     msg: str
     code: str = "I050"
 
@@ -1184,7 +1184,7 @@ class InvalidDisabledSourceInTestNode(WarnLevel, Cli, File):
 
 
 @dataclass
-class InvalidRefInTestNode(WarnLevel, Cli, File):
+class InvalidRefInTestNode(WarnLevel):
     msg: str
     code: str = "I051"
 
@@ -1193,7 +1193,7 @@ class InvalidRefInTestNode(WarnLevel, Cli, File):
 
 
 @dataclass
-class RunningOperationCaughtError(ErrorLevel, Cli, File):
+class RunningOperationCaughtError(ErrorLevel):
     exc: Exception
     code: str = "Q001"
 
@@ -1202,7 +1202,7 @@ class RunningOperationCaughtError(ErrorLevel, Cli, File):
 
 
 @dataclass
-class RunningOperationUncaughtError(ErrorLevel, Cli, File):
+class RunningOperationUncaughtError(ErrorLevel):
     exc: Exception
     code: str = "FF01"
 
@@ -1211,7 +1211,7 @@ class RunningOperationUncaughtError(ErrorLevel, Cli, File):
 
 
 @dataclass
-class DbtProjectError(ErrorLevel, Cli, File):
+class DbtProjectError(ErrorLevel):
     code: str = "A009"
 
     def message(self) -> str:
@@ -1219,7 +1219,7 @@ class DbtProjectError(ErrorLevel, Cli, File):
 
 
 @dataclass
-class DbtProjectErrorException(ErrorLevel, Cli, File):
+class DbtProjectErrorException(ErrorLevel):
     exc: Exception
     code: str = "A010"
 
@@ -1228,7 +1228,7 @@ class DbtProjectErrorException(ErrorLevel, Cli, File):
 
 
 @dataclass
-class DbtProfileError(ErrorLevel, Cli, File):
+class DbtProfileError(ErrorLevel):
     code: str = "A011"
 
     def message(self) -> str:
@@ -1236,7 +1236,7 @@ class DbtProfileError(ErrorLevel, Cli, File):
 
 
 @dataclass
-class DbtProfileErrorException(ErrorLevel, Cli, File):
+class DbtProfileErrorException(ErrorLevel):
     exc: Exception
     code: str = "A012"
 
@@ -1245,7 +1245,7 @@ class DbtProfileErrorException(ErrorLevel, Cli, File):
 
 
 @dataclass
-class ProfileListTitle(InfoLevel, Cli, File):
+class ProfileListTitle(InfoLevel):
     code: str = "A013"
 
     def message(self) -> str:
@@ -1253,7 +1253,7 @@ class ProfileListTitle(InfoLevel, Cli, File):
 
 
 @dataclass
-class ListSingleProfile(InfoLevel, Cli, File):
+class ListSingleProfile(InfoLevel):
     profile: str
     code: str = "A014"
 
@@ -1262,7 +1262,7 @@ class ListSingleProfile(InfoLevel, Cli, File):
 
 
 @dataclass
-class NoDefinedProfiles(InfoLevel, Cli, File):
+class NoDefinedProfiles(InfoLevel):
     code: str = "A015"
 
     def message(self) -> str:
@@ -1270,7 +1270,7 @@ class NoDefinedProfiles(InfoLevel, Cli, File):
 
 
 @dataclass
-class ProfileHelpMessage(InfoLevel, Cli, File):
+class ProfileHelpMessage(InfoLevel):
     code: str = "A016"
 
     def message(self) -> str:
@@ -1283,7 +1283,7 @@ https://docs.getdbt.com/docs/configure-your-profile
 
 
 @dataclass
-class CatchableExceptionOnRun(ShowException, DebugLevel, Cli, File):
+class CatchableExceptionOnRun(ShowException, DebugLevel):
     exc: Exception
     code: str = "W002"
 
@@ -1292,7 +1292,7 @@ class CatchableExceptionOnRun(ShowException, DebugLevel, Cli, File):
 
 
 @dataclass
-class InternalExceptionOnRun(DebugLevel, Cli, File):
+class InternalExceptionOnRun(DebugLevel):
     build_path: str
     exc: Exception
     code: str = "W003"
@@ -1314,7 +1314,7 @@ the error persists, open an issue at https://github.com/dbt-labs/dbt-core
 # This prints the stack trace at the debug level while allowing just the nice exception message
 # at the error level - or whatever other level chosen.  Used in multiple places.
 @dataclass
-class PrintDebugStackTrace(ShowException, DebugLevel, Cli, File):
+class PrintDebugStackTrace(ShowException, DebugLevel):
     code: str = "Z011"
 
     def message(self) -> str:
@@ -1322,7 +1322,7 @@ class PrintDebugStackTrace(ShowException, DebugLevel, Cli, File):
 
 
 @dataclass
-class GenericExceptionOnRun(ErrorLevel, Cli, File):
+class GenericExceptionOnRun(ErrorLevel):
     build_path: Optional[str]
     unique_id: str
     exc: str  # TODO: make this the actual exception once we have a better searilization strategy
@@ -1340,7 +1340,7 @@ class GenericExceptionOnRun(ErrorLevel, Cli, File):
 
 
 @dataclass
-class NodeConnectionReleaseError(ShowException, DebugLevel, Cli, File):
+class NodeConnectionReleaseError(ShowException, DebugLevel):
     node_name: str
     exc: Exception
     code: str = "W005"
@@ -1351,7 +1351,7 @@ class NodeConnectionReleaseError(ShowException, DebugLevel, Cli, File):
 
 
 @dataclass
-class CheckCleanPath(InfoLevel, Cli):
+class CheckCleanPath(InfoLevel, NoFile):
     path: str
     code: str = "Z012"
 
@@ -1360,7 +1360,7 @@ class CheckCleanPath(InfoLevel, Cli):
 
 
 @dataclass
-class ConfirmCleanPath(InfoLevel, Cli):
+class ConfirmCleanPath(InfoLevel, NoFile):
     path: str
 
     code: str = "Z013"
@@ -1370,7 +1370,7 @@ class ConfirmCleanPath(InfoLevel, Cli):
 
 
 @dataclass
-class ProtectedCleanPath(InfoLevel, Cli):
+class ProtectedCleanPath(InfoLevel, NoFile):
     path: str
     code: str = "Z014"
 
@@ -1379,7 +1379,7 @@ class ProtectedCleanPath(InfoLevel, Cli):
 
 
 @dataclass
-class FinishedCleanPaths(InfoLevel, Cli):
+class FinishedCleanPaths(InfoLevel, NoFile):
     code: str = "Z015"
 
     def message(self) -> str:
@@ -1387,7 +1387,7 @@ class FinishedCleanPaths(InfoLevel, Cli):
 
 
 @dataclass
-class OpenCommand(InfoLevel, Cli, File):
+class OpenCommand(InfoLevel):
     open_cmd: str
     profiles_dir: str
     code: str = "Z016"
@@ -1405,7 +1405,7 @@ class OpenCommand(InfoLevel, Cli, File):
 
 
 @dataclass
-class DepsNoPackagesFound(InfoLevel, Cli, File):
+class DepsNoPackagesFound(InfoLevel):
     code: str = "M013"
 
     def message(self) -> str:
@@ -1413,7 +1413,7 @@ class DepsNoPackagesFound(InfoLevel, Cli, File):
 
 
 @dataclass
-class DepsStartPackageInstall(InfoLevel, Cli, File):
+class DepsStartPackageInstall(InfoLevel):
     package_name: str
     code: str = "M014"
 
@@ -1422,7 +1422,7 @@ class DepsStartPackageInstall(InfoLevel, Cli, File):
 
 
 @dataclass
-class DepsInstallInfo(InfoLevel, Cli, File):
+class DepsInstallInfo(InfoLevel):
     version_name: str
     code: str = "M015"
 
@@ -1431,7 +1431,7 @@ class DepsInstallInfo(InfoLevel, Cli, File):
 
 
 @dataclass
-class DepsUpdateAvailable(InfoLevel, Cli, File):
+class DepsUpdateAvailable(InfoLevel):
     version_latest: str
     code: str = "M016"
 
@@ -1440,7 +1440,7 @@ class DepsUpdateAvailable(InfoLevel, Cli, File):
 
 
 @dataclass
-class DepsUTD(InfoLevel, Cli, File):
+class DepsUTD(InfoLevel):
     code: str = "M017"
 
     def message(self) -> str:
@@ -1448,7 +1448,7 @@ class DepsUTD(InfoLevel, Cli, File):
 
 
 @dataclass
-class DepsListSubdirectory(InfoLevel, Cli, File):
+class DepsListSubdirectory(InfoLevel):
     subdirectory: str
     code: str = "M018"
 
@@ -1457,7 +1457,7 @@ class DepsListSubdirectory(InfoLevel, Cli, File):
 
 
 @dataclass
-class DepsNotifyUpdatesAvailable(InfoLevel, Cli, File):
+class DepsNotifyUpdatesAvailable(InfoLevel):
     packages: List[str]
     code: str = "M019"
 
@@ -1467,7 +1467,7 @@ class DepsNotifyUpdatesAvailable(InfoLevel, Cli, File):
 
 
 @dataclass
-class DatabaseErrorRunning(InfoLevel, Cli, File):
+class DatabaseErrorRunning(InfoLevel):
     hook_type: str
     code: str = "E038"
 
@@ -1476,7 +1476,7 @@ class DatabaseErrorRunning(InfoLevel, Cli, File):
 
 
 @dataclass
-class EmptyLine(InfoLevel, Cli, File):
+class EmptyLine(InfoLevel):
     code: str = "Z017"
 
     def message(self) -> str:
@@ -1484,7 +1484,7 @@ class EmptyLine(InfoLevel, Cli, File):
 
 
 @dataclass
-class HooksRunning(InfoLevel, Cli, File):
+class HooksRunning(InfoLevel):
     num_hooks: int
     hook_type: str
     code: str = "E039"
@@ -1495,7 +1495,7 @@ class HooksRunning(InfoLevel, Cli, File):
 
 
 @dataclass
-class HookFinished(InfoLevel, Cli, File):
+class HookFinished(InfoLevel):
     stat_line: str
     execution: str
     code: str = "E040"
@@ -1505,7 +1505,7 @@ class HookFinished(InfoLevel, Cli, File):
 
 
 @dataclass
-class WriteCatalogFailure(ErrorLevel, Cli, File):
+class WriteCatalogFailure(ErrorLevel):
     num_exceptions: int
     code: str = "E041"
 
@@ -1515,7 +1515,7 @@ class WriteCatalogFailure(ErrorLevel, Cli, File):
 
 
 @dataclass
-class CatalogWritten(InfoLevel, Cli, File):
+class CatalogWritten(InfoLevel):
     path: str
     code: str = "E042"
 
@@ -1524,7 +1524,7 @@ class CatalogWritten(InfoLevel, Cli, File):
 
 
 @dataclass
-class CannotGenerateDocs(InfoLevel, Cli, File):
+class CannotGenerateDocs(InfoLevel):
     code: str = "E043"
 
     def message(self) -> str:
@@ -1532,7 +1532,7 @@ class CannotGenerateDocs(InfoLevel, Cli, File):
 
 
 @dataclass
-class BuildingCatalog(InfoLevel, Cli, File):
+class BuildingCatalog(InfoLevel):
     code: str = "E044"
 
     def message(self) -> str:
@@ -1540,7 +1540,7 @@ class BuildingCatalog(InfoLevel, Cli, File):
 
 
 @dataclass
-class CompileComplete(InfoLevel, Cli, File):
+class CompileComplete(InfoLevel):
     code: str = "Q002"
 
     def message(self) -> str:
@@ -1548,7 +1548,7 @@ class CompileComplete(InfoLevel, Cli, File):
 
 
 @dataclass
-class FreshnessCheckComplete(InfoLevel, Cli, File):
+class FreshnessCheckComplete(InfoLevel):
     code: str = "Q003"
 
     def message(self) -> str:
@@ -1556,7 +1556,7 @@ class FreshnessCheckComplete(InfoLevel, Cli, File):
 
 
 @dataclass
-class ServingDocsPort(InfoLevel, Cli, File):
+class ServingDocsPort(InfoLevel):
     address: str
     port: int
     code: str = "Z018"
@@ -1566,7 +1566,7 @@ class ServingDocsPort(InfoLevel, Cli, File):
 
 
 @dataclass
-class ServingDocsAccessInfo(InfoLevel, Cli, File):
+class ServingDocsAccessInfo(InfoLevel):
     port: str
     code: str = "Z019"
 
@@ -1575,7 +1575,7 @@ class ServingDocsAccessInfo(InfoLevel, Cli, File):
 
 
 @dataclass
-class ServingDocsExitInfo(InfoLevel, Cli, File):
+class ServingDocsExitInfo(InfoLevel):
     code: str = "Z020"
 
     def message(self) -> str:
@@ -1583,7 +1583,7 @@ class ServingDocsExitInfo(InfoLevel, Cli, File):
 
 
 @dataclass
-class SeedHeader(InfoLevel, Cli, File):
+class SeedHeader(InfoLevel):
     header: str
     code: str = "Q004"
 
@@ -1592,7 +1592,7 @@ class SeedHeader(InfoLevel, Cli, File):
 
 
 @dataclass
-class SeedHeaderSeperator(InfoLevel, Cli, File):
+class SeedHeaderSeperator(InfoLevel):
     len_header: int
     code: str = "Q005"
 
@@ -1601,7 +1601,7 @@ class SeedHeaderSeperator(InfoLevel, Cli, File):
 
 
 @dataclass
-class RunResultWarning(WarnLevel, Cli, File):
+class RunResultWarning(WarnLevel):
     resource_type: str
     node_name: str
     path: str
@@ -1613,7 +1613,7 @@ class RunResultWarning(WarnLevel, Cli, File):
 
 
 @dataclass
-class RunResultFailure(ErrorLevel, Cli, File):
+class RunResultFailure(ErrorLevel):
     resource_type: str
     node_name: str
     path: str
@@ -1625,7 +1625,7 @@ class RunResultFailure(ErrorLevel, Cli, File):
 
 
 @dataclass
-class StatsLine(InfoLevel, Cli, File):
+class StatsLine(InfoLevel):
     stats: Dict
     code: str = "Z023"
 
@@ -1635,7 +1635,7 @@ class StatsLine(InfoLevel, Cli, File):
 
 
 @dataclass
-class RunResultError(ErrorLevel, Cli, File):
+class RunResultError(ErrorLevel):
     msg: str
     code: str = "Z024"
 
@@ -1644,7 +1644,7 @@ class RunResultError(ErrorLevel, Cli, File):
 
 
 @dataclass
-class RunResultErrorNoMessage(ErrorLevel, Cli, File):
+class RunResultErrorNoMessage(ErrorLevel):
     status: str
     code: str = "Z025"
 
@@ -1653,7 +1653,7 @@ class RunResultErrorNoMessage(ErrorLevel, Cli, File):
 
 
 @dataclass
-class SQLCompiledPath(InfoLevel, Cli, File):
+class SQLCompiledPath(InfoLevel):
     path: str
     code: str = "Z026"
 
@@ -1662,7 +1662,7 @@ class SQLCompiledPath(InfoLevel, Cli, File):
 
 
 @dataclass
-class SQlRunnerException(ShowException, DebugLevel, Cli, File):
+class SQlRunnerException(ShowException, DebugLevel):
     exc: Exception
     code: str = "Q006"
 
@@ -1671,7 +1671,7 @@ class SQlRunnerException(ShowException, DebugLevel, Cli, File):
 
 
 @dataclass
-class CheckNodeTestFailure(InfoLevel, Cli, File):
+class CheckNodeTestFailure(InfoLevel):
     relation_name: str
     code: str = "Z027"
 
@@ -1682,7 +1682,7 @@ class CheckNodeTestFailure(InfoLevel, Cli, File):
 
 
 @dataclass
-class FirstRunResultError(ErrorLevel, Cli, File):
+class FirstRunResultError(ErrorLevel):
     msg: str
     code: str = "Z028"
 
@@ -1691,7 +1691,7 @@ class FirstRunResultError(ErrorLevel, Cli, File):
 
 
 @dataclass
-class AfterFirstRunResultError(ErrorLevel, Cli, File):
+class AfterFirstRunResultError(ErrorLevel):
     msg: str
     code: str = "Z029"
 
@@ -1700,7 +1700,7 @@ class AfterFirstRunResultError(ErrorLevel, Cli, File):
 
 
 @dataclass
-class EndOfRunSummary(InfoLevel, Cli, File):
+class EndOfRunSummary(InfoLevel):
     num_errors: int
     num_warnings: int
     keyboard_interrupt: bool = False
@@ -1722,7 +1722,7 @@ class EndOfRunSummary(InfoLevel, Cli, File):
 
 
 @dataclass
-class PrintStartLine(InfoLevel, Cli, File, NodeInfo):
+class PrintStartLine(InfoLevel, NodeInfo):
     description: str
     index: int
     total: int
@@ -1740,7 +1740,7 @@ class PrintStartLine(InfoLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintHookStartLine(InfoLevel, Cli, File, NodeInfo):
+class PrintHookStartLine(InfoLevel, NodeInfo):
     statement: str
     index: int
     total: int
@@ -1758,7 +1758,7 @@ class PrintHookStartLine(InfoLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintHookEndLine(InfoLevel, Cli, File, NodeInfo):
+class PrintHookEndLine(InfoLevel, NodeInfo):
     statement: str
     status: str
     index: int
@@ -1779,7 +1779,7 @@ class PrintHookEndLine(InfoLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class SkippingDetails(InfoLevel, Cli, File, NodeInfo):
+class SkippingDetails(InfoLevel, NodeInfo):
     resource_type: str
     schema: str
     node_name: str
@@ -1800,7 +1800,7 @@ class SkippingDetails(InfoLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintErrorTestResult(ErrorLevel, Cli, File, NodeInfo):
+class PrintErrorTestResult(ErrorLevel, NodeInfo):
     name: str
     index: int
     num_models: int
@@ -1819,7 +1819,7 @@ class PrintErrorTestResult(ErrorLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintPassTestResult(InfoLevel, Cli, File, NodeInfo):
+class PrintPassTestResult(InfoLevel, NodeInfo):
     name: str
     index: int
     num_models: int
@@ -1838,7 +1838,7 @@ class PrintPassTestResult(InfoLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintWarnTestResult(WarnLevel, Cli, File, NodeInfo):
+class PrintWarnTestResult(WarnLevel, NodeInfo):
     name: str
     index: int
     num_models: int
@@ -1858,7 +1858,7 @@ class PrintWarnTestResult(WarnLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintFailureTestResult(ErrorLevel, Cli, File, NodeInfo):
+class PrintFailureTestResult(ErrorLevel, NodeInfo):
     name: str
     index: int
     num_models: int
@@ -1878,7 +1878,7 @@ class PrintFailureTestResult(ErrorLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintSkipBecauseError(ErrorLevel, Cli, File):
+class PrintSkipBecauseError(ErrorLevel):
     schema: str
     relation: str
     index: int
@@ -1894,7 +1894,7 @@ class PrintSkipBecauseError(ErrorLevel, Cli, File):
 
 
 @dataclass
-class PrintModelErrorResultLine(ErrorLevel, Cli, File, NodeInfo):
+class PrintModelErrorResultLine(ErrorLevel, NodeInfo):
     description: str
     status: str
     index: int
@@ -1914,7 +1914,7 @@ class PrintModelErrorResultLine(ErrorLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintModelResultLine(InfoLevel, Cli, File, NodeInfo):
+class PrintModelResultLine(InfoLevel, NodeInfo):
     description: str
     status: str
     index: int
@@ -1934,7 +1934,7 @@ class PrintModelResultLine(InfoLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintSnapshotErrorResultLine(ErrorLevel, Cli, File, NodeInfo):
+class PrintSnapshotErrorResultLine(ErrorLevel, NodeInfo):
     status: str
     description: str
     cfg: Dict
@@ -1955,7 +1955,7 @@ class PrintSnapshotErrorResultLine(ErrorLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintSnapshotResultLine(InfoLevel, Cli, File, NodeInfo):
+class PrintSnapshotResultLine(InfoLevel, NodeInfo):
     status: str
     description: str
     cfg: Dict
@@ -1976,7 +1976,7 @@ class PrintSnapshotResultLine(InfoLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintSeedErrorResultLine(ErrorLevel, Cli, File, NodeInfo):
+class PrintSeedErrorResultLine(ErrorLevel, NodeInfo):
     status: str
     index: int
     total: int
@@ -1997,7 +1997,7 @@ class PrintSeedErrorResultLine(ErrorLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintSeedResultLine(InfoLevel, Cli, File, NodeInfo):
+class PrintSeedResultLine(InfoLevel, NodeInfo):
     status: str
     index: int
     total: int
@@ -2018,7 +2018,7 @@ class PrintSeedResultLine(InfoLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintHookEndErrorLine(ErrorLevel, Cli, File, NodeInfo):
+class PrintHookEndErrorLine(ErrorLevel, NodeInfo):
     source_name: str
     table_name: str
     index: int
@@ -2038,7 +2038,7 @@ class PrintHookEndErrorLine(ErrorLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintHookEndErrorStaleLine(ErrorLevel, Cli, File, NodeInfo):
+class PrintHookEndErrorStaleLine(ErrorLevel, NodeInfo):
     source_name: str
     table_name: str
     index: int
@@ -2058,7 +2058,7 @@ class PrintHookEndErrorStaleLine(ErrorLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintHookEndWarnLine(WarnLevel, Cli, File, NodeInfo):
+class PrintHookEndWarnLine(WarnLevel, NodeInfo):
     source_name: str
     table_name: str
     index: int
@@ -2078,7 +2078,7 @@ class PrintHookEndWarnLine(WarnLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintHookEndPassLine(InfoLevel, Cli, File, NodeInfo):
+class PrintHookEndPassLine(InfoLevel, NodeInfo):
     source_name: str
     table_name: str
     index: int
@@ -2098,7 +2098,7 @@ class PrintHookEndPassLine(InfoLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class PrintCancelLine(ErrorLevel, Cli, File):
+class PrintCancelLine(ErrorLevel):
     conn_name: str
     code: str = "Q021"
 
@@ -2111,7 +2111,7 @@ class PrintCancelLine(ErrorLevel, Cli, File):
 
 
 @dataclass
-class DefaultSelector(InfoLevel, Cli, File):
+class DefaultSelector(InfoLevel):
     name: str
     code: str = "Q022"
 
@@ -2120,7 +2120,7 @@ class DefaultSelector(InfoLevel, Cli, File):
 
 
 @dataclass
-class NodeStart(DebugLevel, Cli, File, NodeInfo):
+class NodeStart(DebugLevel, NodeInfo):
     unique_id: str
     report_node_data: ParsedModelNode
     code: str = "Q023"
@@ -2130,7 +2130,7 @@ class NodeStart(DebugLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class NodeFinished(DebugLevel, Cli, File, NodeInfo):
+class NodeFinished(DebugLevel, NodeInfo):
     unique_id: str
     report_node_data: ParsedModelNode
     run_result: RunResult
@@ -2145,7 +2145,7 @@ class NodeFinished(DebugLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class QueryCancelationUnsupported(InfoLevel, Cli, File):
+class QueryCancelationUnsupported(InfoLevel):
     type: str
     code: str = "Q025"
 
@@ -2157,7 +2157,7 @@ class QueryCancelationUnsupported(InfoLevel, Cli, File):
 
 
 @dataclass
-class ConcurrencyLine(InfoLevel, Cli, File):
+class ConcurrencyLine(InfoLevel):
     num_threads: int
     target_name: str
     code: str = "Q026"
@@ -2167,7 +2167,7 @@ class ConcurrencyLine(InfoLevel, Cli, File):
 
 
 @dataclass
-class NodeCompiling(DebugLevel, Cli, File, NodeInfo):
+class NodeCompiling(DebugLevel, NodeInfo):
     unique_id: str
     report_node_data: ParsedModelNode
     code: str = "Q030"
@@ -2177,7 +2177,7 @@ class NodeCompiling(DebugLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class NodeExecuting(DebugLevel, Cli, File, NodeInfo):
+class NodeExecuting(DebugLevel, NodeInfo):
     unique_id: str
     report_node_data: ParsedModelNode
     code: str = "Q031"
@@ -2187,7 +2187,7 @@ class NodeExecuting(DebugLevel, Cli, File, NodeInfo):
 
 
 @dataclass
-class StarterProjectPath(DebugLevel, Cli, File):
+class StarterProjectPath(DebugLevel):
     dir: str
     code: str = "A017"
 
@@ -2196,7 +2196,7 @@ class StarterProjectPath(DebugLevel, Cli, File):
 
 
 @dataclass
-class ConfigFolderDirectory(InfoLevel, Cli, File):
+class ConfigFolderDirectory(InfoLevel):
     dir: str
     code: str = "A018"
 
@@ -2205,7 +2205,7 @@ class ConfigFolderDirectory(InfoLevel, Cli, File):
 
 
 @dataclass
-class NoSampleProfileFound(InfoLevel, Cli, File):
+class NoSampleProfileFound(InfoLevel):
     adapter: str
     code: str = "A019"
 
@@ -2214,7 +2214,7 @@ class NoSampleProfileFound(InfoLevel, Cli, File):
 
 
 @dataclass
-class ProfileWrittenWithSample(InfoLevel, Cli, File):
+class ProfileWrittenWithSample(InfoLevel):
     name: str
     path: str
     code: str = "A020"
@@ -2226,7 +2226,7 @@ class ProfileWrittenWithSample(InfoLevel, Cli, File):
 
 
 @dataclass
-class ProfileWrittenWithTargetTemplateYAML(InfoLevel, Cli, File):
+class ProfileWrittenWithTargetTemplateYAML(InfoLevel):
     name: str
     path: str
     code: str = "A021"
@@ -2238,7 +2238,7 @@ class ProfileWrittenWithTargetTemplateYAML(InfoLevel, Cli, File):
 
 
 @dataclass
-class ProfileWrittenWithProjectTemplateYAML(InfoLevel, Cli, File):
+class ProfileWrittenWithProjectTemplateYAML(InfoLevel):
     name: str
     path: str
     code: str = "A022"
@@ -2250,7 +2250,7 @@ class ProfileWrittenWithProjectTemplateYAML(InfoLevel, Cli, File):
 
 
 @dataclass
-class SettingUpProfile(InfoLevel, Cli, File):
+class SettingUpProfile(InfoLevel):
     code: str = "A023"
 
     def message(self) -> str:
@@ -2258,7 +2258,7 @@ class SettingUpProfile(InfoLevel, Cli, File):
 
 
 @dataclass
-class InvalidProfileTemplateYAML(InfoLevel, Cli, File):
+class InvalidProfileTemplateYAML(InfoLevel):
     code: str = "A024"
 
     def message(self) -> str:
@@ -2266,7 +2266,7 @@ class InvalidProfileTemplateYAML(InfoLevel, Cli, File):
 
 
 @dataclass
-class ProjectNameAlreadyExists(InfoLevel, Cli, File):
+class ProjectNameAlreadyExists(InfoLevel):
     name: str
     code: str = "A025"
 
@@ -2275,7 +2275,7 @@ class ProjectNameAlreadyExists(InfoLevel, Cli, File):
 
 
 @dataclass
-class GetAddendum(InfoLevel, Cli, File):
+class GetAddendum(InfoLevel):
     msg: str
     code: str = "A026"
 
@@ -2284,7 +2284,7 @@ class GetAddendum(InfoLevel, Cli, File):
 
 
 @dataclass
-class DepsSetDownloadDirectory(DebugLevel, Cli, File):
+class DepsSetDownloadDirectory(DebugLevel):
     path: str
     code: str = "A027"
 
@@ -2293,7 +2293,7 @@ class DepsSetDownloadDirectory(DebugLevel, Cli, File):
 
 
 @dataclass
-class EnsureGitInstalled(ErrorLevel, Cli, File):
+class EnsureGitInstalled(ErrorLevel):
     code: str = "Z036"
 
     def message(self) -> str:
@@ -2303,7 +2303,7 @@ class EnsureGitInstalled(ErrorLevel, Cli, File):
 
 
 @dataclass
-class DepsCreatingLocalSymlink(DebugLevel, Cli, File):
+class DepsCreatingLocalSymlink(DebugLevel):
     code: str = "Z037"
 
     def message(self) -> str:
@@ -2311,7 +2311,7 @@ class DepsCreatingLocalSymlink(DebugLevel, Cli, File):
 
 
 @dataclass
-class DepsSymlinkNotAvailable(DebugLevel, Cli, File):
+class DepsSymlinkNotAvailable(DebugLevel):
     code: str = "Z038"
 
     def message(self) -> str:
@@ -2319,7 +2319,7 @@ class DepsSymlinkNotAvailable(DebugLevel, Cli, File):
 
 
 @dataclass
-class FoundStats(InfoLevel, Cli, File):
+class FoundStats(InfoLevel):
     stat_line: str
     code: str = "W006"
 
@@ -2329,7 +2329,7 @@ class FoundStats(InfoLevel, Cli, File):
 
 # TODO: should this have NodeInfo on it?
 @dataclass
-class CompilingNode(DebugLevel, Cli, File):
+class CompilingNode(DebugLevel):
     unique_id: str
     code: str = "Q027"
 
@@ -2338,7 +2338,7 @@ class CompilingNode(DebugLevel, Cli, File):
 
 
 @dataclass
-class WritingInjectedSQLForNode(DebugLevel, Cli, File):
+class WritingInjectedSQLForNode(DebugLevel):
     unique_id: str
     code: str = "Q028"
 
@@ -2347,7 +2347,7 @@ class WritingInjectedSQLForNode(DebugLevel, Cli, File):
 
 
 @dataclass
-class DisableTracking(WarnLevel, Cli, File):
+class DisableTracking(WarnLevel):
     code: str = "Z039"
 
     def message(self) -> str:
@@ -2355,7 +2355,7 @@ class DisableTracking(WarnLevel, Cli, File):
 
 
 @dataclass
-class SendingEvent(DebugLevel, Cli, File):
+class SendingEvent(DebugLevel):
     kwargs: str
     code: str = "Z040"
 
@@ -2364,7 +2364,7 @@ class SendingEvent(DebugLevel, Cli, File):
 
 
 @dataclass
-class SendEventFailure(DebugLevel, Cli, File):
+class SendEventFailure(DebugLevel):
     code: str = "Z041"
 
     def message(self) -> str:
@@ -2372,7 +2372,7 @@ class SendEventFailure(DebugLevel, Cli, File):
 
 
 @dataclass
-class FlushEvents(DebugLevel, Cli):
+class FlushEvents(DebugLevel, NoFile):
     code: str = "Z042"
 
     def message(self) -> str:
@@ -2380,7 +2380,7 @@ class FlushEvents(DebugLevel, Cli):
 
 
 @dataclass
-class FlushEventsFailure(DebugLevel, Cli):
+class FlushEventsFailure(DebugLevel, NoFile):
     code: str = "Z043"
 
     def message(self) -> str:
@@ -2388,7 +2388,7 @@ class FlushEventsFailure(DebugLevel, Cli):
 
 
 @dataclass
-class TrackingInitializeFailure(ShowException, DebugLevel, Cli, File):
+class TrackingInitializeFailure(ShowException, DebugLevel):
     code: str = "Z044"
 
     def message(self) -> str:
@@ -2396,7 +2396,7 @@ class TrackingInitializeFailure(ShowException, DebugLevel, Cli, File):
 
 
 @dataclass
-class RetryExternalCall(DebugLevel, Cli, File):
+class RetryExternalCall(DebugLevel):
     attempt: int
     max: int
     code: str = "Z045"
@@ -2406,7 +2406,7 @@ class RetryExternalCall(DebugLevel, Cli, File):
 
 
 @dataclass
-class GeneralWarningMsg(WarnLevel, Cli, File):
+class GeneralWarningMsg(WarnLevel):
     msg: str
     log_fmt: str
     code: str = "Z046"
@@ -2418,7 +2418,7 @@ class GeneralWarningMsg(WarnLevel, Cli, File):
 
 
 @dataclass
-class GeneralWarningException(WarnLevel, Cli, File):
+class GeneralWarningException(WarnLevel):
     exc: Exception
     log_fmt: str
     code: str = "Z047"
@@ -2430,7 +2430,7 @@ class GeneralWarningException(WarnLevel, Cli, File):
 
 
 @dataclass
-class EventBufferFull(WarnLevel, Cli, File):
+class EventBufferFull(WarnLevel):
     code: str = "Z048"
 
     def message(self) -> str:

--- a/test/unit/test_events.py
+++ b/test/unit/test_events.py
@@ -424,7 +424,7 @@ class TestEventJSONSerialization(TestCase):
 
         # if we have everything we need to test, try to serialize everything
         for event in sample_values:
-            d = event_to_serializable_dict(event, lambda _: event.get_ts_rfc3339(), lambda x: x.message())
+            d = event_to_serializable_dict(event, lambda _: event.get_ts_rfc3339())
             try:
                 json.dumps(d)
             except TypeError as e:


### PR DESCRIPTION
### Description

- Simplifies destination logic from opt in to opt out. Only 9 events opt out of file logging.
- Removes the destination-specific human readable message distinction since it was never used
- Previously, since every event had to have a destination the inherited class `Event` was on top of the destination types. Now since that's no longer true, I put `Event` on top of the log levels since every event inherits from a log level. If I didn't do this we'd have to add `Event` to every concrete class which would be less than ideal.

### Reviewers
There are a lot of lines that just remove `, Cli, File` from concrete classes. To see the more important code, consider looking at each commit since I sectioned these changes off into one commit.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
