### PR TITLE
Add 1.2.latest branch to scheduled test matrix

### DIFF
--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -39,7 +39,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        branch: [1.0.latest, 1.1.latest, main]
+        branch: [1.0.latest, 1.1.latest, 1.2.latest, main]
 
     steps:
     - name: Call CI workflow for ${{ matrix.branch }} branch


### PR DESCRIPTION
### Description
For our scheduled release branch testing, we need to add `1.2.latest` to the branch matrix

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
