### PR TITLE
Partial parsing bug with empty schema file - ensure None is not passed to load_yaml_text

### DIFF
--- a/.changes/unreleased/Fixes-20230101-223405.yaml
+++ b/.changes/unreleased/Fixes-20230101-223405.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Bug when partial parsing with an empty schema file
+time: 2023-01-01T22:34:05.97322-05:00
+custom:
+  Author: gshank
+  Issue: "4850"

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -634,9 +634,8 @@ class BaseContext(metaclass=ContextMeta):
             {% endif %}
 
         This supports all flags defined in flags submodule (core/dbt/flags.py)
-        TODO: Replace with object that provides read-only access to flag values
         """
-        return flags
+        return flags.get_flag_obj()
 
     @contextmember
     @staticmethod

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -1,7 +1,9 @@
-import os
+# Do not import the os package because we expose this package in jinja
+from os import name as os_name, path as os_path, getcwd as os_getcwd, getenv as os_getenv
 import multiprocessing
+from argparse import Namespace
 
-if os.name != "nt":
+if os_name != "nt":
     # https://bugs.python.org/issue41567
     import multiprocessing.popen_spawn_posix  # type: ignore
 from pathlib import Path
@@ -10,14 +12,14 @@ from typing import Optional
 # PROFILES_DIR must be set before the other flags
 # It also gets set in main.py and in set_from_args because the rpc server
 # doesn't go through exactly the same main arg processing.
-GLOBAL_PROFILES_DIR = os.path.join(os.path.expanduser("~"), ".dbt")
-LOCAL_PROFILES_DIR = os.getcwd()
+GLOBAL_PROFILES_DIR = os_path.join(os_path.expanduser("~"), ".dbt")
+LOCAL_PROFILES_DIR = os_getcwd()
 # Use the current working directory if there is a profiles.yml file present there
-if os.path.exists(Path(LOCAL_PROFILES_DIR) / Path("profiles.yml")):
+if os_path.exists(Path(LOCAL_PROFILES_DIR) / Path("profiles.yml")):
     DEFAULT_PROFILES_DIR = LOCAL_PROFILES_DIR
 else:
     DEFAULT_PROFILES_DIR = GLOBAL_PROFILES_DIR
-PROFILES_DIR = os.path.expanduser(os.getenv("DBT_PROFILES_DIR", DEFAULT_PROFILES_DIR))
+PROFILES_DIR = os_path.expanduser(os_getenv("DBT_PROFILES_DIR", DEFAULT_PROFILES_DIR))
 
 STRICT_MODE = False  # Only here for backwards compatibility
 FULL_REFRESH = False  # subcommand
@@ -88,7 +90,7 @@ def env_set_truthy(key: str) -> Optional[str]:
     """Return the value if it was set to a "truthy" string value or None
     otherwise.
     """
-    value = os.getenv(key)
+    value = os_getenv(key)
     if not value or value.lower() in ("0", "false", "f"):
         return None
     return value
@@ -101,7 +103,7 @@ def env_set_bool(env_value):
 
 
 def env_set_path(key: str) -> Optional[Path]:
-    value = os.getenv(key)
+    value = os_getenv(key)
     if value is None:
         return value
     else:
@@ -181,7 +183,7 @@ def get_flag_value(flag, args, user_config):
     if flag == "PRINTER_WIDTH":  # must be ints
         flag_value = int(flag_value)
     if flag == "PROFILES_DIR":
-        flag_value = os.path.abspath(flag_value)
+        flag_value = os_path.abspath(flag_value)
 
     return flag_value
 
@@ -205,7 +207,7 @@ def _load_flag_value(flag, args, user_config):
 def _get_flag_value_from_env(flag):
     # Environment variables use pattern 'DBT_{flag name}'
     env_flag = _get_env_flag(flag)
-    env_value = os.getenv(env_flag)
+    env_value = os_getenv(env_flag)
     if env_value is None or env_value == "":
         return None
 
@@ -241,4 +243,21 @@ def get_flag_dict():
         "log_cache_events": LOG_CACHE_EVENTS,
         "quiet": QUIET,
         "no_print": NO_PRINT,
+        "cache_selected_only": CACHE_SELECTED_ONLY,
+        "target_path": TARGET_PATH,
+        "log_path": LOG_PATH,
     }
+
+
+# This is used by core/dbt/context/base.py to return a flag object
+# in Jinja.
+def get_flag_obj():
+    new_flags = Namespace()
+    for k, v in get_flag_dict().items():
+        setattr(new_flags, k.upper(), v)
+    # The following 3 are CLI arguments only so they're not full-fledged flags,
+    # but we put in flags for users.
+    setattr(new_flags, "FULL_REFRESH", FULL_REFRESH)
+    setattr(new_flags, "STORE_FAILURES", STORE_FAILURES)
+    setattr(new_flags, "WHICH", WHICH)
+    return new_flags

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -100,8 +100,11 @@ schema_file_keys = (
 def yaml_from_file(source_file: SchemaSourceFile) -> Dict[str, Any]:
     """If loading the yaml fails, raise an exception."""
     path = source_file.path.relative_path
+    # File contents filed is Optional, and is sometimes None, so ensure
+    # we are not passing in None to load_yaml_text.
+    contents = source_file.contents if source_file.contents else ""
     try:
-        return load_yaml_text(source_file.contents, source_file.path)
+        return load_yaml_text(contents, source_file.path)
     except ValidationException as e:
         raise YamlLoadFailure(source_file.project_name, path, e)
 

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -99,14 +99,11 @@ schema_file_keys = (
 
 def yaml_from_file(source_file: SchemaSourceFile) -> Dict[str, Any]:
     """If loading the yaml fails, raise an exception."""
-    path = source_file.path.relative_path
-    # File contents filed is Optional, and is sometimes None, so ensure
-    # we are not passing in None to load_yaml_text.
-    contents = source_file.contents if source_file.contents else ""
     try:
-        return load_yaml_text(contents, source_file.path)
+        # source_file.contents can sometimes be None
+        return load_yaml_text(source_file.contents or "", source_file.path)
     except ValidationException as e:
-        raise YamlLoadFailure(source_file.project_name, path, e)
+        raise YamlLoadFailure(source_file.project_name, source_file.path.relative_path, e)
 
 
 class ParserRef:

--- a/test/integration/068_partial_parsing_tests/test_partial_parsing.py
+++ b/test/integration/068_partial_parsing_tests/test_partial_parsing.py
@@ -477,6 +477,8 @@ class TestMacros(BasePPTest):
         # initial run so we have a msgpack file
         self.setup_directories()
         self.copy_file('test-files/model_one.sql', 'models/model_one.sql')
+        # use empty_schema file for bug #4850
+        self.copy_file('test-files/empty_schema.yml', 'models/eschema.yml')
         results = self.run_dbt()
 
         # add a new ref override macro

--- a/tests/functional/context_methods/test_builtin_functions.py
+++ b/tests/functional/context_methods/test_builtin_functions.py
@@ -112,8 +112,9 @@ class TestContextBuiltins:
         expected = "invocation_result: {'debug': True, 'log_format': 'json', 'write_json': True, 'use_colors': True, 'printer_width': 80, 'version_check': True, 'partial_parse': True, 'static_parser': True, 'profiles_dir': "
         assert expected in str(result)
 
-        expected = "'send_anonymous_usage_stats': False, 'quiet': False, 'no_print': False, 'macro': 'validate_invocation', 'args': '{my_variable: test_variable}', 'which': 'run-operation', 'rpc_method': 'run-operation', 'indirect_selection': 'eager'}"
-        assert expected in str(result)
+        expected = ("'send_anonymous_usage_stats': False", "'quiet': False", "'no_print': False", "'cache_selected_only': False", "'macro': 'validate_invocation'", "'args': '{my_variable: test_variable}'", "'which': 'run-operation'", "'rpc_method': 'run-operation'", "'indirect_selection': 'eager'")
+        for element in expected:
+            assert element in str(result)
 
     def test_builtin_dbt_metadata_envs_function(self, project, monkeypatch):
         envs = {


### PR DESCRIPTION
resolves #4850


### Description

The "contents" of a file object is defined as Optional[str] but load_yaml_text does not support passing in None from contents. Ensure that if field is set to None, an empty string is passed.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
