### PR TITLE
CT-710 fix test graph selection

### DIFF
--- a/.changes/unreleased/Under the Hood-20220601-112648.yaml
+++ b/.changes/unreleased/Under the Hood-20220601-112648.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Fix unit test test_graph_selection
+time: 2022-06-01T11:26:48.725831-04:00
+custom:
+  Author: gshank
+  Issue: "5323"
+  PR: "5324"

--- a/core/dbt/graph/selector_spec.py
+++ b/core/dbt/graph/selector_spec.py
@@ -2,7 +2,7 @@ import os
 import re
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from dbt.dataclass_schema import StrEnum
+from dbt.dataclass_schema import StrEnum, dbtClassMixin
 
 from typing import Set, Iterator, List, Optional, Dict, Union, Any, Iterable, Tuple
 from .graph import UniqueId
@@ -169,7 +169,7 @@ class SelectionCriteria:
         )
 
 
-class BaseSelectionGroup(Iterable[SelectionSpec], metaclass=ABCMeta):
+class BaseSelectionGroup(dbtClassMixin, Iterable[SelectionSpec], metaclass=ABCMeta):
     def __init__(
         self,
         components: Iterable[SelectionSpec],

--- a/test/unit/test_graph_selection.py
+++ b/test/unit/test_graph_selection.py
@@ -11,6 +11,13 @@ from dbt.node_types import NodeType
 
 import networkx as nx
 
+from dbt import flags
+
+from argparse import Namespace
+from dbt.contracts.project import UserConfig
+
+flags.set_from_args(Namespace(), UserConfig())
+
 
 def _get_graph():
     integer_graph = nx.balanced_tree(2, 2, nx.DiGraph())


### PR DESCRIPTION
resolves #5323


### Description

A flag was added to graph selection code. The unit test test_graph_selection.py fails when you run it separately because the flags were not instantiated. This fixes the test.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
