### PR TITLE
Decouple project creation logic from tasks CT-299

### DIFF
--- a/.changes/unreleased/Under the Hood-20220330-101439.yaml
+++ b/.changes/unreleased/Under the Hood-20220330-101439.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Adds config util for ad-hoc creation of project objs or dicts
+time: 2022-03-30T10:14:39.746196-05:00
+custom:
+  Author: iknox-fa
+  Issue: "4808"
+  PR: "4981"

--- a/core/dbt/config/utils.py
+++ b/core/dbt/config/utils.py
@@ -1,9 +1,15 @@
-from typing import Dict, Any
+from argparse import Namespace
+from typing import Any, Dict, Optional, Union
+from xmlrpc.client import Boolean
+from dbt.contracts.project import UserConfig
 
+import dbt.flags as flags
 from dbt.clients import yaml_helper
+from dbt.config import Profile, Project, read_user_config
+from dbt.config.renderer import DbtProjectYamlRenderer, ProfileRenderer
 from dbt.events.functions import fire_event
-from dbt.exceptions import raise_compiler_error, ValidationException
 from dbt.events.types import InvalidVarsYAML
+from dbt.exceptions import ValidationException, raise_compiler_error
 
 
 def parse_cli_vars(var_string: str) -> Dict[str, Any]:
@@ -21,3 +27,47 @@ def parse_cli_vars(var_string: str) -> Dict[str, Any]:
     except ValidationException:
         fire_event(InvalidVarsYAML())
         raise
+
+
+def get_project_config(
+    project_path: str,
+    profile_name: str,
+    args: Namespace = Namespace(),
+    cli_vars: Optional[Dict[str, Any]] = None,
+    profile: Optional[Profile] = None,
+    user_config: Optional[UserConfig] = None,
+    return_dict: Boolean = True,
+) -> Union[Project, Dict]:
+    """Returns a project config (dict or object) from a given project path and profile name.
+
+    Args:
+        project_path: Path to project
+        profile_name: Name of profile
+        args: An argparse.Namespace that represents what would have been passed in on the
+            command line (optional)
+        cli_vars: A dict of any vars that would have been passed in on the command line (optional)
+            (see parse_cli_vars above for formatting details)
+        profile: A dbt.config.profile.Profile object (optional)
+        user_config: A dbt.contracts.project.UserConfig object (optional)
+        return_dict: Return a dict if true, return the full dbt.config.project.Project object if false
+
+    Returns:
+        A full project config
+
+    """
+    # Generate a profile if not provided
+    if profile is None:
+        # Generate user_config if not provided
+        if user_config is None:
+            user_config = read_user_config(flags.PROFILES_DIR)
+        # Update flags
+        flags.set_from_args(args, user_config)
+        profile = Profile.render_from_args(args, ProfileRenderer(cli_vars), profile_name)
+    # Generate a project
+    project = Project.from_project_root(
+        project_path,
+        DbtProjectYamlRenderer(profile),
+        verify_version=bool(flags.VERSION_CHECK),
+    )
+    # Return
+    return project.to_project_config() if return_dict else project

--- a/test/integration/039_config_tests/models-ok/ok.sql
+++ b/test/integration/039_config_tests/models-ok/ok.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('seed') }}

--- a/test/integration/039_config_tests/project/dbt_project.yml
+++ b/test/integration/039_config_tests/project/dbt_project.yml
@@ -1,0 +1,8 @@
+--- 
+config-version: 2
+model-paths: 
+  - models-ok
+name: test
+profile: test
+test-paths: []
+version: "1.0"

--- a/test/integration/039_config_tests/project/profiles.yml
+++ b/test/integration/039_config_tests/project/profiles.yml
@@ -1,0 +1,24 @@
+--- 
+config: 
+  send_anonymous_usage_stats: false
+test: 
+  outputs: 
+    default2: 
+      dbname: dbt
+      host: localhost
+      pass: password
+      port: 5432
+      schema: test16486474128741104874_config_039
+      threads: 4
+      type: postgres
+      user: root
+    noaccess: 
+      dbname: dbt
+      host: localhost
+      pass: password
+      port: 5432
+      schema: test16486474128741104874_config_039
+      threads: 4
+      type: postgres
+      user: noaccess
+  target: default2

--- a/test/integration/039_config_tests/test_configs.py
+++ b/test/integration/039_config_tests/test_configs.py
@@ -321,7 +321,6 @@ class TestConfigGetDefault(DBTIntegrationTest):
 
 
 class TestConfigUtils(DBTIntegrationTest):
-
     @property
     def schema(self):
         return "config_039"
@@ -329,26 +328,23 @@ class TestConfigUtils(DBTIntegrationTest):
     @property
     def models(self):
         return "models"
-    
+
     @property
     def project_config(self):
         project_path = os.path.dirname(os.path.realpath(__file__)) + "/project"
         project_config = get_project_config(
-            project_path,
-            "test",
-            Namespace(profiles_dir=project_path)
+            project_path, "test", Namespace(profiles_dir=project_path)
         )
-        
+
         # thanks yaml :(
         project_config["name"] = str(project_config["name"])
         project_config["version"] = str(project_config["version"])
         return project_config
-        
 
-    @use_profile('postgres')
+    @use_profile("postgres")
     def test_postgres_get_project_config(self):
 
-        seed_result = self.run_dbt(['seed'], expect_pass=True)
-        run_result = self.run_dbt(['run'], expect_pass=True)
+        seed_result = self.run_dbt(["seed"], expect_pass=True)
+        run_result = self.run_dbt(["run"], expect_pass=True)
         self.assertEqual(len(seed_result), 1)
         self.assertEqual(len(run_result), 1)

--- a/test/integration/039_config_tests/test_configs.py
+++ b/test/integration/039_config_tests/test_configs.py
@@ -1,9 +1,11 @@
+from datetime import datetime
 import os
 import shutil
 
 from test.integration.base import DBTIntegrationTest, use_profile
 from dbt.exceptions import CompilationException
-
+from dbt.config.utils import get_project_config
+from argparse import Namespace
 
 class TestConfigs(DBTIntegrationTest):
     @property
@@ -243,6 +245,7 @@ class TestUnusedModelConfigs(DBTIntegrationTest):
 
         self.run_dbt(['seed'])
 
+
 class TestConfigIndivTests(DBTIntegrationTest):
     @property
     def schema(self):
@@ -298,7 +301,6 @@ class TestConfigIndivTests(DBTIntegrationTest):
         self.assertEqual(results[1].status, 'fail')
 
 
-
 class TestConfigGetDefault(DBTIntegrationTest):
     @property
     def schema(self):
@@ -316,3 +318,37 @@ class TestConfigGetDefault(DBTIntegrationTest):
         self.assertEqual(len(results), 1)
         self.assertEqual(str(results[0].status), 'error')
         self.assertIn('column "default_value" does not exist', results[0].message)
+
+
+class TestConfigUtils(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "config_039"
+
+    @property
+    def models(self):
+        return "models"
+    
+    @property
+    def project_config(self):
+        project_path = os.path.dirname(os.path.realpath(__file__)) + "/project"
+        project_config = get_project_config(
+            project_path,
+            "test",
+            Namespace(profiles_dir=project_path)
+        )
+        
+        # thanks yaml :(
+        project_config["name"] = str(project_config["name"])
+        project_config["version"] = str(project_config["version"])
+        return project_config
+        
+
+    @use_profile('postgres')
+    def test_postgres_get_project_config(self):
+
+        seed_result = self.run_dbt(['seed'], expect_pass=True)
+        run_result = self.run_dbt(['run'], expect_pass=True)
+        self.assertEqual(len(seed_result), 1)
+        self.assertEqual(len(run_result), 1)


### PR DESCRIPTION
Resolves #4804

### Description
Adds a utility to dbt.config to allow for ad-hoc project object generation

### Additional context
This isn't a great solution-- A much better pattern would be to untangle the way we current launch tasks and incorporate a built-the-project-first approach as a first class citizen instead of a random config util.  I started work down that path but issues with our various context managers and time limitations have foiled that plan.  The work done in that direction can be seen on [this WIP branch ](https://github.com/dbt-labs/dbt-core/tree/iknox-untangle-task-launching)and will be useful in future cli-related work.



### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
