### PR TITLE
remove env var to enable debug and add breakpoint

### DIFF
--- a/.changes/unreleased/Features-20220724-122624.yaml
+++ b/.changes/unreleased/Features-20220724-122624.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add breakpoint() function and remove env var requirment to enable it
+time: 2022-07-24T12:26:24.593183-07:00
+custom:
+  Author: ChenyuLInx
+  Issue: "0"
+  PR: "5519"

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -311,18 +311,22 @@ class BaseContext(metaclass=ContextMeta):
             msg = f"Env var required but not provided: '{var}'"
             raise_parsing_error(msg)
 
-    if os.environ.get("DBT_MACRO_DEBUGGING"):
+    @contextmember
+    @staticmethod
+    def debug(frame_level=3):
 
-        @contextmember
-        @staticmethod
-        def debug():
-            """Enter a debugger at this line in the compiled jinja code."""
-            import sys
-            import ipdb  # type: ignore
+        """Enter a debugger at this line in the compiled jinja code."""
+        import sys
+        import ipdb  # type: ignore
 
-            frame = sys._getframe(3)
-            ipdb.set_trace(frame)
-            return ""
+        frame = sys._getframe(frame_level)
+        ipdb.set_trace(frame)
+        return ""
+
+    @contextmember
+    @staticmethod
+    def breakpoint():
+        BaseContext.debug(frame_level=4)
 
     @contextmember("return")
     @staticmethod


### PR DESCRIPTION
### Description
This PR will remove the need to set a env var before being able to use debugger in the Macros. It will all add the function `breakpoint()` as another entry point as it matches the name of existing functionality in python 
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
