### PR TITLE
Fix bug with incorrectly negating having common prefix to identify project path

### DIFF
--- a/core/dbt/task/clean.py
+++ b/core/dbt/task/clean.py
@@ -10,7 +10,7 @@ class CleanTask(ProjectOnlyTask):
 
     def __is_project_path(self, path):
         proj_path = os.path.abspath('.')
-        return not os.path.commonprefix(
+        return os.path.commonprefix(
             [proj_path, os.path.abspath(path)]
         ) == proj_path
 


### PR DESCRIPTION

### Description

Fixing an erroneously negated check for project files making paths. non-local to project, to be considered protected 

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR