### PR TITLE
Bumping hologram version

### DIFF
--- a/.changes/unreleased/Dependencies-20220506-160907.yaml
+++ b/.changes/unreleased/Dependencies-20220506-160907.yaml
@@ -3,5 +3,5 @@ body: "Bumping hologram version"
 time: 2022-05-06T16:09:07.000000-05:00
 custom:
   Author: leahwicz
-  Issue: "4904"
+  Issue: "5219"
   PR: "5218"

--- a/.changes/unreleased/Dependencies-20220506-160907.yaml
+++ b/.changes/unreleased/Dependencies-20220506-160907.yaml
@@ -1,0 +1,7 @@
+kind: Dependencies
+body: "Bumping hologram version"
+time: 2022-05-06T16:09:07.000000-05:00
+custom:
+  Author: leahwicz
+  Issue: "4904"
+  PR: "5218"

--- a/core/setup.py
+++ b/core/setup.py
@@ -56,7 +56,7 @@ setup(
         "agate>=1.6,<1.6.4",
         "click>=7.0,<9",
         "colorama>=0.3.9,<0.4.5",
-        "hologram==0.0.14",
+        "hologram==0.0.15",
         "isodate>=0.6,<0.7",
         "logbook>=1.5,<1.6",
         "mashumaro==2.9",

--- a/core/setup.py
+++ b/core/setup.py
@@ -56,7 +56,7 @@ setup(
         "agate>=1.6,<1.6.4",
         "click>=7.0,<9",
         "colorama>=0.3.9,<0.4.5",
-        "hologram==0.0.15",
+        "hologram>=0.0.14,<=0.0.15",
         "isodate>=0.6,<0.7",
         "logbook>=1.5,<1.6",
         "mashumaro==2.9",


### PR DESCRIPTION
resolves #5219

### Description
This bumps to use the latest version of hologram that was released. The new version has updated dependencies that previously were causing conflicts with other Airflow dependencies.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
