### PR TITLE
Include py.typed in MANIFEST.in

### DIFF
--- a/.changes/unreleased/Fixes-20220823-112633.yaml
+++ b/.changes/unreleased/Fixes-20220823-112633.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Include py.typed in MANIFEST.in. This enables packages that install dbt-core
+  from pypi to use mypy.
+time: 2022-08-23T11:26:33.8415455-07:00
+custom:
+  Author: panasenco
+  Issue: "5703"
+  PR: "5703"

--- a/core/MANIFEST.in
+++ b/core/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include dbt/include *.py *.sql *.yml *.html *.md .gitkeep .gitignore
+include dbt/py.typed


### PR DESCRIPTION
This enables packages that install dbt-core from pypi to use mypy.

Resolves #5737

### Description

Currently when developing a dbt adapter and installing dbt-core with pip, I get errors like the following when trying to run mypy:
```
error: Skipping analyzing "dbt.contracts.connection": module is installed, but missing library stubs or py.typed marker
error: Skipping analyzing "dbt.events": module is installed, but missing library stubs or py.typed marker
```

This is because the file [py.typed](core/py.typed) is not included in the package uploaded to pypi.

The PR aims to include the file in the official dbt-core package to allow type checking in packages that depend on it.

I tested a local install and the file `py.typed` is now included in the `dbt` folder.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
