### PR TITLE
Fix deprecated set-output commands

### DIFF
--- a/.changes/unreleased/Under the Hood-20221027-180753.yaml
+++ b/.changes/unreleased/Under the Hood-20221027-180753.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Fix deprecated GH action command
+time: 2022-10-27T18:07:53.205506+02:00
+custom:
+  Author: kevinneville
+  Issue: "6153"
+  PR: "6152"

--- a/.github/_README.md
+++ b/.github/_README.md
@@ -138,7 +138,7 @@ Some triggers of note that we use:
         id: fp
         run: |
           FILEPATH=.changes/unreleased/Dependencies-${{ steps.filename_time.outputs.time }}.yaml
-          echo "::set-output name=FILEPATH::$FILEPATH"
+          echo "FILEPATH=$FILEPATH" >> $GITHUB_OUTPUT
   ```
 
 - Print out all variables you will reference as the first step of a job.  This allows for easier debugging.  The first job should log all inputs.  Subsequent jobs should reference outputs of other jobs, if present.
@@ -163,9 +163,9 @@ Some triggers of note that we use:
     - name: Set Variables
       id: variables
       run: |
-        echo "::set-output name=important_path::'performance/runner/Cargo.toml'"
-        echo "::set-output name=release_id::${{github.event.inputs.release_id}}"
-        echo "::set-output name=open_prs::${{github.event.inputs.open_prs}}"
+        echo "important_path='performance/runner/Cargo.toml'" >> $GITHUB_OUTPUT
+        echo "release_id=${{github.event.inputs.release_id}}" >> $GITHUB_OUTPUT
+        echo "open_prs=${{github.event.inputs.open_prs}}" >> $GITHUB_OUTPUT
 
   job2:
     needs: [job1]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Get current date
         if: always()
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H_%M_%S')" #no colons allowed for artifacts
+        run: echo "date=$(date +'%Y-%m-%dT%H_%M_%S')" >> $GITHUB_OUTPUT #no colons allowed for artifacts
 
       - uses: actions/upload-artifact@v2
         if: always()
@@ -166,7 +166,7 @@ jobs:
       - name: Get current date
         if: always()
         id: date
-        run: echo "::set-output name=date::$(date +'%Y_%m_%dT%H_%M_%S')" #no colons allowed for artifacts
+        run: echo "date=$(date +'%Y_%m_%dT%H_%M_%S')" >> $GITHUB_OUTPUT #no colons allowed for artifacts
 
       - uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -41,9 +41,9 @@ jobs:
         id: version
         run: |
           IFS="." read -r MAJOR MINOR PATCH <<< ${{ github.event.inputs.version_number }}
-          echo "::set-output name=major::$MAJOR"
-          echo "::set-output name=minor::$MINOR"
-          echo "::set-output name=patch::$PATCH"
+          echo "major=$MAJOR" >> $GITHUB_OUTPUT
+          echo "minor=$MINOR" >> $GITHUB_OUTPUT
+          echo "patch=$PATCH" >> $GITHUB_OUTPUT
 
       - name: Is pkg 'latest'
         id: latest
@@ -70,8 +70,8 @@ jobs:
       - name: Get docker build arg
         id: build_arg
         run: |
-          echo "::set-output name=build_arg_name::"$(echo ${{ github.event.inputs.package }} | sed 's/\-/_/g')
-          echo "::set-output name=build_arg_value::"$(echo ${{ github.event.inputs.package }} | sed 's/postgres/core/g')
+          echo "build_arg_name="$(echo ${{ github.event.inputs.package }} | sed 's/\-/_/g') >> $GITHUB_OUTPUT
+          echo "build_arg_value="$(echo ${{ github.event.inputs.package }} | sed 's/postgres/core/g') >> $GITHUB_OUTPUT
 
       - name: Log in to the GHCR
         uses: docker/login-action@v1

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -70,8 +70,11 @@ jobs:
       - name: Get docker build arg
         id: build_arg
         run: |
-          echo "build_arg_name="$(echo ${{ github.event.inputs.package }} | sed 's/\-/_/g') >> $GITHUB_OUTPUT
-          echo "build_arg_value="$(echo ${{ github.event.inputs.package }} | sed 's/postgres/core/g') >> $GITHUB_OUTPUT
+          SNAKE_CASE_PACKAGE=$(echo ${{ github.event.inputs.package }} | sed 's/\-/_/g')
+          CORE_PACKAGE=$(echo ${{ github.event.inputs.package }} | sed 's/postgres/core/g')
+
+          echo "build_arg_name=$SNAKE_CASE_PACKAGE" >> $GITHUB_OUTPUT
+          echo "build_arg_value=$CORE_PACKAGE" >> $GITHUB_OUTPUT
 
       - name: Log in to the GHCR
         uses: docker/login-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,7 @@ jobs:
         env:
           IS_PRERELEASE: ${{ contains(github.event.inputs.version_number, 'rc') ||  contains(github.event.inputs.version_number, 'b') }}
         run: |
-          echo ::set-output name=isPrerelease::$IS_PRERELEASE
+          echo "isPrerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
 
       - name: Creating GitHub Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Set branch value
         id: variables
         run: |
-          echo "::set-output name=BRANCH_NAME::prep-release/${{ github.event.inputs.version_number }}_$GITHUB_RUN_ID"
+          echo "BRANCH_NAME=prep-release/${{ github.event.inputs.version_number }}_${GITHUB_RUN_ID}" >> $GITHUB_OUTPUT
 
       - name: Create PR branch
         run: |


### PR DESCRIPTION
resolves #6153 

### Description

As communicated by Github in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ these commands should be replaced.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
