### PR TITLE
Remove duplicate dbt script entry

### DIFF
--- a/.changes/unreleased/Fixes-20220601-081314.yaml
+++ b/.changes/unreleased/Fixes-20220601-081314.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Remove duplicate dbt script entry
+time: 2022-06-01T08:13:14.067001+10:00
+custom:
+  Author: groodt
+  Issue: "5314"
+  PR: "5304"

--- a/core/scripts/dbt
+++ b/core/scripts/dbt
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-import sys
-import dbt.main
-import logging
-
-if __name__ == "__main__":
-    dbt.main.main(sys.argv[1:])

--- a/core/setup.py
+++ b/core/setup.py
@@ -47,9 +47,6 @@ setup(
             "dbt = dbt.main:main",
         ],
     },
-    scripts=[
-        "scripts/dbt",
-    ],
     install_requires=[
         "Jinja2==2.11.3",
         "MarkupSafe>=0.23,<2.1",


### PR DESCRIPTION
### Description

Resolves: https://github.com/dbt-labs/dbt-core/issues/5314

There is a duplicate `dbt` script entry in setup.py

When installing the wheel, the `console_script` is overwriting the hand-written code in `scripts/dbt`. `pip` should not be overwriting files during installation and will begin to log warnings at some point in future. See: https://github.com/pypa/pip/issues/4625#issuecomment-320506401

You can confirm this by installing `dbt-core` into a `venv`. The contents of the `dbt` script is an autogenerated console_script defined in entry_points and not the handwritten script.

```
/tmp
myvenv ❯ cat myvenv/bin/dbt
#!/private/tmp/myvenv/bin/python3.9
# -*- coding: utf-8 -*-
import re
import sys
from dbt.main import main
if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
    sys.exit(main())
```

<hr />

This also results in errors when using `pypa/installer` which is stricter than pip.

```
/tmp
❯ python3 -m venv dbt_venv

/tmp
❯ source dbt_venv/bin/activate.fish

/tmp
dbt_venv ❯ python -m pip install installer
Collecting installer
  Using cached installer-0.5.1-py3-none-any.whl (452 kB)
Installing collected packages: installer
Successfully installed installer-0.5.1
WARNING: You are using pip version 22.0.4; however, version 22.1.1 is available.
You should consider upgrading via the '/private/tmp/dbt_venv/bin/python -m pip install --upgrade pip' command.

/tmp
dbt_venv ❯ python -m installer --destdir /tmp/example ~/Downloads/dbt_core-1.1.0-py3-none-any.whl
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/private/tmp/dbt_venv/lib/python3.9/site-packages/installer/__main__.py", line 85, in <module>
    _main(sys.argv[1:], "python -m installer")
  File "/private/tmp/dbt_venv/lib/python3.9/site-packages/installer/__main__.py", line 81, in _main
    installer.install(source, destination, {})
  File "/private/tmp/dbt_venv/lib/python3.9/site-packages/installer/_core.py", line 109, in install
    record = destination.write_file(
  File "/private/tmp/dbt_venv/lib/python3.9/site-packages/installer/destinations.py", line 203, in write_file
    return self.write_to_fs(
  File "/private/tmp/dbt_venv/lib/python3.9/site-packages/installer/destinations.py", line 167, in write_to_fs
    raise FileExistsError(message)
FileExistsError: File already exists: /tmp/example/private/tmp/dbt_venv/bin/dbt
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
