### PR TITLE
Fix "dbt found two resources" error with multiple snapshot blocks in one file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Contributors:
 ### Fixes
 - Fix bug causing empty node level meta, snapshot config errors ([#4459](https://github.com/dbt-labs/dbt-core/issues/4459), [#4726](https://github.com/dbt-labs/dbt-core/pull/4726))
 - Fix slow `dbt run` when using Postgres adapter, by deduplicating relations in `postgres_get_relations` ([#3058](https://github.com/dbt-labs/dbt-core/issues/3058), [#4521](https://github.com/dbt-labs/dbt-core/pull/4521))
+- Fix partial parsing bug with multiple snapshot blocks ([#4771](https//github.com/dbt-labs/dbt-core/issues/4772), [#4773](https://github.com/dbt-labs/dbt-core/pull/4773))
 
 ## dbt-core 1.0.3 (TBD)
 

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -291,10 +291,10 @@ class PartialParsing:
         if self.already_scheduled_for_parsing(old_source_file):
             return
 
-        # These files only have one node.
-        unique_id = None
+        # These files only have one node except for snapshots
+        unique_ids = []
         if old_source_file.nodes:
-            unique_id = old_source_file.nodes[0]
+            unique_ids = old_source_file.nodes
         else:
             # It's not clear when this would actually happen.
             # Logging in case there are other associated errors.
@@ -305,7 +305,7 @@ class PartialParsing:
         self.deleted_manifest.files[file_id] = old_source_file
         self.saved_files[file_id] = deepcopy(new_source_file)
         self.add_to_pp_files(new_source_file)
-        if unique_id:
+        for unique_id in unique_ids:
             self.remove_node_in_saved(new_source_file, unique_id)
 
     def remove_node_in_saved(self, source_file, unique_id):
@@ -379,7 +379,7 @@ class PartialParsing:
         if not source_file.nodes:
             fire_event(PartialParsingMissingNodes(file_id=source_file.file_id))
             return
-        # There is generally only 1 node for SQL files, except for macros
+        # There is generally only 1 node for SQL files, except for macros and snapshots
         for unique_id in source_file.nodes:
             self.remove_node_in_saved(source_file, unique_id)
             self.schedule_referencing_nodes_for_parsing(unique_id)

--- a/test/integration/068_partial_parsing_tests/test-files/snapshot.sql
+++ b/test/integration/068_partial_parsing_tests/test-files/snapshot.sql
@@ -13,3 +13,17 @@ select * from {{ ref('orders') }}
 
 {% endsnapshot %}
 
+{% snapshot orders2_snapshot %}
+
+{{
+    config(
+      target_schema=schema,
+      strategy='check',
+      unique_key='id',
+      check_cols=['order_date'],
+    )
+}}
+
+select * from {{ ref('orders') }}
+
+{% endsnapshot %}

--- a/test/integration/068_partial_parsing_tests/test-files/snapshot2.sql
+++ b/test/integration/068_partial_parsing_tests/test-files/snapshot2.sql
@@ -1,3 +1,4 @@
+- add a comment
 {% snapshot orders_snapshot %}
 
 {{
@@ -8,7 +9,22 @@
       check_cols=['status'],
     )
 }}
+
 select * from {{ ref('orders') }}
 
 {% endsnapshot %}
 
+{% snapshot orders2_snapshot %}
+
+{{
+    config(
+      target_schema=schema,
+      strategy='check',
+      unique_key='id',
+      check_cols=['order_date'],
+    )
+}}
+
+select * from {{ ref('orders') }}
+
+{% endsnapshot %}

--- a/test/integration/068_partial_parsing_tests/test_partial_parsing.py
+++ b/test/integration/068_partial_parsing_tests/test_partial_parsing.py
@@ -503,10 +503,12 @@ class TestSnapshots(BasePPTest):
         manifest = get_manifest()
         snapshot_id = 'snapshot.test.orders_snapshot'
         self.assertIn(snapshot_id, manifest.nodes)
+        snapshot2_id = 'snapshot.test.orders2_snapshot'
+        self.assertIn(snapshot2_id, manifest.nodes)
 
         # run snapshot
         results = self.run_dbt(["--partial-parse", "snapshot"])
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 2)
 
         # modify snapshot
         self.copy_file('test-files/snapshot2.sql', 'snapshots/snapshot.sql')


### PR DESCRIPTION
resolves #4771

### Description

Loop through nodes when processing mssat files, instead of assuming that there is only one.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
