### PR TITLE
Add changelog and whitespace fix to version bump Action

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,7 +1,7 @@
 # **what?**
 # This workflow will take the new version number to bump to. With that
 # it will run versionbump to update the version number everywhere in the
-# code base and then run changie to create the corresponding changelog. 
+# code base and then run changie to create the corresponding changelog.
 # A PR will be created with the changes that can be reviewed before committing.
 
 # **why?**
@@ -28,7 +28,7 @@ jobs:
         run: |
           echo "all variables defined as inputs"
           echo The version_number: ${{ github.event.inputs.version_number }}
-    
+
       - name: Check out the repository
         uses: actions/checkout@v2
 
@@ -54,7 +54,7 @@ jobs:
           pip install -r dev-requirements.txt
           env/bin/bumpversion --allow-dirty --new-version ${{ github.event.inputs.version_number }} major
           git status
- 
+
       # this step will fail on whitespace errors but also correct them
       - name: Format bumpversion file
         continue-on-error: true

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -62,7 +62,7 @@ jobs:
           brew install pre-commit
           pre-commit run trailing-whitespace --files .bumpversion.cfg
           git status
-          
+
       - name: Run changie
         run: |
           brew tap miniscruff/changie https://github.com/miniscruff/changie
@@ -75,7 +75,7 @@ jobs:
             echo $version --- $prerelease
             changie batch $version  --move-dir "$version" --prerelease "$prerelease"
           else
-            changie batch ${{ github.event.inputs.version_number }}  --move-dir '${{ github.event.inputs.version_number }}' --remove-prereleases 
+            changie batch ${{ github.event.inputs.version_number }}  --move-dir '${{ github.event.inputs.version_number }}' --remove-prereleases
           fi
           changie merge
           git status

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,18 +1,15 @@
 # **what?**
-# This workflow will take a version number and a dry run flag. With that
+# This workflow will take the new version number to bump to. With that
 # it will run versionbump to update the version number everywhere in the
-# code base and then generate an update Docker requirements file. If this
-# is a dry run, a draft PR will open with the changes. If this isn't a dry
-# run, the changes will be committed to the branch this is run on.
+# code base and then run changie to create the corresponding changelog. 
+# A PR will be created with the changes that can be reviewed before committing.
 
 # **why?**
 # This is to aid in releasing dbt and making sure we have updated
-# the versions and Docker requirements in all places.
+# the versions and changelog all places.
 
 # **when?**
-# This is triggered either manually OR
-# from the repository_dispatch event "version-bump" which is sent from
-# the dbt-release repo Action
+# This is triggered manually
 
 name: Version Bump
 
@@ -22,32 +19,18 @@ on:
       version_number:
        description: 'The version number to bump to'
        required: true
-      is_dry_run:
-       description: 'Creates a draft PR to allow testing instead of committing to a branch'
-       required: true
-       default: 'true'
-  repository_dispatch:
-    types: [version-bump]
 
 jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
+      - name: "[DEBUG] Print Variables"
+        run: |
+          echo "all variables defined as inputs"
+          echo The version_number: ${{ github.event.inputs.version_number }}
+    
       - name: Check out the repository
         uses: actions/checkout@v2
-
-      - name: Set version and dry run values
-        id: variables
-        env:
-          VERSION_NUMBER: "${{ github.event.client_payload.version_number == '' && github.event.inputs.version_number || github.event.client_payload.version_number }}"
-          IS_DRY_RUN: "${{ github.event.client_payload.is_dry_run == '' && github.event.inputs.is_dry_run || github.event.client_payload.is_dry_run }}"
-        run: |
-          echo Repository dispatch event version: ${{ github.event.client_payload.version_number }}
-          echo Repository dispatch event dry run: ${{ github.event.client_payload.is_dry_run }}
-          echo Workflow dispatch event version: ${{ github.event.inputs.version_number }}
-          echo Workflow dispatch event dry run: ${{ github.event.inputs.is_dry_run }}
-          echo ::set-output name=VERSION_NUMBER::$VERSION_NUMBER
-          echo ::set-output name=IS_DRY_RUN::$IS_DRY_RUN
 
       - uses: actions/setup-python@v2
         with:
@@ -60,52 +43,58 @@ jobs:
           pip install --upgrade pip
 
       - name: Create PR branch
-        if: ${{ steps.variables.outputs.IS_DRY_RUN == 'true' }}
         run: |
-          git checkout -b bumping-version/${{steps.variables.outputs.VERSION_NUMBER}}_$GITHUB_RUN_ID
-          git push origin bumping-version/${{steps.variables.outputs.VERSION_NUMBER}}_$GITHUB_RUN_ID
-          git branch --set-upstream-to=origin/bumping-version/${{steps.variables.outputs.VERSION_NUMBER}}_$GITHUB_RUN_ID bumping-version/${{steps.variables.outputs.VERSION_NUMBER}}_$GITHUB_RUN_ID
-
-      # - name: Generate Docker requirements
-      #  run: |
-      #    source env/bin/activate
-      #    pip install -r requirements.txt
-      #    pip freeze -l > docker/requirements/requirements.txt
-      #    git status
+          git checkout -b bumping-version/${{ github.event.inputs.version_number }}_$GITHUB_RUN_ID
+          git push origin bumping-version/${{ github.event.inputs.version_number }}_$GITHUB_RUN_ID
+          git branch --set-upstream-to=origin/bumping-version/${{ github.event.inputs.version_number }}_$GITHUB_RUN_ID bumping-version/${{ github.event.inputs.version_number }}_$GITHUB_RUN_ID
 
       - name: Bump version
         run: |
           source env/bin/activate
           pip install -r dev-requirements.txt
-          env/bin/bumpversion --allow-dirty --new-version ${{steps.variables.outputs.VERSION_NUMBER}} major
+          env/bin/bumpversion --allow-dirty --new-version ${{ github.event.inputs.version_number }} major
           git status
-
-      - name: Commit version bump directly
-        uses: EndBug/add-and-commit@v7
-        if: ${{ steps.variables.outputs.IS_DRY_RUN == 'false' }}
-        with:
-          author_name: 'Github Build Bot'
-          author_email: 'buildbot@fishtownanalytics.com'
-          message: 'Bumping version to ${{steps.variables.outputs.VERSION_NUMBER}}'
+ 
+      # this step will fail on whitespace errors but also correct them
+      - name: Format bumpversion file
+        continue-on-error: true
+        run: |
+          brew install pre-commit
+          pre-commit run trailing-whitespace --files .bumpversion.cfg
+          git status
+          
+      - name: Run changie
+        run: |
+          brew tap miniscruff/changie https://github.com/miniscruff/changie
+          brew install changie
+          regex="([1-9].[0-9].[0-9])?([rc|b]{1,2}[1-9])"
+          if [[ ${{ github.event.inputs.version_number }} =~ $regex ]]
+          then
+            version="${BASH_REMATCH[1]}"
+            prerelease="${BASH_REMATCH[2]}"
+            echo $version --- $prerelease
+            changie batch $version  --move-dir "$version" --prerelease "$prerelease"
+          else
+            changie batch ${{ github.event.inputs.version_number }}  --move-dir '${{ github.event.inputs.version_number }}' --remove-prereleases 
+          fi
+          changie merge
+          git status
 
       - name: Commit version bump to branch
         uses: EndBug/add-and-commit@v7
-        if: ${{ steps.variables.outputs.IS_DRY_RUN == 'true' }}
         with:
           author_name: 'Github Build Bot'
           author_email: 'buildbot@fishtownanalytics.com'
-          message: 'Bumping version to ${{steps.variables.outputs.VERSION_NUMBER}}'
-          branch: 'bumping-version/${{steps.variables.outputs.VERSION_NUMBER}}_${{GITHUB.RUN_ID}}'
-          push: 'origin origin/bumping-version/${{steps.variables.outputs.VERSION_NUMBER}}_${{GITHUB.RUN_ID}}'
+          message: 'Bumping version to ${{ github.event.inputs.version_number }}'
+          branch: 'bumping-version/${{ github.event.inputs.version_number }}_${{GITHUB.RUN_ID}}'
+          push: 'origin origin/bumping-version/${{ github.event.inputs.version_number }}_${{GITHUB.RUN_ID}}'
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
-        if: ${{ steps.variables.outputs.IS_DRY_RUN == 'true' }}
         with:
           author: 'Github Build Bot <buildbot@fishtownanalytics.com>'
-          draft: true
           base: ${{github.ref}}
-          title: 'Bumping version to ${{steps.variables.outputs.VERSION_NUMBER}}'
-          branch: 'bumping-version/${{steps.variables.outputs.VERSION_NUMBER}}_${{GITHUB.RUN_ID}}'
+          title: 'Bumping version to ${{ github.event.inputs.version_number }}'
+          branch: 'bumping-version/${{ github.event.inputs.version_number }}_${{GITHUB.RUN_ID}}'
           labels: |
             Skip Changelog

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -6,7 +6,7 @@
 
 # **why?**
 # This is to aid in releasing dbt and making sure we have updated
-# the versions and changelog all places.
+# the version in all places and generated the changelog.
 
 # **when?**
 # This is triggered manually

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -41,16 +41,16 @@ jobs:
           python3 -m venv env
           source env/bin/activate
           pip install --upgrade pip
-          
-      - name: Audit Version and Parse Into Parts 
-        id: semver 
-        uses: dbt-labs/actions/parse-semver@v1 
-        with: 
+
+      - name: Audit Version and Parse Into Parts
+        id: semver
+        uses: dbt-labs/actions/parse-semver@v1
+        with:
           version: ${{ github.event.inputs.version_number }}
 
-      - name: Set branch value 
-        id: variables 
-        run: | 
+      - name: Set branch value
+        id: variables
+        run: |
           echo "::set-output name=BRANCH_NAME::prep-release/${{ github.event.inputs.version_number }}_$GITHUB_RUN_ID"
 
       - name: Create PR branch

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -75,7 +75,7 @@ jobs:
             echo $version --- $prerelease
             changie batch $version  --move-dir "$version" --prerelease "$prerelease"
           else
-            changie batch ${{ github.event.inputs.version_number }}  --move-dir '${{ github.event.inputs.version_number }}' --remove-prereleases
+            changie batch ${{ github.event.inputs.version_number }}  --include '${{ github.event.inputs.version_number }}' --remove-prereleases
           fi
           changie merge
           git status

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       version_number:
-       description: 'The version number to bump to'
+       description: 'The version number to bump to (ex. 1.2.0, 1.3.0b1)'
        required: true
 
 jobs:
@@ -41,12 +41,23 @@ jobs:
           python3 -m venv env
           source env/bin/activate
           pip install --upgrade pip
+          
+      - name: Audit Version and Parse Into Parts 
+        id: semver 
+        uses: dbt-labs/actions/parse-semver@v1 
+        with: 
+          version: ${{ github.event.inputs.version_number }}
+
+      - name: Set branch value 
+        id: variables 
+        run: | 
+          echo "::set-output name=BRANCH_NAME::prep-release/${{ github.event.inputs.version_number }}_$GITHUB_RUN_ID"
 
       - name: Create PR branch
         run: |
-          git checkout -b bumping-version/${{ github.event.inputs.version_number }}_$GITHUB_RUN_ID
-          git push origin bumping-version/${{ github.event.inputs.version_number }}_$GITHUB_RUN_ID
-          git branch --set-upstream-to=origin/bumping-version/${{ github.event.inputs.version_number }}_$GITHUB_RUN_ID bumping-version/${{ github.event.inputs.version_number }}_$GITHUB_RUN_ID
+          git checkout -b ${{ steps.variables.outputs.BRANCH_NAME }}
+          git push origin ${{ steps.variables.outputs.BRANCH_NAME }}
+          git branch --set-upstream-to=origin/${{ steps.variables.outputs.BRANCH_NAME }} ${{ steps.variables.outputs.BRANCH_NAME }}
 
       - name: Bump version
         run: |
@@ -67,15 +78,11 @@ jobs:
         run: |
           brew tap miniscruff/changie https://github.com/miniscruff/changie
           brew install changie
-          regex="([1-9].[0-9].[0-9])?([rc|b]{1,2}[1-9])"
-          if [[ ${{ github.event.inputs.version_number }} =~ $regex ]]
+          if [[ ${{ steps.semver.outputs.is-pre-release }} -eq 1 ]]
           then
-            version="${BASH_REMATCH[1]}"
-            prerelease="${BASH_REMATCH[2]}"
-            echo $version --- $prerelease
-            changie batch $version  --move-dir "$version" --prerelease "$prerelease"
+            changie batch ${{ steps.semver.outputs.base-version }}  --move-dir '${{ steps.semver.outputs.base-version }}' --prerelease '${{ steps.semver.outputs.pre-release }}'
           else
-            changie batch ${{ github.event.inputs.version_number }}  --include '${{ github.event.inputs.version_number }}' --remove-prereleases
+            changie batch ${{ steps.semver.outputs.base-version }}  --include '${{ steps.semver.outputs.base-version }}' --remove-prereleases
           fi
           changie merge
           git status
@@ -86,8 +93,8 @@ jobs:
           author_name: 'Github Build Bot'
           author_email: 'buildbot@fishtownanalytics.com'
           message: 'Bumping version to ${{ github.event.inputs.version_number }} and generate CHANGELOG'
-          branch: 'bumping-version/${{ github.event.inputs.version_number }}_${{GITHUB.RUN_ID}}'
-          push: 'origin origin/bumping-version/${{ github.event.inputs.version_number }}_${{GITHUB.RUN_ID}}'
+          branch: '${{ steps.variables.outputs.BRANCH_NAME }}'
+          push: 'origin origin/${{ steps.variables.outputs.BRANCH_NAME }}'
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
@@ -95,6 +102,6 @@ jobs:
           author: 'Github Build Bot <buildbot@fishtownanalytics.com>'
           base: ${{github.ref}}
           title: 'Bumping version to ${{ github.event.inputs.version_number }} and generate changelog'
-          branch: 'bumping-version/${{ github.event.inputs.version_number }}_${{GITHUB.RUN_ID}}'
+          branch: '${{ steps.variables.outputs.BRANCH_NAME }}'
           labels: |
             Skip Changelog

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           author: 'Github Build Bot <buildbot@fishtownanalytics.com>'
           base: ${{github.ref}}
-          title: 'Bumping version to ${{ github.event.inputs.version_number }}'
+          title: 'Bumping version to ${{ github.event.inputs.version_number }} and generate changelog'
           branch: 'bumping-version/${{ github.event.inputs.version_number }}_${{GITHUB.RUN_ID}}'
           labels: |
             Skip Changelog

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           author_name: 'Github Build Bot'
           author_email: 'buildbot@fishtownanalytics.com'
-          message: 'Bumping version to ${{ github.event.inputs.version_number }}'
+          message: 'Bumping version to ${{ github.event.inputs.version_number }} and generate CHANGELOG'
           branch: 'bumping-version/${{ github.event.inputs.version_number }}_${{GITHUB.RUN_ID}}'
           push: 'origin origin/bumping-version/${{ github.event.inputs.version_number }}_${{GITHUB.RUN_ID}}'
 


### PR DESCRIPTION
### Description
The changes simplify this workflow from it's first iteration:

1) It adds changelog generation
2) It scrubs whitespace auto-generated by running `bumpversion`
3) Removes the option to not be a dry run. Instead, we will always create a PR and defaults to creating a PR (right now let's make sure we have eyes on this change before automating this commit away, that can be in the larger Release workflow changes)

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
