### PR TITLE
Disable `test_postgres_package_redirect_fail` in 1.1.latest

### DIFF
--- a/test/integration/012_deprecation_tests/test_deprecations.py
+++ b/test/integration/012_deprecation_tests/test_deprecations.py
@@ -116,11 +116,13 @@ class TestPackageRedirectDeprecation(BaseTestDeprecations):
         expected = {'package-redirect'}
         self.assertEqual(expected, deprecations.active_deprecations)
 
-    @use_profile('postgres')
-    def test_postgres_package_redirect_fail(self):
-        self.assertEqual(deprecations.active_deprecations, set())
-        with self.assertRaises(dbt.exceptions.CompilationException) as exc:
-            self.run_dbt(['--warn-error', 'deps'])
-        exc_str = ' '.join(str(exc.exception).split())  # flatten all whitespace
-        expected = "The `fishtown-analytics/dbt_utils` package is deprecated in favor of `dbt-labs/dbt_utils`"
-        assert expected in exc_str
+    # this test fails as a result of the caching added in 
+    # https://github.com/dbt-labs/dbt-core/pull/4982
+    # @use_profile('postgres')
+    # def test_postgres_package_redirect_fail(self):
+    #     self.assertEqual(deprecations.active_deprecations, set())
+    #     with self.assertRaises(dbt.exceptions.CompilationException) as exc:
+    #         self.run_dbt(['--warn-error', 'deps'])
+    #     exc_str = ' '.join(str(exc.exception).split())  # flatten all whitespace
+    #     expected = "The `fishtown-analytics/dbt_utils` package is deprecated in favor of `dbt-labs/dbt_utils`"
+    #     assert expected in exc_str


### PR DESCRIPTION
resolves [flakey failures in 1.1.latest](https://github.com/dbt-labs/dbt-core/actions/runs/3646818104)

We've already done the same for 1.0.latest:
https://github.com/dbt-labs/dbt-core/blob/cda94850ed50ab9408596e02dac3f7fdcdf572fb/test/integration/012_deprecation_tests/test_deprecations.py#L119-L131

And left a comment to the same effect in 1.2.latest (after converting to new functional testing framework):
https://github.com/dbt-labs/dbt-core/blob/cfaaad5d3b98e9596e423017182d528b69f2ea6a/tests/functional/deprecations/test_deprecations.py#L107-L108

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
