### PR TITLE
seed: Add new macro get_csv_sql

### DIFF
--- a/.changes/unreleased/Features-20220503-142934.yaml
+++ b/.changes/unreleased/Features-20220503-142934.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: 'seed: Add new macro get_csv_sql'
+time: 2022-05-03T14:29:34.847959075Z
+custom:
+  Author: adamantike
+  Issue: "5206"
+  PR: "5207"

--- a/core/dbt/include/global_project/macros/materializations/seeds/helpers.sql
+++ b/core/dbt/include/global_project/macros/materializations/seeds/helpers.sql
@@ -44,6 +44,17 @@
 {% endmacro %}
 
 
+{% macro get_csv_sql(create_or_truncate_sql, insert_sql) %}
+    {{ adapter.dispatch('get_csv_sql', 'dbt')(create_or_truncate_sql, insert_sql) }}
+{% endmacro %}
+
+{% macro default__get_csv_sql(create_or_truncate_sql, insert_sql) %}
+    {{ create_or_truncate_sql }};
+    -- dbt seed --
+    {{ insert_sql }}
+{% endmacro %}
+
+
 {% macro get_binding_char() -%}
   {{ adapter.dispatch('get_binding_char', 'dbt')() }}
 {%- endmacro %}

--- a/core/dbt/include/global_project/macros/materializations/seeds/seed.sql
+++ b/core/dbt/include/global_project/macros/materializations/seeds/seed.sql
@@ -31,9 +31,7 @@
   {% set sql = load_csv_rows(model, agate_table) %}
 
   {% call noop_statement('main', code ~ ' ' ~ rows_affected, code, rows_affected) %}
-    {{ create_table_sql }};
-    -- dbt seed --
-    {{ sql }}
+    {{ get_csv_sql(create_table_sql, sql) }};
   {% endcall %}
 
   {% set target_relation = this.incorporate(type='table') %}


### PR DESCRIPTION
### Description

The implementation of this new macro `get_csv_sql` comes as a suggestion by @jtcohen6 at https://github.com/dbt-labs/dbt-snowflake/issues/112#issuecomment-1103715140.

The underlying reason is that the `dbt-snowflake` package needs to run these queries inside a transaction, but with the current implementation, the fix would require to duplicate the entire default seed materialization logic in the package.

Resolves #5206

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
