### PR TITLE
FEAT: new columns in snapshots for adapters w/o bools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Add deps module README ([#4686](https://github.com/dbt-labs/dbt-core/pull/4686/))
 - Initial conversion of tests to pytest ([#4690](https://github.com/dbt-labs/dbt-core/issues/4690), [#4691](https://github.com/dbt-labs/dbt-core/pull/4691))
 - Fix errors in Windows for tests/functions ([#4781](https://github.com/dbt-labs/dbt-core/issues/4781), [#4767](https://github.com/dbt-labs/dbt-core/pull/4767))
+- Enable more dialects to snapshot sources with added columns, even those that don't support boolean datatypes ([#4489](https://github.com/dbt-labs/dbt-core/pull/4489))
 
 Contributors:
 - [@NiallRees](https://github.com/NiallRees) ([#4447](https://github.com/dbt-labs/dbt-core/pull/4447))

--- a/core/dbt/include/global_project/macros/materializations/snapshots/helpers.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshots/helpers.sql
@@ -22,6 +22,13 @@
     {# no-op #}
 {% endmacro %}
 
+{% macro get_true_sql() %}
+  {{ adapter.dispatch('get_true_sql', 'dbt')() }}
+{% endmacro %}
+
+{% macro default__get_true_sql() %}
+    {{ return('TRUE') }}
+{% endmacro %}
 
 {% macro snapshot_staging_table(strategy, source_sql, target_relation) -%}
   {{ adapter.dispatch('snapshot_staging_table', 'dbt')(strategy, source_sql, target_relation) }}

--- a/core/dbt/include/global_project/macros/materializations/snapshots/strategies.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshots/strategies.sql
@@ -157,7 +157,7 @@
     {%- set row_changed_expr -%}
     (
     {%- if column_added -%}
-        TRUE
+        {{ get_true_sql() }}
     {%- else -%}
     {%- for col in check_cols -%}
         {{ snapshotted_rel }}.{{ col }} != {{ current_rel }}.{{ col }}


### PR DESCRIPTION
resolves #4489


### Description
creates a new macro get_true_sql(), that can be dispatched so as to avoid the issue described in https://github.com/dbt-labs/dbt-core/issues/4488

-- Author @dataders 

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
