### PR TITLE
[BUGFIX] Force `tox` to update `pip` (fixes `psycopg2-binary @ 2.9.5`)

### DIFF
--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -70,7 +70,7 @@ setup(
     },
     install_requires=[
         "dbt-core=={}".format(package_version),
-        "{}~=2.9.4".format(DBT_PSYCOPG2_NAME),
+        "{}~=2.8".format(DBT_PSYCOPG2_NAME),
     ],
     zip_safe=False,
     classifiers=[

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -70,7 +70,7 @@ setup(
     },
     install_requires=[
         "dbt-core=={}".format(package_version),
-        "{}~=2.8".format(DBT_PSYCOPG2_NAME),
+        "{}~=2.9.4".format(DBT_PSYCOPG2_NAME),
     ],
     zip_safe=False,
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -4,18 +4,19 @@ envlist = unit,integration
 
 [testenv:{unit,py37,py38,py39,py310,py}]
 description = unit testing
+download = true
 skip_install = true
 passenv = DBT_* PYTEST_ADDOPTS
 commands =
   {envpython} -m pytest --cov=core {posargs} test/unit
   {envpython} -m pytest --cov=core {posargs} tests/unit
 deps =
-  -U pip
   -rdev-requirements.txt
   -reditable-requirements.txt
 
 [testenv:{integration,py37-integration,py38-integration,py39-integration,py310-integration,py-integration}]
 description = adapter plugin integration testing
+download = true
 skip_install = true
 passenv = DBT_* POSTGRES_TEST_* PYTEST_ADDOPTS
 commands =
@@ -24,6 +25,5 @@ commands =
   {envpython} -m pytest --cov=core {posargs} tests/adapter
 
 deps =
-  -U pip
   -rdev-requirements.txt
   -reditable-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ commands =
   {envpython} -m pytest --cov=core {posargs} test/unit
   {envpython} -m pytest --cov=core {posargs} tests/unit
 deps =
+  -U pip
   -rdev-requirements.txt
   -reditable-requirements.txt
 
@@ -23,5 +24,6 @@ commands =
   {envpython} -m pytest --cov=core {posargs} tests/adapter
 
 deps =
+  -U pip
   -rdev-requirements.txt
   -reditable-requirements.txt


### PR DESCRIPTION
resolves #6135

### Description
  It appears hat there's a bug in the latest version of psycopg2-binary (2.9.5) when installing in tox + windows + pip @ 22.2.2  
  
This PR changes our tox config to always update pip on each run (something we should probably do anyway).
  
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
