### PR TITLE
Prevent docs gen workflow on forks

### DIFF
--- a/.changes/unreleased/Under the Hood-20221206-094015.yaml
+++ b/.changes/unreleased/Under the Hood-20221206-094015.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Prevent doc gen workflow from running on forks
+time: 2022-12-06T09:40:15.301984-06:00
+custom:
+  Author: stu-k
+  Issue: "6386"
+  PR: "6390"

--- a/.github/workflows/generate-cli-api-docs.yml
+++ b/.github/workflows/generate-cli-api-docs.yml
@@ -34,6 +34,7 @@ jobs:
   check_gen:
     name: check if generation needed
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
     outputs:
       cli_dir_changed: ${{ steps.check_cli.outputs.cli_dir_changed }}
       docs_dir_changed: ${{ steps.check_docs.outputs.docs_dir_changed }}
@@ -44,8 +45,6 @@ jobs:
         echo "env.CLI_DIR:        ${{ env.CLI_DIR }}"
         echo "env.DOCS_BUILD_DIR: ${{ env.DOCS_BUILD_DIR }}"
         echo "env.DOCS_DIR:       ${{ env.DOCS_DIR }}"
-        echo ">>>>> git log"
-        git log --pretty=oneline | head -5
 
     - name: git checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
resolves #6386

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

Adds a conditional to the `check_gen` step of the CLI API doc gen workflow to prevent being run off of forks. Tested on [a fork](https://github.com/dbt-labs/dbt-core/pull/6389):
<img width="710" alt="Screen Shot 2022-12-06 at 9 38 05 AM" src="https://user-images.githubusercontent.com/25089304/205956799-d44f3ea7-fe3a-41d9-a5b8-97522d35bc02.png">


### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
