### PR TITLE
Improve tracking error logging message

### DIFF
--- a/.changes/unreleased/Under the Hood-20220504-010031.yaml
+++ b/.changes/unreleased/Under the Hood-20220504-010031.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Improve tracking error logging message
+time: 2022-05-04T01:00:31.60387036+02:00
+custom:
+  Author: NicolasPA
+  Issue: "5197"
+  PR: "5211"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -2352,11 +2352,15 @@ class WritingInjectedSQLForNode(DebugLevel):
 
 
 @dataclass
-class DisableTracking(WarnLevel):
+class DisableTracking(DebugLevel):
     code: str = "Z039"
 
     def message(self) -> str:
-        return "Error sending message, disabling tracking"
+        return (
+            "Error sending anonymous usage statistics. Disabling tracking for this execution. "
+            "If you wish to permanently disable tracking, see: "
+            "https://docs.getdbt.com/reference/global-configs#send-anonymous-usage-stats."
+        )
 
 
 @dataclass


### PR DESCRIPTION
Resolves #5197

### Description

The error message logged when tracking posting fails now makes it more
obvious that it is related to DBT's internal anonymous usage
statistics, and explains how to disable it.

As tracking failure doesn't real concern most users, we also reduce the
logging level to "DEBUG" so it doesn't appear during normal use.

The use case that triggered this change proposal is using DBT without 
an internet connection and wondering what this error meant.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
