### PR TITLE
fix printer task logic for warnings

### DIFF
--- a/.changes/unreleased/Fixes-20220316-174940.yaml
+++ b/.changes/unreleased/Fixes-20220316-174940.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: 'dbt tests with a set severity level of warn may still trigger error level log
+  events '
+time: 2022-03-16T17:49:40.236594-05:00
+custom:
+  Author: iknox-fa
+  Issue: "4814"
+  PR: "4883"

--- a/core/dbt/task/printer.py
+++ b/core/dbt/task/printer.py
@@ -98,10 +98,10 @@ def print_run_result_error(result, newline: bool = True, is_warning: bool = Fals
                 )
             )
 
-        if result.message and not is_warning:
-            fire_event(RunResultError(msg=result.message))
-        else:
-            fire_event(RunResultErrorNoMessage(status=result.status))
+            if result.message:
+                fire_event(RunResultError(msg=result.message))
+            else:
+                fire_event(RunResultErrorNoMessage(status=result.status))
 
         if result.node.build_path is not None:
             with TextOnly():

--- a/core/dbt/task/printer.py
+++ b/core/dbt/task/printer.py
@@ -98,7 +98,7 @@ def print_run_result_error(result, newline: bool = True, is_warning: bool = Fals
                 )
             )
 
-        if result.message:
+        if result.message and not is_warning:
             fire_event(RunResultError(msg=result.message))
         else:
             fire_event(RunResultErrorNoMessage(status=result.status))
@@ -145,7 +145,6 @@ def print_run_end_messages(results, keyboard_interrupt: bool = False) -> None:
                 keyboard_interrupt=keyboard_interrupt,
             )
         )
-
         for error in errors:
             print_run_result_error(error, is_warning=False)
 

--- a/core/dbt/task/printer.py
+++ b/core/dbt/task/printer.py
@@ -145,6 +145,7 @@ def print_run_end_messages(results, keyboard_interrupt: bool = False) -> None:
                 keyboard_interrupt=keyboard_interrupt,
             )
         )
+
         for error in errors:
             print_run_result_error(error, is_warning=False)
 


### PR DESCRIPTION
Resolves #4814 and CT-316
### Description
TL;DR-- When a dbt test has a severity level explicitly set to warn it may still trigger an error (the default) if it also contains a message

See 4814 for further details
### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
