### PR TITLE
Fix test deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Under the hood
 - Testing cleanup ([#4496](https://github.com/dbt-labs/dbt-core/pull/4496), [#4509](https://github.com/dbt-labs/dbt-core/pull/4509))
+- Clean up test deprecation warnings ([#3988](https://github.com/dbt-labs/dbt-core/issue/3988), [#4556](https://github.com/dbt-labs/dbt-core/pull/4556))
 
 ## dbt-core 1.0.1 (January 03, 2022)
 

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from typing import List, Dict, Any, Tuple, cast, Optional
 
 import networkx as nx  # type: ignore
+import pickle
 import sqlparse
 
 from dbt import flags
@@ -162,7 +163,8 @@ class Linker:
         for node_id in self.graph:
             data = manifest.expect(node_id).to_dict(omit_none=True)
             out_graph.add_node(node_id, **data)
-        nx.write_gpickle(out_graph, outfile)
+        with open(outfile, 'wb') as outfh:
+            pickle.dump(out_graph, outfh, protocol=pickle.HIGHEST_PROTOCOL)
 
 
 class Compiler:

--- a/core/dbt/graph/graph.py
+++ b/core/dbt/graph/graph.py
@@ -31,11 +31,13 @@ class Graph:
         """Returns all nodes having a path to `node` in `graph`"""
         if not self.graph.has_node(node):
             raise InternalException(f'Node {node} not found in the graph!')
-        with nx.utils.reversed(self.graph):
-            anc = nx.single_source_shortest_path_length(G=self.graph,
-                                                        source=node,
-                                                        cutoff=max_depth)\
-                .keys()
+        # This used to use nx.utils.reversed(self.graph), but that is deprecated,
+        # so changing to use self.graph.reverse(copy=False) as recommeneded
+        G = self.graph.reverse(copy=False) if self.graph.is_directed() else self.graph
+        anc = nx.single_source_shortest_path_length(G=G,
+                                                    source=node,
+                                                    cutoff=max_depth)\
+            .keys()
         return anc - {node}
 
     def descendants(

--- a/core/dbt/semver.py
+++ b/core/dbt/semver.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import re
+import warnings
 from typing import List
 
 from packaging import version as packaging_version
@@ -145,10 +146,13 @@ class VersionSpecifier(VersionSpecification):
                     return 1
                 if b is None:
                     return -1
-            if packaging_version.parse(a) > packaging_version.parse(b):
-                return 1
-            elif packaging_version.parse(a) < packaging_version.parse(b):
-                return -1
+            # This suppresses the LegacyVersion deprecation warning
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=DeprecationWarning)
+                if packaging_version.parse(a) > packaging_version.parse(b):
+                    return 1
+                elif packaging_version.parse(a) < packaging_version.parse(b):
+                    return -1
 
         equal = ((self.matcher == Matchers.GREATER_THAN_OR_EQUAL and
                   other.matcher == Matchers.LESS_THAN_OR_EQUAL) or

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore:.*'soft_unicode' has been renamed to 'soft_str'*:DeprecationWarning


### PR DESCRIPTION
resolves #3988

### Description

Fix warnings that we see at the end of tests (from pytest). Two networkx deprecation warnings were fixed by using different functions, as recommended. The LegacyVersion deprecation warning was trapped in our semver.py package. The warnings caused by jinja use of 'soft_unicode' instead of 'soft_str' were suppresed in a pytest.ini file.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
