### PR TITLE
drop support for Python 3.7.0 and 3.7.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,5 +80,5 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.7.2",
 )


### PR DESCRIPTION
resolves #4584

Running dbt v1.0.0 and v0.21 (and possibly other dbt versions) with these Python versions causes a Python exception to be thrown. This disallows installing dbt with when running pip with these versions.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
