### PR TITLE
Improve pluralizations for Documentation and SqlOperation NodeTypes

### DIFF
--- a/.changes/unreleased/Fixes-20220609-115246.yaml
+++ b/.changes/unreleased/Fixes-20220609-115246.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Improve pluralizations for Documentation and SqlOperation NodeTypes
+time: 2022-06-09T11:52:46.578469-05:00
+custom:
+  Author: pdebelak
+  Issue: "5352"
+  PR: "5356"

--- a/core/dbt/node_types.py
+++ b/core/dbt/node_types.py
@@ -55,10 +55,13 @@ class NodeType(StrEnum):
         ]
 
     def pluralize(self) -> str:
-        if self == "analysis":
+        if self is self.Analysis:
             return "analyses"
-        else:
-            return f"{self}s"
+        if self is self.Documentation:
+            return "docs blocks"
+        if self is self.SqlOperation:
+            return "sql operations"
+        return f"{self}s"
 
 
 class RunHookType(StrEnum):

--- a/core/dbt/node_types.py
+++ b/core/dbt/node_types.py
@@ -12,8 +12,8 @@ class NodeType(StrEnum):
     Seed = "seed"
     # TODO: rm?
     RPCCall = "rpc"
-    SqlOperation = "sql"
-    Documentation = "docs"
+    SqlOperation = "sql operation"
+    Documentation = "docs block"
     Source = "source"
     Macro = "macro"
     Exposure = "exposure"
@@ -57,10 +57,6 @@ class NodeType(StrEnum):
     def pluralize(self) -> str:
         if self is self.Analysis:
             return "analyses"
-        if self is self.Documentation:
-            return "docs blocks"
-        if self is self.SqlOperation:
-            return "sql operations"
         return f"{self}s"
 
 

--- a/test/unit/test_node_types.py
+++ b/test/unit/test_node_types.py
@@ -1,27 +1,27 @@
 import pytest
 from dbt.node_types import NodeType
 
-node_type_pluralizations = [
-    (NodeType.Model, "models"),
-    (NodeType.Analysis, "analyses"),
-    (NodeType.Test, "tests"),
-    (NodeType.Snapshot, "snapshots"),
-    (NodeType.Operation, "operations"),
-    (NodeType.Seed, "seeds"),
-    (NodeType.RPCCall, "rpcs"),
-    (NodeType.SqlOperation, "sql operations"),
-    (NodeType.Documentation, "docs blocks"),
-    (NodeType.Source, "sources"),
-    (NodeType.Macro, "macros"),
-    (NodeType.Exposure, "exposures"),
-    (NodeType.Metric, "metrics"),
-]
+node_type_pluralizations = {
+    NodeType.Model: "models",
+    NodeType.Analysis: "analyses",
+    NodeType.Test: "tests",
+    NodeType.Snapshot: "snapshots",
+    NodeType.Operation: "operations",
+    NodeType.Seed: "seeds",
+    NodeType.RPCCall: "rpcs",
+    NodeType.SqlOperation: "sql operations",
+    NodeType.Documentation: "docs blocks",
+    NodeType.Source: "sources",
+    NodeType.Macro: "macros",
+    NodeType.Exposure: "exposures",
+    NodeType.Metric: "metrics",
+}
 
 
 def test_all_types_have_pluralizations():
-    assert set(NodeType) == set(t for t, _ in node_type_pluralizations)
+    assert set(NodeType) == set(node_type_pluralizations)
 
 
-@pytest.mark.parametrize("node_type, pluralization", node_type_pluralizations)
+@pytest.mark.parametrize("node_type, pluralization", node_type_pluralizations.items())
 def test_pluralizes_correctly(node_type, pluralization):
     assert node_type.pluralize() == pluralization

--- a/test/unit/test_node_types.py
+++ b/test/unit/test_node_types.py
@@ -1,0 +1,27 @@
+import pytest
+from dbt.node_types import NodeType
+
+node_type_pluralizations = [
+    (NodeType.Model, "models"),
+    (NodeType.Analysis, "analyses"),
+    (NodeType.Test, "tests"),
+    (NodeType.Snapshot, "snapshots"),
+    (NodeType.Operation, "operations"),
+    (NodeType.Seed, "seeds"),
+    (NodeType.RPCCall, "rpcs"),
+    (NodeType.SqlOperation, "sql operations"),
+    (NodeType.Documentation, "docs blocks"),
+    (NodeType.Source, "sources"),
+    (NodeType.Macro, "macros"),
+    (NodeType.Exposure, "exposures"),
+    (NodeType.Metric, "metrics"),
+]
+
+
+def test_all_types_have_pluralizations():
+    assert set(NodeType) == set(t for t, _ in node_type_pluralizations)
+
+
+@pytest.mark.parametrize("node_type, pluralization", node_type_pluralizations)
+def test_pluralizes_correctly(node_type, pluralization):
+    assert node_type.pluralize() == pluralization


### PR DESCRIPTION
resolves #5352

### Description

Previously these were `docss` and `sqlss` which leaves something to be desired.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
