### PR TITLE
Clarify steps to reopen a stale issue

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           stale-issue-message: "This issue has been marked as Stale because it has been open for 180 days with no activity. If you would like the issue to remain open, please remove the stale label or comment on the issue, or it will be closed in 7 days."
           stale-pr-message: "This PR has been marked as Stale because it has been open for 180 days with no activity. If you would like the PR to remain open, please remove the stale label or comment on the PR, or it will be closed in 7 days."
+          close-issue-message: "Although we are closing this issue as stale, it's not gone forever. Issues can be reopened if there is renewed community interest; add a comment to notify the maintainers."
           # mark issues/PRs stale when they haven't seen activity in 180 days
           days-before-stale: 180
           # ignore checking issues with the following labels


### PR DESCRIPTION
resolves [early morning Slack conversation](https://dbt-labs.slack.com/archives/C0131TY7EEA/p1645626917731989?thread_ts=1645581600.999489)

### Description

I thought that stale issues could be reopened by anyone; turns out that's just because I'm in the dbt Labs GitHub org. This PR adds a comment when an issue is closed for staleness, explaining that it's not forever and what to do if someone wants to bring it back. 

It assumes that someone is subscribed to the firehose of events (currently true) and sees the comment requesting more attention. If that changes in the future, maybe we need the "re-open bot" that @jtcohen6 described to @ a member of the Core team, round-robin style.

I haven't added a message for stale PRs because they're likely to only impact the opening user (who I assume can reopen their own PR) and they're less of a problem. Happy to add that in as well, as well as to take feedback on the specific phrasing.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
~I have updated the `CHANGELOG.md` and added information about my change~
