### PR TITLE
Allowing partitions in external table to be a list

### DIFF
--- a/.changes/unreleased/Features-20220925-211651.yaml
+++ b/.changes/unreleased/Features-20220925-211651.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Allow partitions in external tables to be supplied as a list
+time: 2022-09-25T21:16:51.051239654+02:00
+custom:
+  Author: pgoslatara
+  Issue: "5929"
+  PR: "5930"

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -232,7 +232,7 @@ class ExternalTable(AdditionalPropertiesAllowed, Mergeable):
     file_format: Optional[str] = None
     row_format: Optional[str] = None
     tbl_properties: Optional[str] = None
-    partitions: Optional[List[ExternalPartition]] = None
+    partitions: Optional[Union[List[str], List[ExternalPartition]]] = None
 
     def __bool__(self):
         return self.location is not None


### PR DESCRIPTION
resolves #5929

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

Allow partitions in external tables to be a list of values. Currently both `name` and `data_type` keys are required for each column. This PR on dbt-external-tables` seeks to simplify specifying partitions for Spark/Databricks connections.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
