### PR TITLE
FIX: update connections.py to support connection_timeout parameter

### DIFF
--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -19,6 +19,7 @@ class PostgresCredentials(Credentials):
     role: Optional[str]
     port: Port
     password: str  # on postgres the password is mandatory
+    connect_timeout: Optional[int] = 10
     search_path: Optional[str] = None
     keepalives_idle: int = 0  # 0 means to use the default value
     sslmode: Optional[str] = None
@@ -99,7 +100,7 @@ class PostgresConnectionManager(SQLConnectionManager):
                 host=credentials.host,
                 password=credentials.password,
                 port=credentials.port,
-                connect_timeout=10,
+                connect_timeout=credentials.connect_timeout,
                 **kwargs)
 
             if credentials.role:


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

There is an issue with PostgreSQL connection timeout with unstable network connection. After some investigation I've found that it's hardcoded to set connection timeout to 10s and the connect_timeout parameter of profile is not applied. So, this PR will fix it by replacing the hardcoded value with an optional connect_timeout field of the PostgresCredentials dataclass with default value to 10 seconds (current behavior). Summary, after this patch applied there are two options: 
- specify the connect_timeout parameter in profile and change the current behavior to the desirable;
- do not specify anything and keep the current behavior.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
