### PR TITLE
Break tox's passenv parameters into multiple lines

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = unit,integration
 [testenv:{unit,py37,py38,py39,py310,py}]
 description = unit testing
 skip_install = true
-passenv = 
+passenv =
   DBT_*
   PYTEST_ADDOPTS
 commands = {envpython} -m pytest --cov=core {posargs} test/unit
@@ -16,7 +16,7 @@ deps =
 [testenv:{integration,py37-integration,py38-integration,py39-integration,py310-integration,py-integration}]
 description = adapter plugin integration testing
 skip_install = true
-passenv = 
+passenv =
   DBT_*
   POSTGRES_TEST_*
   PYTEST_ADDOPTS

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ skip_install = true
 passenv = 
   DBT_*
   PYTEST_ADDOPTS
-
 commands = {envpython} -m pytest --cov=core {posargs} test/unit
 deps =
   -rdev-requirements.txt
@@ -17,7 +16,10 @@ deps =
 [testenv:{integration,py37-integration,py38-integration,py39-integration,py310-integration,py-integration}]
 description = adapter plugin integration testing
 skip_install = true
-passenv = DBT_* POSTGRES_TEST_* PYTEST_ADDOPTS
+passenv = 
+  DBT_*
+  POSTGRES_TEST_*
+  PYTEST_ADDOPTS
 commands =
   {envpython} -m pytest --cov=core -m profile_postgres {posargs} test/integration
   {envpython} -m pytest --cov=core {posargs} tests/functional

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,10 @@ envlist = unit,integration
 [testenv:{unit,py37,py38,py39,py310,py}]
 description = unit testing
 skip_install = true
-passenv = DBT_* PYTEST_ADDOPTS
+passenv = 
+  DBT_* 
+  PYTEST_ADDOPTS
+
 commands = {envpython} -m pytest --cov=core {posargs} test/unit
 deps =
   -rdev-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = unit,integration
 description = unit testing
 skip_install = true
 passenv = 
-  DBT_* 
+  DBT_*
   PYTEST_ADDOPTS
 
 commands = {envpython} -m pytest --cov=core {posargs} test/unit


### PR DESCRIPTION
resolves #6421


### Description

Break passenv into multiple lines to work with new version of tox

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)

### After merge
- [ ] Close https://github.com/dbt-labs/dbt-core/issues/6421 manually. Since this PR is a backport, the issue will not be resolved automatically upon merging.