### PR TITLE
Set flags from args in lib module for dbt-server

### DIFF
--- a/core/dbt/lib.py
+++ b/core/dbt/lib.py
@@ -5,27 +5,24 @@ from dbt import flags
 from collections import namedtuple
 
 RuntimeArgs = namedtuple(
-    'RuntimeArgs', 'project_dir profiles_dir single_threaded profile_name'
+    'RuntimeArgs', 'project_dir profiles_dir single_threaded'
 )
 
-
-def get_dbt_config(project_dir, single_threaded=False):
+def get_dbt_config(project_dir, args=None, single_threaded=False):
     from dbt.config.runtime import RuntimeConfig
     import dbt.adapters.factory
     import dbt.events.functions
-
     if os.getenv('DBT_PROFILES_DIR'):
         profiles_dir = os.getenv('DBT_PROFILES_DIR')
     else:
         profiles_dir = os.path.expanduser("~/.dbt")
-
     # Construct a phony config
     config = RuntimeConfig.from_args(RuntimeArgs(
-        project_dir, profiles_dir, single_threaded, 'user'
+        project_dir, profiles_dir, single_threaded
     ))
     # Clear previously registered adapters--
     # this fixes cacheing behavior on the dbt-server
-    flags.set_from_args('', config)
+    flags.set_from_args(args, config)
     dbt.adapters.factory.reset_adapters()
     # Load the relevant adapter
     dbt.adapters.factory.register_adapter(config)

--- a/core/dbt/lib.py
+++ b/core/dbt/lib.py
@@ -5,7 +5,7 @@ from dbt import flags
 from collections import namedtuple
 
 RuntimeArgs = namedtuple(
-    'RuntimeArgs', 'project_dir profiles_dir single_threaded'
+    'RuntimeArgs', 'project_dir profiles_dir single_threaded profile target'
 )
 
 def get_dbt_config(project_dir, args=None, single_threaded=False):
@@ -16,9 +16,13 @@ def get_dbt_config(project_dir, args=None, single_threaded=False):
         profiles_dir = os.getenv('DBT_PROFILES_DIR')
     else:
         profiles_dir = os.path.expanduser("~/.dbt")
+
+    profile = args.profile if hasattr(args, 'profile') else None
+    target = args.target if hasattr(args, 'target') else None
+
     # Construct a phony config
     config = RuntimeConfig.from_args(RuntimeArgs(
-        project_dir, profiles_dir, single_threaded
+        project_dir, profiles_dir, single_threaded, profile, target
     ))
     # Clear previously registered adapters--
     # this fixes cacheing behavior on the dbt-server

--- a/core/dbt/lib.py
+++ b/core/dbt/lib.py
@@ -8,6 +8,7 @@ RuntimeArgs = namedtuple(
     'RuntimeArgs', 'project_dir profiles_dir single_threaded profile target'
 )
 
+
 def get_dbt_config(project_dir, args=None, single_threaded=False):
     from dbt.config.runtime import RuntimeConfig
     import dbt.adapters.factory

--- a/core/dbt/lib.py
+++ b/core/dbt/lib.py
@@ -18,12 +18,11 @@ def get_dbt_config(project_dir, args=None, single_threaded=False):
     else:
         profiles_dir = os.path.expanduser("~/.dbt")
 
-    profile = args.profile if hasattr(args, 'profile') else None
     target = args.target if hasattr(args, 'target') else None
 
-    # Construct a phony config
+    # Construct a phony config-- hardcoding user to match dbt-cloud for now
     config = RuntimeConfig.from_args(RuntimeArgs(
-        project_dir, profiles_dir, single_threaded, profile, target
+        project_dir, profiles_dir, single_threaded, 'user', target
     ))
     # Clear previously registered adapters--
     # this fixes cacheing behavior on the dbt-server

--- a/core/dbt/lib.py
+++ b/core/dbt/lib.py
@@ -18,11 +18,12 @@ def get_dbt_config(project_dir, args=None, single_threaded=False):
     else:
         profiles_dir = os.path.expanduser("~/.dbt")
 
+    profile = args.profile if hasattr(args, 'profile') else None
     target = args.target if hasattr(args, 'target') else None
 
-    # Construct a phony config-- hardcoding user to match dbt-cloud for now
+    # Construct a phony config
     config = RuntimeConfig.from_args(RuntimeArgs(
-        project_dir, profiles_dir, single_threaded, 'user', target
+        project_dir, profiles_dir, single_threaded, profile, target
     ))
     # Clear previously registered adapters--
     # this fixes cacheing behavior on the dbt-server


### PR DESCRIPTION
resolves #TIGER-84 and Tiger-99

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

Changes are only in the `dbt.lib` model, which is the wrapper for dbt-server use cases. This updates config creation to pull in args passed to the server from client command flags, if any exist. This change is needed to enable use of several command flags that need to be applied prior to dbt task execution. This PR also defaults the profile to 'user' -- it looks like we may have attempted to do so before, but we had the field name wrong (`profile_name` vs `profile`)

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
