### PR TITLE
CT-729 Include schema model config in unrendered config

### DIFF
--- a/.changes/unreleased/Fixes-20220607-123058.yaml
+++ b/.changes/unreleased/Fixes-20220607-123058.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Include schema file config in unrendered_config
+time: 2022-06-07T12:30:58.535207-04:00
+custom:
+  Author: gshank
+  Issue: "5338"
+  PR: "5344"

--- a/core/dbt/parser/base.py
+++ b/core/dbt/parser/base.py
@@ -309,7 +309,9 @@ class ConfiguredParser(
 
         # unrendered_config is used to compare the original database/schema/alias
         # values and to handle 'same_config' and 'same_contents' calls
-        parsed_node.unrendered_config = config.build_config_dict(rendered=False)
+        parsed_node.unrendered_config = config.build_config_dict(
+            rendered=False, patch_config_dict=patch_config_dict
+        )
 
         parsed_node.config_call_dict = config._config_call_dict
 

--- a/tests/functional/artifacts/expected_manifest.py
+++ b/tests/functional/artifacts/expected_manifest.py
@@ -205,9 +205,13 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
         schema="test", docs={"node_color": None, "show": False}
     )
 
-    unrendered_model_config = get_unrendered_model_config(materialized="view")
+    unrendered_model_config = get_unrendered_model_config(
+        materialized="view", docs={"show": False}
+    )
 
-    unrendered_second_config = get_unrendered_model_config(schema="test", materialized="view")
+    unrendered_second_config = get_unrendered_model_config(
+        schema="test", materialized="view", docs={"show": False}
+    )
 
     seed_config = get_rendered_seed_config()
     unrendered_seed_config = get_unrendered_seed_config()

--- a/tests/functional/configs/test_configs_in_schema_files.py
+++ b/tests/functional/configs/test_configs_in_schema_files.py
@@ -23,7 +23,7 @@ models:
         meta:
             owner: 'Julie Smith'
             my_attr: "{{ var('my_var') }}"
-        materialization: view
+        materialized: view
 
     columns:
       - name: id
@@ -56,6 +56,22 @@ models_alt__tagged__model_sql = """
 {{
     config(
         materialized='table',
+        tags=['tag_2_in_model'],
+    )
+}}
+
+select 4 as id, 2 as value
+"""
+
+models_no_materialized__model_sql = """
+{{
+    config(
+        tags=['tag_1_in_model'],
+    )
+}}
+
+{{
+    config(
         tags=['tag_2_in_model'],
     )
 }}
@@ -189,6 +205,21 @@ class TestSchemaFileConfigs:
         tables = project.get_tables_in_schema()
         assert tables["model"] == "table"
         check_relations_equal(project.adapter, ["some_seed", "model"])
+
+        # Remove materialized config from model
+        write_file(models_no_materialized__model_sql, project.project_root, "models", "tagged", "model.sql")
+        results = run_dbt(["run"])
+        manifest = get_manifest(project.project_root)
+        model_node = manifest.nodes[model_id]
+
+        assert model_node.config.materialized == "view"
+        model_unrendered_config = {
+            "materialized": "view",
+            "meta": {'my_attr': 'TESTING', 'owner': 'Julie Smith'},
+            "tags": ["tag_1_in_model",
+                     "tag_2_in_model"],
+        }
+        assert model_node.unrendered_config == model_unrendered_config
 
         # look for test meta
         schema_file_id = model_node.patch_path

--- a/tests/functional/configs/test_configs_in_schema_files.py
+++ b/tests/functional/configs/test_configs_in_schema_files.py
@@ -207,17 +207,23 @@ class TestSchemaFileConfigs:
         check_relations_equal(project.adapter, ["some_seed", "model"])
 
         # Remove materialized config from model
-        write_file(models_no_materialized__model_sql, project.project_root, "models", "tagged", "model.sql")
+        write_file(
+            models_no_materialized__model_sql,
+            project.project_root,
+            "models",
+            "tagged",
+            "model.sql",
+        )
         results = run_dbt(["run"])
+        assert len(results) == 2
         manifest = get_manifest(project.project_root)
         model_node = manifest.nodes[model_id]
 
         assert model_node.config.materialized == "view"
         model_unrendered_config = {
             "materialized": "view",
-            "meta": {'my_attr': 'TESTING', 'owner': 'Julie Smith'},
-            "tags": ["tag_1_in_model",
-                     "tag_2_in_model"],
+            "meta": {"my_attr": "TESTING", "owner": "Julie Smith"},
+            "tags": ["tag_1_in_model", "tag_2_in_model"],
         }
         assert model_node.unrendered_config == model_unrendered_config
 


### PR DESCRIPTION
resolves #5338


### Description

Unrendered_config originally only included config from models. When we added config for models in schema files, we didn't include that in unrendered_config. Unrendered_config still doesn't include model config from dbt_project.yml, since the code explicitly avoided that. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
