### PR TITLE
task init: support older click v7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Contributors:
 - Fix bug in retry logic for bad response from hub and when there is a bad git tarball download. ([#4577](https://github.com/dbt-labs/dbt-core/issues/4577), [#4579](https://github.com/dbt-labs/dbt-core/issues/4579), [#4609](https://github.com/dbt-labs/dbt-core/pull/4609)) 
 - Restore previous log level (DEBUG) when a test depends on a disabled resource. Still WARN if the resource is missing ([#4594](https://github.com/dbt-labs/dbt-core/issues/4594), [#4647](https://github.com/dbt-labs/dbt-core/pull/4647))
 - Add project name validation to `dbt init` ([#4490](https://github.com/dbt-labs/dbt-core/issues/4490),[#4536](https://github.com/dbt-labs/dbt-core/pull/4536))
+- Support click versions in the v7.x series ([#4681](https://github.com/dbt-labs/dbt-core/pull/4681))
 
 Contributors:
 * [@amirkdv](https://github.com/amirkdv) ([#4536](https://github.com/dbt-labs/dbt-core/pull/4536))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Contributors:
 
 Contributors:
 * [@amirkdv](https://github.com/amirkdv) ([#4536](https://github.com/dbt-labs/dbt-core/pull/4536))
+* [@twilly](https://github.com/twilly) ([#4681](https://github.com/dbt-labs/dbt-core/pull/4681))
 
 ## dbt-core 1.0.2 (TBD)
 ### Fixes

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -50,7 +50,8 @@ Need help? Don't hesitate to reach out to us via GitHub issues or on Slack:
 Happy modeling!
 """
 
-# https://click.palletsprojects.com/en/8.0.x/api/?highlight=float#types
+# https://click.palletsprojects.com/en/8.0.x/api/#types
+# click v7.0 has UNPROCESSED, STRING, INT, FLOAT, BOOL, and UUID available.
 click_type_mapping = {
     "string": click.STRING,
     "int": click.INT,

--- a/core/setup.py
+++ b/core/setup.py
@@ -53,7 +53,7 @@ setup(
     install_requires=[
         'Jinja2==2.11.3',
         'agate>=1.6,<1.6.4',
-        'click>=8,<9',
+        'click>=7.0,<9',
         'colorama>=0.3.9,<0.4.5',
         'hologram==0.0.14',
         'isodate>=0.6,<0.7',


### PR DESCRIPTION
`dbt init` uses click for interactively setting up a project. The
version constraints currently ask for click >= 8 but v7.0 has nearly the
same prompt/confirm/echo API. prompt added a feature that isn't used.
confirm has a behavior change if the default is None, but
confirm(..., default=None) is not used. Long story short, we can relax
the version constraint to allow installing with an older click library.

Ref: Issue #4566

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
