### PR TITLE
Add name validation for metrics

### DIFF
--- a/.changes/unreleased/Under the Hood-20220914-132632.yaml
+++ b/.changes/unreleased/Under the Hood-20220914-132632.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Add name validation for metrics
+time: 2022-09-14T13:26:32.387524-05:00
+custom:
+  Author: emmyoop
+  Issue: "5456"
+  PR: "1111"

--- a/.changes/unreleased/Under the Hood-20220914-132632.yaml
+++ b/.changes/unreleased/Under the Hood-20220914-132632.yaml
@@ -4,4 +4,4 @@ time: 2022-09-14T13:26:32.387524-05:00
 custom:
   Author: emmyoop
   Issue: "5456"
-  PR: "1111"
+  PR: "5841"

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -489,8 +489,10 @@ class UnparsedMetric(dbtClassMixin, Replaceable):
             errors = []
             if " " in data["name"]:
                 errors.append("cannot contain spaces")
-            if len(data["name"]) > 126:
-                errors.append("cannot contain more than 126 characters")
+            # This handles failing queries due to too long metric names.
+            # It only occurs in BigQuery and Snowflake (Postgres/Redshift truncate)
+            if len(data["name"]) > 250:
+                errors.append("cannot contain more than 250 characters")
             if not (re.match(r"^[A-Za-z]", data["name"])):
                 errors.append("must begin with a letter")
             if not (re.match(r"[\w-]+$", data["name"])):
@@ -498,7 +500,7 @@ class UnparsedMetric(dbtClassMixin, Replaceable):
 
             if errors:
                 raise ParsingException(
-                    f"Metrics name '{data['name']}' is invalid.  It {', '.join(e for e in errors)}"
+                    f"The metric name '{data['name']}' is invalid.  It {', '.join(e for e in errors)}"
                 )
 
         if data.get("calculation_method") == "expression":

--- a/tests/functional/metrics/fixture_metrics.py
+++ b/tests/functional/metrics/fixture_metrics.py
@@ -13,3 +13,11 @@ mock_purchase_data_csv = """purchased_at,payment_type,payment_total
 2021-02-19 04:22:41,jcb,2834.96
 2021-02-19 13:28:50,china-unionpay,2440.98
 """.strip()
+
+models__people_sql = """
+select 1 as id, 'Drew' as first_name, 'Banin' as last_name, 'yellow' as favorite_color, true as loves_dbt, 5 as tenure, current_timestamp as created_at
+union all
+select 1 as id, 'Jeremy' as first_name, 'Cohen' as last_name, 'indigo' as favorite_color, true as loves_dbt, 4 as tenure, current_timestamp as created_at
+union all
+select 1 as id, 'Callum' as first_name, 'McCann' as last_name, 'emerald' as favorite_color, true as loves_dbt, 0 as tenure, current_timestamp as created_at
+"""

--- a/tests/functional/metrics/test_metric_configs.py
+++ b/tests/functional/metrics/test_metric_configs.py
@@ -4,6 +4,9 @@ from dbt.exceptions import CompilationException
 from dbt.tests.util import run_dbt, update_config_file, get_manifest
 
 
+from tests.functional.metrics.fixture_metrics import models__people_sql
+
+
 class MetricConfigTests:
     @pytest.fixture(scope="class", autouse=True)
     def setUp(self):
@@ -44,14 +47,6 @@ metrics:
         operator: 'is'
         value: 'true'
 
-"""
-
-models__people_sql = """
-select 1 as id, 'Drew' as first_name, 'Banin' as last_name, 'yellow' as favorite_color, true as loves_dbt, 5 as tenure, current_timestamp as created_at
-union all
-select 1 as id, 'Jeremy' as first_name, 'Cohen' as last_name, 'indigo' as favorite_color, true as loves_dbt, 4 as tenure, current_timestamp as created_at
-union all
-select 1 as id, 'Callum' as first_name, 'McCann' as last_name, 'emerald' as favorite_color, true as loves_dbt, 0 as tenure, current_timestamp as created_at
 """
 
 

--- a/tests/functional/metrics/test_metric_helper_functions.py
+++ b/tests/functional/metrics/test_metric_helper_functions.py
@@ -3,6 +3,8 @@ import pytest
 from dbt.tests.util import run_dbt, get_manifest
 from dbt.contracts.graph.metrics import ResolvedMetricReference
 
+from tests.functional.metrics.fixture_metrics import models__people_sql
+
 metrics__yml = """
 version: 2
 
@@ -50,14 +52,6 @@ metrics:
     expression: "{{metric('average_tenure')}} + 1 "
     timestamp: created_at
     time_grains: [day, week, month]
-"""
-
-models__people_sql = """
-select 1 as id, 'Drew' as first_name, 'Banin' as last_name, 'yellow' as favorite_color, true as loves_dbt, 5 as tenure, current_timestamp as created_at
-union all
-select 1 as id, 'Jeremy' as first_name, 'Cohen' as last_name, 'indigo' as favorite_color, true as loves_dbt, 4 as tenure, current_timestamp as created_at
-union all
-select 1 as id, 'Callum' as first_name, 'McCann' as last_name, 'emerald' as favorite_color, true as loves_dbt, 0 as tenure, current_timestamp as created_at
 """
 
 

--- a/tests/functional/metrics/test_metrics.py
+++ b/tests/functional/metrics/test_metrics.py
@@ -301,7 +301,7 @@ version: 2
 
 metrics:
 
-  - name: this_name_is_going_to_contain_more_than_126_characters_but_be_otherwise_acceptable_and_then_will_throw_an_error_which_I_expect_to_happen
+  - name: this_name_is_going_to_contain_more_than_250_characters_but_be_otherwise_acceptable_and_then_will_throw_an_error_which_I_expect_to_happen_and_repeat_this_name_is_going_to_contain_more_than_250_characters_but_be_otherwise_acceptable_and_then_will_throw_an_error_which_I_expect_to_happen
     label: "Number of people"
     description: Total count of people
     model: "ref('people')"
@@ -326,10 +326,10 @@ class TestLongName:
             "people.sql": models__people_sql,
         }
 
-    def test_names_with_leading_number(self, project):
+    def test_long_name(self, project):
         with pytest.raises(ParsingException) as exc:
             run_dbt(["run"])
-        assert "cannot contain more than 126 characters" in str(exc.value)
+        assert "cannot contain more than 250 characters" in str(exc.value)
 
 
 downstream_model_sql = """

--- a/tests/functional/metrics/test_metrics.py
+++ b/tests/functional/metrics/test_metrics.py
@@ -219,8 +219,9 @@ class TestNamesWithSpaces:
         }
 
     def test_names_with_spaces(self, project):
-        with pytest.raises(ParsingException):
+        with pytest.raises(ParsingException) as exc:
             run_dbt(["run"])
+        assert "cannot contain spaces" in str(exc.value)
 
 
 names_with_special_chars_metrics_yml = """
@@ -254,8 +255,9 @@ class TestNamesWithSpecialChar:
         }
 
     def test_names_with_special_char(self, project):
-        with pytest.raises(ParsingException):
+        with pytest.raises(ParsingException) as exc:
             run_dbt(["run"])
+        assert "must contain only letters, numbers and underscores" in str(exc.value)
 
 
 names_with_leading_numeric_metrics_yml = """
@@ -289,8 +291,9 @@ class TestNamesWithLeandingNumber:
         }
 
     def test_names_with_leading_number(self, project):
-        with pytest.raises(ParsingException):
+        with pytest.raises(ParsingException) as exc:
             run_dbt(["run"])
+        assert "must begin with a letter" in str(exc.value)
 
 
 long_name_metrics_yml = """
@@ -315,7 +318,7 @@ metrics:
 """
 
 
-class TestNamesWithLeadingNumber:
+class TestLongName:
     @pytest.fixture(scope="class")
     def models(self):
         return {
@@ -324,8 +327,9 @@ class TestNamesWithLeadingNumber:
         }
 
     def test_names_with_leading_number(self, project):
-        with pytest.raises(ParsingException):
+        with pytest.raises(ParsingException) as exc:
             run_dbt(["run"])
+        assert "cannot contain more than 126 characters" in str(exc.value)
 
 
 downstream_model_sql = """

--- a/tests/functional/metrics/test_metrics.py
+++ b/tests/functional/metrics/test_metrics.py
@@ -3,7 +3,7 @@ import pytest
 from dbt.tests.util import run_dbt, get_manifest
 from dbt.exceptions import ParsingException
 
-from tests.functional.metrics.fixture_metrics import mock_purchase_data_csv
+from tests.functional.metrics.fixture_metrics import mock_purchase_data_csv, models__people_sql
 
 
 models__people_metrics_yml = """
@@ -54,14 +54,6 @@ metrics:
         operator: 'is'
         value: 'true'
 
-"""
-
-models__people_sql = """
-select 1 as id, 'Drew' as first_name, 'Banin' as last_name, 'yellow' as favorite_color, true as loves_dbt, 5 as tenure, current_timestamp as created_at
-union all
-select 1 as id, 'Jeremy' as first_name, 'Cohen' as last_name, 'indigo' as favorite_color, true as loves_dbt, 4 as tenure, current_timestamp as created_at
-union all
-select 1 as id, 'Callum' as first_name, 'McCann' as last_name, 'emerald' as favorite_color, true as loves_dbt, 0 as tenure, current_timestamp as created_at
 """
 
 
@@ -215,19 +207,6 @@ metrics:
     meta:
         my_meta: 'testing'
 
-  - name: collective tenure
-    label: "Collective tenure"
-    description: Total number of years of team experience
-    model: "ref('people')"
-    calculation_method: sum
-    expression: tenure
-    timestamp: created_at
-    time_grains: [day]
-    filters:
-      - field: loves_dbt
-        operator: 'is'
-        value: 'true'
-
 """
 
 
@@ -240,6 +219,111 @@ class TestNamesWithSpaces:
         }
 
     def test_names_with_spaces(self, project):
+        with pytest.raises(ParsingException):
+            run_dbt(["run"])
+
+
+names_with_special_chars_metrics_yml = """
+version: 2
+
+metrics:
+
+  - name: number_of_people!
+    label: "Number of people"
+    description: Total count of people
+    model: "ref('people')"
+    calculation_method: count
+    expression: "*"
+    timestamp: created_at
+    time_grains: [day, week, month]
+    dimensions:
+      - favorite_color
+      - loves_dbt
+    meta:
+        my_meta: 'testing'
+
+"""
+
+
+class TestNamesWithSpecialChar:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people_metrics.yml": names_with_special_chars_metrics_yml,
+            "people.sql": models__people_sql,
+        }
+
+    def test_names_with_special_char(self, project):
+        with pytest.raises(ParsingException):
+            run_dbt(["run"])
+
+
+names_with_leading_numeric_metrics_yml = """
+version: 2
+
+metrics:
+
+  - name: 1_number_of_people
+    label: "Number of people"
+    description: Total count of people
+    model: "ref('people')"
+    calculation_method: count
+    expression: "*"
+    timestamp: created_at
+    time_grains: [day, week, month]
+    dimensions:
+      - favorite_color
+      - loves_dbt
+    meta:
+        my_meta: 'testing'
+
+"""
+
+
+class TestNamesWithLeandingNumber:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people_metrics.yml": names_with_leading_numeric_metrics_yml,
+            "people.sql": models__people_sql,
+        }
+
+    def test_names_with_leading_number(self, project):
+        with pytest.raises(ParsingException):
+            run_dbt(["run"])
+
+
+long_name_metrics_yml = """
+version: 2
+
+metrics:
+
+  - name: this_name_is_going_to_contain_more_than_126_characters_but_be_otherwise_acceptable_and_then_will_throw_an_error_which_I_expect_to_happen
+    label: "Number of people"
+    description: Total count of people
+    model: "ref('people')"
+    calculation_method: count
+    expression: "*"
+    timestamp: created_at
+    time_grains: [day, week, month]
+    dimensions:
+      - favorite_color
+      - loves_dbt
+    meta:
+        my_meta: 'testing'
+
+"""
+
+
+class TestNamesWithLeadingNumber:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people_metrics.yml": long_name_metrics_yml,
+            "people.sql": models__people_sql,
+        }
+
+    def test_names_with_leading_number(self, project):
         with pytest.raises(ParsingException):
             run_dbt(["run"])
 


### PR DESCRIPTION
resolves #5456

### Description

Adds name validation rules:
* Metric name characters must be alphanumeric or underscore
* Metric name must begin with an letter (this allows us to get around the BQ naming prefixes which all begin with _ )
* Metric names must be 126 characters or less (Redshift constraint. BQ and Snowflake are longer)

Adding exposure name validation in #5844 

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
