### PR TITLE
Paw/ct 1652 restore default logging

### DIFF
--- a/.changes/unreleased/Fixes-20221214-155307.yaml
+++ b/.changes/unreleased/Fixes-20221214-155307.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Repair a regression which prevented basic logging before the logging subsystem
+  is completely configured.
+time: 2022-12-14T15:53:07.396512-05:00
+custom:
+  Author: peterallenwebb
+  Issue: "6434"

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -114,7 +114,9 @@ def cleanup_event_logger():
 # currently fire before logs can be configured by setup_event_logger(), we
 # create a default configuration with default settings and no file output.
 EVENT_MANAGER: EventManager = EventManager()
-EVENT_MANAGER.add_logger(_get_logbook_log_config() if flags.ENABLE_LEGACY_LOGGER else _get_stdout_config())
+EVENT_MANAGER.add_logger(
+    _get_logbook_log_config() if flags.ENABLE_LEGACY_LOGGER else _get_stdout_config()
+)
 
 
 # This global, and the following two functions for capturing stdout logs are

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -38,7 +38,7 @@ def setup_event_logger(log_path: str, level_override: Optional[EventLevel] = Non
         EVENT_MANAGER.add_logger(_get_logfile_config(os.path.join(log_path, "dbt.log")))
 
 
-def _get_stdout_config(level: Optional[EventLevel]) -> LoggerConfig:
+def _get_stdout_config(level: Optional[EventLevel] = None) -> LoggerConfig:
     fmt = LineFormat.PlainText
     if flags.LOG_FORMAT == "json":
         fmt = LineFormat.Json
@@ -90,7 +90,7 @@ def _logfile_filter(log_cache_events: bool, evt: BaseEvent) -> bool:
     )
 
 
-def _get_logbook_log_config(level: Optional[EventLevel]) -> LoggerConfig:
+def _get_logbook_log_config(level: Optional[EventLevel] = None) -> LoggerConfig:
     config = _get_stdout_config(level)
     config.name = "logbook_log"
     config.filter = NoFilter if flags.LOG_CACHE_EVENTS else lambda e: not isinstance(e, Cache)
@@ -110,15 +110,12 @@ def cleanup_event_logger():
     EVENT_MANAGER.callbacks.clear()
 
 
-# The default event manager will not log anything, but some tests run code that
-# generates events, without configuring the event manager, so we create an empty
-# manager here until there is a better testing strategy in place.
+# Since dbt-rpc does not do its own log setup, and since some events can
+# currently fire before logs can be configured by setup_event_logger(), we
+# create a default configuration with default settings and no file output.
 EVENT_MANAGER: EventManager = EventManager()
+EVENT_MANAGER.add_logger(_get_logbook_log_config() if flags.ENABLE_LEGACY_LOGGER else _get_stdout_config())
 
-# Since dbt-rpc does not do its own log setup, we set up logbook if legacy
-# logging is enabled.
-if flags.ENABLE_LEGACY_LOGGER:
-    EVENT_MANAGER.add_logger(_get_logbook_log_config(None))
 
 # This global, and the following two functions for capturing stdout logs are
 # an unpleasant hack we intend to remove as part of API-ification. The GitHub


### PR DESCRIPTION
resolves #6436

### Description

Restore logging to stdout before the logging subsystem is fully configured, so that earlier errors are still presented to the user in some form.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
