### PR TITLE
Retry after failure to download or failure to open files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Contributors:
 - Projects created using `dbt init` now have the correct `seeds` directory created (instead of `data`) ([#4588](https://github.com/dbt-labs/dbt-core/issues/4588), [#4599](https://github.com/dbt-labs/dbt-core/pull/4589))
 - Don't require a profile for dbt deps and clean commands ([#4554](https://github.com/dbt-labs/dbt-core/issues/4554), [#4610](https://github.com/dbt-labs/dbt-core/pull/4610))
 - Select modified.body works correctly when new model added([#4570](https://github.com/dbt-labs/dbt-core/issues/4570), [#4631](https://github.com/dbt-labs/dbt-core/pull/4631))
+- Fix bug in retry logic for bad response from hub and when there is a bad git tarball download. ([#4577](https://github.com/dbt-labs/dbt-core/issues/4577), [#4579](https://github.com/dbt-labs/dbt-core/issues/4579), [#4609](https://github.com/dbt-labs/dbt-core/pull/4609)) 
 
 ## dbt-core 1.0.1 (January 03, 2022)
 

--- a/core/dbt/clients/registry.py
+++ b/core/dbt/clients/registry.py
@@ -33,6 +33,11 @@ def _get(path, registry_base_url=None):
     resp = requests.get(url, timeout=30)
     fire_event(RegistryProgressGETResponse(url=url, resp_code=resp.status_code))
     resp.raise_for_status()
+
+    # It is unexpected for the content of the response to be None so if it is, raising this error
+    # will cause this function to retry (if called within _get_with_retries) and hopefully get
+    # a response.  This seems to happen when there's an issue with the Hub.
+    # See https://github.com/dbt-labs/dbt-core/issues/4577
     if resp.json() is None:
         raise requests.exceptions.ContentDecodingError(
             'Request error: The response is None', response=resp

--- a/core/dbt/clients/registry.py
+++ b/core/dbt/clients/registry.py
@@ -33,7 +33,7 @@ def _get(path, registry_base_url=None):
     resp = requests.get(url, timeout=30)
     fire_event(RegistryProgressGETResponse(url=url, resp_code=resp.status_code))
     resp.raise_for_status()
-    if resp is None:
+    if resp.json() is None:
         raise requests.exceptions.ContentDecodingError(
             'Request error: The response is None', response=resp
         )

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -485,7 +485,7 @@ def untar_package(
 ) -> None:
     tar_path = convert_path(tar_path)
     tar_dir_name = None
-    with tarfile.open(tar_path, 'r') as tarball:
+    with tarfile.open(tar_path, 'r:gz') as tarball:
         tarball.extractall(dest_dir)
         tar_dir_name = os.path.commonprefix(tarball.getnames())
     if rename_to:

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -774,6 +774,10 @@ def system_error(operation_name):
 
 
 class ConnectionException(Exception):
+    """
+    There was a problem with the connection that returned a bad response,
+    timed out, or resulted in a file that is corrupt.
+    """
     pass
 
 

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -601,7 +601,9 @@ class MultiDict(Mapping[str, Any]):
 
 def _connection_exception_retry(fn, max_attempts: int, attempt: int = 0):
     """Attempts to run a function that makes an external call, if the call fails
-    on a connection error, timeout or other exception, it will be tried up to 5 more times.
+    on a connection error, timeout or decompression issue, it will be tried up to 5 more times.
+    See https://github.com/dbt-labs/dbt-core/issues/4579 for context on this decompression issues
+    specifically.
     """
     try:
         return fn()

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -10,6 +10,7 @@ import jinja2
 import json
 import os
 import requests
+from tarfile import ReadError
 import time
 from pathlib import PosixPath, WindowsPath
 
@@ -600,7 +601,7 @@ class MultiDict(Mapping[str, Any]):
 
 def _connection_exception_retry(fn, max_attempts: int, attempt: int = 0):
     """Attempts to run a function that makes an external call, if the call fails
-    on a connection error or timeout, it will be tried up to 5 more times.
+    on a connection error, timeout or other exception, it will be tried up to 5 more times.
     """
     try:
         return fn()
@@ -608,6 +609,7 @@ def _connection_exception_retry(fn, max_attempts: int, attempt: int = 0):
         requests.exceptions.ConnectionError,
         requests.exceptions.Timeout,
         requests.exceptions.ContentDecodingError,
+        ReadError,
     ) as exc:
         if attempt <= max_attempts - 1:
             fire_event(RetryExternalCall(attempt=attempt, max=max_attempts))

--- a/test/unit/test_core_dbt_utils.py
+++ b/test/unit/test_core_dbt_utils.py
@@ -1,4 +1,5 @@
 import requests
+import tarfile
 import unittest
 
 from dbt.exceptions import ConnectionException
@@ -22,10 +23,20 @@ class TestCoreDbtUtils(unittest.TestCase):
         connection_exception_retry(lambda: Counter._add_with_limited_exception(), 5)
         self.assertEqual(2, counter) # 2 = original attempt plus 1 retry
 
+    def test_connection_timeout(self):
+        Counter._reset()
+        connection_exception_retry(lambda: Counter._add_with_timeout(), 5)
+        self.assertEqual(2, counter) # 2 = original attempt plus 1 retry
+
     def test_connection_exception_retry_success_none_response(self):
         Counter._reset()
         connection_exception_retry(lambda: Counter._add_with_none_exception(), 5)
         self.assertEqual(2, counter) # 2 = original attempt returned None, plus 1 retry
+
+    def test_connection_exception_retry_success_failed_untar(self):
+        Counter._reset()
+        connection_exception_retry(lambda: Counter._add_with_untar_exception(), 5)
+        self.assertEqual(2, counter) # 2 = original attempt returned ReadError, plus 1 retry
 
 
 counter:int = 0 
@@ -42,11 +53,21 @@ class Counter():
         counter+=1
         if counter < 2:
             raise requests.exceptions.ConnectionError
+    def _add_with_timeout():
+        global counter
+        counter+=1
+        if counter < 2:
+            raise requests.exceptions.Timeout
     def _add_with_none_exception():
         global counter
         counter+=1
         if counter < 2:
             raise requests.exceptions.ContentDecodingError
+    def _add_with_untar_exception():
+        global counter
+        counter+=1
+        if counter < 2:
+            raise tarfile.ReadError
     def _reset():
         global counter
         counter = 0


### PR DESCRIPTION
resolves #4579, #4577


### Description

- Add retry logic when there's a problem extracting the tarball.
- Fix retry logic when a response is `NoneType`.
- Add relevant unit tests.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
