### PR TITLE
fix: check length of args of python model function before accessing i…

### DIFF
--- a/.changes/unreleased/Fixes-20221011-160715.yaml
+++ b/.changes/unreleased/Fixes-20221011-160715.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: check length of args of python model function before accessing it
+time: 2022-10-11T16:07:15.464093-04:00
+custom:
+  Author: chamini2
+  Issue: "6041"
+  PR: "6042"

--- a/core/dbt/parser/models.py
+++ b/core/dbt/parser/models.py
@@ -45,7 +45,7 @@ class PythonValidationVisitor(ast.NodeVisitor):
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         if node.name == "model":
             self.num_model_def += 1
-            if not node.args.args[0].arg == "dbt":
+            if node.args.args and not node.args.args[0].arg == "dbt":
                 self.dbt_errors.append("'dbt' not provided for model as the first argument")
             if len(node.args.args) != 2:
                 self.dbt_errors.append(

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -623,7 +623,17 @@ def model(dbt):
         self.parser.manifest.files[block.file.file_id] = block.file
         with self.assertRaises(ParsingException):
             self.parser.parse_file(block)
-    
+
+    def test_wrong_python_model_def_miss_session(self):
+        py_code = """
+def model():
+    return df
+        """
+        block = self.file_block_for(py_code, 'nested/py_model.py')
+        self.parser.manifest.files[block.file.file_id] = block.file
+        with self.assertRaises(ParsingException):
+            self.parser.parse_file(block)
+
     def test_wrong_python_model_def_wrong_arg(self):
         """ First argument for python model should be dbt
         """


### PR DESCRIPTION
…t (#6042)

* fix: check length of args of python model function before accessing it

* Add test

* changie

(cherry picked from commit dcd6ef733b4665393e2bef09ae4a2e542692f28e)

resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
