### PR TITLE
link changelog to dbt-docs for Docs kind

### DIFF
--- a/.changes/1.3.0/Docs-20220728-140258.yaml
+++ b/.changes/1.3.0/Docs-20220728-140258.yaml
@@ -3,5 +3,5 @@ body: Update dependency inline-source from ^6.1.5 to ^7.2.0
 time: 2022-07-28T14:02:58.441963-07:00
 custom:
   Author: emmyoop
-  Issue: "5574"
-  PR: "5577"
+  Issue: "299"
+  PR: "291"

--- a/.changes/1.3.0/Docs-20220728-140329.yaml
+++ b/.changes/1.3.0/Docs-20220728-140329.yaml
@@ -3,5 +3,5 @@ body: Update dependency jest from ^26.2.2 to ^28.1.3
 time: 2022-07-28T14:03:29.837274-07:00
 custom:
   Author: emmyoop
-  Issue: "5574"
-  PR: "5577"
+  Issue: "299"
+  PR: "291"

--- a/.changes/1.3.0/Docs-20220728-140351.yaml
+++ b/.changes/1.3.0/Docs-20220728-140351.yaml
@@ -3,5 +3,5 @@ body: Update dependency underscore from ^1.9.0 to ^1.13.4
 time: 2022-07-28T14:03:51.123441-07:00
 custom:
   Author: emmyoop
-  Issue: "5574"
-  PR: "5577"
+  Issue: "299"
+  PR: "291"

--- a/.changes/1.3.0/Docs-20220728-140425.yaml
+++ b/.changes/1.3.0/Docs-20220728-140425.yaml
@@ -3,5 +3,5 @@ body: Update dependency webpack-cli from ^3.3.12 to ^4.7.0
 time: 2022-07-28T14:04:25.629638-07:00
 custom:
   Author: emmyoop
-  Issue: "5574"
-  PR: "5577"
+  Issue: "299"
+  PR: "291"

--- a/.changes/1.3.0/Docs-20220728-140449.yaml
+++ b/.changes/1.3.0/Docs-20220728-140449.yaml
@@ -3,5 +3,5 @@ body: Update dependency webpack-dev-server from ^3.1.11 to ^4.9.3
 time: 2022-07-28T14:04:49.637369-07:00
 custom:
   Author: emmyoop
-  Issue: "5574"
-  PR: "5577"
+  Issue: "299"
+  PR: "291"

--- a/.changes/1.3.0/Docs-20220728-140620.yaml
+++ b/.changes/1.3.0/Docs-20220728-140620.yaml
@@ -4,5 +4,5 @@ body: Searches no longer require perfect matches, and instead consider each word
 time: 2022-07-28T14:06:20.371364-07:00
 custom:
   Author: joellabes
-  Issue: "5574"
-  PR: "5577"
+  Issue: "143"
+  PR: "145"

--- a/.changes/1.3.0/Docs-20220728-140806.yaml
+++ b/.changes/1.3.0/Docs-20220728-140806.yaml
@@ -3,5 +3,5 @@ body: Support the renaming of SQL to code happening in dbt-core
 time: 2022-07-28T14:08:06.184934-07:00
 custom:
   Author: jtcohen6 stu-k drewbanin ChenyuLInx
-  Issue: "5574"
-  PR: "5577"
+  Issue: "299"
+  PR: "292"

--- a/.changes/unreleased/Docs-20220804-134138.yaml
+++ b/.changes/unreleased/Docs-20220804-134138.yaml
@@ -3,5 +3,5 @@ body: Leverages `docs.node_color` from `dbt-core` to color nodes in the DAG
 time: 2022-08-04T13:41:38.669987-05:00
 custom:
   Author: matt-winkler sungchun12 b-per
-  Issue: "5613"
-  PR: "5614"
+  Issue: "44"
+  PR: "281"

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -39,7 +39,6 @@ custom:
 - key: PR
   label: GitHub Pull Request Number
   type: int
-  optional: true
   minInt: 1
 
 footerFormat: |

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -13,7 +13,7 @@ kinds:
   - label: Features
   - label: Fixes
   - label: Docs
-    changeFormat: '- {{.Body}} ([dbt-docs/#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-docs/issues/{{.Custom.Issue}}), [#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-docs/pull/{{.Custom.PR}}))'
+    changeFormat: '- {{.Body}} ([dbt-docs/#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-docs/issues/{{.Custom.Issue}}), [dbt-docs/#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-docs/pull/{{.Custom.PR}}))'
   - label: Under the Hood
   - label: Dependencies
     changeFormat: '- {{.Body}} ([#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
@@ -38,8 +38,8 @@ custom:
   minInt: 1
 - key: PR
   label: GitHub Pull Request Number
-  optional: true
   type: int
+  optional: true
   minInt: 1
 
 footerFormat: |
@@ -53,11 +53,12 @@ footerFormat: |
       {{- $authorLower := lower $author }}
       {{- /* we only want to include non-core team contributors */}}
       {{- if not (has $authorLower $core_team)}}
-        {{- /* Docs kinds link back to dbt-docs instead of dbt-core PRs */}}
+        {{- /* Docs kind link back to dbt-docs instead of dbt-core PRs */}}
+        {{- $prLink := $change.Kind }}
         {{- if eq $change.Kind "Docs" }}
-          {{- $prLink := "[dbt-docs/#{{ $change.Custom.PR }}](https://github.com/dbt-labs/dbt-docs/pull/{{$change.Custom.PR}}) }}"
+          {{- $prLink = "[dbt-docs/#pr](https://github.com/dbt-labs/dbt-docs/pull/pr)" | replace "pr" $change.Custom.PR }}
         {{- else }}
-          {{- $prLink := "[#{{ $change.Custom.PR }}](https://github.com/dbt-labs/dbt-core/pull/{{$change.Custom.PR}}) }}"
+          {{- $prLink = "[#pr](https://github.com/dbt-labs/dbt-core/pull/pr)" | replace "pr" $change.Custom.PR }}
         {{- end }}
         {{- /* check if this contributor has other PRs associated with them already */}}
         {{- if hasKey $contributorDict $author }}
@@ -65,7 +66,7 @@ footerFormat: |
           {{- $prList = append $prList $prLink  }}
           {{- $contributorDict := set $contributorDict $author $prList }}
         {{- else }}
-          {{- $prList := list $change.Custom.PR }}
+          {{- $prList := list $prLink }}
           {{- $contributorDict := set $contributorDict $author $prList }}
         {{- end }}
       {{- end}}

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -16,9 +16,9 @@ kinds:
     changeFormat: '- {{.Body}} ([dbt-docs/#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-docs/issues/{{.Custom.Issue}}), [dbt-docs/#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-docs/pull/{{.Custom.PR}}))'
   - label: Under the Hood
   - label: Dependencies
-    changeFormat: '- {{.Body}} ([#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
+    changeFormat: '- {{.Body}} ({{if ne .Custom.Issue ""}}[#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-core/issues/{{.Custom.Issue}}), {{end}}[#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
   - label: Security
-    changeFormat: '- {{.Body}} ([#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
+    changeFormat: '- {{.Body}} ({{if ne .Custom.Issue ""}}[#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-core/issues/{{.Custom.Issue}}), {{end}}[#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
 
 newlines:
   afterChangelogHeader: 1

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -54,7 +54,7 @@ footerFormat: |
       {{- /* we only want to include non-core team contributors */}}
       {{- if not (has $authorLower $core_team)}}
         {{- /* Docs kinds link back to dbt-docs instead of dbt-core PRs */}}
-        {{- if $change.Kind == 'Docs'}}
+        {{- if eq $change.Kind "Docs" }}
           {{- $prLink := "[dbt-docs/#{{ $change.Custom.PR }}](https://github.com/dbt-labs/dbt-docs/pull/{{$change.Custom.PR}}) }}"
         {{- else }}
           {{- $prLink := "[#{{ $change.Custom.PR }}](https://github.com/dbt-labs/dbt-core/pull/{{$change.Custom.PR}}) }}"

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -7,19 +7,13 @@ versionExt: md
 versionFormat: '## dbt-core {{.Version}} - {{.Time.Format "January 02, 2006"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: '- {{.Body}} ([#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-core/issues/{{.Custom.Issue}}), [#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
-kindConfig:
-  - label: Docs
-    changeFormat: '- {{.Body}} custom docs formatting enabled!'
-  - label: Dependencies
-    changeFormat: '- {{.Body}} custom deps formatting enabled!'
-  - label: Security
-    changeFormat: '- {{.Body}} custom Security formatting enabled!'
 
 kinds:
   - label: Breaking Changes
   - label: Features
   - label: Fixes
   - label: Docs
+    changeFormat: '- {{.Body}} custom docs formatting enabled!'
   - label: Under the Hood
   - label: Dependencies
   - label: Security

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -7,14 +7,28 @@ versionExt: md
 versionFormat: '## dbt-core {{.Version}} - {{.Time.Format "January 02, 2006"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: '- {{.Body}} ([#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-core/issues/{{.Custom.Issue}}), [#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
+kindConfig:
+  - label: Docs
+    changeFormat: '- {{.Body}} custom docs formatting enabled!'
+  - label: Dependencies
+    changeFormat: '- {{.Body}} custom deps formatting enabled!'
+  - label: Security
+    changeFormat: '- {{.Body}} custom Security formatting enabled!'
+
 kinds:
-- label: Breaking Changes
-- label: Features
-- label: Fixes
-- label: Docs
-- label: Under the Hood
-- label: Dependencies
-- label: Security
+  - label: Breaking Changes
+  - label: Features
+  - label: Fixes
+  - label: Docs
+  - label: Under the Hood
+  - label: Dependencies
+  - label: Security
+newlines:
+  afterChangelogHeader: 1
+  afterKind: 1
+  afterChangelogVersion: 1
+  beforeKind: 1
+  endOfVersion: 1
 custom:
 - key: Author
   label: GitHub Username(s) (separated by a single space if multiple)
@@ -23,11 +37,11 @@ custom:
 - key: Issue
   label: GitHub Issue Number
   type: int
-  minLength: 4
+  minInt: 1
 - key: PR
   label: GitHub Pull Request Number
   type: int
-  minLength: 4
+  minInt: 1
 footerFormat: |
   {{- $contributorDict := dict }}
   {{- /* any names added to this list should be all lowercase for later matching purposes */}}

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -13,16 +13,20 @@ kinds:
   - label: Features
   - label: Fixes
   - label: Docs
-    changeFormat: '- {{.Body}} custom docs formatting enabled!'
+    changeFormat: '- {{.Body}} ([dbt-docs/#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-docs/issues/{{.Custom.Issue}}), [#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-docs/pull/{{.Custom.PR}}))'
   - label: Under the Hood
   - label: Dependencies
+    changeFormat: '- {{.Body}} ([#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
   - label: Security
+    changeFormat: '- {{.Body}} ([#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
+
 newlines:
   afterChangelogHeader: 1
   afterKind: 1
   afterChangelogVersion: 1
   beforeKind: 1
   endOfVersion: 1
+
 custom:
 - key: Author
   label: GitHub Username(s) (separated by a single space if multiple)
@@ -34,8 +38,10 @@ custom:
   minInt: 1
 - key: PR
   label: GitHub Pull Request Number
+  optional: true
   type: int
   minInt: 1
+
 footerFormat: |
   {{- $contributorDict := dict }}
   {{- /* any names added to this list should be all lowercase for later matching purposes */}}
@@ -47,11 +53,16 @@ footerFormat: |
       {{- $authorLower := lower $author }}
       {{- /* we only want to include non-core team contributors */}}
       {{- if not (has $authorLower $core_team)}}
-        {{- $pr := $change.Custom.PR }}
+        {{- /* Docs kinds link back to dbt-docs instead of dbt-core PRs */}}
+        {{- if $change.Kind == 'Docs'}}
+          {{- $prLink := "[dbt-docs/#{{ $change.Custom.PR }}](https://github.com/dbt-labs/dbt-docs/pull/{{$change.Custom.PR}}) }}"
+        {{- else }}
+          {{- $prLink := "[#{{ $change.Custom.PR }}](https://github.com/dbt-labs/dbt-core/pull/{{$change.Custom.PR}}) }}"
+        {{- end }}
         {{- /* check if this contributor has other PRs associated with them already */}}
         {{- if hasKey $contributorDict $author }}
           {{- $prList := get $contributorDict $author }}
-          {{- $prList = append $prList $pr  }}
+          {{- $prList = append $prList $prLink  }}
           {{- $contributorDict := set $contributorDict $author $prList }}
         {{- else }}
           {{- $prList := list $change.Custom.PR }}
@@ -64,6 +75,6 @@ footerFormat: |
   {{- if $contributorDict}}
   ### Contributors
   {{- range $k,$v := $contributorDict }}
-  - [@{{$k}}](https://github.com/{{$k}}) ({{ range $index, $element := $v }}{{if $index}}, {{end}}[#{{$element}}](https://github.com/dbt-labs/dbt-core/pull/{{$element}}){{end}})
+  - [@{{$k}}](https://github.com/{{$k}}) ({{ range $index, $element := $v }}{{if $index}}, {{end}}{{$element}}{{end}})
   {{- end }}
   {{- end }}


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-docs/issues/290

### Description

This PR does a few things, all concerning the formatting of changelogs via changie.

1.  Links `Docs` kinds back to `dbt-docs` instead of somewhat arbitrary issues/PRs within this repo.  This is more accurate and will also allow us to automate moving changelogs from `dbt-docs` into `dbt-core`. 
2. Removes the link to the #4904 for Kinds `Dependency` and `Security` since they are bot PRs with no real issue.
3. Links to the `dbt-docs` PR in the Contributors section
4. Adds newlines after various sections

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
