### PR TITLE
v1.0.4 changelog with one entry

### DIFF
--- a/.changes/1.0.4.md
+++ b/.changes/1.0.4.md
@@ -1,0 +1,3 @@
+## dbt-core 1.0.4 - March 18, 2022
+### Fixes
+- Depend on new dbt-extractor version with fixed GitHub links to resolve Homebrew installation issues ([#4891](https://github.com/dbt-labs/dbt-core/issues/4891), [#4890](https://github.com/dbt-labs/dbt-core/pull/4890))

--- a/.changes/1.0.5-rc1.md
+++ b/.changes/1.0.5-rc1.md
@@ -6,7 +6,6 @@
 - Catch all Requests Exceptions on deps install to attempt retries.  Also log the exceptions hit. ([#4849](https://github.com/dbt-labs/dbt-core/issues/4849), [#4865](https://github.com/dbt-labs/dbt-core/pull/4865))
 - Fix partial parsing bug with multiple snapshot blocks ([#4771](https://github.com/dbt-labs/dbt-core/issues/4771), [#4773](https://github.com/dbt-labs/dbt-core/pull/4773))
 - Use cli_vars instead of context to create package and selector renderers ([#4876](https://github.com/dbt-labs/dbt-core/issues/4876), [#4878](https://github.com/dbt-labs/dbt-core/pull/4878))
-- depend on new dbt-extractor version with fixed github links ([#4891](https://github.com/dbt-labs/dbt-core/issues/4891), [#4890](https://github.com/dbt-labs/dbt-core/pull/4890))
 ### Under the Hood
 - Automate changelog generation with changie ([#4652](https://github.com/dbt-labs/dbt-core/issues/4652), [#4743](https://github.com/dbt-labs/dbt-core/pull/4743))
 - Fix broken links for changelog generation and tweak GHA to only post a comment once when changelog entry is missing. ([#4848](https://github.com/dbt-labs/dbt-core/issues/4848), [#4857](https://github.com/dbt-labs/dbt-core/pull/4857))

--- a/.changes/1.0.5-rc1.md
+++ b/.changes/1.0.5-rc1.md
@@ -11,5 +11,6 @@
 - Fix broken links for changelog generation and tweak GHA to only post a comment once when changelog entry is missing. ([#4848](https://github.com/dbt-labs/dbt-core/issues/4848), [#4857](https://github.com/dbt-labs/dbt-core/pull/4857))
 ### Docs
 - Resolve errors related to operations preventing DAG from generating in the docs.  Also patch a spark issue to allow search to filter accurately past the missing columns. ([#4578](https://github.com/dbt-labs/dbt-core/issues/4578), [#4763](https://github.com/dbt-labs/dbt-core/pull/4763))
+
 Contributors:
   - [twilly](https://github.com/twilly) ([#4681](https://github.com/dbt-labs/dbt-core/pull/4681))

--- a/.changes/1.0.5/Fixes-20220317-132418.yaml
+++ b/.changes/1.0.5/Fixes-20220317-132418.yaml
@@ -1,8 +1,0 @@
-kind: Fixes
-body: depend on new dbt-extractor version with fixed github links
-time: 2022-03-17T13:24:18.419599-04:00
-custom:
-  Author: nathaniel-may
-  Issue: "4891"
-  PR: "4890"
-  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,18 @@
 - Catch all Requests Exceptions on deps install to attempt retries.  Also log the exceptions hit. ([#4849](https://github.com/dbt-labs/dbt-core/issues/4849), [#4865](https://github.com/dbt-labs/dbt-core/pull/4865))
 - Fix partial parsing bug with multiple snapshot blocks ([#4771](https://github.com/dbt-labs/dbt-core/issues/4771), [#4773](https://github.com/dbt-labs/dbt-core/pull/4773))
 - Use cli_vars instead of context to create package and selector renderers ([#4876](https://github.com/dbt-labs/dbt-core/issues/4876), [#4878](https://github.com/dbt-labs/dbt-core/pull/4878))
-- depend on new dbt-extractor version with fixed github links ([#4891](https://github.com/dbt-labs/dbt-core/issues/4891), [#4890](https://github.com/dbt-labs/dbt-core/pull/4890))
+
 ### Under the Hood
 - Automate changelog generation with changie ([#4652](https://github.com/dbt-labs/dbt-core/issues/4652), [#4743](https://github.com/dbt-labs/dbt-core/pull/4743))
 - Fix broken links for changelog generation and tweak GHA to only post a comment once when changelog entry is missing. ([#4848](https://github.com/dbt-labs/dbt-core/issues/4848), [#4857](https://github.com/dbt-labs/dbt-core/pull/4857))
+
 ### Docs
 - Resolve errors related to operations preventing DAG from generating in the docs.  Also patch a spark issue to allow search to filter accurately past the missing columns. ([#4578](https://github.com/dbt-labs/dbt-core/issues/4578), [#4763](https://github.com/dbt-labs/dbt-core/pull/4763))
 Contributors:
   - [twilly](https://github.com/twilly) ([#4681](https://github.com/dbt-labs/dbt-core/pull/4681))
+
+## dbt-core 1.0.4 (March 18, 2022)
+- Depend on new dbt-extractor version with fixed GitHub links to resolve Homebrew installation issues ([#4891](https://github.com/dbt-labs/dbt-core/issues/4891), [#4890](https://github.com/dbt-labs/dbt-core/pull/4890))
 
 
 ## dbt-core 1.0.3 (February 21, 2022)


### PR DESCRIPTION
The changelog entry for v1.0.4 was generated, but it was batched into v1.0.5 instead of being present at the time of the v1.0.4 release. This caused confusion for community members ([thread](https://getdbt.slack.com/archives/C37J8BQEL/p1648050925596919), [thread](https://getdbt.slack.com/archives/C2JRRQDTL/p1648040418489059)).

My sense is, this could have happened because:
- We missed the changelog generation step (`changie batch`), because this is not yet automated (https://github.com/dbt-labs/dbt-core/issues/4789)
- We released v1.0.4 from a separate dedicated branch, not `1.0.latest`, because there were already-merged changes we wanted to first include in a RC

I am also going to update the [v1.0.4 release notes](https://github.com/dbt-labs/dbt-core/releases/tag/v1.0.4)