### PR TITLE
Use sys.exit instead of exit

### DIFF
--- a/.changes/unreleased/Fixes-20220808-112001.yaml
+++ b/.changes/unreleased/Fixes-20220808-112001.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Use sys.exit instead of exit
+time: 2022-08-08T11:20:01.838171926-04:00
+custom:
+  Author: varun-dc
+  Issue: "5621"
+  PR: "5627"

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import re
 import shutil
+import sys
 from typing import Optional
 
 import yaml
@@ -302,7 +303,7 @@ class InitTask(BaseTask):
         available_adapters = list(_get_adapter_plugin_names())
         if not len(available_adapters):
             print("No adapters available. Go to https://docs.getdbt.com/docs/available-adapters")
-            exit(1)
+            sys.exit(1)
         project_name = self.get_valid_project_name()
         project_path = Path(project_name)
         if project_path.exists():


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/5621

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

`exit` is implicitly imported, but it's not recommended to use it in programs (see linked issue for more details).
Changes the usage to use `sys.exit` instead. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
