### PR TITLE
Switch the Makefile to use the default installed Python version instead of py38 for local testing

### DIFF
--- a/.changes/unreleased/Under the Hood-20220518-095144.yaml
+++ b/.changes/unreleased/Under the Hood-20220518-095144.yaml
@@ -1,0 +1,8 @@
+kind: Under the Hood
+body: Use the default Python version for local dev and test instead of requiring Python
+  3.8
+time: 2022-05-18T09:51:44.603193-07:00
+custom:
+  Author: jwills
+  Issue: "5257"
+  PR: "5269"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 .DEFAULT_GOAL:=help
 
+# The version of python to use for tests with tox,
+# defaults to py38 but can be set by the user by
+# exporting the environment variable: `DBT_PY` to py, py39, py37, etc.
+DBT_PY ?= py38
+
 # Optional flag to run target in a docker container.
 # (example `make test USE_DOCKER=true`)
 ifeq ($(USE_DOCKER),true)
@@ -34,27 +39,27 @@ lint: .env ## Runs flake8 and mypy code checks against staged changes.
 	$(DOCKER_CMD) pre-commit run mypy-check --hook-stage manual | grep -v "INFO"
 
 .PHONY: unit
-unit: .env ## Runs unit tests with py38.
+unit: .env ## Runs unit tests with $(DBT_PY).
 	@\
-	$(DOCKER_CMD) tox -e py38
+	$(DOCKER_CMD) tox -e $(DBT_PY)
 
 .PHONY: test
-test: .env ## Runs unit tests with py38 and code checks against staged changes.
+test: .env ## Runs unit tests with $(DBT_PY) and code checks against staged changes.
 	@\
-	$(DOCKER_CMD) tox -e py38; \
+	$(DOCKER_CMD) tox -e $(DBT_PY); \
 	$(DOCKER_CMD) pre-commit run black-check --hook-stage manual | grep -v "INFO"; \
 	$(DOCKER_CMD) pre-commit run flake8-check --hook-stage manual | grep -v "INFO"; \
 	$(DOCKER_CMD) pre-commit run mypy-check --hook-stage manual | grep -v "INFO"
 
 .PHONY: integration
-integration: .env ## Runs postgres integration tests with py38.
+integration: .env ## Runs postgres integration tests with $(DBT_PY).
 	@\
-	$(DOCKER_CMD) tox -e py38-integration -- -nauto
+	$(DOCKER_CMD) tox -e $(DBT_PY)-integration -- -nauto
 
 .PHONY: integration-fail-fast
-integration-fail-fast: .env ## Runs postgres integration tests with py38 in "fail fast" mode.
+integration-fail-fast: .env ## Runs postgres integration tests with $(DBT_PY) in "fail fast" mode.
 	@\
-	$(DOCKER_CMD) tox -e py38-integration -- -x -nauto
+	$(DOCKER_CMD) tox -e $(DBT_PY)-integration -- -x -nauto
 
 .PHONY: setup-db
 setup-db: ## Setup Postgres database with docker-compose for system testing.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,5 @@
 .DEFAULT_GOAL:=help
 
-# The version of python to use for tests with tox,
-# defaults to py38 but can be set by the user by
-# exporting the environment variable: `DBT_PY` to py, py39, py37, etc.
-DBT_PY ?= py38
-
 # Optional flag to run target in a docker container.
 # (example `make test USE_DOCKER=true`)
 ifeq ($(USE_DOCKER),true)
@@ -39,27 +34,27 @@ lint: .env ## Runs flake8 and mypy code checks against staged changes.
 	$(DOCKER_CMD) pre-commit run mypy-check --hook-stage manual | grep -v "INFO"
 
 .PHONY: unit
-unit: .env ## Runs unit tests with $(DBT_PY).
+unit: .env ## Runs unit tests with py
 	@\
-	$(DOCKER_CMD) tox -e $(DBT_PY)
+	$(DOCKER_CMD) tox -e py
 
 .PHONY: test
-test: .env ## Runs unit tests with $(DBT_PY) and code checks against staged changes.
+test: .env ## Runs unit tests with py and code checks against staged changes.
 	@\
-	$(DOCKER_CMD) tox -e $(DBT_PY); \
+	$(DOCKER_CMD) tox -e py; \
 	$(DOCKER_CMD) pre-commit run black-check --hook-stage manual | grep -v "INFO"; \
 	$(DOCKER_CMD) pre-commit run flake8-check --hook-stage manual | grep -v "INFO"; \
 	$(DOCKER_CMD) pre-commit run mypy-check --hook-stage manual | grep -v "INFO"
 
 .PHONY: integration
-integration: .env ## Runs postgres integration tests with $(DBT_PY).
+integration: .env ## Runs postgres integration tests with py-integration
 	@\
-	$(DOCKER_CMD) tox -e $(DBT_PY)-integration -- -nauto
+	$(DOCKER_CMD) tox -e py-integration -- -nauto
 
 .PHONY: integration-fail-fast
-integration-fail-fast: .env ## Runs postgres integration tests with $(DBT_PY) in "fail fast" mode.
+integration-fail-fast: .env ## Runs postgres integration tests with py-integration in "fail fast" mode.
 	@\
-	$(DOCKER_CMD) tox -e $(DBT_PY)-integration -- -x -nauto
+	$(DOCKER_CMD) tox -e py-integration -- -x -nauto
 
 .PHONY: setup-db
 setup-db: ## Setup Postgres database with docker-compose for system testing.


### PR DESCRIPTION
resolves #5257

This is a pretty simple string substitution PR, changing up all instances of `py38` to `py` in the `Makefile`, to support running with the user's local default python version instead of always requiring Python 3.8.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
