### PR TITLE
[CT-679] flip logic around reset color detection

### DIFF
--- a/.changes/unreleased/Fixes-20220617-160027.yaml
+++ b/.changes/unreleased/Fixes-20220617-160027.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: fixes handling of RESET color code with USE_COLORS=False
+time: 2022-06-17T16:00:27.038058-04:00
+custom:
+  Author: darin-reify
+  Issue: "5288"
+  PR: "5394"

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -180,7 +180,7 @@ def create_debug_text_log_line(e: T_Event) -> str:
     if type(e) == MainReportVersion:
         separator = 30 * "="
         log_line = f"\n\n{separator} {get_ts()} | {get_invocation_id()} {separator}\n"
-    color_tag: str = "" if this.format_color else Style.RESET_ALL
+    color_tag: str = "" if not this.format_color else Style.RESET_ALL
     ts: str = get_ts().strftime("%H:%M:%S.%f")
     scrubbed_msg: str = scrub_secrets(e.message(), env_secrets())
     level: str = e.level_tag() if len(e.level_tag()) == 5 else f"{e.level_tag()} "

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -169,6 +169,7 @@ def event_to_serializable_dict(
 def reset_color() -> str:
     return "" if not this.format_color else Style.RESET_ALL
 
+
 def create_info_text_log_line(e: T_Event) -> str:
     color_tag: str = reset_color()
     ts: str = get_ts().strftime("%H:%M:%S")

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -166,8 +166,11 @@ def event_to_serializable_dict(
 
 # translates an Event to a completely formatted text-based log line
 # type hinting everything as strings so we don't get any unintentional string conversions via str()
+def reset_color() -> str:
+    return "" if not this.format_color else Style.RESET_ALL
+
 def create_info_text_log_line(e: T_Event) -> str:
-    color_tag: str = "" if this.format_color else Style.RESET_ALL
+    color_tag: str = reset_color()
     ts: str = get_ts().strftime("%H:%M:%S")
     scrubbed_msg: str = scrub_secrets(e.message(), env_secrets())
     log_line: str = f"{color_tag}{ts}  {scrubbed_msg}"
@@ -180,7 +183,7 @@ def create_debug_text_log_line(e: T_Event) -> str:
     if type(e) == MainReportVersion:
         separator = 30 * "="
         log_line = f"\n\n{separator} {get_ts()} | {get_invocation_id()} {separator}\n"
-    color_tag: str = "" if not this.format_color else Style.RESET_ALL
+    color_tag: str = reset_color()
     ts: str = get_ts().strftime("%H:%M:%S.%f")
     scrubbed_msg: str = scrub_secrets(e.message(), env_secrets())
     level: str = e.level_tag() if len(e.level_tag()) == 5 else f"{e.level_tag()} "


### PR DESCRIPTION
- this makes is so that the reset color code won't be appended to logs
  when `use-colors` is false.

resolves #5288

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
