### PR TITLE
Adding scheduled CI testing Action

### DIFF
--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -38,6 +38,7 @@ jobs:
       # latest run for results and it gets confused when we kick off multiple runs
       # at once. There is a race condition so we will just run in sequential order.
       max-parallel: 1
+      fail-fast: false
       matrix:
         branch: [main, 1.0.latest, 1.1.latest]
 

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -24,8 +24,6 @@ on:
 
   workflow_dispatch: # for manual triggering
 
-  pull_request: # PR testing only- will remove before merging
-
 # no special access is needed
 permissions: read-all
 

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -30,7 +30,8 @@ on:
 permissions: read-all
 
 jobs:
-  dispatch:
+  kick-off-ci:
+    name: Kick-off CI
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -56,7 +56,7 @@ jobs:
       with:
         status: ${{ job.status }}
         notification_title: 'dbt-core scheduled run of "${{ matrix.branch }}" branch not successful'
-        message_format: ':x: CI on branch ${{"matrix.branch" steps.trigger-step.outputs.workflow-conclusion }}'
-        footer: 'Linked failed CI run $${{steps.trigger-step.outputs.workflow-url}}'
+        message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.trigger-step.outputs.workflow-conclusion }}'
+        footer: 'Linked failed CI run $${{ steps.trigger-step.outputs.workflow-url }}'
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -56,7 +56,7 @@ jobs:
       with:
         status: ${{ job.status }}
         notification_title: 'dbt-core scheduled run of "${{ matrix.branch }}" branch not successful'
-        message_format: '${{ :x: CI on branch "matrix.branch" steps.trigger-step.outputs.workflow-conclusion }}'
+        message_format: ':x: CI on branch ${{"matrix.branch" steps.trigger-step.outputs.workflow-conclusion }}'
         footer: 'Linked failed CI run $${{steps.trigger-step.outputs.workflow-url}}'
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -40,7 +40,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        branch: [main, 1.0.latest, 1.1.latest]
+        branch: [1.0.latest, 1.1.latest, main]
 
     steps:
     - name: Call CI workflow for ${{ matrix.branch }} branch
@@ -58,6 +58,6 @@ jobs:
         status: ${{ job.status }}
         notification_title: 'dbt-core scheduled run of "${{ matrix.branch }}" branch not successful'
         message_format: ':x: CI on branch "${{ matrix.branch }}" ${{ steps.trigger-step.outputs.workflow-conclusion }}'
-        footer: 'Linked failed CI run $${{ steps.trigger-step.outputs.workflow-url }}'
+        footer: 'Linked failed CI run ${{ steps.trigger-step.outputs.workflow-url }}'
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -1,0 +1,62 @@
+# **what?**
+# The purpose of this workflow is to trigger CI to run for each
+# release branch and main branch on a regular cadence. If the CI workflow
+# fails for a branch, it will post to dev-core-alerts to raise awareness.
+# The 'aurelien-baudet/workflow-dispatch' Action triggers the existing
+# CI worklow file on the given branch to run so that even if we change the
+# CI workflow file in the future, the one that is tailored for the given
+# release branch will be used.
+
+# **why?**
+# Ensures release branches and main are always shippable and not broken.
+# Also, can catch any dependencies shifting beneath us that might
+# introduce breaking changes (could also impact Cloud).
+
+# **when?**
+# Mainly on a schedule of 9:00, 13:00, 18:00 UTC everyday.
+# Manual trigger can also test on demand
+
+name: Release branch scheduled testing
+
+on:
+  schedule:
+    - cron: '0 9,13,18 * * *' # 9:00, 13:00, 18:00 UTC
+
+  workflow_dispatch: # for manual triggering
+
+  pull_request: # PR testing only- will remove before merging
+
+# no special access is needed
+permissions: read-all
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+
+    strategy:
+      # must run CI 1 branch at a time b/c the workflow-dispatch Action polls for
+      # latest run for results and it gets confused when we kick off multiple runs
+      # at once. There is a race condition so we will just run in sequential order.
+      max-parallel: 1
+      matrix:
+        branch: [main, 1.0.latest, 1.1.latest]
+
+    steps:
+    - name: Call CI workflow for ${{ matrix.branch }} branch
+      id: trigger-step
+      uses: aurelien-baudet/workflow-dispatch@v2.1.1
+      with:
+        workflow: main.yml
+        ref: ${{ matrix.branch }}
+        token: ${{ secrets.FISHTOWN_BOT_PAT }}
+
+    - name: Post failure to Slack
+      uses: ravsamhq/notify-slack-action@v1
+      if: ${{ always() && !contains(steps.trigger-step.outputs.workflow-conclusion,'success') }}
+      with:
+        status: ${{ job.status }}
+        notification_title: 'dbt-core scheduled run of "${{ matrix.branch }}" branch not successful'
+        message_format: '${{ :x: CI on branch "matrix.branch" steps.trigger-step.outputs.workflow-conclusion }}'
+        footer: 'Linked failed CI run $${{steps.trigger-step.outputs.workflow-url}}'
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}


### PR DESCRIPTION
### Description
This new action will achieve 2 things:
* Regularly test our release branches and `main` on a cadence to make sure they are shippable so we can release at any point in case of a security incident or a Cloud outage
* Detect and report to Slack when CI is broken. This could be indicative of a dependency introducing on a breaking change that may be breaking Cloud (i.e. networkx)

Loom: https://www.loom.com/share/6746e21b439f4b5990bf49a63d0f8480
Example run: https://github.com/dbt-labs/dbt-core/actions/runs/2468529405 

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
