### PR TITLE
Fix snapshot_check_all_get_existing_columns: use adapter.get_columns_in_relation

### DIFF
--- a/.changes/unreleased/Fixes-20220511-123238.yaml
+++ b/.changes/unreleased/Fixes-20220511-123238.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix column comparison in snapshot_check_all_get_existing_columns to use adapter.get_columns_in_relation
+time: 2022-05-11T12:32:38.313321+02:00
+custom:
+  Author: jtcohen6
+  Issue: "5222"
+  PR: "5232"

--- a/core/dbt/include/global_project/macros/materializations/snapshots/strategies.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshots/strategies.sql
@@ -126,7 +126,7 @@
         {% do exceptions.raise_compiler_error("Invalid value for 'check_cols': " ~ check_cols_config) %}
     {% endif %}
 
-    {%- set existing_cols = get_columns_in_relation(target_relation) | map(attribute = 'name') | list -%}
+    {%- set existing_cols = adapter.get_columns_in_relation(target_relation) | map(attribute = 'name') | list -%}
     {%- set ns = namespace() -%} {#-- handle for-loop scoping with a namespace --#}
     {%- set ns.column_added = false -%}
 


### PR DESCRIPTION
#5223 caused failing tests overnight in `dbt-spark` + `dbt-databricks`

The code was written to use the `get_columns_in_relation` _macro_, rather than the `get_columns_in_relation` _adapter method_ (Python). We should aim for consistency between these—but elsewhere in `dbt-core`, we do call it as `adapter.get_columns_in_relation`, so we should do the same here.

Here's the breakdown:
- For most "SQL adapters," the adapter method just redirects to the macro (SQL): [source](https://github.com/dbt-labs/dbt-core/blob/3996a69861d5ba9a460092c93b7e08d8e2a63f88/core/dbt/adapters/sql/impl.py#L151-L154)
- In `dbt-bigquery`, the macro redirects to the adapter method, since all the actual logic is in Python (no SQL involved): [source](https://github.com/dbt-labs/dbt-bigquery/blob/15f35b4ff7658fff0783b40fb7b0347344692f4c/dbt/include/bigquery/macros/adapters.sql#L93-L95)
- In `dbt-spark`, the logic is written in _both_ Python _and_ SQL. The adapter method calls the macro, but it also does some of its own post-processing, which is missed if you just call the macro directly. I'll open a follow-up PR to rework this for consistency, but the change in this PR should be sufficient to get tests passing again.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
