### PR TITLE
CT-1150: Include flat_graph in manifest.deepcopy(), tests

### DIFF
--- a/.changes/unreleased/Under the Hood-20220929-134406.yaml
+++ b/.changes/unreleased/Under the Hood-20220929-134406.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Added flat_graph attribute the Manifest class's deepcopy() coverage
+time: 2022-09-29T13:44:06.275941-04:00
+custom:
+  Author: peterallenwebb
+  Issue: "5809"
+  PR: "5975"

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -780,7 +780,7 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         return frozenset(x.database for x in chain(self.nodes.values(), self.sources.values()))
 
     def deepcopy(self):
-        return Manifest(
+        copy = Manifest(
             nodes={k: _deepcopy(v) for k, v in self.nodes.items()},
             sources={k: _deepcopy(v) for k, v in self.sources.items()},
             macros={k: _deepcopy(v) for k, v in self.macros.items()},
@@ -793,6 +793,8 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
             files={k: _deepcopy(v) for k, v in self.files.items()},
             state_check=_deepcopy(self.state_check),
         )
+        copy.build_flat_graph()
+        return copy
 
     def build_parent_and_child_maps(self):
         edge_members = list(

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -547,6 +547,34 @@ class ManifestTest(unittest.TestCase):
         resource_fqns = manifest.get_resource_fqns()
         self.assertEqual(resource_fqns, expect)
 
+    def test__deepcopy_copies_flat_graph(self):
+        test_node = ParsedModelNode(
+                name='events',
+                database='dbt',
+                schema='analytics',
+                alias='events',
+                resource_type=NodeType.Model,
+                unique_id='model.snowplow.events',
+                fqn=['snowplow', 'events'],
+                package_name='snowplow',
+                refs=[],
+                sources=[],
+                metrics=[],
+                depends_on=DependsOn(),
+                config=self.model_config,
+                tags=[],
+                path='events.sql',
+                original_file_path='events.sql',
+                root_path='',
+                meta={},
+                language='sql',
+                raw_code='does not matter',
+                checksum=FileHash.empty())
+
+        original = make_manifest(nodes=[test_node])
+        original.build_flat_graph()
+        copy = original.deepcopy()
+        self.assertEqual(original.flat_graph, copy.flat_graph)
 
 class MixedManifestTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
resolves #5809 

### Description

Adds the flat_graph attribute to set of Manifest class elements that are copied by deepcopy(), correcting what was presumably an oversight.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
