### PR TITLE
Add `selected_resources` to the Jinja context

### DIFF
--- a/.changes/unreleased/Features-20220404-190439.yaml
+++ b/.changes/unreleased/Features-20220404-190439.yaml
@@ -1,0 +1,9 @@
+kind: Features
+body: Add a variable called selected_resources in the Jinja context containing a list
+  of all the resources matching the nodes for  the --select, --exclude and/or --selector
+  parameters.
+time: 2022-04-04T19:04:39.347479+02:00
+custom:
+  Author: b-per
+  Issue: "3471"
+  PR: "5001"

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, NoReturn, Optional, Mapping
 
 from dbt import flags
 from dbt import tracking
+from dbt import selected_resources
 from dbt.clients.jinja import get_rendered
 from dbt.clients.yaml_helper import yaml, safe_load, SafeLoader, Loader, Dumper  # noqa: F401
 from dbt.contracts.graph.compiled import CompiledResource
@@ -555,6 +556,15 @@ class BaseContext(metaclass=ContextMeta):
         TODO: Replace with object that provides read-only access to flag values
         """
         return flags
+
+    @contextproperty
+    def selected_resources(self) -> Any:
+        """The `selected_resources` variable contains a list of the resources
+        selected based on the parameters provided to the dbt command.
+        Currently, is not populated for the command `run-operation` that
+        doesn't support `--select`.
+        """
+        return selected_resources.SELECTED_RESOURCES
 
     @contextmember
     @staticmethod

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, NoReturn, Optional, Mapping
 
 from dbt import flags
 from dbt import tracking
-from dbt import selected_resources
 from dbt.clients.jinja import get_rendered
 from dbt.clients.yaml_helper import yaml, safe_load, SafeLoader, Loader, Dumper  # noqa: F401
 from dbt.contracts.graph.compiled import CompiledResource
@@ -556,15 +555,6 @@ class BaseContext(metaclass=ContextMeta):
         TODO: Replace with object that provides read-only access to flag values
         """
         return flags
-
-    @contextproperty
-    def selected_resources(self) -> Any:
-        """The `selected_resources` variable contains a list of the resources
-        selected based on the parameters provided to the dbt command.
-        Currently, is not populated for the command `run-operation` that
-        doesn't support `--select`.
-        """
-        return selected_resources.SELECTED_RESOURCES
 
     @contextmember
     @staticmethod

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -62,6 +62,8 @@ from dbt.node_types import NodeType
 
 from dbt.utils import merge, AttrDict, MultiDict
 
+from dbt import selected_resources
+
 import agate
 
 
@@ -1240,6 +1242,15 @@ class ModelContext(ProviderContext):
         if self.model.resource_type == NodeType.Operation:
             return None
         return self.db_wrapper.Relation.create_from(self.config, self.model)
+
+    @contextproperty
+    def selected_resources(self) -> Any:
+        """The `selected_resources` variable contains a list of the resources
+        selected based on the parameters provided to the dbt command.
+        Currently, is not populated for the command `run-operation` that
+        doesn't support `--select`.
+        """
+        return selected_resources.SELECTED_RESOURCES
 
 
 # This is called by '_context_for', used in 'render_with_context'

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1145,6 +1145,15 @@ class ProviderContext(ManifestContext):
             msg = f"Env var required but not provided: '{var}'"
             raise_parsing_error(msg)
 
+    @contextproperty
+    def selected_resources(self) -> List[str]:
+        """The `selected_resources` variable contains a list of the resources
+        selected based on the parameters provided to the dbt command.
+        Currently, is not populated for the command `run-operation` that
+        doesn't support `--select`.
+        """
+        return selected_resources.SELECTED_RESOURCES
+
 
 class MacroContext(ProviderContext):
     """Internally, macros can be executed like nodes, with some restrictions:
@@ -1242,15 +1251,6 @@ class ModelContext(ProviderContext):
         if self.model.resource_type == NodeType.Operation:
             return None
         return self.db_wrapper.Relation.create_from(self.config, self.model)
-
-    @contextproperty
-    def selected_resources(self) -> Any:
-        """The `selected_resources` variable contains a list of the resources
-        selected based on the parameters provided to the dbt command.
-        Currently, is not populated for the command `run-operation` that
-        doesn't support `--select`.
-        """
-        return selected_resources.SELECTED_RESOURCES
 
 
 # This is called by '_context_for', used in 'render_with_context'

--- a/core/dbt/graph/selector.py
+++ b/core/dbt/graph/selector.py
@@ -17,6 +17,8 @@ from dbt.contracts.graph.compiled import GraphMemberNode
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.state import PreviousState
 
+from dbt import selected_resources
+
 
 def get_package_names(nodes):
     return set([node.split(".")[1] for node in nodes])
@@ -269,6 +271,7 @@ class NodeSelector(MethodManager):
         dependecies.
         """
         selected_nodes = self.get_selected(spec)
+        selected_resources.set_selected_resources(selected_nodes)
         new_graph = self.full_graph.get_subset_graph(selected_nodes)
         # should we give a way here for consumers to mutate the graph?
         return GraphQueue(new_graph.graph, self.manifest, selected_nodes)

--- a/core/dbt/selected_resources.py
+++ b/core/dbt/selected_resources.py
@@ -1,0 +1,6 @@
+SELECTED_RESOURCES = []
+
+
+def set_selected_resources(selected_resources):
+    global SELECTED_RESOURCES
+    SELECTED_RESOURCES = list(selected_resources)

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -221,6 +221,7 @@ REQUIRED_MACRO_KEYS = REQUIRED_QUERY_HEADER_KEYS | {
     'sql',
     'sql_now',
     'adapter_macro',
+    'selected_resources'
 }
 REQUIRED_MODEL_KEYS = REQUIRED_MACRO_KEYS | {'this'}
 MAYBE_KEYS = frozenset({'debug'})

--- a/tests/functional/selected_resources/fixtures.py
+++ b/tests/functional/selected_resources/fixtures.py
@@ -1,0 +1,35 @@
+on_run_start_macro_assert_selected_models_expected_list = """
+{% macro assert_selected_models_expected_list(expected_list) %}
+
+  {% if execute %}
+
+    {% set sorted_selected_resources = selected_resources | sort %}
+    {% set sorted_expected_list = expected_list | sort %}
+
+    {% if sorted_selected_resources != sorted_expected_list %}
+      {{ exceptions.raise_compiler_error("FAIL: sorted_selected_resources" ~ sorted_selected_resources ~ " is different from " ~ sorted_expected_list) }}
+    {% endif %}
+
+  {% endif %}
+
+{% endmacro %}
+"""
+
+
+my_model1 = """
+select 1 as id
+"""
+
+my_model2 = """
+select * from {{ ref('model1') }}
+"""
+
+my_snapshot = """
+{% snapshot cc_all_snapshot %}
+    {{ config(
+        check_cols='all', unique_key='id', strategy='check',
+        target_database=database, target_schema=schema
+    ) }}
+    select * from {{ ref('model2') }}
+{% endsnapshot %}
+"""

--- a/tests/functional/selected_resources/fixtures.py
+++ b/tests/functional/selected_resources/fixtures.py
@@ -1,7 +1,7 @@
 on_run_start_macro_assert_selected_models_expected_list = """
 {% macro assert_selected_models_expected_list(expected_list) %}
 
-  {% if execute %}
+  {% if execute and (expected_list is not none) %}
 
     {% set sorted_selected_resources = selected_resources | sort %}
     {% set sorted_expected_list = expected_list | sort %}

--- a/tests/functional/selected_resources/test_selected_resources.py
+++ b/tests/functional/selected_resources/test_selected_resources.py
@@ -1,0 +1,81 @@
+import pytest
+from dbt.tests.util import run_dbt
+from tests.functional.selected_resources.fixtures import (
+    on_run_start_macro_assert_selected_models_expected_list,
+    my_model1,
+    my_model2,
+    my_snapshot,
+)
+
+
+@pytest.fixture(scope="class")
+def macros():
+    return {
+        "assert_selected_models_expected_list.sql": on_run_start_macro_assert_selected_models_expected_list,
+    }
+
+
+@pytest.fixture(scope="class")
+def models():
+    return {"model1.sql": my_model1, "model2.sql": my_model2}
+
+
+@pytest.fixture(scope="class")
+def snapshots():
+    return {
+        "my_snapshot.sql": my_snapshot,
+    }
+
+
+@pytest.fixture(scope="class")
+def project_config_update():
+    return {
+        "on-run-start": "{{ assert_selected_models_expected_list(var('expected_list',[])) }}",
+    }
+
+
+def test_selected_resources_build(project):
+    results = run_dbt(
+        [
+            "build",
+            "--select",
+            "model1+",
+            "--vars",
+            '{"expected_list": ["model.test.model1", "model.test.model2", "snapshot.test.cc_all_snapshot"]}',
+        ]
+    )
+    assert results[0].status == "success"
+
+
+def test_selected_resources_run(project):
+    results = run_dbt(
+        [
+            "run",
+            "--select",
+            "model1+",
+            "--vars",
+            '{"expected_list": ["model.test.model2", "model.test.model1"]}',
+        ]
+    )
+    assert results[0].status == "success"
+
+
+def test_selected_resources_build_all(project):
+    results = run_dbt(
+        [
+            "build",
+            "--vars",
+            '{"expected_list": ["model.test.model1", "model.test.model2", "snapshot.test.cc_all_snapshot"]}',
+        ]
+    )
+    assert results[0].status == "success"
+
+
+def test_selected_resources_build_no_model(project):
+    results = run_dbt(["build", "--select", "model_that_does_not_exist"])
+    assert not results
+
+
+def test_selected_resources_test_no_model(project):
+    results = run_dbt(["test", "--select", "model1+", "--vars", '{"expected_list": []}'])
+    assert not results


### PR DESCRIPTION
resolves #3471

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

I don't know if I followed the correct approach but this code is adding a variable called `selected_resources` to the Jinja context. This is a list of all models/tests/snapshots etc... captured by the selectors for the dbt run. I checked how `flags` were added to the context and did the same for `selected_resources`, hence why it is under the `core/dbt` folder.

The issue #3471 also mentions making this available for `run-operation` but this will be taken care of in another issue.

My testing approach is to use a `on-run-start` hook to compare the value of `selected_resources` with the expected one.

If this is merged the docs will need to be updated to mention the new variable and highlight that similar to `graph` is will only contain some information at `execute` time.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
