### PR TITLE
remove missing setup.py file (holdover from pip install dbt

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -24,8 +24,6 @@ values =
 [bumpversion:part:pre]
 first_value = 1
 
-[bumpversion:file:setup.py]
-
 [bumpversion:file:core/setup.py]
 
 [bumpversion:file:core/dbt/version.py]

--- a/.changes/unreleased/Fixes-20220317-163051.yaml
+++ b/.changes/unreleased/Fixes-20220317-163051.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Update bumpervsion config to stop looking for missing setup.py
+time: 2022-03-17T16:30:51.299919-05:00
+custom:
+  Author: iknox-fa
+  Issue: "-1"
+  PR: "4896"


### PR DESCRIPTION
resolves:  No ticket

### Description
Updates bumpversion.cfg to reflect removal of root dir setup.py, which was a holdover from `pip install dbt`

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
