### PR TITLE
Add friendlier error messages when packages yml is malformed

### DIFF
--- a/.changes/unreleased/Features-20220912-125935.yaml
+++ b/.changes/unreleased/Features-20220912-125935.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Friendlier error messages when packages.yml is malformed
+time: 2022-09-12T12:59:35.121188+01:00
+custom:
+  Author: jared-rimmer
+  Issue: "5486"
+  PR: "5812"

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -83,17 +83,6 @@ class RegistryPackage(Package):
         else:
             return [str(self.version)]
 
-    def __post_init__(self):
-        if not self.version:
-            raise ValidationError(
-                "When installing from the Hub package index, version is a required property"
-            )
-
-        if "/" not in self.package:
-            raise ValidationError(
-                f"{self.package} was not found in the package index. Packages on the index require a namespace, e.g dbt-labs/dbt_utils"
-            )
-
 
 PackageSpec = Union[LocalPackage, GitPackage, RegistryPackage]
 
@@ -101,6 +90,22 @@ PackageSpec = Union[LocalPackage, GitPackage, RegistryPackage]
 @dataclass
 class PackageConfig(dbtClassMixin, Replaceable):
     packages: List[PackageSpec]
+
+    @classmethod
+    def validate(cls, data):
+        for package in data["packages"]:
+            if not package["version"]:
+                raise ValidationError(
+                    f"{package['package']} is missing the version. When installing from the Hub "
+                    "package index, version is a required property"
+                )
+
+            if "/" not in package["package"]:
+                raise ValidationError(
+                    f"{package['package']} was not found in the package index. Packages on the index "
+                    "require a namespace, e.g dbt-labs/dbt_utils"
+                )
+        super().validate(data)
 
 
 @dataclass

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -83,6 +83,17 @@ class RegistryPackage(Package):
         else:
             return [str(self.version)]
 
+    def __post_init__(self):
+        if not self.version:
+            raise ValidationError(
+                "When installing from the Hub package index, version is a required property"
+            )
+
+        if "/" not in self.package:
+            raise ValidationError(
+                f"{self.package} was not found in the package index. Packages on the index require a namespace, e.g dbt-labs/dbt_utils"
+            )
+
 
 PackageSpec = Union[LocalPackage, GitPackage, RegistryPackage]
 

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -93,18 +93,19 @@ class PackageConfig(dbtClassMixin, Replaceable):
 
     @classmethod
     def validate(cls, data):
-        for package in data["packages"]:
-            if not package["version"]:
-                raise ValidationError(
-                    f"{package['package']} is missing the version. When installing from the Hub "
-                    "package index, version is a required property"
-                )
+        for package in data.get("packages", data):
+            if isinstance(package, dict) and package.get("package"):
+                if not package["version"]:
+                    raise ValidationError(
+                        f"{package['package']} is missing the version. When installing from the Hub "
+                        "package index, version is a required property"
+                    )
 
-            if "/" not in package["package"]:
-                raise ValidationError(
-                    f"{package['package']} was not found in the package index. Packages on the index "
-                    "require a namespace, e.g dbt-labs/dbt_utils"
-                )
+                if "/" not in package["package"]:
+                    raise ValidationError(
+                        f"{package['package']} was not found in the package index. Packages on the index "
+                        "require a namespace, e.g dbt-labs/dbt_utils"
+                    )
         super().validate(data)
 
 

--- a/test/unit/test_deps.py
+++ b/test/unit/test_deps.py
@@ -22,7 +22,6 @@ from dbt.version import get_installed_version
 
 from dbt.dataclass_schema import ValidationError
 
-
 class TestLocalPackage(unittest.TestCase):
     def test_init(self):
         a_contract = LocalPackage.from_dict({'local': '/path/to/package'})
@@ -242,6 +241,26 @@ class TestHubPackage(unittest.TestCase):
             "Could not find a matching compatible version for package "
             "dbt-labs-test/a\n  Requested range: =0.1.4, =0.1.4\n  "
             "Compatible versions: ['0.1.2', '0.1.3']\n"
+        )
+        assert msg in str(exc.exception)
+
+    def test_validation_error_message_when_version_is_missing(self):
+
+        with self.assertRaises(ValidationError) as exc:
+            a = RegistryPackage(package='dbt-labs-test/a', version=None)
+
+        msg = (
+            "When installing from the Hub package index, version is a required property"
+        )
+        assert msg in str(exc.exception)
+
+    def test_validation_error_message_when_package_namespace_is_missing(self):
+
+        with self.assertRaises(ValidationError) as exc:
+            a = RegistryPackage(package='dbt-labs', version='0.1.3')
+
+        msg = (
+            "dbt-labs was not found in the package index. Packages on the index require a namespace, e.g dbt-labs/dbt_utils"
         )
         assert msg in str(exc.exception)
 

--- a/test/unit/test_deps.py
+++ b/test/unit/test_deps.py
@@ -244,26 +244,6 @@ class TestHubPackage(unittest.TestCase):
         )
         assert msg in str(exc.exception)
 
-    def test_validation_error_message_when_version_is_missing(self):
-
-        with self.assertRaises(ValidationError) as exc:
-            a = RegistryPackage(package='dbt-labs-test/a', version=None)
-
-        msg = (
-            "When installing from the Hub package index, version is a required property"
-        )
-        assert msg in str(exc.exception)
-
-    def test_validation_error_message_when_package_namespace_is_missing(self):
-
-        with self.assertRaises(ValidationError) as exc:
-            a = RegistryPackage(package='dbt-labs', version='0.1.3')
-
-        msg = (
-            "dbt-labs was not found in the package index. Packages on the index require a namespace, e.g dbt-labs/dbt_utils"
-        )
-        assert msg in str(exc.exception)
-
     def test_resolve_conflict(self):
         a_contract = RegistryPackage(
             package='dbt-labs-test/a',
@@ -673,3 +653,27 @@ class TestPackageSpec(unittest.TestCase):
         resolved = resolve_packages(package_config.packages, mock.MagicMock(project_name='test'))
         self.assertEqual(resolved[0].name, 'dbt-labs-test/a')
         self.assertEqual(resolved[0].version, '0.1.4a1')
+
+    def test_validation_error_when_version_is_missing_from_package_config(self):
+        
+        packages_data = {"packages": [{'package': 'dbt-labs-test/b', 'version': None}]}
+        
+        with self.assertRaises(ValidationError) as exc:
+            a = PackageConfig.validate(data=packages_data)
+
+        msg = (
+            "dbt-labs-test/b is missing the version. When installing from the Hub package index, version is a required property"
+        )
+        assert msg in str(exc.exception)
+
+    def test_validation_error_when_namespace_is_missing_from_package_config(self):
+        
+        packages_data = {"packages": [{'package': 'dbt-labs', 'version': '1.0.0'}]}
+        
+        with self.assertRaises(ValidationError) as exc:
+            a = PackageConfig.validate(data=packages_data)
+
+        msg = (
+            "dbt-labs was not found in the package index. Packages on the index require a namespace, e.g dbt-labs/dbt_utils"
+        )
+        assert msg in str(exc.exception)


### PR DESCRIPTION
resolves #5486 

### Description

- Added `__post_init__` method to `RegistryPackage` dataclass that checks that a version has been provided and that the name of the package contains a "/".
- Added corresponding tests to check the error messages stated in the issue are returned to the user.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
