### PR TITLE
added git-blame-ignore-revs file

### DIFF
--- a/.changes/unreleased/Under the Hood-20220408-135525.yaml
+++ b/.changes/unreleased/Under the Hood-20220408-135525.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Added .git-blame-ignore-revs file to mask re-formmating commits from git blame
+time: 2022-04-08T13:55:25.790513-05:00
+custom:
+  Author: iknox-fa
+  Issue: "5004"
+  PR: "5019"

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Reformatting dbt-core via black, flake8, mypy, and assorted pre-commit hooks.
+43e3fc22c4eae4d3d901faba05e33c40f1f1dc5a


### PR DESCRIPTION
resolves # 5004


### Description
Hides a large reformatting commit from bit-blame

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
