### PR TITLE
[Backport 1.2.latest] tox fix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,12 @@ envlist = unit,integration
 [testenv:{unit,py37,py38,py39,py310,py}]
 description = unit testing
 skip_install = true
-passenv = DBT_* PYTEST_ADDOPTS
-commands = {envpython} -m pytest --cov=core {posargs} test/unit
+passenv =
+  DBT_*
+  PYTEST_ADDOPTS
+commands =
+  {envpython} -m pytest --cov=core {posargs} test/unit
+  {envpython} -m pytest --cov=core {posargs} tests/unit
 deps =
   -rdev-requirements.txt
   -reditable-requirements.txt
@@ -14,7 +18,10 @@ deps =
 [testenv:{integration,py37-integration,py38-integration,py39-integration,py310-integration,py-integration}]
 description = adapter plugin integration testing
 skip_install = true
-passenv = DBT_* POSTGRES_TEST_* PYTEST_ADDOPTS
+passenv =
+  DBT_*
+  POSTGRES_TEST_*
+  PYTEST_ADDOPTS
 commands =
   {envpython} -m pytest --cov=core -m profile_postgres {posargs} test/integration
   {envpython} -m pytest --cov=core {posargs} tests/functional


### PR DESCRIPTION
Backport https://github.com/dbt-labs/dbt-core/pull/6405 to `1.2.latest`

Realizing that we might not need backports to earlier versions, because the failing tests (around `grants`) are ones we added those in v1.2