### PR TITLE
Add executed_command to Jinja context

### DIFF
--- a/.changes/unreleased/Features-20220515-142325.yaml
+++ b/.changes/unreleased/Features-20220515-142325.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add executed_command to Jinja context
+time: 2022-05-15T14:23:25.2078669+02:00
+custom:
+  Author: SOVALINUX
+  Issue: "5251"
+  PR: "5252"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -63,6 +63,7 @@ from dbt.node_types import NodeType
 from dbt.utils import merge, AttrDict, MultiDict
 
 from dbt import selected_resources
+from dbt import executed_command
 
 import agate
 
@@ -1153,6 +1154,13 @@ class ProviderContext(ManifestContext):
         doesn't support `--select`.
         """
         return selected_resources.SELECTED_RESOURCES
+
+    @contextproperty
+    def executed_command(self) -> str:
+        """The `executed_command` variable contains a dbt command that is executed at the moment.
+        It might be useful to differentiate behavior while `test` command is executed.
+        """
+        return executed_command.EXECUTED_COMMAND
 
 
 class MacroContext(ProviderContext):

--- a/core/dbt/executed_command.py
+++ b/core/dbt/executed_command.py
@@ -1,0 +1,6 @@
+EXECUTED_COMMAND = ""
+
+
+def set_executed_command(executed_command):
+    global EXECUTED_COMMAND
+    EXECUTED_COMMAND = executed_command

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -37,6 +37,7 @@ import dbt.task.serve as serve_task
 import dbt.task.snapshot as snapshot_task
 import dbt.task.test as test_task
 from dbt.profiler import profiler
+from dbt import executed_command
 from dbt.adapters.factory import reset_adapters, cleanup_connections
 
 import dbt.tracking
@@ -1199,5 +1200,7 @@ def parse_args(args, cls=DBTArgumentParser):
         # and exit with a error
         p.print_help()
         p.exit(1)
+
+    executed_command.set_executed_command(getattr(parsed, "which", None))
 
     return parsed


### PR DESCRIPTION
resolves #5251 

### Description

Add support for `executed_command` to Jinja context

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
