### PR TITLE
Working solution serialization bug.

### DIFF
--- a/core/dbt/events/adapter_endpoint.py
+++ b/core/dbt/events/adapter_endpoint.py
@@ -13,7 +13,7 @@ class AdapterLogger:
     name: str
 
     def debug(self, msg, *args, exc_info=None, extra=None, stack_info=False):
-        event = AdapterEventDebug(name=self.name, base_msg=msg, args=args)
+        event = AdapterEventDebug(name=self.name, base_msg=str(msg), args=args)
 
         event.exc_info = exc_info
         event.extra = extra
@@ -22,7 +22,7 @@ class AdapterLogger:
         fire_event(event)
 
     def info(self, msg, *args, exc_info=None, extra=None, stack_info=False):
-        event = AdapterEventInfo(name=self.name, base_msg=msg, args=args)
+        event = AdapterEventInfo(name=self.name, base_msg=str(msg), args=args)
 
         event.exc_info = exc_info
         event.extra = extra
@@ -31,7 +31,7 @@ class AdapterLogger:
         fire_event(event)
 
     def warning(self, msg, *args, exc_info=None, extra=None, stack_info=False):
-        event = AdapterEventWarning(name=self.name, base_msg=msg, args=args)
+        event = AdapterEventWarning(name=self.name, base_msg=str(msg), args=args)
 
         event.exc_info = exc_info
         event.extra = extra
@@ -40,7 +40,7 @@ class AdapterLogger:
         fire_event(event)
 
     def error(self, msg, *args, exc_info=None, extra=None, stack_info=False):
-        event = AdapterEventError(name=self.name, base_msg=msg, args=args)
+        event = AdapterEventError(name=self.name, base_msg=str(msg), args=args)
 
         event.exc_info = exc_info
         event.extra = extra
@@ -50,7 +50,7 @@ class AdapterLogger:
 
     # The default exc_info=True is what makes this method different
     def exception(self, msg, *args, exc_info=True, extra=None, stack_info=False):
-        event = AdapterEventError(name=self.name, base_msg=msg, args=args)
+        event = AdapterEventError(name=self.name, base_msg=str(msg), args=args)
 
         event.exc_info = exc_info
         event.extra = extra
@@ -59,7 +59,7 @@ class AdapterLogger:
         fire_event(event)
 
     def critical(self, msg, *args, exc_info=False, extra=None, stack_info=False):
-        event = AdapterEventError(name=self.name, base_msg=msg, args=args)
+        event = AdapterEventError(name=self.name, base_msg=str(msg), args=args)
 
         event.exc_info = exc_info
         event.extra = extra


### PR DESCRIPTION
resolves #5436

### Description
Ho, boy! What an odyssey.

#### reproducing the error

((Test case))
dbt --no-use-colors --log-format json run -s asdf | jq .msg
asdf.sql: select * from foo.bar

——————

dbt-bigquery==1.0.0
dbt-core==1.0.8

> 1 of 1 START table model my_dataset.asdf........................................ [RUN]
> Unhandled error while executing model.jaffle_shop.asdf
> Pickling client objects is explicitly not supported.
> Clients have non-trivial state that is local and unpickleable.
> 1 of 1 ERROR creating table model my_dataset.asdf............................... [ERROR in 0.61s]
> Finished running 1 table model in 1.47s.
> Completed with 1 error and 0 warnings:
> Pickling client objects is explicitly not supported.
> Clients have non-trivial state that is local and unpickleable.

dbt-bigquery==1.1.0
dbt-core==1.1.2

dbt-bigquery==1.2.0
dbt-bigquery==1.3.0b2

dbt-core==1.3.0b2
dbt-core==1.2.1

> 1 of 1 START table model my_dataset.asdf ....................................... [RUN]
> 1 of 1 ERROR creating table model my_dataset.asdf .............................. [ERROR in 0.53s]
> Finished running 1 table model in 1.17s.
> Completed with 1 error and 0 warnings:
> Compilation Error in macro statement (macros/etc/statement.sql)
>   Object of type NotFound is not JSON serializable
> 
>   > in macro materialization_table_bigquery (macros/materializations/table.sql)
>   > called by macro statement (macros/etc/statement.sql)

#### the error

`json.dumps` presumes that all elements within a dictionary can be simply rendered as a json string. But complex objects inside the argument will cause a serialization error. This happens precisely at line 209 of core/dbt/events/functions. 

The spec of `AdapterEventBase`--see line 56--assumes that the `base_msg` is a `str`. However, the `base_msg` can be anything, really, since `logger.debug` may take any exception type. So, if  we force the message given to logger functions to be a string, the spec matches reality and the error vanishes. Local proof of it working on development.

![image](https://user-images.githubusercontent.com/67295367/190897375-d2792dcd-dfd8-4f88-bd1b-2dc786a2fd97.png)

This error is what the user OwenKephart graciously documented over in [Bigquery issue 206](https://github.com/dbt-labs/dbt-bigquery/issues/206) as a desired output for my test case model, designed to fail.

QED.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
