### PR TITLE
Fix label selection syntax and trigger

### DIFF
--- a/.github/workflows/bot-changelog.yml
+++ b/.github/workflows/bot-changelog.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Create and commit changelog on bot PR
       if: ${{ contains(github.event.pull_request.labels.*.name, matrix.label) }}
       id: bot_changelog
-      uses: emmyoop/changie_bot@v1.0
+      uses: emmyoop/changie_bot@v1.0.1
       with:
         GITHUB_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
         commit_author_name: "Github Build Bot"

--- a/.github/workflows/bot-changelog.yml
+++ b/.github/workflows/bot-changelog.yml
@@ -28,7 +28,7 @@ name: Bot Changelog
 on:
   pull_request:
     # catch when the PR is opened with the label or when the label is added
-    types: [opened, labeled]
+    types: [labeled]
 
 permissions:
   contents: write
@@ -48,7 +48,7 @@ jobs:
     steps:
 
     - name: Create and commit changelog on bot PR
-      if: "contains(github.event.pull_request.labels.*.name, ${{ matrix.label }})"
+      if: ${{ contains(github.event.pull_request.labels.*.name, matrix.label) }}
       id: bot_changelog
       uses: emmyoop/changie_bot@v1.0
       with:
@@ -58,4 +58,4 @@ jobs:
         commit_message: "Add automated changelog yaml from template for bot PR"
         changie_kind: ${{ matrix.changie_kind }}
         label: ${{ matrix.label }}
-        custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n  Issue: 4904\n  PR: ${{ github.event.pull_request.number }}\n"
+        custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n  Issue: 4904\n  PR: ${{ github.event.pull_request.number }}"


### PR DESCRIPTION
resolves #5719 

### Description

1.  Fixes newline bug.
2. Fixes bug with label detection format failing
3. Changed to only run `on: [labeled]`.  Previously it ran `on: [opened, labeled]` and would trigger twice when a PR was opened with the appropriate error.  This could cause 2 changelog entries to appear.  `on: [labeled]` still triggers on the PR when it's opened with the label.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
