### PR TITLE
Metrics flexible timegrains

### DIFF
--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -67,6 +67,7 @@ class ColumnInfo(AdditionalPropertiesMixin, ExtensibleDbtClassMixin, Replaceable
     quote: Optional[bool] = None
     is_dimension: Optional[bool] = False
     is_primary_key: Optional[bool] = False
+    time_grains: Optional[List[str]] = field(default_factory=list)
     tags: List[str] = field(default_factory=list)
     _extra: Dict[str, Any] = field(default_factory=dict)
 

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -106,9 +106,9 @@ class EntityRelationshipType(StrEnum):
 @dataclass
 class EntityRelationship(dbtClassMixin, Replaceable):
     to: str
-    join_keys: Union[str,List[str]]
+    join_keys: Union[str, List[str]]
     relationship_type: EntityRelationshipType
-    
+
 
 @dataclass
 class HasDocs(AdditionalPropertiesMixin, ExtensibleDbtClassMixin, Replaceable):
@@ -140,6 +140,7 @@ class UnparsedColumn(HasTests):
     tags: List[str] = field(default_factory=list)
     is_dimension: Optional[bool] = False
     is_primary_key: Optional[bool] = False
+    time_grains: Optional[List[str]] = field(default_factory=list)
     data_type: Optional[str] = None
 
 
@@ -516,7 +517,7 @@ class UnparsedMetric(dbtClassMixin, Replaceable):
     timestamp: str
     expression: str
     description: str = ""
-    time_grains: List[str] = field(default_factory=list)
+    time_grains: Optional[List[str]] = field(default_factory=list)
     dimensions: Union[Dict[str, Any], List[str]] = field(default_factory=dict)
     window: Optional[MetricTime] = None
     model: Optional[str] = None

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1170,7 +1170,7 @@ def _process_refs_for_exposure(manifest: Manifest, current_project: str, exposur
         manifest.update_exposure(exposure)
 
 
-def _process_dimensions_and_relationships_for_metric(
+def _process_semantic_information_for_metric(
     manifest: Manifest,
     target_model: ManifestNode,
     metric: ParsedMetric,
@@ -1188,6 +1188,10 @@ def _process_dimensions_and_relationships_for_metric(
         primary_model_dimensions = [
             col for col in target_model.columns.values() if col.is_dimension
         ]
+        import pdb
+
+        pdb.set_trace()
+        timestamp_col = target_model.columns[metric.timestamp]
 
         # validate declared dims from primary model
         for dim in primary_model_dimensions:
@@ -1219,7 +1223,7 @@ def _process_dimensions_and_relationships_for_metric(
                     current_project,
                     metric.package_name,
                 )
- 
+
                 metric.depends_on.nodes.append(to_model.unique_id)
 
                 new_dims = [col for col in to_model.columns.values() if col.is_dimension]
@@ -1231,6 +1235,16 @@ def _process_dimensions_and_relationships_for_metric(
                             f"Dimension columns must declare a `data_type` attribute. {col.name} is missing this configuration."
                         )
                     metric.dimensions[to_model.name].append(col.name)
+
+        import pdb
+
+        pdb.set_trace()
+
+        # if metric.time_grains:
+        #     pass
+        # elif timestamp_col:
+        #     inferred_time_grains  = timestamp_col.time_grains
+        #     metric.time_grains = inferred_time_grains
 
 
 def _process_refs_for_metric(manifest: Manifest, current_project: str, metric: ParsedMetric):
@@ -1273,7 +1287,7 @@ def _process_refs_for_metric(manifest: Manifest, current_project: str, metric: P
 
         metric.depends_on.nodes.append(target_model_id)
 
-        _process_dimensions_and_relationships_for_metric(
+        _process_semantic_information_for_metric(
             manifest, target_model, metric, target_model_package, current_project
         )
 
@@ -1378,20 +1392,20 @@ def _process_refs_for_node(manifest: Manifest, current_project: str, node: Manif
 def _process_semantic_information_for_node(
     manifest: Manifest, current_project: str, node: ManifestNode
 ):
-    """ Given a manifest and a node in that manifest, process all of the semantic 
+    """Given a manifest and a node in that manifest, process all of the semantic
     information for the related nodes. This occurs in multiple steps:
       1. If the node is a seed or model and is_public is true, continue with compilation. Otherwise ignore.
       2. Loop through all of the models listed in relationships and check if they also
       have is_public set to true. If not, append to a list and then raise that list in a CompilationException.
-      3. Loop through the columns where is_primary_key is set to true and then create a 
+      3. Loop through the columns where is_primary_key is set to true and then create a
       composite list at the model level of those columns
       4. Create the inverse_relationship of each relationship and validate it against the other model.
       If it doesn't exist, add it. If a relationship exists with the same name, confirm that the properties match.
       If the properties don't match, raise a CompilationException.
-      
+
     """
     target_model_package: Optional[str] = None
-    
+
     # Limit this parsing to public models/seeds that have relationships
     if node.resource_type == "model" and node.is_public == True:
 
@@ -1399,11 +1413,9 @@ def _process_semantic_information_for_node(
         # flag that are being referenced with relationships
         non_public_models = []
 
-        # Setting the primary_keys field in the node to be a combination of all 
+        # Setting the primary_keys field in the node to be a combination of all
         # columns that have is_primary_key set to true
-        primary_key_columns = [
-            column for column in node.columns.values() if column.is_primary_key
-        ]
+        primary_key_columns = [column for column in node.columns.values() if column.is_primary_key]
         # Appending the values of all primary key columns into a primary_key list
         # at the model level
         for column in primary_key_columns:
@@ -1411,7 +1423,9 @@ def _process_semantic_information_for_node(
 
         # Use a generator expression to create the set of public models/seeds
         # that have relationships, which we'll use to iterate on
-        nodes_with_relationships = (relationship for relationship in node.relationships if len(node.relationships) > 0)
+        nodes_with_relationships = (
+            relationship for relationship in node.relationships if len(node.relationships) > 0
+        )
         for relationship in nodes_with_relationships:
 
             # Here we overwrite the base value of the join_keys if it is a string and replace
@@ -1434,40 +1448,47 @@ def _process_semantic_information_for_node(
                 join_keys=relationship.join_keys,
                 relationship_type=EntityRelationshipType(relationship.relationship_type.inverse()),
             )
-            
-            # TODO: Clean up this very messy code. See if way we can check 
-            # relationship.to against to_model.relationships without it breaking 
+
+            # TODO: Clean up this very messy code. See if way we can check
+            # relationship.to against to_model.relationships without it breaking
             # because the latter is a EntityRelationship
-            
-            #Checks if the relationship already exists and only creates if not
+
+            # Checks if the relationship already exists and only creates if not
             if len(to_model.relationships) > 0:
                 for to_model_relationship in to_model.relationships:
 
                     # TODO: Clean up how the entity relationship class matches. Strings feel bad
-                    #Relationship exists, carry on as normal
-                    if inverse_relationship == to_model_relationship and str(inverse_relationship.relationship_type) == str(to_model_relationship.relationship_type):
+                    # Relationship exists, carry on as normal
+                    if inverse_relationship == to_model_relationship and str(
+                        inverse_relationship.relationship_type
+                    ) == str(to_model_relationship.relationship_type):
                         continue
 
                     # If the relationship name exists but other properties don't raise an error
-                    elif inverse_relationship.to == to_model_relationship.to and (inverse_relationship.join_keys != to_model_relationship.join_keys or str(inverse_relationship.relationship_type) != str(to_model_relationship.relationship_type)):
+                    elif inverse_relationship.to == to_model_relationship.to and (
+                        inverse_relationship.join_keys != to_model_relationship.join_keys
+                        or str(inverse_relationship.relationship_type)
+                        != str(to_model_relationship.relationship_type)
+                    ):
                         raise dbt.exceptions.CompilationException(
                             f"""The relationship between {relationship.to} and {inverse_relationship.to} does not match. Please ensure that the join_key(s) and relationship_types match"""
                         )
 
                     # If none of the above conditions are triggered, write the new relationship!
-                    else: 
+                    else:
                         to_model.relationships.append(inverse_relationship)
                         manifest.update_node(to_model)
-            
-            else: 
+
+            else:
                 to_model.relationships.append(inverse_relationship)
                 manifest.update_node(to_model)
 
-        #Looping through public models that have relationships established to raise compilation error
-        if len(non_public_models) > 0: 
+        # Looping through public models that have relationships established to raise compilation error
+        if len(non_public_models) > 0:
             raise dbt.exceptions.CompilationException(
                 f"""The model(s) {', '.join(non_public_models)} have relationships established but are not public models. Please set the `is_public` property to true for these model(s)."""
             )
+
 
 def _process_sources_for_exposure(
     manifest: Manifest, current_project: str, exposure: ParsedExposure

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -142,10 +142,12 @@ class ParserRef:
             quote = column.quote
             is_dimension = column.is_dimension
             is_primary_key = column.is_primary_key
+            time_grains = column.time_grains
         else:
             quote = None
             is_dimension = False
             is_primary_key = False
+            time_grains = None
         self.column_info[column.name] = ColumnInfo(
             name=column.name,
             description=description,
@@ -156,6 +158,7 @@ class ParserRef:
             _extra=column.extra,
             is_dimension=is_dimension,
             is_primary_key=is_primary_key,
+            time_grains=time_grains,
         )
 
     @classmethod


### PR DESCRIPTION
### Description

- Makes `time_grains` optional for a metric 
- Adds `time_grains` as a column level attribute
- Establishes hierarchy of how to inherit the timegrains
  1. Metric definiton
  2. column spec
  3. metric configs (i.e. in `dbt_project.yml`)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
