### PR TITLE
Custom names for generic tests

### DIFF
--- a/.changes/unreleased/Features-20220318-085756.yaml
+++ b/.changes/unreleased/Features-20220318-085756.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Support custom names for generic tests
+time: 2022-03-18T08:57:56.05584+01:00
+custom:
+  Author: jtcohen6
+  Issue: "3348"
+  PR: "4898"

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -838,31 +838,46 @@ def raise_duplicate_macro_name(node_1, node_2, namespace) -> NoReturn:
 
 def raise_duplicate_resource_name(node_1, node_2):
     duped_name = node_1.name
+    node_type = NodeType(node_1.resource_type)
+    pluralized = (
+        node_type.pluralize()
+        if node_1.resource_type == node_2.resource_type
+        else "resources"  # still raise if ref() collision, e.g. model + seed
+    )
 
-    if node_1.resource_type in NodeType.refable():
-        get_func = 'ref("{}")'.format(duped_name)
-    elif node_1.resource_type == NodeType.Source:
+    action = "looking for"
+    # duplicate 'ref' targets
+    if node_type in NodeType.refable():
+        formatted_name = f'ref("{duped_name}")'
+    # duplicate sources
+    elif node_type == NodeType.Source:
         duped_name = node_1.get_full_source_name()
-        get_func = node_1.get_source_representation()
-    elif node_1.resource_type == NodeType.Documentation:
-        get_func = 'doc("{}")'.format(duped_name)
-    elif node_1.resource_type == NodeType.Test and "schema" in node_1.tags:
-        return
+        formatted_name = node_1.get_source_representation()
+    # duplicate docs blocks
+    elif node_type == NodeType.Documentation:
+        formatted_name = f'doc("{duped_name}")'
+    # duplicate generic tests
+    elif node_type == NodeType.Test and hasattr(node_1, "test_metadata"):
+        column_name = f'column "{node_1.column_name}" in ' if node_1.column_name else ""
+        # TODO: we need a better way of storing the target model/source/etc in generic tests
+        model_name = ".".join((node_1.refs or node_1.sources)[0])
+        duped_name = f'{node_1.name}" defined on {column_name}"{model_name}'
+        action = "running"
+        formatted_name = "tests"
+    # all other resource types
     else:
-        get_func = '"{}"'.format(duped_name)
+        formatted_name = duped_name
 
+    # should this be raise_parsing_error instead?
     raise_compiler_error(
-        'dbt found two resources with the name "{}". Since these resources '
-        "have the same name,\ndbt will be unable to find the correct resource "
-        "when {} is used. To fix this,\nchange the name of one of "
-        "these resources:\n- {} ({})\n- {} ({})".format(
-            duped_name,
-            get_func,
-            node_1.unique_id,
-            node_1.original_file_path,
-            node_2.unique_id,
-            node_2.original_file_path,
-        )
+        f'dbt found two {pluralized} with the name "{duped_name}". '
+        f"\n"
+        f"\nSince these resources have the same name, dbt will be unable to find the correct resource "
+        f"\nwhen {action} {formatted_name}. "
+        f"\n"
+        f"\nTo fix this, change the name of one of these resources: "
+        f"\n- {node_1.unique_id} ({node_1.original_file_path}) "
+        f"\n- {node_2.unique_id} ({node_2.original_file_path})"
     )
 
 

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -859,8 +859,7 @@ def raise_duplicate_resource_name(node_1, node_2):
     # duplicate generic tests
     elif node_type == NodeType.Test and hasattr(node_1, "test_metadata"):
         column_name = f'column "{node_1.column_name}" in ' if node_1.column_name else ""
-        # TODO: we need a better way of storing the target model/source/etc in generic tests
-        model_name = ".".join((node_1.refs or node_1.sources)[0])
+        model_name = node_1.file_key_name
         duped_name = f'{node_1.name}" defined on {column_name}"{model_name}'
         action = "running"
         formatted_name = "tests"
@@ -870,14 +869,16 @@ def raise_duplicate_resource_name(node_1, node_2):
 
     # should this be raise_parsing_error instead?
     raise_compiler_error(
-        f'dbt found two {pluralized} with the name "{duped_name}". '
-        f"\n"
-        f"\nSince these resources have the same name, dbt will be unable to find the correct resource "
-        f"\nwhen {action} {formatted_name}. "
-        f"\n"
-        f"\nTo fix this, change the name of one of these resources: "
-        f"\n- {node_1.unique_id} ({node_1.original_file_path}) "
-        f"\n- {node_2.unique_id} ({node_2.original_file_path})"
+        f"""
+dbt found two {pluralized} with the name "{duped_name}".
+
+Since these resources have the same name, dbt will be unable to find the correct resource
+when {action} {formatted_name}.
+
+To fix this, change the name of one of these resources:
+- {node_1.unique_id} ({node_1.original_file_path})
+- {node_2.unique_id} ({node_2.original_file_path})
+    """.strip()
     )
 
 

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -294,13 +294,23 @@ class TestBuilder(Generic[Testable]):
                 "test must be dict or str, got {} (value {})".format(type(test), test)
             )
 
-        test = list(test.items())
-        if len(test) != 1:
-            raise_parsing_error(
-                "test definition dictionary must have exactly one key, got"
-                " {} instead ({} keys)".format(test, len(test))
-            )
-        test_name, test_args = test[0]
+        # If the test is a dictionary with top-level keys, the test name is "test_name"
+        # and the rest are arguments
+        # {'name': 'my_favorite_test', 'test_name': 'unique', 'config': {'where': '1=1'}}
+        if "test_name" in test.keys():
+            test_name = test.pop("test_name")
+            test_args = test
+        # If the test is a nested dictionary with one top-level key, the test name
+        # is the dict name, and nested keys are arguments
+        # {'unique': {'name': 'my_favorite_test', 'config': {'where': '1=1'}}}
+        else:
+            test = list(test.items())
+            if len(test) != 1:
+                raise_parsing_error(
+                    "test definition dictionary must have exactly one key, got"
+                    " {} instead ({} keys)".format(test, len(test))
+                )
+            test_name, test_args = test[0]
 
         if not isinstance(test_args, dict):
             raise_parsing_error(

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -273,6 +273,10 @@ class TestBuilder(Generic[Testable]):
         self.fqn_name: str = ""
 
         if "name" in self.args:
+            # TODO: Should we append the model name to the test name here?
+            # Or trust the user to have globally unique names within their project?
+            # Logic like this, with accounting for source table targets:
+            # generic_test_name = f"{self.args["name"]}_{target.name}"
             self.compiled_name = self.args["name"]
             self.fqn_name = self.args["name"]
             del self.args["name"]

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -29,6 +29,7 @@ def synthesize_generic_test_names(
     test_type: str, test_name: str, args: Dict[str, Any]
 ) -> Tuple[str, str]:
     # Using the type, name, and arguments to this generic test, synthesize a (hopefully) unique name
+    # Will not be unique if multiple tests have same name + arguments, and only configs differ
     # Returns a shorter version (hashed/truncated, for the compiled file)
     # as well as the full name (for the unique_id + FQN)
     flat_args = []
@@ -273,10 +274,8 @@ class TestBuilder(Generic[Testable]):
         self.fqn_name: str = ""
 
         if "name" in self.args:
-            # TODO: Should we append the model name to the test name here?
-            # Or trust the user to have globally unique names within their project?
-            # Logic like this, with accounting for source table targets:
-            # generic_test_name = f"{self.args["name"]}_{target.name}"
+            # Trust the user to have a unique name for this model + column combo
+            # otherwise, raise_duplicate_resource_name later on
             self.compiled_name = self.args["name"]
             self.fqn_name = self.args["name"]
             del self.args["name"]

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -274,8 +274,8 @@ class TestBuilder(Generic[Testable]):
         self.fqn_name: str = ""
 
         if "name" in self.args:
-            # Trust the user to have a unique name for this model + column combo
-            # otherwise, raise_duplicate_resource_name later on
+            # Assign the user-defined name here, which will be checked for uniqueness later
+            # we will raise an error if two tests have same name for same model + column combo
             self.compiled_name = self.args["name"]
             self.fqn_name = self.args["name"]
             del self.args["name"]

--- a/test/integration/025_duplicate_model_tests/test_duplicate_exposure.py
+++ b/test/integration/025_duplicate_model_tests/test_duplicate_exposure.py
@@ -14,7 +14,7 @@ class TestDuplicateExposure(DBTIntegrationTest):
 
     @use_profile("postgres")
     def test_postgres_duplicate_exposure(self):
-        message = "dbt found two resources with the name"
+        message = "dbt found two exposures with the name"
         try:
             self.run_dbt(["compile"])
             self.assertTrue(False, "dbt did not throw for duplicate exposures")

--- a/test/integration/025_duplicate_model_tests/test_duplicate_model.py
+++ b/test/integration/025_duplicate_model_tests/test_duplicate_model.py
@@ -14,7 +14,7 @@ class TestDuplicateModelEnabled(DBTIntegrationTest):
 
     @use_profile("postgres")
     def test_postgres_duplicate_model_enabled(self):
-        message = "dbt found two resources with the name"
+        message = "dbt found two models with the name"
         try:
             self.run_dbt(["run"])
             self.assertTrue(False, "dbt did not throw for duplicate models")
@@ -80,7 +80,7 @@ class TestDuplicateModelEnabledAcrossPackages(DBTIntegrationTest):
     @use_profile("postgres")
     def test_postgres_duplicate_model_enabled_across_packages(self):
         self.run_dbt(["deps"])
-        message = "dbt found two resources with the name"
+        message = "dbt found two models with the name"
         try:
             self.run_dbt(["run"])
             self.assertTrue(False, "dbt did not throw for duplicate models")

--- a/test/integration/025_duplicate_model_tests/test_duplicate_source.py
+++ b/test/integration/025_duplicate_model_tests/test_duplicate_source.py
@@ -14,7 +14,7 @@ class TestDuplicateSourceEnabled(DBTIntegrationTest):
 
     @use_profile("postgres")
     def test_postgres_duplicate_source_enabled(self):
-        message = "dbt found two resources with the name"
+        message = "dbt found two sources with the name"
         try:
             self.run_dbt(["compile"])
             self.assertTrue(False, "dbt did not throw for duplicate sources")

--- a/tests/functional/schema_tests/fixtures.py
+++ b/tests/functional/schema_tests/fixtures.py
@@ -420,6 +420,73 @@ name_collision__base_extension_sql = """
 SELECT 'NOT_NULL' AS id
 """
 
+
+dupe_generic_tests_collide__schema_yml = """
+version: 2
+models:
+- name: model_a
+  columns:
+  - name: id
+    tests:
+    - not_null:
+        config:
+          where: "1=1"
+    - not_null:
+        config:
+          where: "1=2"
+
+"""
+
+dupe_generic_tests_collide__model_a = """
+SELECT 'NOT_NULL' AS id
+"""
+
+
+custom_generic_test_names__schema_yml = """
+version: 2
+models:
+- name: model_a
+  columns:
+  - name: id
+    tests:
+    - not_null:
+        name: not_null_where_1_equals_1
+        config:
+          where: "1=1"
+    - not_null:
+        name: not_null_where_1_equals_2
+        config:
+          where: "1=2"
+
+"""
+
+custom_generic_test_names__model_a = """
+SELECT 'NOT_NULL' AS id
+"""
+
+custom_generic_test_names_alt_format__schema_yml = """
+version: 2
+models:
+- name: model_a
+  columns:
+  - name: id
+    tests:
+    - name: not_null_where_1_equals_1
+      test_name: not_null
+      config:
+        where: "1=1"
+    - name: not_null_where_1_equals_2
+      test_name: not_null
+      config:
+        where: "1=2"
+
+"""
+
+custom_generic_test_names_alt_format__model_a = """
+SELECT 'NOT_NULL' AS id
+"""
+
+
 test_context_where_subq_macros__custom_generic_test_sql = """
 /*{# This test will fail if get_where_subquery() is missing from TestContext + TestMacroNamespace #}*/
 
@@ -1263,6 +1330,30 @@ def name_collision():
         "schema.yml": name_collision__schema_yml,
         "base.sql": name_collision__base_sql,
         "base_extension.sql": name_collision__base_extension_sql,
+    }
+
+
+@pytest.fixture(scope="class")
+def dupe_tests_collide():
+    return {
+        "schema.yml": dupe_generic_tests_collide__schema_yml,
+        "model_a.sql": dupe_generic_tests_collide__model_a,
+    }
+
+
+@pytest.fixture(scope="class")
+def custom_generic_test_names():
+    return {
+        "schema.yml": custom_generic_test_names__schema_yml,
+        "model_a.sql": custom_generic_test_names__model_a,
+    }
+
+
+@pytest.fixture(scope="class")
+def custom_generic_test_names_alt_format():
+    return {
+        "schema.yml": custom_generic_test_names_alt_format__schema_yml,
+        "model_a.sql": custom_generic_test_names_alt_format__model_a,
     }
 
 

--- a/tests/functional/schema_tests/test_schema_v2_tests.py
+++ b/tests/functional/schema_tests/test_schema_v2_tests.py
@@ -16,6 +16,9 @@ from tests.functional.schema_tests.fixtures import (  # noqa: F401
     seeds,
     test_context_models,
     name_collision,
+    dupe_tests_collide,
+    custom_generic_test_names,
+    custom_generic_test_names_alt_format,
     test_context_where_subq_macros,
     invalid_schema_models,
     all_models,
@@ -25,7 +28,7 @@ from tests.functional.schema_tests.fixtures import (  # noqa: F401
     project_files,
     case_sensitive_models__uppercase_SQL,
 )
-from dbt.exceptions import ParsingException
+from dbt.exceptions import ParsingException, CompilationException
 from dbt.contracts.results import TestStatus
 
 
@@ -656,6 +659,60 @@ class TestSchemaTestNameCollision:
         ]
         assert test_results[0].node.unique_id in expected_unique_ids
         assert test_results[1].node.unique_id in expected_unique_ids
+
+
+class TestGenericTestsCollide:
+    @pytest.fixture(scope="class")
+    def models(self, dupe_tests_collide):  # noqa: F811
+        return dupe_tests_collide
+
+    def test_generic_test_collision(
+        self,
+        project,
+    ):
+        """These tests collide, since only the configs differ"""
+        with pytest.raises(CompilationException) as exc:
+            run_dbt()
+        assert "dbt found two tests with the name" in str(exc)
+
+
+class TestGenericTestsCustomNames:
+    @pytest.fixture(scope="class")
+    def models(self, custom_generic_test_names):  # noqa: F811
+        return custom_generic_test_names
+
+    def test_collision_test_names_get_hash(
+        self,
+        project,
+    ):
+        """These tests don't collide, since they have user-provided custom names"""
+        results = run_dbt()
+        test_results = run_dbt(["test"])
+
+        # model + both tests run
+        assert len(results) == 1
+        assert len(test_results) == 2
+
+        # custom names propagate to the unique_id
+        expected_unique_ids = [
+            "test.test.not_null_where_1_equals_1.7b96089006",
+            "test.test.not_null_where_1_equals_2.8ae586e17f",
+        ]
+        assert test_results[0].node.unique_id in expected_unique_ids
+        assert test_results[1].node.unique_id in expected_unique_ids
+
+
+class TestGenericTestsCustomNamesAltFormat(TestGenericTestsCustomNames):
+    @pytest.fixture(scope="class")
+    def models(self, custom_generic_test_names_alt_format):  # noqa: F811
+        return custom_generic_test_names_alt_format
+
+    # exactly as above, just alternative format for yaml definition
+    def test_collision_test_names_get_hash(
+        self,
+        project,
+    ):
+        super().test_collision_test_names_get_hash(project)
 
 
 class TestInvalidSchema:

--- a/tests/functional/schema_tests/test_schema_v2_tests.py
+++ b/tests/functional/schema_tests/test_schema_v2_tests.py
@@ -681,7 +681,8 @@ class TestGenericTestsCustomNames:
     def models(self, custom_generic_test_names):  # noqa: F811
         return custom_generic_test_names
 
-    def test_collision_test_names_get_hash(
+    # users can define custom names for specific instances of generic tests
+    def test_generic_tests_with_custom_names(
         self,
         project,
     ):
@@ -712,7 +713,9 @@ class TestGenericTestsCustomNamesAltFormat(TestGenericTestsCustomNames):
         self,
         project,
     ):
-        super().test_collision_test_names_get_hash(project)
+        """These tests don't collide, since they have user-provided custom names,
+        defined using an alternative format"""
+        super().test_generic_tests_with_custom_names(project)
 
 
 class TestInvalidSchema:


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/3348#issuecomment-1031840405
resolves #4012

The fuller issue is about rethinking how we construct `unique_id`. The comment, and this PR, seeks to address the narrower issue that we've seen come up most often in the community (and in https://github.com/dbt-labs/dbt-core/issues/4684, https://github.com/dbt-labs/dbt-core/issues/4102, etc).

### TODO

- [x] Do we want to append the model/source name to the test name? Or trust users to pick globally unique ones?
- [x] Do people like this proposed syntax?
- [x] Add integration tests, ideally using the new `pytest` framework :)

### Description

Support this:
```yml
models:
  - name: my_model
    columns:
      - name: id
        tests:
          - unique:
              name: my_cool_test
```
```
$ dbt test
...
07:43:51  1 of 1 START test my_cool_test.................................................. [RUN]
07:43:51  1 of 1 PASS my_cool_test........................................................ [PASS in 0.03s]
```

### Why this change?

See the linked comment for thorough explanation. Quick answers below:
- Better control over the name of the test as it appears in console output. Aliasing the database tables was nice, but insufficient
- Naming generic tests is a step toward documenting tests, until we can support actual test descriptions (#3249)
- Avoid collisions between generic tests that are identical except for differences in configuration, e.g.

What this PR doesn't do: Alter, in any way, the logic that dbt uses to synthesize generic test names if no custom name is provided. The proposal in https://github.com/dbt-labs/dbt-core/issues/3348#issuecomment-1031840405 does include a cleaner more consistent approach to hashed test names. I opted against it, to keep the changes here minimal and additive-only. We can discuss whether that change feels necessary.

### While we're here...

Also add support for defining tests as unified dictionaries, like other resource types, in addition to nested dictionaries with the test name as the top-level key. If done in this way, the name of the generic test (`unique`, `not_null`, etc) is defined as `test_name`.
```yml
models:
  - name: my_model
    columns:
      - name: id
        tests:
          # these are equivalent
          - accepted_values:
              name: only_allow_abc
              values: ['a', 'b', 'c']
              config:
                severity: warn
                where: 1=1
          - name: only_allow_abc
            test_name: accepted_values
            values: ['a', 'b', 'c']
            config:
              severity: warn
              where: 1=1
```

I like the second formulation a bit better when defining lots of custom properties and configurations. It's important to continue supporting the first spec; after all, most generic tests are defined with a single keyword (the test name alone).

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
