### PR TITLE
add missing test for escape single quotes

### DIFF
--- a/.changes/unreleased/Under the Hood-20220912-135340.yaml
+++ b/.changes/unreleased/Under the Hood-20220912-135340.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: add missing test for escape single quotes
+time: 2022-09-12T13:53:40.902222+02:00
+custom:
+  Author: sdebruyn
+  Issue: "5811"
+  PR: "5810"

--- a/tests/adapter/dbt/tests/adapter/utils/test_escape_single_quotes.py
+++ b/tests/adapter/dbt/tests/adapter/utils/test_escape_single_quotes.py
@@ -31,3 +31,7 @@ class BaseEscapeSingleQuotesBackslash(BaseUtils):
 
 class TestEscapeSingleQuotes(BaseEscapeSingleQuotesQuote):
     pass
+
+
+class TestEscapeSingleQuotesBackslash(BaseEscapeSingleQuotesBackslash):
+    pass


### PR DESCRIPTION
The BaseEscapeSingleQuotesBackslash was not tested in this file and does not follow the conventions from the other file.

resolves #5811 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
