### PR TITLE
Revert "Bump python from 3.10.7-slim-bullseye to 3.11.0-slim-bullseye in /docker"

### DIFF
--- a/.changes/unreleased/Dependency-20221031-000329.yaml
+++ b/.changes/unreleased/Dependency-20221031-000329.yaml
@@ -1,7 +1,0 @@
-kind: "Dependency"
-body: "Bump python from 3.10.7-slim-bullseye to 3.11.0-slim-bullseye in /docker"
-time: 2022-10-31T00:03:29.00000Z
-custom:
-  Author: dependabot[bot]
-  Issue: 4904
-  PR: 6180

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG build_for=linux/amd64
 ##
 # base image (abstract)
 ##
-FROM --platform=$build_for python:3.11.0-slim-bullseye as base
+FROM --platform=$build_for python:3.10.7-slim-bullseye as base
 
 # N.B. The refs updated automagically every release via bumpversion
 # N.B. dbt-postgres is currently found in the core codebase so a value of dbt-core@<some_version> is correct


### PR DESCRIPTION
resolves #6275 

Reverts dbt-labs/dbt-core#6180

We shouldn't be using py11 for the Docker images yet since we don't officially support it

