### PR TITLE
Allow the target name to be set in profile_template.yml

### DIFF
--- a/.changes/unreleased/Features-20220428-065644.yaml
+++ b/.changes/unreleased/Features-20220428-065644.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: allow target as an option in profile_template.yml
+time: 2022-04-28T06:56:44.511519-04:00
+custom:
+  Author: alexrosenfeld10
+  Issue: "5179"
+  PR: "5184"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 1. [About this document](#about-this-document)
 2. [Getting the code](#getting-the-code)
 3. [Setting up an environment](#setting-up-an-environment)
-4. [Running `dbt` in development](#running-dbt-in-development)
+4. [Running `dbt` in development](#running-dbt-core-in-development)
 5. [Testing dbt-core](#testing)
 6. [Submitting a Pull Request](#submitting-a-pull-request)
 
@@ -56,10 +56,10 @@ These are the tools used in `dbt-core` development and testing:
 - [`flake8`](https://flake8.pycqa.org/en/latest/) for code linting
 - [`black`](https://github.com/psf/black) for code formatting
 - [`mypy`](https://mypy.readthedocs.io/en/stable/) for static type checking
-- [`pre-commit`](https.pre-commit.com) to easily run those checks
+- [`pre-commit`](https://pre-commit.com) to easily run those checks
 - [`changie`](https://changie.dev/) to create changelog entries, without merge conflicts
 - [`make`](https://users.cs.duke.edu/~ola/courses/programming/Makefiles/Makefiles.html) to run multiple setup or test steps in combination. Don't worry too much, nobody _really_ understands how `make` works, and our Makefile aims to be super simple.
-- [Github Actions](https://github.com/features/actions) for automating tests and checks, once a PR is pushed to the `dbt-core` repository
+- [GitHub Actions](https://github.com/features/actions) for automating tests and checks, once a PR is pushed to the `dbt-core` repository
 
 A deep understanding of these tools in not required to effectively contribute to `dbt-core`, but we recommend checking out the attached documentation if you're interested in learning more about each one.
 
@@ -144,14 +144,14 @@ make test
 # Runs postgres integration tests with py38 in "fail fast" mode.
 make integration
 ```
-> These make targets assume you have a local install of a recent version of [`tox`](https://tox.readthedocs.io/en/latest/) for unit/integration testing and pre-commit for code quality checks,
+> These make targets assume you have a local installation of a recent version of [`tox`](https://tox.readthedocs.io/en/latest/) for unit/integration testing and pre-commit for code quality checks,
 > unless you use choose a Docker container to run tests. Run `make help` for more info.
 
 Check out the other targets in the Makefile to see other commonly used test
 suites.
 
 #### `pre-commit`
-[`pre-commit`](https.pre-commit.com) takes care of running all code-checks for formatting and linting. Run `make dev` to install `pre-commit` in your local environment.  Once this is done you can use any of the linter-based make targets as well as a git pre-commit hook that will ensure proper formatting and linting.
+[`pre-commit`](https://pre-commit.com) takes care of running all code-checks for formatting and linting. Run `make dev` to install `pre-commit` in your local environment.  Once this is done you can use any of the linter-based make targets as well as a git pre-commit hook that will ensure proper formatting and linting.
 
 #### `tox`
 

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -186,7 +186,7 @@ class InitTask(BaseTask):
         initial_target = profile_template.get("fixed", {})
         prompts = profile_template.get("prompts", {})
         target = self.generate_target_from_input(prompts, initial_target)
-        target_name = target.pop('target', "dev")
+        target_name = target.pop("target", "dev")
         profile = {"outputs": {target_name: target}, "target": target_name}
         self.write_profile(profile, profile_name)
 

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -186,7 +186,9 @@ class InitTask(BaseTask):
         initial_target = profile_template.get("fixed", {})
         prompts = profile_template.get("prompts", {})
         target = self.generate_target_from_input(prompts, initial_target)
-        profile = {"outputs": {"dev": target}, "target": "dev"}
+        maybe_target_name = target.pop('target', None)
+        target_name = maybe_target_name if maybe_target_name is not None else "dev"
+        profile = {"outputs": {target_name: target}, "target": target_name}
         self.write_profile(profile, profile_name)
 
     def create_profile_from_target(self, adapter: str, profile_name: str):

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -186,8 +186,7 @@ class InitTask(BaseTask):
         initial_target = profile_template.get("fixed", {})
         prompts = profile_template.get("prompts", {})
         target = self.generate_target_from_input(prompts, initial_target)
-        maybe_target_name = target.pop('target', None)
-        target_name = maybe_target_name if maybe_target_name is not None else "dev"
+        target_name = target.pop('target', "dev")
         profile = {"outputs": {target_name: target}, "target": target_name}
         self.write_profile(profile, profile_name)
 

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -42,7 +42,7 @@ def _dbt_psycopg2_name():
 
 package_name = "dbt-postgres"
 package_version = "1.2.0a1"
-description = """The postgres adpter plugin for dbt (data build tool)"""
+description = """The postgres adapter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_directory, "README.md")) as f:

--- a/test/integration/040_init_tests/test_init.py
+++ b/test/integration/040_init_tests/test_init.py
@@ -205,7 +205,11 @@ test:
   host: localhost
   dbname: my_db
   schema: my_schema
+  target: my_target
 prompts:
+  target:
+    hint: 'The target name'
+    type: string
   port:
     hint: 'The port (for integer test purposes)'
     type: int
@@ -220,12 +224,14 @@ prompts:
         manager.attach_mock(mock_prompt, 'prompt')
         manager.attach_mock(mock_confirm, 'confirm')
         manager.prompt.side_effect = [
+            'my_target',
             5432,
             'test_username',
             'test_password'
         ]
         self.run_dbt(['init'])
         manager.assert_has_calls([
+            call.prompt('target (The target name)', default=None, hide_input=False, type=click.STRING),
             call.prompt('port (The port (for integer test purposes))', default=5432, hide_input=False, type=click.INT),
             call.prompt('user (Your username)', default=None, hide_input=False, type=None),
             call.prompt('pass (Your password)', default=None, hide_input=True, type=None)
@@ -234,7 +240,7 @@ prompts:
         with open(os.path.join(self.test_root_dir, 'profiles.yml'), 'r') as f:
             assert f.read() == """test:
   outputs:
-    dev:
+    my_target:
       dbname: my_db
       host: localhost
       pass: test_password
@@ -243,7 +249,7 @@ prompts:
       threads: 4
       type: postgres
       user: test_username
-  target: dev
+  target: my_target
 """
 
     @use_profile('postgres')


### PR DESCRIPTION
resolves #5179 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

As per title, this allows a `target` key to be set in `profile_template.yml`, instead of being hardcoded to `dev`. I borrowed an existing test case because this is a pretty simple change. If that's not alright I'm happy to add a dedicated test if that's seen as necessary.

I also fixed a few random typos I found while I was setting up locally. If desired I can certainly pull those out into a separate PR.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
