### PR TITLE
Runtime: Prevent introspective queries at compile (SL only)

### DIFF
--- a/core/dbt/lib.py
+++ b/core/dbt/lib.py
@@ -1,16 +1,13 @@
 # TODO: this file is one big TODO
 # from dataclasses import dataclass
-from collections import namedtuple
 from dataclasses import dataclass
 import os
-from dbt.contracts.results import NodeStatus, RunningStatus, collect_timing_info
+from dbt.contracts.results import RunningStatus, collect_timing_info
 from dbt.events.functions import fire_event
 from dbt.events.types import NodeCompiling, NodeExecuting
 from dbt.exceptions import RuntimeException
 from dbt import flags
-from dbt.task.base import ExecutionContext
 from dbt.task.sql import SqlCompileRunner
-import time
 
 @dataclass
 class RuntimeArgs():

--- a/core/dbt/lib.py
+++ b/core/dbt/lib.py
@@ -17,7 +17,7 @@ class RuntimeArgs():
     profile: str
     target: str
 
-class SqlCompileRunnerNoWarehouseConnection(SqlCompileRunner):
+class SqlCompileRunnerNoIntrospection(SqlCompileRunner):
     def compile_and_execute(self, manifest, ctx):
         """
         This version of this method does not connect to the data warehouse.
@@ -156,7 +156,7 @@ def compile_sql(manifest, project_path, sql):
     # from dbt.task.sql import SqlCompileRunner
 
     config, node, adapter = _get_operation_node(manifest, project_path, sql)
-    runner = SqlCompileRunnerNoWarehouseConnection(config, adapter, node, 1, 1)
+    runner = SqlCompileRunnerNoIntrospection(config, adapter, node, 1, 1)
     return runner.safe_run(manifest)
 
 

--- a/core/dbt/lib.py
+++ b/core/dbt/lib.py
@@ -9,6 +9,7 @@ from dbt.exceptions import RuntimeException
 from dbt import flags
 from dbt.task.sql import SqlCompileRunner
 
+
 @dataclass
 class RuntimeArgs():
     project_dir: str
@@ -16,6 +17,7 @@ class RuntimeArgs():
     single_threaded: bool
     profile: str
     target: str
+
 
 class SqlCompileRunnerNoIntrospection(SqlCompileRunner):
     def compile_and_execute(self, manifest, ctx):
@@ -63,6 +65,7 @@ class SqlCompileRunnerNoIntrospection(SqlCompileRunner):
             ctx.timing.append(timing_info)
 
         return result
+
 
 def get_dbt_config(project_dir, args=None, single_threaded=False):
     from dbt.config.runtime import RuntimeConfig

--- a/test/unit/test_lib.py
+++ b/test/unit/test_lib.py
@@ -1,8 +1,17 @@
 import os
 import unittest
 from unittest import mock
+import dbt
+from dbt.contracts.files import FileHash
+from dbt.contracts.graph.manifest import Manifest
+from dbt.contracts.graph.model_config import NodeConfig
+from dbt.contracts.graph.parsed import ParsedModelNode
 from dbt.contracts.results import RunningStatus
-from dbt.lib import SqlCompileRunnerNoIntrospection
+from dbt.lib import SqlCompileRunnerNoIntrospection, compile_sql
+from dbt.adapters.snowflake import Plugin
+from dbt.node_types import NodeType
+
+from test.unit.utils import clear_plugin, config_from_parts_or_dicts, inject_adapter
 
 
 class TestContext():
@@ -17,26 +26,33 @@ class TestContext():
 class SqlCompileRunnerNoIntrospectionTest(unittest.TestCase):
     def setUp(self):
             self.ctx = TestContext()
-            self.manifest = {'mock':'data'}
+            self.manifest = {'mock':'manifest'}
+            self.adapter = Plugin.adapter({})
+            self.adapter.connection_for = mock.MagicMock()
+            inject_adapter(self.adapter, Plugin)
+
+    def tearDown(self):
+        clear_plugin(Plugin)
 
     def test__compile_and_execute__with_connection(self):
         """
         By default, env var for allowing introspection is true, and calling this
         method should defer to the parent method.
         """
-        with mock.patch('dbt.task.base.BaseRunner.compile_and_execute') as parent_compile:
-            runner = SqlCompileRunnerNoIntrospection(None, None, None, 1, 1)
+        with mock.patch('dbt.task.sql.GenericSqlRunner.compile') as mock_compile:
+            runner = SqlCompileRunnerNoIntrospection({}, self.adapter, None, 1, 1)
             runner.compile_and_execute(self.manifest, self.ctx)
-            parent_compile.assert_called_once_with(self.manifest, self.ctx)
+            mock_compile.assert_called_once_with(self.manifest)
+            self.adapter.connection_for.assert_called_once()
 
+    
     def test__compile_and_execute__without_connection(self):
         """
         This tests only that the proper compile_and_execute is called if introspection is disabled
         """
         with mock.patch.dict(os.environ, {"__DBT_ALLOW_INTROSPECTION": "0"}):
-            with mock.patch('dbt.task.base.BaseRunner.compile_and_execute') as mock_parent_compile:
-                with mock.patch('dbt.task.sql.GenericSqlRunner.compile') as mock_sql_compile:
-                    runner = SqlCompileRunnerNoIntrospection(None, None, None, 1, 1)
-                    runner.compile_and_execute(self.manifest, self.ctx)
-                    mock_parent_compile.assert_not_called()
-                    mock_sql_compile.assert_called_once_with(self.manifest)
+            with mock.patch('dbt.task.sql.GenericSqlRunner.compile') as mock_compile:
+                runner = SqlCompileRunnerNoIntrospection({}, self.adapter, None, 1, 1)
+                runner.compile_and_execute(self.manifest, self.ctx)
+                self.adapter.connection_for.assert_not_called()
+                mock_compile.assert_called_once_with(self.manifest)

--- a/test/unit/test_lib.py
+++ b/test/unit/test_lib.py
@@ -4,6 +4,7 @@ from unittest import mock
 from dbt.contracts.results import RunningStatus
 from dbt.lib import SqlCompileRunnerNoIntrospection
 
+
 class TestContext():
     node = mock.MagicMock()
     node._event_status = {

--- a/test/unit/test_lib.py
+++ b/test/unit/test_lib.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from unittest import mock
 from dbt.contracts.results import RunningStatus
-from dbt.lib import SqlCompileRunnerNoWarehouseConnection
+from dbt.lib import SqlCompileRunnerNoIntrospection
 
 class TestContext():
     node = mock.MagicMock()
@@ -13,7 +13,7 @@ class TestContext():
     timing = []
 
 
-class SqlCompileRunnerNoWarehouseConnectionTest(unittest.TestCase):
+class SqlCompileRunnerNoIntrospectionTest(unittest.TestCase):
     def setUp(self):
             self.ctx = TestContext()
             self.manifest = {'mock':'data'}
@@ -24,7 +24,7 @@ class SqlCompileRunnerNoWarehouseConnectionTest(unittest.TestCase):
         method should defer to the parent method.
         """
         with mock.patch('dbt.task.base.BaseRunner.compile_and_execute') as parent_compile:
-            runner = SqlCompileRunnerNoWarehouseConnection(None, None, None, 1, 1)
+            runner = SqlCompileRunnerNoIntrospection(None, None, None, 1, 1)
             runner.compile_and_execute(self.manifest, self.ctx)
             parent_compile.assert_called_once_with(self.manifest, self.ctx)
 
@@ -35,7 +35,7 @@ class SqlCompileRunnerNoWarehouseConnectionTest(unittest.TestCase):
         with mock.patch.dict(os.environ, {"__DBT_ALLOW_INTROSPECTION": "0"}):
             with mock.patch('dbt.task.base.BaseRunner.compile_and_execute') as mock_parent_compile:
                 with mock.patch('dbt.task.sql.GenericSqlRunner.compile') as mock_sql_compile:
-                    runner = SqlCompileRunnerNoWarehouseConnection(None, None, None, 1, 1)
+                    runner = SqlCompileRunnerNoIntrospection(None, None, None, 1, 1)
                     runner.compile_and_execute(self.manifest, self.ctx)
                     mock_parent_compile.assert_not_called()
                     mock_sql_compile.assert_called_once_with(self.manifest)

--- a/test/unit/test_lib.py
+++ b/test/unit/test_lib.py
@@ -1,18 +1,8 @@
 import os
 import unittest
 from unittest import mock
-import dbt
-from dbt.contracts.files import FileHash
-from dbt.contracts.graph.manifest import Manifest
-from dbt.contracts.graph.model_config import NodeConfig
-from dbt.contracts.graph.parsed import ParsedModelNode
 from dbt.contracts.results import RunningStatus
-from dbt.lib import SqlCompileRunnerNoWarehouseConnection, compile_sql
-from dbt.adapters.snowflake import Plugin
-from dbt.node_types import NodeType
-
-from test.unit.utils import clear_plugin, config_from_parts_or_dicts, inject_adapter
-
+from dbt.lib import SqlCompileRunnerNoWarehouseConnection
 
 class TestContext():
     node = mock.MagicMock()
@@ -26,79 +16,7 @@ class TestContext():
 class SqlCompileRunnerNoWarehouseConnectionTest(unittest.TestCase):
     def setUp(self):
             self.ctx = TestContext()
-            self.maxDiff = None
-
-            self.model_config = NodeConfig.from_dict({
-                'enabled': True,
-                'materialized': 'view',
-                'persist_docs': {},
-                'post-hook': [],
-                'pre-hook': [],
-                'vars': {},
-                'quoting': {},
-                'column_types': {},
-                'tags': [],
-            })
-
-            project_cfg = {
-                'name': 'X',
-                'version': '0.1',
-                'profile': 'test',
-                'project-root': '/tmp/dbt/some-test-project',
-                'config-version': 2,
-            }
-            profile_cfg = {
-                'outputs': {
-                    'test': {
-                        'client_session_keep_alive': False,
-                        'type': 'snowflake',
-                        'database': 'TEST',
-                        'user': 'root',
-                        'account': 'ska12345',
-                        'password': 'password',
-                        'role': 'TESTER',
-                        'schema': 'semantic_layer',
-                        'warehouse': 'test_warehouse'
-                    }
-                },
-                'target': 'test'
-            }
-
-            self.config = config_from_parts_or_dicts(project_cfg, profile_cfg)
-            self.manifest = Manifest(
-              macros={},
-              nodes={
-                  'model.root.view': ParsedModelNode(
-                      name='view',
-                      database='dbt',
-                      schema='analytics',
-                      alias='view',
-                      resource_type=NodeType.Model,
-                      unique_id='model.root.view',
-                      fqn=['root', 'view'],
-                      package_name='root',
-                      root_path='/usr/src/app',
-                      config=self.model_config,
-                      path='view.sql',
-                      original_file_path='view.sql',
-                      language='sql',
-                      raw_code='with cte as (select * from something_else) select * from {{ref("ephemeral")}}',
-                      checksum=FileHash.from_contents(''),
-                  ),
-              },
-              sources={},
-              docs={},
-              disabled=[],
-              files={},
-              exposures={},
-              metrics={},
-              selectors={},
-            )
-            self.adapter = Plugin.adapter(self.config)
-            inject_adapter(self.adapter, Plugin)
-
-    def tearDown(self):
-        clear_plugin(Plugin)
+            self.manifest = {'mock':'data'}
 
     def test__compile_and_execute__with_connection(self):
         """
@@ -106,19 +24,18 @@ class SqlCompileRunnerNoWarehouseConnectionTest(unittest.TestCase):
         method should defer to the parent method.
         """
         with mock.patch('dbt.task.base.BaseRunner.compile_and_execute') as parent_compile:
-            runner = SqlCompileRunnerNoWarehouseConnection(self.config, self.adapter, self.manifest.nodes['model.root.view'], 1, 1)
+            runner = SqlCompileRunnerNoWarehouseConnection(None, None, None, 1, 1)
             runner.compile_and_execute(self.manifest, self.ctx)
             parent_compile.assert_called_once_with(self.manifest, self.ctx)
 
-    
     def test__compile_and_execute__without_connection(self):
         """
         This tests only that the proper compile_and_execute is called if introspection is disabled
         """
         with mock.patch.dict(os.environ, {"__DBT_ALLOW_INTROSPECTION": "0"}):
-            with mock.patch('dbt.task.base.BaseRunner.compile_and_execute') as parent_compile:
-                with mock.patch('dbt.task.sql.GenericSqlRunner.compile') as mock_compile:
-                    runner = SqlCompileRunnerNoWarehouseConnection(self.config, self.adapter, self.manifest.nodes['model.root.view'], 1, 1)
+            with mock.patch('dbt.task.base.BaseRunner.compile_and_execute') as mock_parent_compile:
+                with mock.patch('dbt.task.sql.GenericSqlRunner.compile') as mock_sql_compile:
+                    runner = SqlCompileRunnerNoWarehouseConnection(None, None, None, 1, 1)
                     runner.compile_and_execute(self.manifest, self.ctx)
-                    parent_compile.assert_not_called()
-                    mock_compile.assert_called_once_with(self.manifest)
+                    mock_parent_compile.assert_not_called()
+                    mock_sql_compile.assert_called_once_with(self.manifest)

--- a/test/unit/test_lib.py
+++ b/test/unit/test_lib.py
@@ -1,0 +1,124 @@
+import os
+import unittest
+from unittest import mock
+import dbt
+from dbt.contracts.files import FileHash
+from dbt.contracts.graph.manifest import Manifest
+from dbt.contracts.graph.model_config import NodeConfig
+from dbt.contracts.graph.parsed import ParsedModelNode
+from dbt.contracts.results import RunningStatus
+from dbt.lib import SqlCompileRunnerNoWarehouseConnection, compile_sql
+from dbt.adapters.snowflake import Plugin
+from dbt.node_types import NodeType
+
+from test.unit.utils import clear_plugin, config_from_parts_or_dicts, inject_adapter
+
+
+class TestContext():
+    node = mock.MagicMock()
+    node._event_status = {
+        "node_status": RunningStatus.Started
+    }
+    node.is_ephemeral_model = True
+    timing = []
+
+
+class SqlCompileRunnerNoWarehouseConnectionTest(unittest.TestCase):
+    def setUp(self):
+            self.ctx = TestContext()
+            self.maxDiff = None
+
+            self.model_config = NodeConfig.from_dict({
+                'enabled': True,
+                'materialized': 'view',
+                'persist_docs': {},
+                'post-hook': [],
+                'pre-hook': [],
+                'vars': {},
+                'quoting': {},
+                'column_types': {},
+                'tags': [],
+            })
+
+            project_cfg = {
+                'name': 'X',
+                'version': '0.1',
+                'profile': 'test',
+                'project-root': '/tmp/dbt/some-test-project',
+                'config-version': 2,
+            }
+            profile_cfg = {
+                'outputs': {
+                    'test': {
+                        'client_session_keep_alive': False,
+                        'type': 'snowflake',
+                        'database': 'TEST',
+                        'user': 'root',
+                        'account': 'ska12345',
+                        'password': 'password',
+                        'role': 'TESTER',
+                        'schema': 'semantic_layer',
+                        'warehouse': 'test_warehouse'
+                    }
+                },
+                'target': 'test'
+            }
+
+            self.config = config_from_parts_or_dicts(project_cfg, profile_cfg)
+            self.manifest = Manifest(
+              macros={},
+              nodes={
+                  'model.root.view': ParsedModelNode(
+                      name='view',
+                      database='dbt',
+                      schema='analytics',
+                      alias='view',
+                      resource_type=NodeType.Model,
+                      unique_id='model.root.view',
+                      fqn=['root', 'view'],
+                      package_name='root',
+                      root_path='/usr/src/app',
+                      config=self.model_config,
+                      path='view.sql',
+                      original_file_path='view.sql',
+                      language='sql',
+                      raw_code='with cte as (select * from something_else) select * from {{ref("ephemeral")}}',
+                      checksum=FileHash.from_contents(''),
+                  ),
+              },
+              sources={},
+              docs={},
+              disabled=[],
+              files={},
+              exposures={},
+              metrics={},
+              selectors={},
+            )
+            self.adapter = Plugin.adapter(self.config)
+            inject_adapter(self.adapter, Plugin)
+
+    def tearDown(self):
+        clear_plugin(Plugin)
+
+    def test__compile_and_execute__with_connection(self):
+        """
+        By default, env var for allowing introspection is true, and calling this
+        method should defer to the parent method.
+        """
+        with mock.patch('dbt.task.base.BaseRunner.compile_and_execute') as parent_compile:
+            runner = SqlCompileRunnerNoWarehouseConnection(self.config, self.adapter, self.manifest.nodes['model.root.view'], 1, 1)
+            runner.compile_and_execute(self.manifest, self.ctx)
+            parent_compile.assert_called_once_with(self.manifest, self.ctx)
+
+    
+    def test__compile_and_execute__without_connection(self):
+        """
+        This tests only that the proper compile_and_execute is called if introspection is disabled
+        """
+        with mock.patch.dict(os.environ, {"__DBT_ALLOW_INTROSPECTION": "0"}):
+            with mock.patch('dbt.task.base.BaseRunner.compile_and_execute') as parent_compile:
+                with mock.patch('dbt.task.sql.GenericSqlRunner.compile') as mock_compile:
+                    runner = SqlCompileRunnerNoWarehouseConnection(self.config, self.adapter, self.manifest.nodes['model.root.view'], 1, 1)
+                    runner.compile_and_execute(self.manifest, self.ctx)
+                    parent_compile.assert_not_called()
+                    mock_compile.assert_called_once_with(self.manifest)


### PR DESCRIPTION
resolves #[RUNTIME-443](https://dbtlabs.atlassian.net/browse/RUNTIME-443)

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

This PR conditionally no-ops warehouse connection at compile depending on an env var. This is a temporary solution to more complex permissions requirements for the semantic layer.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
