### PR TITLE
feature/deps-regex-semver

### DIFF
--- a/.changes/unreleased/Under the Hood-20220613-170703.yaml
+++ b/.changes/unreleased/Under the Hood-20220613-170703.yaml
@@ -1,0 +1,8 @@
+kind: Under the Hood
+body: Added the suggested RegEx to check the SemVer string within a package dependency
+  and improved invalid version error handling.
+time: 2022-06-13T17:07:03.773668-05:00
+custom:
+  Author: fivetran-joemarkiewicz
+  Issue: "5201"
+  PR: "5370"

--- a/core/dbt/semver.py
+++ b/core/dbt/semver.py
@@ -95,7 +95,7 @@ class VersionSpecifier(VersionSpecification):
 
         if not match:
             raise dbt.exceptions.SemverException(
-                '"{}" is not a valid semantic version.'.format(version_string)
+                f'"{version_string}" is not a valid semantic version.'
             )
 
         matched = {k: v for k, v in match.groupdict().items() if v is not None}
@@ -425,15 +425,6 @@ def resolve_to_specific_version(requested_range, available_versions):
             max_version_string = version_string
 
     return max_version_string
-
-
-def semver_regex_versioning(versions: List[str]) -> bool:
-    for version_string in versions:
-        try:
-            VersionSpecifier.from_version_string(version_string)
-        except Exception:
-            return False
-    return True
 
 
 def filter_installable(versions: List[str], install_prerelease: bool) -> List[str]:

--- a/core/dbt/semver.py
+++ b/core/dbt/semver.py
@@ -29,6 +29,7 @@ class VersionSpecification(dbtClassMixin):
     build: Optional[str] = None
     matcher: Matchers = Matchers.EXACT
 
+
 _MATCHERS = r"(?P<matcher>\>=|\>|\<|\<=|=)?"
 _NUM_NO_LEADING_ZEROS = r"(0|[1-9]\d*)"
 _ALPHA = r"[0-9A-Za-z-]*"
@@ -425,13 +426,15 @@ def resolve_to_specific_version(requested_range, available_versions):
 
     return max_version_string
 
+
 def semver_regex_versioning(versions: List[str]) -> bool:
     for version_string in versions:
         try:
             VersionSpecifier.from_version_string(version_string)
         except Exception:
-                return False
+            return False
     return True
+
 
 def filter_installable(versions: List[str], install_prerelease: bool) -> List[str]:
     installable = []

--- a/core/dbt/semver.py
+++ b/core/dbt/semver.py
@@ -29,11 +29,10 @@ class VersionSpecification(dbtClassMixin):
     build: Optional[str] = None
     matcher: Matchers = Matchers.EXACT
 
-
 _MATCHERS = r"(?P<matcher>\>=|\>|\<|\<=|=)?"
-_NUM_NO_LEADING_ZEROS = r"(0|[1-9][0-9]*)"
+_NUM_NO_LEADING_ZEROS = r"(0|[1-9]\d*)"
 _ALPHA = r"[0-9A-Za-z-]*"
-_ALPHA_NO_LEADING_ZEROS = r"(0|[1-9A-Za-z-][0-9A-Za-z-]*)"
+_ALPHA_NO_LEADING_ZEROS = r"(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
 
 _BASE_VERSION_REGEX = r"""
 (?P<major>{num_no_leading_zeros})\.
@@ -95,7 +94,7 @@ class VersionSpecifier(VersionSpecification):
 
         if not match:
             raise dbt.exceptions.SemverException(
-                'Could not parse version "{}"'.format(version_string)
+                '"{}" is not a valid semantic version.'.format(version_string)
             )
 
         matched = {k: v for k, v in match.groupdict().items() if v is not None}
@@ -426,6 +425,13 @@ def resolve_to_specific_version(requested_range, available_versions):
 
     return max_version_string
 
+def semver_regex_versioning(versions: List[str]) -> bool:
+    for version_string in versions:
+        try:
+            VersionSpecifier.from_version_string(version_string)
+        except Exception:
+                return False
+    return True
 
 def filter_installable(versions: List[str], install_prerelease: bool) -> List[str]:
     installable = []

--- a/test/unit/test_semver.py
+++ b/test/unit/test_semver.py
@@ -1,11 +1,19 @@
 import unittest
 import itertools
 
+from typing import List
 from dbt.exceptions import VersionsNotCompatibleException
 from dbt.semver import VersionSpecifier, UnboundedVersionSpecifier, \
     VersionRange, reduce_versions, versions_compatible, \
-    resolve_to_specific_version, filter_installable, semver_regex_versioning
+    resolve_to_specific_version, filter_installable
 
+def semver_regex_versioning(versions: List[str]) -> bool:
+    for version_string in versions:
+        try:
+            VersionSpecifier.from_version_string(version_string)
+        except Exception:
+            return False
+    return True
 
 def create_range(start_version_string, end_version_string):
     start = UnboundedVersionSpecifier()

--- a/test/unit/test_semver.py
+++ b/test/unit/test_semver.py
@@ -4,7 +4,7 @@ import itertools
 from dbt.exceptions import VersionsNotCompatibleException
 from dbt.semver import VersionSpecifier, UnboundedVersionSpecifier, \
     VersionRange, reduce_versions, versions_compatible, \
-    resolve_to_specific_version, filter_installable
+    resolve_to_specific_version, filter_installable, semver_regex_versioning
 
 
 def create_range(start_version_string, end_version_string):
@@ -44,6 +44,25 @@ class TestSemver(unittest.TestCase):
             versions_compatible('>0.0.1', '0.0.2'))
         self.assertFalse(
             versions_compatible('0.4.5a1', '0.4.5a2'))
+
+    def test__semver_regex_versions(self):
+        self.assertTrue(semver_regex_versioning(
+            ['0.0.4','1.2.3','10.20.30','1.1.2-prerelease+meta','1.1.2+meta','1.1.2+meta-valid',
+            '1.0.0-alpha','1.0.0-beta','1.0.0-alpha.beta','1.0.0-alpha.beta.1','1.0.0-alpha.1',
+            '1.0.0-alpha0.valid','1.0.0-alpha.0valid','1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay',
+            '1.0.0-rc.1+build.1','2.0.0-rc.1+build.123','1.2.3-beta','10.2.3-DEV-SNAPSHOT','1.2.3-SNAPSHOT-123',
+            '1.0.0','2.0.0','1.1.7','2.0.0+build.1848','2.0.1-alpha.1227','1.0.0-alpha+beta','1.2.3----RC-SNAPSHOT.12.9.1--.12+788',
+            '1.2.3----R-S.12.9.1--.12+meta','1.2.3----RC-SNAPSHOT.12.9.1--.12','1.0.0+0.build.1-rc.10000aaa-kk-0.1',
+            '99999999999999999999999.999999999999999999.99999999999999999','1.0.0-0A.is.legal']))
+
+        self.assertFalse(semver_regex_versioning(
+            ['1','1.2','1.2.3-0123','1.2.3-0123.0123','1.1.2+.123','+invalid','-invalid','-invalid+invalid',
+            '-invalid.01','alpha','alpha.beta','alpha.beta.1','alpha.1','alpha+beta','alpha_beta','alpha.',
+            'alpha..','beta','1.0.0-alpha_beta','-alpha.','1.0.0-alpha..','1.0.0-alpha..1','1.0.0-alpha...1',
+            '1.0.0-alpha....1','1.0.0-alpha.....1','1.0.0-alpha......1','1.0.0-alpha.......1','01.1.1','1.01.1',
+            '1.1.01','1.2','1.2.3.DEV','1.2-SNAPSHOT','1.2.31.2.3----RC-SNAPSHOT.12.09.1--..12+788','1.2-RC-SNAPSHOT',
+            '-1.0.3-gamma+b7718','+justmeta','9.8.7+meta+meta','9.8.7-whatever+meta+meta',
+            '99999999999999999999999.999999999999999999.99999999999999999----RC-SNAPSHOT.12.09.1--------------------------------..12']))
 
     def test__reduce_versions(self):
         self.assertVersionSetResult(


### PR DESCRIPTION
resolves #5201 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

In this PR I incorporate the [suggested regular expression](https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string) (RegEx) to check a SemVer string for when `dbt deps` is invoked. Truth be told, when breaking out [this](https://regex101.com/r/Ly7O1x/3/) expression, there wasn't too much difference from what was included previously. Please let me know if I missed anything.

In addition to the above, I updated the error that is shown when the versioning does not fit within the new regex rules. This error message will be descriptive to show users that the version most likely needs to be modified. 

Finally, I added unit testing to ensure **all** variations of the valid versions shown [here](https://regex101.com/r/Ly7O1x/3/) are truly valid, and that **all** variations of the invalid versions shown [here](https://regex101.com/r/Ly7O1x/3/) are truly invalid. Please note, I ended up creating a new function to simply test if the version triggered the error message upon invoking the `from_version_string` function. Please let me know if this was not needed and there was just a unit test I was simply missing! This is my first attempt at unit tests so happy to modify where needed! 😄 

### CLI Output
Based off these changes, if the version provided for a package does not match the regex rules then we should see a clearer error. See below for my validation of the error message
![image](https://user-images.githubusercontent.com/74217849/173456050-c164de9b-9e68-4b50-966a-cae7ab7fa0c2.png)


### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
☝️ I don't think this is needed, but please let me know and I can if that is required.
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
