### PR TITLE
Use cli_vars instead of context to create package and selector renderers

### DIFF
--- a/.changes/unreleased/Fixes-20220316-155420.yaml
+++ b/.changes/unreleased/Fixes-20220316-155420.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Use cli_vars instead of context to create package and selector renderers
+time: 2022-03-16T15:54:20.608384-04:00
+custom:
+  Author: gshank
+  Issue: "4876"
+  PR: "4878"

--- a/core/dbt/config/renderer.py
+++ b/core/dbt/config/renderer.py
@@ -115,10 +115,10 @@ class DbtProjectYamlRenderer(BaseRenderer):
         "Project config"
 
     def get_package_renderer(self) -> BaseRenderer:
-        return PackageRenderer(self.context)
+        return PackageRenderer(self.ctx_obj.cli_vars)
 
     def get_selector_renderer(self) -> BaseRenderer:
-        return SelectorRenderer(self.context)
+        return SelectorRenderer(self.ctx_obj.cli_vars)
 
     def render_project(
         self,


### PR DESCRIPTION

resolves #4876

### Description

Fix errors rendering vars in packages.yml and selectors.yml.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
