### PR TITLE
Fix postgres handling for unlimited varchars

### DIFF
--- a/.changes/unreleased/Fixes-20220523-103843.yaml
+++ b/.changes/unreleased/Fixes-20220523-103843.yaml
@@ -4,5 +4,5 @@ body: Remove the default 256 characters limit on postgres character varying type
 time: 2022-05-23T10:38:43.392232+02:00
 custom:
   Author: shrodingers
-  Issue: "636"
+  Issue: "5238"
   PR: "5292"

--- a/.changes/unreleased/Fixes-20220523-103843.yaml
+++ b/.changes/unreleased/Fixes-20220523-103843.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Remove the default 256 characters limit on postgres character varying type when
+  no limitation is set
+time: 2022-05-23T10:38:43.392232+02:00
+custom:
+  Author: shrodingers
+  Issue: "636"
+  PR: "5292"

--- a/plugins/postgres/dbt/adapters/postgres/relation.py
+++ b/plugins/postgres/dbt/adapters/postgres/relation.py
@@ -26,7 +26,7 @@ class PostgresRelation(BaseRelation):
 class PostgresColumn(Column):
     @property
     def data_type(self):
-        # on postgres, do not convert 'text' to 'varchar()'
-        if self.dtype.lower() == "text":
+        # on postgres, do not convert 'text' or 'varchar' to 'varchar()'
+        if self.dtype.lower() == "text" or (self.dtype.lower() == "varchar" and self.char_size is None):
             return self.dtype
         return super().data_type

--- a/plugins/postgres/dbt/adapters/postgres/relation.py
+++ b/plugins/postgres/dbt/adapters/postgres/relation.py
@@ -27,6 +27,8 @@ class PostgresColumn(Column):
     @property
     def data_type(self):
         # on postgres, do not convert 'text' or 'varchar' to 'varchar()'
-        if self.dtype.lower() == "text" or (self.dtype.lower() == "varchar" and self.char_size is None):
+        if self.dtype.lower() == "text" or (
+            self.dtype.lower() == "character varying" and self.char_size is None
+        ):
             return self.dtype
         return super().data_type


### PR DESCRIPTION
resolves #5238 

### Description

Handles `varchar` the same way as `text` for postgres columns (since unlimited `varchar` on postgres is not implicitely limited to 256 characters as on redshift)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
