### PR TITLE
Fix YAML parsing with anchors and duplicate keys in dbt_project.yml file

### DIFF
--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -438,7 +438,8 @@ class InvalidSelectorException(RuntimeException):
 
 
 class DuplicateYamlKeyException(CompilationException):
-    pass
+    def __str__(self):
+        return self.msg
 
 
 def raise_compiler_error(msg, node=None) -> NoReturn:

--- a/test/unit/test_yaml_loader.py
+++ b/test/unit/test_yaml_loader.py
@@ -37,4 +37,4 @@ class YamlLoadingUnitTest(unittest.TestCase):
 
     def test_load_duped_var(self):
         dbt_project_yml = load_yaml_text(project_with_duped_var)
-        assert(dbt_project_yml)
+        assert(dbt_project_yml) == {'var': {'foo': 'bar'}}

--- a/test/unit/test_yaml_loader.py
+++ b/test/unit/test_yaml_loader.py
@@ -21,20 +21,8 @@ postgres:
   target: dev
 """
 
-project_with_duped_var = """
-# dbt_project.yml
-
-vars:
-  foo: bar
-  foo: bar
-"""
-
 class YamlLoadingUnitTest(unittest.TestCase):
 
     def test_load_yaml_anchors(self):
         profile_yml = load_yaml_text(profile_with_anchor)
         assert(profile_yml)
-
-    def test_load_duped_var(self):
-        dbt_project_yml = load_yaml_text(project_with_duped_var)
-        assert(dbt_project_yml) == {'var': {'foo': 'bar'}}

--- a/test/unit/test_yaml_loader.py
+++ b/test/unit/test_yaml_loader.py
@@ -1,0 +1,40 @@
+from dbt.clients.yaml_helper import load_yaml_text
+import unittest
+
+profile_with_anchor = """
+# profiles.yml
+
+postgres:
+  outputs:
+    dev: &profile
+      type: postgres
+      host: localhost
+      user: root
+      password: password
+      schema: public
+      database: postgres
+      port: 5432
+      threads: 8
+    prod:
+      <<: *profile
+    uat: *profile
+  target: dev
+"""
+
+project_with_duped_var = """
+# dbt_project.yml
+
+vars:
+  foo: bar
+  foo: bar
+"""
+
+class YamlLoadingUnitTest(unittest.TestCase):
+
+    def test_load_yaml_anchors(self):
+        profile_yml = load_yaml_text(profile_with_anchor)
+        assert(profile_yml)
+
+    def test_load_duped_var(self):
+        dbt_project_yml = load_yaml_text(project_with_duped_var)
+        assert(dbt_project_yml)

--- a/tests/functional/duplications/test_basic_duplications.py
+++ b/tests/functional/duplications/test_basic_duplications.py
@@ -39,7 +39,7 @@ class TestBasicDuplications:
 
     def test_warning_in_stdout(self, project):
         results, stdout = run_dbt_and_capture(["run"])
-        assert "Duplicate 'models' key found in yaml file models/schema.yml" in stdout
+        assert "Duplicate 'models' key found in yaml" in stdout
 
     def test_exception_is_raised_with_warn_error_flag(self, project):
         with pytest.raises(DuplicateYamlKeyException):


### PR DESCRIPTION
resolves #5268, #5331 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

Just pondering on a fix for the linked issues.

1. ~~Seems like `safe_load` is used in multiple places - so just revert to previous behaviour by default + option to use the newly introduced `UniqueKeyLoader`.~~
2. Looks like a call to `flatten_mapping` sorts out the YAML anchors.

This seems to work for:

```yaml
# ~/.dbt/profiles.yml

postgres:
  outputs:
    dev: &profile
      type: postgres
      host: localhost
      user: root
      password: password
      schema: public
      database: postgres
      port: 5432
      threads: 8
    prod:
      <<: *profile
    uat: *profile
  target: dev
```

and

```yaml
# dbt_project.yml

...
vars:
  foo: bar
  foo: bar
...
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
