### PR TITLE
added permissions settings for docker release workflow

### DIFF
--- a/.changes/unreleased/Fixes-20220318-095846.yaml
+++ b/.changes/unreleased/Fixes-20220318-095846.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Corrected permissions settings for docker release workflow
+time: 2022-03-18T09:58:46.061468-05:00
+custom:
+  Author: iknox-fa
+  Issue: "4902"
+  PR: "4903"

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -12,6 +12,9 @@
 
 name: Docker release
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Resolves #4902 / CT-387

### Description
Corrects permissions issue in docker release workflow

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
