### PR TITLE
Alternative Modified Backport of #4619

### DIFF
--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -306,6 +306,13 @@ def send_exc_to_logger(
         )
 
 
+# an alternative to fire_event which only creates and logs the event value
+# if the condition is met. Does nothing otherwise.
+def fire_event_if(conditional: bool, lazy_e: Callable[[], Event]) -> None:
+    if conditional:
+        fire_event(lazy_e())
+
+
 # top-level method for accessing the new eventing system
 # this is where all the side effects happen branched by event type
 # (i.e. - mutating the event history, printing to stdout, logging

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -699,7 +699,7 @@ class RenameSchema(DebugLevel, Cli, File, Cache):
 
 @dataclass
 class DumpBeforeAddGraph(DebugLevel, Cli, File, Cache):
-    # large value. delay not necessary since every debug level message is logged anyway.
+    # large value. delay creation with fire_event_if.
     dump: Dict[str, List[str]]
     code: str = "E031"
 
@@ -709,7 +709,7 @@ class DumpBeforeAddGraph(DebugLevel, Cli, File, Cache):
 
 @dataclass
 class DumpAfterAddGraph(DebugLevel, Cli, File, Cache):
-    # large value. delay not necessary since every debug level message is logged anyway.
+    # large value. delay creation with fire_event_if.
     dump: Dict[str, List[str]]
     code: str = "E032"
 
@@ -719,7 +719,7 @@ class DumpAfterAddGraph(DebugLevel, Cli, File, Cache):
 
 @dataclass
 class DumpBeforeRenameSchema(DebugLevel, Cli, File, Cache):
-    # large value. delay not necessary since every debug level message is logged anyway.
+    # large value. delay creation with fire_event_if.
     dump: Dict[str, List[str]]
     code: str = "E033"
 
@@ -729,7 +729,7 @@ class DumpBeforeRenameSchema(DebugLevel, Cli, File, Cache):
 
 @dataclass
 class DumpAfterRenameSchema(DebugLevel, Cli, File, Cache):
-    # large value. delay not necessary since every debug level message is logged anyway.
+    # large value. delay creation with fire_event_if.
     dump: Dict[str, List[str]]
     code: str = "E034"
 


### PR DESCRIPTION
resolves #4569

###Description

This commit defers the expensive function dump_graph to only be called in the event the value is going to be logged. Without this change, users always generate this expensive graph regardless of the value of the flag `--log-cache-events`. This is an alternative solution to the one proposed in #4656.

This backport of #4619 is separate from the original commit so that we do not have to backport #4505 which introduced mashumaro as the internal serializer for the events module. In order to keep this backport simple, I implemented it by adding a new function `fire_event_if` that only constructs the event and logs it if the condition is met. This keeps logging concerns within the logging module while exposing conditional logging at call sites. Tests for the original commit are not directly applicable anymore because we are not using `fire_event` anymore.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
