### PR TITLE
feat: skip project name prompt with --skip-profile-setup flag

### DIFF
--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -2296,6 +2296,15 @@ class DepsSetDownloadDirectory(DebugLevel):
 
 
 @dataclass
+class ProjectInvalidName(InfoLevel):
+    name: str
+    code: str = "A028"
+
+    def message(self) -> str:
+        return f"{self.name} is not a valid project name."
+
+
+@dataclass
 class EnsureGitInstalled(ErrorLevel):
     code: str = "Z036"
 


### PR DESCRIPTION
resolves #5056

### Description
Check if the `--skip-profile-setup` flag is set, if so, no prompt is triggered upon an invalid project name.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
