### PR TITLE
[CT-700] [Bug] Logging tons of asterisks for sensitive env vars 

### DIFF
--- a/.changes/unreleased/Fixes-20220723-215330.yaml
+++ b/.changes/unreleased/Fixes-20220723-215330.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: CT-700 [Bug] Logging tons of asterisks when sensitive env vars are missing
+time: 2022-07-23T21:53:30.907759094+02:00
+custom:
+  Author: Goodkat
+  Issue: "5312"
+  PR: "5518"

--- a/.changes/unreleased/Fixes-20220723-215330.yaml
+++ b/.changes/unreleased/Fixes-20220723-215330.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: CT-700 [Bug] Logging tons of asterisks when sensitive env vars are missing
+body: Ignore empty strings passed in as secrets
 time: 2022-07-23T21:53:30.907759094+02:00
 custom:
   Author: Goodkat

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -116,7 +116,7 @@ def stop_capture_stdout_logs() -> None:
 
 
 def env_secrets() -> List[str]:
-    return [v for k, v in os.environ.items() if k.startswith(SECRET_ENV_PREFIX)]
+    return [v for k, v in os.environ.items() if k.startswith(SECRET_ENV_PREFIX) and v.strip()]
 
 
 def scrub_secrets(msg: str, secrets: List[str]) -> str:


### PR DESCRIPTION
Created PR in response to this issue:
[CT-700] [Bug] Logging tons of asterisks when sensitive env vars are missing
https://github.com/dbt-labs/dbt-core/issues/5312

resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)


[CT-700]: https://dbtlabs.atlassian.net/browse/CT-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ