### PR TITLE
Extended validations for the project names

### DIFF
--- a/.changes/unreleased/Fixes-20220805-221022.yaml
+++ b/.changes/unreleased/Fixes-20220805-221022.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Extended validations for the project names
+time: 2022-08-05T22:10:22.746830854+02:00
+custom:
+  Author: Goodkat
+  Issue: "5379"
+  PR: "5620"

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -265,7 +265,7 @@ class InitTask(BaseTask):
         available_adapters = list(_get_adapter_plugin_names())
         for adapter_name in available_adapters:
             try:
-                internal_package_names.add(get_adapter_package_names(adapter_name))
+                internal_package_names.update(get_adapter_package_names(adapter_name))
             except dbt.exceptions.InternalException:
                 pass
         while not ProjectName.is_valid(name) or name in internal_package_names:

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -264,11 +264,7 @@ class InitTask(BaseTask):
         internal_package_names = {GLOBAL_PROJECT_NAME}
         available_adapters = list(_get_adapter_plugin_names())
         for adapter_name in available_adapters:
-            try:
-                internal_package_names.update(get_adapter_package_names(adapter_name))
-            # When no adapter plugins found
-            except dbt.exceptions.InternalException:
-                pass
+            internal_package_names.update(f"dbt_{adapter_name}")
         while not ProjectName.is_valid(name) or name in internal_package_names:
             if name:
                 click.echo(name + " is not a valid project name.")

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -36,8 +36,6 @@ from dbt.include.global_project import PROJECT_NAME as GLOBAL_PROJECT_NAME
 
 from dbt.task.base import BaseTask, move_to_nearest_project_dir
 
-from dbt.adapters.factory import get_adapter_package_names
-
 DOCS_URL = "https://docs.getdbt.com/docs/configure-your-profile"
 SLACK_URL = "https://community.getdbt.com/"
 

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -266,6 +266,7 @@ class InitTask(BaseTask):
         for adapter_name in available_adapters:
             try:
                 internal_package_names.update(get_adapter_package_names(adapter_name))
+            # When no adapter plugins found
             except dbt.exceptions.InternalException:
                 pass
         while not ProjectName.is_valid(name) or name in internal_package_names:

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -264,15 +264,15 @@ class InitTask(BaseTask):
         internal_package_names = {GLOBAL_PROJECT_NAME}
         available_adapters = list(_get_adapter_plugin_names())
         for adapter_name in available_adapters:
-            try:            
+            try:
                 internal_package_names.add(get_adapter_package_names(adapter_name))
-            except:
+            except dbt.exceptions.InternalException:
                 pass
         while not ProjectName.is_valid(name) or name in internal_package_names:
             if name:
                 click.echo(name + " is not a valid project name.")
             name = click.prompt("Enter a name for your project (letters, digits, underscore)")
-        
+
         return name
 
     def run(self):


### PR DESCRIPTION
resolves #5379

### Description

In response to the issue [#5379](https://github.com/dbt-labs/dbt-core/issues/5379)
We need to check that the user-provided project name doesn't match ```dbt```, a.k.a.```GLOBAL_PROJECT_NAME``` as well as  the user-provided name also doesn't collide with one of the installed plugins' reserved package names (```dbt_snowflake```, ```dbt_bigquery```, etc). 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
