### PR TITLE
Check dbt-core version requirements when installing Hub packages

### DIFF
--- a/.changes/unreleased/Features-20220815-134312.yaml
+++ b/.changes/unreleased/Features-20220815-134312.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Check dbt-core version requirements when installing Hub packages
+time: 2022-08-15T13:43:12.965143+01:00
+custom:
+  Author: jtcohen6
+  Issue: "5648"
+  PR: "5651"

--- a/core/dbt/clients/registry.py
+++ b/core/dbt/clients/registry.py
@@ -138,8 +138,7 @@ def is_compatible_version(package_spec, dbt_version) -> bool:
         supported_versions = [
             semver.VersionSpecifier.from_version_string(v) for v in require_dbt_version
         ]
-        supported_range = semver.reduce_versions(*supported_versions)
-        return semver.versions_compatible(dbt_version, supported_range.start, supported_range.end)
+        return semver.versions_compatible(dbt_version, *supported_versions)
 
 
 def get_compatible_versions(package_name, dbt_version, should_version_check) -> List["str"]:
@@ -157,12 +156,6 @@ def get_compatible_versions(package_name, dbt_version, should_version_check) -> 
             for pkg_version, info in response.items()
             if is_compatible_version(info, dbt_version)
         ]
-
-        if not compatible_versions:
-            raise Exception(
-                f"No compatible versions of {package_name} found for dbt-core version {dbt_version}"
-            )
-
         return compatible_versions
 
 

--- a/core/dbt/clients/registry.py
+++ b/core/dbt/clients/registry.py
@@ -127,16 +127,14 @@ def package_version(package_name, version, registry_base_url=None) -> Dict[str, 
 
 
 def is_compatible_version(package_spec, dbt_version) -> bool:
-    works_with = package_spec.get("works_with")
-    if not works_with:
-        # if version requirements are missing or empty, assume it's compatible
+    require_dbt_version = package_spec.get("require_dbt_version")
+    if not require_dbt_version:
+        # if version requirements are missing or empty, assume any version is compatible
         return True
     else:
         # determine whether dbt_version satisfies this package's require-dbt-version config
-        if isinstance(works_with, list):
-            require_dbt_version = [str(v) for v in works_with]
-        elif works_with:
-            require_dbt_version = [works_with]
+        if not isinstance(require_dbt_version, list):
+            require_dbt_version = [require_dbt_version]
         supported_versions = [
             semver.VersionSpecifier.from_version_string(v) for v in require_dbt_version
         ]

--- a/core/dbt/deps/registry.py
+++ b/core/dbt/deps/registry.py
@@ -145,6 +145,7 @@ class RegistryUnpinnedPackage(RegistryPackageMixin, UnpinnedPackage[RegistryPinn
         else:
             target = None
         if not target:
+            # raise an exception if no installable target version is found
             package_version_not_found(self.package, range_, installable, should_version_check)
         latest_compatible = installable[-1]
         return RegistryPinnedPackage(

--- a/core/dbt/deps/registry.py
+++ b/core/dbt/deps/registry.py
@@ -136,7 +136,7 @@ class RegistryUnpinnedPackage(RegistryPackageMixin, UnpinnedPackage[RegistryPinn
         installable = semver.filter_installable(
             compatible_versions, self.install_prerelease or prerelease_version_specified
         )
-        available_latest = installable[-1]
+        latest_compatible = installable[-1]
 
         # for now, pick a version and then recurse. later on,
         # we'll probably want to traverse multiple options
@@ -146,5 +146,5 @@ class RegistryUnpinnedPackage(RegistryPackageMixin, UnpinnedPackage[RegistryPinn
         if not target:
             package_version_not_found(self.package, range_, installable)
         return RegistryPinnedPackage(
-            package=self.package, version=target, version_latest=available_latest
+            package=self.package, version=target, version_latest=latest_compatible
         )

--- a/core/dbt/deps/registry.py
+++ b/core/dbt/deps/registry.py
@@ -136,15 +136,17 @@ class RegistryUnpinnedPackage(RegistryPackageMixin, UnpinnedPackage[RegistryPinn
         installable = semver.filter_installable(
             compatible_versions, self.install_prerelease or prerelease_version_specified
         )
-        latest_compatible = installable[-1]
-
-        # for now, pick a version and then recurse. later on,
-        # we'll probably want to traverse multiple options
-        # so we can match packages. not going to make a difference
-        # right now.
-        target = semver.resolve_to_specific_version(range_, installable)
+        if installable:
+            # for now, pick a version and then recurse. later on,
+            # we'll probably want to traverse multiple options
+            # so we can match packages. not going to make a difference
+            # right now.
+            target = semver.resolve_to_specific_version(range_, installable)
+        else:
+            target = None
         if not target:
-            package_version_not_found(self.package, range_, installable)
+            package_version_not_found(self.package, range_, installable, should_version_check)
+        latest_compatible = installable[-1]
         return RegistryPinnedPackage(
             package=self.package, version=target, version_latest=latest_compatible
         )

--- a/core/dbt/deps/resolver.py
+++ b/core/dbt/deps/resolver.py
@@ -120,7 +120,6 @@ def resolve_packages(
 ) -> List[PinnedPackage]:
     pending = PackageListing.from_contracts(packages)
     final = PackageListing()
-
     renderer = DbtProjectYamlRenderer(config, config.cli_vars)
 
     while pending:

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -778,9 +778,10 @@ def package_not_found(package_name):
 
 def package_version_not_found(package_name, version_range, available_versions):
     base_msg = (
-        "Could not find a matching version for package {}\n"
+        "Could not find a matching compatible version for package {}\n"
         "  Requested range: {}\n"
-        "  Available versions: {}"
+        "  Compatible versions: {}\n"
+        "  (Not shown: versions incompatible with installed version of dbt-core)"
     )
     raise_dependency_error(base_msg.format(package_name, version_range, available_versions))
 

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -787,8 +787,8 @@ def package_version_not_found(
     addendum = (
         (
             "\n"
-            "  Not shown: package versions incompatible with installed version of dbt-core"
-            "  Update your requested range, or run 'dbt --no-version-check deps'"
+            "  Not shown: package versions incompatible with installed version of dbt-core\n"
+            "  To include them, run 'dbt --no-version-check deps'"
         )
         if should_version_check
         else ""

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -776,14 +776,25 @@ def package_not_found(package_name):
     raise_dependency_error("Package {} was not found in the package index".format(package_name))
 
 
-def package_version_not_found(package_name, version_range, available_versions):
+def package_version_not_found(
+    package_name, version_range, available_versions, should_version_check
+):
     base_msg = (
         "Could not find a matching compatible version for package {}\n"
         "  Requested range: {}\n"
         "  Compatible versions: {}\n"
-        "  (Not shown: versions incompatible with installed version of dbt-core)"
     )
-    raise_dependency_error(base_msg.format(package_name, version_range, available_versions))
+    addendum = (
+        (
+            "\n"
+            "  Not shown: package versions incompatible with installed version of dbt-core"
+            "  Update your requested range, or run 'dbt --no-version-check deps'"
+        )
+        if should_version_check
+        else ""
+    )
+    msg = base_msg.format(package_name, version_range, available_versions) + addendum
+    raise_dependency_error(msg)
 
 
 def invalid_materialization_argument(name, argument):

--- a/test/unit/test_deps.py
+++ b/test/unit/test_deps.py
@@ -239,8 +239,7 @@ class TestHubPackage(unittest.TestCase):
         msg = (
             "Could not find a matching compatible version for package "
             "dbt-labs-test/a\n  Requested range: =0.1.4, =0.1.4\n  "
-            "Compatible versions: ['0.1.2', '0.1.3']\n  "
-            "(Not shown: versions incompatible with installed version of dbt-core)"
+            "Compatible versions: ['0.1.2', '0.1.3']\n"
         )
         self.assertEqual(msg, str(exc.exception))
 

--- a/test/unit/test_deps.py
+++ b/test/unit/test_deps.py
@@ -581,7 +581,7 @@ class TestPackageSpec(unittest.TestCase):
                         'blahblah': 'asdfas',
                     },
                     # this one shouldn't be picked!
-                    'works_with': require_next_version,
+                    'require_dbt_version': require_next_version,
                     'downloads': {
                         'tarball': 'https://example.com/invalid-url!',
                         'extra': 'field',

--- a/test/unit/test_deps.py
+++ b/test/unit/test_deps.py
@@ -237,9 +237,10 @@ class TestHubPackage(unittest.TestCase):
         with self.assertRaises(dbt.exceptions.DependencyException) as exc:
             a.resolved()
         msg = (
-            "Could not find a matching version for package "
+            "Could not find a matching compatible version for package "
             "dbt-labs-test/a\n  Requested range: =0.1.4, =0.1.4\n  "
-            "Available versions: ['0.1.2', '0.1.3']"
+            "Compatible versions: ['0.1.2', '0.1.3']\n  "
+            "(Not shown: versions incompatible with installed version of dbt-core)"
         )
         self.assertEqual(msg, str(exc.exception))
 

--- a/test/unit/test_deps.py
+++ b/test/unit/test_deps.py
@@ -241,7 +241,7 @@ class TestHubPackage(unittest.TestCase):
             "dbt-labs-test/a\n  Requested range: =0.1.4, =0.1.4\n  "
             "Compatible versions: ['0.1.2', '0.1.3']\n"
         )
-        self.assertEqual(msg, str(exc.exception))
+        assert msg in str(exc.exception)
 
     def test_resolve_conflict(self):
         a_contract = RegistryPackage(


### PR DESCRIPTION
Resolves #5648

Depends on https://github.com/dbt-labs/hubcap/pull/146
For testing, check out https://github.com/dbt-labs/hub.getdbt.com/pull/1770

~As mentioned in the Hubcap PR above, I'm reusing the existing (and always empty) `works_with` field from the Hub API to represent the package's `require-dbt-version`. I'm not sure it's an old field being used for something in very old versions of `dbt-core`.~ This PR leverages a new API field added in the Hubcap PR above: `require_dbt_version`.

### Description

- Replace `registry.get_available_versions` with `registry.get_compatible_versions`, which only returns package versions whose `require-dbt-version` config is compatible with the currently installed version of `dbt-core`
- If a user has disabled `VERSION_CHECK` (e.g. `dbt --no-version-check deps`), then dbt will _not_ check for version compatibility
- Update unit tests

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] ~I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or~ docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
