### PR TITLE
Updating metric attributes renamed event

### DIFF
--- a/.changes/unreleased/Under the Hood-20230104-155257.yaml
+++ b/.changes/unreleased/Under the Hood-20230104-155257.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Updating the deprecation warning in the metric attributes renamed event
+time: 2023-01-04T15:52:57.916398-06:00
+custom:
+  Author: callum-mcdata
+  Issue: "6507"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -392,7 +392,6 @@ class MetricAttributesRenamed(WarnLevel, pt.MetricAttributesRenamed):  # noqa
             "\n  'sql'              -> 'expression'"
             "\n  'type'             -> 'calculation_method'"
             "\n  'type: expression' -> 'calculation_method: derived'"
-            "\nThe old metric parameter names will be fully deprecated in v1.4."
             f"\nPlease remove them from the metric definition of metric '{self.metric_name}'"
             "\nRelevant issue here: https://github.com/dbt-labs/dbt-core/issues/5849"
         )


### PR DESCRIPTION
resolves #6507 

### Description
Updates the event message for a metric that is using the pre-1.3 property names.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
