### PR TITLE
add compliation and cache tracking

### DIFF
--- a/.changes/unreleased/Under the Hood-20220321-142854.yaml
+++ b/.changes/unreleased/Under the Hood-20220321-142854.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Add Graph Compilation and Adapter Cache tracking
+time: 2022-03-21T14:28:54.160087-04:00
+custom:
+  Author: ChenyuLInx
+  Issue: "4625"
+  PR: "4912"

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -50,6 +50,7 @@ from dbt.exceptions import (
 
 from dbt.graph import GraphQueue, NodeSelector, SelectionSpec, parse_difference, Graph
 from dbt.parser.manifest import ManifestLoader
+import dbt.tracking
 
 import dbt.exceptions
 from dbt import flags
@@ -88,7 +89,12 @@ class ManifestTask(ConfiguredTask):
 
     def _runtime_initialize(self):
         self.load_manifest()
+
+        start_compile_manifest = time.perf_counter()
         self.compile_manifest()
+        compile_time = time.perf_counter() - start_compile_manifest
+        if dbt.tracking.active_user is not None:
+            dbt.tracking.track_runnable_timing({"graph_compilation_elapsed": compile_time})
 
 
 class GraphRunnableTask(ManifestTask):
@@ -391,7 +397,13 @@ class GraphRunnableTask(ManifestTask):
             self._skipped_children[dep_node_id] = cause
 
     def populate_adapter_cache(self, adapter):
+        start_populate_cache = time.perf_counter()
         adapter.set_relations_cache(self.manifest)
+        cache_populate_time = time.perf_counter() - start_populate_cache
+        if dbt.tracking.active_user is not None:
+            dbt.tracking.track_runnable_timing(
+                {"adapter_cache_construction_elapsed": cache_populate_time}
+            )
 
     def before_hooks(self, adapter):
         pass

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -44,6 +44,7 @@ LOAD_ALL_TIMING_SPEC = "iglu:com.dbt/load_all_timing/jsonschema/1-0-3"
 RESOURCE_COUNTS = "iglu:com.dbt/resource_counts/jsonschema/1-0-0"
 EXPERIMENTAL_PARSER = "iglu:com.dbt/experimental_parser/jsonschema/1-0-0"
 PARTIAL_PARSER = "iglu:com.dbt/partial_parser/jsonschema/1-0-1"
+RUNNABLE_TIMING = "iglu:com.dbt/runnable/jsonschema/1-0-0"
 DBT_INVOCATION_ENV = "DBT_INVOCATION_ENV"
 
 
@@ -407,6 +408,18 @@ def track_partial_parser(options):
         active_user,
         category="dbt",
         action="partial_parser",
+        label=get_invocation_id(),
+        context=context,
+    )
+
+
+def track_runnable_timing(options):
+    context = [SelfDescribingJson(RUNNABLE_TIMING, options)]
+    assert active_user is not None, "Cannot track runnable info when active user is None"
+    track(
+        active_user,
+        category="dbt",
+        action="runnable",
         label=get_invocation_id(),
         context=context,
     )

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -419,7 +419,7 @@ def track_runnable_timing(options):
     track(
         active_user,
         category="dbt",
-        action="runnable",
+        action="runnable_timing",
         label=get_invocation_id(),
         context=context,
     )


### PR DESCRIPTION
resolves #4625

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Add tracking for compilation time and adapter cache population time. The compilation time and adapter cache time will be sent to snowplow events table as separate event under the action `runnable`. 
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
