### PR TITLE
Even more scrubbing

### DIFF
--- a/.changes/unreleased/Fixes-20220425-203924.yaml
+++ b/.changes/unreleased/Fixes-20220425-203924.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Scrub secret env vars from CommandError in exception stacktrace
+time: 2022-04-25T20:39:24.365495+02:00
+custom:
+  Author: jtcohen6
+  Issue: "5151"
+  PR: "5152"

--- a/core/dbt/clients/git.py
+++ b/core/dbt/clients/git.py
@@ -2,7 +2,7 @@ import re
 import os.path
 
 from dbt.clients.system import run_cmd, rmdir
-from dbt.events.functions import fire_event
+from dbt.events.functions import fire_event, scrub_secrets, env_secrets
 from dbt.events.types import (
     GitSparseCheckoutSubdirectory,
     GitProgressCheckoutRevision,
@@ -28,7 +28,7 @@ def _is_commit(revision: str) -> bool:
 
 
 def _raise_git_cloning_error(repo, revision, error):
-    stderr = error.stderr.decode("utf-8").strip()
+    stderr = scrub_secrets(error.stderr.decode("utf-8").strip(), env_secrets())
     if "usage: git" in stderr:
         stderr = stderr.split("\nusage: git")[0]
     if re.match("fatal: destination path '(.+)' already exists", stderr):

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -13,7 +13,7 @@ import requests
 import stat
 from typing import Type, NoReturn, List, Optional, Dict, Any, Tuple, Callable, Union
 
-from dbt.events.functions import fire_event
+from dbt.events.functions import fire_event, scrub_secrets, env_secrets
 from dbt.events.types import (
     SystemErrorRetrievingModTime,
     SystemCouldNotWrite,
@@ -431,7 +431,8 @@ def run_cmd(cwd: str, cmd: List[str], env: Optional[Dict[str, Any]] = None) -> T
 
     if proc.returncode != 0:
         fire_event(SystemReportReturnCode(returncode=proc.returncode))
-        raise dbt.exceptions.CommandResultError(cwd, cmd, proc.returncode, out, err)
+        scrubbed_cmd = list(scrub_secrets(cmd_txt, env_secrets()) for cmd_txt in cmd)
+        raise dbt.exceptions.CommandResultError(cwd, scrubbed_cmd, proc.returncode, out, err)
 
     return out, err
 

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -383,10 +383,11 @@ class FailedToConnectException(DatabaseException):
 
 class CommandError(RuntimeException):
     def __init__(self, cwd, cmd, message="Error running command"):
+        cmd_scrubbed = list(scrub_secrets(cmd_txt, env_secrets()) for cmd_txt in cmd)
         super().__init__(message)
         self.cwd = cwd
-        self.cmd = cmd
-        self.args = (cwd, cmd, message)
+        self.cmd = cmd_scrubbed
+        self.args = (cwd, cmd_scrubbed, message)
 
     def __str__(self):
         if len(self.cmd) == 0:


### PR DESCRIPTION
resolves #5151

### Description

- Scrub `cmd` in `CommandError`, which `clients.system.run_cmd` raises and `clients.git.clone` catches
- Also scrub (again) in `clients.git._raise_git_cloning_error`... even though it should be scrubbed yet again in `dbt.exceptions.bad_package_spec`

### Locally

```yml
packages:
  - git: "https://fakeuser:{{ env_var('DBT_ENV_SECRET_GIT_TOKEN') }}@github.com/dbt-labs/fake-repo.git"
```

Invoking `dbt-core` as a Python module...

```
>>> from dbt.main import handle_and_check
>>> handle_and_check(['deps'])
18:33:14  Running with dbt=1.2.0-a1
Traceback (most recent call last):
  File "/Users/jerco/dev/product/dbt-core/core/dbt/clients/git.py", line 65, in clone
    result = run_cmd(cwd, clone_cmd, env={"LC_ALL": "C"})
  File "/Users/jerco/dev/product/dbt-core/core/dbt/clients/system.py", line 435, in run_cmd
    raise dbt.exceptions.CommandResultError(cwd, scrubbed_cmd, proc.returncode, out, err)
dbt.exceptions.CommandResultError: Got a non-zero returncode running: ['/usr/bin/git', 'clone', '--depth', '1', 'https://fakeuser:*****@github.com/dbt-labs/fake-repo.git', '3031f9cd09251a86b0009166b1370c80']

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jerco/dev/product/dbt-core/core/dbt/main.py", line 191, in handle_and_check
    task, res = run_from_args(parsed)
  File "/Users/jerco/dev/product/dbt-core/core/dbt/main.py", line 238, in run_from_args
    results = task.run()
  File "/Users/jerco/dev/product/dbt-core/core/dbt/task/deps.py", line 56, in run
    final_deps = resolve_packages(packages, self.config)
  File "/Users/jerco/dev/product/dbt-core/core/dbt/deps/resolver.py", line 131, in resolve_packages
    target = final[package].resolved().fetch_metadata(config, renderer)
  File "/Users/jerco/dev/product/dbt-core/core/dbt/deps/base.py", line 86, in fetch_metadata
    self._cached_metadata = self._fetch_metadata(project, renderer)
  File "/Users/jerco/dev/product/dbt-core/core/dbt/deps/git.py", line 93, in _fetch_metadata
    path = self._checkout()
  File "/Users/jerco/dev/product/dbt-core/core/dbt/deps/git.py", line 79, in _checkout
    dir_ = git.clone_and_checkout(
  File "/Users/jerco/dev/product/dbt-core/core/dbt/clients/git.py", line 137, in clone_and_checkout
    _, err = clone(
  File "/Users/jerco/dev/product/dbt-core/core/dbt/clients/git.py", line 67, in clone
    _raise_git_cloning_error(repo, revision, exc)
  File "/Users/jerco/dev/product/dbt-core/core/dbt/clients/git.py", line 37, in _raise_git_cloning_error
    bad_package_spec(repo, revision, stderr)
  File "/Users/jerco/dev/product/dbt-core/core/dbt/exceptions.py", line 709, in bad_package_spec
    raise InternalException(scrub_secrets(msg, env_secrets()))
dbt.exceptions.InternalException: Error checking out spec='None' for repo https://fakeuser:*****@github.com/dbt-labs/fake-repo.git
Cloning into '3031f9cd09251a86b0009166b1370c80'...
remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
fatal: Authentication failed for 'https://github.com/dbt-labs/fake-repo.git/'
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
