### PR TITLE
CT-1349, create dynamic sources

### DIFF
--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -290,6 +290,12 @@ class UnparsedSourceDefinition(dbtClassMixin, Replaceable):
 
 
 @dataclass
+class UnparsedDynamicSourceDefinition(UnparsedSourceDefinition):
+    tables_exclude_pattern: Optional[str] = None
+    tables_include_pattern: Optional[str] = None
+
+
+@dataclass
 class SourceTablePatch(dbtClassMixin):
     name: str
     description: Optional[str] = None

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -11,6 +11,7 @@ from dbt.contracts.graph.unparsed import UnparsedSourceTableDefinition
 from dbt.dataclass_schema import ValidationError, dbtClassMixin
 
 from dbt.adapters.factory import get_adapter, get_adapter_package_names
+from dbt.adapters.base import BaseRelation
 from dbt.clients.jinja import get_rendered, add_rendered_test_kwargs
 from dbt.clients.yaml_helper import load_yaml_text
 from dbt.parser.schema_renderer import SchemaYamlRenderer
@@ -80,6 +81,7 @@ from dbt.parser.generic_test_builders import (
 from dbt.ui import warning_tag
 from dbt.utils import get_pseudo_test_path, coerce_dict_str
 
+import re
 
 TestDef = Union[str, Dict[str, Any]]
 


### PR DESCRIPTION
resolves CT-1349(https://github.com/dbt-labs/dbt-core/issues/6067)

### Description

Creates a sub-type of "sources" named "dynamic_sources", user can define the source by specifying the following:
- The schema
- The regex for tables includes pattern
- The regex for tables excludes pattern
i.e.
```dynamic_sources:
  - name: dbt_alice
    schema: dbt_alice
    tables_exclude_pattern: raw_\S+_tmp
    tables_include_pattern: raw_\S+
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
