### PR TITLE
[HOTFIX] update dbt-extractor dependency

### DIFF
--- a/.changes/unreleased/Fixes-20220317-132418.yaml
+++ b/.changes/unreleased/Fixes-20220317-132418.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: depend on new dbt-extractor version with fixed github links
+time: 2022-03-17T13:24:18.419599-04:00
+custom:
+  Author: nathaniel-may
+  Issue: "4891"
+  PR: "4890"

--- a/core/setup.py
+++ b/core/setup.py
@@ -64,7 +64,7 @@ setup(
         "networkx>=2.3,<3",
         "packaging>=20.9,<22.0",
         "sqlparse>=0.2.3,<0.5",
-        "dbt-extractor==0.4.0",
+        "dbt-extractor~=0.4.1",
         "typing-extensions>=3.7.4,<4.2",
         "werkzeug>=1,<3",
         # the following are all to match snowflake-connector-python


### PR DESCRIPTION
resolves #4891

### Description

Github security rules changed over and the published version of the dbt extractor used a github link to resolve its dependency on tree-sitter-jinja2 that is causing it to fail for installations from source mainly affecting homebrew users. This in conjunction with the new release of dbt-extractor will fix the issue.

This must be backported to 1.0.latest and released to resolve the issue.