### PR TITLE
Adding missing permissions on GHA

### DIFF
--- a/.github/workflows/jira-transition.yml
+++ b/.github/workflows/jira-transition.yml
@@ -15,6 +15,8 @@ on:
   issues:
     types: [closed, deleted, reopened]
 
+# no permissions beyond the default needed here
+
 jobs:
   call-label-action:
     uses: dbt-labs/jira-actions/.github/workflows/jira-transition.yml@main

--- a/.github/workflows/jira-transition.yml
+++ b/.github/workflows/jira-transition.yml
@@ -15,7 +15,8 @@ on:
   issues:
     types: [closed, deleted, reopened]
 
-# no permissions beyond the default needed here
+# no special access is needed
+permissions: read-all
 
 jobs:
   call-label-action:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ on:
        description: 'The release version number (i.e. 1.0.0b1)'
        required: true
 
+permissions:
+  contents: write # this is the permission that allows creating a new release
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -21,6 +21,8 @@ on:
       - "*.latest"
       - "releases/*"
 
+# no permissions beyond the default needed here
+
 env:
   LATEST_SCHEMA_PATH: ${{ github.workspace }}/new_schemas
   SCHEMA_DIFF_ARTIFACT: ${{ github.workspace }}//schema_schanges.txt

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -21,7 +21,8 @@ on:
       - "*.latest"
       - "releases/*"
 
-# no permissions beyond the default needed here
+# no special access is needed
+permissions: read-all
 
 env:
   LATEST_SCHEMA_PATH: ${{ github.workspace }}/new_schemas

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -20,6 +20,10 @@ on:
        description: 'The version number to bump to (ex. 1.2.0, 1.3.0b1)'
        required: true
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   bump:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
This PR is to fill in any missing permissions in all our GHA in this repo. Right now our repo is defaulted to give read/write access to all GHA and I want to change it to default to read access only and then force us to explicitly opt into write access when needed. This is just a good security practice to keep the permission scope as limited as possible unless otherwise needed. When this setting is toggled to read only, the Actions that are missing listing the correct permissions will fail so this PR is to fill in those gaps now so this change doesn't break workflows.

Current setting:
![image](https://user-images.githubusercontent.com/60146280/190707908-ab0c6bec-6e2d-442c-9a3f-7b20a382e6c4.png)

⭐ I will not flip this switch on the setting until we are ready and can switch it back if it breaks any GHA in an unforeseen way

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
