### PR TITLE
Updated string formatting on non-f-strings.

### DIFF
--- a/.changes/unreleased/Under the Hood-20221017-151511.yaml
+++ b/.changes/unreleased/Under the Hood-20221017-151511.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Fixed extra whitespace in strings introduced by black.
+time: 2022-10-17T15:15:11.499246-05:00
+custom:
+  Author: luke-bassett
+  Issue: "1350"
+  PR: "6086"

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -581,7 +581,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         :rtype: List[self.Relation]
         """
         raise NotImplementedException(
-            "`list_relations_without_caching` is not implemented for this " "adapter!"
+            "`list_relations_without_caching` is not implemented for this adapter!"
         )
 
     ###

--- a/core/dbt/clients/_jinja_blocks.py
+++ b/core/dbt/clients/_jinja_blocks.py
@@ -367,9 +367,9 @@ class BlockIterator:
         if self.current:
             linecount = self.data[: self.current.end].count("\n") + 1
             dbt.exceptions.raise_compiler_error(
-                (
-                    "Reached EOF without finding a close tag for " "{} (searched from line {})"
-                ).format(self.current.block_type_name, linecount)
+                ("Reached EOF without finding a close tag for {} (searched from line {})").format(
+                    self.current.block_type_name, linecount
+                )
             )
 
         if collect_raw_data:

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -248,7 +248,7 @@ class PartialProject(RenderComponents):
     project_name: Optional[str] = field(
         metadata=dict(
             description=(
-                "The name of the project. This should always be set and will not " "be rendered"
+                "The name of the project. This should always be set and will not be rendered"
             )
         )
     )

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -126,7 +126,7 @@ class ContextMeta(type):
 
 
 class Var:
-    UndefinedVarError = "Required var '{}' not found in config:\nVars " "supplied to {} = {}"
+    UndefinedVarError = "Required var '{}' not found in config:\nVars supplied to {} = {}"
     _VAR_NOTSET = object()
 
     def __init__(

--- a/core/dbt/contracts/connection.py
+++ b/core/dbt/contracts/connection.py
@@ -94,7 +94,7 @@ class Connection(ExtensibleDbtClassMixin, Replaceable):
                 self._handle.resolve(self)
             except RecursionError as exc:
                 raise InternalException(
-                    "A connection's open() method attempted to read the " "handle value"
+                    "A connection's open() method attempted to read the handle value"
                 ) from exc
         return self._handle
 

--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -339,7 +339,7 @@ def process_freshness_result(result: FreshnessNodeResult) -> FreshnessNodeOutput
     criteria = result.node.freshness
     if criteria is None:
         raise InternalException(
-            "Somehow evaluated a freshness result for a source " "that has no freshness criteria!"
+            "Somehow evaluated a freshness result for a source that has no freshness criteria!"
         )
     return SourceFreshnessOutput(
         unique_id=unique_id,

--- a/core/dbt/graph/graph.py
+++ b/core/dbt/graph/graph.py
@@ -90,7 +90,7 @@ class Graph:
         for node in include_nodes:
             if node not in new_graph:
                 raise ValueError(
-                    "Couldn't find model '{}' -- does it exist or is " "it disabled?".format(node)
+                    "Couldn't find model '{}' -- does it exist or is it disabled?".format(node)
                 )
 
         return Graph(new_graph)

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -28,9 +28,7 @@ if sys.platform == "win32" and (not os.getenv("TERM") or os.getenv("TERM") == "N
     colorama.init(wrap=True)
 
 STDOUT_LOG_FORMAT = "{record.message}"
-DEBUG_LOG_FORMAT = (
-    "{record.time:%Y-%m-%d %H:%M:%S.%f%z} " "({record.thread_name}): " "{record.message}"
-)
+DEBUG_LOG_FORMAT = "{record.time:%Y-%m-%d %H:%M:%S.%f%z} ({record.thread_name}): {record.message}"
 
 
 def get_secret_env() -> List[str]:

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -298,7 +298,7 @@ class SchemaParser(SimpleParser[GenericTestBlock, ParsedGenericTestNode]):
 
         except ParsingException as exc:
             context = _trimmed(str(target))
-            msg = "Invalid test config given in {}:" "\n\t{}\n\t@: {}".format(
+            msg = "Invalid test config given in {}:\n\t{}\n\t@: {}".format(
                 target.original_file_path, exc.msg, context
             )
             raise ParsingException(msg) from exc

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -317,7 +317,7 @@ class SourcePatcher:
         unused_tables: Dict[SourceKey, Optional[Set[str]]],
     ) -> str:
         msg = [
-            "During parsing, dbt encountered source overrides that had no " "target:",
+            "During parsing, dbt encountered source overrides that had no target:",
         ]
         for key, table_names in unused_tables.items():
             patch = self.manifest.source_patches[key]

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -461,7 +461,7 @@ class BaseRunner(metaclass=ABCMeta):
                 print_run_result_error(result=self.skip_cause, newline=False)
                 if self.skip_cause is None:  # mypy appeasement
                     raise InternalException(
-                        "Skip cause not set but skip was somehow caused by " "an ephemeral failure"
+                        "Skip cause not set but skip was somehow caused by an ephemeral failure"
                     )
                 # set an error so dbt will exit with an error code
                 error_message = (

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -64,7 +64,7 @@ class CompileTask(GraphRunnableTask):
         state = self.previous_state
         if state is None:
             raise RuntimeException(
-                "Received a --defer argument, but no value was provided " "to --state"
+                "Received a --defer argument, but no value was provided to --state"
             )
 
         if state.manifest is None:
@@ -77,7 +77,7 @@ class CompileTask(GraphRunnableTask):
             return
         if self.manifest is None:
             raise InternalException(
-                "Expected to defer to manifest, but there is no runtime " "manifest to defer from!"
+                "Expected to defer to manifest, but there is no runtime manifest to defer from!"
             )
         self.manifest.merge_from_artifact(
             adapter=adapter,

--- a/core/dbt/task/freshness.py
+++ b/core/dbt/task/freshness.py
@@ -135,7 +135,7 @@ class FreshnessRunner(BaseRunner):
         # broken, raise!
         if compiled_node.loaded_at_field is None:
             raise InternalException(
-                "Got to execute for source freshness of a source that has no " "loaded_at_field!"
+                "Got to execute for source freshness of a source that has no loaded_at_field!"
             )
 
         relation = self.adapter.Relation.create_from_source(compiled_node)

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -459,7 +459,7 @@ class GraphRunnableTask(ManifestTask):
         if len(self._flattened_nodes) == 0:
             with TextOnly():
                 fire_event(EmptyLine())
-            msg = "Nothing to do. Try checking your model " "configs and model specification args"
+            msg = "Nothing to do. Try checking your model configs and model specification args"
             warn_or_error(msg, log_fmt=warning_tag("{}"))
             result = self.get_result(
                 results=[],

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -491,11 +491,11 @@ class SingleThreadedExecutor(ConnectingExecutor):
             self, fn, *args = args
         elif not args:
             raise TypeError(
-                "descriptor 'submit' of 'SingleThreadedExecutor' object needs " "an argument"
+                "descriptor 'submit' of 'SingleThreadedExecutor' object needs an argument"
             )
         else:
             raise TypeError(
-                "submit expected at least 1 positional argument, " "got %d" % (len(args) - 1)
+                "submit expected at least 1 positional argument, got %d" % (len(args) - 1)
             )
         fut = concurrent.futures.Future()
         try:

--- a/tests/functional/artifacts/expected_manifest.py
+++ b/tests/functional/artifacts/expected_manifest.py
@@ -1275,7 +1275,7 @@ def expected_references_manifest(project):
             },
             "test.view_summary": {
                 "block_contents": (
-                    "A view of the summary of the ephemeral copy of the " "seed data"
+                    "A view of the summary of the ephemeral copy of the seed data"
                 ),
                 "name": "view_summary",
                 "original_file_path": docs_path,


### PR DESCRIPTION
### resolves
This resolves the non-f-string portion of this issue https://github.com/dbt-labs/dbt-core/issues/6068. The rest was covered by this PR https://github.com/dbt-labs/dbt-core/pull/6082.

### Description

Found all cases of strings separated by white space on a single line and
removed white space separation. EX: "hello " "world" -> "hello world".

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
