### PR TITLE
Add invocation_args_dict to ProviderContext

### DIFF
--- a/.changes/unreleased/Features-20220908-081315.yaml
+++ b/.changes/unreleased/Features-20220908-081315.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add invocation args dict to ProviderContext class
+time: 2022-09-08T08:13:15.17337+01:00
+custom:
+  Author: jared-rimmer
+  Issue: "5524"
+  PR: "5782"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -63,7 +63,7 @@ from dbt.exceptions import (
 from dbt.config import IsFQNResource
 from dbt.node_types import NodeType, ModelLanguage
 
-from dbt.utils import merge, AttrDict, MultiDict
+from dbt.utils import merge, AttrDict, MultiDict, args_to_dict
 
 from dbt import selected_resources
 
@@ -709,6 +709,10 @@ class ProviderContext(ManifestContext):
             internal_packages,
             self.model,
         )
+
+    @contextproperty
+    def invocation_args_to_dict(self):
+        return args_to_dict(self.config.args)
 
     @contextproperty
     def _sql_results(self) -> Dict[str, AttrDict]:

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -711,7 +711,7 @@ class ProviderContext(ManifestContext):
         )
 
     @contextproperty
-    def invocation_args_to_dict(self):
+    def invocation_args_dict(self):
         return args_to_dict(self.config.args)
 
     @contextproperty

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -238,7 +238,7 @@ REQUIRED_MACRO_KEYS = REQUIRED_QUERY_HEADER_KEYS | {
     "sql_now",
     "adapter_macro",
     "selected_resources",
-    "invocation_args_to_dict"
+    "invocation_args_dict",
 }
 REQUIRED_MODEL_KEYS = REQUIRED_MACRO_KEYS | {"this", "compiled_code",}
 MAYBE_KEYS = frozenset({"debug"})
@@ -429,11 +429,11 @@ def test_invocation_args_to_dict_in_macro_runtime_context(
     )
 
     # Comes from dbt/flags.py as they are the only values set that aren't None at default
-    assert ctx["invocation_args_to_dict"]["event_buffer_size"] == 100000
-    assert ctx["invocation_args_to_dict"]["printer_width"] == 80
+    assert ctx["invocation_args_dict"]["event_buffer_size"] == 100000
+    assert ctx["invocation_args_dict"]["printer_width"] == 80
 
     # Comes from unit/utils.py config_from_parts_or_dicts method
-    assert ctx["invocation_args_to_dict"]["profile_dir"] == "/dev/null"
+    assert ctx["invocation_args_dict"]["profile_dir"] == "/dev/null"
 
 def test_model_parse_context(config_postgres, manifest_fx, get_adapter, get_include_paths):
     ctx = providers.generate_parser_model_context(

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -238,6 +238,7 @@ REQUIRED_MACRO_KEYS = REQUIRED_QUERY_HEADER_KEYS | {
     "sql_now",
     "adapter_macro",
     "selected_resources",
+    "invocation_args_to_dict"
 }
 REQUIRED_MODEL_KEYS = REQUIRED_MACRO_KEYS | {"this", "compiled_code",}
 MAYBE_KEYS = frozenset({"debug"})
@@ -417,6 +418,22 @@ def test_macro_runtime_context(config_postgres, manifest_fx, get_adapter, get_in
     )
     assert_has_keys(REQUIRED_MACRO_KEYS, MAYBE_KEYS, ctx)
 
+def test_invocation_args_to_dict_in_macro_runtime_context(
+    config_postgres, manifest_fx, get_adapter, get_include_paths
+):
+    ctx = providers.generate_runtime_macro_context(
+        macro=manifest_fx.macros["macro.root.macro_a"],
+        config=config_postgres,
+        manifest=manifest_fx,
+        package_name="root",
+    )
+
+    # Comes from dbt/flags.py as they are the only values set that aren't None at default
+    assert ctx["invocation_args_to_dict"]["event_buffer_size"] == 100000
+    assert ctx["invocation_args_to_dict"]["printer_width"] == 80
+
+    # Comes from unit/utils.py config_from_parts_or_dicts method
+    assert ctx["invocation_args_to_dict"]["profile_dir"] == "/dev/null"
 
 def test_model_parse_context(config_postgres, manifest_fx, get_adapter, get_include_paths):
     ctx = providers.generate_parser_model_context(

--- a/tests/functional/context_methods/test_builtin_functions.py
+++ b/tests/functional/context_methods/test_builtin_functions.py
@@ -25,7 +25,7 @@ macros__validate_zip_sql = """
 
 macros__validate_invocation_sql = """
 {% macro validate_invocation(my_variable) %}
-    {{ log("invocation_result: "~ invocation_args_to_dict) }}
+    {{ log("invocation_result: "~ invocation_args_dict) }}
 {% endmacro %}
 """
 
@@ -62,7 +62,7 @@ class TestContextBuiltins:
         assert f"zip_result: {expected_zip}" in log_output
         assert f"zip_strict_result: {expected_zip}" in log_output
 
-    def test_builtin_invocation_args_to_dict_function(self, project):
+    def test_builtin_invocation_args_dict_function(self, project):
         _, log_output = run_dbt_and_capture(
             [
                 "--debug",

--- a/tests/functional/context_methods/test_builtin_functions.py
+++ b/tests/functional/context_methods/test_builtin_functions.py
@@ -95,13 +95,14 @@ class TestContextBuiltins:
         )
 
         assert result
-        
+
         # Result is checked in two parts because profiles_dir is unique each test run
         expected = "invocation_result: {'debug': True, 'log_format': 'json', 'write_json': True, 'use_colors': True, 'printer_width': 80, 'version_check': True, 'partial_parse': True, 'static_parser': True, 'profiles_dir': "
         assert expected in str(result)
 
         expected = "'send_anonymous_usage_stats': False, 'event_buffer_size': 100000, 'quiet': False, 'no_print': False, 'macro': 'validate_invocation', 'args': '{my_variable: test_variable}', 'which': 'run-operation', 'rpc_method': 'run-operation', 'indirect_selection': 'eager'}"
         assert expected in str(result)
+
 
 class TestContextBuiltinExceptions:
     # Assert compilation errors are raised with _strict equivalents


### PR DESCRIPTION
resolves #5524 

### Description

- Added a `invocation_args_dict` contextproperty to the ProviderContext class.
- Added a test in `test_context.py` using a MacroContext
- Added a test in `test_builtin_functions` that prints {{invocation_args_dict}} to the logs. Again using a MacroContext

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
