### PR TITLE
Tweak `triage-label.yml` to trigger off issue labels instead of PR labels

### DIFF
--- a/.github/workflows/triage-labels.yml
+++ b/.github/workflows/triage-labels.yml
@@ -23,15 +23,11 @@ permissions:
 
 jobs:
   triage_label:
-    if: github.event.label.name == 'awaiting_response'
-
+    if: contains(github.event.issue.labels.*.name, 'awaiting_response')
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-ecosystem/action-remove-labels@v1
+      - name: initial labeling
+        uses: andymckay/labeler@master
         with:
-          labels: awaiting_response
-      - uses: actions-ecosystem/action-add-labels@v1
-        with:
-          labels: triage
+          add-labels: "triage"
+          remove-labels: "awaiting_response"

--- a/.github/workflows/triage-labels.yml
+++ b/.github/workflows/triage-labels.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   triage_label:
-    if: "contains(github.event.issues.labels.*.name, 'awaiting_response')"
+    if: github.event.label.name == 'awaiting_response'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
resolves #5159

### Description

The first pass triggered off PR labels instead of issue labels.  This also upgrades to a single action that will add/remove labels in a single step.  It's a bit more readable now.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
