### PR TITLE
Pin `MarkupSafe==2.0.1`

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -52,6 +52,7 @@ setup(
     ],
     install_requires=[
         "Jinja2==2.11.3",
+        "MarkupSafe==2.0.1",
         "agate>=1.6,<1.6.4",
         "click>=7.0,<9",
         "colorama>=0.3.9,<0.4.5",


### PR DESCRIPTION
Resolves #4745

- This is a temporary measure that should enable installation from `main`
- Need to backport this to `1.0.latest` for inclusion in the next v1.0 patch (v1.0.2)
- Let's also discuss longer-term resolutions for v1.1+