### PR TITLE
Avoid reading the profile multiple times for every dbt run/compile/docs generate/deps

### DIFF
--- a/.changes/unreleased/Fixes-20221116-130228.yaml
+++ b/.changes/unreleased/Fixes-20221116-130228.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fixed reaading the Profiles.yml file multiple times for every dbt operation.
+time: 2022-11-16T13:02:28.837792+05:30
+custom:
+  Author: akashrn5
+  Issue: "6263"
+  PR: "6264"

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -259,7 +259,7 @@ class PartialProject(RenderComponents):
         metadata=dict(description=("If True, verify the dbt version matches the required version"))
     )
 
-    def render_profile_name(self, renderer) -> Optional[str]:
+    def render_profile_name(self, renderer, raw_profiles) -> Optional[str]:
         if self.profile_name is None:
             return None
         return renderer.render_value(self.profile_name)

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -176,7 +176,7 @@ def handle_and_check(args):
         parsed = parse_args(args)
 
         # Set flags from args, user config, and env vars
-        user_config = read_user_config(flags.PROFILES_DIR)  # This is read again later
+        user_config, raw_profiles = read_user_config(flags.PROFILES_DIR)  # This is read again later
         flags.set_from_args(parsed, user_config)
         dbt.tracking.initialize_from_flags()
         # Set log_format from flags
@@ -195,7 +195,7 @@ def handle_and_check(args):
 
             with adapter_management():
 
-                task, res = run_from_args(parsed)
+                task, res = run_from_args(parsed, raw_profiles)
                 success = task.interpret_results(res)
 
             return res, success
@@ -217,12 +217,12 @@ def track_run(task):
         dbt.tracking.flush()
 
 
-def run_from_args(parsed):
+def run_from_args(parsed, raw_profiles):
     log_cache_events(getattr(parsed, "log_cache_events", False))
 
     # this will convert DbtConfigErrors into RuntimeExceptions
     # task could be any one of the task objects
-    task = parsed.cls.from_args(args=parsed)
+    task = parsed.cls.from_args(args=parsed, raw_profiles=raw_profiles)
 
     # Set up logging
     log_path = None

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -102,11 +102,11 @@ class BaseTask(metaclass=ABCMeta):
             log_manager.format_text()
 
     @classmethod
-    def from_args(cls, args):
+    def from_args(cls, args, raw_profiles: Dict[str, Any]):
         try:
             # This is usually RuntimeConfig but will be UnsetProfileConfig
             # for the clean or deps tasks
-            config = cls.ConfigType.from_args(args)
+            config = cls.ConfigType.from_args(args, raw_profiles)
         except dbt.exceptions.DbtProjectError as exc:
             fire_event(DbtProjectError())
             fire_event(DbtProjectErrorException(exc=str(exc)))
@@ -182,9 +182,9 @@ class ConfiguredTask(BaseTask):
         register_adapter(self.config)
 
     @classmethod
-    def from_args(cls, args):
+    def from_args(cls, args, raw_profiles: Dict[str, Any]):
         move_to_nearest_project_dir(args)
-        return super().from_args(args)
+        return super().from_args(args, raw_profiles)
 
 
 class ExecutionContext:


### PR DESCRIPTION
resolves #6263 

### Description
This PR fixes the reading the profiles.yml file multiple times for every dbt operation.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
