### PR TITLE
Fix issue link for changelog entry from PR#5859

### DIFF
--- a/.changes/1.4.0/Features-20220408-165459.yaml
+++ b/.changes/1.4.0/Features-20220408-165459.yaml
@@ -4,4 +4,4 @@ body: Added favor-state flag to optionally favor state nodes even if unselected 
 time: 2022-04-08T16:54:59.696564+01:00
 custom:
   Author: daniel-murray josephberni
-  Issue: "2968"
+  Issue: "5016"


### PR DESCRIPTION
The current link is to a much broader discussion (https://github.com/dbt-labs/dbt-core/issues/2968). This is misleading in the changelog & release notes. I believe https://github.com/dbt-labs/dbt-core/pull/5859 intended to link to https://github.com/dbt-labs/dbt-core/issues/5016, given that's the issue it closed.