### PR TITLE
Prettify duration message at end of execution

### DIFF
--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1501,10 +1501,11 @@ class HooksRunning(InfoLevel):
 class HookFinished(InfoLevel):
     stat_line: str
     execution: str
+    execution_time: float
     code: str = "E040"
 
     def message(self) -> str:
-        return f"Finished running {self.stat_line}{self.execution}."
+        return f"Finished running {self.stat_line}{self.execution} ({self.execution_time:0.2f}s)."
 
 
 @dataclass

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -398,11 +398,15 @@ class RunTask(CompileTask):
         execution = ""
 
         if execution_time is not None:
-            execution = " in {execution_time:0.2f}s".format(execution_time=execution_time)
+            execution = utils.humanise_execution_time(execution_time=execution_time)
 
         with TextOnly():
             fire_event(EmptyLine())
-        fire_event(HookFinished(stat_line=stat_line, execution=execution))
+        fire_event(
+            HookFinished(
+                stat_line=stat_line, execution=execution, execution_time=execution_time
+            )
+        )
 
     def _get_deferred_manifest(self) -> Optional[WritableManifest]:
         if not self.args.defer:

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -316,6 +316,12 @@ def timestring() -> str:
     # isoformat doesn't include the mandatory trailing 'Z' for UTC.
     return datetime.datetime.utcnow().isoformat() + "Z"
 
+def humanise_execution_time(execution_time: int) -> str:
+    minutes, seconds = divmod(execution_time, 60)
+    hours, minutes = divmod(minutes, 60)
+
+    return f" in {int(hours)} hours {int(minutes)} minutes and {seconds:0.2f} seconds"
+
 
 class JSONEncoder(json.JSONEncoder):
     """A 'custom' json encoder that does normal json encoder things, but also


### PR DESCRIPTION
resolves #5253

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

- Added a new function in utils called `humanise_execution_time` that returns a string in the format: `X hours Y minutes and Z seconds`
- Format `execution`, as a string, with hours/minutes/seconds (`1 hours 6 minutes and 51 seconds`)
- Add `execution_time` (float, representing seconds) as a dataclass attribute that gets passed into HookFinished, and included in its structured (JSON) output, even if it isn't templated into the human-freindly message
- Final output after a dbt run looks like `Finished running 1 table model, 1 view model in 0 hours 0 minutes and 0.36 seconds (0.36s).`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
