### PR TITLE
Test for Koalas DataFrames

### DIFF
--- a/tests/adapter/dbt/tests/adapter/python_model/test_spark.py
+++ b/tests/adapter/dbt/tests/adapter/python_model/test_spark.py
@@ -57,6 +57,25 @@ def model(dbt, session):
     return df
 """
 
+KOALAS_MODEL = """
+import databricks.koalas as ks
+
+
+def model(dbt, session):
+    dbt.config(
+        materialized="table",
+    )
+
+    df = ks.DataFrame(
+        {'City': ['Buenos Aires', 'Brasilia', 'Santiago', 'Bogota', 'Caracas'],
+        'Country': ['Argentina', 'Brazil', 'Chile', 'Colombia', 'Venezuela'],
+        'Latitude': [-34.58, -15.78, -33.45, 4.60, 10.48],
+        'Longitude': [-58.66, -47.91, -70.66, -74.08, -66.86]}
+        )
+
+    return df
+"""
+
 
 class BasePySparkTests:
     @pytest.fixture(scope="class")
@@ -65,9 +84,10 @@ class BasePySparkTests:
             "pandas_df.py": PANDAS_MODEL,
             "pyspark_df.py": PYSPARK_MODEL,
             "pandas_on_spark_df.py": PANDAS_ON_SPARK_MODEL,
+            "koalas_df.py": KOALAS_MODEL,
         }
 
     def test_different_dataframes(self, project):
         # test
         results = run_dbt(["run"])
-        assert len(results) == 3
+        assert len(results) == 4


### PR DESCRIPTION
resolves #5927

Continuing work merged in https://github.com/dbt-labs/dbt-core/pull/5906

### Description

Test case for Koalas DataFrames (the predecessor to pandas-on-Spark DataFrames AKA pandas API DataFrames).

### Group of related pull requests
- https://github.com/dbt-labs/dbt-core/pull/5928 (this one)
- https://github.com/dbt-labs/dbt-bigquery/pull/321
- https://github.com/dbt-labs/dbt-spark/pull/474

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] ~I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or~ docs changes are not required/relevant for this PR
- [x] ~I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)~
