### PR TITLE
add optional shorthand to full refresh command

### DIFF
--- a/.changes/unreleased/Features-20220919-112903.yaml
+++ b/.changes/unreleased/Features-20220919-112903.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: add -fr flag shorthand
+time: 2022-09-19T11:29:03.774678-05:00
+custom:
+  Author: dave-connors-3
+  Issue: "5878"
+  PR: "5879"

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -83,6 +83,7 @@ fail_fast = click.option(
 
 full_refresh = click.option(
     "--full-refresh",
+    "-fr",
     help="If specified, dbt will drop incremental models and fully-recalculate the incremental table from the model definition.",
     is_flag=True,
 )

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -620,6 +620,7 @@ def _add_table_mutability_arguments(*subparsers):
     for sub in subparsers:
         sub.add_argument(
             "--full-refresh",
+            "-fr",
             action="store_true",
             help="""
             If specified, dbt will drop incremental models and

--- a/tests/functional/materializations/test_runtime_materialization.py
+++ b/tests/functional/materializations/test_runtime_materialization.py
@@ -138,20 +138,20 @@ class TestRuntimeMaterialization:
         project,
     ):
         # initial full-refresh should have no effect
-        results = run_dbt(["run", "--full-refresh"])
+        results = run_dbt(["run", "-fr"])
         assert len(results) == 3
 
         check_relations_equal(project.adapter, ["seed", "view", "incremental", "materialized"])
 
         # adds one record to the incremental model. full-refresh should truncate then re-run
         project.run_sql(invalidate_incremental_sql)
-        results = run_dbt(["run", "--full-refresh"])
+        results = run_dbt(["run", "-fr"])
         assert len(results) == 3
         check_relations_equal(project.adapter, ["seed", "incremental"])
 
         project.run_sql(update_sql)
 
-        results = run_dbt(["run", "--full-refresh"])
+        results = run_dbt(["run", "-fr"])
         assert len(results) == 3
 
         check_relations_equal(project.adapter, ["seed", "view", "incremental", "materialized"])
@@ -181,7 +181,7 @@ class TestRuntimeMaterialization:
         project.run_sql(create_incremental__dbt_tmp_sql)
         assert len(results) == 1
 
-        results = run_dbt(["run", "--model", "incremental", "--full-refresh"])
+        results = run_dbt(["run", "--model", "incremental", "-fr"])
         assert len(results) == 1
 
         check_table_does_not_exist(project.adapter, "incremental__dbt_tmp")


### PR DESCRIPTION
resolves #5878 

### Description

Adds an optional shorthand for the `--full-refresh` flag!

`dbt build -fr` for an incremental model passes:

<img width="820" alt="image" src="https://user-images.githubusercontent.com/73915542/191066297-0f525aff-d7fb-48a2-ae35-a143aaf4d04d.png">

and acts as expected:

```
[0m16:11:54.082634 [debug] [Thread-7  ]: Began running node model.davebt.incremental
[0m16:11:54.083352 [info ] [Thread-7  ]: 4 of 5 START sql incremental model dbt_dconnors.incremental .................... [RUN]
[0m16:11:54.085262 [debug] [Thread-7  ]: Acquiring new snowflake connection "model.davebt.incremental"
[0m16:11:54.085788 [debug] [Thread-7  ]: Began compiling node model.davebt.incremental
[0m16:11:54.086130 [debug] [Thread-7  ]: Compiling model.davebt.incremental
[0m16:11:54.104372 [debug] [Thread-7  ]: Writing injected SQL for node "model.davebt.incremental"
[0m16:11:54.105039 [debug] [Thread-7  ]: finished collecting timing info
[0m16:11:54.105302 [debug] [Thread-7  ]: Began executing node model.davebt.incremental
[0m16:11:54.153305 [debug] [Thread-7  ]: Writing runtime sql for node "model.davebt.incremental"
[0m16:11:54.154408 [debug] [Thread-7  ]: Using snowflake connection "model.davebt.incremental"
[0m16:11:54.154609 [debug] [Thread-7  ]: On model.davebt.incremental: /* {"app": "dbt", "dbt_version": "1.3.0b2", "profile_name": "dbt_metrics_integration_tests", "target_name": "snowflake", "node_id": "model.davebt.incremental"} */
create or replace transient table development.dbt_dconnors.incremental  as
        (

with 

final as (

    select * from development.dbt_dconnors.mock_incrementing_source

    
)

select * from final
        );
``` 

Opening as a draft for now, assuming I need some testing here, but didn't find a test that quite looked like the right place at first glance!

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
