### PR TITLE
Reverting back to older ubuntu image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         include:
           - python-version: 3.8
             os: windows-latest

--- a/.github/workflows/structured-logging-schema-check.yml
+++ b/.github/workflows/structured-logging-schema-check.yml
@@ -22,7 +22,7 @@ jobs:
   # run the performance measurements on the current or default branch
   test-schema:
     name: Test Log Schema
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       # turns warnings into errors
       RUSTFLAGS: "-D warnings"


### PR DESCRIPTION
### Description
GitHub changed the `ubuntu-latest` image from Ubuntu-20.04 to Ubuntu-22.04 which caused our CI to break. As a temporary fix to unblock CI, let's revert back to the older image and use that until we know why things broke

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
