### PR TITLE
Flexibilize MarkupSafe pinned version

### DIFF
--- a/.changes/unreleased/Fixes-20220413-151735.yaml
+++ b/.changes/unreleased/Fixes-20220413-151735.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Relax minimum supported version of MarkupSafe
+time: 2022-04-13T15:17:35.055274145-03:00
+custom:
+  Author: adamantike
+  Issue: "4745"
+  PR: "5039"

--- a/core/setup.py
+++ b/core/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
     install_requires=[
         "Jinja2==2.11.3",
-        "MarkupSafe==2.0.1",
+        "MarkupSafe>=0.23,<2.1",
         "agate>=1.6,<1.6.4",
         "click>=7.0,<9",
         "colorama>=0.3.9,<0.4.5",


### PR DESCRIPTION
### Description

The current `MarkupSafe` pinned version has been added in #4746 as a temporary fix for #4745.

However, the current restrictive approach isn't compatible with other libraries that could require an even older version of `MarkupSafe`, like Airflow `2.2.2` [0], which requires `markupsafe>=1.1.1, <2.0`.

To avoid that issue, we can allow a greater range of supported `MarkupSafe` versions. Considering the direct dependency `dbt-core` has is `Jinja2==2.11.3`, we can use its pinning as the lower bound, which is `MarkupSafe>=0.23` [1].

This fix should be also backported this to `1.0.latest` for inclusion in the next v1.0 patch.

[0] https://github.com/adamantike/airflow/blob/2.2.2/setup.cfg#L125
[1] https://github.com/pallets/jinja/blob/2.11.3/setup.py#L53

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
