### PR TITLE
Remove unneeded code in default snapshot materialization

### DIFF
--- a/.changes/unreleased/Under the Hood-20220404-144708.yaml
+++ b/.changes/unreleased/Under the Hood-20220404-144708.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Remove unneeded create_schema in snapshot materialization
+time: 2022-04-04T14:47:08.960642+02:00
+custom:
+  Author: jtcohen6
+  Issue: "4742"
+  PR: "4993"

--- a/core/dbt/include/global_project/macros/materializations/snapshots/snapshot.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshots/snapshot.sql
@@ -6,10 +6,6 @@
   {%- set strategy_name = config.get('strategy') -%}
   {%- set unique_key = config.get('unique_key') %}
 
-  {% if not adapter.check_schema_exists(model.database, model.schema) %}
-    {% do create_schema(model.database, model.schema) %}
-  {% endif %}
-
   {% set target_relation_exists, target_relation = get_or_create_relation(
           database=model.database,
           schema=model.schema,


### PR DESCRIPTION
resolves #4742

Not just unneeded, also incorrect!

### Description

See https://github.com/dbt-labs/dbt-core/issues/4742#issuecomment-1087506405 for the archaeology

**tl;dr:**
- We added this in-materialization `create_schema` a _long_ time ago (Dec 2017), back when snapshots were archives defined in `dbt_project.yml`
- When we converted archives to snapshots (real DAG nodes), in 2019, we did the thing that makes schema creation happen implicitly during the `snapshot` task, just like for models in the `run` task
- We never removed the explicit `create_schema` from the snapshot materialization. We even tweaked it to fix unexpected behavior, when the real fix would have been to remove it entirely
- Let's remove it entirely :)

### Testing

This is already covered by [`test_cross_schema_snapshot`](https://github.com/dbt-labs/dbt-core/blob/main/tests/functional/simple_snapshot/test_cross_schema_snapshot.py#L38), which would fail if dbt did not first create `{test_schema}_snapshotted` while running the `snapshot` task.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
