### PR TITLE
Add invocation_id to default query-comment

### DIFF
--- a/.changes/unreleased/Features-20221117-115148.yaml
+++ b/.changes/unreleased/Features-20221117-115148.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add invocation_id to default query-comment
+time: 2022-11-17T11:51:48.801725Z
+custom:
+  Author: NiallRees
+  Issue: "6277"
+  PR: "6277"

--- a/core/dbt/contracts/connection.py
+++ b/core/dbt/contracts/connection.py
@@ -204,6 +204,7 @@ DEFAULT_QUERY_COMMENT = """
     dbt_version=dbt_version,
     profile_name=target.get('profile_name'),
     target_name=target.get('target_name'),
+    invocation_id=invocation_id,
 ) -%}
 {%- if node is not none -%}
   {%- do comment_dict.update(


### PR DESCRIPTION
Useful for matching queries onto specific model runs. Results in:

```
/* {"app": "dbt", "dbt_version": "1.4.0a1", "profile_name": "x", "target_name": "dev", "invocation_id": "14caee1b-4e64-48c7-91ef-7ba8e5fdd734", "node_id": "model.dbt_artifacts.dim_dbt__models"} */;
```

Would also love to add the dbt Cloud `runId`, but wanted to get thoughts before I just added that in.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
