### PR TITLE
Fix dependency changelog kind

### DIFF
--- a/.changes/1.4.0-b1.md
+++ b/.changes/1.4.0-b1.md
@@ -65,9 +65,6 @@
 - Bump black from 22.8.0 to 22.10.0 ([#6019](https://github.com/dbt-labs/dbt-core/pull/6019))
 - Bump mashumaro[msgpack] from 3.0.4 to 3.1.1 in /core ([#6108](https://github.com/dbt-labs/dbt-core/pull/6108))
 - Update colorama requirement from <0.4.6,>=0.3.9 to >=0.3.9,<0.4.7 in /core ([#6144](https://github.com/dbt-labs/dbt-core/pull/6144))
-
-### Dependency
-
 - Bump mashumaro[msgpack] from 3.1.1 to 3.2 in /core ([#4904](https://github.com/dbt-labs/dbt-core/issues/4904))
 
 ### Contributors

--- a/.changes/1.4.0/Dependency-20221205-002118.yaml
+++ b/.changes/1.4.0/Dependency-20221205-002118.yaml
@@ -1,4 +1,4 @@
-kind: "Dependency"
+kind: "Dependencies"
 body: "Bump mashumaro[msgpack] from 3.1.1 to 3.2 in /core"
 time: 2022-12-05T00:21:18.00000Z
 custom:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,9 +72,6 @@
 - Bump black from 22.8.0 to 22.10.0 ([#6019](https://github.com/dbt-labs/dbt-core/pull/6019))
 - Bump mashumaro[msgpack] from 3.0.4 to 3.1.1 in /core ([#6108](https://github.com/dbt-labs/dbt-core/pull/6108))
 - Update colorama requirement from <0.4.6,>=0.3.9 to >=0.3.9,<0.4.7 in /core ([#6144](https://github.com/dbt-labs/dbt-core/pull/6144))
-
-### Dependency
-
 - Bump mashumaro[msgpack] from 3.1.1 to 3.2 in /core ([#4904](https://github.com/dbt-labs/dbt-core/issues/4904))
 
 ### Contributors


### PR DESCRIPTION
### Description

`Dependency` and `Dependencies` were both listed as kinds in the changelog.  This consolidates them.

This was a bug that I fixed in https://github.com/dbt-labs/dbt-core/blob/main/.github/workflows/bot-changelog.yml but there was one leftover changelog yaml.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
