### PR TITLE
get_response type hint is AdapterResponse only.

### DIFF
--- a/.changes/unreleased/Breaking Changes-20220316-031311.yaml
+++ b/.changes/unreleased/Breaking Changes-20220316-031311.yaml
@@ -1,5 +1,5 @@
 kind: Breaking Changes
-body: get_response now only returns a connection.AdapterReponse in type hints
+body: get_response and execute now only return a connection.AdapterReponse in type hints
 time: 2022-03-16T03:13:11.656007-07:00
 custom:
   Author: versusfacit

--- a/.changes/unreleased/Breaking Changes-20220316-031311.yaml
+++ b/.changes/unreleased/Breaking Changes-20220316-031311.yaml
@@ -1,0 +1,7 @@
+kind: Breaking Changes
+body: get_response now only returns a connection.AdapterReponse in type hints
+time: 2022-03-16T03:13:11.656007-07:00
+custom:
+  Author: versusfacit
+  Issue: "4499"
+  PR: "4869"

--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -281,15 +281,15 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def execute(
         self, sql: str, auto_begin: bool = False, fetch: bool = False
-    ) -> Tuple[Union[str, AdapterResponse], agate.Table]:
+    ) -> Tuple[AdapterResponse, agate.Table]:
         """Execute the given SQL.
 
         :param str sql: The sql to execute.
         :param bool auto_begin: If set, and dbt is not currently inside a
             transaction, automatically begin one.
         :param bool fetch: If set, fetch results.
-        :return: A tuple of the status and the results (empty if fetch=False).
-        :rtype: Tuple[Union[str, AdapterResponse], agate.Table]
+        :return: A tuple of the query status and results (empty if fetch=False).
+        :rtype: Tuple[AdapterResponse, agate.Table]
         """
         raise dbt.exceptions.NotImplementedException(
             "`execute` is not implemented for this adapter!"

--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -4,7 +4,7 @@ import os
 # multiprocessing.RLock is a function returning this type
 from multiprocessing.synchronize import RLock
 from threading import get_ident
-from typing import Dict, Tuple, Hashable, Optional, ContextManager, List, Union
+from typing import Dict, Tuple, Hashable, Optional, ContextManager, List
 
 import agate
 

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -221,7 +221,7 @@ class BaseAdapter(metaclass=AdapterMeta):
     @available.parse(lambda *a, **k: ("", empty_table()))
     def execute(
         self, sql: str, auto_begin: bool = False, fetch: bool = False
-    ) -> Tuple[Union[str, AdapterResponse], agate.Table]:
+    ) -> Tuple[AdapterResponse, agate.Table]:
         """Execute the given SQL. This is a thin wrapper around
         ConnectionManager.execute.
 
@@ -229,8 +229,8 @@ class BaseAdapter(metaclass=AdapterMeta):
         :param bool auto_begin: If set, and dbt is not currently inside a
             transaction, automatically begin one.
         :param bool fetch: If set, fetch results.
-        :return: A tuple of the status and the results (empty if fetch=False).
-        :rtype: Tuple[Union[str, AdapterResponse], agate.Table]
+        :return: A tuple of the query status and results (empty if fetch=False).
+        :rtype: Tuple[AdapterResponse, agate.Table]
         """
         return self.connections.execute(sql=sql, auto_begin=auto_begin, fetch=fetch)
 

--- a/core/dbt/adapters/protocol.py
+++ b/core/dbt/adapters/protocol.py
@@ -155,7 +155,7 @@ class AdapterProtocol(  # type: ignore[misc]
 
     def execute(
         self, sql: str, auto_begin: bool = False, fetch: bool = False
-    ) -> Tuple[Union[str, AdapterResponse], agate.Table]:
+    ) -> Tuple[AdapterResponse, agate.Table]:
         ...
 
     def get_compiler(self) -> Compiler_T:

--- a/core/dbt/adapters/sql/connections.py
+++ b/core/dbt/adapters/sql/connections.py
@@ -78,7 +78,7 @@ class SQLConnectionManager(BaseConnectionManager):
             return connection, cursor
 
     @abc.abstractclassmethod
-    def get_response(cls, cursor: Any) -> Union[AdapterResponse, str]:
+    def get_response(cls, cursor: Any) -> AdapterResponse:
         """Get the status of the cursor."""
         raise dbt.exceptions.NotImplementedException(
             "`get_response` is not implemented for this adapter!"

--- a/core/dbt/adapters/sql/connections.py
+++ b/core/dbt/adapters/sql/connections.py
@@ -117,7 +117,7 @@ class SQLConnectionManager(BaseConnectionManager):
 
     def execute(
         self, sql: str, auto_begin: bool = False, fetch: bool = False
-    ) -> Tuple[Union[AdapterResponse, str], agate.Table]:
+    ) -> Tuple[AdapterResponse, agate.Table]:
         sql = self._add_query_comment(sql)
         _, cursor = self.add_query(sql, auto_begin)
         response = self.get_response(cursor)

--- a/core/dbt/adapters/sql/connections.py
+++ b/core/dbt/adapters/sql/connections.py
@@ -1,6 +1,6 @@
 import abc
 import time
-from typing import List, Optional, Tuple, Any, Iterable, Dict, Union
+from typing import List, Optional, Tuple, Any, Iterable, Dict
 
 import agate
 


### PR DESCRIPTION
resolves #4499 

A low-code PR which sets the intention for adapter method return types: Remove type `str` from return type hint's of `get_response`. Optionally, remove type `str` from return type hint's of `execute` method too!

### Description

We have two options to merge this PR. Choose your adventure 🗺️ :
1. only the first commit, which touches only `SQLConnectionManager.get_response` as mentioned in original ticket
2. the entire PR which changes the type signature of the `BaseConnectionManager.execute ... -> Union[str, AdapterResponse]` to mixin `get_response` changes

See Appendix for why we should do option `2`. Do share your opinion.
I surveyed Postgres, Redshift (inherits from Postgres), Snowflake (uses AdapterResponse), and Spark (uses AdapterResponse), this won't break dbt-labs adapters. 

This is a breaking change (in the spec) for anyone who continues to use `str`.

The issue asks to enforce this type, but Python is dynamic so all we can do is strongly suggest via those type hints. Plus, it's the Pythonic thing to trust the implementor after all.

### Appendix. Why should we merge changes to `BaseConnectionManager.execute` too?

Good question! By altering the spec for `get_response`, `execute` no longer needs this as a return type. It has this signature because it (historically) returns the response of `get_response` which will soon be changed. An adapter may bypass `get_response` and instead just implement over `BaseConnectionManager` ([Bigquery does this](https://github.com/dbt-labs/dbt-bigquery/blob/a426d3aaee7cb2b642fc0cbfe421d785c67529e3/dbt/adapters/bigquery/connections.py#L162)).

In a way, I'd argue, to truly change the underlying spec-question this issue seeks to address, we must also change execute.

For sanity's sake, I researched our adapters and confirmed that changing execute won't break our current repos:
▶️  dbt-core/core/dbt/adapters/base/connections.py:282 [`execute` abstract interface method]
✅  [Postgres](https://github.com/dbt-labs/dbt-core/blob/15077d087c04006f5f0a4351773c06022ce2a08d/core/dbt/adapters/sql/connections.py#L118): uses `PostgresConnectionManager` which inherits from `BaseConnectionManager`
✅ [Redshift](https://github.com/dbt-labs/dbt-redshift/blob/4b81b0be700e926faba4963388d00c232d6493fe/dbt/adapters/redshift/connections.py#L70): uses `PostgresConnectionManager` with no `execute` override
✅ [Snowflake](https://github.com/dbt-labs/dbt-snowflake/blob/032d2bb9203ee42b0863ee964162d97d1c0a51a0/dbt/adapters/snowflake/connections.py#L205): inherits from `SQLConnectionManager` with no override
✅ [Spark](https://github.com/dbt-labs/dbt-spark/blob/d7f1d38d0dcf272dc0e513db4eeada0c08c407f5/dbt/adapters/spark/connections.py#L277): inherits from `SQLConnectionManager` with no override
✅ [Bigquery](https://github.com/dbt-labs/dbt-bigquery/blob/a426d3aaee7cb2b642fc0cbfe421d785c67529e3/dbt/adapters/bigquery/connections.py#L405): implements its own `execute` which returns `AdapterResponse`, not a `Union`

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
