### PR TITLE
Add ALLOW_UNUSED_CONFIG_PATHS flag

### DIFF
--- a/.changes/unreleased/Features-20221017-170747.yaml
+++ b/.changes/unreleased/Features-20221017-170747.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: New ALLOW_UNUSED_CONFIG_PATHS flag
+time: 2022-10-17T17:07:47.601694-05:00
+custom:
+  Author: katieclaiborne felippecaso
+  Issue: "6080"
+  PR: "6091"

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -45,6 +45,7 @@ NO_PRINT = None
 CACHE_SELECTED_ONLY = None
 TARGET_PATH = None
 LOG_PATH = None
+ALLOW_UNUSED_CONFIG_PATHS = None
 
 _NON_BOOLEAN_FLAGS = [
     "LOG_FORMAT",
@@ -84,6 +85,7 @@ flag_defaults = {
     "CACHE_SELECTED_ONLY": False,
     "TARGET_PATH": None,
     "LOG_PATH": None,
+    "ALLOW_UNUSED_CONFIG_PATHS": True,
 }
 
 
@@ -134,7 +136,7 @@ def set_from_args(args, user_config):
     global WRITE_JSON, PARTIAL_PARSE, USE_COLORS, STORE_FAILURES, PROFILES_DIR, DEBUG, LOG_FORMAT
     global INDIRECT_SELECTION, VERSION_CHECK, FAIL_FAST, SEND_ANONYMOUS_USAGE_STATS
     global PRINTER_WIDTH, WHICH, LOG_CACHE_EVENTS, EVENT_BUFFER_SIZE, QUIET, NO_PRINT, CACHE_SELECTED_ONLY
-    global TARGET_PATH, LOG_PATH
+    global TARGET_PATH, LOG_PATH, ALLOW_UNUSED_CONFIG_PATHS
 
     STRICT_MODE = False  # backwards compatibility
     # cli args without user_config or env var option
@@ -164,6 +166,7 @@ def set_from_args(args, user_config):
     CACHE_SELECTED_ONLY = get_flag_value("CACHE_SELECTED_ONLY", args, user_config)
     TARGET_PATH = get_flag_value("TARGET_PATH", args, user_config)
     LOG_PATH = get_flag_value("LOG_PATH", args, user_config)
+    ALLOW_UNUSED_CONFIG_PATHS = get_flag_value("ALLOW_UNUSED_CONFIG_PATHS", args, user_config)
 
     _set_overrides_from_env()
 
@@ -245,4 +248,5 @@ def get_flag_dict():
         "event_buffer_size": EVENT_BUFFER_SIZE,
         "quiet": QUIET,
         "no_print": NO_PRINT,
+        "allow_unused_config_paths": ALLOW_UNUSED_CONFIG_PATHS,
     }

--- a/test/unit/test_flags.py
+++ b/test/unit/test_flags.py
@@ -276,3 +276,17 @@ class TestFlags(TestCase):
         os.environ.pop('DBT_EVENT_BUFFER_SIZE')
         delattr(self.args, 'event_buffer_size')
         self.user_config.event_buffer_size = None
+
+         # allow_unused_config_paths
+        self.user_config.allow_unused_config_paths = True
+        flags.set_from_args(self.args, self.user_config)
+        self.assertEqual(flags.ALLOW_UNUSED_CONFIG_PATHS, True)
+        os.environ['DBT_ALLOW_UNUSED_CONFIG_PATHS'] = 'false'
+        flags.set_from_args(self.args, self.user_config)
+        self.assertEqual(flags.ALLOW_UNUSED_CONFIG_PATHS, False)
+        setattr(self.args, 'allow_unused_config_paths', True)
+        flags.set_from_args(self.args, self.user_config)
+        self.assertEqual(flags.ALLOW_UNUSED_CONFIG_PATHS, True)
+        # cleanup
+        os.environ.pop('DBT_ALLOW_UNUSED_CONFIG_PATHS')
+        delattr(self.args, 'allow_unused_config_paths')

--- a/tests/functional/context_methods/test_builtin_functions.py
+++ b/tests/functional/context_methods/test_builtin_functions.py
@@ -112,7 +112,7 @@ class TestContextBuiltins:
         expected = "invocation_result: {'debug': True, 'log_format': 'json', 'write_json': True, 'use_colors': True, 'printer_width': 80, 'version_check': True, 'partial_parse': True, 'static_parser': True, 'profiles_dir': "
         assert expected in str(result)
 
-        expected = "'send_anonymous_usage_stats': False, 'event_buffer_size': 100000, 'quiet': False, 'no_print': False, 'macro': 'validate_invocation', 'args': '{my_variable: test_variable}', 'which': 'run-operation', 'rpc_method': 'run-operation', 'indirect_selection': 'eager'}"
+        expected = "'send_anonymous_usage_stats': False, 'event_buffer_size': 100000, 'quiet': False, 'no_print': False, 'macro': 'validate_invocation', 'args': '{my_variable: test_variable}', 'which': 'run-operation', 'rpc_method': 'run-operation', 'indirect_selection': 'eager', 'allow_unused_config_paths': True}"
         assert expected in str(result)
 
     def test_builtin_dbt_metadata_envs_function(self, project, monkeypatch):


### PR DESCRIPTION
resolves #6080

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->
Added a new `ALLOW_UNUSED_CONFIG_PATHS` flag, which can be used to raise an error when unused config paths are present.
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
