### PR TITLE
Fix bug accessing target in deps and clean commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 ## dbt-core 1.1.0 (TBD)
 
-## dbt-core 1.0.3 (TBD)
-
-### Fixes
-- Fix bug causing empty node level meta, snapshot config errors ([#4459](https://github.com/dbt-labs/dbt-core/issues/4459), [#4726](https://github.com/dbt-labs/dbt-core/pull/4726))
-
 ### Features
 - Added Support for Semantic Versioning ([#4644](https://github.com/dbt-labs/dbt-core/pull/4644))
 - New Dockerfile to support specific db adapters and platforms.  See docker/README.md for details ([#4495](https://github.com/dbt-labs/dbt-core/issues/4495), [#4487](https://github.com/dbt-labs/dbt-core/pull/4487))
@@ -30,6 +25,17 @@ Contributors:
 - [@alswang18](https://github.com/alswang18) ([#4644](https://github.com/dbt-labs/dbt-core/pull/4644))
 - [@emartens](https://github.com/ehmartens) ([#4701](https://github.com/dbt-labs/dbt-core/pull/4701))
 - [@mdesmet](https://github.com/mdesmet) ([#4604](https://github.com/dbt-labs/dbt-core/pull/4604))
+
+
+## dbt-core 1.0.4 (TBD)
+
+### Fixes
+- Fix bug causing empty node level meta, snapshot config errors ([#4459](https://github.com/dbt-labs/dbt-core/issues/4459), [#4726](https://github.com/dbt-labs/dbt-core/pull/4726))
+
+## dbt-core 1.0.3 (TBD)
+
+### Fixes
+- Fix bug accessing target fields in deps and clean commands ([#4752](https://github.com/dbt-labs/dbt-core/issues/4752), [#4758](https://github.com/dbt-labs/dbt-core/issues/4758))
 
 ## dbt-core 1.0.2 (TBD)
 

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -11,7 +11,7 @@ from .renderer import DbtProjectYamlRenderer, ProfileRenderer
 from .utils import parse_cli_vars
 from dbt import flags
 from dbt.adapters.factory import get_relation_class_by_name, get_include_paths
-from dbt.helper_types import FQNPath, PathSet
+from dbt.helper_types import FQNPath, PathSet, DictDefaultNone
 from dbt.config.profile import read_user_config
 from dbt.contracts.connection import AdapterRequiredConfig, Credentials
 from dbt.contracts.graph.manifest import ManifestMetadata
@@ -396,7 +396,7 @@ class UnsetProfile(Profile):
         self.threads = -1
 
     def to_target_dict(self):
-        return {}
+        return DictDefaultNone({})
 
     def __getattribute__(self, name):
         if name in {"profile_name", "target_name", "threads"}:
@@ -431,7 +431,7 @@ class UnsetProfileConfig(RuntimeConfig):
 
     def to_target_dict(self):
         # re-override the poisoned profile behavior
-        return {}
+        return DictDefaultNone({})
 
     @classmethod
     def from_parts(

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -11,7 +11,7 @@ from .renderer import DbtProjectYamlRenderer, ProfileRenderer
 from .utils import parse_cli_vars
 from dbt import flags
 from dbt.adapters.factory import get_relation_class_by_name, get_include_paths
-from dbt.helper_types import FQNPath, PathSet, DictDefaultNone
+from dbt.helper_types import FQNPath, PathSet, DictDefaultEmptyStr
 from dbt.config.profile import read_user_config
 from dbt.contracts.connection import AdapterRequiredConfig, Credentials
 from dbt.contracts.graph.manifest import ManifestMetadata
@@ -396,7 +396,7 @@ class UnsetProfile(Profile):
         self.threads = -1
 
     def to_target_dict(self):
-        return DictDefaultNone({})
+        return DictDefaultEmptyStr({})
 
     def __getattribute__(self, name):
         if name in {"profile_name", "target_name", "threads"}:
@@ -431,7 +431,7 @@ class UnsetProfileConfig(RuntimeConfig):
 
     def to_target_dict(self):
         # re-override the poisoned profile behavior
-        return DictDefaultNone({})
+        return DictDefaultEmptyStr({})
 
     @classmethod
     def from_parts(

--- a/core/dbt/helper_types.py
+++ b/core/dbt/helper_types.py
@@ -134,7 +134,7 @@ class Lazy(Generic[T]):
 
 
 # This class is used in to_target_dict, so that accesses to missing keys
-# will return None instead of Undefined
-class DictDefaultNone(dict):
+# will return an empty string instead of Undefined
+class DictDefaultEmptyStr(dict):
     def __getitem__(self, key):
-        return dict.get(self, key)
+        return dict.get(self, key, "")

--- a/core/dbt/helper_types.py
+++ b/core/dbt/helper_types.py
@@ -131,3 +131,10 @@ class Lazy(Generic[T]):
         if self.memo is None:
             self.memo = self._typed_eval_f()
         return self.memo
+
+
+# This class is used in to_target_dict, so that accesses to missing keys
+# will return None instead of Undefined
+class DictDefaultNone(dict):
+    def __getitem__(self, key):
+        return dict.get(self, key)

--- a/test/integration/006_simple_dependency_tests/test_simple_dependency.py
+++ b/test/integration/006_simple_dependency_tests/test_simple_dependency.py
@@ -257,6 +257,15 @@ class TestSimpleDependencyBadProfile(DBTIntegrationTest):
     def models(self):
         return "models"
 
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'models': {
+                '+any_config': "{{ target.name }}",
+            }
+        }
+
     def postgres_profile(self):
         # Need to set the environment variable here initially because
         # the unittest setup does a load_config.

--- a/test/integration/006_simple_dependency_tests/test_simple_dependency.py
+++ b/test/integration/006_simple_dependency_tests/test_simple_dependency.py
@@ -263,6 +263,7 @@ class TestSimpleDependencyBadProfile(DBTIntegrationTest):
             'config-version': 2,
             'models': {
                 '+any_config': "{{ target.name }}",
+                '+enabled': "{{ target.name in ['redshift', 'postgres'] | as_bool }}"
             }
         }
 


### PR DESCRIPTION
resolves #4752

### Description

After changes in #4610, direct access to target.<attribute> fails with cryptic message "cannot pickle undefined object", because an empty dictionary was returned for the target. This changes the behavior of deps and clean commands to return a dict subclass that returns None for attempts to access a dictionary key.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
