### PR TITLE
Fix/fix quotes behaviour in snapshots

### DIFF
--- a/core/dbt/include/global_project/macros/materializations/snapshots/strategies.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshots/strategies.sql
@@ -126,14 +126,14 @@
         {% do exceptions.raise_compiler_error("Invalid value for 'check_cols': " ~ check_cols_config) %}
     {% endif %}
 
-    {%- set existing_cols = adapter.get_columns_in_relation(target_relation) | map(attribute = 'name') | map(adapter.quote) | list -%}
+    {%- set existing_cols = adapter.get_columns_in_relation(target_relation) | map(attribute = 'name') | list -%}
     {%- set ns = namespace() -%} {#-- handle for-loop scoping with a namespace --#}
     {%- set ns.column_added = false -%}
 
     {%- set intersection = [] -%}
     {%- for col in query_columns -%}
         {%- if col in existing_cols -%}
-            {%- do intersection.append(col) -%}
+            {%- do intersection.append(adapter.quote(col)) -%}
         {%- else -%}
             {% set ns.column_added = true %}
         {%- endif -%}

--- a/core/dbt/include/global_project/macros/materializations/snapshots/strategies.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshots/strategies.sql
@@ -126,7 +126,7 @@
         {% do exceptions.raise_compiler_error("Invalid value for 'check_cols': " ~ check_cols_config) %}
     {% endif %}
 
-    {%- set existing_cols = adapter.get_columns_in_relation(target_relation) | map(attribute = 'name') | list -%}
+    {%- set existing_cols = adapter.get_columns_in_relation(target_relation) | map(attribute = 'name') | map(adapter.quote) | list -%}
     {%- set ns = namespace() -%} {#-- handle for-loop scoping with a namespace --#}
     {%- set ns.column_added = false -%}
 


### PR DESCRIPTION
resolves #2975


### Description

At least on Snowflake, using the check_columns='all' strategy for snapshots does not properly take into account quotes in column names. With this PR the quotes are added automatically if the adapter supports them. I think it should work on all the databases since the name of the column is taken directly from the database itself.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
