### PR TITLE
Fix: column comparison logic for check-strategy snapshots

### DIFF
--- a/.changes/unreleased/Fixes-20220509-130021.yaml
+++ b/.changes/unreleased/Fixes-20220509-130021.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Fix column comparison in snapshot_check_all_get_existing_columns for check-strategy
+  snapshots with explicit check_cols defined
+time: 2022-05-09T13:00:21.649028+02:00
+custom:
+  Author: jtcohen6
+  Issue: "5222"
+  PR: "5223"

--- a/core/dbt/include/global_project/macros/materializations/snapshots/strategies.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshots/strategies.sql
@@ -104,22 +104,30 @@
 
 
 {% macro snapshot_check_all_get_existing_columns(node, target_exists, check_cols_config) -%}
+    {%- if not target_exists -%}
+        {#-- no table yet -> return whatever the query does --#}
+        {{ return((false, query_columns)) }}
+    {%- endif -%}
+
+    {#-- handle any schema changes --#}
+    {%- set target_relation = adapter.get_relation(database=node.database, schema=node.schema, identifier=node.alias) -%}
+
     {% if check_cols_config == 'all' %}
         {%- set query_columns = get_columns_in_query(node['compiled_sql']) -%}
+
     {% elif check_cols_config is iterable and (check_cols_config | length) > 0 %}
-        {% set query_columns = check_cols_config %}
+        {#-- query for proper casing/quoting, to support comparison below --#}
+        {%- set select_check_cols_from_target -%}
+          select {{ check_cols_config | join(', ') }} from ({{ node['compiled_sql'] }}) subq
+        {%- endset -%}
+        {% set query_columns = get_columns_in_query(select_check_cols_from_target) %}
+
     {% else %}
         {% do exceptions.raise_compiler_error("Invalid value for 'check_cols': " ~ check_cols_config) %}
     {% endif %}
-    {%- if not target_exists -%}
-        {# no table yet -> return whatever the query does #}
-        {{ return([false, query_columns]) }}
-    {%- endif -%}
-    {# handle any schema changes #}
-    {%- set target_table = node.get('alias', node.get('name')) -%}
-    {%- set target_relation = adapter.get_relation(database=node.database, schema=node.schema, identifier=target_table) -%}
-    {%- set existing_cols = get_columns_in_query('select * from ' ~ target_relation) -%}
-    {%- set ns = namespace() -%} {# handle for-loop scoping with a namespace #}
+
+    {%- set existing_cols = get_columns_in_relation(target_relation) | map(attribute = 'name') | list -%}
+    {%- set ns = namespace() -%} {#-- handle for-loop scoping with a namespace --#}
     {%- set ns.column_added = false -%}
 
     {%- set intersection = [] -%}
@@ -130,7 +138,7 @@
             {% set ns.column_added = true %}
         {%- endif -%}
     {%- endfor -%}
-    {{ return([ns.column_added, intersection]) }}
+    {{ return((ns.column_added, intersection)) }}
 {%- endmacro %}
 
 


### PR DESCRIPTION
resolves #5222
resolves https://github.com/dbt-labs/dbt-snowflake/issues/154

### Description

The logic in `snapshot_check_all_get_existing_columns` added by https://github.com/dbt-labs/dbt-core/pull/4893 doesn't account for cases where the user-configured `check_cols` doesn't match the database's column quoting/casing.

This is almost always true on Snowflake, which is where we've been seeing test failures. The snapshot doesn't fail explicitly, but it always considers the column schema to have changed, so it adds new records _every single time it runs_.

I added a new test case, on top of the one added in #4893. It fails without the changes to the macro in this PR, and passes with them.

For a longer-term resolution, and to ensure this doesn't happen again, let's:
- Move `tests/functional/simple_snapshot` into the "adapter zone" and get it running on Snowflake
- Create a mechanism to proactively test `dbt-core` changes against one/all adapter(s): https://github.com/dbt-labs/dbt-core/issues/4988

That's out of scope for the current PR, which is just trying to fix the nightly tests in `dbt-snowflake`, and preclude an unintended regression in v1.2.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
