### PR TITLE
Fix multi threaded test failures

### DIFF
--- a/.changes/unreleased/Under the Hood-20220408-114040.yaml
+++ b/.changes/unreleased/Under the Hood-20220408-114040.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: update test file to pass in multi threaded runs
+time: 2022-04-08T11:40:40.547981-04:00
+custom:
+  Author: nathaniel-may
+  Issue: "4904"
+  PR: "5015"

--- a/tests/functional/graph_selection/test_tag_selection.py
+++ b/tests/functional/graph_selection/test_tag_selection.py
@@ -97,35 +97,43 @@ class TestTagSelection(SelectionFixtures):
         _verify_select_tag(results)
 
     def test_select_tag_selector_str(self, project):
+        run_dbt(["seed"])
         results = run_dbt(["run", "--selector", "tag_specified_as_string_str"])
         _verify_select_tag(results)
 
     def test_select_tag_selector_dict(self, project):
+        run_dbt(["seed"])
         results = run_dbt(["run", "--selector", "tag_specified_as_string_dict"])
         _verify_select_tag(results)
 
     def test_select_tag_and_children(self, project):  # noqa
+        run_dbt(["seed"])
         results = run_dbt(["run", "--models", "+tag:specified_in_project+"])
         _verify_select_tag_and_children(results)
 
     def test_select_tag_and_children_selector_str(self, project):  # noqa
+        run_dbt(["seed"])
         results = run_dbt(["run", "--selector", "tag_specified_in_project_children_str"])
         _verify_select_tag_and_children(results)
 
     def test_select_tag_and_children_selector_dict(self, project):  # noqa
+        run_dbt(["seed"])
         results = run_dbt(["run", "--selector", "tag_specified_in_project_children_dict"])
         _verify_select_tag_and_children(results)
 
     def test_select_tag_in_model_with_project_config(self, project):  # noqa
+        run_dbt(["seed"])
         results = run_dbt(["run", "--models", "tag:bi"])
         _verify_select_bi(results)
 
     def test_select_tag_in_model_with_project_config_selector(self, project):  # noqa
+        run_dbt(["seed"])
         results = run_dbt(["run", "--selector", "tagged-bi"])
         _verify_select_bi(results)
 
     # check that model configs aren't squashed by project configs
     def test_select_tag_in_model_with_project_config_parents_children(self, project):  # noqa
+        run_dbt(["seed"])
         results = run_dbt(["run", "--models", "@tag:users"])
         assert len(results) == 4
 
@@ -159,6 +167,7 @@ class TestTagSelection(SelectionFixtures):
         ]
 
     def test_select_tag_in_model_with_project_config_parents_children_selectors(self, project):
+        run_dbt(["seed"])
         results = run_dbt(["run", "--selector", "user_tagged_childrens_parents"])
         assert len(results) == 4
 


### PR DESCRIPTION
### Description

This is a follow up to #4986. This test file relied on tests being run in serial. Now that they are run in parallel, they fail when the first test isn't run first. Adding the dbt seed run to the start of every test fixes this.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
