### PR TITLE
Add notes on invoking Python methods in adapter macros

### DIFF
--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -130,8 +130,14 @@ class BaseAdapter(metaclass=AdapterMeta):
     methods are marked with a (passable) in their docstrings. Check docstrings
     for type information, etc.
 
-    To implement a macro, implement "${adapter_type}__${macro_name}". in the
+    To implement a macro, implement "${adapter_type}__${macro_name}" in the
     adapter's internal project.
+
+    To invoke a method in an adapter macro, call it on the 'adapter' Jinja
+    object using dot syntax.
+
+    To invoke a method in model code, add the @available decorator atop a method
+    declaration. Methods are invoked as macros.
 
     Methods:
         - exception_handler


### PR DESCRIPTION

### Description

Downloading knowledge from research over [a recent Slack thread](https://getdbt.slack.com/archives/C030A0UF5LM/p1653668173172789). 

Sister PR going into the dbt docs repo.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
