### PR TITLE
Add `--quiet` flag and `print` Jinja function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added Support for Semantic Versioning ([#4644](https://github.com/dbt-labs/dbt-core/pull/4644))
 - New Dockerfile to support specific db adapters and platforms.  See docker/README.md for details ([#4495](https://github.com/dbt-labs/dbt-core/issues/4495), [#4487](https://github.com/dbt-labs/dbt-core/pull/4487))
 - Allow unique_key to take a list ([#2479](https://github.com/dbt-labs/dbt-core/issues/2479), [#4618](https://github.com/dbt-labs/dbt-core/pull/4618))
+- Add `--quiet` global flag and `print` Jinja function ([#3451](https://github.com/dbt-labs/dbt-core/issues/3451), [#4701](https://github.com/dbt-labs/dbt-core/pull/4701))
 
 ### Fixes
 - User wasn't asked for permission to overwite a profile entry when running init inside an existing project ([#4375](https://github.com/dbt-labs/dbt-core/issues/4375), [#4447](https://github.com/dbt-labs/dbt-core/pull/4447))
@@ -19,6 +20,7 @@
 Contributors:
 - [@NiallRees](https://github.com/NiallRees) ([#4447](https://github.com/dbt-labs/dbt-core/pull/4447))
 - [@alswang18](https://github.com/alswang18) ([#4644](https://github.com/dbt-labs/dbt-core/pull/4644))
+- [@emartens](https://github.com/ehmartens) ([#4701](https://github.com/dbt-labs/dbt-core/pull/4701))
 
 ## dbt-core 1.0.2 (TBD)
 

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -571,6 +571,22 @@ class BaseContext(metaclass=ContextMeta):
         """
         return flags
 
+    @contextmember
+    @staticmethod
+    def print(msg: str) -> str:
+        """Prints a line to stdout.
+
+        :param msg: The message to print
+
+        > macros/my_log_macro.sql
+
+            {% macro some_macro(arg1, arg2) %}
+              {{ print("Running some_macro: " ~ arg1 ~ ", " ~ arg2) }}
+            {% endmacro %}"
+        """
+        print(msg)
+        return ''
+
 
 def generate_base_context(cli_vars: Dict[str, Any]) -> Dict[str, Any]:
     ctx = BaseContext(cli_vars)

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -351,6 +351,8 @@ def fire_event(e: Event) -> None:
         # log messages are not constructed if debug messages are never shown.
         if e.level_tag() == 'debug' and not flags.DEBUG:
             return  # eat the message in case it was one of the expensive ones
+        if e.level_tag() != 'error' and flags.QUIET:
+            return  # eat all non-exception messages in quiet mode
 
         log_line = create_log_line(e)
         if log_line:

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -35,6 +35,7 @@ WHICH = None
 INDIRECT_SELECTION = None
 LOG_CACHE_EVENTS = None
 EVENT_BUFFER_SIZE = 100000
+QUIET = None
 
 # Global CLI defaults. These flags are set from three places:
 # CLI args, environment variables, and user_config (profiles.yml).
@@ -55,7 +56,8 @@ flag_defaults = {
     "PRINTER_WIDTH": 80,
     "INDIRECT_SELECTION": 'eager',
     "LOG_CACHE_EVENTS": False,
-    "EVENT_BUFFER_SIZE": 100000
+    "EVENT_BUFFER_SIZE": 100000,
+    "QUIET": False
 }
 
 
@@ -103,7 +105,7 @@ def set_from_args(args, user_config):
         USE_EXPERIMENTAL_PARSER, STATIC_PARSER, WRITE_JSON, PARTIAL_PARSE, \
         USE_COLORS, STORE_FAILURES, PROFILES_DIR, DEBUG, LOG_FORMAT, INDIRECT_SELECTION, \
         VERSION_CHECK, FAIL_FAST, SEND_ANONYMOUS_USAGE_STATS, PRINTER_WIDTH, \
-        WHICH, LOG_CACHE_EVENTS, EVENT_BUFFER_SIZE
+        WHICH, LOG_CACHE_EVENTS, EVENT_BUFFER_SIZE, QUIET
 
     STRICT_MODE = False  # backwards compatibility
     # cli args without user_config or env var option
@@ -128,6 +130,7 @@ def set_from_args(args, user_config):
     INDIRECT_SELECTION = get_flag_value('INDIRECT_SELECTION', args, user_config)
     LOG_CACHE_EVENTS = get_flag_value('LOG_CACHE_EVENTS', args, user_config)
     EVENT_BUFFER_SIZE = get_flag_value('EVENT_BUFFER_SIZE', args, user_config)
+    QUIET = get_flag_value('QUIET', args, user_config)
 
 
 def get_flag_value(flag, args, user_config):
@@ -179,5 +182,6 @@ def get_flag_dict():
         "printer_width": PRINTER_WIDTH,
         "indirect_selection": INDIRECT_SELECTION,
         "log_cache_events": LOG_CACHE_EVENTS,
-        "event_buffer_size": EVENT_BUFFER_SIZE
+        "event_buffer_size": EVENT_BUFFER_SIZE,
+        "quiet": QUIET
     }

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -1090,8 +1090,8 @@ def parse_args(args, cls=DBTArgumentParser):
         action='store_true',
         default=None,
         help='''
-        Supress all non-error logging during dbt execution. Output from
-        {{ print() }} macro are still displayed.
+        Suppress all non-error logging to stdout. Does not affect
+        {{ print() }} macro calls.
         '''
     )
 

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -1084,6 +1084,17 @@ def parse_args(args, cls=DBTArgumentParser):
         '''
     )
 
+    p.add_argument(
+        '-q',
+        '--quiet',
+        action='store_true',
+        default=None,
+        help='''
+        Supress all non-error logging during dbt execution. Output from
+        {{ print() }} macro are still displayed.
+        '''
+    )
+
     subs = p.add_subparsers(title="Available sub-commands")
 
     base_subparser = _build_base_subparser()

--- a/test/integration/044_run_operations_tests/macros/happy_macros.sql
+++ b/test/integration/044_run_operations_tests/macros/happy_macros.sql
@@ -49,3 +49,8 @@
     {{ log((node | string), info=True)}}
   {% endfor %}
 {% endmacro %}
+
+
+{% macro print_something() %}
+  {{ print("You're doing awesome!") }}
+{% endmacro %}

--- a/test/integration/044_run_operations_tests/test_run_operations.py
+++ b/test/integration/044_run_operations_tests/test_run_operations.py
@@ -72,4 +72,5 @@ class TestOperations(DBTIntegrationTest):
 
     @use_profile('postgres')
     def test__postgres_print(self):
+        # Tests that calling the `print()` macro does not cause an exception
         self.run_operation('print_something')

--- a/test/integration/044_run_operations_tests/test_run_operations.py
+++ b/test/integration/044_run_operations_tests/test_run_operations.py
@@ -69,3 +69,7 @@ class TestOperations(DBTIntegrationTest):
     @use_profile('postgres')
     def test__postgres_access_graph(self):
         self.run_operation('log_graph')
+
+    @use_profile('postgres')
+    def test__postgres_print(self):
+        self.run_operation('print_something')

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -186,6 +186,7 @@ REQUIRED_BASE_KEYS = frozenset({
     'invocation_id',
     'modules',
     'flags',
+    'print',
 })
 
 REQUIRED_TARGET_KEYS = REQUIRED_BASE_KEYS | {'target'}

--- a/test/unit/test_flags.py
+++ b/test/unit/test_flags.py
@@ -115,7 +115,7 @@ class TestFlags(TestCase):
         os.environ['DBT_DEBUG'] = 'True'
         flags.set_from_args(self.args, self.user_config)
         self.assertEqual(flags.DEBUG, True)
-        os.environ['DBT_DEUBG'] = 'False'
+        os.environ['DBT_DEBUG'] = 'False'
         setattr(self.args, 'debug', True)
         flags.set_from_args(self.args, self.user_config)
         self.assertEqual(flags.DEBUG, True)
@@ -217,3 +217,10 @@ class TestFlags(TestCase):
         os.environ.pop('DBT_INDIRECT_SELECTION')
         delattr(self.args, 'indirect_selection')
         self.user_config.indirect_selection = None
+
+        # quiet
+        self.user_config.quiet = True
+        flags.set_from_args(self.args, self.user_config)
+        self.assertEqual(flags.QUIET, True)
+        # cleanup
+        self.user_config.quiet = None


### PR DESCRIPTION
resolves #3451 

### Description

This PR addresses the issue linked above following @emmyoop 's suggestions [here](https://github.com/dbt-labs/dbt-core/issues/3451#issuecomment-1031807152).

It creates a new global flag called `--quiet` that suppresses all non-exception output. Additionally it create a Jinja function called `print` whihc prints messages directly to stdout.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
