### PR TITLE
remove key as reserved keyword from test_bool_or

### DIFF
--- a/.changes/unreleased/Under the Hood-20220912-190341.yaml
+++ b/.changes/unreleased/Under the Hood-20220912-190341.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: remove key as reserved keyword from test_bool_or
+time: 2022-09-12T19:03:41.481601+02:00
+custom:
+  Author: sdebruyn
+  Issue: "5817"
+  PR: "5818"

--- a/tests/adapter/dbt/tests/adapter/utils/fixture_bool_or.py
+++ b/tests/adapter/dbt/tests/adapter/utils/fixture_bool_or.py
@@ -1,6 +1,6 @@
 # bool_or
 
-seeds__data_bool_or_csv = """key,val1,val2
+seeds__data_bool_or_csv = """key_column,val1,val2
 abc,1,1
 abc,1,0
 def,1,0
@@ -11,7 +11,7 @@ klm,1,
 """
 
 
-seeds__data_bool_or_expected_csv = """key,value
+seeds__data_bool_or_expected_csv = """key_column,value
 abc,true
 def,false
 hij,true
@@ -35,10 +35,10 @@ data_output as (
 calculate as (
 
     select
-        key,
+        key_column,
         {{ bool_or('val1 = val2') }} as value
     from data
-    group by key
+    group by key_column
 
 )
 
@@ -47,7 +47,7 @@ select
     data_output.value as expected
 from calculate
 left join data_output
-on calculate.key = data_output.key
+on calculate.key_column = data_output.key_column
 """
 
 


### PR DESCRIPTION
resolves #5817 

### Description

Use `key_column` instead of `key` in the test fixture since that would not be a reserved keyword

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
