### PR TITLE
[#4523] Fix error with env_var in hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Issue better error message for incompatible schemas ([#4470](https://github.com/dbt-labs/dbt-core/pull/4442), [#4497](https://github.com/dbt-labs/dbt-core/pull/4497))
 - Remove secrets from error related to packages. ([#4507](https://github.com/dbt-labs/dbt-core/pull/4507))
 - Prevent coercion of boolean values (`True`, `False`) to numeric values (`0`, `1`) in query results ([#4511](https://github.com/dbt-labs/dbt-core/issues/4511), [#4512](https://github.com/dbt-labs/dbt-core/pull/4512))
+- Fix error with an env_var in a project hook ([#4523](https://github.com/dbt-labs/dbt-core/issues/4523), [#4524](https://github.com/dbt-labs/dbt-core/pull/4524))
 
 ###  Docs
 - Fix missing data on exposures in docs ([#4467](https://github.com/dbt-labs/dbt-core/issues/4467))

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1186,10 +1186,12 @@ class ProviderContext(ManifestContext):
             # If this is compiling, do not save because it's irrelevant to parsing.
             if self.model and not hasattr(self.model, 'compiled'):
                 self.manifest.env_vars[var] = return_value
-                source_file = self.manifest.files[self.model.file_id]
-                # Schema files should never get here
-                if source_file.parse_file_type != 'schema':
-                    source_file.env_vars.append(var)
+                # hooks come from dbt_project.yml which doesn't have a real file_id
+                if self.model.file_id in self.manifest.files:
+                    source_file = self.manifest.files[self.model.file_id]
+                    # Schema files should never get here
+                    if source_file.parse_file_type != 'schema':
+                        source_file.env_vars.append(var)
             return return_value
         else:
             msg = f"Env var required but not provided: '{var}'"

--- a/test/integration/014_hook_tests/test_run_hooks.py
+++ b/test/integration/014_hook_tests/test_run_hooks.py
@@ -1,4 +1,5 @@
 from test.integration.base import DBTIntegrationTest, use_profile
+import os
 
 
 class TestPrePostRunHooks(DBTIntegrationTest):
@@ -22,6 +23,7 @@ class TestPrePostRunHooks(DBTIntegrationTest):
             'run_started_at',
             'invocation_id'
         ]
+        os.environ['TERM_TEST'] = 'TESTING'
 
     @property
     def schema(self):
@@ -41,6 +43,7 @@ class TestPrePostRunHooks(DBTIntegrationTest):
                 "{{ custom_run_hook('start', target, run_started_at, invocation_id) }}",
                 "create table {{ target.schema }}.start_hook_order_test ( id int )",
                 "drop table {{ target.schema }}.start_hook_order_test",
+                "{{ log(env_var('TERM_TEST'), info=True) }}",
             ],
             "on-run-end": [
                 "{{ custom_run_hook('end', target, run_started_at, invocation_id) }}",


### PR DESCRIPTION
resolves #4523

### Description

Fix error "Encountered an error:'my_test://./dbt_project.yml'" when an env_var is used in a dbt_project hook. The new code to capture env_vars needs to skip invalid references to the dbt_project.yml file.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
