### PR TITLE
fix - error while generating docs

### DIFF
--- a/.changes/unreleased/Fixes-20221008-222008.yaml
+++ b/.changes/unreleased/Fixes-20221008-222008.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: ' error while generating docs for database designed without schema'
+time: 2022-10-08T22:20:08.559477815+08:00
+custom:
+  Author: forestlzj
+  Issue: "6031"
+  PR: "6032"

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -49,7 +49,7 @@ from dbt.events.types import (
     CodeExecution,
     CodeExecutionStatus,
 )
-from dbt.utils import filter_null_values, executor
+from dbt.utils import filter_null_values, executor, lowercase
 
 from dbt.adapters.base.connections import Connection, AdapterResponse
 from dbt.adapters.base.meta import AdapterMeta, available
@@ -83,7 +83,7 @@ def _catalog_filter_schemas(manifest: Manifest) -> Callable[[agate.Row], bool]:
     """Return a function that takes a row and decides if the row should be
     included in the catalog output.
     """
-    schemas = frozenset((d.lower(), s.lower()) for d, s in manifest.get_used_schemas())
+    schemas = frozenset((lowercase(d), lowercase(s)) for d, s in manifest.get_used_schemas())
 
     def test(row: agate.Row) -> bool:
         table_database = _expect_row_value("table_database", row)


### PR DESCRIPTION
some databases don't have schema , it will have error when generating docs: Encountered an error while generating catalog: 'NoneType' object has no attribute 'lower'  

This is to fix this issue

resolves #6031 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
