### PR TITLE
remove capping version of typing extensions

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -65,7 +65,7 @@ setup(
         "packaging>=20.9,<22.0",
         "sqlparse>=0.2.3,<0.5",
         "dbt-extractor~=0.4.1",
-        "typing-extensions>=3.7.4,<4.2",
+        "typing-extensions>=3.7.4",
         "werkzeug>=1,<3",
         # the following are all to match snowflake-connector-python
         "requests<3.0.0",


### PR DESCRIPTION
resolves #4833

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
`typing-extensions` has been causing installation issues and previous dependent bot PR still capped it. We don't have a need to actually cap it only at 4.2

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
