### PR TITLE
Add inheritance to materialization macro resolution

### DIFF
--- a/.changes/unreleased/Fixes-20220608-104251.yaml
+++ b/.changes/unreleased/Fixes-20220608-104251.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Add inheritance to materialization macro resolution
+time: 2022-06-08T10:42:51.839945-04:00
+custom:
+  Author: volkangurel
+  Issue: "4646"
+  PR: "5348"

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -328,11 +328,6 @@ class Locality(enum.IntEnum):
     Root = 3
 
 
-class Specificity(enum.IntEnum):
-    Default = 1
-    Adapter = 2
-
-
 @dataclass
 class MacroCandidate:
     locality: Locality
@@ -355,12 +350,10 @@ class MacroCandidate:
 
 @dataclass
 class MaterializationCandidate(MacroCandidate):
-    specificity: Specificity
+    specificity: int
 
     @classmethod
-    def from_macro(
-        cls, candidate: MacroCandidate, specificity: Specificity
-    ) -> "MaterializationCandidate":
+    def from_macro(cls, candidate: MacroCandidate, specificity: int) -> "MaterializationCandidate":
         return cls(
             locality=candidate.locality,
             macro=candidate.macro,
@@ -384,9 +377,9 @@ class MaterializationCandidate(MacroCandidate):
     def __lt__(self, other: object) -> bool:
         if not isinstance(other, MaterializationCandidate):
             return NotImplemented
-        if self.specificity < other.specificity:
-            return True
         if self.specificity > other.specificity:
+            return True
+        if self.specificity < other.specificity:
             return False
         if self.locality < other.locality:
             return True
@@ -671,18 +664,22 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
                 disabled_by_file_id[node.file_id] = node
         return disabled_by_file_id
 
+    def _get_parent_adapter_types(self, adapter_type: str) -> List[str]:
+        from dbt.adapters.factory import get_adapter_type_names
+
+        # order matters for dispatch:
+        #  1. current adapter
+        #  2. any parent adapters (dependencies)
+        #  3. 'default'
+        return get_adapter_type_names(adapter_type) + ["default"]
+
     def _materialization_candidates_for(
         self,
         project_name: str,
         materialization_name: str,
-        adapter_type: Optional[str],
+        adapter_type: str,
+        specificity: int,
     ) -> CandidateList:
-
-        if adapter_type is None:
-            specificity = Specificity.Default
-        else:
-            specificity = Specificity.Adapter
-
         full_name = dbt.utils.get_materialization_macro_name(
             materialization_name=materialization_name,
             adapter_type=adapter_type,
@@ -702,8 +699,9 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
                     project_name=project_name,
                     materialization_name=materialization_name,
                     adapter_type=atype,
+                    specificity=specificity,
                 )
-                for atype in (adapter_type, None)
+                for specificity, atype in enumerate(self._get_parent_adapter_types(adapter_type))
             )
         )
         return candidates.last()

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -350,6 +350,10 @@ class MacroCandidate:
 
 @dataclass
 class MaterializationCandidate(MacroCandidate):
+    # specificity describes where in the inheritance chain this materialization candidate is
+    # a specificity of 0 means a materialization defined by the current adapter
+    # the highest the specificity describes a default materialization. the value itself depends on
+    # how many adapters there are in the inheritance chain
     specificity: int
 
     @classmethod
@@ -665,6 +669,8 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         return disabled_by_file_id
 
     def _get_parent_adapter_types(self, adapter_type: str) -> List[str]:
+        # This is duplicated logic from core/dbt/context/providers.py
+        # Ideally this would instead be incorporating actual dispatch logic
         from dbt.adapters.factory import get_adapter_type_names
 
         # order matters for dispatch:
@@ -699,7 +705,7 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
                     project_name=project_name,
                     materialization_name=materialization_name,
                     adapter_type=atype,
-                    specificity=specificity,
+                    specificity=specificity,  # where in the inheritance chain this candidate is
                 )
                 for specificity, atype in enumerate(self._get_parent_adapter_types(adapter_type))
             )

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -12,6 +12,7 @@ import pytest
 import dbt.flags
 import dbt.version
 from dbt import tracking
+from dbt.adapters.base.plugin import AdapterPlugin
 from dbt.contracts.files import FileHash
 from dbt.contracts.graph.manifest import Manifest, ManifestMetadata
 from dbt.contracts.graph.parsed import (
@@ -36,7 +37,7 @@ from dbt.events.functions import get_invocation_id
 from dbt.node_types import NodeType
 import freezegun
 
-from .utils import MockMacro, MockDocumentation, MockSource, MockNode, MockMaterialization, MockGenerateMacro
+from .utils import MockMacro, MockDocumentation, MockSource, MockNode, MockMaterialization, MockGenerateMacro, inject_plugin
 
 
 REQUIRED_PARSED_NODE_KEYS = frozenset({
@@ -1005,6 +1006,27 @@ FindMaterializationSpec = namedtuple('FindMaterializationSpec', 'macros,adapter_
 
 
 def _materialization_parameter_sets():
+    # inject the plugins used for materialization parameter tests
+    with mock.patch('dbt.adapters.base.plugin.project_name_from_path') as get_name:
+        get_name.return_value = 'foo'
+        FooPlugin = AdapterPlugin(
+            adapter=mock.MagicMock(),
+            credentials=mock.MagicMock(),
+            include_path='/path/to/root/plugin',
+        )
+        FooPlugin.adapter.type.return_value = 'foo'
+        inject_plugin(FooPlugin)
+
+        get_name.return_value = 'bar'
+        BarPlugin = AdapterPlugin(
+            adapter=mock.MagicMock(),
+            credentials=mock.MagicMock(),
+            include_path='/path/to/root/plugin',
+            dependencies=['foo'],
+        )
+        BarPlugin.adapter.type.return_value = 'bar'
+        inject_plugin(BarPlugin)
+
     sets = [
         FindMaterializationSpec(macros=[], adapter_type='foo', expected=None),
     ]
@@ -1077,6 +1099,15 @@ def _materialization_parameter_sets():
             expected=('dep', 'foo'),
         ),
     ])
+
+    # inherit from parent adapter
+    sets.extend(
+        FindMaterializationSpec(
+            macros=[MockMaterialization(project, adapter_type='foo')],
+            adapter_type='bar',
+            expected=(project, 'foo'),
+        ) for project in ['root', 'dep', 'dbt']
+    )
 
     return sets
 

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -1108,6 +1108,13 @@ def _materialization_parameter_sets():
             expected=(project, 'foo'),
         ) for project in ['root', 'dep', 'dbt']
     )
+    sets.extend(
+        FindMaterializationSpec(
+            macros=[MockMaterialization(project, adapter_type='foo'), MockMaterialization(project, adapter_type='bar')],
+            adapter_type='bar',
+            expected=(project, 'bar'),
+        ) for project in ['root', 'dep', 'dbt']
+    )
 
     return sets
 


### PR DESCRIPTION
addresses parts of #4646

### Description

Adapter inheritance currently works for macro resolution but doesn't work for materialization macro resolution. This PR updates the logic for the materialization macro resolution to use inheritance as well.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
