### PR TITLE
[#4554] Don't require a profile for dbt deps and clean commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 - Projects created using `dbt init` now have the correct `seeds` directory created (instead of `data`) ([#4588](https://github.com/dbt-labs/dbt-core/issues/4588), [#4599](https://github.com/dbt-labs/dbt-core/pull/4589))
+- Don't require a profile for dbt deps and clean commands ([#4554](https://github.com/dbt-labs/dbt-core/issues/4554), [#4610](https://github.com/dbt-labs/dbt-core/pull/4610))
 
 ## dbt-core 1.0.1 (January 03, 2022)
 

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -796,24 +796,6 @@ class MissingProfileTarget(InfoLevel):
 
 
 @dataclass
-class ProfileLoadError(ShowException, DebugLevel):
-    exc: Exception
-    code: str = "A006"
-
-    def message(self) -> str:
-        return f"Profile not loaded due to error: {self.exc}"
-
-
-@dataclass
-class ProfileNotFound(InfoLevel):
-    profile_name: Optional[str]
-    code: str = "A007"
-
-    def message(self) -> str:
-        return f'No profile "{self.profile_name}" found, continuing with no target'
-
-
-@dataclass
 class InvalidVarsYAML(ErrorLevel):
     code: str = "A008"
 
@@ -2528,8 +2510,6 @@ if 1 == 0:
     TimingInfoCollected()
     MergedFromState(nbr_merged=0, sample=[])
     MissingProfileTarget(profile_name='', target_name='')
-    ProfileLoadError(exc=Exception(''))
-    ProfileNotFound(profile_name='')
     InvalidVarsYAML()
     GenericTestFileParse(path='')
     MacroFileParse(path='')

--- a/test/unit/test_events.py
+++ b/test/unit/test_events.py
@@ -233,8 +233,6 @@ sample_values = [
     TimingInfoCollected(),
     MergedFromState(nbr_merged=0, sample=[]),
     MissingProfileTarget(profile_name='', target_name=''),
-    ProfileLoadError(exc=Exception('')),
-    ProfileNotFound(profile_name=''),
     InvalidVarsYAML(),
     GenericTestFileParse(path=''),
     MacroFileParse(path=''),


### PR DESCRIPTION
resolves #4554

### Description

Changing a profile parsing exception from a CompilationException to a ParsingException caused a failure in the code that intended to trap the error.

Switch to not loading the profile when we don't need it, and remove code that incorrectly reported the nature of the error.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
