### PR TITLE
update flake8 to remove line length req

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,5 +8,5 @@ ignore =
     W504
     E203 # makes Flake8 work like black
     E741
-max-line-length = 140
+    E501 # long line checking is done in black
 exclude = test


### PR DESCRIPTION
No ticket, fix bug in flake8 + black setup regarding line length.  Now we just let black deal with long lines and ignore them for flake8.
### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
