### PR TITLE
fix: check if a relation exists before creating one with ref

### DIFF
--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -483,7 +483,16 @@ class RuntimeRefResolver(BaseRefResolver):
                 disabled=isinstance(target_model, Disabled),
             )
         self.validate(target_model, target_name, target_package)
-        return self.create_relation(target_model, target_name)
+        relation = self.db_wrapper._adapter.get_relation(
+            database=target_model.database,
+            schema=target_model.schema,
+            identifier=target_model.identifier
+        )
+        if relation is not None:
+            return relation
+        else:
+            # we need to create a relation if no existing relation was found
+            return self.create_relation(target_model, target_name)
 
     def create_relation(self, target_model: ManifestNode, name: str) -> RelationProxy:
         if target_model.is_ephemeral_model:


### PR DESCRIPTION
resolves #6155

### Description

Use the adapter to get a relation during ref execution (importantly just during runtime) to preserve relation metadata such as type when it has been defined.
When no relation is found, create a new one as was previously done

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
