### PR TITLE
Improve CompilationException messaging for generic test Jinja rendering

### DIFF
--- a/.changes/unreleased/Under the Hood-20220617-150744.yaml
+++ b/.changes/unreleased/Under the Hood-20220617-150744.yaml
@@ -1,4 +1,4 @@
-kind: Under the Hood
+kind: Fixes
 body: Add context to compilation errors generated while rendering generic test configuration
   values.
 time: 2022-06-17T15:07:44.751037-04:00

--- a/.changes/unreleased/Under the Hood-20220617-150744.yaml
+++ b/.changes/unreleased/Under the Hood-20220617-150744.yaml
@@ -1,0 +1,8 @@
+kind: Under the Hood
+body: Add context to compilation errors generated while rendering generic test configuration
+  values.
+time: 2022-06-17T15:07:44.751037-04:00
+custom:
+  Author: nicholasyager
+  Issue: "5294"
+  PR: "5393"

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -270,14 +270,13 @@ class TestBuilder(Generic[Testable]):
                     # See https://github.com/dbt-labs/dbt-core/issues/4103
                     # and https://github.com/dbt-labs/dbt-core/issues/5294
                     raise_compiler_error(
-                        f"\tThe {self.target.name}.{column_name} column's "
-                        f'"{self.name}" test references an undefined \n'
-                        f"\tmacro in its {key} configuration argument. "
+                        f"The {self.target.name}.{column_name} column's "
+                        f'"{self.name}" test references an undefined '
+                        f"macro in its {key} configuration argument. "
                         f"The macro {e.msg}.\n"
-                        "\tPlease note that the generic test configuration"
-                        " parser currently does\n"
-                        "\tusing custom macros to"
-                        " populate configuration values\n"
+                        "Please note that the generic test configuration parser "
+                        "currently does not support using custom macros to "
+                        "populate configuration values"
                     )
 
             if value is not None:

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -270,12 +270,14 @@ class TestBuilder(Generic[Testable]):
                     # See https://github.com/dbt-labs/dbt-core/issues/4103
                     # and https://github.com/dbt-labs/dbt-core/issues/5294
                     raise_compiler_error(
-                        f'The "{key}" test config argument provided on the '
-                        f'"{column_name}" column of "{self.target.name}" '
-                        f'contains an undefined macro. The {e.msg}.\n\n'
-                        'The generic test configuration parser currently '
-                        'does not support using custom macros to populate '
-                        'configuration values.'
+                        f"\tThe {self.target.name}.{column_name} column's  "
+                        f'"{self.name}" test references an undefined \n'
+                        f"\tmacro in its {key} configuration argument. "
+                        f"The {e.msg}.\n"
+                        "\tPlease note that the generic test configuration"
+                        " parser currently does\n"
+                        "\tnot support using custom macros to"
+                        " populate configuration values\n"
                     )
 
             if value is not None:

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -270,13 +270,13 @@ class TestBuilder(Generic[Testable]):
                     # See https://github.com/dbt-labs/dbt-core/issues/4103
                     # and https://github.com/dbt-labs/dbt-core/issues/5294
                     raise_compiler_error(
-                        f"\tThe {self.target.name}.{column_name} column's  "
+                        f"\tThe {self.target.name}.{column_name} column's "
                         f'"{self.name}" test references an undefined \n'
                         f"\tmacro in its {key} configuration argument. "
-                        f"The {e.msg}.\n"
+                        f"The macro {e.msg}.\n"
                         "\tPlease note that the generic test configuration"
                         " parser currently does\n"
-                        "\tnot support using custom macros to"
+                        "\tusing custom macros to"
                         " populate configuration values\n"
                     )
 

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -21,7 +21,7 @@ from dbt.contracts.graph.unparsed import (
     UnparsedNodeUpdate,
     UnparsedExposure,
 )
-from dbt.exceptions import raise_compiler_error, raise_parsing_error
+from dbt.exceptions import raise_compiler_error, raise_parsing_error, UndefinedMacroException
 from dbt.parser.search import FileBlock
 
 
@@ -257,7 +257,27 @@ class TestBuilder(Generic[Testable]):
             if not value and "config" in self.args:
                 value = self.args["config"].pop(key, None)
             if isinstance(value, str):
-                value = get_rendered(value, render_ctx, native=True)
+
+                try:
+                    value = get_rendered(value, render_ctx, native=True)
+                except UndefinedMacroException as e:
+
+                    # Generic tests do not include custom macros in the Jinja
+                    # rendering context, so this will almost always fail. As it
+                    # currently stands, the error message is inscrutable, which
+                    # has caused issues for some projects migrating from
+                    # pre-0.20.0 to post-0.20.0.
+                    # See https://github.com/dbt-labs/dbt-core/issues/4103
+                    # and https://github.com/dbt-labs/dbt-core/issues/5294
+                    raise_compiler_error(
+                        f'The "{key}" test config argument provided on the '
+                        f'"{column_name}" column of "{self.target.name}" '
+                        f'contains an undefined macro. The {e.msg}.\n\n'
+                        'The generic test configuration parser currently '
+                        'does not support using custom macros to populate '
+                        'configuration values.'
+                    )
+
             if value is not None:
                 self.config[key] = value
 

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -306,8 +306,9 @@ class SchemaParser(SimpleParser[GenericTestBlock, ParsedGenericTestNode]):
 
         except CompilationException as exc:
             context = _trimmed(str(target))
-            msg = "Invalid generic test configuration given in {}:" "\n{}\n\t@: {}".format(
-                target.original_file_path, exc.msg, context
+            msg = (
+                "Invalid generic test configuration given in "
+                f"{target.original_file_path}: \n{exc.msg}\n\t@: {context}"
             )
             raise CompilationException(msg) from exc
 

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -57,6 +57,7 @@ from dbt.exceptions import (
     InternalException,
     raise_duplicate_source_patch_name,
     warn_or_error,
+    CompilationException,
 )
 from dbt.node_types import NodeType
 from dbt.parser.base import SimpleParser
@@ -302,6 +303,14 @@ class SchemaParser(SimpleParser[GenericTestBlock, ParsedGenericTestNode]):
                 target.original_file_path, exc.msg, context
             )
             raise ParsingException(msg) from exc
+
+        except CompilationException as exc:
+            context = _trimmed(str(target))
+            msg = "Invalid generic test configuration given in {}:" "\n{}\n\t@: {}".format(
+                target.original_file_path, exc.msg, context
+            )
+            raise CompilationException(msg) from exc
+
         original_name = os.path.basename(target.original_file_path)
         compiled_path = get_pseudo_test_path(builder.compiled_name, original_name)
 

--- a/tests/functional/schema_tests/fixtures.py
+++ b/tests/functional/schema_tests/fixtures.py
@@ -442,6 +442,24 @@ SELECT 'NOT_NULL' AS id
 """
 
 
+custom_generic_test_config_custom_macro__schema_yml = """
+version: 2
+models:
+- name: model_a
+  columns:
+  - name: id
+    tests:
+    - not_null:
+        config:
+          where: "id = (select id from {{ ref('model_a') }} limit 1)"
+
+"""
+
+custom_generic_test_config_custom_macro__model_a = """
+SELECT 1 AS id
+"""
+
+
 custom_generic_test_names__schema_yml = """
 version: 2
 models:
@@ -1338,6 +1356,14 @@ def dupe_tests_collide():
     return {
         "schema.yml": dupe_generic_tests_collide__schema_yml,
         "model_a.sql": dupe_generic_tests_collide__model_a,
+    }
+
+
+@pytest.fixture(scope="class")
+def custom_generic_test_config_custom_macros():
+    return {
+        "schema.yml": custom_generic_test_config_custom_macro__schema_yml,
+        "model_a.sql": custom_generic_test_config_custom_macro__model_a,
     }
 
 

--- a/tests/functional/schema_tests/test_schema_v2_tests.py
+++ b/tests/functional/schema_tests/test_schema_v2_tests.py
@@ -17,6 +17,7 @@ from tests.functional.schema_tests.fixtures import (  # noqa: F401
     test_context_models,
     name_collision,
     dupe_tests_collide,
+    custom_generic_test_config_custom_macros,
     custom_generic_test_names,
     custom_generic_test_names_alt_format,
     test_context_where_subq_macros,
@@ -674,6 +675,21 @@ class TestGenericTestsCollide:
         with pytest.raises(CompilationException) as exc:
             run_dbt()
         assert "dbt found two tests with the name" in str(exc)
+
+
+class TestGenericTestsConfigCustomMacros:
+    @pytest.fixture(scope="class")
+    def models(self, custom_generic_test_config_custom_macros):  # noqa: F811
+        return custom_generic_test_config_custom_macros
+
+    def test_generic_test_config_custom_macros(
+        self,
+        project,
+    ):
+        """This test has a reference to a custom macro its configs"""
+        with pytest.raises(CompilationException) as exc:
+            run_dbt()
+        assert "Invalid generic test configuration" in str(exc)
 
 
 class TestGenericTestsCustomNames:


### PR DESCRIPTION
Resolves #5294 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

In issue #5294, the reporter was having difficulties identifying the source of a `CompliationException` during a migration from 0.19.1 to 1.0.1. The original error message is as follows:

```
Compilation Error
  'dbt_utils' is undefined. This can happen when calling a macro that does not exist. Check for typos and/or install package dependencies with "dbt deps".
```

The message above does not provide any context as to where the issue was originating from.

This PR adds an exception handler for `UndefinedMacroException`s to the `TestBuilder` class so that additional context can be added to the exception raised in the event that a custom macro (or otherwise undefined macro) is reference in a generic test's configuration values. Additionally, a `CompilationException` exception handler was added to the `_parse_generic_test` method of `SchemaParser` so that the schema file that raised the `CompilationException` is also reported.

The new exception message is as follows:

```
Compilation Error
  Invalid generic test configuration given in models/example/schema.yml:
  The {target.name}.{column_name} column's "{test_name}" test references an undefined macro in its where {config_name} argument. The macro '{macro_name}' is undefined.
  Please note that the generic test configuration parser currently does not support using custom macros to populate configuration values
  	@: UnparsedNodeUpdate(original_file_path='model...ne)
```

A test has been added to confirm that a `CompilationException` is raised as expected when a custom macro is referenced in a generic test's config values, and to confirm that the appropriate exception message is returned.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
