### PR TITLE
switch out to use internal action for triage labels

### DIFF
--- a/.github/workflows/triage-labels.yml
+++ b/.github/workflows/triage-labels.yml
@@ -23,5 +23,5 @@ permissions:
 
 jobs:
   triage_label:
-    uses: dbt-labs/actions/.github/workflows/triage-labels.yml@er/centralize-triage-workflows
+    uses: dbt-labs/actions/.github/workflows/triage-labels.yml@main
     secrets: inherit

--- a/.github/workflows/triage-labels.yml
+++ b/.github/workflows/triage-labels.yml
@@ -23,11 +23,5 @@ permissions:
 
 jobs:
   triage_label:
-    if: contains(github.event.issue.labels.*.name, 'awaiting_response')
-    runs-on: ubuntu-latest
-    steps:
-      - name: initial labeling
-        uses: andymckay/labeler@master
-        with:
-          add-labels: "triage"
-          remove-labels: "awaiting_response"
+    uses: dbt-labs/actions/.github/workflows/triage-labels.yml@er/centralize-triage-workflows
+    secrets: inherit


### PR DESCRIPTION
resolves https://github.com/dbt-labs/actions/issues/35

### Description

Replaces current action to sue internal relabeling.  Tested in personal repo. This action will need to be added in all repos we track with the triage project.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
