### PR TITLE
updated event message

### DIFF
--- a/.changes/unreleased/Fixes-20220407-161134.yaml
+++ b/.changes/unreleased/Fixes-20220407-161134.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Make the warning message for a full event deque more descriptive
+time: 2022-04-07T16:11:34.614988-05:00
+custom:
+  Author: iknox-fa
+  Issue: "4962"
+  PR: "5011"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -2439,7 +2439,10 @@ class EventBufferFull(WarnLevel):
     code: str = "Z048"
 
     def message(self) -> str:
-        return "Internal event buffer full. Earliest events will be dropped (FIFO)."
+        return (
+            "Internal logging/event buffer full."
+            "Earliest logs/events will be dropped as new ones are fired (FIFO)."
+        )
 
 
 @dataclass


### PR DESCRIPTION
resolves # 4962

### Description
A more descriptive warning when the internal event deque is full.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
