### PR TITLE
CT-1685: Restore certain aspects of legacy logging behavior important…

### DIFF
--- a/.changes/unreleased/Under the Hood-20221213-214106.yaml
+++ b/.changes/unreleased/Under the Hood-20221213-214106.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Restore important legacy logging behaviors, following refactor which removed
+  them
+time: 2022-12-13T21:41:06.815133-05:00
+custom:
+  Author: peterallenwebb
+  Issue: "6437"

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -18,10 +18,6 @@ import uuid
 LOG_VERSION = 3
 metadata_vars: Optional[Dict[str, str]] = None
 
-# The default event manager will not log anything, but some tests run code that
-# generates events, without configuring the event manager.
-EVENT_MANAGER: EventManager = EventManager()
-
 
 def setup_event_logger(log_path: str, level_override: Optional[EventLevel] = None):
     cleanup_event_logger()
@@ -113,6 +109,16 @@ def cleanup_event_logger():
     EVENT_MANAGER.loggers.clear()
     EVENT_MANAGER.callbacks.clear()
 
+
+# The default event manager will not log anything, but some tests run code that
+# generates events, without configuring the event manager, so we create an empty
+# manager here until there is a better testing strategy in place.
+EVENT_MANAGER: EventManager = EventManager()
+
+# Since dbt-rpc does not do its own log setup, we set up logbook if legacy
+# logging is enabled.
+if flags.ENABLE_LEGACY_LOGGER:
+    EVENT_MANAGER.add_logger(_get_logbook_log_config(None))
 
 # This global, and the following two functions for capturing stdout logs are
 # an unpleasant hack we intend to remove as part of API-ification. The GitHub


### PR DESCRIPTION
resolves #6437 

### Description

These changes restore the behavior described in the associated issue. The legacy (logbook) logger is now active by default, and the appropriate log level is applied to ensure the events are seen by dbt-rpc.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
