### PR TITLE
Proposed updates to issue "wayfinder"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -11,12 +11,16 @@ body:
     attributes:
       label: Is this a new bug in dbt-core?
       description: >
-        Issues aren't the right place for requesting help or troubleshooting code in your own dbt project.
-        Bugs in adapter plugins should be opened in that adapter's repository.
-        Bugs in dbt Cloud should be reported to [support](mailto:support@getdbt.com).
+        In other words, is this an error, flaw, failure or fault in our software?
+        
+        If this is a bug that broke existing functionality that used to work, please open a regression issue.
+        If this is a bug in an adapter plugin, please open an issue in the adapter's repository.
+        If this is a bug experienced while using dbt Cloud, please report to [support](mailto:support@getdbt.com).
+        If this is a request for help or troubleshooting code in your own dbt project, please join our [dbt Community Slack](https://www.getdbt.com/community/join-the-community/) or open a [Discussion question](https://github.com/dbt-labs/docs.getdbt.com/discussions).
+        
         Please search to see if an issue already exists for the bug you encountered.
       options:
-        - label: I believe this is a bug in dbt-core
+        - label: I believe this is a new bug in dbt-core
           required: true
         - label: I have searched the existing issues, and I could not find an existing issue for this bug
           required: true
@@ -25,13 +29,13 @@ body:
       label: Current Behavior
       description: A concise description of what you're experiencing.
     validations:
-      required: false
+      required: true
   - type: textarea
     attributes:
       label: Expected Behavior
       description: A concise description of what you expected to happen.
     validations:
-      required: false
+      required: true
   - type: textarea
     attributes:
       label: Steps To Reproduce
@@ -42,7 +46,7 @@ body:
         3. Run '...'
         4. See error...
     validations:
-      required: false
+      required: true
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -12,12 +12,12 @@ body:
       label: Is this a new bug in dbt-core?
       description: >
         In other words, is this an error, flaw, failure or fault in our software?
-        
+
         If this is a bug that broke existing functionality that used to work, please open a regression issue.
         If this is a bug in an adapter plugin, please open an issue in the adapter's repository.
         If this is a bug experienced while using dbt Cloud, please report to [support](mailto:support@getdbt.com).
         If this is a request for help or troubleshooting code in your own dbt project, please join our [dbt Community Slack](https://www.getdbt.com/community/join-the-community/) or open a [Discussion question](https://github.com/dbt-labs/docs.getdbt.com/discussions).
-        
+
         Please search to see if an issue already exists for the bug you encountered.
       options:
         - label: I believe this is a new bug in dbt-core

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask the community for help
-    url: https://docs.getdbt.com/guides/legacy/getting-help
+    url: https://github.com/dbt-labs/docs.getdbt.com/discussions
     about: Need help troubleshooting? Check out our guide on how to ask
   - name: Contact dbt Cloud support
     url: mailto:support@getdbt.com

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     about: Need help troubleshooting? Check out our guide on how to ask
   - name: Contact dbt Cloud support
     url: mailto:support@getdbt.com
-    about: Contact dbt Cloud support
+    about: Are you using dbt Cloud? Contact our support team for help!
   - name: Participate in Discussions
     url: https://github.com/dbt-labs/dbt-core/discussions
     about: Do you have a Big Idea for dbt? Read open discussions, or start a new one

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,14 @@
+blank_issues_enabled: false
 contact_links:
+  - name: Ask the community for help
+    url: https://docs.getdbt.com/guides/legacy/getting-help
+    about: Need help troubleshooting? Check out our guide on how to ask
+  - name: Contact dbt Cloud support
+    url: mailto:support@getdbt.com
+    about: Contact dbt Cloud support
+  - name: Participate in Discussions
+    url: https://github.com/dbt-labs/dbt-core/discussions
+    about: Do you have a Big Idea for dbt? Read open discussions, or start a new one
   - name: Create an issue for dbt-redshift
     url: https://github.com/dbt-labs/dbt-redshift/issues/new/choose
     about: Report a bug or request a feature for dbt-redshift
@@ -8,9 +18,6 @@ contact_links:
   - name: Create an issue for dbt-snowflake
     url: https://github.com/dbt-labs/dbt-snowflake/issues/new/choose
     about: Report a bug or request a feature for dbt-snowflake
-  - name: Ask a question or get support
-    url: https://docs.getdbt.com/docs/guides/getting-help
-    about: Ask a question or request support
-  - name: Questions on Stack Overflow
-    url: https://stackoverflow.com/questions/tagged/dbt
-    about: Look at questions/answers at Stack Overflow
+  - name: Create an issue for dbt-spark
+    url: https://github.com/dbt-labs/dbt-spark/issues/new/choose
+    about: Report a bug or request a feature for dbt-spark

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,5 @@
 name: ✨ Feature
-description: Suggest an idea for dbt
+description: Propose a straightforward extension of dbt functionality
 title: "[Feature] <title>"
 labels: ["enhancement", "triage"]
 body:
@@ -9,18 +9,24 @@ body:
         Thanks for taking the time to fill out this feature request!
   - type: checkboxes
     attributes:
-      label: Is there an existing feature request for this?
-      description: Please search to see if an issue already exists for the feature you would like.
-      options:
-        - label: I have searched the existing issues
-          required: true
-      label: Is this your first time opening an issue?
+      label: Is this your first time submitting a feature request?
+      description: >
+        We want to make sure that features are distinct and discoverable,
+        so that other members of the community can find them and offer their thoughts.
+
+        Issues are the right place to request straightforward extensions of existing dbt functionality.
+        For "big ideas" about future capabilities of dbt, we ask that you open a
+        [discussion](https://github.com/dbt-labs/dbt-core/discussions) in the "Ideas" category instead.
       options:
         - label: I have read the [expectations for open source contributors](https://docs.getdbt.com/docs/contributing/oss-expectations)
           required: true
+        - label: I have searched the existing issues, and I could not find an existing issue for this feature
+          required: true
+        - label: I am requesting a straightforward extension of existing dbt functionality, rather than a Big Idea better suited to a discussion
+          required: true
   - type: textarea
     attributes:
-      label: Describe the Feature
+      label: Describe the feature
       description: A clear and concise description of what you want to happen.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/regression-report.yml
+++ b/.github/ISSUE_TEMPLATE/regression-report.yml
@@ -9,7 +9,7 @@ body:
         Thanks for taking the time to fill out this regression report!
   - type: checkboxes
     attributes:
-      label: Is this a net-new regression in a recent version of dbt-core?
+      label: Is this a regression in a recent version of dbt-core?
       description: >
         A regression is when documented functionality works as expected in an older version of dbt-core,
         and no longer works after upgrading to a newer version of dbt-core
@@ -23,13 +23,13 @@ body:
       label: Current Behavior
       description: A concise description of what you're experiencing.
     validations:
-      required: false
+      required: true
   - type: textarea
     attributes:
       label: Expected/Previous Behavior
       description: A concise description of what you expected to happen.
     validations:
-      required: false
+      required: true
   - type: textarea
     attributes:
       label: Steps To Reproduce
@@ -40,7 +40,7 @@ body:
         3. Run '...'
         4. See error...
     validations:
-      required: false
+      required: true
   - type: textarea
     id: logs
     attributes:
@@ -57,14 +57,16 @@ body:
         examples:
           - **OS**: Ubuntu 20.04
           - **Python**: 3.9.12 (`python3 --version`)
-          - **dbt-core**: 1.1.1 (`dbt --version`)
+          - **dbt-core (working version)**: 1.1.1 (`dbt --version`)
+          - **dbt-core (regression version)**: 1.2.0 (`dbt --version`)
       value: |
         - OS:
         - Python:
-        - dbt:
+        - dbt (working version):
+        - dbt (regression version):
       render: markdown
     validations:
-      required: false
+      required: true
   - type: dropdown
     id: database
     attributes:

--- a/.github/ISSUE_TEMPLATE/regression-report.yml
+++ b/.github/ISSUE_TEMPLATE/regression-report.yml
@@ -1,24 +1,22 @@
-name: 🐞 Bug
-description: Report a bug or an issue you've found with dbt
-title: "[Bug] <title>"
-labels: ["bug", "triage"]
+name: ☣️ Regression
+description: Report a regression you've observed in a newer version of dbt
+title: "[Regression] <title>"
+labels: ["bug", "regression", "triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report!
+        Thanks for taking the time to fill out this regression report!
   - type: checkboxes
     attributes:
-      label: Is this a new bug in dbt-core?
+      label: Is this a net-new regression in a recent version of dbt-core?
       description: >
-        Issues aren't the right place for requesting help or troubleshooting code in your own dbt project.
-        Bugs in adapter plugins should be opened in that adapter's repository.
-        Bugs in dbt Cloud should be reported to [support](mailto:support@getdbt.com).
-        Please search to see if an issue already exists for the bug you encountered.
+        A regression is when documented functionality works as expected in an older version of dbt-core,
+        and no longer works after upgrading to a newer version of dbt-core
       options:
-        - label: I believe this is a bug in dbt-core
+        - label: I believe this is a regression in dbt-core functionality
           required: true
-        - label: I have searched the existing issues, and I could not find an existing issue for this bug
+        - label: I have searched the existing issues, and I could not find an existing issue for this regression
           required: true
   - type: textarea
     attributes:
@@ -28,7 +26,7 @@ body:
       required: false
   - type: textarea
     attributes:
-      label: Expected Behavior
+      label: Expected/Previous Behavior
       description: A concise description of what you expected to happen.
     validations:
       required: false
@@ -71,7 +69,7 @@ body:
     id: database
     attributes:
       label: Which database adapter are you using with dbt?
-      description: If the bug is specific to the database or adapter, please open the issue in that adapter's repository instead
+      description: If the regression is specific to the database or adapter, please open the issue in that adapter's repository instead
       multiple: true
       options:
         - postgres


### PR DESCRIPTION
<img width="257" alt="Screenshot 2022-06-30 at 12 18 36" src="https://user-images.githubusercontent.com/13897643/176653888-254c1a33-2ecb-4b46-b8c5-e1ba82206307.png">

## What problem(s) are we trying to solve?

- Community members opening `dbt-core` issues, when it's not the appropriate or most expedient channel for getting the help they need, or the response they're after
- High-priority regressions getting lost in the shuffle, because they appear at first like any other bug report

## Changes in this PR

### Issue templates
- Add a new "Regression" issue type/template, for high-priority bugs that regress from functionality in older versions of `dbt-core`
- Fix the `checkboxes` structure, and add some more "checks." In particular, ask users whether their feature request should actually be an `Idea`-type discussion. Very open to thoughts on the language here.

### Wayfinder
- Fix the link to the "getting help" docs guide (broken pending https://github.com/dbt-labs/docs.getdbt.com/pull/1643)
- Add a link to Discussions
- Add an explicit external link for dbt Cloud support
- Remove the link to StackOverflow, since this isn't really what we're recommending. Should we link folks to create discussions in this repo / docs repo instead? I'm still not totally clear on what our recommended path is, per ["getting help"](https://docs.getdbt.com/guides/legacy/getting-help) + ["OSS expectations"](https://docs.getdbt.com/docs/contributing/oss-expectations)

### todo?

We discussed adding a dedicated issue template for "Unable to Install" cases as well, to create a dedicated stream for those separate from Bug Report. I haven't done that yet, but I can. I think it could also reasonably fall under the purview of "Regression" (= a thing that used to work and no longer does). We'll want to make clear that the priority order is `pip` >>> everything else, and that Homebrew installation issues should actually be reported in the `homebrew-dbt` repo.