### PR TITLE
Fixing broken CI for `1.0.latest`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,4 +81,5 @@ setup(
         'Programming Language :: Python :: 3.9',
     ],
     python_requires=">=3.7",
+    packages=[]
 )


### PR DESCRIPTION
### Description
Currently, the build package step is broken in `1.0.latest` for CI. [Example failed build](https://github.com/dbt-labs/dbt-core/runs/5872002659?check_suite_focus=true)

The problem is that `setuptools` [made a breaking change in version 61](https://setuptools.pypa.io/en/latest/history.html#id35) (our last successful run on `1.0.latest` was with version 60) in which if no `packages` attribute was specified in the `setup.py` file, then it would automatically search and find packages to include (which it found conflicting ones). By specifying the packages attribute in the base `setup.py` file, it defaults back to what we were doing before and not pulling in non-specified packages

**Background:**
For `setup.py` at the base of the repo, this was originally used for when we released a `dbt` package with all the adapters in it. We used this file to create the last and one time only `dbt-1.0.0` package and then stopped in favor of the `dbt-<adapter>-1.0.x` patches. This file doesn't exist in `main` anymore and therefore we didn't see CI fail there. Why don't we remove this file from `1.0.latest`? It would involve us making changes in a couple other places to clean-up and instead of introducing more changes, we can just continue creating this package that doesn't get released anymore (only the case for this branch- not for `main` and any minor versions going forward).

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
