### PR TITLE
DRAFT: Changing properties for metrics and models

### DIFF
--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -217,6 +217,7 @@ class ParsedNodeDefaults(NodeInfoMixin, ParsedNodeMandatory):
     deferred: bool = False
     is_public: Optional[bool] = False
     relationships: List[EntityRelationship] = field(default_factory=list)
+    primary_keys: List[str] = field(default_factory=list)
     unrendered_config: Dict[str, Any] = field(default_factory=dict)
     created_at: float = field(default_factory=lambda: time.time())
     config_call_dict: Dict[str, Any] = field(default_factory=dict)
@@ -251,7 +252,7 @@ class ParsedNode(ParsedNodeDefaults, ParsedNodeMixins, SerializableType):
     @classmethod
     def _deserialize(cls, dct: Dict[str, int]):
         # The serialized ParsedNodes do not differ from each other
-        # in fields that would allow 'from_dict' to distinguis
+        # in fields that would allow 'from_dict' to distinguish
         # between them.
         resource_type = dct["resource_type"]
         if resource_type == "model":

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -106,9 +106,9 @@ class EntityRelationshipType(StrEnum):
 @dataclass
 class EntityRelationship(dbtClassMixin, Replaceable):
     to: str
-    join_key: str
+    join_keys: Union[str,List[str]]
     relationship_type: EntityRelationshipType
-
+    
 
 @dataclass
 class HasDocs(AdditionalPropertiesMixin, ExtensibleDbtClassMixin, Replaceable):

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -834,7 +834,7 @@ class ManifestLoader:
             if node.created_at < self.started_at:
                 continue
             _process_refs_for_node(self.manifest, current_project, node)
-            _process_inverse_relationships_for_node(self.manifest, current_project, node)
+            _process_semantic_information_for_node(self.manifest, current_project, node)
         for exposure in self.manifest.exposures.values():
             if exposure.created_at < self.started_at:
                 continue
@@ -955,12 +955,6 @@ class ManifestLoader:
                     self.manifest.add_node_nofile(node)
 
         self.manifest.rebuild_ref_lookup()
-
-    # def process_inverse_relationships(self, current_project: str):
-    #     for node in self.manifest.nodes.values():
-    #         if node.created_at < self.started_at:
-    #             continue
-    #         _process_inverse_relationships_for_node(self.manifest, current_project, node)
 
 
 def invalid_ref_fail_unless_test(node, target_model_name, target_model_package, disabled):
@@ -1388,7 +1382,7 @@ def _process_refs_for_node(manifest: Manifest, current_project: str, node: Manif
         manifest.update_node(node)
 
 
-def _process_inverse_relationships_for_node(
+def _process_semantic_information_for_node(
     manifest: Manifest, current_project: str, node: ManifestNode
 ):
     """Given a manifest and a node in that manifest, process the inverse relationships for the related nodes"""

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1396,7 +1396,14 @@ def _process_inverse_relationships_for_node(
     
     """Limit this parsing to public models that have relationships"""
     if node.resource_type == "model" and len(node.relationships) > 0 and node.is_public == True:
+
         for relationship in node.relationships:
+
+            """Here we overwrite the base value of the join_keys if it is a string and replace
+            it with a list value for the manifest"""
+            if type(relationship.join_keys) == str:
+                relationship.join_keys = [relationship.join_keys]
+
             to_model = manifest.resolve_ref(
                 relationship.to, target_model_package, current_project, node.package_name
             )
@@ -1410,7 +1417,7 @@ def _process_inverse_relationships_for_node(
             """Using the to_model, create an inverse relationship in the model"""
             inverse_relationship = EntityRelationship(
                 to=node.name,
-                join_key=relationship.join_key,
+                join_keys=relationship.join_keys,
                 relationship_type=EntityRelationshipType(relationship.relationship_type.inverse()),
             )
             
@@ -1425,7 +1432,7 @@ def _process_inverse_relationships_for_node(
                     if inverse_relationship == to_model_relationship and str(inverse_relationship.relationship_type) == str(to_model_relationship.relationship_type):
                         continue
 
-                    elif inverse_relationship.to == to_model_relationship.to and (inverse_relationship.join_key != to_model_relationship.join_key or str(inverse_relationship.relationship_type) != str(to_model_relationship.relationship_type)):
+                    elif inverse_relationship.to == to_model_relationship.to and (inverse_relationship.join_keys != to_model_relationship.join_keys or str(inverse_relationship.relationship_type) != str(to_model_relationship.relationship_type)):
                         raise dbt.exceptions.CompilationException(
                             f"""The relationship between {relationship.to} and {inverse_relationship.to} does not match. Please ensure that the join_key(s) and relationship_types match"""
                         )


### PR DESCRIPTION
### Description
This PR adds a few things:
- validation that any model that has a relationship established to/from it is set to `is_public`
- logic to check that relationships created across public/entities don't already exist OR match what already exists.
- changing `join_key` to `join_keys` and supporting it as a list.
  - additional logic in `manifest.py` to overwrite single str values to lists
- renaming the `_process_for_inverse_relationships` function to `_process_semantic_information` so it can be the hub for all semantic manifest parsing.
- Adding the `primary_keys` property in the manifest underneath each model/seed node. This is then populated as a composite of the names from all columns where `is_primary_key` is set to true.

To do the first part I commented out some code in metric validation because this should live at the model/node level IMO. 

The second part is messy because of comparisons against data classes being a bit out of my wheelhouse. I suspect there are much cleaner ways to write EntityRelationship comparisons than casting the relationship type to string so it can compare 😅 

The third part is an extension of the logic in part 3 with some overwriting of values in conditional statements. I tried using `_listify` but wasn't able to get it to work so figured I'd punt that off to a review later on.