### PR TITLE
Add support for File Selectors and add file selectors to the default method selector list

### DIFF
--- a/.changes/unreleased/Features-20220512-215748.yaml
+++ b/.changes/unreleased/Features-20220512-215748.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Adds file selectors and support for file selectors in the default method selector
+time: 2022-05-12T21:57:48.289674-07:00
+custom:
+  Author: jwills
+  Issue: "5240"
+  PR: "5241"

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -39,6 +39,7 @@ class MethodName(StrEnum):
     Tag = "tag"
     Source = "source"
     Path = "path"
+    File = "file"
     Package = "package"
     Config = "config"
     TestName = "test_name"
@@ -280,7 +281,7 @@ class MetricSelectorMethod(SelectorMethod):
 
 class PathSelectorMethod(SelectorMethod):
     def search(self, included_nodes: Set[UniqueId], selector: str) -> Iterator[UniqueId]:
-        """Yields nodes from inclucded that match the given path."""
+        """Yields nodes from included that match the given path."""
         # use '.' and not 'root' for easy comparison
         root = Path.cwd()
         paths = set(p.relative_to(root) for p in root.glob(selector))
@@ -291,6 +292,14 @@ class PathSelectorMethod(SelectorMethod):
             if ofp in paths:
                 yield node
             elif any(parent in paths for parent in ofp.parents):
+                yield node
+
+
+class FileSelectorMethod(SelectorMethod):
+    def search(self, included_nodes: Set[UniqueId], selector: str) -> Iterator[UniqueId]:
+        """Yields nodes from included that match the given file name."""
+        for node, real_node in self.all_nodes(included_nodes):
+            if Path(real_node.original_file_path).name == selector:
                 yield node
 
 

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -598,6 +598,7 @@ class MethodManager:
         MethodName.Tag: TagSelectorMethod,
         MethodName.Source: SourceSelectorMethod,
         MethodName.Path: PathSelectorMethod,
+        MethodName.File: FileSelectorMethod,
         MethodName.Package: PackageSelectorMethod,
         MethodName.Config: ConfigSelectorMethod,
         MethodName.TestName: TestNameSelectorMethod,

--- a/core/dbt/graph/selector_spec.py
+++ b/core/dbt/graph/selector_spec.py
@@ -80,7 +80,7 @@ class SelectionCriteria:
     def default_method(cls, value: str) -> MethodName:
         if _probably_path(value):
             return MethodName.Path
-        elif "." in value:
+        elif value.lower().endswith(".sql"):
             return MethodName.File
         else:
             return MethodName.FQN

--- a/core/dbt/graph/selector_spec.py
+++ b/core/dbt/graph/selector_spec.py
@@ -80,6 +80,8 @@ class SelectionCriteria:
     def default_method(cls, value: str) -> MethodName:
         if _probably_path(value):
             return MethodName.Path
+        elif "." in value:
+            return MethodName.File
         else:
             return MethodName.FQN
 

--- a/test/unit/test_graph_selector_methods.py
+++ b/test/unit/test_graph_selector_methods.py
@@ -1,4 +1,5 @@
 import copy
+
 import pytest
 from unittest import mock
 
@@ -31,6 +32,7 @@ from dbt.graph.selector_methods import (
     TagSelectorMethod,
     SourceSelectorMethod,
     PathSelectorMethod,
+    FileSelectorMethod,
     PackageSelectorMethod,
     ConfigSelectorMethod,
     TestNameSelectorMethod,
@@ -701,6 +703,20 @@ def test_select_path(manifest):
         manifest, method, 'models/missing.sql')
     assert not search_manifest_using_method(
         manifest, method, 'models/missing*')
+
+
+def test_select_file(manifest):
+    methods = MethodManager(manifest, None)
+    method = methods.get_method('file', [])
+    assert isinstance(method, FileSelectorMethod)
+    assert method.arguments == []
+
+    assert search_manifest_using_method(
+        manifest, method, 'table_model.sql') == {'table_model'}
+    assert search_manifest_using_method(
+        manifest, method, 'union_model.sql') == {'union_model', 'mynamespace.union_model'}
+    assert not search_manifest_using_method(
+        manifest, method, 'missing.sql')
 
 
 def test_select_package(manifest):


### PR DESCRIPTION
resolves this small gripe: "To this day, I can’t give dbt a file name and hope it figures out what I mean, but instead I still have to remove the .sql at the end."

https://pedram.substack.com/p/we-need-to-talk-about-dbt

and thus fix #5240 

### Description

I'm adding a `FileSelectorMethod` that uses the name of a .sql file as the way to find model(s) to run via a selector and I added a check to the `default_method` code that does an automatic determination of which selector method to use that will prefer the `File` selector to the `FQN` selector for selector values that end with the string ".sql".

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
