### PR TITLE
New ancestor/descendant algo

### DIFF
--- a/.changes/unreleased/Fixes-20220601-135908.yaml
+++ b/.changes/unreleased/Fixes-20220601-135908.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Change node ancestor/descendant algo, fixes issue where downstream models aren't
+  run when using networkx >= 2.8.1
+time: 2022-06-01T13:59:08.886215-05:00
+custom:
+  Author: iknox-fa
+  Issue: "5286"
+  PR: "5326"

--- a/core/dbt/graph/graph.py
+++ b/core/dbt/graph/graph.py
@@ -28,20 +28,16 @@ class Graph:
         """Returns all nodes having a path to `node` in `graph`"""
         if not self.graph.has_node(node):
             raise InternalException(f"Node {node} not found in the graph!")
-        # This used to use nx.utils.reversed(self.graph), but that is deprecated,
-        # so changing to use self.graph.reverse(copy=False) as recommeneded
-        G = self.graph.reverse(copy=False) if self.graph.is_directed() else self.graph
-        anc = nx.single_source_shortest_path_length(G=G, source=node, cutoff=max_depth).keys()
-        return anc - {node}
+        return {
+            child
+            for _, child in nx.bfs_edges(self.graph, node, reverse=True, depth_limit=max_depth)
+        }
 
     def descendants(self, node: UniqueId, max_depth: Optional[int] = None) -> Set[UniqueId]:
         """Returns all nodes reachable from `node` in `graph`"""
         if not self.graph.has_node(node):
             raise InternalException(f"Node {node} not found in the graph!")
-        des = nx.single_source_shortest_path_length(
-            G=self.graph, source=node, cutoff=max_depth
-        ).keys()
-        return des - {node}
+        return {child for _, child in nx.bfs_edges(self.graph, node, depth_limit=max_depth)}
 
     def select_childrens_parents(self, selected: Set[UniqueId]) -> Set[UniqueId]:
         ancestors_for = self.select_children(selected) | selected


### PR DESCRIPTION
resolves #5286

### Description
Updates ancestor/descendant algos to something more sane that also seems to correct an as-yet-undetermined root cause bug in either networkx or in the internal graph construction.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
