### PR TITLE
Fix handling of top-level exceptions

### DIFF
--- a/.changes/unreleased/Fixes-20220726-113636.yaml
+++ b/.changes/unreleased/Fixes-20220726-113636.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix handling of top-level exceptions
+time: 2022-07-26T11:36:36.824979-04:00
+custom:
+  Author: gshank
+  Issue: "4357"
+  PR: "5560"

--- a/.changes/unreleased/Fixes-20220726-113636.yaml
+++ b/.changes/unreleased/Fixes-20220726-113636.yaml
@@ -3,5 +3,5 @@ body: Fix handling of top-level exceptions
 time: 2022-07-26T11:36:36.824979-04:00
 custom:
   Author: gshank
-  Issue: "4357"
+  Issue: "5564"
   PR: "5560"

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -105,6 +105,8 @@ class ErrorLevel(EventSerialization, Event):
 
 
 # prevents an event from going to the file
+# This should not be used in core code. It is currently
+# only used in integration tests.
 class NoFile:
     pass
 

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -105,8 +105,8 @@ class ErrorLevel(EventSerialization, Event):
 
 
 # prevents an event from going to the file
-# This should not be used in core code. It is currently
-# only used in integration tests.
+# This should rarely be used in core code. It is currently
+# only used in integration tests and for the 'clean' command.
 class NoFile:
     pass
 

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -218,7 +218,7 @@ def create_log_line(e: T_Event, file_output=False) -> Optional[str]:
         return create_info_text_log_line(e)  # console output
 
 
-# allows for resuse of this obnoxious if else tree.
+# allows for reuse of this obnoxious if else tree.
 # do not use for exceptions, it doesn't pass along exc_info, stack_info, or extra
 def send_to_logger(l: Union[Logger, logbook.Logger], level_tag: str, log_line: str):
     if not log_line:

--- a/core/dbt/events/test_types.py
+++ b/core/dbt/events/test_types.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from .types import InfoLevel, DebugLevel, WarnLevel, ErrorLevel, ShowException, NoFile
+from dbt.events.types import InfoLevel, DebugLevel, WarnLevel, ErrorLevel, ShowException
+from dbt.events.base_types import NoFile
 
 
 # Keeping log messages for testing separate since they are used for debugging.

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -4,6 +4,7 @@ from dbt import ui
 from dbt.helper_types import Lazy
 from dbt.events.base_types import (
     Event,
+    NoFile,
     DebugLevel,
     InfoLevel,
     WarnLevel,
@@ -1352,8 +1353,10 @@ class NodeConnectionReleaseError(ShowException, DebugLevel):
         return "Error releasing connection for node {}: {!s}".format(self.node_name, self.exc)
 
 
+# We don't write "clean" events to the log, because the clean command
+# may have removed the log directory.
 @dataclass
-class CheckCleanPath(InfoLevel):
+class CheckCleanPath(InfoLevel, NoFile):
     path: str
     code: str = "Z012"
 
@@ -1362,7 +1365,7 @@ class CheckCleanPath(InfoLevel):
 
 
 @dataclass
-class ConfirmCleanPath(InfoLevel):
+class ConfirmCleanPath(InfoLevel, NoFile):
     path: str
     code: str = "Z013"
 
@@ -1371,7 +1374,7 @@ class ConfirmCleanPath(InfoLevel):
 
 
 @dataclass
-class ProtectedCleanPath(InfoLevel):
+class ProtectedCleanPath(InfoLevel, NoFile):
     path: str
     code: str = "Z014"
 
@@ -1380,7 +1383,7 @@ class ProtectedCleanPath(InfoLevel):
 
 
 @dataclass
-class FinishedCleanPaths(InfoLevel):
+class FinishedCleanPaths(InfoLevel, NoFile):
     code: str = "Z015"
 
     def message(self) -> str:

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -4,7 +4,6 @@ from dbt import ui
 from dbt.helper_types import Lazy
 from dbt.events.base_types import (
     Event,
-    NoFile,
     DebugLevel,
     InfoLevel,
     WarnLevel,
@@ -94,7 +93,7 @@ class AdapterEventError(ErrorLevel, AdapterEventBase, ShowException):
 
 
 @dataclass
-class MainKeyboardInterrupt(InfoLevel, NoFile):
+class MainKeyboardInterrupt(InfoLevel):
     code: str = "Z001"
 
     def message(self) -> str:
@@ -102,7 +101,7 @@ class MainKeyboardInterrupt(InfoLevel, NoFile):
 
 
 @dataclass
-class MainEncounteredError(ErrorLevel, NoFile):
+class MainEncounteredError(ErrorLevel):
     e: BaseException
     code: str = "Z002"
 
@@ -111,7 +110,7 @@ class MainEncounteredError(ErrorLevel, NoFile):
 
 
 @dataclass
-class MainStackTrace(DebugLevel, NoFile):
+class MainStackTrace(ErrorLevel):
     stack_trace: str
     code: str = "Z003"
 
@@ -1354,7 +1353,7 @@ class NodeConnectionReleaseError(ShowException, DebugLevel):
 
 
 @dataclass
-class CheckCleanPath(InfoLevel, NoFile):
+class CheckCleanPath(InfoLevel):
     path: str
     code: str = "Z012"
 
@@ -1363,7 +1362,7 @@ class CheckCleanPath(InfoLevel, NoFile):
 
 
 @dataclass
-class ConfirmCleanPath(InfoLevel, NoFile):
+class ConfirmCleanPath(InfoLevel):
     path: str
     code: str = "Z013"
 
@@ -1372,7 +1371,7 @@ class ConfirmCleanPath(InfoLevel, NoFile):
 
 
 @dataclass
-class ProtectedCleanPath(InfoLevel, NoFile):
+class ProtectedCleanPath(InfoLevel):
     path: str
     code: str = "Z014"
 
@@ -1381,7 +1380,7 @@ class ProtectedCleanPath(InfoLevel, NoFile):
 
 
 @dataclass
-class FinishedCleanPaths(InfoLevel, NoFile):
+class FinishedCleanPaths(InfoLevel):
     code: str = "Z015"
 
     def message(self) -> str:
@@ -2382,7 +2381,7 @@ class SendEventFailure(DebugLevel):
 
 
 @dataclass
-class FlushEvents(DebugLevel, NoFile):
+class FlushEvents(DebugLevel):
     code: str = "Z042"
 
     def message(self) -> str:
@@ -2390,7 +2389,7 @@ class FlushEvents(DebugLevel, NoFile):
 
 
 @dataclass
-class FlushEventsFailure(DebugLevel, NoFile):
+class FlushEventsFailure(DebugLevel):
     code: str = "Z043"
 
     def message(self) -> str:

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -142,7 +142,6 @@ def main(args=None):
             exit_code = e.code
 
         except BaseException as e:
-            traceback.print_exc()
             fire_event(MainEncounteredError(e=str(e)))
             fire_event(MainStackTrace(stack_trace=traceback.format_exc()))
             exit_code = ExitCodes.UnhandledError.value


### PR DESCRIPTION
resolves #5564


### Description

Errors that were caught as BaseExceptions in the main function were not displaying or storing the stack trace because it was flagged as debug level and also flagged as not to be written to the file. I have removed the "NoFile" flag from the events that handle top level exceptions and left it only for integration tests and "clean" command events.

A different pr will be used to address catching exception in threads.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
