### PR TITLE
Manifest deserialization error with disabled models

### DIFF
--- a/core/dbt/contracts/util.py
+++ b/core/dbt/contracts/util.py
@@ -243,13 +243,22 @@ and the up-to-date metric property '{}'. Please remove the deprecated property.
     return data
 
 
+def rename_sql_attr(node_content: dict) -> dict:
+    if "raw_sql" in node_content:
+        node_content["raw_code"] = node_content.pop("raw_sql")
+    if "compiled_sql" in node_content:
+        node_content["compiled_code"] = node_content.pop("compiled_sql")
+    node_content["language"] = "sql"
+    return node_content
+
+
 def upgrade_manifest_json(manifest: dict) -> dict:
     for node_content in manifest.get("nodes", {}).values():
-        if "raw_sql" in node_content:
-            node_content["raw_code"] = node_content.pop("raw_sql")
-        if "compiled_sql" in node_content:
-            node_content["compiled_code"] = node_content.pop("compiled_sql")
-        node_content["language"] = "sql"
+        node_content = rename_sql_attr(node_content)
+    for disabled_unique_id in manifest.get("disabled", {}).values():
+        # There can be multiple disabled nodes for the same unique_id
+        # so make sure all the nodes get the attr renamed
+        node_content = [rename_sql_attr(n) for n in disabled_unique_id]
     for metric_content in manifest.get("metrics", {}).values():
         # handle attr renames + value translation ("expression" -> "derived")
         metric_content = rename_metric_attr(metric_content)

--- a/core/dbt/contracts/util.py
+++ b/core/dbt/contracts/util.py
@@ -255,10 +255,10 @@ def rename_sql_attr(node_content: dict) -> dict:
 def upgrade_manifest_json(manifest: dict) -> dict:
     for node_content in manifest.get("nodes", {}).values():
         node_content = rename_sql_attr(node_content)
-    for disabled_unique_id in manifest.get("disabled", {}).values():
+    for disabled in manifest.get("disabled", {}).values():
         # There can be multiple disabled nodes for the same unique_id
         # so make sure all the nodes get the attr renamed
-        node_content = [rename_sql_attr(n) for n in disabled_unique_id]
+        disabled = [rename_sql_attr(n) for n in disabled]
     for metric_content in manifest.get("metrics", {}).values():
         # handle attr renames + value translation ("expression" -> "derived")
         metric_content = rename_metric_attr(metric_content)


### PR DESCRIPTION
resolves #5883 

### Description

While running v1.3, account for disabled nodes when trying to deserialize a manifest produced by v1.2 (for use with --state comparison functionality)

Note: skipping changelog since this is really a tweak to what we added for current beta

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
