### PR TITLE
Pin `MarkupSafe==2.0.1 (#4746)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@
 - Testing cleanup ([#4496](https://github.com/dbt-labs/dbt-core/pull/4496), [#4509](https://github.com/dbt-labs/dbt-core/pull/4509))
 - Clean up test deprecation warnings ([#3988](https://github.com/dbt-labs/dbt-core/issue/3988), [#4556](https://github.com/dbt-labs/dbt-core/pull/4556))
 
-## dbt-core 1.0.2 (TBD)
+## dbt-core 1.0.2 (Release TBD)
+
+### Dependencies
+- Pin `MarkupSafe==2.0.1`. Deprecation of `soft_unicode` in `MarkupSafe==2.1.0` is not supported by `Jinja2==2.11`
+
+## dbt-core 1.0.2rc1 (February 4, 2022)
 
 ### Fixes
 - Projects created using `dbt init` now have the correct `seeds` directory created (instead of `data`) ([#4588](https://github.com/dbt-labs/dbt-core/issues/4588), [#4599](https://github.com/dbt-labs/dbt-core/pull/4589))

--- a/core/setup.py
+++ b/core/setup.py
@@ -52,6 +52,7 @@ setup(
     ],
     install_requires=[
         'Jinja2==2.11.3',
+        'MarkupSafe==2.0.1',
         'agate>=1.6,<1.6.4',
         'click>=8,<9',
         'colorama>=0.3.9,<0.4.5',


### PR DESCRIPTION
Backport of #4746, for inclusion in v1.0.2 (final)