### PR TITLE
Bump setup.py file to 1.0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 
 if 'sdist' not in sys.argv:
     print('')
-    print('As of v1.0.3, `pip install dbt` is no longer supported.')
+    print('As of v1.0.4, `pip install dbt` is no longer supported.')
     print('Instead, please use one of the following.')
     print('')
     print('**To use dbt with your specific database, platform, or query engine:**')
@@ -50,7 +50,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
 
 
 package_name = "dbt"
-package_version = "1.0.3"
+package_version = "1.0.4"
 description = """With dbt, data analysts and engineers can build analytics \
 the way engineers build applications."""
 


### PR DESCRIPTION
### Description

This file still exists in the release branch but the version bump script doesn't cover it since we ran it from `main` and removed setup.py there. We need to bump this so we can run the release

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
