### PR TITLE
add typing to DepsTask.run

### DIFF
--- a/core/dbt/deps/base.py
+++ b/core/dbt/deps/base.py
@@ -74,7 +74,7 @@ class PinnedPackage(BasePackage):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def install(self, project):
+    def install(self, project, renderer):
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1706,7 +1706,7 @@ class DepsNotifyUpdatesAvailable(InfoLevel, pt.DepsNotifyUpdatesAvailable):
     def message(self) -> str:
         return "Updates available for packages: {} \
                 \nUpdate your versions in packages.yml, then run dbt deps".format(
-            self.packages
+            self.packages.value
         )
 
 

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -13,7 +13,7 @@ from dbt.events.base_types import (
     ErrorLevel,
     TestLevel,
 )
-from dbt.events.proto_types import NodeInfo, RunResultMsg, ReferenceKeyMsg
+from dbt.events.proto_types import ListOfStrings, NodeInfo, RunResultMsg, ReferenceKeyMsg
 from importlib import reload
 import dbt.events.functions as event_funcs
 import dbt.flags as flags
@@ -321,7 +321,8 @@ sample_values = [
     DepsInstallInfo(version_name=""),
     DepsUpdateAvailable(version_latest=""),
     DepsListSubdirectory(subdirectory=""),
-    DepsNotifyUpdatesAvailable(packages=[]),
+    DepsNotifyUpdatesAvailable(packages=ListOfStrings()),
+    DepsNotifyUpdatesAvailable(packages=ListOfStrings(['dbt-utils'])),
     DatabaseErrorRunningHook(hook_type=""),
     EmptyLine(),
     HooksRunning(num_hooks=0, hook_type=""),


### PR DESCRIPTION
resolves #6191

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->
`fire_event(DepsNotifyUpdatesAvailable(packages=packages_to_upgrade))` was previously passing `packages` as a list of strings which could not be serialized to the new `ListOfStrings` protobuf type during logging.

`dbt --log-format json deps` logged the following error event when installing a package that has an update available:

> {"exc": "type DepsNotifyUpdatesAvailable is not serializable. 'str' object has no attribute 'to_dict'", "info": {"code": "Z002", "extra": {}, "invocation_id": "1e59a3df-3a23-42d9-aa45-d2246092cd70", "level": "error", "msg": "Encountered an error:\ntype DepsNotifyUpdatesAvailable is not serializable. 'str' object has no attribute 'to_dict'", "name": "MainEncounteredError", "pid": 51212, "thread": "MainThread", "ts": "2022-11-02T00:02:17.987107Z"}}

Ideally mypy would have caught this issue but `DepsTask.run` was not scanned by mypy because the method signature did not have type annotations. After adding type annotations to the `DepsTask.run`, `mypy` was able to detect the issue (as well as a few others which are also addressed in this change): 

```
❯ mypy core/dbt/task/deps.py
core/dbt/task/deps.py:90: error: Argument "packages" to "DepsNotifyUpdatesAvailable" has incompatible type "List[str]"; expected "ListOfStrings"
Found 1 error in 1 file (checked 1 source file)
```



### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
