### PR TITLE
add defer_to_manifest in before_run to fix faulty deferred docs generate

### DIFF
--- a/.changes/unreleased/Fixes-20221226-010211.yaml
+++ b/.changes/unreleased/Fixes-20221226-010211.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: fix docs generate --defer by adding defer_to_manifest to before_run
+time: 2022-12-26T01:02:11.630614+01:00
+custom:
+  Author: mivanicova
+  Issue: "6488"

--- a/core/dbt/task/freshness.py
+++ b/core/dbt/task/freshness.py
@@ -147,6 +147,10 @@ class FreshnessSelector(ResourceTypeSelector):
 
 
 class FreshnessTask(GraphRunnableTask):
+    def defer_to_manifest(self, adapter, selected_uids):
+        # freshness don't defer
+        return
+
     def result_path(self):
         if self.args.output:
             return os.path.realpath(self.args.output)

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -179,6 +179,10 @@ class ListTask(GraphRunnableTask):
         else:
             return self.args.select
 
+    def defer_to_manifest(self, adapter, selected_uids):
+        # list don't defer
+        return
+
     def get_node_selector(self):
         if self.manifest is None or self.graph is None:
             raise InternalException("manifest and graph must be set to get perform node selection")

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -419,6 +419,7 @@ class GraphRunnableTask(ManifestTask):
     def before_run(self, adapter, selected_uids: AbstractSet[str]):
         with adapter.connection_named("master"):
             self.populate_adapter_cache(adapter)
+            self.defer_to_manifest(adapter, selected_uids)
 
     def after_run(self, adapter, results):
         pass

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -152,6 +152,10 @@ class GraphRunnableTask(ManifestTask):
     def get_node_selector(self) -> NodeSelector:
         raise NotImplementedException(f"get_node_selector not implemented for task {type(self)}")
 
+    @abstractmethod
+    def defer_to_manifest(self, adapter, selected_uids: AbstractSet[str]):
+        raise NotImplementedException(f"defer_to_manifest not implemented for task {type(self)}")
+
     def get_graph_queue(self) -> GraphQueue:
         selector = self.get_node_selector()
         spec = self.get_selection_spec()

--- a/test/integration/062_defer_state_tests/test_defer_state.py
+++ b/test/integration/062_defer_state_tests/test_defer_state.py
@@ -111,7 +111,7 @@ class TestDeferState(DBTIntegrationTest):
 
         # test generate docs
         # no state, wrong schema, empty nodes 
-        catalog=self.run_dbt(['docs','generate','--target', 'otherschema'])
+        catalog = self.run_dbt(['docs','generate','--target', 'otherschema'])
         assert not catalog.nodes
 
         # no state, run also fails
@@ -121,7 +121,7 @@ class TestDeferState(DBTIntegrationTest):
         results = self.run_dbt(['test', '-m', 'view_model+', '--state', 'state', '--defer', '--target', 'otherschema'])
 
         # defer docs generate with state, catalog refers schema from the happy times
-        catalog=self.run_dbt(['docs','generate', '-m', 'view_model+', '--state', 'state', '--defer','--target', 'otherschema'])
+        catalog = self.run_dbt(['docs','generate', '-m', 'view_model+', '--state', 'state', '--defer','--target', 'otherschema'])
         assert self.other_schema not in catalog.nodes["seed.test.seed"].metadata.schema
         assert self.unique_schema() in catalog.nodes["seed.test.seed"].metadata.schema
 

--- a/test/integration/062_defer_state_tests/test_defer_state.py
+++ b/test/integration/062_defer_state_tests/test_defer_state.py
@@ -109,11 +109,21 @@ class TestDeferState(DBTIntegrationTest):
         # no state, wrong schema, failure.
         self.run_dbt(['test', '--target', 'otherschema'], expect_pass=False)
 
+        # test generate docs
+        # no state, wrong schema, empty nodes 
+        catalog=self.run_dbt(['docs','generate','--target', 'otherschema'])
+        assert not catalog.nodes
+
         # no state, run also fails
         self.run_dbt(['run', '--target', 'otherschema'], expect_pass=False)
 
         # defer test, it succeeds
         results = self.run_dbt(['test', '-m', 'view_model+', '--state', 'state', '--defer', '--target', 'otherschema'])
+
+        # defer docs generate with state, catalog refers schema from the happy times
+        catalog=self.run_dbt(['docs','generate', '-m', 'view_model+', '--state', 'state', '--defer','--target', 'otherschema'])
+        assert self.other_schema not in catalog.nodes["seed.test.seed"].metadata.schema
+        assert self.unique_schema() in catalog.nodes["seed.test.seed"].metadata.schema
 
         # with state it should work though
         results = self.run_dbt(['run', '-m', 'view_model', '--state', 'state', '--defer', '--target', 'otherschema'])


### PR DESCRIPTION
resolves #6124

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

The `dbt docs generate --defer` command does not work as expected as it ignores the `state`. This PR fixes the issue by:
- adding call to defer_to_manifest to before_run  of compile/docs generate
- extending integration tests to validate that the  generated catalog is  indeed coming from the deferred state

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
