### PR TITLE
Backport 4647 to 1.0.latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Don't require a profile for dbt deps and clean commands ([#4554](https://github.com/dbt-labs/dbt-core/issues/4554), [#4610](https://github.com/dbt-labs/dbt-core/pull/4610))
 - Select modified.body works correctly when new model added([#4570](https://github.com/dbt-labs/dbt-core/issues/4570), [#4631](https://github.com/dbt-labs/dbt-core/pull/4631))
 - Fix bug in retry logic for bad response from hub and when there is a bad git tarball download. ([#4577](https://github.com/dbt-labs/dbt-core/issues/4577), [#4579](https://github.com/dbt-labs/dbt-core/issues/4579), [#4609](https://github.com/dbt-labs/dbt-core/pull/4609)) 
+- Restore previous log level (DEBUG) when a test depends on a disabled resource. Still WARN if the resource is missing ([#4594](https://github.com/dbt-labs/dbt-core/issues/4594), [#4647](https://github.com/dbt-labs/dbt-core/pull/4647))
 
 ## dbt-core 1.0.1 (January 03, 2022)
 

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1166,12 +1166,12 @@ class InvalidDisabledSourceInTestNode(WarnLevel, Cli, File):
 
 
 @dataclass
-class InvalidRefInTestNode(WarnLevel, Cli, File):
+class InvalidRefInTestNode(DebugLevel, Cli, File):
     msg: str
     code: str = "I051"
 
     def message(self) -> str:
-        return ui.warning_tag(self.msg)
+        return self.msg
 
 
 @dataclass


### PR DESCRIPTION
Backport for #4647 to `1.0.latest` for inclusion in v1.0.2

Restore previous (pre-v1.0) behavior for this message's log level (DEBUG, not WARN). This significantly declutters stdout for users of packages that enable/disable models as a common pattern.