### PR TITLE
Print more information on log line interop test failures

### DIFF
--- a/.changes/unreleased/Under the Hood-20220816-122032.yaml
+++ b/.changes/unreleased/Under the Hood-20220816-122032.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: add more information to log line interop test failures
+time: 2022-08-16T12:20:32.119588+01:00
+custom:
+  Author: nathaniel-may
+  Issue: "5658"
+  PR: "5659"

--- a/test/interop/log_parsing/src/main.rs
+++ b/test/interop/log_parsing/src/main.rs
@@ -1,4 +1,3 @@
-
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -7,15 +6,15 @@ use std::fs::File;
 use std::io::{self, BufRead};
 use walkdir::WalkDir;
 
-
 // Applies schema tests to file input
 // if these fail, we either have a problem in dbt that needs to be resolved
 // or we have changed our interface and the log_version should be bumped in dbt,
 // modeled appropriately here, and publish new docs for the new log_version.
 fn main() -> Result<(), Box<dyn Error>> {
     let log_name = "dbt.log";
-    let path = env::var("LOG_DIR").expect("must pass absolute log path to tests with env var `LOG_DIR=/logs/live/here/`");
-    
+    let path = env::var("LOG_DIR")
+        .expect("must pass absolute log path to tests with env var `LOG_DIR=/logs/live/here/`");
+
     println!("Looking for files named `{}` in {}", log_name, path);
     let lines: Vec<String> = get_input(&path, log_name)?;
     println!("collected {} log lines.", lines.len());
@@ -23,12 +22,19 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("");
 
     println!("testing type-level schema compliance by deserializing each line...");
-    let log_lines: Vec<LogLine> = deserialized_input(&lines)
-        .map_err(|e| format!("schema test failure: json doesn't match type definition\n{}", e))?;
+    let log_lines: Vec<LogLine> = deserialized_input(&lines).map_err(|e| {
+        format!(
+            "schema test failure: json doesn't match type definition\n{}",
+            e
+        )
+    })?;
     println!("Done.");
 
     println!("");
-    println!("because we skip non-json log lines, there are {} collected values to test.", log_lines.len());
+    println!(
+        "because we skip non-json log lines, there are {} collected values to test.",
+        log_lines.len()
+    );
     println!("");
 
     // make sure when we read a string in then output it back to a string the two strings
@@ -49,7 +55,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-
 // each nested type of LogLine should define its own value_test function
 // that asserts values are within an expected set of values when possible.
 trait ValueTest {
@@ -68,11 +73,11 @@ struct LogLine {
     level: String,
     invocation_id: String,
     thread_name: String,
-    data: serde_json::Value,      // TODO be more specific
+    data: serde_json::Value, // TODO be more specific
 }
 
 impl ValueTest for LogLine {
-    fn value_test(&self){
+    fn value_test(&self) {
         assert_eq!(
             self.log_version, 2,
             "The log version changed. Be sure this was intentional."
@@ -99,7 +104,7 @@ impl ValueTest for LogLine {
 // this requires handling the date with "%Y-%m-%dT%H:%M:%S%.6f" which requires this
 // boilerplate-looking module.
 mod custom_date_format {
-    use chrono::{NaiveDateTime, DateTime, Utc};
+    use chrono::{DateTime, NaiveDateTime, Utc};
     use serde::{self, Deserialize, Deserializer, Serializer};
 
     const FORMAT: &'static str = "%Y-%m-%dT%H:%M:%S%.6fZ";
@@ -117,7 +122,10 @@ mod custom_date_format {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        Ok(DateTime::<Utc>::from_utc(NaiveDateTime::parse_from_str(&s, FORMAT).map_err(serde::de::Error::custom)?, Utc))
+        Ok(DateTime::<Utc>::from_utc(
+            NaiveDateTime::parse_from_str(&s, FORMAT).map_err(serde::de::Error::custom)?,
+            Utc,
+        ))
     }
 }
 
@@ -134,16 +142,26 @@ fn get_input(path: &str, file_name: &str) -> Result<Vec<String>, String> {
             let f_name = e.file_name().to_string_lossy();
             if f_name.ends_with(file_name) {
                 let contents = File::open(e.path())
-                    .map_err(|e| format!("Something went wrong opening the log file {}\n{}", f_name, e))
+                    .map_err(|e| {
+                        format!(
+                            "Something went wrong opening the log file {}\n{}",
+                            f_name, e
+                        )
+                    })
                     .and_then(|file| {
                         io::BufReader::new(file)
                             .lines()
                             .map(|l| {
-                                l.map_err(|e| format!("Something went wrong reading lines of the log file {}\n{}", f_name, e))
+                                l.map_err(|e| {
+                                    format!(
+                                        "Something went wrong reading lines of the log file {}\n{}",
+                                        f_name, e
+                                    )
+                                })
                             })
                             .collect::<Result<Vec<String>, String>>()
                     });
-                    
+
                 Some(contents)
             } else {
                 None
@@ -177,24 +195,22 @@ fn deserialized_input(log_lines: &[String]) -> serde_json::Result<Vec<LogLine>> 
 // We can't compare the two serialized strings because the original logline will contain many
 // fields that aren't yet modeled in this deserializer. We aren't checking that everything matches up,
 // just these modeled fields, so we have to deserialize twice.
-fn deserialize_twice<'a, T : Serialize + Deserialize<'a>>(
+fn deserialize_twice<'a, T: Serialize + Deserialize<'a>>(
     json_str: &'a str,
 ) -> Result<(serde_json::Value, serde_json::Value), String> {
     // deserialize the string into a JSON value with no knowledge of T's structure
-    let deserialized_json = serde_json::from_str::<serde_json::Value>(json_str)
-        .map_err(|_| json_str)?;
+    let deserialized_json =
+        serde_json::from_str::<serde_json::Value>(json_str).map_err(|_| json_str)?;
 
     // deserialize the string into a T
-    let deserialized_t = serde_json::from_str::<'a, T>(json_str)
-        .map_err(|_| json_str)?;
+    let deserialized_t = serde_json::from_str::<'a, T>(json_str).map_err(|_| json_str)?;
 
     // serialize the T value into a string again
-    let serialized_t = serde_json::to_string(&deserialized_t)
-        .map_err(|_| json_str)?;
+    let serialized_t = serde_json::to_string(&deserialized_t).map_err(|_| json_str)?;
 
     // deserialize the string into a JSON value
-    let deserialized_t_json = serde_json::from_str::<serde_json::Value>(&serialized_t)
-        .map_err(|_| json_str)?;
+    let deserialized_t_json =
+        serde_json::from_str::<serde_json::Value>(&serialized_t).map_err(|_| json_str)?;
 
     Ok((deserialized_json, deserialized_t_json))
 }
@@ -203,7 +219,7 @@ fn deserialize_twice<'a, T : Serialize + Deserialize<'a>>(
 // json objects are not the same. this will dig into the values to find an inner json value where they differ.
 fn compare_json(x: &serde_json::Value, y: &serde_json::Value) -> Result<(), serde_json::Value> {
     if x == y {
-        return Ok(())
+        return Ok(());
     }
 
     match (x, y) {
@@ -239,10 +255,10 @@ fn compare_json(x: &serde_json::Value, y: &serde_json::Value) -> Result<(), serd
             // only reaches here if all the keys are the same and all of the values are the same
             // and the top-level equality check on the map failed.
             Ok(())
-        },
+        }
 
         // must be a non-object json value. since there are no keys to specify, return the first value.
-        (x, _) => Err(x.clone())
+        (x, _) => Err(x.clone()),
     }
 }
 
@@ -275,9 +291,9 @@ mod tests {
 
     #[test]
     fn test_values() {
-        assert!(deserialized_input(&[LOG_LINE.to_owned()]).map(|v| {
-            v.into_iter().map(|ll| ll.value_test())
-        }).is_ok())
+        assert!(deserialized_input(&[LOG_LINE.to_owned()])
+            .map(|v| { v.into_iter().map(|ll| ll.value_test()) })
+            .is_ok())
     }
 
     #[test]

--- a/test/interop/log_parsing/src/main.rs
+++ b/test/interop/log_parsing/src/main.rs
@@ -184,17 +184,13 @@ fn deserialized_input(log_lines: &[String]) -> serde_json::Result<Vec<LogLine>> 
         .collect()
 }
 
-// Take a json string, deserialize it, serialize it, then deserialize it again.
-// return the two json values so their values can be compared.
-// this helps to check if the deserialize-serialize loop drops necessary information, or adds unexpected information.
+// Take a json string, deserialize it to a known value, and a generic json value.
+// return the two json values so they can be compared.
+// this helps to check if the deserialize-serialize loop for the known value drops necessary information.
 //
 // This function is used as a helper to check every json logline that dbt outputs for expected values.
 // In practice, this often returns an Err value if the logs have unexpected non-json values such as logged
 // exceptions, warnings, or printed statements.
-//
-// We can't compare the two serialized strings because the original logline will contain many
-// fields that aren't yet modeled in this deserializer. We aren't checking that everything matches up,
-// just these modeled fields, so we have to deserialize twice.
 fn deserialize_twice<'a, T: Serialize + Deserialize<'a>>(
     json_str: &'a str,
 ) -> Result<(serde_json::Value, serde_json::Value), String> {


### PR DESCRIPTION
resolves #5658

### Description

Adds more information to std out when these log tests fail. Also refactors the code to be higher quality.

### Reviewers

This has a few whitespace changes. My non-whitespace changes start at 167 of the original. You can start at `test_deserialize_serialize_is_unchanged` which is the test. This calls the helper functions that have been modified.

The biggest risk of this change is that I could have weakened the test so it would pass in more situations. I, of course, don't suspect this is the case but it should be verified by the reviewer.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
