### PR TITLE
ConfigSelectorMethod should check for bools

### DIFF
--- a/.changes/unreleased/Fixes-20220920-181856.yaml
+++ b/.changes/unreleased/Fixes-20220920-181856.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: ConfigSelectorMethod should check for bools
+time: 2022-09-20T18:18:56.630628+01:00
+custom:
+  Author: danielcmessias
+  Issue: "5890"
+  PR: "5889"

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -356,7 +356,10 @@ class ConfigSelectorMethod(SelectorMethod):
             except AttributeError:
                 continue
             else:
-                if selector == value:
+                # if the config is a bool then check against the strings "true"/"false"
+                if ((selector == value) or
+                   (value is True and CaseInsensitive(selector) == "true") or
+                   (value is False and CaseInsensitive(selector) == "false")):
                     yield node
 
 

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -356,11 +356,16 @@ class ConfigSelectorMethod(SelectorMethod):
             except AttributeError:
                 continue
             else:
-                # if the config is a bool then check against the strings "true"/"false"
-                if ((selector == value) or
-                   (value is True and CaseInsensitive(selector) == "true") or
-                   (value is False and CaseInsensitive(selector) == "false")):
-                    yield node
+                if isinstance(value, list):
+                    if ((selector in value) or 
+                       (CaseInsensitive(selector) == "true" and True in value) or
+                       (CaseInsensitive(selector) == "false" and False in value)):
+                       yield node
+                else:
+                    if ((selector == value) or
+                    (CaseInsensitive(selector) == "true" and value is True) or
+                    (CaseInsensitive(selector) == "false") and value is False):
+                        yield node
 
 
 class ResourceTypeSelectorMethod(SelectorMethod):

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -357,14 +357,19 @@ class ConfigSelectorMethod(SelectorMethod):
                 continue
             else:
                 if isinstance(value, list):
-                    if ((selector in value) or 
-                       (CaseInsensitive(selector) == "true" and True in value) or
-                       (CaseInsensitive(selector) == "false" and False in value)):
-                       yield node
+                    if (
+                        (selector in value)
+                        or (CaseInsensitive(selector) == "true" and True in value)
+                        or (CaseInsensitive(selector) == "false" and False in value)
+                    ):
+                        yield node
                 else:
-                    if ((selector == value) or
-                    (CaseInsensitive(selector) == "true" and value is True) or
-                    (CaseInsensitive(selector) == "false") and value is False):
+                    if (
+                        (selector == value)
+                        or (CaseInsensitive(selector) == "true" and value is True)
+                        or (CaseInsensitive(selector) == "false")
+                        and value is False
+                    ):
                         yield node
 
 

--- a/test/unit/test_graph_selector_methods.py
+++ b/test/unit/test_graph_selector_methods.py
@@ -471,12 +471,19 @@ def table_model(ephemeral_model):
         'pkg',
         'table_model',
         'select * from {{ ref("ephemeral_model") }}',
-        config_kwargs={'materialized': 'table'},
+         config_kwargs={
+            'materialized': 'table',
+            'meta': {
+            # Other properties to test in test_select_config_variations
+            'string_property': 'some_string',
+            'truthy_bool_property': True,
+            'falsy_bool_property': False,
+            'list_property': ['some_value', True, False]},
+        },
         refs=[ephemeral_model],
         tags=['uses_ephemeral'],
         path='subdirectory/table_model.sql'
     )
-
 
 @pytest.fixture
 def table_model_py(seed):
@@ -779,6 +786,28 @@ def test_select_config_materialized(manifest):
     assert search_manifest_using_method(manifest, method, 'table') == {
         'table_model', 'table_model_py', 'table_model_csv', 'union_model', 'mynamespace.union_model'}
 
+def test_select_config_meta(manifest):
+    methods = MethodManager(manifest, None)
+
+    string_method = methods.get_method('config', ['meta', 'string_property'])
+    assert search_manifest_using_method(manifest, string_method, 'some_string') == {'table_model'}
+    assert not search_manifest_using_method(manifest, string_method, 'other_string') == {'table_model'}
+
+    truthy_bool_method = methods.get_method('config', ['meta', 'truthy_bool_property'])
+    assert search_manifest_using_method(manifest, truthy_bool_method, 'true') == {'table_model'}
+    assert not search_manifest_using_method(manifest, truthy_bool_method, 'false') == {'table_model'}
+    assert not search_manifest_using_method(manifest, truthy_bool_method, 'other') == {'table_model'}
+
+    falsy_bool_method = methods.get_method('config', ['meta', 'falsy_bool_property'])
+    assert search_manifest_using_method(manifest, falsy_bool_method, 'false') == {'table_model'}
+    assert not search_manifest_using_method(manifest, falsy_bool_method, 'true') == {'table_model'}
+    assert not search_manifest_using_method(manifest, falsy_bool_method, 'other') == {'table_model'}
+
+    list_method = methods.get_method('config', ['meta', 'list_property'])
+    assert search_manifest_using_method(manifest, list_method, 'some_value') == {'table_model'}
+    assert search_manifest_using_method(manifest, list_method, 'true') == {'table_model'}
+    assert search_manifest_using_method(manifest, list_method, 'false') == {'table_model'}
+    assert not search_manifest_using_method(manifest, list_method, 'other') == {'table_model'}
 
 def test_select_test_name(manifest):
     methods = MethodManager(manifest, None)

--- a/test/unit/test_graph_selector_methods.py
+++ b/test/unit/test_graph_selector_methods.py
@@ -474,11 +474,12 @@ def table_model(ephemeral_model):
          config_kwargs={
             'materialized': 'table',
             'meta': {
-            # Other properties to test in test_select_config_variations
-            'string_property': 'some_string',
-            'truthy_bool_property': True,
-            'falsy_bool_property': False,
-            'list_property': ['some_value', True, False]},
+                # Other properties to test in test_select_config_meta
+                'string_property': 'some_string',
+                'truthy_bool_property': True,
+                'falsy_bool_property': False,
+                'list_property': ['some_value', True, False]
+            },
         },
         refs=[ephemeral_model],
         tags=['uses_ephemeral'],


### PR DESCRIPTION
# resolves

https://github.com/dbt-labs/dbt-core/issues/5890 
https://github.com/dbt-labs/dbt-core/issues/5482 
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

The `ConfigSelectorMethod` only checks for string equality. If you have a config property that is boolean, there is no way to match it.

Consider the example:

```yaml
# schema.yml
models:
  - name: some_model
    config:
      meta:
        pii: true
```

Then running `dbt  run --select config.meta.pii:true` would not match. The only way for it work would be to encapsulate the property as a string (`pii: "true"`), not ideal.

This is a small change such that if the property is a bool, check (case-insensitively) against the strings "true" / "false".



<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
