### PR TITLE
[CT-472] feat: Retrying method for acquiring connection handles

### DIFF
--- a/.changes/unreleased/Features-20220715-035555.yaml
+++ b/.changes/unreleased/Features-20220715-035555.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Support retrying Postgres (and Redshift!) connection attempts in the prescence
+  of transient network issues
+time: 2022-07-15T03:55:55.270637265+02:00
+custom:
+  Author: tomasfarias
+  Issue: "5022"
+  PR: "5432"

--- a/.changes/unreleased/Features-20220715-035555.yaml
+++ b/.changes/unreleased/Features-20220715-035555.yaml
@@ -1,6 +1,6 @@
 kind: Features
-body: Support retrying Postgres (and Redshift!) connection attempts in the prescence
-  of transient network issues
+body: Add reusable function for retrying adapter connections. Utilize said function
+  to add retries for Postgres (and Redshift).
 time: 2022-07-15T03:55:55.270637265+02:00
 custom:
   Author: tomasfarias

--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -178,6 +178,10 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
     ) -> Connection:
         """Given a Connection, set its handle by calling Connection.credentials.acquire_handle.
 
+        The acquire_handle method call will be retried up to retry_limit times to deal
+        with transient connection errors. By default, retry_limit is set to 1, however, only
+        exceptions in exception_handlers will be retried unless retry_all is also set to True.
+
         :param Connection connection: An instance of a Connection that
             needs a handle to be set, usually when attempting to open it.
         :param AdapterLogger logger: A logger to emit messages on retry

--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -227,18 +227,12 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
                 if is_expected:
                     logger.debug(
                         "Got an error when attempting to open a "
-                        "{conn_type} connection. Retrying due to "
+                        f"{cls.TYPE} connection. Retrying due to "
                         "either retry configuration set to true."
                         "This was attempt number: {attempt} of "
-                        "{max_attempts}. "
-                        "Retrying in {timeout} "
-                        "seconds. Error: '{error}'".format(
-                            conn_type=cls.TYPE,
-                            attempt=attempt,
-                            max_attempts=max_attempts,
-                            timeout=timeout,
-                            error=e,
-                        )
+                        f"{max_attempts}. "
+                        f"Retrying in {timeout} "
+                        f"seconds. Error: '{e}'"
                     )
 
                     exc_handler = exception_handlers.get(type(e), None)
@@ -251,28 +245,20 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
                 if retry_all is True:
                     logger.warning(
                         "Got unexpected an error when attempting to open a "
-                        "{conn_type} connection. Retrying due to "
+                        f"{cls.TYPE} connection. Retrying due to "
                         "'retry_all' configuration set to true."
-                        "This was attempt number: {attempt} of "
-                        "{max_attempts}. "
-                        "Retrying in {timeout} "
-                        "seconds. Error: '{error}'".format(
-                            conn_type=cls.TYPE,
-                            attempt=attempt,
-                            max_attempts=max_attempts,
-                            timeout=timeout,
-                            error=e,
-                        )
+                        f"This was attempt number: {attempt} of "
+                        f"{max_attempts}. "
+                        f"Retrying in {timeout} "
+                        f"seconds. Error: '{e}'"
                     )
                     sleep(timeout)
                     continue
 
                 logger.warning(
                     "Got unexpected an error when attempting to open a "
-                    "{conn_type} connection. This was attempt number: "
-                    "{attempt} of {max_attempts}. Error: '{error}'".format(
-                        conn_type=cls.TYPE, attempt=attempt, max_attempts=max_attempts, error=e
-                    )
+                    f"{cls.TYPE} connection. This was attempt number: "
+                    f"{attempt} of {max_attempts}. Error: '{e}'"
                 )
                 break
 

--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -1,6 +1,7 @@
 import abc
 import os
 from time import sleep
+import sys
 
 # multiprocessing.RLock is a function returning this type
 from multiprocessing.synchronize import RLock
@@ -221,7 +222,8 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
                 "retry_timeout cannot be negative or return a negative time."
             )
 
-        if retry_limit < 0:
+        if retry_limit < 0 or retry_limit > sys.getrecursionlimit():
+            # This guard is not perfect others may add to the recursion limit (e.g. built-ins).
             connection.handle = None
             connection.state = ConnectionState.FAIL
             raise dbt.exceptions.FailedToConnectException("retry_limit cannot be negative")

--- a/core/dbt/contracts/connection.py
+++ b/core/dbt/contracts/connection.py
@@ -178,6 +178,9 @@ class Credentials(ExtensibleDbtClassMixin, Replaceable, metaclass=abc.ABCMeta):
             )
         return dct
 
+    def acquire_handle(self, **kwargs):
+        raise NotImplementedError
+
 
 class UserConfigContract(Protocol):
     send_anonymous_usage_stats: bool

--- a/core/dbt/contracts/connection.py
+++ b/core/dbt/contracts/connection.py
@@ -178,9 +178,6 @@ class Credentials(ExtensibleDbtClassMixin, Replaceable, metaclass=abc.ABCMeta):
             )
         return dct
 
-    def acquire_handle(self, **kwargs):
-        raise NotImplementedError
-
 
 class UserConfigContract(Protocol):
     send_anonymous_usage_stats: bool

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -153,8 +153,11 @@ class PostgresConnectionManager(SQLConnectionManager):
             return handle
 
         retryable_exceptions = [
-            # OperationalError is subclassed by all psycopg2 Connection Exceptions
-            # and it's raised by generic connection errors without an error code.
+            # OperationalError is subclassed by all psycopg2 Connection Exceptions and it's raised
+            # by generic connection timeouts without an error code. This is a limitation of
+            # psycopg2 which doesn't provide subclasses for errors without a SQLSTATE error code.
+            # The limitation has been known for a while and there are no efforts to tackle it.
+            # See: https://github.com/psycopg/psycopg2/issues/682
             psycopg2.errors.OperationalError,
         ]
 

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -55,22 +55,6 @@ class PostgresCredentials(Credentials):
             "sslmode",
         )
 
-    def acquire_handle(self, **kwargs):
-        """Acquire a handle for a Postgres connection with the given credentials."""
-        handle = psycopg2.connect(
-            dbname=self.database,
-            user=self.user,
-            host=self.host,
-            password=self.password,
-            port=self.port,
-            connect_timeout=self.connect_timeout,
-            **kwargs,
-        )
-
-        if self.role:
-            handle.cursor().execute("set role {}".format(self.role))
-        return handle
-
 
 class PostgresConnectionManager(SQLConnectionManager):
     TYPE = "postgres"

--- a/test/unit/test_adapter_connection_manager.py
+++ b/test/unit/test_adapter_connection_manager.py
@@ -1,0 +1,259 @@
+import unittest
+from unittest import mock
+
+import dbt.exceptions
+
+import psycopg2
+
+from dbt.contracts.connection import Connection
+from dbt.adapters.base import BaseConnectionManager
+from dbt.adapters.postgres import PostgresCredentials, PostgresConnectionManager
+from dbt.events import AdapterLogger
+
+
+class BaseConnectionManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.postgres_credentials = PostgresCredentials(
+            host="localhost",
+            user="test-user",
+            port=1111,
+            password="test-password",
+            database="test-db",
+            schema="test-schema",
+        )
+        self.logger = AdapterLogger("test")
+        self.postgres_connection = Connection("postgres", None, self.postgres_credentials)
+
+    def test_set_connection_handle(self):
+        conn = self.postgres_connection
+
+        def acquire_handle():
+            return True
+
+        conn.credentials.acquire_handle = acquire_handle
+
+        conn = BaseConnectionManager.set_connection_handle(conn, self.logger)
+
+        assert conn.state == "open"
+        assert conn.handle is True
+
+    def test_set_connection_handle_fails_unhandled(self):
+        conn = self.postgres_connection
+
+        def acquire_handle():
+            raise ValueError("Something went horribly wrong")
+
+        conn.credentials.acquire_handle = acquire_handle
+
+        with self.assertRaisesRegex(
+            dbt.exceptions.FailedToConnectException, "Something went horribly wrong"
+        ):
+
+            BaseConnectionManager.set_connection_handle(
+                conn,
+                self.logger,
+                timeout=0,
+            )
+
+        assert conn.state == "fail"
+        assert conn.handle is None
+
+    def test_set_connection_handle_fails_handled(self):
+        conn = self.postgres_connection
+
+        def acquire_handle():
+            raise ValueError("Something went horribly wrong")
+
+        conn.credentials.acquire_handle = acquire_handle
+
+        handlers = {
+            ValueError: None,
+        }
+
+        with self.assertRaisesRegex(
+            dbt.exceptions.FailedToConnectException, "Something went horribly wrong"
+        ):
+
+            BaseConnectionManager.set_connection_handle(
+                conn, self.logger, timeout=0, exception_handlers=handlers
+            )
+
+        assert conn.state == "fail"
+        assert conn.handle is None
+
+    def test_set_connection_handle_passes_handled(self):
+        conn = self.postgres_connection
+        is_handled = False
+        handled_exc = None
+
+        def acquire_handle():
+            nonlocal is_handled
+
+            if is_handled:
+                return True
+            raise ValueError("Something went horribly wrong")
+
+        conn.credentials.acquire_handle = acquire_handle
+
+        def handle_value_error(e):
+            nonlocal handled_exc
+            nonlocal is_handled
+
+            handled_exc = e
+            is_handled = True
+
+        handlers = {
+            ValueError: handle_value_error,
+        }
+
+        conn = BaseConnectionManager.set_connection_handle(
+            conn, self.logger, timeout=0, exception_handlers=handlers
+        )
+
+        assert conn.state == "open"
+        assert conn.handle is True
+        assert is_handled is True
+        assert isinstance(handled_exc, ValueError)
+        assert handled_exc.args == ("Something went horribly wrong",)
+
+    def test_set_connection_handle_attempts(self):
+        conn = self.postgres_connection
+        attempts = 0
+
+        def acquire_handle():
+            nonlocal attempts
+            attempts += 1
+
+            raise ValueError("Something went horribly wrong")
+
+        conn.credentials.acquire_handle = acquire_handle
+
+        handlers = {
+            ValueError: None,
+        }
+
+        with self.assertRaisesRegex(
+            dbt.exceptions.FailedToConnectException, "Something went horribly wrong"
+        ):
+            BaseConnectionManager.set_connection_handle(
+                conn,
+                self.logger,
+                timeout=0,
+                exception_handlers=handlers,
+                retry_limit=10,
+            )
+
+        assert conn.state == "fail"
+        assert conn.handle is None
+        assert attempts == 11
+
+    def test_set_connection_handle_attempts_with_retry_all(self):
+        conn = self.postgres_connection
+        attempts = 0
+
+        def acquire_handle():
+            nonlocal attempts
+            attempts += 1
+
+            raise TypeError("An unhandled thing went horribly wrong")
+
+        conn.credentials.acquire_handle = acquire_handle
+
+        handlers = {
+            ValueError: None,
+        }
+
+        with self.assertRaisesRegex(
+            dbt.exceptions.FailedToConnectException, "An unhandled thing went horribly wrong"
+        ):
+            BaseConnectionManager.set_connection_handle(
+                conn,
+                self.logger,
+                timeout=0,
+                exception_handlers=handlers,
+                retry_all=True,
+                retry_limit=15,
+            )
+
+        assert conn.state == "fail"
+        assert conn.handle is None
+        assert attempts == 16
+
+    def test_set_connection_handle_passes_multiple_handled(self):
+        conn = self.postgres_connection
+        is_value_err_handled = False
+        is_type_err_handled = False
+
+        def acquire_handle():
+            nonlocal is_value_err_handled
+            nonlocal is_type_err_handled
+
+            if is_value_err_handled and is_type_err_handled:
+                return True
+            elif is_type_err_handled:
+                raise ValueError("Something went horribly wrong")
+            else:
+                raise TypeError("An unhandled thing went horribly wrong")
+
+        conn.credentials.acquire_handle = acquire_handle
+
+        def handle_value_error(e):
+            nonlocal is_value_err_handled
+            is_value_err_handled = True
+
+        def handle_type_error(e):
+            nonlocal is_type_err_handled
+            is_type_err_handled = True
+
+        handlers = {
+            ValueError: handle_value_error,
+            TypeError: handle_type_error,
+        }
+
+        conn = BaseConnectionManager.set_connection_handle(
+            conn,
+            self.logger,
+            timeout=0,
+            exception_handlers=handlers,
+            retry_limit=2,
+        )
+
+        assert conn.state == "open"
+        assert conn.handle is True
+        assert is_type_err_handled is True
+        assert is_value_err_handled is True
+
+
+class PostgresConnectionManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.credentials = PostgresCredentials(
+            host="localhost",
+            user="test-user",
+            port=1111,
+            password="test-password",
+            database="test-db",
+            schema="test-schema",
+            retry_timeout=0,
+        )
+        self.connection = Connection("postgres", None, self.credentials)
+
+    def test_open(self):
+        conn = self.connection
+        attempt = 0
+
+        def acquire_handle(*args, **kwargs):
+            nonlocal attempt
+            attempt += 1
+
+            if attempt <= 3:
+                raise psycopg2.errors.ConnectionFailure("Connection has failed")
+
+            return True
+
+        conn.credentials.acquire_handle = acquire_handle
+
+        PostgresConnectionManager.open(conn)
+
+        assert attempt == 4
+        assert conn.state == "open"
+        assert conn.handle is True

--- a/test/unit/test_adapter_connection_manager.py
+++ b/test/unit/test_adapter_connection_manager.py
@@ -29,8 +29,10 @@ class BaseConnectionManagerTest(unittest.TestCase):
 
         This test uses a Connection populated with test PostgresCredentials values, and
         expects the Connection.handle attribute to be set to True and it's state to
-        "open". Moreover, this must happen in the first attempt as no exception would
-        be raised for retrying. A mock acquire_handle is set to simulate a real connection
+        "open", after calling retry_connection.
+
+        Moreover, the attribute should be set in the first attempt as no exception would
+        be raised for retrying. A mock connect function is used to simulate a real connection
         passing on the first attempt.
         """
         conn = self.postgres_connection


### PR DESCRIPTION
resolves #5022 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

Some adapters implement retrying functionality when attempting to open a connection. For example, see [dbt-snowflake](https://github.com/dbt-labs/dbt-snowflake/blob/main/dbt/adapters/snowflake/connections.py#L264=).

However, other adapters were missing this functionality, perhaps most notably dbt-postgres.

Although we could have just added a similar loop as the one in dbt-snowflake to dbt-postgres, this PR attempts to implement a common method `set_connection_handle` in `BaseConnectionManager` that any adapter may use when subclassing  `BaseConnectionManager`, in an attempt to provide a method and/or interface that all adapters can use, to avoid duplication.

The new method works by looping `retry_limit + 1` times. In each loop iteration we attempt to call `Connection.credentials.acquire_handle`. This latest method should be implemented by every adapter developer that wishes to utilize the retry functionality when subclassing `Credentials`, as it's heavily dependent on each adapter. For example, for dbt-postgres, the method would call `psycopg2.connect` with a given set of credentials.

On every loop, we check for exceptions we can handle, as specified in a `exception_handlers` dictionary. Upon encountering one, we log, call any additional function included in the dictionary, and retry. This allows other adapters, like dbt-bigquery, to call functions upon retrying specific exceptions (see sample commit in "In other adapters" section). Upon encountering an unexpected exception, we immediately break from the loop, set the connection state to FAIL, and raise a `FailedToConnectException` exception. However, if `retry_all` is set to `True`, we will be retrying on every exception regardless if it was unexpected. 

Moreover, this PR refactors dbt-postgres to use `set_connection_handle`, as well as adds some new `PostgresCredentials` attributes to customize the retry behavior. Most notably, we provide a `retry_on_errors` attribute with a default value of `"OperationalError"`. This attribute takes either a [PostgreSQL error code](https://www.postgresql.org/docs/current/errcodes-appendix.html) or a [psycopg2 exception class string](https://www.psycopg.org/docs/module.html#exceptions), upon which being raised during connecting a retry occurs. I chose `"OperationalError"` as a default value for two reasons:
* Connection errors, in particular timeouts, raise exceptions of this class.
* Timeouts specifically do not contain a PostgreSQL error code (`pgcode is None`), so a class name must be used instead.

#### Alternatives

An early implementation of `set_connection_handle` took a `Callable` argument instead of calling `Connection.credentials.acquire_handle`, and it was up to each subclass of `BaseConnectionManager` to provide this callable during `open`. However, given that the `Credentials` are taken from the `Connection` object itself, it seemed redundant to both pass the connection object and a callable that takes a credentials object when the connection already has the credentials in an attribute. Nonetheless, I added an optional `credentials` argument that overrides the `Connection.credentials`.

Another idea I had was to ignore `BaseConnectionManager` entirely, and implement the retrying functionality in `Credentials`. Then, just have each subclass implementation of `BaseConnectionManager.open` call `connection.credentials.acquire_handle()` (or a `connections.acquire_handle()` that simply passes the call). However, given that both dbt-snowflake and dbt-bigquery implement retrying in its subclasses of `BaseConnectionManager`, I discarded this idea. It goes without saying that if more context is shared  I'm more than willing to go with this alternative approach.

A second idea I had was to simply refactor the utility function [`_connection_exception_retry`](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/utils.py#L608=). I opted not to go with this simply because adapters that have implemented retries did so without using it. That being said, this is something we could reconsider, and at the end of the day I do lack a lot of context to make this call.

#### In other adapters

Additionally to this PR, I've also pushed two commits to my forks of dbt-snowflake and dbt-bigquery to show how they may be refactored to use `set_connection_handle`, instead of their current implementations. I will keep these two commits up to date with any changes that we make here, and I will be more than glad to eventually open PRs for those two as well. That being said, I'm not familiar with dbt-snowflake and dbt-bigquery, so some input is required to set, for example, default retry-able errors, and credential attributes names (as they can conflict across adapters).

dbt-BigQuery commit: https://github.com/tomasfarias/dbt-bigquery/commit/488bd817f7b4350e465df403a6f2415bf4b02b04

dbt-Snowflake commit: https://github.com/tomasfarias/dbt-snowflake/commit/b97894ae85327aae224bac7c803d4c16174edc75

I noticed that dbt-bigquery [does some operations](https://github.com/dbt-labs/dbt-bigquery/blob/main/dbt/adapters/bigquery/connections.py#L308=) when it's choosing which credentials to use for connecting that are implemented in `BigQueryConnectionManager`. It appears to me that we could still implement a `acquire_handle` method in `BigQueryCredentials`, but this implementation will need reviewing, specially as I don't have experience with bigquery.

#### Testing

Naturally, I wanted to add testing for this new method, however I couldn't find any unit testing of `BaseConnectionManager` or `PostgresConnectionManager`, so I simply dropped a new file where I thought would make sense. I'm more than open to refactor this. Testing coverage may be extended if deemed necessary.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
