### PR TITLE
[Backport 1.2.lastest] Retrying method for acquiring connection handles (#5432)

### DIFF
--- a/.changes/unreleased/Features-20220715-035555.yaml
+++ b/.changes/unreleased/Features-20220715-035555.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Add reusable function for retrying adapter connections. Utilize said function
+  to add retries for Postgres (and Redshift).
+time: 2022-07-15T03:55:55.270637265+02:00
+custom:
+  Author: tomasfarias
+  Issue: "5022"
+  PR: "5432"

--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -1,10 +1,24 @@
 import abc
 import os
+from time import sleep
+import sys
 
 # multiprocessing.RLock is a function returning this type
 from multiprocessing.synchronize import RLock
 from threading import get_ident
-from typing import Dict, Tuple, Hashable, Optional, ContextManager, List
+from typing import (
+    Any,
+    Dict,
+    Tuple,
+    Hashable,
+    Optional,
+    ContextManager,
+    List,
+    Type,
+    Union,
+    Iterable,
+    Callable,
+)
 
 import agate
 
@@ -21,6 +35,7 @@ from dbt.contracts.graph.manifest import Manifest
 from dbt.adapters.base.query_headers import (
     MacroQueryStringSetter,
 )
+from dbt.events import AdapterLogger
 from dbt.events.functions import fire_event
 from dbt.events.types import (
     NewConnection,
@@ -33,6 +48,9 @@ from dbt.events.types import (
     RollbackFailed,
 )
 from dbt import flags
+
+SleepTime = Union[int, float]  # As taken by time.sleep.
+AdapterHandle = Any  # Adapter connection handle objects can be any class.
 
 
 class BaseConnectionManager(metaclass=abc.ABCMeta):
@@ -158,6 +176,94 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
 
         conn.name = conn_name
         return conn
+
+    @classmethod
+    def retry_connection(
+        cls,
+        connection: Connection,
+        connect: Callable[[], AdapterHandle],
+        logger: AdapterLogger,
+        retryable_exceptions: Iterable[Type[Exception]],
+        retry_limit: int = 1,
+        retry_timeout: Union[Callable[[int], SleepTime], SleepTime] = 1,
+        _attempts: int = 0,
+    ) -> Connection:
+        """Given a Connection, set its handle by calling connect.
+
+        The calls to connect will be retried up to retry_limit times to deal with transient
+        connection errors. By default, one retry will be attempted if retryable_exceptions is set.
+
+        :param Connection connection: An instance of a Connection that needs a handle to be set,
+            usually when attempting to open it.
+        :param connect: A callable that returns the appropiate connection handle for a
+            given adapter. This callable will be retried retry_limit times if a subclass of any
+            Exception in retryable_exceptions is raised by connect.
+        :type connect: Callable[[], AdapterHandle]
+        :param AdapterLogger logger: A logger to emit messages on retry attempts or errors. When
+            handling expected errors, we call debug, and call warning on unexpected errors or when
+            all retry attempts have been exhausted.
+        :param retryable_exceptions: An iterable of exception classes that if raised by
+            connect should trigger a retry.
+        :type retryable_exceptions: Iterable[Type[Exception]]
+        :param int retry_limit: How many times to retry the call to connect. If this limit
+            is exceeded before a successful call, a FailedToConnectException will be raised.
+            Must be non-negative.
+        :param retry_timeout: Time to wait between attempts to connect. Can also take a
+            Callable that takes the number of attempts so far, beginning at 0, and returns an int
+            or float to be passed to time.sleep.
+        :type retry_timeout: Union[Callable[[int], SleepTime], SleepTime] = 1
+        :param int _attempts: Parameter used to keep track of the number of attempts in calling the
+            connect function across recursive calls. Passed as an argument to retry_timeout if it
+            is a Callable. This parameter should not be set by the initial caller.
+        :raises dbt.exceptions.FailedToConnectException: Upon exhausting all retry attempts without
+            successfully acquiring a handle.
+        :return: The given connection with its appropriate state and handle attributes set
+            depending on whether we successfully acquired a handle or not.
+        """
+        timeout = retry_timeout(_attempts) if callable(retry_timeout) else retry_timeout
+        if timeout < 0:
+            raise dbt.exceptions.FailedToConnectException(
+                "retry_timeout cannot be negative or return a negative time."
+            )
+
+        if retry_limit < 0 or retry_limit > sys.getrecursionlimit():
+            # This guard is not perfect others may add to the recursion limit (e.g. built-ins).
+            connection.handle = None
+            connection.state = ConnectionState.FAIL
+            raise dbt.exceptions.FailedToConnectException("retry_limit cannot be negative")
+
+        try:
+            connection.handle = connect()
+            connection.state = ConnectionState.OPEN
+            return connection
+
+        except tuple(retryable_exceptions) as e:
+            if retry_limit <= 0:
+                connection.handle = None
+                connection.state = ConnectionState.FAIL
+                raise dbt.exceptions.FailedToConnectException(str(e))
+
+            logger.debug(
+                f"Got a retryable error when attempting to open a {cls.TYPE} connection.\n"
+                f"{retry_limit} attempts remaining. Retrying in {timeout} seconds.\n"
+                f"Error:\n{e}"
+            )
+
+            sleep(timeout)
+            return cls.retry_connection(
+                connection=connection,
+                connect=connect,
+                logger=logger,
+                retry_limit=retry_limit - 1,
+                retry_timeout=retry_timeout,
+                retryable_exceptions=retryable_exceptions,
+                _attempts=_attempts + 1,
+            )
+
+        except Exception as e:
+            connection.handle = None
+            connection.state = ConnectionState.FAIL
+            raise dbt.exceptions.FailedToConnectException(str(e))
 
     @abc.abstractmethod
     def cancel_open(self) -> Optional[List[str]]:

--- a/test/unit/test_adapter_connection_manager.py
+++ b/test/unit/test_adapter_connection_manager.py
@@ -1,0 +1,494 @@
+import unittest
+from unittest import mock
+import sys
+
+import dbt.exceptions
+
+import psycopg2
+
+from dbt.contracts.connection import Connection
+from dbt.adapters.base import BaseConnectionManager
+from dbt.adapters.postgres import PostgresCredentials, PostgresConnectionManager
+from dbt.events import AdapterLogger
+
+
+class BaseConnectionManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.postgres_credentials = PostgresCredentials(
+            host="localhost",
+            user="test-user",
+            port=1111,
+            password="test-password",
+            database="test-db",
+            schema="test-schema",
+        )
+        self.logger = AdapterLogger("test")
+        self.postgres_connection = Connection("postgres", None, self.postgres_credentials)
+
+    def test_retry_connection(self):
+        """Test a dummy handle is set on a connection on the first attempt.
+
+        This test uses a Connection populated with test PostgresCredentials values, and
+        expects the Connection.handle attribute to be set to True and it's state to
+        "open", after calling retry_connection.
+
+        Moreover, the attribute should be set in the first attempt as no exception would
+        be raised for retrying. A mock connect function is used to simulate a real connection
+        passing on the first attempt.
+        """
+        conn = self.postgres_connection
+        attempts = 0
+
+        def connect():
+            nonlocal attempts
+            attempts += 1
+            return True
+
+        conn = BaseConnectionManager.retry_connection(
+            conn,
+            connect,
+            self.logger,
+            retryable_exceptions=[],
+        )
+
+        assert conn.state == "open"
+        assert conn.handle is True
+        assert attempts == 1
+
+    def test_retry_connection_fails_unhandled(self):
+        """Test setting a handle fails upon raising a non-handled exception.
+
+        This test uses a Connection populated with test PostgresCredentials values, and
+        expects a ValueError to be raised by a mock connect function. As a
+        result:
+        * The Connection state should be "fail" and the handle None.
+        * The resulting attempt count should be 1 as we are not explicitly configured to handle a
+          ValueError.
+        * retry_connection should raise a FailedToConnectException with the Exception message.
+        """
+        conn = self.postgres_connection
+        attempts = 0
+
+        def connect():
+            nonlocal attempts
+            attempts += 1
+            raise ValueError("Something went horribly wrong")
+
+        with self.assertRaisesRegex(
+            dbt.exceptions.FailedToConnectException, "Something went horribly wrong"
+        ):
+
+            BaseConnectionManager.retry_connection(
+                conn,
+                connect,
+                self.logger,
+                retry_limit=1,
+                retry_timeout=lambda attempt: 0,
+                retryable_exceptions=(TypeError,),
+            )
+
+        assert conn.state == "fail"
+        assert conn.handle is None
+        assert attempts == 1
+
+    def test_retry_connection_fails_handled(self):
+        """Test setting a handle fails upon raising a handled exception.
+
+        This test uses a Connection populated with test PostgresCredentials values, and
+        expects a ValueError to be raised by a mock connect function.
+        As a result:
+        * The Connection state should be "fail" and the handle None.
+        * The resulting attempt count should be 2 as we are configured to handle a ValueError.
+        * retry_connection should raise a FailedToConnectException with the Exception message.
+        """
+        conn = self.postgres_connection
+        attempts = 0
+
+        def connect():
+            nonlocal attempts
+            attempts += 1
+            raise ValueError("Something went horribly wrong")
+
+        with self.assertRaisesRegex(
+            dbt.exceptions.FailedToConnectException, "Something went horribly wrong"
+        ):
+
+            BaseConnectionManager.retry_connection(
+                conn,
+                connect,
+                self.logger,
+                retry_timeout=0,
+                retryable_exceptions=(ValueError,),
+                retry_limit=1,
+            )
+
+        assert conn.state == "fail"
+        assert conn.handle is None
+
+    def test_retry_connection_passes_handled(self):
+        """Test setting a handle fails upon raising a handled exception.
+
+        This test uses a Connection populated with test PostgresCredentials values, and
+        expects a ValueError to be raised by a mock connect function only the first
+        time is called. Upon handling the exception once, connect should return.
+        As a result:
+        * The Connection state should be "open" and the handle True.
+        * The resulting attempt count should be 2 as we are configured to handle a ValueError.
+        """
+        conn = self.postgres_connection
+        is_handled = False
+        attempts = 0
+
+        def connect():
+            nonlocal is_handled
+            nonlocal attempts
+
+            attempts += 1
+
+            if is_handled:
+                return True
+
+            is_handled = True
+            raise ValueError("Something went horribly wrong")
+
+        conn = BaseConnectionManager.retry_connection(
+            conn,
+            connect,
+            self.logger,
+            retry_timeout=0,
+            retryable_exceptions=(ValueError,),
+            retry_limit=1,
+        )
+
+        assert conn.state == "open"
+        assert conn.handle is True
+        assert is_handled is True
+        assert attempts == 2
+
+    def test_retry_connection_attempts(self):
+        """Test setting a handle fails upon raising a handled exception multiple times.
+
+        This test uses a Connection populated with test PostgresCredentials values, and
+        expects a ValueError to be raised by a mock connect function. As a result:
+        * The Connection state should be "fail" and the handle None, as connect
+          never returns.
+        * The resulting attempt count should be 11 as we are configured to handle a ValueError.
+        * retry_connection should raise a FailedToConnectException with the Exception message.
+        """
+        conn = self.postgres_connection
+        attempts = 0
+
+        def connect():
+            nonlocal attempts
+            attempts += 1
+
+            raise ValueError("Something went horribly wrong")
+
+        with self.assertRaisesRegex(
+            dbt.exceptions.FailedToConnectException, "Something went horribly wrong"
+        ):
+            BaseConnectionManager.retry_connection(
+                conn,
+                connect,
+                self.logger,
+                retry_timeout=0,
+                retryable_exceptions=(ValueError,),
+                retry_limit=10,
+            )
+
+        assert conn.state == "fail"
+        assert conn.handle is None
+        assert attempts == 11
+
+    def test_retry_connection_fails_handling_all_exceptions(self):
+        """Test setting a handle fails after exhausting all attempts.
+
+        This test uses a Connection populated with test PostgresCredentials values, and
+        expects a TypeError to be raised by a mock connect function. As a result:
+        * The Connection state should be "fail" and the handle None, as connect
+          never returns.
+        * The resulting attempt count should be 11 as we are configured to handle all Exceptions.
+        * retry_connection should raise a FailedToConnectException with the Exception message.
+        """
+        conn = self.postgres_connection
+        attempts = 0
+
+        def connect():
+            nonlocal attempts
+            attempts += 1
+
+            raise TypeError("An unhandled thing went horribly wrong")
+
+        with self.assertRaisesRegex(
+            dbt.exceptions.FailedToConnectException, "An unhandled thing went horribly wrong"
+        ):
+            BaseConnectionManager.retry_connection(
+                conn,
+                connect,
+                self.logger,
+                retry_timeout=0,
+                retryable_exceptions=[Exception],
+                retry_limit=15,
+            )
+
+        assert conn.state == "fail"
+        assert conn.handle is None
+        assert attempts == 16
+
+    def test_retry_connection_passes_multiple_handled(self):
+        """Test setting a handle passes upon handling multiple exceptions.
+
+        This test uses a Connection populated with test PostgresCredentials values, and
+        expects a mock connect to raise a ValueError in the first invocation and a
+        TypeError in the second invocation. As a result:
+        * The Connection state should be "open" and the handle True, as connect
+          returns after both exceptions have been handled.
+        * The resulting attempt count should be 3.
+        """
+        conn = self.postgres_connection
+        is_value_err_handled = False
+        is_type_err_handled = False
+        attempts = 0
+
+        def connect():
+            nonlocal is_value_err_handled
+            nonlocal is_type_err_handled
+            nonlocal attempts
+
+            attempts += 1
+
+            if is_value_err_handled and is_type_err_handled:
+                return True
+            elif is_type_err_handled:
+                is_value_err_handled = True
+                raise ValueError("Something went horribly wrong")
+            else:
+                is_type_err_handled = True
+                raise TypeError("An unhandled thing went horribly wrong")
+
+        conn = BaseConnectionManager.retry_connection(
+            conn,
+            connect,
+            self.logger,
+            retry_timeout=0,
+            retryable_exceptions=(ValueError, TypeError),
+            retry_limit=2,
+        )
+
+        assert conn.state == "open"
+        assert conn.handle is True
+        assert is_type_err_handled is True
+        assert is_value_err_handled is True
+        assert attempts == 3
+
+    def test_retry_connection_passes_none_excluded(self):
+        """Test setting a handle passes upon handling multiple exceptions.
+
+        This test uses a Connection populated with test PostgresCredentials values, and
+        expects a mock connect to raise a ValueError in the first invocation and a
+        TypeError in the second invocation. As a result:
+        * The Connection state should be "open" and the handle True, as connect
+          returns after both exceptions have been handled.
+        * The resulting attempt count should be 3.
+        """
+        conn = self.postgres_connection
+        is_value_err_handled = False
+        is_type_err_handled = False
+        attempts = 0
+
+        def connect():
+            nonlocal is_value_err_handled
+            nonlocal is_type_err_handled
+            nonlocal attempts
+
+            attempts += 1
+
+            if is_value_err_handled and is_type_err_handled:
+                return True
+            elif is_type_err_handled:
+                is_value_err_handled = True
+                raise ValueError("Something went horribly wrong")
+            else:
+                is_type_err_handled = True
+                raise TypeError("An unhandled thing went horribly wrong")
+
+        conn = BaseConnectionManager.retry_connection(
+            conn,
+            connect,
+            self.logger,
+            retry_timeout=0,
+            retryable_exceptions=(ValueError, TypeError),
+            retry_limit=2,
+        )
+
+        assert conn.state == "open"
+        assert conn.handle is True
+        assert is_type_err_handled is True
+        assert is_value_err_handled is True
+        assert attempts == 3
+
+    def test_retry_connection_retry_limit(self):
+        """Test retry_connection raises an exception with a negative retry limit."""
+        conn = self.postgres_connection
+        attempts = 0
+
+        def connect():
+            nonlocal attempts
+            attempts += 1
+            return True
+
+        with self.assertRaisesRegex(
+            dbt.exceptions.FailedToConnectException, "retry_limit cannot be negative"
+        ):
+            BaseConnectionManager.retry_connection(
+                conn,
+                connect,
+                self.logger,
+                retry_timeout=0,
+                retryable_exceptions=(ValueError,),
+                retry_limit=-2,
+            )
+
+        assert conn.state == "fail"
+        assert conn.handle is None
+        assert attempts == 0
+
+    def test_retry_connection_retry_timeout(self):
+        """Test retry_connection raises an exception with a negative timeout."""
+        conn = self.postgres_connection
+        attempts = 0
+
+        def connect():
+            nonlocal attempts
+            attempts += 1
+            return True
+
+        for retry_timeout in [-10, -2.5, lambda _: -100, lambda _: -10.1]:
+            with self.assertRaisesRegex(
+                dbt.exceptions.FailedToConnectException,
+                "retry_timeout cannot be negative or return a negative time",
+            ):
+                BaseConnectionManager.retry_connection(
+                    conn,
+                    connect,
+                    self.logger,
+                    retry_timeout=-10,
+                    retryable_exceptions=(ValueError,),
+                    retry_limit=2,
+                )
+
+        assert conn.state == "init"
+        assert conn.handle is None
+        assert attempts == 0
+
+    def test_retry_connection_exceeds_recursion_limit(self):
+        """Test retry_connection raises an exception with retries that exceed recursion limit."""
+        conn = self.postgres_connection
+        attempts = 0
+
+        def connect():
+            nonlocal attempts
+            attempts += 1
+            return True
+
+        with self.assertRaisesRegex(
+            dbt.exceptions.FailedToConnectException,
+            "retry_limit cannot be negative",
+        ):
+            BaseConnectionManager.retry_connection(
+                conn,
+                connect,
+                self.logger,
+                retry_timeout=2,
+                retryable_exceptions=(ValueError,),
+                retry_limit=sys.getrecursionlimit() + 1,
+            )
+
+        assert conn.state == "fail"
+        assert conn.handle is None
+        assert attempts == 0
+
+    def test_retry_connection_with_exponential_backoff_timeout(self):
+        """Test retry_connection with an exponential backoff timeout.
+
+        We assert the provided exponential backoff function gets passed the right attempt number
+        and produces the expected timeouts.
+        """
+        conn = self.postgres_connection
+        attempts = 0
+        timeouts = []
+
+        def connect():
+            nonlocal attempts
+            attempts += 1
+
+            if attempts < 12:
+                raise ValueError("Keep trying!")
+            return True
+
+        def exp_backoff(n):
+            nonlocal timeouts
+            computed = 2**n
+            # We store the computed values to ensure they match the expected backoff...
+            timeouts.append((n, computed))
+            # but we return 0 as we don't want the test to go on forever.
+            return 0
+
+        conn = BaseConnectionManager.retry_connection(
+            conn,
+            connect,
+            self.logger,
+            retry_timeout=exp_backoff,
+            retryable_exceptions=(ValueError,),
+            retry_limit=12,
+        )
+
+        assert conn.state == "open"
+        assert conn.handle is True
+        assert attempts == 12
+        assert timeouts == [(n, 2**n) for n in range(12)]
+
+
+class PostgresConnectionManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.credentials = PostgresCredentials(
+            host="localhost",
+            user="test-user",
+            port=1111,
+            password="test-password",
+            database="test-db",
+            schema="test-schema",
+            retries=2,
+        )
+        self.connection = Connection("postgres", None, self.credentials)
+
+    def test_open(self):
+        """Test opening a Postgres Connection with failures in the first 3 attempts.
+
+        This test uses a Connection populated with test PostgresCredentials values, and
+        expects a mock connect to raise a psycopg2.errors.ConnectionFailuer
+        in the first 3 invocations, after which the mock should return True. As a result:
+        * The Connection state should be "open" and the handle True, as connect
+          returns in the 4th attempt.
+        * The resulting attempt count should be 4.
+        """
+        conn = self.connection
+        attempt = 0
+
+        def connect(*args, **kwargs):
+            nonlocal attempt
+            attempt += 1
+
+            if attempt <= 2:
+                raise psycopg2.errors.ConnectionFailure("Connection has failed")
+
+            return True
+
+        with mock.patch("psycopg2.connect", wraps=connect) as mock_connect:
+            PostgresConnectionManager.open(conn)
+
+            assert mock_connect.call_count == 3
+
+        assert attempt == 3
+        assert conn.state == "open"
+        assert conn.handle is True


### PR DESCRIPTION
### Description
Backport #5432 to `1.2.latest` for the RC2 release

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
