### PR TITLE
Add unit tests per Colin's idea

### DIFF
--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -75,6 +75,15 @@ class TestAdapterLogger:
         event = AdapterEventDebug(name="dbt_tests", base_msg="boop{x}boop", args=())
         assert "boop{x}boop" in event.message()
 
+        # ensure AdapterLogger and subclasses makes all base_msg members
+        # of type string; when someone writes logger.debug(a) where a is
+        # any non-string object
+        event = AdapterEventDebug(name="dbt_tests", base_msg=[1,2,3], args=(3,))
+        assert isinstance(event.base_msg, str)
+
+        event = MacroEventDebug(msg=[1,2,3])
+        assert isinstance(event.msg, str)
+
 
 class TestEventCodes:
 


### PR DESCRIPTION
### Description

Add unit tests for recent stringifier functors added to events library.

@colin-rogers-dbt raised the possibility of this for #5874 and after considering it, I figured, hey, we might as well.

The tests added will fail unless the so-called Functor classes that have `__post_init__`s are included.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR