### PR TITLE
[Postgresql] Postgresql index creation improvement

### DIFF
--- a/.changes/unreleased/Fixes-20220831-092545.yaml
+++ b/.changes/unreleased/Fixes-20220831-092545.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: '[CT-37] [Bug] <Postgresql> Postgresql index creation improvement'
+time: 2022-08-31T09:25:45.300953721+02:00
+custom:
+  Author: Goodkat
+  Issue: "4567"
+  PR: "5746"

--- a/core/dbt/include/global_project/macros/materializations/models/table/table.sql
+++ b/core/dbt/include/global_project/macros/materializations/models/table/table.sql
@@ -38,7 +38,7 @@
       {{ adapter.rename_relation(existing_relation, backup_relation) }}
   {% endif %}
 
-  {{ adapter.rename_relation(intermediate_relation, target_relation) }}  
+  {{ adapter.rename_relation(intermediate_relation, target_relation) }}
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 

--- a/core/dbt/include/global_project/macros/materializations/models/table/table.sql
+++ b/core/dbt/include/global_project/macros/materializations/models/table/table.sql
@@ -31,14 +31,14 @@
     {{ get_create_table_as_sql(False, intermediate_relation, sql) }}
   {%- endcall %}
 
+  {% do create_indexes(target_relation) %}
+
   -- cleanup
   {% if existing_relation is not none %}
       {{ adapter.rename_relation(existing_relation, backup_relation) }}
   {% endif %}
 
-  {{ adapter.rename_relation(intermediate_relation, target_relation) }}
-
-  {% do create_indexes(target_relation) %}
+  {{ adapter.rename_relation(intermediate_relation, target_relation) }}  
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 


### PR DESCRIPTION
resolves #4567

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Using Postgresql as a transactional reporting layer against big tables requires index creation. Locking the big tables during index creation sometimes creates problems when reporting tool tries to query the db at the same time. The solution is building the index on the empty table before populating it so the initial index build with the shared lock is quicker.
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
