### PR TITLE
Tidying up materialization logic: relation names, cache loading, etc

### DIFF
--- a/.changes/unreleased/Under the Hood-20220509-092628.yaml
+++ b/.changes/unreleased/Under the Hood-20220509-092628.yaml
@@ -1,0 +1,8 @@
+kind: Under the Hood
+body: 'Clean up materialization logic: more consistent relation names, loading from
+  cache'
+time: 2022-05-09T09:26:28.551068+02:00
+custom:
+  Author: jtcohen6
+  Issue: "2869"
+  PR: "4921"

--- a/core/dbt/include/global_project/macros/adapters/relation.sql
+++ b/core/dbt/include/global_project/macros/adapters/relation.sql
@@ -86,8 +86,8 @@
 {% endmacro %}
 
 
-{# a user-friendly interface into adapter.get_relation #}
-{% macro load_relation(relation) %}
+-- a user-friendly interface into adapter.get_relation
+{% macro load_cached_relation(relation) %}
   {% do return(adapter.get_relation(
     database=relation.database,
     schema=relation.schema,
@@ -95,8 +95,12 @@
   )) -%}
 {% endmacro %}
 
+-- old name for backwards compatibility
+{% macro load_relation(relation) %}
+    {{ return(load_cached_relation(relation)) }}
+{% endmacro %}
 
-{# not used much, here for backwards compatibility #}
+
 {% macro drop_relation_if_exists(relation) %}
   {% if relation is not none %}
     {{ adapter.drop_relation(relation) }}

--- a/core/dbt/include/global_project/macros/materializations/models/table/table.sql
+++ b/core/dbt/include/global_project/macros/materializations/models/table/table.sql
@@ -1,27 +1,19 @@
 {% materialization table, default %}
-  {%- set identifier = model['alias'] -%}
 
-  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
-  {%- set target_relation = api.Relation.create(identifier=identifier,
-                                                schema=schema,
-                                                database=database,
-                                                type='table') -%}
+  {%- set existing_relation = load_cached_relation(this) -%}
+  {%- set target_relation = this.incorporate(type='table') %}
   {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}
   -- the intermediate_relation should not already exist in the database; get_relation
   -- will return None in that case. Otherwise, we get a relation that we can drop
   -- later, before we try to use this name for the current operation
-  {%- set preexisting_intermediate_relation = adapter.get_relation(identifier=intermediate_relation['identifier'],
-                                                                   schema=schema,
-                                                                   database=database) -%}
+  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
   /*
       See ../view/view.sql for more information about this relation.
   */
-  {%- set backup_relation_type = 'table' if old_relation is none else old_relation.type -%}
+  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}
   {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
   -- as above, the backup_relation should not already exist
-  {%- set preexisting_backup_relation = adapter.get_relation(identifier=backup_relation['identifier'],
-                                                             schema=schema,
-                                                             database=database) -%}
+  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
 
   -- drop the temp relations if they exist already in the database
   {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
@@ -38,8 +30,8 @@
   {%- endcall %}
 
   -- cleanup
-  {% if old_relation is not none %}
-      {{ adapter.rename_relation(old_relation, backup_relation) }}
+  {% if existing_relation is not none %}
+      {{ adapter.rename_relation(existing_relation, backup_relation) }}
   {% endif %}
 
   {{ adapter.rename_relation(intermediate_relation, target_relation) }}

--- a/core/dbt/include/global_project/macros/materializations/models/view/view.sql
+++ b/core/dbt/include/global_project/macros/materializations/models/view/view.sql
@@ -1,37 +1,30 @@
 {%- materialization view, default -%}
 
-  {%- set identifier = model['alias'] -%}
-
-  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
-  {%- set target_relation = api.Relation.create(identifier=identifier, schema=schema, database=database,
-                                                type='view') -%}
+  {%- set existing_relation = load_cached_relation(this) -%}
+  {%- set target_relation = this.incorporate(type='view') -%}
   {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}
 
   -- the intermediate_relation should not already exist in the database; get_relation
   -- will return None in that case. Otherwise, we get a relation that we can drop
   -- later, before we try to use this name for the current operation
-  {%- set preexisting_intermediate_relation = adapter.get_relation(identifier=intermediate_relation['identifier'],
-                                                                   schema=schema,
-                                                                   database=database) -%}
+  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
   /*
      This relation (probably) doesn't exist yet. If it does exist, it's a leftover from
      a previous run, and we're going to try to drop it immediately. At the end of this
-     materialization, we're going to rename the "old_relation" to this identifier,
+     materialization, we're going to rename the "existing_relation" to this identifier,
      and then we're going to drop it. In order to make sure we run the correct one of:
        - drop view ...
        - drop table ...
 
-     We need to set the type of this relation to be the type of the old_relation, if it exists,
-     or else "view" as a sane default if it does not. Note that if the old_relation does not
+     We need to set the type of this relation to be the type of the existing_relation, if it exists,
+     or else "view" as a sane default if it does not. Note that if the existing_relation does not
      exist, then there is nothing to move out of the way and subsequentally drop. In that case,
      this relation will be effectively unused.
   */
-  {%- set backup_relation_type = 'view' if old_relation is none else old_relation.type -%}
+  {%- set backup_relation_type = 'view' if existing_relation is none else existing_relation.type -%}
   {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
   -- as above, the backup_relation should not already exist
-  {%- set preexisting_backup_relation = adapter.get_relation(identifier=backup_relation['identifier'],
-                                                             schema=schema,
-                                                             database=database) -%}
+  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
@@ -44,13 +37,13 @@
 
   -- build model
   {% call statement('main') -%}
-    {{ create_view_as(intermediate_relation, sql) }}
+    {{ get_create_view_as_sql(intermediate_relation, sql) }}
   {%- endcall %}
 
   -- cleanup
   -- move the existing view out of the way
-  {% if old_relation is not none %}
-    {{ adapter.rename_relation(old_relation, backup_relation) }}
+  {% if existing_relation is not none %}
+    {{ adapter.rename_relation(existing_relation, backup_relation) }}
   {% endif %}
   {{ adapter.rename_relation(intermediate_relation, target_relation) }}
 

--- a/test/integration/017_runtime_materialization_tests/create_incremental__dbt_tmp.sql
+++ b/test/integration/017_runtime_materialization_tests/create_incremental__dbt_tmp.sql
@@ -1,0 +1,4 @@
+
+create table {schema}.incremental__dbt_tmp as (	
+    select 1 as id	
+);	


### PR DESCRIPTION
Inspired by:
- @epapineau's awesome work consolidating tricky materialization logic in #4921, which I was trying to test / understand locally
- Work we've scoped for v1.2 (https://github.com/dbt-labs/dbt-core/discussions/5091), including #5089 — with the goal of doing _more_ in core materializations, and require less copy-paste-edited code in adapter plugins

### Description

- Rename `load_relation` to `load_cached_relation` (with backwards compat). Use this macro much more frequently, rather than `adapter.get_relation` (verbose + harder to read)
- Even more consistent naming: `existing_relation` (never `old_relation`), `temp_relation`, `intermediate_relation`, `backup_relation`. Always `X_relation`, never `X_identifier`.
- Use `get_create_table_as_sql` or `get_create_view_as_sql`, instead of `create_table_as` or `create_view_as` (per #4154). Long-term goal: better distinguish between static macros that `-> str` ("returns SQL"), and "dirty" macros that `-> Result` (runs query by itself, a la `adapter.rename_relation`).
- Adds back test case removed in #4921, with the understanding that before these PRs go into `main`, this will need to be ported over to the new test location [here](https://github.com/dbt-labs/dbt-core/blob/ab0c3510ebe70a67fb669b88e6ea36aff2f46339/tests/functional/materializations/test_runtime_materialization.py#L179-L182)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
