### PR TITLE
cache after retrying not while retrying

### DIFF
--- a/core/dbt/clients/registry.py
+++ b/core/dbt/clients/registry.py
@@ -31,7 +31,7 @@ def _get_url(name, registry_base_url=None):
 
 
 def _get_with_retries(package_name, registry_base_url=None):
-    get_fn = functools.partial(_get_cached, package_name, registry_base_url)
+    get_fn = functools.partial(_get, package_name, registry_base_url)
     return connection_exception_retry(get_fn, 5)
 
 
@@ -111,12 +111,12 @@ def _get(package_name, registry_base_url=None):
     return response
 
 
-_get_cached = memoized(_get)
+_get_cached = memoized(_get_with_retries)
 
 
 def package(package_name, registry_base_url=None) -> Dict[str, Any]:
     # returns a dictionary of metadata for all versions of a package
-    response = _get_with_retries(package_name, registry_base_url)
+    response = _get_cached(package_name, registry_base_url)
     return response["versions"]
 
 


### PR DESCRIPTION
resolves #5023

### Description

The previous solution was calling retries on the cached version of `_get`.  Because of that, when `_get` raised an exception and went to repeat, it repeated with the cached version of `_get` since it was calling with the same input.  Since it previously raised an exception its return value was None and hence when continuing the processing, we get `TypeError: 'NoneType' object is not subscriptable`.

This change caches the retries so we will retry up to 5 times.  If after 5 tries there is no success, an exception is raised and processing stops.  Otherwise it was a success and we got the data in an expected format so using a cached version of the returned data is acceptable.

Todo: Add a unit test that mocks the response and tests caching.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
