### PR TITLE
Remove PR from most changelog kinds

### DIFF
--- a/.changes/unreleased/Dependency-20220923-000646.yaml
+++ b/.changes/unreleased/Dependency-20220923-000646.yaml
@@ -3,5 +3,4 @@ body: "Update pathspec requirement from ~=0.9.0 to >=0.9,<0.11 in /core"
 time: 2022-09-23T00:06:46.00000Z
 custom:
   Author: dependabot[bot]
-  Issue: 4904
   PR: 5917

--- a/.changes/unreleased/Dependency-20220923-000646.yaml
+++ b/.changes/unreleased/Dependency-20220923-000646.yaml
@@ -1,4 +1,4 @@
-kind: "Dependency"
+kind: "Dependencies"
 body: "Update pathspec requirement from ~=0.9.0 to >=0.9,<0.11 in /core"
 time: 2022-09-23T00:06:46.00000Z
 custom:

--- a/.changes/unreleased/Dependency-20220923-000646.yaml
+++ b/.changes/unreleased/Dependency-20220923-000646.yaml
@@ -3,4 +3,4 @@ body: "Update pathspec requirement from ~=0.9.0 to >=0.9,<0.11 in /core"
 time: 2022-09-23T00:06:46.00000Z
 custom:
   Author: dependabot[bot]
-  PR: 5917
+  PR: "5917"

--- a/.changes/unreleased/Dependency-20221007-000848.yaml
+++ b/.changes/unreleased/Dependency-20221007-000848.yaml
@@ -3,5 +3,4 @@ body: "Bump black from 22.8.0 to 22.10.0"
 time: 2022-10-07T00:08:48.00000Z
 custom:
   Author: dependabot[bot]
-  Issue: 4904
   PR: 6019

--- a/.changes/unreleased/Dependency-20221007-000848.yaml
+++ b/.changes/unreleased/Dependency-20221007-000848.yaml
@@ -1,4 +1,4 @@
-kind: "Dependency"
+kind: "Dependencies"
 body: "Bump black from 22.8.0 to 22.10.0"
 time: 2022-10-07T00:08:48.00000Z
 custom:

--- a/.changes/unreleased/Dependency-20221007-000848.yaml
+++ b/.changes/unreleased/Dependency-20221007-000848.yaml
@@ -3,4 +3,4 @@ body: "Bump black from 22.8.0 to 22.10.0"
 time: 2022-10-07T00:08:48.00000Z
 custom:
   Author: dependabot[bot]
-  PR: 6019
+  PR: "6019"

--- a/.changes/unreleased/Dependency-20221020-000753.yaml
+++ b/.changes/unreleased/Dependency-20221020-000753.yaml
@@ -3,5 +3,4 @@ body: "Bump mashumaro[msgpack] from 3.0.4 to 3.1.1 in /core"
 time: 2022-10-20T00:07:53.00000Z
 custom:
   Author: dependabot[bot]
-  Issue: 4904
   PR: 6108

--- a/.changes/unreleased/Dependency-20221020-000753.yaml
+++ b/.changes/unreleased/Dependency-20221020-000753.yaml
@@ -3,4 +3,4 @@ body: "Bump mashumaro[msgpack] from 3.0.4 to 3.1.1 in /core"
 time: 2022-10-20T00:07:53.00000Z
 custom:
   Author: dependabot[bot]
-  PR: 6108
+  PR: "6108"

--- a/.changes/unreleased/Dependency-20221020-000753.yaml
+++ b/.changes/unreleased/Dependency-20221020-000753.yaml
@@ -1,4 +1,4 @@
-kind: "Dependency"
+kind: "Dependencies"
 body: "Bump mashumaro[msgpack] from 3.0.4 to 3.1.1 in /core"
 time: 2022-10-20T00:07:53.00000Z
 custom:

--- a/.changes/unreleased/Dependency-20221026-000910.yaml
+++ b/.changes/unreleased/Dependency-20221026-000910.yaml
@@ -3,5 +3,4 @@ body: "Update colorama requirement from <0.4.6,>=0.3.9 to >=0.3.9,<0.4.7 in /cor
 time: 2022-10-26T00:09:10.00000Z
 custom:
   Author: dependabot[bot]
-  Issue: 4904
   PR: 6144

--- a/.changes/unreleased/Dependency-20221026-000910.yaml
+++ b/.changes/unreleased/Dependency-20221026-000910.yaml
@@ -3,4 +3,4 @@ body: "Update colorama requirement from <0.4.6,>=0.3.9 to >=0.3.9,<0.4.7 in /cor
 time: 2022-10-26T00:09:10.00000Z
 custom:
   Author: dependabot[bot]
-  PR: 6144
+  PR: "6144"

--- a/.changes/unreleased/Dependency-20221026-000910.yaml
+++ b/.changes/unreleased/Dependency-20221026-000910.yaml
@@ -1,4 +1,4 @@
-kind: "Dependency"
+kind: "Dependencies"
 body: "Update colorama requirement from <0.4.6,>=0.3.9 to >=0.3.9,<0.4.7 in /core"
 time: 2022-10-26T00:09:10.00000Z
 custom:

--- a/.changes/unreleased/Docs-20220908-154157.yaml
+++ b/.changes/unreleased/Docs-20220908-154157.yaml
@@ -4,4 +4,3 @@ time: 2022-09-08T15:41:57.689162-04:00
 custom:
   Author: andy-clapson
   Issue: "5791"
-  PR: "5684"

--- a/.changes/unreleased/Docs-20221007-090656.yaml
+++ b/.changes/unreleased/Docs-20221007-090656.yaml
@@ -4,4 +4,3 @@ time: 2022-10-07T09:06:56.446078-05:00
 custom:
   Author: stu-k
   Issue: "5528"
-  PR: "6022"

--- a/.changes/unreleased/Docs-20221017-171411.yaml
+++ b/.changes/unreleased/Docs-20221017-171411.yaml
@@ -3,4 +3,3 @@ time: 2022-10-17T17:14:11.715348-05:00
 custom:
   Author: paulbenschmidt
   Issue: "5880"
-  PR: "324"

--- a/.changes/unreleased/Docs-20221116-155743.yaml
+++ b/.changes/unreleased/Docs-20221116-155743.yaml
@@ -4,4 +4,3 @@ time: 2022-11-16T15:57:43.204201+01:00
 custom:
   Author: jtcohen6
   Issue: "323"
-  PR: "346"

--- a/.changes/unreleased/Docs-20221202-150523.yaml
+++ b/.changes/unreleased/Docs-20221202-150523.yaml
@@ -4,4 +4,3 @@ time: 2022-12-02T15:05:23.695333-07:00
 custom:
   Author: dbeatty10
   Issue: "6368"
-  PR: "6371"

--- a/.changes/unreleased/Features-20220408-165459.yaml
+++ b/.changes/unreleased/Features-20220408-165459.yaml
@@ -5,4 +5,3 @@ time: 2022-04-08T16:54:59.696564+01:00
 custom:
   Author: daniel-murray josephberni
   Issue: "2968"
-  PR: "5859"

--- a/.changes/unreleased/Features-20220817-154857.yaml
+++ b/.changes/unreleased/Features-20220817-154857.yaml
@@ -4,4 +4,3 @@ time: 2022-08-17T15:48:57.225267-04:00
 custom:
   Author: gshank
   Issue: "5610"
-  PR: "5643"

--- a/.changes/unreleased/Features-20220912-125935.yaml
+++ b/.changes/unreleased/Features-20220912-125935.yaml
@@ -4,4 +4,3 @@ time: 2022-09-12T12:59:35.121188+01:00
 custom:
   Author: jared-rimmer
   Issue: "5486"
-  PR: "5812"

--- a/.changes/unreleased/Features-20220914-095625.yaml
+++ b/.changes/unreleased/Features-20220914-095625.yaml
@@ -4,4 +4,3 @@ time: 2022-09-14T09:56:25.97818-07:00
 custom:
   Author: colin-rogers-dbt
   Issue: "5521"
-  PR: "5838"

--- a/.changes/unreleased/Features-20220925-211651.yaml
+++ b/.changes/unreleased/Features-20220925-211651.yaml
@@ -4,4 +4,3 @@ time: 2022-09-25T21:16:51.051239654+02:00
 custom:
   Author: pgoslatara
   Issue: "5929"
-  PR: "5930"

--- a/.changes/unreleased/Features-20221003-110705.yaml
+++ b/.changes/unreleased/Features-20221003-110705.yaml
@@ -4,4 +4,3 @@ time: 2022-10-03T11:07:05.381632-05:00
 custom:
   Author: dave-connors-3
   Issue: "5990"
-  PR: "5991"

--- a/.changes/unreleased/Features-20221102-150003.yaml
+++ b/.changes/unreleased/Features-20221102-150003.yaml
@@ -5,4 +5,3 @@ time: 2022-11-02T15:00:03.000805-05:00
 custom:
   Author: racheldaniel
   Issue: "6201"
-  PR: "6202"

--- a/.changes/unreleased/Features-20221114-185207.yaml
+++ b/.changes/unreleased/Features-20221114-185207.yaml
@@ -4,4 +4,3 @@ time: 2022-11-14T18:52:07.788593+02:00
 custom:
   Author: haritamar
   Issue: "6246"
-  PR: "6247"

--- a/.changes/unreleased/Features-20221130-112913.yaml
+++ b/.changes/unreleased/Features-20221130-112913.yaml
@@ -4,4 +4,3 @@ time: 2022-11-30T11:29:13.256034-05:00
 custom:
   Author: michelleark
   Issue: "6057"
-  PR: "6342"

--- a/.changes/unreleased/Fixes-20220916-104854.yaml
+++ b/.changes/unreleased/Fixes-20220916-104854.yaml
@@ -4,4 +4,3 @@ time: 2022-09-16T10:48:54.162273-05:00
 custom:
   Author: emmyoop
   Issue: "3992"
-  PR: "5868"

--- a/.changes/unreleased/Fixes-20221010-113218.yaml
+++ b/.changes/unreleased/Fixes-20221010-113218.yaml
@@ -4,4 +4,3 @@ time: 2022-10-10T11:32:18.752322-05:00
 custom:
   Author: emmyoop
   Issue: "6030"
-  PR: "6038"

--- a/.changes/unreleased/Fixes-20221011-160715.yaml
+++ b/.changes/unreleased/Fixes-20221011-160715.yaml
@@ -4,4 +4,3 @@ time: 2022-10-11T16:07:15.464093-04:00
 custom:
   Author: chamini2
   Issue: "6041"
-  PR: "6042"

--- a/.changes/unreleased/Fixes-20221016-173742.yaml
+++ b/.changes/unreleased/Fixes-20221016-173742.yaml
@@ -5,4 +5,3 @@ time: 2022-10-16T17:37:42.846683-07:00
 custom:
   Author: versusfacit
   Issue: "5436"
-  PR: "5874"

--- a/.changes/unreleased/Fixes-20221107-095314.yaml
+++ b/.changes/unreleased/Fixes-20221107-095314.yaml
@@ -4,4 +4,3 @@ time: 2022-11-07T09:53:14.340257-06:00
 custom:
   Author: ChenyuLInx
   Issue: "5625"
-  PR: "6059"

--- a/.changes/unreleased/Fixes-20221115-081021.yaml
+++ b/.changes/unreleased/Fixes-20221115-081021.yaml
@@ -4,4 +4,3 @@ time: 2022-11-15T08:10:21.527884-05:00
 custom:
   Author: justbldwn
   Issue: "6245"
-  PR: "6251"

--- a/.changes/unreleased/Fixes-20221202-164859.yaml
+++ b/.changes/unreleased/Fixes-20221202-164859.yaml
@@ -4,4 +4,3 @@ time: 2022-12-02T16:48:59.029519-05:00
 custom:
   Author: gshank
   Issue: "6055"
-  PR: "6081"

--- a/.changes/unreleased/Under the Hood-20220927-194259.yaml
+++ b/.changes/unreleased/Under the Hood-20220927-194259.yaml
@@ -4,4 +4,3 @@ time: 2022-09-27T19:42:59.241433-07:00
 custom:
   Author: max-sixty
   Issue: "5946"
-  PR: "5947"

--- a/.changes/unreleased/Under the Hood-20220929-134406.yaml
+++ b/.changes/unreleased/Under the Hood-20220929-134406.yaml
@@ -4,4 +4,3 @@ time: 2022-09-29T13:44:06.275941-04:00
 custom:
   Author: peterallenwebb
   Issue: "5809"
-  PR: "5975"

--- a/.changes/unreleased/Under the Hood-20221005-120310.yaml
+++ b/.changes/unreleased/Under the Hood-20221005-120310.yaml
@@ -4,4 +4,3 @@ time: 2022-10-05T12:03:10.061263-07:00
 custom:
   Author: max-sixty
   Issue: "5983"
-  PR: "5983"

--- a/.changes/unreleased/Under the Hood-20221007-094627.yaml
+++ b/.changes/unreleased/Under the Hood-20221007-094627.yaml
@@ -4,4 +4,3 @@ time: 2022-10-07T09:46:27.682872-05:00
 custom:
   Author: emmyoop
   Issue: "6023"
-  PR: "6024"

--- a/.changes/unreleased/Under the Hood-20221007-140044.yaml
+++ b/.changes/unreleased/Under the Hood-20221007-140044.yaml
@@ -4,4 +4,3 @@ time: 2022-10-07T14:00:44.227644-07:00
 custom:
   Author: max-sixty
   Issue: "6028"
-  PR: "5978"

--- a/.changes/unreleased/Under the Hood-20221013-181912.yaml
+++ b/.changes/unreleased/Under the Hood-20221013-181912.yaml
@@ -4,4 +4,3 @@ time: 2022-10-13T18:19:12.167548-04:00
 custom:
   Author: peterallenwebb
   Issue: "5229"
-  PR: "6025"

--- a/.changes/unreleased/Under the Hood-20221017-151511.yaml
+++ b/.changes/unreleased/Under the Hood-20221017-151511.yaml
@@ -4,4 +4,3 @@ time: 2022-10-17T15:15:11.499246-05:00
 custom:
   Author: luke-bassett
   Issue: "1350"
-  PR: "6086"

--- a/.changes/unreleased/Under the Hood-20221017-155844.yaml
+++ b/.changes/unreleased/Under the Hood-20221017-155844.yaml
@@ -4,4 +4,3 @@ time: 2022-10-17T15:58:44.676549-04:00
 custom:
   Author: eve-johns
   Issue: "6068"
-  PR: "6082"

--- a/.changes/unreleased/Under the Hood-20221028-104837.yaml
+++ b/.changes/unreleased/Under the Hood-20221028-104837.yaml
@@ -4,4 +4,3 @@ time: 2022-10-28T10:48:37.687886-04:00
 custom:
   Author: gshank
   Issue: "6171"
-  PR: "6172"

--- a/.changes/unreleased/Under the Hood-20221028-110344.yaml
+++ b/.changes/unreleased/Under the Hood-20221028-110344.yaml
@@ -4,4 +4,3 @@ time: 2022-10-28T11:03:44.887836-04:00
 custom:
   Author: gshank
   Issue: "6173"
-  PR: "6174"

--- a/.changes/unreleased/Under the Hood-20221108-074550.yaml
+++ b/.changes/unreleased/Under the Hood-20221108-074550.yaml
@@ -4,4 +4,3 @@ time: 2022-11-08T07:45:50.589147-06:00
 custom:
   Author: stu-k
   Issue: "5942"
-  PR: "6226"

--- a/.changes/unreleased/Under the Hood-20221108-115633.yaml
+++ b/.changes/unreleased/Under the Hood-20221108-115633.yaml
@@ -4,4 +4,3 @@ time: 2022-11-08T11:56:33.743042-06:00
 custom:
   Author: stu-k
   Issue: "5770"
-  PR: "6228"

--- a/.changes/unreleased/Under the Hood-20221108-133104.yaml
+++ b/.changes/unreleased/Under the Hood-20221108-133104.yaml
@@ -4,4 +4,3 @@ time: 2022-11-08T13:31:04.788547-06:00
 custom:
   Author: stu-k
   Issue: "5771"
-  PR: "6230"

--- a/.changes/unreleased/Under the Hood-20221116-130037.yaml
+++ b/.changes/unreleased/Under the Hood-20221116-130037.yaml
@@ -4,4 +4,3 @@ time: 2022-11-16T13:00:37.916202-06:00
 custom:
   Author: stu-k
   Issue: "5942"
-  PR: "6187"

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -6,19 +6,67 @@ changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## dbt-core {{.Version}} - {{.Time.Format "January 02, 2006"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: '- {{.Body}} ([#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-core/issues/{{.Custom.Issue}}), [#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
+changeFormat: |
+  {{- $IssueList := list }}
+  {{- $changes := splitList " " $.Custom.Issue }}
+  {{- range $issueNbr := $changes }}
+    {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-core/issues/nbr)" | replace "nbr" $issueNbr }}
+    {{- $IssueList = append $IssueList $changeLink  }}
+  {{- end }}
+  - {{.Body}} ({{ range $index, $element := $IssueList }}{{if $index}}, {{end}}{{$element}}{{end}})
 
 kinds:
   - label: Breaking Changes
   - label: Features
   - label: Fixes
   - label: Docs
-    changeFormat: '- {{.Body}} ([dbt-docs/#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-docs/issues/{{.Custom.Issue}}), [dbt-docs/#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-docs/pull/{{.Custom.PR}}))'
+    changeFormat: |
+      {{- $IssueList := list }}
+      {{- $changes := splitList " " $.Custom.Issue }}
+      {{- range $issueNbr := $changes }}
+        {{- $changeLink := "[dbt-docs/#nbr](https://github.com/dbt-labs/dbt-docs/issues/nbr)" | replace "nbr" $issueNbr }}
+        {{- $IssueList = append $IssueList $changeLink }}
+      {{- end }}
+      - {{.Body}} ({{ range $index, $element := $IssueList }}{{if $index}}, {{end}}{{$element}}{{end}})
   - label: Under the Hood
   - label: Dependencies
-    changeFormat: '- {{.Body}} ({{if ne .Custom.Issue ""}}[#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-core/issues/{{.Custom.Issue}}), {{end}}[#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
+    changeFormat: |
+      {{- $PRList := list }}
+      {{- $changes := splitList " " $.Custom.PR }}
+      {{- range $pullrequest := $changes }}
+        {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-core/pull/nbr)" | replace "nbr" $pullrequest }}
+        {{- $PRList = append $PRList $changeLink  }}
+      {{- end }}
+      - {{.Body}} ({{ range $index, $element := $PRList }}{{if $index}}, {{end}}{{$element}}{{end}})
+    skipGlobalChoices: true
+    additionalChoices:
+      - key: Author
+        label: GitHub Username(s) (separated by a single space if multiple)
+        type: string
+        minLength: 3
+      - key: PR
+        label: GitHub Pull Request Number (separated by a single space if multiple)
+        type: int
+        minInt: 1
   - label: Security
-    changeFormat: '- {{.Body}} ({{if ne .Custom.Issue ""}}[#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-core/issues/{{.Custom.Issue}}), {{end}}[#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
+    changeFormat: |
+      {{- $PRList := list }}
+      {{- $changes := splitList " " $.Custom.PR }}
+      {{- range $pullrequest := $changes }}
+        {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-core/pull/nbr)" | replace "nbr" $pullrequest }}
+        {{- $PRList = append $PRList $changeLink  }}
+      {{- end }}
+      - {{.Body}} ({{ range $index, $element := $PRList }}{{if $index}}, {{end}}{{$element}}{{end}})
+    skipGlobalChoices: true
+    additionalChoices:
+      - key: Author
+        label: GitHub Username(s) (separated by a single space if multiple)
+        type: string
+        minLength: 3
+      - key: PR
+        label: GitHub Pull Request Number (separated by a single space if multiple)
+        type: int
+        minInt: 1
 
 newlines:
   afterChangelogHeader: 1
@@ -33,11 +81,7 @@ custom:
   type: string
   minLength: 3
 - key: Issue
-  label: GitHub Issue Number
-  type: int
-  minInt: 1
-- key: PR
-  label: GitHub Pull Request Number
+  label: GitHub Issue Number (separated by a single space if multiple)
   type: int
   minInt: 1
 
@@ -47,28 +91,31 @@ footerFormat: |
   {{- $core_team := list "michelleark" "peterallenwebb" "emmyoop" "nathaniel-may" "gshank" "leahwicz" "chenyulinx" "stu-k" "iknox-fa" "versusfacit" "mcknight-42" "jtcohen6" "dependabot[bot]" "snyk-bot" "colin-rogers-dbt" }}
   {{- range $change := .Changes }}
     {{- $authorList := splitList " " $change.Custom.Author }}
-    {{- /* loop through all authors for a PR */}}
+    {{- /* loop through all authors for a single changelog */}}
     {{- range $author := $authorList }}
       {{- $authorLower := lower $author }}
       {{- /* we only want to include non-core team contributors */}}
       {{- if not (has $authorLower $core_team)}}
-        {{- /* Docs kind link back to dbt-docs instead of dbt-core PRs */}}
-        {{- $prLink := $change.Kind }}
-        {{- if eq $change.Kind "Docs" }}
-          {{- $prLink = "[dbt-docs/#pr](https://github.com/dbt-labs/dbt-docs/pull/pr)" | replace "pr" $change.Custom.PR }}
-        {{- else }}
-          {{- $prLink = "[#pr](https://github.com/dbt-labs/dbt-core/pull/pr)" | replace "pr" $change.Custom.PR }}
-        {{- end }}
-        {{- /* check if this contributor has other PRs associated with them already */}}
-        {{- if hasKey $contributorDict $author }}
-          {{- $prList := get $contributorDict $author }}
-          {{- $prList = append $prList $prLink  }}
-          {{- $contributorDict := set $contributorDict $author $prList }}
-        {{- else }}
-          {{- $prList := list $prLink }}
-          {{- $contributorDict := set $contributorDict $author $prList }}
-        {{- end }}
-      {{- end}}
+        {{- $changeList := splitList " " $change.Custom.Author }}
+          {{- /* Docs kind link back to dbt-docs instead of dbt-core issues */}}
+          {{- $changeLink := $change.Kind }}
+          {{- if or (eq $change.Kind "Dependencies") (eq $change.Kind "Security") }}
+            {{- $changeLink = "[#nbr](https://github.com/dbt-labs/dbt-core/pull/nbr)" | replace "nbr" $change.Custom.PR }}
+          {{- else if eq $change.Kind "Docs"}}
+            {{- $changeLink = "[dbt-docs/#nbr](https://github.com/dbt-labs/dbt-docs/issues/nbr)" | replace "nbr" $change.Custom.Issue }}
+          {{- else }}
+            {{- $changeLink = "[#nbr](https://github.com/dbt-labs/dbt-core/issues/nbr)" | replace "nbr" $change.Custom.Issue }}
+          {{- end }}
+          {{- /* check if this contributor has other changes associated with them already */}}
+          {{- if hasKey $contributorDict $author }}
+            {{- $contributionList := get $contributorDict $author }}
+            {{- $contributionList = append $contributionList $changeLink  }}
+            {{- $contributorDict := set $contributorDict $author $contributionList }}
+          {{- else }}
+            {{- $contributionList := list $changeLink }}
+            {{- $contributorDict := set $contributorDict $author $contributionList }}
+          {{- end }}
+        {{- end}}
     {{- end}}
   {{- end }}
   {{- /* no indentation here for formatting so the final markdown doesn't have unneeded indentations */}}

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -46,8 +46,8 @@ kinds:
         minLength: 3
       - key: PR
         label: GitHub Pull Request Number (separated by a single space if multiple)
-        type: int
-        minInt: 1
+        type: string
+        minLength: 1
   - label: Security
     changeFormat: |
       {{- $PRList := list }}
@@ -65,8 +65,8 @@ kinds:
         minLength: 3
       - key: PR
         label: GitHub Pull Request Number (separated by a single space if multiple)
-        type: int
-        minInt: 1
+        type: string
+        minLength: 1
 
 newlines:
   afterChangelogHeader: 1
@@ -82,8 +82,8 @@ custom:
   minLength: 3
 - key: Issue
   label: GitHub Issue Number (separated by a single space if multiple)
-  type: int
-  minInt: 1
+  type: string
+  minLength: 1
 
 footerFormat: |
   {{- $contributorDict := dict }}

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -12,7 +12,7 @@ changeFormat: |
   {{- range $issueNbr := $changes }}
     {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-core/issues/nbr)" | replace "nbr" $issueNbr }}
     {{- $IssueList = append $IssueList $changeLink  }}
-  {{- end }}
+  {{- end -}}
   - {{.Body}} ({{ range $index, $element := $IssueList }}{{if $index}}, {{end}}{{$element}}{{end}})
 
 kinds:
@@ -26,7 +26,7 @@ kinds:
       {{- range $issueNbr := $changes }}
         {{- $changeLink := "[dbt-docs/#nbr](https://github.com/dbt-labs/dbt-docs/issues/nbr)" | replace "nbr" $issueNbr }}
         {{- $IssueList = append $IssueList $changeLink }}
-      {{- end }}
+      {{- end -}}
       - {{.Body}} ({{ range $index, $element := $IssueList }}{{if $index}}, {{end}}{{$element}}{{end}})
   - label: Under the Hood
   - label: Dependencies
@@ -36,7 +36,7 @@ kinds:
       {{- range $pullrequest := $changes }}
         {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-core/pull/nbr)" | replace "nbr" $pullrequest }}
         {{- $PRList = append $PRList $changeLink  }}
-      {{- end }}
+      {{- end -}}
       - {{.Body}} ({{ range $index, $element := $PRList }}{{if $index}}, {{end}}{{$element}}{{end}})
     skipGlobalChoices: true
     additionalChoices:
@@ -55,7 +55,7 @@ kinds:
       {{- range $pullrequest := $changes }}
         {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-core/pull/nbr)" | replace "nbr" $pullrequest }}
         {{- $PRList = append $PRList $changeLink  }}
-      {{- end }}
+      {{- end -}}
       - {{.Body}} ({{ range $index, $element := $PRList }}{{if $index}}, {{end}}{{$element}}{{end}})
     skipGlobalChoices: true
     additionalChoices:

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -6,7 +6,7 @@ changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## dbt-core {{.Version}} - {{.Time.Format "January 02, 2006"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: |
+changeFormat: |-
   {{- $IssueList := list }}
   {{- $changes := splitList " " $.Custom.Issue }}
   {{- range $issueNbr := $changes }}
@@ -20,7 +20,7 @@ kinds:
   - label: Features
   - label: Fixes
   - label: Docs
-    changeFormat: |
+    changeFormat: |-
       {{- $IssueList := list }}
       {{- $changes := splitList " " $.Custom.Issue }}
       {{- range $issueNbr := $changes }}
@@ -30,7 +30,7 @@ kinds:
       - {{.Body}} ({{ range $index, $element := $IssueList }}{{if $index}}, {{end}}{{$element}}{{end}})
   - label: Under the Hood
   - label: Dependencies
-    changeFormat: |
+    changeFormat: |-
       {{- $PRList := list }}
       {{- $changes := splitList " " $.Custom.PR }}
       {{- range $pullrequest := $changes }}
@@ -49,7 +49,7 @@ kinds:
         type: string
         minLength: 1
   - label: Security
-    changeFormat: |
+    changeFormat: |-
       {{- $PRList := list }}
       {{- $changes := splitList " " $.Custom.PR }}
       {{- range $pullrequest := $changes }}

--- a/.github/workflows/bot-changelog.yml
+++ b/.github/workflows/bot-changelog.yml
@@ -58,4 +58,4 @@ jobs:
         commit_message: "Add automated changelog yaml from template for bot PR"
         changie_kind: ${{ matrix.changie_kind }}
         label: ${{ matrix.label }}
-        custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n  Issue: 4904\n  PR: ${{ github.event.pull_request.number }}"
+        custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n  PR: ${{ github.event.pull_request.number }}"

--- a/.github/workflows/bot-changelog.yml
+++ b/.github/workflows/bot-changelog.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         include:
           - label: "dependencies"
-            changie_kind: "Dependency"
+            changie_kind: "Dependencies"
           - label: "snyk"
             changie_kind: "Security"
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,13 +201,15 @@ Here are some general rules for adding tests:
 * Sometimes flake8 complains about lines that are actually fine, in which case you can put a comment on the line such as: # noqa or # noqa: ANNN, where ANNN is the error code that flake8 issues.
 * To collect output for `CProfile`, run dbt with the `-r` option and the name of an output file, i.e. `dbt -r dbt.cprof run`. If you just want to profile parsing, you can do: `dbt -r dbt.cprof parse`. `pip` install `snakeviz` to view the output. Run `snakeviz dbt.cprof` and output will be rendered in a browser window.
 
-## Adding a CHANGELOG Entry
+## Adding or modifying a CHANGELOG Entry
 
 We use [changie](https://changie.dev) to generate `CHANGELOG` entries. **Note:** Do not edit the `CHANGELOG.md` directly. Your modifications will be lost.
 
 Follow the steps to [install `changie`](https://changie.dev/guide/installation/) for your system.
 
-Once changie is installed and your PR is created, simply run `changie new` and changie will walk you through the process of creating a changelog entry.  Commit the file that's created and your changelog entry is complete!
+Once changie is installed and your PR is created for a new feature, simply run `changie new` and changie will walk you through the process of creating a changelog entry.  Commit the file that's created and your changelog entry is complete!
+
+If you are contributing to a feature already in progress, you will modify the changie yaml file in `dbt/.changes/unreleased` related to your change.  If you need help finding this file, please ask!
 
 You don't need to worry about which `dbt-core` version your change will go into. Just create the changelog entry with `changie`, and open your PR against the `main` branch. All merged changes will be included in the next minor version of `dbt-core`. The Core maintainers _may_ choose to "backport" specific changes in order to patch older minor versions. In that case, a maintainer will take care of that backport after merging your PR, before releasing the new version of `dbt-core`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,9 +207,15 @@ We use [changie](https://changie.dev) to generate `CHANGELOG` entries. **Note:**
 
 Follow the steps to [install `changie`](https://changie.dev/guide/installation/) for your system.
 
-Once changie is installed and your PR is created for a new feature, simply run `changie new` and changie will walk you through the process of creating a changelog entry.  Commit the file that's created and your changelog entry is complete!
+Once changie is installed and your PR is created for a new feature, simply run the following command and changie will walk you through the process of creating a changelog entry:
 
-If you are contributing to a feature already in progress, you will modify the changie yaml file in `dbt/.changes/unreleased` related to your change.  If you need help finding this file, please ask!
+```bash
+changie new
+```
+
+Commit the file that's created and your changelog entry is complete!
+
+If you are contributing to a feature already in progress, you will modify the changie yaml file in dbt/.changes/unreleased/ related to your change. If you need help finding this file, please ask within the discussion for the pull request!
 
 You don't need to worry about which `dbt-core` version your change will go into. Just create the changelog entry with `changie`, and open your PR against the `main` branch. All merged changes will be included in the next minor version of `dbt-core`. The Core maintainers _may_ choose to "backport" specific changes in order to patch older minor versions. In that case, a maintainer will take care of that backport after merging your PR, before releasing the new version of `dbt-core`.
 


### PR DESCRIPTION
resolves #6332 

### Description

Removes changelog from all but `Dependency` and `Security` kinds.  Removes issue from those.

Allows for multiple issues (or PRs depending on kind) to be entered for a single change.

Note: I also found that the `changelog-bot` was using the `Dependency` kind while the `.changie.yaml` was using `Dependencies`.  I synced them to be `Dependencies`.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
