### PR TITLE
Adding Skip Changelog label to Version Bump action

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -107,3 +107,5 @@ jobs:
           base: ${{github.ref}}
           title: 'Bumping version to ${{steps.variables.outputs.VERSION_NUMBER}}'
           branch: 'bumping-version/${{steps.variables.outputs.VERSION_NUMBER}}_${{GITHUB.RUN_ID}}'
+          labels: |
+            Skip Changelog


### PR DESCRIPTION
resolves #4907

### Description
This just adds the `Skip Changelog` label to the Version Bump action since we don't want to have an entry for this. I checked the documentation and it uses no quotes and newlines for labels with spaces

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
