### PR TITLE
Add bugged version tag value to finds.

### DIFF
--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -966,11 +966,11 @@ def raise_duplicate_source_patch_name(patch_1, patch_2):
     )
 
 
-def raise_invalid_schema_yml_version(path, issue):
+def raise_invalid_property_yml_version(path, issue):
     raise_compiler_error(
-        "The schema file at {} is invalid because {}. Please consult the "
-        "documentation for more information on schema.yml syntax:\n\n"
-        "https://docs.getdbt.com/docs/schemayml-files".format(path, issue)
+        "The yml property file at {} is invalid because {}. Please consult the "
+        "documentation for more information on yml property file syntax:\n\n"
+        "https://docs.getdbt.com/reference/configs-and-properties".format(path, issue)
     )
 
 
@@ -1048,7 +1048,7 @@ CONTEXT_EXPORTS = {
         raise_dependency_error,
         raise_duplicate_patch_name,
         raise_duplicate_resource_name,
-        raise_invalid_schema_yml_version,
+        raise_invalid_property_yml_version,
         raise_not_implemented,
         relation_wrong_type,
     ]

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -547,18 +547,22 @@ class SchemaParser(SimpleParser[GenericTestBlock, ParsedGenericTestNode]):
 
 def check_format_version(file_path, yaml_dct) -> None:
     if "version" not in yaml_dct:
-        raise_invalid_property_yml_version(file_path, "no version is specified")
+        raise_invalid_property_yml_version(
+            file_path,
+            "the yml property file {} is missing a version tag".format(file_path)
+        )
 
     version = yaml_dct["version"]
     # if it's not an integer, the version is malformed, or not
     # set. Either way, only 'version: 2' is supported.
     if not isinstance(version, int):
         raise_invalid_property_yml_version(
-            file_path, "the version must be an integer. {} is not an integer".format(version)
+            file_path,
+            "its 'version:' tag must be an integer value. {} is not an integer".format(version)
         )
     if version != 2:
         raise_invalid_property_yml_version(
-            file_path, "version {} is unsupported for property files".format(version)
+            file_path, "its 'version:' tag is set to {}. Only 2 is supported".format(version)
         )
 
 

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -557,7 +557,8 @@ def check_format_version(file_path, yaml_dct) -> None:
     if not isinstance(version, int):
         raise_invalid_property_yml_version(
             file_path,
-            "its 'version:' tag must be an integer value. {} is not an integer".format(version),
+            "its 'version:' tag must be an integer (e.g. version: 2)."
+            " {} is not an integer".format(version),
         )
     if version != 2:
         raise_invalid_property_yml_version(

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -548,8 +548,7 @@ class SchemaParser(SimpleParser[GenericTestBlock, ParsedGenericTestNode]):
 def check_format_version(file_path, yaml_dct) -> None:
     if "version" not in yaml_dct:
         raise_invalid_property_yml_version(
-            file_path,
-            "the yml property file {} is missing a version tag".format(file_path)
+            file_path, "the yml property file {} is missing a version tag".format(file_path)
         )
 
     version = yaml_dct["version"]
@@ -558,11 +557,11 @@ def check_format_version(file_path, yaml_dct) -> None:
     if not isinstance(version, int):
         raise_invalid_property_yml_version(
             file_path,
-            "its 'version:' tag must be an integer value. {} is not an integer".format(version)
+            "its 'version:' tag must be an integer value. {} is not an integer".format(version),
         )
     if version != 2:
         raise_invalid_property_yml_version(
-            file_path, "its 'version:' tag is set to {}. Only 2 is supported".format(version)
+            file_path, "its 'version:' tag is set to {}.  Only 2 is supported".format(version)
         )
 
 

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -49,7 +49,7 @@ from dbt.exceptions import (
     warn_invalid_patch,
     validator_error_message,
     JSONValidationException,
-    raise_invalid_schema_yml_version,
+    raise_invalid_property_yml_version,
     ValidationException,
     ParsingException,
     raise_duplicate_patch_name,
@@ -94,7 +94,10 @@ schema_file_keys = (
 
 
 def error_context(
-    path: str, key: str, data: Any, cause: Union[str, ValidationException, JSONValidationException]
+    path: str,
+    key: str,
+    data: Any,
+    cause: Union[str, ValidationException, JSONValidationException],
 ) -> str:
     """Provide contextual information about an error while parsing"""
     if isinstance(cause, str):
@@ -544,15 +547,19 @@ class SchemaParser(SimpleParser[GenericTestBlock, ParsedGenericTestNode]):
 
 def check_format_version(file_path, yaml_dct) -> None:
     if "version" not in yaml_dct:
-        raise_invalid_schema_yml_version(file_path, "no version is specified")
+        raise_invalid_property_yml_version(file_path, "no version is specified")
 
     version = yaml_dct["version"]
     # if it's not an integer, the version is malformed, or not
     # set. Either way, only 'version: 2' is supported.
     if not isinstance(version, int):
-        raise_invalid_schema_yml_version(file_path, "the version is not an integer")
+        raise_invalid_property_yml_version(
+            file_path, "the version must be an integer. {} is not an integer".format(version)
+        )
     if version != 2:
-        raise_invalid_schema_yml_version(file_path, "version {} is not supported".format(version))
+        raise_invalid_property_yml_version(
+            file_path, "version {} is unsupported for property files".format(version)
+        )
 
 
 Parsed = TypeVar("Parsed", UnpatchedSourceDefinition, ParsedNodePatch, ParsedMacroPatch)


### PR DESCRIPTION
## What's this?

A small change to an exception raised during yml property file parsing.

For a before-after demonstration, I put a value '2.0' for the `version:` tag in a property value.

Before: 
<img width="563" alt="image" src="https://user-images.githubusercontent.com/67295367/156459385-31e0d6ae-69a1-4acf-81cc-0a41224ecc23.png">
After: 
<img width="570" alt="image" src="https://user-images.githubusercontent.com/67295367/156491027-96e9c0ab-5ed1-4407-9d08-f39be8361398.png">

I'm not married to the wording here, but I thought verbosity was better since the definition of "version" is very cloudy to users.

## Why this?

From question threads in the dbt Slack. Here's two of many: https://getdbt.slack.com/archives/CBSQTAPLG/p1646223161801819

Users are running into issues with the `version:` tag in property files. The way docs and `dbt init` is setup seems to be confusing some to think `1.0` is the property value everywhere. This is partially because `config-version` and `version` tags; this triggers a hard to debug issue when users copy the `version:` tag from their dbt_project.yml which is a semantic version tag. `config-vers. They're having trouble locating the field causing the error. To recreate the issue:
1. have a property file
2. make version something other than an integer.

The error message without the tag ends up having users kind of guess what's wrong when we could very easily provide clearer guidance by including the value. I don't think much else is needed here, although this will extend into a dbt docs PR, sounds like. Even though we give the filepath in the bug, some users seem to think this means the version in `dbt_project.yml` or somesuch. Or they end up guessing what they need to fix.

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change
