### PR TITLE
Add language to tracked fields in run_model

### DIFF
--- a/.changes/unreleased/Under the Hood-20220713-124925.yaml
+++ b/.changes/unreleased/Under the Hood-20220713-124925.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Added language to tracked fields in run_model event
+time: 2022-07-13T12:49:25.362678-05:00
+custom:
+  Author: stu-k
+  Issue: "0000"
+  PR: "5469"

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -122,6 +122,7 @@ def track_model_run(index, num_nodes, run_model_result):
             "model_id": utils.get_hash(run_model_result.node),
             "hashed_contents": utils.get_hashed_contents(run_model_result.node),
             "timing": [t.to_dict(omit_none=True) for t in run_model_result.timing],
+            "language": str(run_model_result.node.config.language),
         }
     )
 

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -35,7 +35,7 @@ COLLECTOR_PROTOCOL = "https"
 
 INVOCATION_SPEC = "iglu:com.dbt/invocation/jsonschema/1-0-2"
 PLATFORM_SPEC = "iglu:com.dbt/platform/jsonschema/1-0-0"
-RUN_MODEL_SPEC = "iglu:com.dbt/run_model/jsonschema/1-0-1"
+RUN_MODEL_SPEC = "iglu:com.dbt/run_model/jsonschema/1-0-2"
 INVOCATION_ENV_SPEC = "iglu:com.dbt/invocation_env/jsonschema/1-0-0"
 PACKAGE_INSTALL_SPEC = "iglu:com.dbt/package_install/jsonschema/1-0-0"
 RPC_REQUEST_SPEC = "iglu:com.dbt/rpc_request/jsonschema/1-0-1"


### PR DESCRIPTION
resolves [CT-615](https://dbtlabs.atlassian.net/browse/CT-615)

### Description

Added `language` to the tracked fields during a `run_model` event.
![Screen Shot 2022-07-13 at 12 25 23 PM](https://user-images.githubusercontent.com/25089304/178798060-7469776a-99ce-4120-ad26-f0fcebcce0e8.png)
