### PR TITLE
Treat dense text blobs as binary for `git grep`

### DIFF
--- a/.changes/unreleased/Under the Hood-20221219-193435.yaml
+++ b/.changes/unreleased/Under the Hood-20221219-193435.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Treat dense text blobs as binary for `git grep`
+time: 2022-12-19T19:34:35.890275-07:00
+custom:
+  Author: dbeatty10
+  Issue: "6294"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+core/dbt/include/index.html binary
+tests/functional/artifacts/data/state/*/manifest.json binary


### PR DESCRIPTION
resolves #6294

### Description

Without this PR, try the following:
```shell
git grep "unrendered_config" tests
```

Not fun!

Then try again with this PR.

Much better:
```
$ git grep "unrendered_config" tests                 
Binary file tests/functional/artifacts/data/state/v1/manifest.json matches
Binary file tests/functional/artifacts/data/state/v2/manifest.json matches
Binary file tests/functional/artifacts/data/state/v3/manifest.json matches
Binary file tests/functional/artifacts/data/state/v4/manifest.json matches
Binary file tests/functional/artifacts/data/state/v5/manifest.json matches
Binary file tests/functional/artifacts/data/state/v6/manifest.json matches
Binary file tests/functional/artifacts/data/state/v7/manifest.json matches
Binary file tests/functional/artifacts/data/state/v8/manifest.json matches
tests/functional/artifacts/expected_manifest.py:                "unrendered_config": unrendered_model_config,
tests/functional/artifacts/expected_manifest.py:                "unrendered_config": unrendered_second_config,
tests/functional/artifacts/expected_manifest.py:                "unrendered_config": unrendered_seed_config,
...
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] ~This PR includes tests, or~ tests are not required/relevant for this PR
- [x] ~I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or~ docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
