### PR TITLE
update label check for dependabot action

### DIFF
--- a/.github/workflows/dependency-changelog.yml
+++ b/.github/workflows/dependency-changelog.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   dependency_changelog:
-    if: ${{ github.event.label.name == 'dependencies' }}
+    if: "contains(github.event.pull_request.labels.*.name, 'dependencies')"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Fix small bug where action to add changelog file never kicked off if the label was added before PR creation.  It still worked if you added label after creation.

test to add label [after PR creation](https://github.com/emmyoop/action_testing/pull/11)

test to add label [before PR creation](https://github.com/emmyoop/action_testing/pull/10)

This should eventually be moved over to shared actions since we will need it across multiple repos.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] ~This PR includes tests, or~ tests are not required/relevant for this PR
- [x] ~I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or~ docs changes are not required/relevant for this PR
- [ ] ~I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)~
