### PR TITLE
draft: allow users to augment their jinja context with python objects

### DIFF
--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -17,6 +17,7 @@ from dbt.exceptions import (
 from dbt.logger import SECRET_ENV_PREFIX
 from dbt.events.functions import fire_event, get_invocation_id
 from dbt.events.types import MacroEventInfo, MacroEventDebug
+from dbt.utils import get_dbt_config_module
 from dbt.version import __version__ as dbt_version
 
 # These modules are added to the context. Consider alternative
@@ -651,6 +652,22 @@ class BaseContext(metaclass=ContextMeta):
             {{ dt_local }}
         """  # noqa
         return get_context_modules()
+
+    @contextproperty
+    def extra_jinja_context(self) -> Any:
+        """
+        Looks for `extra_jinja_context` in a dbt_config in your
+        PYTHONPATH and exposes it in your jinja context
+        """
+        extra_jinja_context = {}
+        try:
+            dbt_config = get_dbt_config_module()
+            if dbt_config and hasattr(dbt_config, "extra_jinja_context"):
+                extra_jinja_context = dbt_config.extra_jinja_context
+        except Exception:
+            # do nothin'!
+            pass
+        return extra_jinja_context
 
     @contextproperty
     def flags(self) -> Any:

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -20,6 +20,7 @@ from dbt.events.functions import fire_event
 from dbt.events.types import RetryExternalCall, RecordRetryException
 from dbt import flags
 from enum import Enum
+from importlib import import_module
 from typing_extensions import Protocol
 from typing import (
     Tuple,
@@ -659,3 +660,19 @@ def args_to_dict(args):
             var_args[key] = str(var_args[key])
         dict_args[key] = var_args[key]
     return dict_args
+
+
+def get_dbt_config_module():
+    """
+    Looks for a module `dbt_config` somewhere in your PYTHONPATH
+    and returns it. This allows for things like the `extra_jinja_context`
+    configuration hook that can contain python callables or objects, and
+    gets exposed in your jinja context.
+    """
+    dbt_config = None
+    try:
+        dbt_config = import_module("dbt_config")
+    except Exception:
+        # do nothin'!
+        pass
+    return dbt_config


### PR DESCRIPTION
This is a bit of a proposal and proof of concept at the same time.
It gives a handle to people over their jinja context, allowing them
to inject python objects in there under a `extra_jinja_context`
namespace.

## how?

```bash
export PYTHONPATH=~/.dbt
```

Assuming a file `~/.dbt/dbt_config.py`
```python
# anything added into `extra_jinja_context` becomes available
# in the jinja context under a namespace of the same name
extra_jinja_context = {
    'hello': 'world',
    'test': lambda x: x,
}
```

assuming a model `test.sql`
```sql
SELECT '{{ extra_jinja_context.hello }}' AS test
UNION ALL
SELECT '{{ extra_jinja_context.test('print me') }}' AS test
```

## why?

Writing Jinja is ok when you're writing a lot of SQL with a bit of logic
in it, but highly suboptimal when writing complex logic with a bit of
string outputs. Clearly python is superior to Jinja in many ways:

* access to the full python standard lib
* access to external/powerful libs
* Turing complete, object oriented
* testable using sane mechanisms

## use cases
Use cases are limitless. Bind, hook, trigger, generate SQL.
In order of legitimacy:

* string processing, what you'd typically use Jinja macros for, but
  maybe you prefer python functions over jinja macros. Our main use
  case is creating a `generate_incremental_load_date_bounds()` where
  we'll look at `vars` to offer different loading modes (catchup, date
  range, date list, offsets, ...)
* custom logging similar to
  [this](https://github.com/dbt-labs/dbt-event-logging) but much more
  flexible, we happen to use BigQuery and this particular approach
  doesn't work for BigQuery
* custom logic for hooks
* trigger external things (webhooks!)
* ...

## need more thinking / conversation

* I'm introducing `dbt_config.py`, a new place where python logic can be
  injected into dbt-core, it can be powerful, but can lead to
  environment issues / complexity. People need to not abuse this file.
  No `import pandas as pd` in there please! Where should this live?
  `~/.dbt/`?
* Seems like it'd be great to do this at the project level too, so a
  project can be packaged with the extra jinja context it needs to
  operate. `macros/my_macros.py` anyone!? Conceptually that makes a dbt
  project also a python app in some ways and that may not be ideal.
* interoperability: people sharing projects may need to also share
  dbt_config.py and put it in their pythonpath. It's not that outrageous
  but raises the complexity of the project / env setup. This kind of
  complexity already exist with stuff like `profiles.yml`

# TODO
* agree this is useful
* agree on an approach
* write tests
* write docs
* hand off? 
