### PR TITLE
Updates lib to use new profile name functionality

### DIFF
--- a/.changes/unreleased/Features-20221102-150003.yaml
+++ b/.changes/unreleased/Features-20221102-150003.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: This pulls the profile name from args when constructing a RuntimeConfig in lib.py,
+  enabling the dbt-server to override the value that's in the dbt_project.yml
+time: 2022-11-02T15:00:03.000805-05:00
+custom:
+  Author: racheldaniel
+  Issue: "6201"
+  PR: "6202"

--- a/core/dbt/lib.py
+++ b/core/dbt/lib.py
@@ -1,4 +1,6 @@
 import os
+from dbt.config.project import Project
+from dbt.config.renderer import DbtProjectYamlRenderer
 from dbt.contracts.results import RunningStatus, collect_timing_info
 from dbt.events.functions import fire_event
 from dbt.events.types import NodeCompiling, NodeExecuting
@@ -71,16 +73,24 @@ def get_dbt_config(project_dir, args=None, single_threaded=False):
     else:
         profiles_dir = flags.DEFAULT_PROFILES_DIR
 
+    
+    profile_name = getattr(args, "profile", None)
+
     runtime_args = RuntimeArgs(
         project_dir=project_dir,
         profiles_dir=profiles_dir,
         single_threaded=single_threaded,
-        profile=getattr(args, "profile", None),
+        profile=profile_name,
         target=getattr(args, "target", None),
     )
 
-    # Construct a RuntimeConfig from phony args
-    config = RuntimeConfig.from_args(runtime_args)
+    profile = RuntimeConfig.collect_profile(args=runtime_args, profile_name=profile_name)
+    project_renderer = DbtProjectYamlRenderer(profile, None)
+    project = RuntimeConfig.collect_project(args=runtime_args, project_renderer=project_renderer)
+    assert type(project) is Project
+
+    config = RuntimeConfig.from_parts(project, profile, runtime_args)
+
 
     # Set global flags from arguments
     flags.set_from_args(args, config)

--- a/core/dbt/lib.py
+++ b/core/dbt/lib.py
@@ -73,7 +73,6 @@ def get_dbt_config(project_dir, args=None, single_threaded=False):
     else:
         profiles_dir = flags.DEFAULT_PROFILES_DIR
 
-    
     profile_name = getattr(args, "profile", None)
 
     runtime_args = RuntimeArgs(
@@ -90,7 +89,6 @@ def get_dbt_config(project_dir, args=None, single_threaded=False):
     assert type(project) is Project
 
     config = RuntimeConfig.from_parts(project, profile, runtime_args)
-
 
     # Set global flags from arguments
     flags.set_from_args(args, config)


### PR DESCRIPTION
resolves #6201

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

In order to dynamically pass a profile name to RuntimeConfig creation from the dbt-server, we want to make use of the refactor made [in this branch](https://github.com/dbt-labs/dbt-core/pull/6157).

We will wait to merge this until above changes have been backported to `1.3.0-latest` ([pending PR](https://github.com/dbt-labs/dbt-core/pull/6199)), and will need to backport this to `1.3.0-latest` and `1.2.0-latest`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
