### PR TITLE
Change postgres name truncation logic to be overridable. 

### DIFF
--- a/.changes/unreleased/Fixes-20220815-230409.yaml
+++ b/.changes/unreleased/Fixes-20220815-230409.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Finishing logic upgrade to Redshift for name truncation collisions.
+time: 2022-08-15T23:04:09.173645-07:00
+custom:
+  Author: versusfacit
+  Issue: "5586"
+  PR: "5656"

--- a/plugins/postgres/dbt/include/postgres/macros/adapters.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/adapters.sql
@@ -146,7 +146,7 @@
       {% set suffix = suffix ~ dtstring %}
     {% endif %}
     {% set suffix_length = suffix|length %}
-    {% set relation_max_name_length = 63 %}
+    {% set relation_max_name_length = base_relation.relation_max_name_length() %}
     {% if suffix_length > relation_max_name_length %}
         {% do exceptions.raise_compiler_error('Relation suffix is too long (' ~ suffix_length ~ ' characters). Maximum length is ' ~ relation_max_name_length ~ ' characters.') %}
     {% endif %}


### PR DESCRIPTION

resolves #5586 

### Description

Redshift locally drawing from postgres verified to not run into collisions for models <119 chars. At that level, database limits lead to warehouse caused cache errors. I added an exception message for this case to help users in this case along. It'll be rare in the Redshift case (127 char limit) but not necessarily postgres (63 char limit).

To make sure this worked on the Redshift adapter, I triggered the error, fixed in, then increased local model name lengths to 127 which as expected _retriggered_ the error. 

[Redshift followup PR](https://github.com/dbt-labs/dbt-redshift/pull/167).

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
