### PR TITLE
Ct 201 source config functionality

### DIFF
--- a/core/dbt/context/context_config.py
+++ b/core/dbt/context/context_config.py
@@ -182,6 +182,7 @@ class ContextConfigGenerator(BaseContextConfigGenerator[C]):
 
     def _update_from_config(self, result: C, partial: Dict[str, Any], validate: bool = False) -> C:
         translated = self._active_project.credentials.translate_aliases(partial)
+        # breakpoint()
         return result.update_from(
             translated, self._active_project.credentials.type, validate=validate
         )
@@ -203,6 +204,7 @@ class ContextConfigGenerator(BaseContextConfigGenerator[C]):
             base=base,
             patch_config_dict=patch_config_dict,
         )
+        # breakpoint()
         finalized = config.finalize_and_validate()
         return finalized.to_dict(omit_none=True)
 

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -453,7 +453,7 @@ T = TypeVar("T", bound=GraphMemberNode)
 
 def _update_into(dest: MutableMapping[str, T], new_item: T):
     """Update dest to overwrite whatever is at dest[new_item.unique_id] with
-    new_itme. There must be an existing value to overwrite, and the two nodes
+    new_item. There must be an existing value to overwrite, and the two nodes
     must have the same original file path.
     """
     unique_id = new_item.unique_id

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -688,7 +688,7 @@ class ParsedSourceDefinition(NodeInfoMixin, ParsedSourceMandatory):
         return (
             self.same_database_representation(old)
             and self.same_fqn(old)
-            and self.same_config(old)
+            and self.same_config(old)  # TODO: ct-201 what actually constitues a change?
             and self.same_quoting(old)
             and self.same_freshness(old)
             and self.same_external(old)

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -241,7 +241,7 @@ class Quoting(dbtClassMixin, Mergeable):
 
 
 @dataclass
-class UnparsedSourceTableDefinition(HasColumnTests, HasTests):
+class UnparsedSourceTableDefinition(HasColumnTests, HasConfig, HasTests):
     loaded_at_field: Optional[str] = None
     identifier: Optional[str] = None
     quoting: Quoting = field(default_factory=Quoting)
@@ -257,8 +257,8 @@ class UnparsedSourceTableDefinition(HasColumnTests, HasTests):
 
 
 @dataclass
-class UnparsedSourceDefinition(dbtClassMixin, Replaceable):
-    name: str
+class UnparsedSourceDefinition(dbtClassMixin, Replaceable, HasConfig):
+    name: str = ""
     description: str = ""
     meta: Dict[str, Any] = field(default_factory=dict)
     database: Optional[str] = None
@@ -269,7 +269,6 @@ class UnparsedSourceDefinition(dbtClassMixin, Replaceable):
     loaded_at_field: Optional[str] = None
     tables: List[UnparsedSourceTableDefinition] = field(default_factory=list)
     tags: List[str] = field(default_factory=list)
-    config: Dict[str, Any] = field(default_factory=dict)
 
     @property
     def yaml_key(self) -> "str":
@@ -284,7 +283,7 @@ class UnparsedSourceDefinition(dbtClassMixin, Replaceable):
 
 @dataclass
 class SourceTablePatch(dbtClassMixin):
-    name: str
+    name: str = ""
     description: Optional[str] = None
     meta: Optional[Dict[str, Any]] = None
     data_type: Optional[str] = None

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -365,6 +365,7 @@ class ManifestLoader:
                 self.parse_project(
                     project, project_parser_files[project.project_name], parser_types
                 )
+            # breakpoint() # config as expected
 
             self._perf_info.parse_project_elapsed = time.perf_counter() - start_parse_projects
 
@@ -373,6 +374,7 @@ class ManifestLoader:
             # in SourcePatcher
             start_patch = time.perf_counter()
             patcher = SourcePatcher(self.root_project, self.manifest)
+            # breakpoint()
             patcher.construct_sources()
             self.manifest.sources = patcher.sources
             self._perf_info.patch_sources_elapsed = time.perf_counter() - start_patch
@@ -464,6 +466,7 @@ class ManifestLoader:
                         dct = block.file.pp_dict
                     else:
                         dct = block.file.dict_from_yaml
+                    # breakpoint()
                     parser.parse_file(block, dct=dct)
                 else:
                     parser.parse_file(block)

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -365,7 +365,6 @@ class ManifestLoader:
                 self.parse_project(
                     project, project_parser_files[project.project_name], parser_types
                 )
-            # breakpoint() # config as expected
 
             self._perf_info.parse_project_elapsed = time.perf_counter() - start_parse_projects
 
@@ -374,7 +373,6 @@ class ManifestLoader:
             # in SourcePatcher
             start_patch = time.perf_counter()
             patcher = SourcePatcher(self.root_project, self.manifest)
-            # breakpoint()
             patcher.construct_sources()
             self.manifest.sources = patcher.sources
             self._perf_info.patch_sources_elapsed = time.perf_counter() - start_patch
@@ -466,7 +464,6 @@ class ManifestLoader:
                         dct = block.file.pp_dict
                     else:
                         dct = block.file.dict_from_yaml
-                    # breakpoint()
                     parser.parse_file(block, dct=dct)
                 else:
                     parser.parse_file(block)

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -670,7 +670,6 @@ class SourceParser(YamlDocsReader):
         path = self.yaml.path.original_file_path
         try:
             cls.validate(data)
-            # breakpoint()
             return cls.from_dict(data)
         except (ValidationError, JSONValidationException) as exc:
             msg = error_context(path, self.key, data, exc)
@@ -686,24 +685,11 @@ class SourceParser(YamlDocsReader):
         for data in self.get_key_dicts():
             data = self.project.credentials.translate_aliases(data, recurse=True)
 
-            # try:
-            #     # target_type: UnparsedNodeUpdate, UnparsedAnalysisUpdate,
-            #     # or UnparsedMacroUpdate
-            #     self._target_type().validate(data)
-            #     self.normalize_configs_properties(data, data["path"])
-            #     node = self._target_type().from_dict(data)
-            # except (ValidationError, JSONValidationException) as exc:
-            #     msg = error_context(path, self.key, data, exc)
-            #     raise ParsingException(msg) from exc
-            # else:
-            #     yield node
-
             path = self.yaml.path.original_file_path
 
             self.normalize_configs_properties(data, path)
             is_override = "overrides" in data
             if is_override:
-                # breakpoint()
                 data["path"] = path
                 patch = self._target_from_dict(SourcePatch, data)
                 assert isinstance(self.yaml.file, SchemaSourceFile)
@@ -716,7 +702,6 @@ class SourceParser(YamlDocsReader):
                 source_file.source_patches.append(key)
             else:
                 source = self._target_from_dict(UnparsedSourceDefinition, data)
-                # breakpoint()
                 self.add_source_definitions(source)
         return []
 
@@ -741,7 +726,6 @@ class SourceParser(YamlDocsReader):
         original_file_path = self.yaml.path.original_file_path
         fqn_path = self.yaml.path.relative_path
         for table in source.tables:
-            # breakpoint()
             unique_id = ".".join(
                 [NodeType.Source, self.project.project_name, source.name, table.name]
             )
@@ -760,9 +744,8 @@ class SourceParser(YamlDocsReader):
                 unique_id=unique_id,
                 resource_type=NodeType.Source,
                 fqn=fqn,
-                # config=config,
+                # config=config, #TODO ?
             )
-            # breakpoint()
             self.manifest.add_source(self.yaml.file, source_def)
 
 

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -56,7 +56,6 @@ class SourcePatcher:
     # with SourcePatches to produce ParsedSourceDefinitions.
     def construct_sources(self) -> None:
         for unique_id, unpatched in self.manifest.sources.items():
-            # breakpoint()
             schema_file = self.manifest.files[unpatched.file_id]
             if isinstance(unpatched, ParsedSourceDefinition):
                 # In partial parsing, there will be ParsedSourceDefinitions
@@ -82,7 +81,6 @@ class SourcePatcher:
 
             # Convert UnpatchedSourceDefinition to a ParsedSourceDefinition
             parsed = self.parse_source(patched)
-            # breakpoint()
             if parsed.config.enabled:
                 self.sources[unique_id] = parsed
             else:
@@ -95,7 +93,6 @@ class SourcePatcher:
         unpatched: UnpatchedSourceDefinition,
         patch: Optional[SourcePatch],
     ) -> UnpatchedSourceDefinition:
-        # breakpoint()
 
         # This skips patching if no patch exists because of the
         # performance overhead of converting to and from dicts
@@ -139,14 +136,12 @@ class SourcePatcher:
         # make sure we don't do duplicate tags from source + table
         tags = sorted(set(itertools.chain(source.tags, table.tags)))
 
-        # breakpoint()
         config = self._generate_source_config(
             fqn=target.fqn,
             rendered=True,
             project_name=target.package_name,
             config_call_dict=table.config,
         )
-        # breakpoint()
 
         unrendered_config = self._generate_source_config(
             fqn=target.fqn,

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -56,6 +56,7 @@ class SourcePatcher:
     # with SourcePatches to produce ParsedSourceDefinitions.
     def construct_sources(self) -> None:
         for unique_id, unpatched in self.manifest.sources.items():
+            # breakpoint()
             schema_file = self.manifest.files[unpatched.file_id]
             if isinstance(unpatched, ParsedSourceDefinition):
                 # In partial parsing, there will be ParsedSourceDefinitions
@@ -81,6 +82,7 @@ class SourcePatcher:
 
             # Convert UnpatchedSourceDefinition to a ParsedSourceDefinition
             parsed = self.parse_source(patched)
+            # breakpoint()
             if parsed.config.enabled:
                 self.sources[unique_id] = parsed
             else:
@@ -93,6 +95,7 @@ class SourcePatcher:
         unpatched: UnpatchedSourceDefinition,
         patch: Optional[SourcePatch],
     ) -> UnpatchedSourceDefinition:
+        # breakpoint()
 
         # This skips patching if no patch exists because of the
         # performance overhead of converting to and from dicts
@@ -136,16 +139,20 @@ class SourcePatcher:
         # make sure we don't do duplicate tags from source + table
         tags = sorted(set(itertools.chain(source.tags, table.tags)))
 
+        # breakpoint()
         config = self._generate_source_config(
             fqn=target.fqn,
             rendered=True,
             project_name=target.package_name,
+            config_call_dict=table.config,
         )
+        # breakpoint()
 
         unrendered_config = self._generate_source_config(
             fqn=target.fqn,
             rendered=False,
             project_name=target.package_name,
+            config_call_dict=table.config,
         )
 
         if not isinstance(config, SourceConfig):
@@ -261,7 +268,9 @@ class SourcePatcher:
         )
         return node
 
-    def _generate_source_config(self, fqn: List[str], rendered: bool, project_name: str):
+    def _generate_source_config(
+        self, fqn: List[str], rendered: bool, project_name: str, config_call_dict: Dict[str, Any]
+    ):
         generator: BaseContextConfigGenerator
         if rendered:
             generator = ContextConfigGenerator(self.root_project)
@@ -269,7 +278,7 @@ class SourcePatcher:
             generator = UnrenderedConfigGenerator(self.root_project)
 
         return generator.calculate_node_config(
-            config_call_dict={},
+            config_call_dict=config_call_dict,
             fqn=fqn,
             resource_type=NodeType.Source,
             project_name=project_name,

--- a/tests/functional/sources/test_source_configs.py
+++ b/tests/functional/sources/test_source_configs.py
@@ -12,18 +12,18 @@ class SourceConfigTests:
         pytest.expected_config = SourceConfig(
             enabled=True,
             # TODO: uncomment all this once it's added to SourceConfig, throws error right now
-            # quoting = Quoting(database=False, schema=False, identifier=False, column=False)
-            # freshness = FreshnessThreshold(
-            #     warn_after=Time(count=12, period=TimePeriod.hour),
-            #     error_after=Time(count=24, period=TimePeriod.hour),
-            #     filter=None
-            #     )
-            # loader = "a_loader"
-            # loaded_at_field = some_column
-            # database = custom_database
-            # schema = custom_schema
-            # meta = {'languages': ['python']}
-            # tags = ["important_tag"]
+            quoting=Quoting(database=False, schema=False, identifier=False, column=False),
+            freshness=FreshnessThreshold(
+                warn_after=Time(count=12, period=TimePeriod.hour),
+                error_after=Time(count=24, period=TimePeriod.hour),
+                filter=None,
+            ),
+            loader="a_loader",
+            loaded_at_field="some_column",
+            database="custom_database",
+            schema="custom_schema",
+            meta={"languages": ["python"]},
+            tags=["important_tag"],
         )
 
 
@@ -126,7 +126,7 @@ sources:
 
 
 # Test enabled config at source table level in yaml file
-# expect fail - not implemented
+# expect pass - implemented
 class TestConfigYamlSourceTable(SourceConfigTests):
     @pytest.fixture(scope="class")
     def models(self):
@@ -134,7 +134,6 @@ class TestConfigYamlSourceTable(SourceConfigTests):
             "schema.yml": disabled_source_table__schema_yml,
         }
 
-    @pytest.mark.xfail
     def test_source_config_yaml_source_table(self, project):
         run_dbt(["parse"])
         manifest = get_manifest(project.project_root)
@@ -190,7 +189,7 @@ configs_source_level__schema_yml = """version: 2
 sources:
   - name: test_source
     config:
-        enabled: True
+        enabled: False
         quoting:
             database: False
             schema: False
@@ -212,13 +211,13 @@ sources:
 
 
 # Test configs other than enabled at sources level in yaml file
-# **currently passes since enabled is all that ends up in the
-# node.config since it's the only thing implemented
+# expect fail - not implemented
 class TestAllConfigsSourceLevel(SourceConfigTests):
     @pytest.fixture(scope="class")
     def models(self):
         return {"schema.yml": configs_source_level__schema_yml}
 
+    @pytest.mark.xfail
     def test_source_all_configs_source_level(self, project):
         run_dbt(["parse"])
         manifest = get_manifest(project.project_root)
@@ -263,13 +262,13 @@ sources:
 
 
 # Test configs other than enabled at source table level in yml file
-# expect fail - not implemented
+# only implemented feature so far!
 class TestSourceAllConfigsSourceTable(SourceConfigTests):
     @pytest.fixture(scope="class")
     def models(self):
         return {"schema.yml": configs_source_table__schema_yml}
 
-    @pytest.mark.xfail
+    # @pytest.mark.xfail
     def test_source_all_configs_source_table(self, project):
         run_dbt(["parse"])
         manifest = get_manifest(project.project_root)
@@ -524,13 +523,13 @@ sources:
 
 
 # Check backwards compatibility of setting configs as properties at top level
-# expect pass since the properties don't get copied to the node.config yet so
-# the values match since we haven't build the full SourceConfig yet
+# expect fail - not implemented
 class TestPropertiesAsConfigs(SourceBackwardsCompatibility):
     @pytest.fixture(scope="class")
     def models(self):
         return {"schema.yml": properties_as_configs__schema_yml}
 
+    @pytest.mark.xfail
     def test_source_configs_as_properties(self, project):
         self.check_source_configs_and_properties(project)
 


### PR DESCRIPTION
resolves #3662


### Description

**_Very_** in progress.  But I got the source table level configs set and making it into the manifest.  The source level configs don't work yet.  That's because [`add_source_definitions`](https://github.com/dbt-labs/dbt-core/blob/23fa2d622f6082ee9411a53f00bb5cd0c5440c54/core/dbt/parser/schemas.py#L725) only adds the configs to the table level so the source level gets ignore for now.

What this does:
1. Add config definitions to SourceConfigs
2. Add functionality for configs to end up in the manifest when assigned at the source table level in a yaml file
3. Tests that are expected to fail are marked as such in `test_source_configs.py`
4. Some TODOs of where I'm thinking things might happen

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
