### PR TITLE
Improve checking of schema version for pre-1.0.0 manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix redefined status param of SQLQueryStatus to typecheck the string which passes on `._message` value of `AdapterResponse` or the `str` value sent by adapter plugin.  ([#4463](https://github.com/dbt-labs/dbt-core/pull/4463#issuecomment-990174166))
 - Fix `DepsStartPackageInstall` event to use package name instead of version number. ([#4482](https://github.com/dbt-labs/dbt-core/pull/4482))
 - Reimplement log message to use adapter name instead of the object method. ([#4501](https://github.com/dbt-labs/dbt-core/pull/4501))
+- Issue better error message for incompatible schemas ([#4470](https://github.com/dbt-labs/dbt-core/pull/4442), [#4497](https://github.com/dbt-labs/dbt-core/pull/4497))
 
 ###  Docs
 - Fix missing data on exposures in docs ([#4467](https://github.com/dbt-labs/dbt-core/issues/4467))

--- a/core/dbt/contracts/state.py
+++ b/core/dbt/contracts/state.py
@@ -14,7 +14,8 @@ class PreviousState:
         manifest_path = self.path / 'manifest.json'
         if manifest_path.exists() and manifest_path.is_file():
             try:
-                self.manifest = WritableManifest.read(str(manifest_path))
+                # we want to bail with an error if schema versions don't match
+                self.manifest = WritableManifest.read_and_check_versions(str(manifest_path))
             except IncompatibleSchemaException as exc:
                 exc.add_filename(str(manifest_path))
                 raise
@@ -22,7 +23,8 @@ class PreviousState:
         results_path = self.path / 'run_results.json'
         if results_path.exists() and results_path.is_file():
             try:
-                self.results = RunResultsArtifact.read(str(results_path))
+                # we want to bail with an error if schema versions don't match
+                self.results = RunResultsArtifact.read_and_check_versions(str(results_path))
             except IncompatibleSchemaException as exc:
                 exc.add_filename(str(results_path))
                 raise

--- a/test/integration/062_defer_state_test/previous_state/manifest.json
+++ b/test/integration/062_defer_state_test/previous_state/manifest.json
@@ -1,0 +1,6 @@
+{
+    "metadata": {
+        "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v3.json",
+        "dbt_version": "0.21.1"
+    }
+}

--- a/test/integration/062_defer_state_test/test_modified_state.py
+++ b/test/integration/062_defer_state_test/test_modified_state.py
@@ -6,7 +6,7 @@ import string
 
 import pytest
 
-from dbt.exceptions import CompilationException
+from dbt.exceptions import CompilationException, IncompatibleSchemaException
 
 
 class TestModifiedState(DBTIntegrationTest):
@@ -36,7 +36,7 @@ class TestModifiedState(DBTIntegrationTest):
         for entry in os.listdir(self.test_original_source_path):
             src = os.path.join(self.test_original_source_path, entry)
             tst = os.path.join(self.test_root_dir, entry)
-            if entry in {'models', 'seeds', 'macros'}:
+            if entry in {'models', 'seeds', 'macros', 'previous_state'}:
                 shutil.copytree(src, tst)
             elif os.path.isdir(entry) or entry.endswith('.sql'):
                 os.symlink(src, tst)
@@ -202,3 +202,10 @@ class TestModifiedState(DBTIntegrationTest):
         results, stdout = self.run_dbt_and_capture(['run', '--models', '+state:modified', '--state', './state'])
         assert len(results) == 1
         assert results[0].node.name == 'view_model'
+
+    @use_profile('postgres')
+    def test_postgres_previous_version_manifest(self):
+        # This tests that a different schema version in the file throws an error
+        with self.assertRaises(IncompatibleSchemaException) as exc:
+            results = self.run_dbt(['ls', '-s',  'state:modified',  '--state',  './previous_state'])
+            self.assertRegex(str(exc), r"Expected a schema version")

--- a/test/integration/062_defer_state_test/test_modified_state.py
+++ b/test/integration/062_defer_state_test/test_modified_state.py
@@ -208,4 +208,4 @@ class TestModifiedState(DBTIntegrationTest):
         # This tests that a different schema version in the file throws an error
         with self.assertRaises(IncompatibleSchemaException) as exc:
             results = self.run_dbt(['ls', '-s',  'state:modified',  '--state',  './previous_state'])
-            self.assertRegex(str(exc), r"Expected a schema version")
+            self.assertEqual(exc.CODE, 10014)


### PR DESCRIPTION
resolves #4470

### Description

When loading 'state' from previous manifests and run results, check that the schema version of the artifacts matches the current schema version.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
