### PR TITLE
[Backport] Fix bug accessing target in deps and clean commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,7 @@
-## dbt-core 1.1.0 (TBD)
-
-### Features
-- New Dockerfile to support specific db adapters and platforms.  See docker/README.md for details ([#4495](https://github.com/dbt-labs/dbt-core/issues/4495), [#4487](https://github.com/dbt-labs/dbt-core/pull/4487))
+## dbt-core 1.0.3 (TBD)
 
 ### Fixes
-
-* Add project name validation to `dbt init` ([#4490](https://github.com/dbt-labs/dbt-core/issues/4490),[#4536](https://github.com/dbt-labs/dbt-core/pull/4536))
-
-### Under the hood
-- Testing cleanup ([#4496](https://github.com/dbt-labs/dbt-core/pull/4496), [#4509](https://github.com/dbt-labs/dbt-core/pull/4509))
-- Clean up test deprecation warnings ([#3988](https://github.com/dbt-labs/dbt-core/issue/3988), [#4556](https://github.com/dbt-labs/dbt-core/pull/4556))
+- Fix bug accessing target fields in deps and clean commands ([#4752](https://github.com/dbt-labs/dbt-core/issues/4752), [#4758](https://github.com/dbt-labs/dbt-core/issues/4758))
 
 ## dbt-core 1.0.2 (February 18, 2022)
 

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -14,7 +14,7 @@ from .renderer import DbtProjectYamlRenderer, ProfileRenderer
 from .utils import parse_cli_vars
 from dbt import flags
 from dbt.adapters.factory import get_relation_class_by_name, get_include_paths
-from dbt.helper_types import FQNPath, PathSet
+from dbt.helper_types import FQNPath, PathSet, DictDefaultNone
 from dbt.config.profile import read_user_config
 from dbt.contracts.connection import AdapterRequiredConfig, Credentials
 from dbt.contracts.graph.manifest import ManifestMetadata
@@ -421,7 +421,7 @@ class UnsetProfile(Profile):
         self.threads = -1
 
     def to_target_dict(self):
-        return {}
+        return DictDefaultNone({})
 
     def __getattribute__(self, name):
         if name in {'profile_name', 'target_name', 'threads'}:
@@ -460,7 +460,7 @@ class UnsetProfileConfig(RuntimeConfig):
 
     def to_target_dict(self):
         # re-override the poisoned profile behavior
-        return {}
+        return DictDefaultNone({})
 
     @classmethod
     def from_parts(

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -14,7 +14,7 @@ from .renderer import DbtProjectYamlRenderer, ProfileRenderer
 from .utils import parse_cli_vars
 from dbt import flags
 from dbt.adapters.factory import get_relation_class_by_name, get_include_paths
-from dbt.helper_types import FQNPath, PathSet, DictDefaultNone
+from dbt.helper_types import FQNPath, PathSet, DictDefaultEmptyStr
 from dbt.config.profile import read_user_config
 from dbt.contracts.connection import AdapterRequiredConfig, Credentials
 from dbt.contracts.graph.manifest import ManifestMetadata
@@ -421,7 +421,7 @@ class UnsetProfile(Profile):
         self.threads = -1
 
     def to_target_dict(self):
-        return DictDefaultNone({})
+        return DictDefaultEmptyStr({})
 
     def __getattribute__(self, name):
         if name in {'profile_name', 'target_name', 'threads'}:
@@ -460,7 +460,7 @@ class UnsetProfileConfig(RuntimeConfig):
 
     def to_target_dict(self):
         # re-override the poisoned profile behavior
-        return DictDefaultNone({})
+        return DictDefaultEmptyStr({})
 
     @classmethod
     def from_parts(

--- a/core/dbt/helper_types.py
+++ b/core/dbt/helper_types.py
@@ -96,7 +96,7 @@ PathSet = AbstractSet[FQNPath]
 
 
 # This class is used in to_target_dict, so that accesses to missing keys
-# will return None instead of Undefined
-class DictDefaultNone(dict):
+# will return an empty string instead of Undefined
+class DictDefaultEmptyStr(dict):
     def __getitem__(self, key):
-        return dict.get(self, key)
+        return dict.get(self, key, "")

--- a/core/dbt/helper_types.py
+++ b/core/dbt/helper_types.py
@@ -93,3 +93,10 @@ dbtClassMixin.register_field_encoders({
 
 FQNPath = Tuple[str, ...]
 PathSet = AbstractSet[FQNPath]
+
+
+# This class is used in to_target_dict, so that accesses to missing keys
+# will return None instead of Undefined
+class DictDefaultNone(dict):
+    def __getitem__(self, key):
+        return dict.get(self, key)

--- a/test/integration/006_simple_dependency_test/test_simple_dependency.py
+++ b/test/integration/006_simple_dependency_test/test_simple_dependency.py
@@ -257,6 +257,15 @@ class TestSimpleDependencyBadProfile(DBTIntegrationTest):
     def models(self):
         return "models"
 
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'models': {
+                '+any_config': "{{ target.name }}",
+            }
+        }
+
     def postgres_profile(self):
         # Need to set the environment variable here initially because
         # the unittest setup does a load_config.

--- a/test/integration/006_simple_dependency_test/test_simple_dependency.py
+++ b/test/integration/006_simple_dependency_test/test_simple_dependency.py
@@ -263,6 +263,7 @@ class TestSimpleDependencyBadProfile(DBTIntegrationTest):
             'config-version': 2,
             'models': {
                 '+any_config': "{{ target.name }}",
+                '+enabled': "{{ target.name in ['redshift', 'postgres'] | as_bool }}"
             }
         }
 


### PR DESCRIPTION
resolves #4752

Backport of #4758

### Description

Return empty string from target.<attribute> when running dbt deps and clean commands

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
