### PR TITLE
Add experimental `cache_selected_only` config

### DIFF
--- a/.changes/unreleased/Breaking Changes-20220412-152450.yaml
+++ b/.changes/unreleased/Breaking Changes-20220412-152450.yaml
@@ -1,0 +1,9 @@
+kind: Breaking Changes
+body: 'For adapter plugin maintainers only: Internal adapter method _relations_cache_for_schemas
+  takes an additional argument, cache_schemas, for use with experimental CACHE_SELECTED_ONLY
+  config'
+time: 2022-04-12T15:24:50.159572+02:00
+custom:
+  Author: karunpoudel
+  Issue: "4688"
+  PR: "4860"

--- a/.changes/unreleased/Breaking Changes-20220412-152450.yaml
+++ b/.changes/unreleased/Breaking Changes-20220412-152450.yaml
@@ -1,6 +1,6 @@
 kind: Breaking Changes
-body: 'For adapter plugin maintainers only: Internal adapter method _relations_cache_for_schemas
-  takes an additional argument, cache_schemas, for use with experimental CACHE_SELECTED_ONLY
+body: 'For adapter plugin maintainers only: Internal adapter methods `set_relations_cache` + `_relations_cache_for_schemas`
+  each take an additional argument, for use with experimental `CACHE_SELECTED_ONLY`
   config'
 time: 2022-04-12T15:24:50.159572+02:00
 custom:

--- a/.changes/unreleased/Features-20220316-003847.yaml
+++ b/.changes/unreleased/Features-20220316-003847.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Add `--selected-schema-cache` flag to cache schema object of selected models
+body: Add `--cache_selected_only` flag to cache schema object of selected models
   only.
 time: 2022-03-16T00:38:47.8468296-05:00
 custom:

--- a/.changes/unreleased/Features-20220316-003847.yaml
+++ b/.changes/unreleased/Features-20220316-003847.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Add `--selected-schema-cache` flag to cache schema object of selected models
+  only.
+time: 2022-03-16T00:38:47.8468296-05:00
+custom:
+  Author: karunpoudel
+  Issue: "4688"
+  PR: "4860"

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -340,7 +340,9 @@ class BaseAdapter(metaclass=AdapterMeta):
         # databases
         return info_schema_name_map
 
-    def _relations_cache_for_schemas(self, manifest: Manifest, cache_schemas: Set[BaseRelation] = None) -> None:
+    def _relations_cache_for_schemas(
+            self, manifest: Manifest, cache_schemas: Set[BaseRelation] = None
+    ) -> None:
         """Populate the relations cache for the given schemas. Returns an
         iterable of the schemas populated, as strings.
         """
@@ -371,8 +373,9 @@ class BaseAdapter(metaclass=AdapterMeta):
             cache_update.add((relation.database, relation.schema))
         self.cache.update_schemas(cache_update)
 
-    def set_relations_cache(self, manifest: Manifest, clear: bool = False,
-                            required_schemas: Set[BaseRelation] = None) -> None:
+    def set_relations_cache(
+            self, manifest: Manifest, clear: bool = False, required_schemas: Set[BaseRelation] = None
+    ) -> None:
         """Run a query that gets a populated cache of the relations in the
         database and set the cache on this adapter.
         """

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -340,11 +340,12 @@ class BaseAdapter(metaclass=AdapterMeta):
         # databases
         return info_schema_name_map
 
-    def _relations_cache_for_schemas(self, manifest: Manifest) -> None:
+    def _relations_cache_for_schemas(self, manifest: Manifest, cache_schemas: Set[BaseRelation] = None) -> None:
         """Populate the relations cache for the given schemas. Returns an
         iterable of the schemas populated, as strings.
         """
-        cache_schemas = self._get_cache_schemas(manifest)
+        if not cache_schemas:
+            cache_schemas = self._get_cache_schemas(manifest)
         with executor(self.config) as tpe:
             futures: List[Future[List[BaseRelation]]] = []
             for cache_schema in cache_schemas:
@@ -370,14 +371,15 @@ class BaseAdapter(metaclass=AdapterMeta):
             cache_update.add((relation.database, relation.schema))
         self.cache.update_schemas(cache_update)
 
-    def set_relations_cache(self, manifest: Manifest, clear: bool = False) -> None:
+    def set_relations_cache(self, manifest: Manifest, clear: bool = False,
+                            required_schemas: Set[BaseRelation] = None) -> None:
         """Run a query that gets a populated cache of the relations in the
         database and set the cache on this adapter.
         """
         with self.cache.lock:
             if clear:
                 self.cache.clear()
-            self._relations_cache_for_schemas(manifest)
+            self._relations_cache_for_schemas(manifest, required_schemas)
 
     @available
     def cache_added(self, relation: Optional[BaseRelation]) -> str:

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -341,7 +341,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         return info_schema_name_map
 
     def _relations_cache_for_schemas(
-            self, manifest: Manifest, cache_schemas: Set[BaseRelation] = None
+        self, manifest: Manifest, cache_schemas: Set[BaseRelation] = None
     ) -> None:
         """Populate the relations cache for the given schemas. Returns an
         iterable of the schemas populated, as strings.
@@ -374,7 +374,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         self.cache.update_schemas(cache_update)
 
     def set_relations_cache(
-            self, manifest: Manifest, clear: bool = False, required_schemas: Set[BaseRelation] = None
+        self, manifest: Manifest, clear: bool = False, required_schemas: Set[BaseRelation] = None
     ) -> None:
         """Run a query that gets a populated cache of the relations in the
         database and set the cache on this adapter.

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -253,6 +253,7 @@ class UserConfig(ExtensibleDbtClassMixin, Replaceable, UserConfigContract):
     use_experimental_parser: Optional[bool] = None
     static_parser: Optional[bool] = None
     indirect_selection: Optional[str] = None
+    selected_schema_cache: Optional[bool] = None
 
 
 @dataclass

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -253,7 +253,7 @@ class UserConfig(ExtensibleDbtClassMixin, Replaceable, UserConfigContract):
     use_experimental_parser: Optional[bool] = None
     static_parser: Optional[bool] = None
     indirect_selection: Optional[str] = None
-    selected_schema_cache: Optional[bool] = None
+    cache_selected_only: Optional[bool] = None
 
 
 @dataclass

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -36,6 +36,7 @@ LOG_CACHE_EVENTS = None
 EVENT_BUFFER_SIZE = 100000
 QUIET = None
 NO_PRINT = None
+CACHE_SELECTED_ONLY = None
 
 _NON_BOOLEAN_FLAGS = [
     "LOG_FORMAT",
@@ -69,6 +70,7 @@ flag_defaults = {
     "EVENT_BUFFER_SIZE": 100000,
     "QUIET": False,
     "NO_PRINT": False,
+    "CACHE_SELECTED_ONLY": False,
 }
 
 
@@ -118,7 +120,7 @@ def set_from_args(args, user_config):
     global STRICT_MODE, FULL_REFRESH, WARN_ERROR, USE_EXPERIMENTAL_PARSER, STATIC_PARSER
     global WRITE_JSON, PARTIAL_PARSE, USE_COLORS, STORE_FAILURES, PROFILES_DIR, DEBUG, LOG_FORMAT
     global INDIRECT_SELECTION, VERSION_CHECK, FAIL_FAST, SEND_ANONYMOUS_USAGE_STATS
-    global PRINTER_WIDTH, WHICH, LOG_CACHE_EVENTS, EVENT_BUFFER_SIZE, QUIET, NO_PRINT
+    global PRINTER_WIDTH, WHICH, LOG_CACHE_EVENTS, EVENT_BUFFER_SIZE, QUIET, NO_PRINT, CACHE_SELECTED_ONLY
 
     STRICT_MODE = False  # backwards compatibility
     # cli args without user_config or env var option
@@ -145,6 +147,7 @@ def set_from_args(args, user_config):
     EVENT_BUFFER_SIZE = get_flag_value("EVENT_BUFFER_SIZE", args, user_config)
     QUIET = get_flag_value("QUIET", args, user_config)
     NO_PRINT = get_flag_value("NO_PRINT", args, user_config)
+    CACHE_SELECTED_ONLY = get_flag_value("CACHE_SELECTED_ONLY", args, user_config)
 
     _set_overrides_from_env()
 

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -68,11 +68,7 @@ flag_defaults = {
     "LOG_CACHE_EVENTS": False,
     "EVENT_BUFFER_SIZE": 100000,
     "QUIET": False,
-<<<<<<< HEAD
     "NO_PRINT": False,
-=======
-    "SELECTED_SCHEMA_CACHE": False,
->>>>>>> 54f69f876 (cache schema for selected models)
 }
 
 
@@ -122,11 +118,7 @@ def set_from_args(args, user_config):
     global STRICT_MODE, FULL_REFRESH, WARN_ERROR, USE_EXPERIMENTAL_PARSER, STATIC_PARSER
     global WRITE_JSON, PARTIAL_PARSE, USE_COLORS, STORE_FAILURES, PROFILES_DIR, DEBUG, LOG_FORMAT
     global INDIRECT_SELECTION, VERSION_CHECK, FAIL_FAST, SEND_ANONYMOUS_USAGE_STATS
-<<<<<<< HEAD
     global PRINTER_WIDTH, WHICH, LOG_CACHE_EVENTS, EVENT_BUFFER_SIZE, QUIET, NO_PRINT
-=======
-    global PRINTER_WIDTH, WHICH, LOG_CACHE_EVENTS, EVENT_BUFFER_SIZE, QUIET, SELECTED_SCHEMA_CACHE
->>>>>>> 54f69f876 (cache schema for selected models)
 
     STRICT_MODE = False  # backwards compatibility
     # cli args without user_config or env var option
@@ -152,11 +144,7 @@ def set_from_args(args, user_config):
     LOG_CACHE_EVENTS = get_flag_value("LOG_CACHE_EVENTS", args, user_config)
     EVENT_BUFFER_SIZE = get_flag_value("EVENT_BUFFER_SIZE", args, user_config)
     QUIET = get_flag_value("QUIET", args, user_config)
-<<<<<<< HEAD
     NO_PRINT = get_flag_value("NO_PRINT", args, user_config)
-=======
-    SELECTED_SCHEMA_CACHE = get_flag_value('SELECTED_SCHEMA_CACHE', args, user_config)
->>>>>>> 54f69f876 (cache schema for selected models)
 
     _set_overrides_from_env()
 

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -68,7 +68,11 @@ flag_defaults = {
     "LOG_CACHE_EVENTS": False,
     "EVENT_BUFFER_SIZE": 100000,
     "QUIET": False,
+<<<<<<< HEAD
     "NO_PRINT": False,
+=======
+    "SELECTED_SCHEMA_CACHE": False,
+>>>>>>> 54f69f876 (cache schema for selected models)
 }
 
 
@@ -118,7 +122,11 @@ def set_from_args(args, user_config):
     global STRICT_MODE, FULL_REFRESH, WARN_ERROR, USE_EXPERIMENTAL_PARSER, STATIC_PARSER
     global WRITE_JSON, PARTIAL_PARSE, USE_COLORS, STORE_FAILURES, PROFILES_DIR, DEBUG, LOG_FORMAT
     global INDIRECT_SELECTION, VERSION_CHECK, FAIL_FAST, SEND_ANONYMOUS_USAGE_STATS
+<<<<<<< HEAD
     global PRINTER_WIDTH, WHICH, LOG_CACHE_EVENTS, EVENT_BUFFER_SIZE, QUIET, NO_PRINT
+=======
+    global PRINTER_WIDTH, WHICH, LOG_CACHE_EVENTS, EVENT_BUFFER_SIZE, QUIET, SELECTED_SCHEMA_CACHE
+>>>>>>> 54f69f876 (cache schema for selected models)
 
     STRICT_MODE = False  # backwards compatibility
     # cli args without user_config or env var option
@@ -144,7 +152,11 @@ def set_from_args(args, user_config):
     LOG_CACHE_EVENTS = get_flag_value("LOG_CACHE_EVENTS", args, user_config)
     EVENT_BUFFER_SIZE = get_flag_value("EVENT_BUFFER_SIZE", args, user_config)
     QUIET = get_flag_value("QUIET", args, user_config)
+<<<<<<< HEAD
     NO_PRINT = get_flag_value("NO_PRINT", args, user_config)
+=======
+    SELECTED_SCHEMA_CACHE = get_flag_value('SELECTED_SCHEMA_CACHE', args, user_config)
+>>>>>>> 54f69f876 (cache schema for selected models)
 
     _set_overrides_from_env()
 

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -1096,7 +1096,7 @@ def parse_args(args, cls=DBTArgumentParser):
         Suppress all {{ print() }} macro calls.
         """,
     )
-    
+
     schema_cache_flag = p.add_mutually_exclusive_group()
     schema_cache_flag.add_argument(
         "--cache-selected-only",

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -1096,6 +1096,27 @@ def parse_args(args, cls=DBTArgumentParser):
         Suppress all {{ print() }} macro calls.
         """,
     )
+    
+    schema_cache_flag = p.add_mutually_exclusive_group()
+    schema_cache_flag.add_argument(
+        "--cache-selected-only",
+        action="store_const",
+        const=True,
+        default=None,
+        dest="cache_selected_only",
+        help="""
+        Pre cache database objects relevant to selected resource only.
+        """,
+    )
+    schema_cache_flag.add_argument(
+        "--no-cache-selected-only",
+        action="store_const",
+        const=False,
+        dest="cache_selected_only",
+        help="""
+        Pre cache all database objects related to the project.
+        """,
+    )
 
     subs = p.add_subparsers(title="Available sub-commands")
 

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -436,8 +436,9 @@ class RunTask(CompileTask):
 
     def before_run(self, adapter, selected_uids: AbstractSet[str]):
         with adapter.connection_named("master"):
-            self.create_schemas(adapter, selected_uids)
-            self.populate_adapter_cache(adapter)
+            required_schemas = self.get_model_schemas(adapter, selected_uids)
+            self.create_schemas(adapter, required_schemas)
+            self.populate_adapter_cache(adapter, required_schemas)
             self.defer_to_manifest(adapter, selected_uids)
             self.safe_run_hooks(adapter, RunHookType.Start, {})
 

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -399,9 +399,9 @@ class GraphRunnableTask(ManifestTask):
         for dep_node_id in self.graph.get_dependent_nodes(node_id):
             self._skipped_children[dep_node_id] = cause
 
-    def populate_adapter_cache(self, adapter):
+    def populate_adapter_cache(self, adapter, required_schemas: Set[BaseRelation] = None):
         start_populate_cache = time.perf_counter()
-        if flags.SELECTED_SCHEMA_CACHE is True:
+        if flags.CACHE_SELECTED_ONLY is True:
             adapter.set_relations_cache(self.manifest, required_schemas=required_schemas)
         else:
             adapter.set_relations_cache(self.manifest)

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -401,7 +401,10 @@ class GraphRunnableTask(ManifestTask):
 
     def populate_adapter_cache(self, adapter):
         start_populate_cache = time.perf_counter()
-        adapter.set_relations_cache(self.manifest)
+        if flags.SELECTED_SCHEMA_CACHE is True:
+            adapter.set_relations_cache(self.manifest, required_schemas=required_schemas)
+        else:
+            adapter.set_relations_cache(self.manifest)
         cache_populate_time = time.perf_counter() - start_populate_cache
         if dbt.tracking.active_user is not None:
             dbt.tracking.track_runnable_timing(
@@ -504,8 +507,7 @@ class GraphRunnableTask(ManifestTask):
 
         return result
 
-    def create_schemas(self, adapter, selected_uids: Iterable[str]):
-        required_schemas = self.get_model_schemas(adapter, selected_uids)
+    def create_schemas(self, adapter, required_schemas: Set[BaseRelation]):
         # we want the string form of the information schema database
         required_databases: Set[BaseRelation] = set()
         for required in required_schemas:

--- a/plugins/postgres/dbt/adapters/postgres/impl.py
+++ b/plugins/postgres/dbt/adapters/postgres/impl.py
@@ -126,8 +126,8 @@ class PostgresAdapter(SQLAdapter):
 
         self._link_cached_database_relations(schemas)
 
-    def _relations_cache_for_schemas(self, manifest):
-        super()._relations_cache_for_schemas(manifest)
+    def _relations_cache_for_schemas(self, manifest, cache_schemas=None):
+        super()._relations_cache_for_schemas(manifest, cache_schemas)
         self._link_cached_relations(manifest)
 
     def timestamp_add_sql(self, add_to: str, number: int = 1, interval: str = "hour") -> str:

--- a/test/integration/038_caching_tests/models_multi_schemas/another_schema_model.sql
+++ b/test/integration/038_caching_tests/models_multi_schemas/another_schema_model.sql
@@ -1,0 +1,7 @@
+{{
+    config(
+        materialized='table',
+        schema='another_schema'
+    )
+}}
+select 1 as id

--- a/test/integration/038_caching_tests/models_multi_schemas/model.sql
+++ b/test/integration/038_caching_tests/models_multi_schemas/model.sql
@@ -1,0 +1,6 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+select 1 as id

--- a/test/integration/038_caching_tests/test_caching.py
+++ b/test/integration/038_caching_tests/test_caching.py
@@ -51,3 +51,17 @@ class TestCachingUppercaseModel(TestBaseCaching):
     @use_profile('postgres')
     def test_postgres_cache(self):
         self.cache_run()
+
+class TestCachingSelectedSchemaOnly(TestBaseCaching):
+    @property
+    def models(self):
+        return "models_multi_schemas"
+        
+    def run_and_get_adapter(self):
+        # select only the 'model' in the default schema
+        self.run_dbt(['--cache-selected-only', 'run', '--select', 'model'])
+        return FACTORY.adapters[self.adapter_type]
+
+    @use_profile('postgres')
+    def test_postgres_cache(self):
+        self.cache_run()

--- a/test/unit/test_flags.py
+++ b/test/unit/test_flags.py
@@ -235,3 +235,18 @@ class TestFlags(TestCase):
         self.assertEqual(flags.NO_PRINT, True)
         # cleanup
         self.user_config.no_print = None
+
+        # cache_selected_only
+        self.user_config.cache_selected_only = True
+        flags.set_from_args(self.args, self.user_config)
+        self.assertEqual(flags.CACHE_SELECTED_ONLY, True)
+        os.environ['DBT_CACHE_SELECTED_ONLY'] = 'false'
+        flags.set_from_args(self.args, self.user_config)
+        self.assertEqual(flags.CACHE_SELECTED_ONLY, False)
+        setattr(self.args, 'cache_selected_only', True)
+        flags.set_from_args(self.args, self.user_config)
+        self.assertEqual(flags.CACHE_SELECTED_ONLY, True)
+        # cleanup
+        os.environ.pop('DBT_CACHE_SELECTED_ONLY')
+        delattr(self.args, 'cache_selected_only')
+        self.user_config.cache_selected_only = False


### PR DESCRIPTION
resolves #4688
rebased version of #4860
more tracking + testing to come in https://github.com/dbt-labs/dbt-core/issues/4961

Only other changes:
- `--cache-selected-only` (kebab case) instead of `--cached_selected_only` (snake case)
- Add a breaking change note for the internal adapter method (Python code) with a change in its signature. Among our plugins, only `dbt-postgres` reimplements this method; all the others inherit the base version.

I'd love to include this as "experimental" functionality in v1.1 if possible. We would document it as such: https://github.com/dbt-labs/docs.getdbt.com/pull/1327

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
