### PR TITLE
update flag to -f

### DIFF
--- a/.changes/unreleased/Fixes-20220922-083926.yaml
+++ b/.changes/unreleased/Fixes-20220922-083926.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: shorthand for full refresh should be one character
+time: 2022-09-22T08:39:26.948671-05:00
+custom:
+  Author: dave-connors-3
+  Issue: "5878"
+  PR: "5908"

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -97,7 +97,7 @@ fail_fast = click.option(
 
 full_refresh = click.option(
     "--full-refresh",
-    "-fr",
+    "-f",
     envvar="DBT_FULL_REFRESH",
     help="If specified, dbt will drop incremental models and fully-recalculate the incremental table from the model definition.",
     is_flag=True,

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -618,7 +618,7 @@ def _add_table_mutability_arguments(*subparsers):
     for sub in subparsers:
         sub.add_argument(
             "--full-refresh",
-            "-fr",
+            "-f",
             action="store_true",
             help="""
             If specified, dbt will drop incremental models and

--- a/tests/functional/materializations/test_runtime_materialization.py
+++ b/tests/functional/materializations/test_runtime_materialization.py
@@ -138,20 +138,20 @@ class TestRuntimeMaterialization:
         project,
     ):
         # initial full-refresh should have no effect
-        results = run_dbt(["run", "-fr"])
+        results = run_dbt(["run", "-f"])
         assert len(results) == 3
 
         check_relations_equal(project.adapter, ["seed", "view", "incremental", "materialized"])
 
         # adds one record to the incremental model. full-refresh should truncate then re-run
         project.run_sql(invalidate_incremental_sql)
-        results = run_dbt(["run", "-fr"])
+        results = run_dbt(["run", "-f"])
         assert len(results) == 3
         check_relations_equal(project.adapter, ["seed", "incremental"])
 
         project.run_sql(update_sql)
 
-        results = run_dbt(["run", "-fr"])
+        results = run_dbt(["run", "-f"])
         assert len(results) == 3
 
         check_relations_equal(project.adapter, ["seed", "view", "incremental", "materialized"])
@@ -181,7 +181,7 @@ class TestRuntimeMaterialization:
         project.run_sql(create_incremental__dbt_tmp_sql)
         assert len(results) == 1
 
-        results = run_dbt(["run", "--model", "incremental", "-fr"])
+        results = run_dbt(["run", "--model", "incremental", "-f"])
         assert len(results) == 1
 
         check_table_does_not_exist(project.adapter, "incremental__dbt_tmp")


### PR DESCRIPTION
resolves #5878

### Description

After some discussion with the great @b-per , the standard for shorthand command line flags is a dash followed by a single character, rather than multiple. This allows for chaining multiple shorthand flags together, and is considered best practice! 

This PR updates the changes merged yesterday to follow this standard. 

Supporting Links!
- [Here!](https://softwareengineering.stackexchange.com/questions/70357/command-line-options-style-posix-or-what)
- [Click docs](https://stackoverflow.com/questions/67145068/does-click-support-bunching-short-options-together)


I will miss `-fr` fr fr

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
