### PR TITLE
Add itertools to modules

### DIFF
--- a/.changes/unreleased/Features-20220424-132655.yaml
+++ b/.changes/unreleased/Features-20220424-132655.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Adds itertools to modules Jinja namespace
+time: 2022-04-24T13:26:55.008246+01:00
+custom:
+  Author: bd3dowling
+  Issue: "5130"
+  PR: "5140"

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -23,6 +23,7 @@ from dbt.version import __version__ as dbt_version
 import pytz
 import datetime
 import re
+import itertools
 
 # Contexts in dbt Core
 # Contexts are used for Jinja rendering. They include context methods,
@@ -77,11 +78,35 @@ def get_re_module_context() -> Dict[str, Any]:
     return {name: getattr(re, name) for name in context_exports}
 
 
+def get_itertools_module_context() -> Dict[str, Any]:
+    # Excluded dropwhile, filterfalse, takewhile and groupby;
+    # first 3 illogical for Jinja and last redundant.
+    context_exports = [
+        "count",
+        "cycle",
+        "repeat",
+        "accumulate",
+        "chain",
+        "compress",
+        "islice",
+        "starmap",
+        "tee",
+        "zip_longest",
+        "product",
+        "permutations",
+        "combinations",
+        "combinations_with_replacement",
+    ]
+
+    return {name: getattr(itertools, name) for name in context_exports}
+
+
 def get_context_modules() -> Dict[str, Dict[str, Any]]:
     return {
         "pytz": get_pytz_module_context(),
         "datetime": get_datetime_module_context(),
         "re": get_re_module_context(),
+        "itertools": get_itertools_module_context(),
     }
 
 


### PR DESCRIPTION

resolves: https://github.com/dbt-labs/dbt-core/issues/5130

### Description

Adds `itertools` to `modules` Jinja-"namespace" for usage as global functions.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
