### PR TITLE
Fix adapter reset race condition in lib.py

### DIFF
--- a/core/dbt/lib.py
+++ b/core/dbt/lib.py
@@ -1,10 +1,16 @@
-# TODO: this file is one big TODO
 import os
 from dbt.exceptions import RuntimeException
 from dbt import flags
-from collections import namedtuple
+from dataclasses import dataclass
 
-RuntimeArgs = namedtuple("RuntimeArgs", "project_dir profiles_dir single_threaded profile target")
+
+@dataclass
+class RuntimeArgs:
+    project_dir: str
+    profiles_dir: str
+    single_threaded: bool
+    profile: str
+    target: str
 
 
 def get_dbt_config(project_dir, args=None, single_threaded=False):
@@ -17,27 +23,30 @@ def get_dbt_config(project_dir, args=None, single_threaded=False):
     else:
         profiles_dir = flags.DEFAULT_PROFILES_DIR
 
-    profile = args.profile if hasattr(args, "profile") else None
-    target = args.target if hasattr(args, "target") else None
-
-    # Construct a phony config
-    config = RuntimeConfig.from_args(
-        RuntimeArgs(project_dir, profiles_dir, single_threaded, profile, target)
+    runtime_args = RuntimeArgs(
+        project_dir=project_dir,
+        profiles_dir=profiles_dir,
+        single_threaded=single_threaded,
+        profile=getattr(args, 'profile', None),
+        target=getattr(args, 'target', None),
     )
-    # Clear previously registered adapters--
-    # this fixes cacheing behavior on the dbt-server
+
+    # Construct a RuntimeConfig from phony args
+    config = RuntimeConfig.from_args(runtime_args)
+
+    # Set global flags from arguments
     flags.set_from_args(args, config)
-    dbt.adapters.factory.reset_adapters()
-    # Load the relevant adapter
+
+    # This is idempotent, so we can call it repeatedly
     dbt.adapters.factory.register_adapter(config)
-    # Set invocation id
+
+    # Make sure we have a valid invocation_id
     dbt.events.functions.set_invocation_id()
 
     return config
 
 
 def get_task_by_type(type):
-    # TODO: we need to tell dbt-server what tasks are available
     from dbt.task.run import RunTask
     from dbt.task.list import ListTask
     from dbt.task.seed import SeedTask
@@ -70,16 +79,13 @@ def create_task(type, args, manifest, config):
     def no_op(*args, **kwargs):
         pass
 
-    # TODO: yuck, let's rethink tasks a little
     task = task(args, config)
-
-    # Wow! We can monkeypatch taskCls.load_manifest to return _our_ manifest
     task.load_manifest = no_op
     task.manifest = manifest
     return task
 
 
-def _get_operation_node(manifest, project_path, sql):
+def _get_operation_node(manifest, project_path, sql, node_name):
     from dbt.parser.manifest import process_node
     from dbt.parser.sql import SqlBlockParser
     import dbt.adapters.factory
@@ -92,26 +98,38 @@ def _get_operation_node(manifest, project_path, sql):
     )
 
     adapter = dbt.adapters.factory.get_adapter(config)
-    # TODO : This needs a real name?
-    sql_node = block_parser.parse_remote(sql, "name")
+    sql_node = block_parser.parse_remote(sql, node_name)
     process_node(config, manifest, sql_node)
     return config, sql_node, adapter
 
 
-def compile_sql(manifest, project_path, sql):
+def compile_sql(manifest, project_path, sql, node_name="query"):
     from dbt.task.sql import SqlCompileRunner
 
-    config, node, adapter = _get_operation_node(manifest, project_path, sql)
+    config, node, adapter = _get_operation_node(
+        manifest,
+        project_path,
+        sql,
+        node_name
+    )
+
     runner = SqlCompileRunner(config, adapter, node, 1, 1)
+
     return runner.safe_run(manifest)
 
 
-def execute_sql(manifest, project_path, sql):
+def execute_sql(manifest, project_path, sql, node_name="query"):
     from dbt.task.sql import SqlExecuteRunner
 
-    config, node, adapter = _get_operation_node(manifest, project_path, sql)
+    config, node, adapter = _get_operation_node(
+        manifest,
+        project_path,
+        sql,
+        node_name
+    )
+
     runner = SqlExecuteRunner(config, adapter, node, 1, 1)
-    # TODO: use same interface for runner
+
     return runner.safe_run(manifest)
 
 
@@ -128,5 +146,4 @@ def deserialize_manifest(manifest_msgpack):
 
 
 def serialize_manifest(manifest):
-    # TODO: what should this take as an arg?
     return manifest.to_msgpack()


### PR DESCRIPTION
resolves #5919

### Description

This PR updates the `lib.py` file to avoid mutating global adapter state when generating a RuntimeConfig. This logic was once necessary in order to work around issues with `dbt deps`, though it's fairly clear at this point that we'll need to employ a radically different approach for deps in the future (including higher-order, first-class APIs). In the meantime, this change fixes possible race conditions for concurrent callers of `get_dbt_config`

Additional changes:
- Change RuntimeArgs from a namedtuple to a dataclass fix an error in dbt v1.3.x (via [this PR](https://github.com/dbt-labs/dbt-core/pull/5782), i think)
- Tweaked / fixed up code comments :)
- Made it possible to control manifest sql operation nodes names. Historically, they've been hard-coded to `"name"`. The default value is `query` for backwards compatibility. Just added an optional arg for this

TODO:
 - write tests (would love guidance on the best place to test this! Not sure that we want/need to repro the race condition, but a couple of tests for `lib.py` would be dope here)
 - figure out how to run changie again
 - almost positive black and flake8 are going to yell at me

### Checklist
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
