### PR TITLE
Fix hard_delete_snapshot test to do the right thing.

### DIFF
--- a/.changes/unreleased/Fixes-20220408-155512.yaml
+++ b/.changes/unreleased/Fixes-20220408-155512.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix hard delete snapshot test
+time: 2022-04-08T15:55:12.552138-04:00
+custom:
+  Author: gshank
+  Issue: "4916"
+  PR: "5020"


### PR DESCRIPTION
resolves #4916

### Description

This test wasn't doing the right thing to start with. Because the timestamp being inserted didn't have microseconds, it got the greater than backward. It was supposed to be less than.  

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
