### PR TITLE
Feature CT-665 Allow control over the outer CTE identifier generated in ephemeral materialization

### DIFF
--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Hashable
 from dataclasses import dataclass
 from typing import Optional, TypeVar, Any, Type, Dict, Union, Iterator, Tuple, Set
@@ -203,7 +204,7 @@ class BaseRelation(FakeAPIObject, Hashable):
 
     @staticmethod
     def add_ephemeral_prefix(name: str):
-        return f"__dbt__cte__{name}"
+        return re.sub(r"\W+", "", f"__dbt__cte__{name}")
 
     @classmethod
     def create_ephemeral_from_node(
@@ -211,8 +212,8 @@ class BaseRelation(FakeAPIObject, Hashable):
         config: HasQuoting,
         node: Union[ParsedNode, CompiledNode],
     ) -> Self:
-        # Note that ephemeral models are based on the name.
-        identifier = cls.add_ephemeral_prefix(node.name)
+        # Note that ephemeral models are based on the alias to avoid issues with illegal characters in name (like dots)
+        identifier = cls.add_ephemeral_prefix(node.alias)
         return cls.create(
             type=cls.CTE,
             identifier=identifier,

--- a/test/integration/024_custom_schema_tests/dot-models/second_schema.view-4_illegal-alias.sql
+++ b/test/integration/024_custom_schema_tests/dot-models/second_schema.view-4_illegal-alias.sql
@@ -1,0 +1,8 @@
+{{ 
+    config(
+        materialized='ephemeral'.
+        alias = '<>"*~!@#$%^&*'
+    )
+ }}
+
+select * from {{ ref('first_schema.view_1') }}

--- a/test/integration/024_custom_schema_tests/dot-models/second_schema.view_3-ephemeral.sql
+++ b/test/integration/024_custom_schema_tests/dot-models/second_schema.view_3-ephemeral.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='ephemeral') }}
+
+select * from {{ ref('first_schema.view_1') }}

--- a/test/integration/024_custom_schema_tests/dot-models/view_5.sql
+++ b/test/integration/024_custom_schema_tests/dot-models/view_5.sql
@@ -14,11 +14,19 @@ v2 as (
 
 ),
 
+v3 as (
+
+    select * from {{ ref('second_schema.view_3') }}
+
+),
+
 combined as (
 
     select last_name from v1
     union all
     select last_name from v2
+    union all
+    select last_name from v3
 
 )
 

--- a/test/integration/024_custom_schema_tests/test_custom_schema.py
+++ b/test/integration/024_custom_schema_tests/test_custom_schema.py
@@ -36,7 +36,7 @@ class TestCustomSchema(DBTIntegrationTest):
 
         self.assertTablesEqual("seed", "view_1")
         self.assertTablesEqual("seed", "view_2", schema, self.v2_schema())
-        self.assertTablesEqual("agg", "view_3", schema, self.xf_schema())
+        self.assertTablesEqual("agg", "view_5", schema, self.xf_schema())
 
 
 class TestCustomProjectSchemaWithPrefix(DBTIntegrationTest):


### PR DESCRIPTION
resolves CT-665 #5273 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

Add support for ephemeral models using a dot in file naming convention.
Prioritize alias if specified when creating node identifier and sanitize the identifier to make sure no illegal characters are used when creating CTEs that would cause a runtime error.

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
