### PR TITLE
propseal for modification to drop_test_schema

### DIFF
--- a/.changes/unreleased/Fixes-20220429-160742.yaml
+++ b/.changes/unreleased/Fixes-20220429-160742.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Modifying the drop_test_schema to work better with Redshift issues around locked
+  tables and current transactions
+time: 2022-04-29T16:07:42.750046-05:00
+custom:
+  Author: Mcknight-42
+  Issue: "5200"
+  PR: "5198"

--- a/core/dbt/adapters/sql/impl.py
+++ b/core/dbt/adapters/sql/impl.py
@@ -171,6 +171,7 @@ class SQLAdapter(BaseAdapter):
             "relation": relation,
         }
         self.execute_macro(DROP_SCHEMA_MACRO_NAME, kwargs=kwargs)
+        self.commit_if_has_connection()
         # we can update the cache here
         self.cache.drop_schema(relation.database, relation.schema)
 

--- a/core/dbt/tests/fixtures/project.py
+++ b/core/dbt/tests/fixtures/project.py
@@ -404,11 +404,16 @@ class TestProjInfo:
 
     # Drop the unique test schema, usually called in test cleanup
     def drop_test_schema(self):
-        with get_connection(self.adapter):
-            for schema_name in self.created_schemas:
-                relation = self.adapter.Relation.create(database=self.database, schema=schema_name)
-                self.adapter.drop_schema(relation)
-            self.created_schemas = []
+        for schema_name in self.created_schemas:
+            relation = self.adapter.Relation.create(database=self.database, schema=schema_name)
+            schema = self.adapter.quote_as_configured(relation.schema, "schema")
+            self.run_sql(f"drop schema if exists {schema} cascade")
+        self.created_schemas = []
+        # with get_connection(self.adapter):
+        #     for schema_name in self.created_schemas:
+        #         relation = self.adapter.Relation.create(database=self.database, schema=schema_name)
+        #         self.adapter.drop_schema(relation)
+        #     self.created_schemas = []
 
     # This return a dictionary of table names to 'view' or 'table' values.
     def get_tables_in_schema(self):

--- a/core/dbt/tests/fixtures/project.py
+++ b/core/dbt/tests/fixtures/project.py
@@ -404,16 +404,11 @@ class TestProjInfo:
 
     # Drop the unique test schema, usually called in test cleanup
     def drop_test_schema(self):
-        for schema_name in self.created_schemas:
-            relation = self.adapter.Relation.create(database=self.database, schema=schema_name)
-            schema = self.adapter.quote_as_configured(relation.schema, "schema")
-            self.run_sql(f"drop schema if exists {schema} cascade")
-        self.created_schemas = []
-        # with get_connection(self.adapter):
-        #     for schema_name in self.created_schemas:
-        #         relation = self.adapter.Relation.create(database=self.database, schema=schema_name)
-        #         self.adapter.drop_schema(relation)
-        #     self.created_schemas = []
+        with get_connection(self.adapter):
+            for schema_name in self.created_schemas:
+                relation = self.adapter.Relation.create(database=self.database, schema=schema_name)
+                self.adapter.drop_schema(relation)
+            self.created_schemas = []
 
     # This return a dictionary of table names to 'view' or 'table' values.
     def get_tables_in_schema(self):


### PR DESCRIPTION
resolves # https://github.com/dbt-labs/dbt-redshift/issues/110

### Description
Test files where getting locked due to transactions leaving them in database after test ended leading to error:
```
psycopg2.errors.InternalError_: 1040
DETAIL:  Maximum tables limit exceeded. The maximum number of tables per cluster is 9900 for this instance type. The limit includes permanent and temporary tables. (pid:25694)
```
due to database reaching limit on tables.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
