### PR TITLE
Infer core team membership in changie

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -7,7 +7,7 @@ versionExt: md
 envPrefix: "CHANGIE_"
 versionFormat: '## dbt-core {{.Version}} - {{.Time.Format "January 02, 2006"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: '- {{.env.CORE_TEAM}} {{.Body}} ([#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-core/issues/{{.Custom.Issue}}), [#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
+changeFormat: '- {{.Body}} ([#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-core/issues/{{.Custom.Issue}}), [#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
 
 kinds:
   - label: Breaking Changes
@@ -44,10 +44,15 @@ custom:
 
 footerFormat: |
   {{- $contributorDict := dict }}
-  {{- /* any names added to this list should be all lowercase for later matching purposes */}}
+  {{- /* ensure all names in this list are all lowercase for later matching purposes */}}
   {{- $exclude_authors := list "dependabot[bot]" "snyk-bot"}}
-  {{- $core_team := splitList " " .env.CORE_TEAM }}
-  {{- $exclude_authors := append $exclude_authors $core_team}}
+  {{- $core_team := splitList " " .Env.CORE_TEAM }}
+  {{- $core_team_lower := list }}
+  {{- range $team_member := $core_team }}
+    {{- $team_member_lower := lower $team_member }}
+    {{- $core_team_lower = append $core_team_lower $team_member_lower }}
+  {{- end }}
+  {{- $exclude_authors := concat $exclude_authors $core_team_lower}}
   {{- range $change := .Changes }}
     {{- $authorList := splitList " " $change.Custom.Author }}
     {{- /* loop through all authors for a PR */}}

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -4,9 +4,10 @@ headerPath: header.tpl.md
 versionHeaderPath: ""
 changelogPath: CHANGELOG.md
 versionExt: md
+envPrefix: "CHANGIE_"
 versionFormat: '## dbt-core {{.Version}} - {{.Time.Format "January 02, 2006"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: '- {{.Body}} ([#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-core/issues/{{.Custom.Issue}}), [#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
+changeFormat: '- {{.env.CORE_TEAM}} {{.Body}} ([#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-core/issues/{{.Custom.Issue}}), [#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-core/pull/{{.Custom.PR}}))'
 
 kinds:
   - label: Breaking Changes
@@ -44,14 +45,16 @@ custom:
 footerFormat: |
   {{- $contributorDict := dict }}
   {{- /* any names added to this list should be all lowercase for later matching purposes */}}
-  {{- $core_team := list "michelleark" "peterallenwebb" "emmyoop" "nathaniel-may" "gshank" "leahwicz" "chenyulinx" "stu-k" "iknox-fa" "versusfacit" "mcknight-42" "jtcohen6" "dependabot[bot]" "snyk-bot" "colin-rogers-dbt" }}
+  {{- $exclude_authors := list "dependabot[bot]" "snyk-bot"}}
+  {{- $core_team := splitList " " .env.CORE_TEAM }}
+  {{- $exclude_authors := append $exclude_authors $core_team}}
   {{- range $change := .Changes }}
     {{- $authorList := splitList " " $change.Custom.Author }}
     {{- /* loop through all authors for a PR */}}
     {{- range $author := $authorList }}
       {{- $authorLower := lower $author }}
       {{- /* we only want to include non-core team contributors */}}
-      {{- if not (has $authorLower $core_team)}}
+      {{- if not (has $authorLower $exclude_authors)}}
         {{- /* Docs kind link back to dbt-docs instead of dbt-core PRs */}}
         {{- $prLink := $change.Kind }}
         {{- if eq $change.Kind "Docs" }}


### PR DESCRIPTION
resolves #5516 


### Description

Removes hard coded list of core team members to be replaced by using env var based off the team membership defined in GitHub.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
