### PR TITLE
Avoid saving secrets in SecretContext

### DIFF
--- a/core/dbt/context/secret.py
+++ b/core/dbt/context/secret.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 from .base import BaseContext, contextmember
 
 from dbt.exceptions import raise_parsing_error
+from dbt.logger import SECRET_ENV_PREFIX
 
 
 class SecretContext(BaseContext):
@@ -27,7 +28,11 @@ class SecretContext(BaseContext):
             return_value = default
 
         if return_value is not None:
-            self.env_vars[var] = return_value
+            # do not save secret environment variables
+            if not var.startswith(SECRET_ENV_PREFIX):
+                self.env_vars[var] = return_value
+
+            # return the value even if its a secret
             return return_value
         else:
             msg = f"Env var required but not provided: '{var}'"

--- a/test/integration/068_partial_parsing_tests/test_pp_vars.py
+++ b/test/integration/068_partial_parsing_tests/test_pp_vars.py
@@ -2,6 +2,7 @@ from dbt.exceptions import CompilationException, ParsingException
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.files import ParseFileType
 from dbt.contracts.results import TestStatus
+from dbt.logger import SECRET_ENV_PREFIX
 from dbt.parser.partial import special_override_macros
 from test.integration.base import DBTIntegrationTest, use_profile, normalize, get_manifest
 import shutil
@@ -301,63 +302,6 @@ class ProjectEnvVarTest(BasePPTest):
         del os.environ['ENV_VAR_NAME']
 
 
-class ProfileSecretEnvVarTest(BasePPTest):
-
-    @property
-    def profile_config(self):
-        # Need to set these here because the base integration test class
-        # calls 'load_config' before the tests are run.
-        # Note: only the specified profile is rendered, so there's no
-        # point it setting env_vars in non-used profiles.
-        os.environ['NOT_SECRET_USER'] = 'root'
-        os.environ['DBT_ENV_SECRET_PASS'] = 'password'
-        return {
-            'config': {
-                'send_anonymous_usage_stats': False
-            },
-            'test': {
-                'outputs': {
-                    'dev': {
-                        'type': 'postgres',
-                        'threads': 1,
-                        'host': self.database_host,
-                        'port': 5432,
-                        'user': "root",
-                        'pass': "password",
-                        'user': "{{ env_var('NOT_SECRET_USER') }}",
-                        'pass': "{{ env_var('DBT_ENV_SECRET_PASS') }}",
-                        'dbname': 'dbt',
-                        'schema': self.unique_schema()
-                    },
-                },
-                'target': 'dev'
-            }
-        }
-
-    @use_profile('postgres')
-    def test_postgres_secret_env_vars(self):
-        # Initial run
-        self.setup_directories()
-        self.copy_file('test-files/model_one.sql', 'models/model_one.sql')
-        results = self.run_dbt(["run"])
-        manifest = get_manifest()
-
-        breakpoint()
-        
-        # find the non-secret in the manifest, we expect it to be there.
-        self.assertEqual(manifest.env_vars['NOT_SECRET_USER'], 'root')
-
-        # attempt to find the secret in the manifest. hopefully it's not there
-        try:
-            manifest.env_vars['x']
-            self.assertTrue(False, 'A secret was saved when it shouldn\'t have been')
-        except KeyError:
-            self.AssertTrue(True)
-
-        # cleanup
-        del os.environ['NOT_SECRET_USER']
-        del os.environ['DBT_ENV_SECRET_PASS']
-
 class ProfileEnvVarTest(BasePPTest):
 
     @property
@@ -409,4 +353,24 @@ class ProfileEnvVarTest(BasePPTest):
         self.assertTrue('env vars used in profiles.yml have changed' in log_output)
         manifest = get_manifest()
         self.assertNotEqual(env_vars_checksum, manifest.state_check.profile_env_vars_hash.checksum)
+
+    @use_profile('postgres')
+    def test_postgres_profile_secret_env_vars(self):
+
+        # Initial run
+        os.environ['ENV_VAR_USER'] = 'root'
+        os.environ[SECRET_ENV_PREFIX + 'ENV_VAR_PASS'] = 'password'
+        self.setup_directories()
+        self.copy_file('test-files/model_one.sql', 'models/model_one.sql')
+        results = self.run_dbt(["run"])
+        manifest = get_manifest()
+        env_vars_checksum = manifest.state_check.profile_env_vars_hash.checksum
+
+        # Change a secret var, it shouldn't register because we shouldn't save secrets.
+        os.environ[SECRET_ENV_PREFIX + 'ENV_VAR_PASS'] = 'password2'
+        (results, log_output) = self.run_dbt_and_capture(["run"], expect_pass=True)
+        # I020 is the event code for "env vars used in profiles.yml have changed"
+        self.assertFalse('I020' in log_output) 
+        manifest = get_manifest()
+        self.assertEqual(env_vars_checksum, manifest.state_check.profile_env_vars_hash.checksum)
 


### PR DESCRIPTION
resolves #4650 

### Description

Prevents saving secret environment variables so that partial parsing doesn't get triggered on secret changes.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
