### PR TITLE
improve error message for parsing args

### DIFF
--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -45,10 +45,10 @@ import dbt.tracking
 from dbt.utils import ExitCodes, args_to_dict
 from dbt.config.profile import read_user_config
 from dbt.exceptions import (
+    Exception as dbtException,
     InternalException,
     NotImplementedException,
     FailedToConnectException,
-    ParsingException,
 )
 
 
@@ -149,7 +149,7 @@ def main(args=None):
 
         except BaseException as e:
             fire_event(MainEncounteredError(exc=str(e)))
-            if not isinstance(e, ParsingException):
+            if not isinstance(e, dbtException):
                 fire_event(MainStackTrace(stack_trace=traceback.format_exc()))
             exit_code = ExitCodes.UnhandledError.value
 

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -1,4 +1,5 @@
 from typing import List
+
 from dbt.logger import log_cache_events, log_manager
 
 import argparse
@@ -43,7 +44,12 @@ import dbt.tracking
 
 from dbt.utils import ExitCodes, args_to_dict
 from dbt.config.profile import read_user_config
-from dbt.exceptions import InternalException, NotImplementedException, FailedToConnectException
+from dbt.exceptions import (
+    InternalException,
+    NotImplementedException,
+    FailedToConnectException,
+    ParsingException,
+)
 
 
 class DBTVersion(argparse.Action):
@@ -143,7 +149,8 @@ def main(args=None):
 
         except BaseException as e:
             fire_event(MainEncounteredError(exc=str(e)))
-            fire_event(MainStackTrace(stack_trace=traceback.format_exc()))
+            if not isinstance(e, ParsingException):
+                fire_event(MainStackTrace(stack_trace=traceback.format_exc()))
             exit_code = ExitCodes.UnhandledError.value
 
     sys.exit(exit_code)

--- a/core/dbt/parser/models.py
+++ b/core/dbt/parser/models.py
@@ -88,9 +88,9 @@ class PythonParseVisitor(ast.NodeVisitor):
             return ast.literal_eval(node)
         except (SyntaxError, ValueError, TypeError, MemoryError, RecursionError) as exc:
             msg = validator_error_message(
-                f"Run into the following error when trying to literal_eval an arg \n{exc}\n"
+                f"Error when trying to literal_eval an arg to dbt.ref(), dbt.source(), dbt.config() or dbt.config.get() \n{exc}\n"
                 "https://docs.python.org/3/library/ast.html#ast.literal_eval\n"
-                "In dbt python model, `dbt.ref`, `dbt.source`, `dbt.config` function args only support Python literal structures"
+                "In dbt python model, `dbt.ref`, `dbt.source`, `dbt.config`, `dbt.config.get` function args only support Python literal structures"
             )
             raise ParsingException(msg, node=self.dbt_node) from exc
 

--- a/core/dbt/parser/models.py
+++ b/core/dbt/parser/models.py
@@ -88,9 +88,9 @@ class PythonParseVisitor(ast.NodeVisitor):
             return ast.literal_eval(node)
         except (SyntaxError, ValueError, TypeError, MemoryError, RecursionError) as exc:
             msg = validator_error_message(
-                "In dbt python model, `dbt.ref`, `dbt.source`, `dbt.config` function args only support Python literal structures\n"
+                f"Run into the following error when trying to literal_eval an arg \n{exc}\n"
                 "https://docs.python.org/3/library/ast.html#ast.literal_eval\n"
-                f"Run into the following error when trying to literal_eval an arg \n{exc}"
+                "In dbt python model, `dbt.ref`, `dbt.source`, `dbt.config` function args only support Python literal structures"
             )
             raise ParsingException(msg, node=self.dbt_node) from exc
 

--- a/core/dbt/parser/models.py
+++ b/core/dbt/parser/models.py
@@ -86,11 +86,12 @@ class PythonParseVisitor(ast.NodeVisitor):
     def _safe_eval(self, node):
         try:
             return ast.literal_eval(node)
-        except (SyntaxError, ValueError, TypeError) as exc:
-            msg = validator_error_message(exc)
-            raise ParsingException(msg, node=self.dbt_node) from exc
-        except (MemoryError, RecursionError) as exc:
-            msg = validator_error_message(exc)
+        except (SyntaxError, ValueError, TypeError, MemoryError, RecursionError) as exc:
+            msg = validator_error_message(
+                "In dbt python model, `dbt.ref`, `dbt.source`, `dbt.config` function args only support Python literal structures\n"
+                "https://docs.python.org/3/library/ast.html#ast.literal_eval\n"
+                f"Run into the following error when trying to literal_eval an arg \n{exc}"
+            )
             raise ParsingException(msg, node=self.dbt_node) from exc
 
     def _get_call_literals(self, node):

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -713,6 +713,24 @@ def model(dbt, session):
         with self.assertRaises(CompilationException):
             self.parser.parse_file(block)
 
+    def test_parse_ref_with_non_string(self):
+        py_code = """
+def model(dbt, session):
+
+    model_names = ["orders", "customers"]
+    models = []
+
+    for model_name in model_names:
+        models.extend(dbt.ref(model_name))
+
+    return models[0]
+        """
+        block = self.file_block_for(py_code, 'nested/py_model.py')
+        self.parser.manifest.files[block.file.file_id] = block.file
+        with self.assertRaises(ParsingException):
+            self.parser.parse_file(block)    
+    
+
 
 class StaticModelParserTest(BaseParserTest):
     def setUp(self):


### PR DESCRIPTION
resolves #5887

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Adding more clear error message for parsing error in dbt python model, this is what the new error looks like
```
22:57:25  Running with dbt=1.3.0-b2
22:57:26  Encountered an error:
Parsing Error in model python_model (models/python_model.py)
  Run into the following error when trying to literal_eval an arg 
  malformed node or string: <ast.Name object at 0x14d102970>
  https://docs.python.org/3/library/ast.html#ast.literal_eval
  In dbt python model, `dbt.ref`, `dbt.source`, `dbt.config` function args only support Python literal structures
```
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
