### PR TITLE
[1.0.latest] Lowering networkx dependency

### DIFF
--- a/.changes/unreleased/Dependencies-20220520-120920.yaml
+++ b/.changes/unreleased/Dependencies-20220520-120920.yaml
@@ -1,0 +1,7 @@
+kind: Dependencies
+body: Lowering networkx dependency range due to new version's breaking change
+time: 2022-05-20T12:09:20.999784-04:00
+custom:
+  Author: leahwicz
+  Issue: "5254"
+  PR: "5280"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   </a>
 </p>
 
+
 **[dbt](https://www.getdbt.com/)** enables data analysts and engineers to transform their data using the same practices that software engineers use to build applications.
 
 ![architecture](https://raw.githubusercontent.com/dbt-labs/dbt-core/6c6649f9129d5d108aa3b0526f634cd8f3a9d1ed/etc/dbt-arch.png)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
   </a>
 </p>
 
-
 **[dbt](https://www.getdbt.com/)** enables data analysts and engineers to transform their data using the same practices that software engineers use to build applications.
 
 ![architecture](https://raw.githubusercontent.com/dbt-labs/dbt-core/6c6649f9129d5d108aa3b0526f634cd8f3a9d1ed/etc/dbt-arch.png)

--- a/core/setup.py
+++ b/core/setup.py
@@ -61,7 +61,7 @@ setup(
         'logbook>=1.5,<1.6',
         'mashumaro==2.9',
         'minimal-snowplow-tracker==0.0.2',
-        'networkx>=2.3,<3',
+        'networkx>=2.3,<2.8.1',
         'packaging>=20.9,<22.0',
         'sqlparse>=0.2.3,<0.5',
         'dbt-extractor~=0.4.1',


### PR DESCRIPTION
The new release of networkx (2.8.1) is causing issues with model selection logic so lowering the version range to not include it.