### PR TITLE
ignore markdown files for trim-trailing-whitespace hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,8 @@ repos:
   - id: check-json
   - id: end-of-file-fixer
   - id: trailing-whitespace
+    exclude_types:
+      - "markdown"
   - id: check-case-conflict
 - repo: https://github.com/psf/black
   rev: 21.12b0


### PR DESCRIPTION
No ticket.  
### Description
Quick fix since `.md` files actually need a trailing whitespace sometimes.
Allows the trim-trailing-whitespace hook to skip markdown files.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
