### PR TITLE
Proposed sub-team codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,8 +12,25 @@
 # Changes to GitHub configurations including Actions
 /.github/ @leahwicz
 
-# Adapter / plugin code
-/plugins @dbt-labs/core-adapters
+# Language core modules
+/core/dbt/config/     @dbt-labs/core-language
+/core/dbt/context/    @dbt-labs/core-language
+/core/dbt/contracts/  @dbt-labs/core-language
+/core/dbt/deps/       @dbt-labs/core-language
+/core/dbt/parser/     @dbt-labs/core-language
+
+# Execution core modules
+/core/dbt/events/     @dbt-labs/core-execution
+/core/dbt/graph/      @dbt-labs/core-execution
+/core/dbt/task/       @dbt-labs/core-execution
+
+# Adapter interface, scaffold, Postgres plugin
+/core/dbt/adapters    @dbt-labs/core-adapters
+/core/scripts/create_adapter_plugin.py    @dbt-labs/core-adapters
+/plugins/             @dbt-labs/core-adapters
+
+# Global project: default macros, including generic tests + materializations
+/core/dbt/include/global_project    @dbt-labs/core-execution @dbt-labs/core-adapters
 
 # Perf regression testing framework
 # This excludes the test project files itself since those aren't specific 


### PR DESCRIPTION
Proposed submodule ownership by sub-teams. At the risk of splitting a few hairs:

### Language
- `config`, `context`, `parser` feel pretty uncontroversial to me
- `contracts` feels most relevant to validating project objects, but it does include some contracts related to execution/results
- `deps` - I could go either way. `deps` is obviously a task (Execution), but the nature of that task is the assemblage of dbt source code (Language). I've been assigning package + `deps`-related issues to Language recently, mostly for capacity reasons.

### Execution
- `task` + `graph` (node selection, runtime queuing) should both be fairly uncontroversial
- `events` - _Everyone_ contributed to this module, and Nate was tech lead on the project. Going forward, though, I see the Execution team owning the logging interface, especially as it's a critical interface to the new server.

### Adapters team
- Core `adapters` interface - everything here is exposed to / can be overridden by adapter plugins
- `plugins/`, a.k.a. `dbt-postgres`
- Script for scaffolding new adapters
- (Not here: all the code in Labs-maintained adapter repos!)

The global project — all macro code (including generic tests + materializations) that every single dbt plugin/project uses by default — is a tricky one. This is a very common site of community contribution. It changes runtime behavior (for models, snapshots, tests, etc), it changes the defaults used by all adapters, _and_ it often indicates that changes will be needed in other adapter plugins. I'd say this should be a combination of Execution + Adapters — but I'm open to other thoughts, and we can revisit later on.

### Not assigned to any team (and thereby assigned to everyone)
- The "loose" individual files in `dbt/core`, including beasts like `main.py`. All the more reason to get these organized!
- `core/dbt/include/starter_project` - changes here are fairly rare
- `core/dbt/include/index.html`, a.k.a. https://github.com/dbt-labs/dbt-docs
- Everything in `test/`
- Dockerfile, other release-related scripts