### PR TITLE
Ensure meta is both at node top level and in node.config. Fix snapshots with schema config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## dbt-core 1.1.0 (TBD)
 
+## dbt-core 1.0.3 (TBD)
+
+### Fixes
+- Fix bug causing empty node level meta, snapshot config errors ([#4459](https://github.com/dbt-labs/dbt-core/issues/4459), [#4726](https://github.com/dbt-labs/dbt-core/pull/4726))
+
 ### Features
 - Added Support for Semantic Versioning ([#4644](https://github.com/dbt-labs/dbt-core/pull/4644))
 - New Dockerfile to support specific db adapters and platforms.  See docker/README.md for details ([#4495](https://github.com/dbt-labs/dbt-core/issues/4495), [#4487](https://github.com/dbt-labs/dbt-core/pull/4487))
@@ -36,7 +41,6 @@ Contributors:
 - Restore previous log level (DEBUG) when a test depends on a disabled resource. Still WARN if the resource is missing ([#4594](https://github.com/dbt-labs/dbt-core/issues/4594), [#4647](https://github.com/dbt-labs/dbt-core/pull/4647))
 - Add project name validation to `dbt init` ([#4490](https://github.com/dbt-labs/dbt-core/issues/4490),[#4536](https://github.com/dbt-labs/dbt-core/pull/4536))
 - Support click versions in the v7.x series ([#4681](https://github.com/dbt-labs/dbt-core/pull/4681))
-- Fix bug causing empty node level meta, snapshot config errors ([#4459](https://github.com/dbt-labs/dbt-core/issues/4459), [#4726](https://github.com/dbt-labs/dbt-core/pull/4726))
 
 Contributors:
 * [@amirkdv](https://github.com/amirkdv) ([#4536](https://github.com/dbt-labs/dbt-core/pull/4536))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Contributors:
 - Restore previous log level (DEBUG) when a test depends on a disabled resource. Still WARN if the resource is missing ([#4594](https://github.com/dbt-labs/dbt-core/issues/4594), [#4647](https://github.com/dbt-labs/dbt-core/pull/4647))
 - Add project name validation to `dbt init` ([#4490](https://github.com/dbt-labs/dbt-core/issues/4490),[#4536](https://github.com/dbt-labs/dbt-core/pull/4536))
 - Support click versions in the v7.x series ([#4681](https://github.com/dbt-labs/dbt-core/pull/4681))
+- Fix bug causing empty node level meta, snapshot config errors ([#4459](https://github.com/dbt-labs/dbt-core/issues/4459), [#4726](https://github.com/dbt-labs/dbt-core/pull/4726))
 
 Contributors:
 * [@amirkdv](https://github.com/amirkdv) ([#4536](https://github.com/dbt-labs/dbt-core/pull/4536))

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -157,7 +157,6 @@ class ParsedNodeMixins(dbtClassMixin):
         self.created_at = time.time()
         self.description = patch.description
         self.columns = patch.columns
-        self.meta = patch.meta
         self.docs = patch.docs
 
     def get_materialization(self):

--- a/core/dbt/parser/snapshots.py
+++ b/core/dbt/parser/snapshots.py
@@ -55,8 +55,14 @@ class SnapshotParser(SQLParser[IntermediateSnapshotNode, ParsedSnapshotNode]):
 
     def transform(self, node: IntermediateSnapshotNode) -> ParsedSnapshotNode:
         try:
+            # The config_call_dict is not serialized, because normally
+            # it is not needed after parsing. But since the snapshot node
+            # does this extra to_dict, save and restore it, to keep
+            # the model config when there is also schema config.
+            config_call_dict = node.config_call_dict
             dct = node.to_dict(omit_none=True)
             parsed_node = ParsedSnapshotNode.from_dict(dct)
+            parsed_node.config_call_dict = config_call_dict
             self.set_snapshot_attributes(parsed_node)
             return parsed_node
         except ValidationError as exc:

--- a/test/integration/004_simple_snapshot_tests/models/schema.yml
+++ b/test/integration/004_simple_snapshot_tests/models/schema.yml
@@ -3,3 +3,6 @@ snapshots:
   - name: snapshot_actual
     tests:
       - mutually_exclusive_ranges
+    config:
+      meta:
+        owner: 'a_owner'

--- a/test/integration/039_config_tests/test_configs_in_schema_files.py
+++ b/test/integration/039_config_tests/test_configs_in_schema_files.py
@@ -65,6 +65,9 @@ class TestSchemaFileConfigs(DBTIntegrationTest):
         manifest = get_manifest()
         model_id = 'model.test.model'
         model_node = manifest.nodes[model_id]
+        meta_expected = {'company': 'NuMade', 'project': 'test', 'team': 'Core Team', 'owner': 'Julie Smith', 'my_attr': 'TESTING'}
+        self.assertEqual(model_node.meta, meta_expected)
+        self.assertEqual(model_node.config.meta, meta_expected)
         model_tags = ['tag_1_in_model', 'tag_2_in_model', 'tag_in_project', 'tag_in_schema']
         model_node_tags = model_node.tags.copy()
         model_node_tags.sort()


### PR DESCRIPTION
resolves #4459, #4693

### Description

This fixes a bug in schema file config processing, where an empty meta overwrote the root level meta. It also fixes a bug in snapshot schema config handling, where the snapshot SQL file config was lost.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
