### PR TITLE
Do not render metrics description field when doing render_data

### DIFF
--- a/.changes/unreleased/Fixes-20220803-144221.yaml
+++ b/.changes/unreleased/Fixes-20220803-144221.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix error rendering docs block in metrics description
+time: 2022-08-03T14:42:21.386265-04:00
+custom:
+  Author: gshank
+  Issue: "5585"
+  PR: "5603"

--- a/core/dbt/parser/schema_renderer.py
+++ b/core/dbt/parser/schema_renderer.py
@@ -69,6 +69,8 @@ class SchemaYamlRenderer(BaseRenderer):
         elif self.key == "metrics":
             if keypath[0] == "sql":
                 return False
+            elif self._is_norender_key(keypath[0:]):
+                return False
         else:  # models, seeds, snapshots, analyses
             if self._is_norender_key(keypath[0:]):
                 return False

--- a/test/unit/test_yaml_renderer.py
+++ b/test/unit/test_yaml_renderer.py
@@ -101,3 +101,25 @@ class TestYamlRendering(unittest.TestCase):
         dct = renderer.render_data(dct)
         self.assertEqual(dct, expected)
 
+    def test__metrics(self):
+        context = {
+            "my_time_grains": "[day]"
+        }
+        renderer = SchemaYamlRenderer(context, 'metrics')
+
+        dct = {
+            "name": "my_source",
+            "description": "{{ docs('my_doc') }}",
+            "sql": "select {{ var('my_var') }} from my_table",
+            "time_grains": "{{ my_time_grains }}",
+        }
+        # We expect the sql and description will not be rendered, but
+        # other fields will be
+        expected = {
+            "name": "my_source",
+            "description": "{{ docs('my_doc') }}",
+            "sql": "select {{ var('my_var') }} from my_table",
+            "time_grains": "[day]"
+        }
+        dct = renderer.render_data(dct)
+        self.assertEqual(dct, expected)


### PR DESCRIPTION
resolves #5585

### Description

The addition of a line of code to skip rendering the metrics "sql" attribute caused the "description" attribute to be rendered at the wrong time with the wrong context.

Note: still needs tests.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
