### PR TITLE
Convert git deps to local, faster tests

### DIFF
--- a/tests/fixtures/dbt_integration_project.py
+++ b/tests/fixtures/dbt_integration_project.py
@@ -1,0 +1,101 @@
+import pytest
+
+dbt_integration_project__my_macros_sql = """
+
+
+{% macro do_something(foo, bar) %}
+
+    select
+        '{{ foo }}'::text as foo,
+        '{{ bar }}'::text as bar
+
+{% endmacro %}
+
+"""
+
+
+dbt_integration_project__incremental_sql = """
+
+-- TODO : add dist/sort keys
+{{
+    config(
+        materialized = 'incremental',
+        unique_key   = 'id',
+    )
+}}
+
+
+select * from {{ this.schema }}.seed
+
+{% if is_incremental() %}
+    where updated_at > (select max(updated_at) from {{ this }})
+{% endif %}
+"""
+
+
+dbt_integration_project__schema_yml = """
+version: 2
+models:
+- name: table_model
+  columns:
+  - name: id
+    tests:
+    - unique
+"""
+
+
+dbt_integration_project__table_model_sql = """
+
+-- TODO : add dist/sort keys
+{{
+    config(
+        materialized = 'table',
+    )
+}}
+
+select * from {{ this.schema }}.seed
+"""
+
+dbt_integration_project__view_model_sql = """
+{{
+    config(
+        materialized = 'view',
+    )
+}}
+
+select * from {{ this.schema }}.seed
+"""
+
+
+dbt_integration_project__dbt_project_yml = """
+name: dbt_integration_project
+version: '1.0'
+config-version: 2
+
+model-paths: ["models"]    # paths to models
+analysis-paths: ["analyses"] # path with analysis files which are compiled, but not run
+target-path: "target"      # path for compiled code
+clean-targets: ["target"]  # directories removed by the clean task
+test-paths: ["tests"]       # where to store test results
+seed-paths: ["seeds"]       # load CSVs from this directory with `dbt seed`
+macro-paths: ["macros"]    # where to find macros
+
+profile: user
+
+models:
+    dbt_integration_project:
+"""
+
+
+@pytest.fixture(scope="class")
+def dbt_integration_project():
+    return {
+        "dbt_project.yml": dbt_integration_project__dbt_project_yml,
+        "macros": {"my_macros.sql": dbt_integration_project__my_macros_sql},
+        "models": {
+            "incremental.sql": dbt_integration_project__incremental_sql,
+            "schema.yml": dbt_integration_project__schema_yml,
+            "table_model.sql": dbt_integration_project__table_model_sql,
+            "view_model.sql": dbt_integration_project__view_model_sql,
+        },
+    }

--- a/tests/functional/graph_selection/test_schema_test_graph_selection.py
+++ b/tests/functional/graph_selection/test_schema_test_graph_selection.py
@@ -1,7 +1,9 @@
 import pytest
 
 from dbt.tests.util import run_dbt
+from dbt.tests.fixtures.project import write_project_files
 
+from tests.fixtures.dbt_integration_project import dbt_integration_project  # noqa: F401
 from tests.functional.graph_selection.fixtures import SelectionFixtures
 
 
@@ -26,16 +28,13 @@ def run_schema_and_assert(project, include, exclude, expected_tests):
 
 
 class TestSchemaTestGraphSelection(SelectionFixtures):
+    @pytest.fixture(scope="class", autouse=True)
+    def setUp(self, project_root, dbt_integration_project):  # noqa: F811
+        write_project_files(project_root, "dbt_integration_project", dbt_integration_project)
+
     @pytest.fixture(scope="class")
     def packages(self):
-        return {
-            "packages": [
-                {
-                    "git": "https://github.com/dbt-labs/dbt-integration-project",
-                    "revision": "dbt/1.0.0",
-                }
-            ]
-        }
+        return {"packages": [{"local": "dbt_integration_project"}]}
 
     def test_schema_tests_no_specifiers(self, project):
         run_schema_and_assert(

--- a/tests/functional/schema_tests/test_schema_v2_tests.py
+++ b/tests/functional/schema_tests/test_schema_v2_tests.py
@@ -3,6 +3,8 @@ import os
 import re
 
 from dbt.tests.util import run_dbt, write_file
+from dbt.tests.fixtures.project import write_project_files
+from tests.fixtures.dbt_integration_project import dbt_integration_project  # noqa: F401
 from tests.functional.schema_tests.fixtures import (  # noqa: F401
     wrong_specification_block,
     test_context_where_subq_models,
@@ -386,7 +388,8 @@ class TestHooksForWhich:
 
 class TestCustomSchemaTests:
     @pytest.fixture(scope="class", autouse=True)
-    def setUp(self, project):
+    def setUp(self, project, project_root, dbt_integration_project):  # noqa: F811
+        write_project_files(project_root, "dbt_integration_project", dbt_integration_project)
         project.run_sql_file(os.path.join(project.test_data_dir, "seed.sql"))
 
     @pytest.fixture(scope="class")
@@ -397,8 +400,7 @@ class TestCustomSchemaTests:
                     "local": "./local_dependency",
                 },
                 {
-                    "git": "https://github.com/dbt-labs/dbt-integration-project",
-                    "revision": "dbt/1.0.0",
+                    "local": "./dbt_integration_project",
                 },
             ]
         }


### PR DESCRIPTION
resolves #5514

Copy https://github.com/dbt-labs/dbt-integration-project into a set of local fixtures that we can more quickly set up in functional tests.

### Before: 64.51s

```
$ python3 -m pytest \
> tests/functional/context_methods/test_cli_vars.py::TestCLIVarsPackages \
> tests/functional/graph_selection/test_schema_test_graph_selection.py \
> tests/functional/schema_tests/test_schema_v2_tests.py::TestCustomSchemaTests
============================================= test session starts ==============================================
platform darwin -- Python 3.9.12, pytest-7.0.1, pluggy-1.0.0
rootdir: /Users/jerco/dev/product/dbt-core, configfile: pytest.ini
plugins: xdist-2.5.0, forked-1.4.0, csv-3.0.0, logbook-1.2.0, flaky-3.7.0, mock-3.8.2, dotenv-0.5.2, cov-3.0.0
collected 15 items

tests/functional/context_methods/test_cli_vars.py .                                                      [  6%]
tests/functional/graph_selection/test_schema_test_graph_selection.py .............                       [ 93%]
tests/functional/schema_tests/test_schema_v2_tests.py .                                                  [100%]

======================================== 15 passed in 64.51s (0:01:04) =========================================
```

### After: 15.97s
```
$ python3 -m pytest \
> tests/functional/context_methods/test_cli_vars.py::TestCLIVarsPackages \
> tests/functional/graph_selection/test_schema_test_graph_selection.py \
> tests/functional/schema_tests/test_schema_v2_tests.py::TestCustomSchemaTests
============================================= test session starts ==============================================
platform darwin -- Python 3.9.12, pytest-7.0.1, pluggy-1.0.0
rootdir: /Users/jerco/dev/product/dbt-core, configfile: pytest.ini
plugins: xdist-2.5.0, forked-1.4.0, csv-3.0.0, logbook-1.2.0, flaky-3.7.0, mock-3.8.2, dotenv-0.5.2, cov-3.0.0
collected 15 items

tests/functional/context_methods/test_cli_vars.py .                                                      [  6%]
tests/functional/graph_selection/test_schema_test_graph_selection.py .............                       [ 93%]
tests/functional/schema_tests/test_schema_v2_tests.py .                                                  [100%]

============================================= 15 passed in 15.97s ==============================================
```

### "Mach Speed": 12.52s

@dbeatty10 iykyk  :)

```
$ python3 -m pytest \
> tests/functional/context_methods/test_cli_vars.py::TestCLIVarsPackages \
> tests/functional/graph_selection/test_schema_test_graph_selection.py \
> tests/functional/schema_tests/test_schema_v2_tests.py::TestCustomSchemaTests
======================================== test session starts =========================================
platform darwin -- Python 3.9.12, pytest-7.0.1, pluggy-1.0.0
rootdir: /Users/jerco/dev/product/dbt-core, configfile: pytest.ini
plugins: xdist-2.5.0, forked-1.4.0, csv-3.0.0, logbook-1.2.0, flaky-3.7.0, mock-3.8.2, dotenv-0.5.2, cov-3.0.0
collected 15 items

tests/functional/context_methods/test_cli_vars.py .                                            [  6%]
tests/functional/graph_selection/test_schema_test_graph_selection.py .............             [ 93%]
tests/functional/schema_tests/test_schema_v2_tests.py .                                        [100%]

======================================== 15 passed in 12.52s =========================================
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- ~I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)~
