### PR TITLE
Create --macro-state-in-respective-node option

### DIFF
--- a/.changes/unreleased/Features-20221018-221612.yaml
+++ b/.changes/unreleased/Features-20221018-221612.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Option for --macro-state-in-respective-node
+time: 2022-10-18T22:16:12.4911753-05:00
+custom:
+  Author: karunpoudel
+  Issue: "5922"
+  PR: "6101"

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -198,12 +198,68 @@ class NodeInfoMixin:
 
 
 @dataclass
+class ParsedPatch(HasYamlMetadata, Replaceable):
+    name: str
+    description: str
+    meta: Dict[str, Any]
+    docs: Docs
+    config: Dict[str, Any]
+
+
+# The parsed node update is only the 'patch', not the test. The test became a
+# regular parsed node. Note that description and columns must be present, but
+# may be empty.
+@dataclass
+class ParsedNodePatch(ParsedPatch):
+    columns: Dict[str, ColumnInfo]
+
+
+@dataclass
+class ParsedMacroPatch(ParsedPatch):
+    arguments: List[MacroArgument] = field(default_factory=list)
+
+
+@dataclass
+class ParsedMacro(UnparsedBaseNode, HasUniqueID):
+    name: str
+    macro_sql: str
+    resource_type: NodeType = field(metadata={"restrict": [NodeType.Macro]})
+    # TODO: can macros even have tags?
+    tags: List[str] = field(default_factory=list)
+    # TODO: is this ever populated?
+    depends_on: MacroDependsOn = field(default_factory=MacroDependsOn)
+    description: str = ""
+    meta: Dict[str, Any] = field(default_factory=dict)
+    docs: Docs = field(default_factory=Docs)
+    patch_path: Optional[str] = None
+    arguments: List[MacroArgument] = field(default_factory=list)
+    created_at: float = field(default_factory=lambda: time.time())
+    supported_languages: Optional[List[ModelLanguage]] = None
+
+    def patch(self, patch: ParsedMacroPatch):
+        self.patch_path: Optional[str] = patch.file_id
+        self.description = patch.description
+        self.created_at = time.time()
+        self.meta = patch.meta
+        self.docs = patch.docs
+        self.arguments = patch.arguments
+
+    def same_contents(self, other: Optional["ParsedMacro"]) -> bool:
+        if other is None:
+            return False
+        # the only thing that makes one macro different from another with the
+        # same name/package is its content
+        return self.macro_sql == other.macro_sql
+
+
+@dataclass
 class ParsedNodeDefaults(NodeInfoMixin, ParsedNodeMandatory):
     tags: List[str] = field(default_factory=list)
     refs: List[List[str]] = field(default_factory=list)
     sources: List[List[str]] = field(default_factory=list)
     metrics: List[List[str]] = field(default_factory=list)
     depends_on: DependsOn = field(default_factory=DependsOn)
+    dependent_macro_state: Dict[str, ParsedMacro] = field(default_factory=dict)
     description: str = field(default="")
     columns: Dict[str, ColumnInfo] = field(default_factory=dict)
     meta: Dict[str, Any] = field(default_factory=dict)
@@ -482,61 +538,6 @@ class IntermediateSnapshotNode(ParsedNode):
 class ParsedSnapshotNode(ParsedNode):
     resource_type: NodeType = field(metadata={"restrict": [NodeType.Snapshot]})
     config: SnapshotConfig
-
-
-@dataclass
-class ParsedPatch(HasYamlMetadata, Replaceable):
-    name: str
-    description: str
-    meta: Dict[str, Any]
-    docs: Docs
-    config: Dict[str, Any]
-
-
-# The parsed node update is only the 'patch', not the test. The test became a
-# regular parsed node. Note that description and columns must be present, but
-# may be empty.
-@dataclass
-class ParsedNodePatch(ParsedPatch):
-    columns: Dict[str, ColumnInfo]
-
-
-@dataclass
-class ParsedMacroPatch(ParsedPatch):
-    arguments: List[MacroArgument] = field(default_factory=list)
-
-
-@dataclass
-class ParsedMacro(UnparsedBaseNode, HasUniqueID):
-    name: str
-    macro_sql: str
-    resource_type: NodeType = field(metadata={"restrict": [NodeType.Macro]})
-    # TODO: can macros even have tags?
-    tags: List[str] = field(default_factory=list)
-    # TODO: is this ever populated?
-    depends_on: MacroDependsOn = field(default_factory=MacroDependsOn)
-    description: str = ""
-    meta: Dict[str, Any] = field(default_factory=dict)
-    docs: Docs = field(default_factory=Docs)
-    patch_path: Optional[str] = None
-    arguments: List[MacroArgument] = field(default_factory=list)
-    created_at: float = field(default_factory=lambda: time.time())
-    supported_languages: Optional[List[ModelLanguage]] = None
-
-    def patch(self, patch: ParsedMacroPatch):
-        self.patch_path: Optional[str] = patch.file_id
-        self.description = patch.description
-        self.created_at = time.time()
-        self.meta = patch.meta
-        self.docs = patch.docs
-        self.arguments = patch.arguments
-
-    def same_contents(self, other: Optional["ParsedMacro"]) -> bool:
-        if other is None:
-            return False
-        # the only thing that makes one macro different from another with the
-        # same name/package is its content
-        return self.macro_sql == other.macro_sql
 
 
 @dataclass

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -254,6 +254,7 @@ class UserConfig(ExtensibleDbtClassMixin, Replaceable, UserConfigContract):
     indirect_selection: Optional[str] = None
     cache_selected_only: Optional[bool] = None
     event_buffer_size: Optional[int] = None
+    macro_state_in_respective_node: Optional[bool] = None
 
 
 @dataclass

--- a/core/dbt/contracts/state.py
+++ b/core/dbt/contracts/state.py
@@ -7,9 +7,12 @@ from dbt.exceptions import IncompatibleSchemaException
 
 
 class PreviousState:
-    def __init__(self, path: Path, current_path: Path):
+    def __init__(
+        self, path: Path, current_path: Path, macro_state_in_respective_node: bool = False
+    ):
         self.path: Path = path
         self.current_path: Path = current_path
+        self.macro_state_in_respective_node = macro_state_in_respective_node
         self.manifest: Optional[WritableManifest] = None
         self.results: Optional[RunResultsArtifact] = None
         self.sources: Optional[FreshnessExecutionResultArtifact] = None

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -45,6 +45,7 @@ NO_PRINT = None
 CACHE_SELECTED_ONLY = None
 TARGET_PATH = None
 LOG_PATH = None
+MACRO_STATE_IN_RESPECTIVE_NODE = None
 
 _NON_BOOLEAN_FLAGS = [
     "LOG_FORMAT",
@@ -84,6 +85,7 @@ flag_defaults = {
     "CACHE_SELECTED_ONLY": False,
     "TARGET_PATH": None,
     "LOG_PATH": None,
+    "MACRO_STATE_IN_RESPECTIVE_NODE": False,
 }
 
 
@@ -134,7 +136,7 @@ def set_from_args(args, user_config):
     global WRITE_JSON, PARTIAL_PARSE, USE_COLORS, STORE_FAILURES, PROFILES_DIR, DEBUG, LOG_FORMAT
     global INDIRECT_SELECTION, VERSION_CHECK, FAIL_FAST, SEND_ANONYMOUS_USAGE_STATS
     global PRINTER_WIDTH, WHICH, LOG_CACHE_EVENTS, EVENT_BUFFER_SIZE, QUIET, NO_PRINT, CACHE_SELECTED_ONLY
-    global TARGET_PATH, LOG_PATH
+    global TARGET_PATH, LOG_PATH, MACRO_STATE_IN_RESPECTIVE_NODE
 
     STRICT_MODE = False  # backwards compatibility
     # cli args without user_config or env var option
@@ -164,6 +166,9 @@ def set_from_args(args, user_config):
     CACHE_SELECTED_ONLY = get_flag_value("CACHE_SELECTED_ONLY", args, user_config)
     TARGET_PATH = get_flag_value("TARGET_PATH", args, user_config)
     LOG_PATH = get_flag_value("LOG_PATH", args, user_config)
+    MACRO_STATE_IN_RESPECTIVE_NODE = get_flag_value(
+        "MACRO_STATE_IN_RESPECTIVE_NODE", args, user_config
+    )
 
     _set_overrides_from_env()
 

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -596,6 +596,16 @@ def _add_common_selector_arguments(sub):
         type=Path,
         default=flags.ARTIFACT_STATE_PATH,
     )
+    sub.add_argument(
+        "--macro-state-in-respective-node",
+        action="store_const",
+        const=True,
+        default=None,
+        help="""
+        To be used with --state argument. If set, read the macro's state from 'dependent_macro_state' field in the
+        respective resource node.
+        """,
+    )
 
 
 def _add_selection_arguments(*subparsers):

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -121,7 +121,9 @@ class GraphRunnableTask(ManifestTask):
     def set_previous_state(self):
         if self.args.state is not None:
             self.previous_state = PreviousState(
-                path=self.args.state, current_path=Path(self.config.target_path)
+                path=self.args.state,
+                current_path=Path(self.config.target_path),
+                macro_state_in_respective_node=self.args.macro_state_in_respective_node,
             )
 
     def index_offset(self, value: int) -> int:


### PR DESCRIPTION
resolves #5922

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Add an optional field in ParsedNode called dependent_macro_state that will be referenced for the model's dependent macro's definitions when --state parameter is used with new parameter --macro-state-in-respective-node. The --select state:modified selector will read the macro_sql from dependent_macro_state field instead of the existing macros field in manifest when parameter --macro-state-in-respective-node is provided

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
