### PR TITLE
fix: Avoid access to profile when calling str(UnsetProfileConfig)

### DIFF
--- a/.changes/unreleased/Under the Hood-20220503-195212.yaml
+++ b/.changes/unreleased/Under the Hood-20220503-195212.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: 'Fix: Call str and repr for UnsetProfileConfig without a RuntimeException'
+time: 2022-05-03T19:52:12.793729384+02:00
+custom:
+  Author: tomasfarias
+  Issue: "5081"
+  PR: "5209"

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -1,7 +1,7 @@
 import itertools
 import os
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Any, Optional, Mapping, Iterator, Iterable, Tuple, List, MutableSet, Type
 
@@ -416,6 +416,9 @@ class UnsetProfileConfig(RuntimeConfig):
     """This class acts a lot _like_ a RuntimeConfig, except if your profile is
     missing, any access to profile members results in an exception.
     """
+
+    profile_name: str = field(repr=False)
+    target_name: str = field(repr=False)
 
     def __post_init__(self):
         # instead of futzing with InitVar overrides or rewriting __init__, just

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -437,6 +437,56 @@ class UnsetProfileConfig(RuntimeConfig):
         # re-override the poisoned profile behavior
         return DictDefaultEmptyStr({})
 
+    def to_project_config(self, with_packages=False):
+        """Return a dict representation of the config that could be written to
+        disk with `yaml.safe_dump` to get this configuration.
+
+        Overrides dbt.config.Project.to_project_config to omit undefined profile
+        attributes.
+
+        :param with_packages bool: If True, include the serialized packages
+            file in the root.
+        :returns dict: The serialized profile.
+        """
+        result = deepcopy(
+            {
+                "name": self.project_name,
+                "version": self.version,
+                "project-root": self.project_root,
+                "profile": "",
+                "model-paths": self.model_paths,
+                "macro-paths": self.macro_paths,
+                "seed-paths": self.seed_paths,
+                "test-paths": self.test_paths,
+                "analysis-paths": self.analysis_paths,
+                "docs-paths": self.docs_paths,
+                "asset-paths": self.asset_paths,
+                "target-path": self.target_path,
+                "snapshot-paths": self.snapshot_paths,
+                "clean-targets": self.clean_targets,
+                "log-path": self.log_path,
+                "quoting": self.quoting,
+                "models": self.models,
+                "on-run-start": self.on_run_start,
+                "on-run-end": self.on_run_end,
+                "dispatch": self.dispatch,
+                "seeds": self.seeds,
+                "snapshots": self.snapshots,
+                "sources": self.sources,
+                "tests": self.tests,
+                "vars": self.vars.to_dict(),
+                "require-dbt-version": [v.to_version_string() for v in self.dbt_version],
+                "config-version": self.config_version,
+            }
+        )
+        if self.query_comment:
+            result["query-comment"] = self.query_comment.to_dict(omit_none=True)
+
+        if with_packages:
+            result.update(self.packages.to_dict(omit_none=True))
+
+        return result
+
     @classmethod
     def from_parts(
         cls,

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -1266,7 +1266,7 @@ class TestUnsetProfileConfig(BaseConfigTest):
         config = dbt.config.UnsetProfileConfig.from_parts(project, profile, {})
         project_config = config.to_project_config()
 
-        self.assertEquals(project_config["profile"], "")
+        self.assertEqual(project_config["profile"], "")
 
 
 class TestVariableRuntimeConfigFiles(BaseFileTest):

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -317,7 +317,7 @@ class TestProfile(BaseConfigTest):
             'model-paths': ['models'],
             'source-paths': ['other-models'],
         })
-        with self.assertRaises(dbt.exceptions.DbtProjectError) as exc:            
+        with self.assertRaises(dbt.exceptions.DbtProjectError) as exc:
             project = project_from_config_norender(self.default_project_data)
 
         self.assertIn('source-paths and model-paths', str(exc.exception))
@@ -1228,6 +1228,45 @@ class TestRuntimeConfigFiles(BaseFileTest):
         self.assertEqual(config.seeds, {})
         self.assertEqual(config.packages, PackageConfig(packages=[]))
         self.assertEqual(config.project_name, 'my_test_project')
+
+
+class TestUnsetProfileConfig(BaseConfigTest):
+    def setUp(self):
+        self.profiles_dir = '/invalid-profiles-path'
+        self.project_dir = '/invalid-root-path'
+        super().setUp()
+        self.default_project_data['project-root'] = self.project_dir
+
+    def get_project(self):
+        return project_from_config_norender(self.default_project_data, verify_version=self.args.version_check)
+
+    def get_profile(self):
+        renderer = empty_profile_renderer()
+        return dbt.config.Profile.from_raw_profiles(
+            self.default_profile_data, self.default_project_data['profile'], renderer
+        )
+
+    def test_str(self):
+        project = self.get_project()
+        profile = self.get_profile()
+        config = dbt.config.UnsetProfileConfig.from_parts(project, profile, {})
+
+        str(config)
+
+    def test_repr(self):
+        project = self.get_project()
+        profile = self.get_profile()
+        config = dbt.config.UnsetProfileConfig.from_parts(project, profile, {})
+
+        repr(config)
+
+    def test_to_project_config(self):
+        project = self.get_project()
+        profile = self.get_profile()
+        config = dbt.config.UnsetProfileConfig.from_parts(project, profile, {})
+        project_config = config.to_project_config()
+
+        self.assertEquals(project_config["profile"], "")
 
 
 class TestVariableRuntimeConfigFiles(BaseFileTest):


### PR DESCRIPTION
resolves #5081

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

`dbt.config.UnsetProfileConfig` inherits `__str__` from `dbt.config.Project`. Moreover, `UnsetProfileConfig` raises an exception when attempting to access unset profile attributes. As `Project.__str__` ultimately calls `Project.to_project_config` and accesses said profile attributes, we override `to_project_config` in `UnsetProfileConfig` to avoid accessing the attributes that raise an exception.

This allows calling `str(UnsetProfileConfig)` without a `RuntimeException`.

Furthermore, setting both profile fields (`profile_name` and `target_name`) to `repr=False` allow us to call `repr(UnsetProfileConfig)` without a `RuntimeException`.

Basic unit testing is also included in commit.

Looks like my IDE also cleaned up some whitespace (runs `black` on save). I can revert it if needed.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
