### PR TITLE
add back validator_error_message

### DIFF
--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -2362,3 +2362,14 @@ def materialization_not_available(model, adapter_type):
 def macro_not_found(model, target_macro_id):
     msg = f"'{model.unique_id}' references macro '{target_macro_id}' which is not defined!"
     raise CompilationException(msg=msg, node=model)
+
+
+# adapters use this to format messages.  it should be deprecated but live on for now
+def validator_error_message(exc):
+    """Given a dbt.dataclass_schema.ValidationError (which is basically a
+    jsonschema.ValidationError), return the relevant parts as a string
+    """
+    if not isinstance(exc, dbt.dataclass_schema.ValidationError):
+        return str(exc)
+    path = "[%s]" % "][".join(map(repr, exc.relative_path))
+    return "at path {}: {}".format(path, exc.message)


### PR DESCRIPTION
### Description

When cleaning up exceptions I converted `validator_error_message` from a function to a method on `RuntimeException`.  This leaves it as a method but also adds it back as a function to not break adapters.  #6413 will add the decorator to the function to mark it as deprecated.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
