### PR TITLE
move deprecation check outside package caching

### DIFF
--- a/.changes/unreleased/Under the Hood-20220414-132206.yaml
+++ b/.changes/unreleased/Under the Hood-20220414-132206.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Move package deprecation check outside of package cache
+time: 2022-04-14T13:22:06.157579-05:00
+custom:
+  Author: emmyoop
+  Issue: "5068"
+  PR: "5069"

--- a/core/dbt/clients/registry.py
+++ b/core/dbt/clients/registry.py
@@ -89,6 +89,15 @@ def _get(package_name, registry_base_url=None):
         fire_event(RegistryResponseExtraNestedKeys(response=response))
         raise requests.exceptions.ContentDecodingError(error_msg, response=resp)
 
+    return response
+
+
+_get_cached = memoized(_get_with_retries)
+
+
+def package(package_name, registry_base_url=None) -> Dict[str, Any]:
+    # returns a dictionary of metadata for all versions of a package
+    response = _get_cached(package_name, registry_base_url)
     # Either redirectnamespace or redirectname in the JSON response indicate a redirect
     # redirectnamespace redirects based on package ownership
     # redirectname redirects based on package name
@@ -107,16 +116,6 @@ def _get(package_name, registry_base_url=None):
 
         new_nwo = use_namespace + "/" + use_name
         deprecations.warn("package-redirect", old_name=package_name, new_name=new_nwo)
-
-    return response
-
-
-_get_cached = memoized(_get_with_retries)
-
-
-def package(package_name, registry_base_url=None) -> Dict[str, Any]:
-    # returns a dictionary of metadata for all versions of a package
-    response = _get_cached(package_name, registry_base_url)
     return response["versions"]
 
 


### PR DESCRIPTION
resolves #5068

### Description

Check deprecation of packages outside of package caching.  This is not actually causing error today.  However, the deprecation doesn't get cached so it should live outside that logic.  It's also preventing tests from working as expected so a real fix here allows for better tests.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added information about my change to be included in the [CHANGELOG](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry).
