### PR TITLE
upgrade mypy to latest

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ flake8
 flaky
 freezegun==0.3.12
 ipdb
-mypy==0.782
+mypy==0.910
 pip-tools
 pytest
 pytest-dotenv


### PR DESCRIPTION
### Description

From our version to this version we gain:
- M1 wheels for developers
- `TypeGuard` from 3.10 (and typing extensions) which can be used to replace some uses of `isinstance` for type narrowing
- type narrowing with `type()` not just `isinstance`
- significant performance improvements
- adds the `--exclude` flag for specifying modules
- official 3.9 support
- many bug fixes

The new version typechecks our code base just fine. I suspect it will also typecheck reasonable code that it previously rejected making our lives a tad easier when we work with mypy.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
