### PR TITLE
Fix stdout piped colored output on MacOS and Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Contributors:
 - Fix bug causing empty node level meta, snapshot config errors ([#4459](https://github.com/dbt-labs/dbt-core/issues/4459), [#4726](https://github.com/dbt-labs/dbt-core/pull/4726))
 - Fix slow `dbt run` when using Postgres adapter, by deduplicating relations in `postgres_get_relations` ([#3058](https://github.com/dbt-labs/dbt-core/issues/3058), [#4521](https://github.com/dbt-labs/dbt-core/pull/4521))
 - Fix partial parsing bug with multiple snapshot blocks ([#4771](https//github.com/dbt-labs/dbt-core/issues/4772), [#4773](https://github.com/dbt-labs/dbt-core/pull/4773))
+- Fix lack of color output on Linux and MacOS when piping the output into another process using the shell pipe (`|`) [#4792](https://github.com/dbt-labs/dbt-core/pull/4792)
 
 ## dbt-core 1.0.3 (TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Contributors:
 - Fix partial parsing bug with multiple snapshot blocks ([#4771](https//github.com/dbt-labs/dbt-core/issues/4772), [#4773](https://github.com/dbt-labs/dbt-core/pull/4773))
 - Fix lack of color output on Linux and MacOS when piping the output into another process using the shell pipe (`|`) [#4792](https://github.com/dbt-labs/dbt-core/pull/4792)
 
+Contributors:
+- [@varun-dc ](https://github.com/varun-dc) ([#4792](https://github.com/dbt-labs/dbt-core/pull/4792))
+
 ## dbt-core 1.0.3 (TBD)
 
 ### Fixes

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -55,19 +55,8 @@ invocation_id: Optional[str] = None
 # then we should override the logging stream to use the colorama
 # converter. If the TERM var is set (as with Git Bash), then it's safe
 # to send escape characters and no log handler injection is needed.
-colorama_stdout = sys.stdout
-colorama_wrap = True
-
-colorama.init(wrap=colorama_wrap)
-
-if sys.platform == "win32" and not os.getenv("TERM"):
-    colorama_wrap = False
-    colorama_stdout = colorama.AnsiToWin32(sys.stdout).stream
-
-elif sys.platform == "win32":
-    colorama_wrap = False
-
-colorama.init(wrap=colorama_wrap)
+if sys.platform == "win32":
+    colorama.init(wrap=False)
 
 
 def setup_event_logger(log_path, level_override=None):

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -20,20 +20,11 @@ from dbt.dataclass_schema import dbtClassMixin
 # then we should override the logging stream to use the colorama
 # converter. If the TERM var is set (as with Git Bash), then it's safe
 # to send escape characters and no log handler injection is needed.
-colorama_stdout = sys.stdout
-colorama_wrap = True
-
-colorama.init(wrap=colorama_wrap)
-
-
-if sys.platform == "win32" and not os.getenv("TERM"):
-    colorama_wrap = False
-    colorama_stdout = colorama.AnsiToWin32(sys.stdout).stream
-
-elif sys.platform == "win32":
-    colorama_wrap = False
-
-colorama.init(wrap=colorama_wrap)
+logging_stdout = sys.stdout
+if sys.platform == "win32":
+    if not os.getenv("TERM"):
+        logging_stdout = colorama.AnsiToWin32(sys.stdout).stream
+    colorama.init(wrap=False)
 
 
 STDOUT_LOG_FORMAT = "{record.message}"
@@ -464,7 +455,7 @@ class DelayedFileHandler(logbook.RotatingFileHandler, FormatterMixin):
 
 
 class LogManager(logbook.NestedSetup):
-    def __init__(self, stdout=colorama_stdout, stderr=sys.stderr):
+    def __init__(self, stdout=logging_stdout, stderr=sys.stderr):
         self.stdout = stdout
         self.stderr = stderr
         self._null_handler = logbook.NullHandler()


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/4790

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

Prevent modifcation of stdout stream if the platform is not Windows. This ensures ANSI color codes in the output stream are correctly output to the stdout stream on Linux and MacOS. On Windows I noticed no difference, i.e. the code changes here seems to have no behavioral changes on Windows.

I'm not too familiar with the entirety of the dbt codebase nor the colorama codebase. But debugging the code, I noticed the stdout stream was a colorama object, not a the standard Python stdout stream. Which lead me to the code changes I've touched in this PR.

Regarding Windows, as I mentioned the behavior has not changed. But on Linux and MacOS, I'm seeing color output when I pipe and don't pipe out the stdout stream to another process (`dbt run` and `dbt run | cat`). This was the behavior previous; previous to this PR https://github.com/dbt-labs/dbt-core/pull/4474 I believe. On Windows, both `dbt run` and `dbt run | out-host -paging` (the equivalent of `| cat` afaik) behavior do the same thing as before (color output and no color output respectively). I'm not sure how to fix this on Windows.

To test this, I wasn't able to install my forked version using `pip install git+https://github.com/varun-dc/dbt-core@<branch name>`. So I instead modified the virtualenv pip installed copy locally to verify these changes. You can see the output of running `dbt run` and `dbt run | cat` here,
<img width="834" alt="Screen Shot 2022-02-25 at 1 47 43 PM" src="https://user-images.githubusercontent.com/91232924/155774004-3ed9802e-cf04-4e8d-89e7-952e30d1c328.png">

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist (**TODO**)

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change
