### PR TITLE
Bump backport action version

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -29,6 +29,6 @@ jobs:
     name: Backport
     steps:
       - name: Backport
-        uses: dbt-labs/backport@v1.1.1
+        uses: dbt-labs/backport@v1.1.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
We need to bump the [version of the action](https://github.com/dbt-labs/backport/releases/tag/v1.1.2) up 1 patch version. The new patch version includes (and only includes) the new source branch naming convention which we need to pick-up. See #4920 for more details

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
