### PR TITLE
CT 1549 reorg logging events to have two top level keys

### DIFF
--- a/.changes/unreleased/Under the Hood-20230109-095907.yaml
+++ b/.changes/unreleased/Under the Hood-20230109-095907.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Reorganize structured logging events to have two top keys
+time: 2023-01-09T09:59:07.842187-05:00
+custom:
+  Author: gshank
+  Issue: "6311"

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -19,8 +19,8 @@ from dbt.events.types import (
     SystemErrorRetrievingModTime,
     SystemCouldNotWrite,
     SystemExecutingCmd,
-    SystemStdOutMsg,
-    SystemStdErrMsg,
+    SystemStdOut,
+    SystemStdErr,
     SystemReportReturnCode,
 )
 import dbt.exceptions
@@ -441,8 +441,8 @@ def run_cmd(cwd: str, cmd: List[str], env: Optional[Dict[str, Any]] = None) -> T
     except OSError as exc:
         _interpret_oserror(exc, cwd, cmd)
 
-    fire_event(SystemStdOutMsg(bmsg=out))
-    fire_event(SystemStdErrMsg(bmsg=err))
+    fire_event(SystemStdOut(bmsg=out))
+    fire_event(SystemStdErr(bmsg=err))
 
     if proc.returncode != 0:
         fire_event(SystemReportReturnCode(returncode=proc.returncode))

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -97,6 +97,7 @@ def msg_from_base_event(event: BaseEvent, level: EventLevel = None):
 
     # level in EventInfo must be a string, not an EventLevel
     msg_level: str = level.value if level else event.level_tag().value
+    assert msg_level is not None
     event_info = pt.EventInfo(
         level=msg_level,
         msg=event.message(),

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -90,13 +90,15 @@ class EventMsg(Protocol):
     data: BaseEvent
 
 
-def build_msg_from_base_event(event: BaseEvent, level: EventLevel = None):
+def msg_from_base_event(event: BaseEvent, level: EventLevel = None):
 
     msg_class_name = f"{type(event).__name__}Msg"
     msg_cls = getattr(pt, msg_class_name)
 
+    # level in EventInfo must be a string, not an EventLevel
+    msg_level: str = level.value if level else event.level_tag().value
     event_info = pt.EventInfo(
-        level=str(level or event.level_tag()),
+        level=msg_level,
         msg=event.message(),
         invocation_id=get_invocation_id(),
         extra=get_global_metadata_vars(),

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -4,7 +4,12 @@ import os
 import threading
 from datetime import datetime
 import dbt.events.proto_types as pt
-from typing import Protocol
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # These base types define the _required structure_ for the concrete event #

--- a/core/dbt/events/eventmgr.py
+++ b/core/dbt/events/eventmgr.py
@@ -9,7 +9,7 @@ import threading
 from typing import Any, Callable, List, Optional, TextIO
 from uuid import uuid4
 
-from dbt.events.base_types import BaseEvent, EventLevel, build_msg_from_base_event, EventMsg
+from dbt.events.base_types import BaseEvent, EventLevel, msg_from_base_event, EventMsg
 
 
 # A Filter is a function which takes a BaseEvent and returns True if the event
@@ -44,14 +44,6 @@ _log_level_map = {
     EventLevel.INFO: 20,
     EventLevel.WARN: 30,
     EventLevel.ERROR: 40,
-}
-
-_msg_level_map = {
-    "debug": 10,
-    "test": 10,
-    "info": 20,
-    "warn": 30,
-    "error": 40,
 }
 
 
@@ -119,7 +111,7 @@ class _Logger:
 
     def write_line(self, msg: EventMsg):
         line = self.create_line(msg)
-        python_level = _msg_level_map[msg.info.level]
+        python_level = _log_level_map[EventLevel(msg.info.level)]
         if self._python_logger is not None:
             send_to_logger(self._python_logger, msg.info.level, line)
         elif self._stream is not None and _log_level_map[self.level] <= python_level:
@@ -194,7 +186,7 @@ class EventManager:
         self.invocation_id: str = str(uuid4())
 
     def fire_event(self, e: BaseEvent, level: EventLevel = None) -> None:
-        msg = build_msg_from_base_event(e, level=level)
+        msg = msg_from_base_event(e, level=level)
         for logger in self.loggers:
             if logger.filter(msg):  # type: ignore
                 logger.write_line(msg)

--- a/core/dbt/events/eventmgr.py
+++ b/core/dbt/events/eventmgr.py
@@ -9,16 +9,16 @@ import threading
 from typing import Any, Callable, List, Optional, TextIO
 from uuid import uuid4
 
-from dbt.events.base_types import BaseEvent, EventLevel
+from dbt.events.base_types import BaseEvent, EventLevel, build_msg_from_base_event, EventMsg
 
 
 # A Filter is a function which takes a BaseEvent and returns True if the event
 # should be logged, False otherwise.
-Filter = Callable[[BaseEvent], bool]
+Filter = Callable[[EventMsg], bool]
 
 
 # Default filter which logs every event
-def NoFilter(_: BaseEvent) -> bool:
+def NoFilter(_: EventMsg) -> bool:
     return True
 
 
@@ -46,12 +46,13 @@ _log_level_map = {
     EventLevel.ERROR: 40,
 }
 
-
-# We should consider fixing the problem, but log_level() can return a string for
-# DynamicLevel events, even thought it is supposed to return an EventLevel. This
-# function gets a string for the level, no matter what.
-def _get_level_str(e: BaseEvent) -> str:
-    return e.log_level().value if isinstance(e.log_level(), EventLevel) else str(e.log_level())
+_msg_level_map = {
+    "debug": 10,
+    "test": 10,
+    "info": 20,
+    "warn": 30,
+    "error": 40,
+}
 
 
 # We need this function for now because the numeric log severity levels in
@@ -113,14 +114,14 @@ class _Logger:
 
             self._python_logger = log
 
-    def create_line(self, e: BaseEvent) -> str:
+    def create_line(self, msg: EventMsg) -> str:
         raise NotImplementedError()
 
-    def write_line(self, e: BaseEvent):
-        line = self.create_line(e)
-        python_level = _log_level_map[e.log_level()]
+    def write_line(self, msg: EventMsg):
+        line = self.create_line(msg)
+        python_level = _msg_level_map[msg.info.level]
         if self._python_logger is not None:
-            send_to_logger(self._python_logger, _get_level_str(e), line)
+            send_to_logger(self._python_logger, msg.info.level, line)
         elif self._stream is not None and _log_level_map[self.level] <= python_level:
             self._stream.write(line + "\n")
 
@@ -138,24 +139,26 @@ class _TextLogger(_Logger):
         self.use_colors = config.use_colors
         self.use_debug_format = config.line_format == LineFormat.DebugText
 
-    def create_line(self, e: BaseEvent) -> str:
-        return self.create_debug_line(e) if self.use_debug_format else self.create_info_line(e)
+    def create_line(self, msg: EventMsg) -> str:
+        return self.create_debug_line(msg) if self.use_debug_format else self.create_info_line(msg)
 
-    def create_info_line(self, e: BaseEvent) -> str:
+    def create_info_line(self, msg: EventMsg) -> str:
         ts: str = datetime.utcnow().strftime("%H:%M:%S")
-        scrubbed_msg: str = self.scrubber(e.message())  # type: ignore
+        scrubbed_msg: str = self.scrubber(msg.info.msg)  # type: ignore
         return f"{self._get_color_tag()}{ts}  {scrubbed_msg}"
 
-    def create_debug_line(self, e: BaseEvent) -> str:
+    def create_debug_line(self, msg: EventMsg) -> str:
         log_line: str = ""
         # Create a separator if this is the beginning of an invocation
         # TODO: This is an ugly hack, get rid of it if we can
-        if type(e).__name__ == "MainReportVersion":
+        if msg.info.name == "MainReportVersion":
             separator = 30 * "="
-            log_line = f"\n\n{separator} {datetime.utcnow()} | {self.event_manager.invocation_id} {separator}\n"
-        ts: str = datetime.utcnow().strftime("%H:%M:%S.%f")
-        scrubbed_msg: str = self.scrubber(e.message())  # type: ignore
-        level = _get_level_str(e)
+            log_line = (
+                f"\n\n{separator} {msg.info.ts} | {self.event_manager.invocation_id} {separator}\n"
+            )
+        ts: str = msg.info.ts.strftime("%H:%M:%S.%f")
+        scrubbed_msg: str = self.scrubber(msg.info.msg)  # type: ignore
+        level = msg.info.level
         log_line += (
             f"{self._get_color_tag()}{ts} [{level:<5}]{self._get_thread_name()} {scrubbed_msg}"
         )
@@ -175,11 +178,11 @@ class _TextLogger(_Logger):
 
 
 class _JsonLogger(_Logger):
-    def create_line(self, e: BaseEvent) -> str:
-        from dbt.events.functions import event_to_dict
+    def create_line(self, msg: EventMsg) -> str:
+        from dbt.events.functions import msg_to_dict
 
-        event_dict = event_to_dict(e)
-        raw_log_line = json.dumps(event_dict, sort_keys=True)
+        msg_dict = msg_to_dict(msg)
+        raw_log_line = json.dumps(msg_dict, sort_keys=True)
         line = self.scrubber(raw_log_line)  # type: ignore
         return line
 
@@ -187,16 +190,17 @@ class _JsonLogger(_Logger):
 class EventManager:
     def __init__(self) -> None:
         self.loggers: List[_Logger] = []
-        self.callbacks: List[Callable[[BaseEvent], None]] = []
+        self.callbacks: List[Callable[[EventMsg], None]] = []
         self.invocation_id: str = str(uuid4())
 
-    def fire_event(self, e: BaseEvent) -> None:
+    def fire_event(self, e: BaseEvent, level: EventLevel = None) -> None:
+        msg = build_msg_from_base_event(e, level=level)
         for logger in self.loggers:
-            if logger.filter(e):  # type: ignore
-                logger.write_line(e)
+            if logger.filter(msg):  # type: ignore
+                logger.write_line(msg)
 
         for callback in self.callbacks:
-            callback(e)
+            callback(msg)
 
     def add_logger(self, config: LoggerConfig):
         logger = (

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -172,17 +172,17 @@ def warn_or_error(event, node=None):
 
 # an alternative to fire_event which only creates and logs the event value
 # if the condition is met. Does nothing otherwise.
-def fire_event_if(conditional: bool, lazy_e: Callable[[], BaseEvent]) -> None:
+def fire_event_if(conditional: bool, lazy_e: Callable[[], BaseEvent], level: EventLevel=None) -> None:
     if conditional:
-        fire_event(lazy_e())
+        fire_event(lazy_e(), level=level)
 
 
 # top-level method for accessing the new eventing system
 # this is where all the side effects happen branched by event type
 # (i.e. - mutating the event history, printing to stdout, logging
 # to files, etc.)
-def fire_event(e: BaseEvent) -> None:
-    EVENT_MANAGER.fire_event(e)
+def fire_event(e: BaseEvent, level: EventLevel=None) -> None:
+    EVENT_MANAGER.fire_event(e, level=level)
 
 
 def get_metadata_vars() -> Dict[str, str]:

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -165,7 +165,7 @@ def warn_or_error(event, node=None):
         # TODO: resolve this circular import when at top
         from dbt.exceptions import EventCompilationException
 
-        raise EventCompilationException(event.info.msg, node)
+        raise EventCompilationException(event.message(), node)
     else:
         fire_event(event)
 

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -172,7 +172,9 @@ def warn_or_error(event, node=None):
 
 # an alternative to fire_event which only creates and logs the event value
 # if the condition is met. Does nothing otherwise.
-def fire_event_if(conditional: bool, lazy_e: Callable[[], BaseEvent], level: EventLevel=None) -> None:
+def fire_event_if(
+    conditional: bool, lazy_e: Callable[[], BaseEvent], level: EventLevel = None
+) -> None:
     if conditional:
         fire_event(lazy_e(), level=level)
 
@@ -181,7 +183,7 @@ def fire_event_if(conditional: bool, lazy_e: Callable[[], BaseEvent], level: Eve
 # this is where all the side effects happen branched by event type
 # (i.e. - mutating the event history, printing to stdout, logging
 # to files, etc.)
-def fire_event(e: BaseEvent, level: EventLevel=None) -> None:
+def fire_event(e: BaseEvent, level: EventLevel = None) -> None:
     EVENT_MANAGER.fire_event(e, level=level)
 
 

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -1,9 +1,8 @@
 import betterproto
 from dbt.constants import METADATA_ENV_PREFIX
-from dbt.events.base_types import BaseEvent, Cache, EventLevel, NoFile, NoStdOut
+from dbt.events.base_types import BaseEvent, Cache, EventLevel, NoFile, NoStdOut, EventMsg
 from dbt.events.eventmgr import EventManager, LoggerConfig, LineFormat, NoFilter
 from dbt.events.helpers import env_secrets, scrub_secrets
-from dbt.events.proto_types import EventInfo
 from dbt.events.types import EmptyLine
 import dbt.flags as flags
 from dbt.logger import GLOBAL_LOGGER, make_log_dir_if_missing
@@ -59,14 +58,14 @@ def _get_stdout_config(level: Optional[EventLevel] = None) -> LoggerConfig:
 
 
 def _stdout_filter(
-    log_cache_events: bool, debug_mode: bool, quiet_mode: bool, evt: BaseEvent
+    log_cache_events: bool, debug_mode: bool, quiet_mode: bool, msg: EventMsg
 ) -> bool:
     return (
-        not isinstance(evt, NoStdOut)
-        and (not isinstance(evt, Cache) or log_cache_events)
-        and (evt.log_level() != EventLevel.DEBUG or debug_mode)
-        and (evt.log_level() == EventLevel.ERROR or not quiet_mode)
-        and not (flags.LOG_FORMAT == "json" and type(evt) == EmptyLine)
+        not isinstance(msg.data, NoStdOut)
+        and (not isinstance(msg.data, Cache) or log_cache_events)
+        and (msg.info.level != "debug" or debug_mode)
+        and (msg.info.level == "error" or not quiet_mode)
+        and not (flags.LOG_FORMAT == "json" and type(msg.data) == EmptyLine)
     )
 
 
@@ -82,18 +81,18 @@ def _get_logfile_config(log_path: str) -> LoggerConfig:
     )
 
 
-def _logfile_filter(log_cache_events: bool, evt: BaseEvent) -> bool:
+def _logfile_filter(log_cache_events: bool, msg: EventMsg) -> bool:
     return (
-        not isinstance(evt, NoFile)
-        and not (isinstance(evt, Cache) and not log_cache_events)
-        and not (flags.LOG_FORMAT == "json" and type(evt) == EmptyLine)
+        not isinstance(msg.data, NoFile)
+        and not (isinstance(msg.data, Cache) and not log_cache_events)
+        and not (flags.LOG_FORMAT == "json" and type(msg.data) == EmptyLine)
     )
 
 
 def _get_logbook_log_config(level: Optional[EventLevel] = None) -> LoggerConfig:
     config = _get_stdout_config(level)
     config.name = "logbook_log"
-    config.filter = NoFilter if flags.LOG_CACHE_EVENTS else lambda e: not isinstance(e, Cache)
+    config.filter = NoFilter if flags.LOG_CACHE_EVENTS else lambda e: not isinstance(e.data, Cache)
     config.logger = GLOBAL_LOGGER
     return config
 
@@ -138,23 +137,23 @@ def stop_capture_stdout_logs():
 
 # returns a dictionary representation of the event fields.
 # the message may contain secrets which must be scrubbed at the usage site.
-def event_to_json(event: BaseEvent) -> str:
-    event_dict = event_to_dict(event)
-    raw_log_line = json.dumps(event_dict, sort_keys=True)
+def msg_to_json(msg: EventMsg) -> str:
+    msg_dict = msg_to_dict(msg)
+    raw_log_line = json.dumps(msg_dict, sort_keys=True)
     return raw_log_line
 
 
-def event_to_dict(event: BaseEvent) -> dict:
-    event_dict = dict()
+def msg_to_dict(msg: EventMsg) -> dict:
+    msg_dict = dict()
     try:
-        event_dict = event.to_dict(casing=betterproto.Casing.SNAKE, include_default_values=True)  # type: ignore
+        msg_dict = msg.to_dict(casing=betterproto.Casing.SNAKE, include_default_values=True)  # type: ignore
     except AttributeError as exc:
-        event_type = type(event).__name__
+        event_type = type(msg).__name__
         raise Exception(f"type {event_type} is not serializable. {str(exc)}")
     # We don't want an empty NodeInfo in output
-    if "node_info" in event_dict and event_dict["node_info"]["node_name"] == "":
-        del event_dict["node_info"]
-    return event_dict
+    if "node_info" in msg_dict["data"] and msg_dict["data"]["node_info"]["node_name"] == "":
+        del msg_dict["data"]["node_info"]
+    return msg_dict
 
 
 def warn_or_error(event, node=None):
@@ -206,11 +205,3 @@ def set_invocation_id() -> None:
     # This is primarily for setting the invocation_id for separate
     # commands in the dbt servers. It shouldn't be necessary for the CLI.
     EVENT_MANAGER.invocation_id = str(uuid.uuid4())
-
-
-# Currently used to set the level in EventInfo, so logging events can
-# provide more than one "level". Might be used in the future to set
-# more fields in EventInfo, once some of that information is no longer global
-def info(level="info"):
-    info = EventInfo(level=level)
-    return info

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -63,8 +63,8 @@ def _stdout_filter(
     return (
         not isinstance(msg.data, NoStdOut)
         and (not isinstance(msg.data, Cache) or log_cache_events)
-        and (msg.info.level != "debug" or debug_mode)
-        and (msg.info.level == "error" or not quiet_mode)
+        and (EventLevel(msg.info.level) != EventLevel.DEBUG or debug_mode)
+        and (EventLevel(msg.info.level) == EventLevel.ERROR or not quiet_mode)
         and not (flags.LOG_FORMAT == "json" and type(msg.data) == EmptyLine)
     )
 
@@ -151,7 +151,11 @@ def msg_to_dict(msg: EventMsg) -> dict:
         event_type = type(msg).__name__
         raise Exception(f"type {event_type} is not serializable. {str(exc)}")
     # We don't want an empty NodeInfo in output
-    if "node_info" in msg_dict["data"] and msg_dict["data"]["node_info"]["node_name"] == "":
+    if (
+        "data" in msg_dict
+        and "node_info" in msg_dict["data"]
+        and msg_dict["data"]["node_info"]["node_name"] == ""
+    ):
         del msg_dict["data"]["node_info"]
     return msg_dict
 

--- a/core/dbt/events/proto_types.py
+++ b/core/dbt/events/proto_types.py
@@ -91,1974 +91,3040 @@ class GenericMessage(betterproto.Message):
 class MainReportVersion(betterproto.Message):
     """A001"""
 
+    version: str = betterproto.string_field(1)
+    log_version: int = betterproto.int32_field(2)
+
+
+@dataclass
+class MainReportVersionMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    version: str = betterproto.string_field(2)
-    log_version: int = betterproto.int32_field(3)
+    data: "MainReportVersion" = betterproto.message_field(2)
 
 
 @dataclass
 class MainReportArgs(betterproto.Message):
     """A002"""
 
-    info: "EventInfo" = betterproto.message_field(1)
     args: Dict[str, str] = betterproto.map_field(
-        2, betterproto.TYPE_STRING, betterproto.TYPE_STRING
+        1, betterproto.TYPE_STRING, betterproto.TYPE_STRING
     )
+
+
+@dataclass
+class MainReportArgsMsg(betterproto.Message):
+    info: "EventInfo" = betterproto.message_field(1)
+    data: "MainReportArgs" = betterproto.message_field(2)
 
 
 @dataclass
 class MainTrackingUserState(betterproto.Message):
     """A003"""
 
+    user_state: str = betterproto.string_field(1)
+
+
+@dataclass
+class MainTrackingUserStateMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    user_state: str = betterproto.string_field(2)
+    data: "MainTrackingUserState" = betterproto.message_field(2)
 
 
 @dataclass
 class MergedFromState(betterproto.Message):
     """A004"""
 
+    num_merged: int = betterproto.int32_field(1)
+    sample: List[str] = betterproto.string_field(2)
+
+
+@dataclass
+class MergedFromStateMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    num_merged: int = betterproto.int32_field(2)
-    sample: List[str] = betterproto.string_field(3)
+    data: "MergedFromState" = betterproto.message_field(2)
 
 
 @dataclass
 class MissingProfileTarget(betterproto.Message):
     """A005"""
 
+    profile_name: str = betterproto.string_field(1)
+    target_name: str = betterproto.string_field(2)
+
+
+@dataclass
+class MissingProfileTargetMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    profile_name: str = betterproto.string_field(2)
-    target_name: str = betterproto.string_field(3)
+    data: "MissingProfileTarget" = betterproto.message_field(2)
 
 
 @dataclass
 class InvalidVarsYAML(betterproto.Message):
     """A008"""
 
+    pass
+
+
+@dataclass
+class InvalidVarsYAMLMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "InvalidVarsYAML" = betterproto.message_field(2)
 
 
 @dataclass
 class DbtProjectError(betterproto.Message):
     """A009"""
 
+    pass
+
+
+@dataclass
+class DbtProjectErrorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "DbtProjectError" = betterproto.message_field(2)
 
 
 @dataclass
 class DbtProjectErrorException(betterproto.Message):
     """A010"""
 
+    exc: str = betterproto.string_field(1)
+
+
+@dataclass
+class DbtProjectErrorExceptionMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    exc: str = betterproto.string_field(2)
+    data: "DbtProjectErrorException" = betterproto.message_field(2)
 
 
 @dataclass
 class DbtProfileError(betterproto.Message):
     """A011"""
 
+    pass
+
+
+@dataclass
+class DbtProfileErrorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "DbtProfileError" = betterproto.message_field(2)
 
 
 @dataclass
 class DbtProfileErrorException(betterproto.Message):
     """A012"""
 
+    exc: str = betterproto.string_field(1)
+
+
+@dataclass
+class DbtProfileErrorExceptionMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    exc: str = betterproto.string_field(2)
+    data: "DbtProfileErrorException" = betterproto.message_field(2)
 
 
 @dataclass
 class ProfileListTitle(betterproto.Message):
     """A013"""
 
+    pass
+
+
+@dataclass
+class ProfileListTitleMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "ProfileListTitle" = betterproto.message_field(2)
 
 
 @dataclass
 class ListSingleProfile(betterproto.Message):
     """A014"""
 
+    profile: str = betterproto.string_field(1)
+
+
+@dataclass
+class ListSingleProfileMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    profile: str = betterproto.string_field(2)
+    data: "ListSingleProfile" = betterproto.message_field(2)
 
 
 @dataclass
 class NoDefinedProfiles(betterproto.Message):
     """A015"""
 
+    pass
+
+
+@dataclass
+class NoDefinedProfilesMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "NoDefinedProfiles" = betterproto.message_field(2)
 
 
 @dataclass
 class ProfileHelpMessage(betterproto.Message):
     """A016"""
 
+    pass
+
+
+@dataclass
+class ProfileHelpMessageMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "ProfileHelpMessage" = betterproto.message_field(2)
 
 
 @dataclass
 class StarterProjectPath(betterproto.Message):
     """A017"""
 
+    dir: str = betterproto.string_field(1)
+
+
+@dataclass
+class StarterProjectPathMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    dir: str = betterproto.string_field(2)
+    data: "StarterProjectPath" = betterproto.message_field(2)
 
 
 @dataclass
 class ConfigFolderDirectory(betterproto.Message):
     """A018"""
 
+    dir: str = betterproto.string_field(1)
+
+
+@dataclass
+class ConfigFolderDirectoryMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    dir: str = betterproto.string_field(2)
+    data: "ConfigFolderDirectory" = betterproto.message_field(2)
 
 
 @dataclass
 class NoSampleProfileFound(betterproto.Message):
     """A019"""
 
+    adapter: str = betterproto.string_field(1)
+
+
+@dataclass
+class NoSampleProfileFoundMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    adapter: str = betterproto.string_field(2)
+    data: "NoSampleProfileFound" = betterproto.message_field(2)
 
 
 @dataclass
 class ProfileWrittenWithSample(betterproto.Message):
     """A020"""
 
+    name: str = betterproto.string_field(1)
+    path: str = betterproto.string_field(2)
+
+
+@dataclass
+class ProfileWrittenWithSampleMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    name: str = betterproto.string_field(2)
-    path: str = betterproto.string_field(3)
+    data: "ProfileWrittenWithSample" = betterproto.message_field(2)
 
 
 @dataclass
 class ProfileWrittenWithTargetTemplateYAML(betterproto.Message):
     """A021"""
 
+    name: str = betterproto.string_field(1)
+    path: str = betterproto.string_field(2)
+
+
+@dataclass
+class ProfileWrittenWithTargetTemplateYAMLMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    name: str = betterproto.string_field(2)
-    path: str = betterproto.string_field(3)
+    data: "ProfileWrittenWithTargetTemplateYAMLMsg" = betterproto.message_field(2)
 
 
 @dataclass
 class ProfileWrittenWithProjectTemplateYAML(betterproto.Message):
     """A022"""
 
+    name: str = betterproto.string_field(1)
+    path: str = betterproto.string_field(2)
+
+
+@dataclass
+class ProfileWrittenWithProjectTemplateYAMLMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    name: str = betterproto.string_field(2)
-    path: str = betterproto.string_field(3)
+    data: "ProfileWrittenWithProjectTemplateYAML" = betterproto.message_field(2)
 
 
 @dataclass
 class SettingUpProfile(betterproto.Message):
     """A023"""
 
+    pass
+
+
+@dataclass
+class SettingUpProfileMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "SettingUpProfile" = betterproto.message_field(2)
 
 
 @dataclass
 class InvalidProfileTemplateYAML(betterproto.Message):
     """A024"""
 
+    pass
+
+
+@dataclass
+class InvalidProfileTemplateYAMLMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "InvalidProfileTemplateYAML" = betterproto.message_field(2)
 
 
 @dataclass
 class ProjectNameAlreadyExists(betterproto.Message):
     """A025"""
 
+    name: str = betterproto.string_field(1)
+
+
+@dataclass
+class ProjectNameAlreadyExistsMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    name: str = betterproto.string_field(2)
+    data: "ProjectNameAlreadyExists" = betterproto.message_field(2)
 
 
 @dataclass
 class ProjectCreated(betterproto.Message):
     """A026"""
 
+    project_name: str = betterproto.string_field(1)
+    docs_url: str = betterproto.string_field(2)
+    slack_url: str = betterproto.string_field(3)
+
+
+@dataclass
+class ProjectCreatedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    project_name: str = betterproto.string_field(2)
-    docs_url: str = betterproto.string_field(3)
-    slack_url: str = betterproto.string_field(4)
+    data: "ProjectCreated" = betterproto.message_field(2)
 
 
 @dataclass
 class PackageRedirectDeprecation(betterproto.Message):
     """D001"""
 
+    old_name: str = betterproto.string_field(1)
+    new_name: str = betterproto.string_field(2)
+
+
+@dataclass
+class PackageRedirectDeprecationMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    old_name: str = betterproto.string_field(2)
-    new_name: str = betterproto.string_field(3)
+    data: "PackageRedirectDeprecation" = betterproto.message_field(2)
 
 
 @dataclass
 class PackageInstallPathDeprecation(betterproto.Message):
     """D002"""
 
+    pass
+
+
+@dataclass
+class PackageInstallPathDeprecationMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "PackageInstallPathDeprecation" = betterproto.message_field(2)
 
 
 @dataclass
 class ConfigSourcePathDeprecation(betterproto.Message):
     """D003"""
 
+    deprecated_path: str = betterproto.string_field(1)
+    exp_path: str = betterproto.string_field(2)
+
+
+@dataclass
+class ConfigSourcePathDeprecationMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    deprecated_path: str = betterproto.string_field(2)
-    exp_path: str = betterproto.string_field(3)
+    data: "ConfigSourcePathDeprecation" = betterproto.message_field(2)
 
 
 @dataclass
 class ConfigDataPathDeprecation(betterproto.Message):
     """D004"""
 
+    deprecated_path: str = betterproto.string_field(1)
+    exp_path: str = betterproto.string_field(2)
+
+
+@dataclass
+class ConfigDataPathDeprecationMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    deprecated_path: str = betterproto.string_field(2)
-    exp_path: str = betterproto.string_field(3)
+    data: "ConfigDataPathDeprecation" = betterproto.message_field(2)
 
 
 @dataclass
 class AdapterDeprecationWarning(betterproto.Message):
     """D005"""
 
+    old_name: str = betterproto.string_field(1)
+    new_name: str = betterproto.string_field(2)
+
+
+@dataclass
+class AdapterDeprecationWarningMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    old_name: str = betterproto.string_field(2)
-    new_name: str = betterproto.string_field(3)
+    data: "AdapterDeprecationWarning" = betterproto.message_field(2)
 
 
 @dataclass
 class MetricAttributesRenamed(betterproto.Message):
     """D006"""
 
+    metric_name: str = betterproto.string_field(1)
+
+
+@dataclass
+class MetricAttributesRenamedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    metric_name: str = betterproto.string_field(2)
+    data: "MetricAttributesRenamed" = betterproto.message_field(2)
 
 
 @dataclass
 class ExposureNameDeprecation(betterproto.Message):
     """D007"""
 
+    exposure: str = betterproto.string_field(1)
+
+
+@dataclass
+class ExposureNameDeprecationMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    exposure: str = betterproto.string_field(2)
+    data: "ExposureNameDeprecation" = betterproto.message_field(2)
 
 
 @dataclass
 class AdapterEventDebug(betterproto.Message):
     """E001"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    name: str = betterproto.string_field(2)
+    base_msg: str = betterproto.string_field(3)
+    args: List[str] = betterproto.string_field(4)
+
+
+@dataclass
+class AdapterEventDebugMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    name: str = betterproto.string_field(3)
-    base_msg: str = betterproto.string_field(4)
-    args: List[str] = betterproto.string_field(5)
+    data: "AdapterEventDebug" = betterproto.message_field(2)
 
 
 @dataclass
 class AdapterEventInfo(betterproto.Message):
     """E002"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    name: str = betterproto.string_field(2)
+    base_msg: str = betterproto.string_field(3)
+    args: List[str] = betterproto.string_field(4)
+
+
+@dataclass
+class AdapterEventInfoMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    name: str = betterproto.string_field(3)
-    base_msg: str = betterproto.string_field(4)
-    args: List[str] = betterproto.string_field(5)
+    data: "AdapterEventInfo" = betterproto.message_field(2)
 
 
 @dataclass
 class AdapterEventWarning(betterproto.Message):
     """E003"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    name: str = betterproto.string_field(2)
+    base_msg: str = betterproto.string_field(3)
+    args: List[str] = betterproto.string_field(4)
+
+
+@dataclass
+class AdapterEventWarningMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    name: str = betterproto.string_field(3)
-    base_msg: str = betterproto.string_field(4)
-    args: List[str] = betterproto.string_field(5)
+    data: "AdapterEventWarning" = betterproto.message_field(2)
 
 
 @dataclass
 class AdapterEventError(betterproto.Message):
     """E004"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    name: str = betterproto.string_field(2)
+    base_msg: str = betterproto.string_field(3)
+    args: List[str] = betterproto.string_field(4)
+    exc_info: str = betterproto.string_field(5)
+
+
+@dataclass
+class AdapterEventErrorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    name: str = betterproto.string_field(3)
-    base_msg: str = betterproto.string_field(4)
-    args: List[str] = betterproto.string_field(5)
-    exc_info: str = betterproto.string_field(6)
+    data: "AdapterEventError" = betterproto.message_field(2)
 
 
 @dataclass
 class NewConnection(betterproto.Message):
     """E005"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    conn_type: str = betterproto.string_field(2)
+    conn_name: str = betterproto.string_field(3)
+
+
+@dataclass
+class NewConnectionMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    conn_type: str = betterproto.string_field(3)
-    conn_name: str = betterproto.string_field(4)
+    data: "NewConnection" = betterproto.message_field(2)
 
 
 @dataclass
 class ConnectionReused(betterproto.Message):
     """E006"""
 
+    conn_name: str = betterproto.string_field(1)
+
+
+@dataclass
+class ConnectionReusedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    conn_name: str = betterproto.string_field(2)
+    data: "ConnectionReused" = betterproto.message_field(2)
 
 
 @dataclass
 class ConnectionLeftOpenInCleanup(betterproto.Message):
     """E007"""
 
+    conn_name: str = betterproto.string_field(1)
+
+
+@dataclass
+class ConnectionLeftOpenInCleanupMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    conn_name: str = betterproto.string_field(2)
+    data: "ConnectionLeftOpen" = betterproto.message_field(2)
 
 
 @dataclass
 class ConnectionClosedInCleanup(betterproto.Message):
     """E008"""
 
+    conn_name: str = betterproto.string_field(1)
+
+
+@dataclass
+class ConnectionClosedInCleanupMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    conn_name: str = betterproto.string_field(2)
+    data: "ConnectionClosedInCleanup" = betterproto.message_field(2)
 
 
 @dataclass
 class RollbackFailed(betterproto.Message):
     """E009"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    conn_name: str = betterproto.string_field(2)
+    exc_info: str = betterproto.string_field(3)
+
+
+@dataclass
+class RollbackFailedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    conn_name: str = betterproto.string_field(3)
-    exc_info: str = betterproto.string_field(4)
+    data: "RollbackFailed" = betterproto.message_field(2)
 
 
 @dataclass
 class ConnectionClosed(betterproto.Message):
     """E010"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    conn_name: str = betterproto.string_field(2)
+
+
+@dataclass
+class ConnectionClosedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    conn_name: str = betterproto.string_field(3)
+    data: "ConnectionClosed" = betterproto.message_field(2)
 
 
 @dataclass
 class ConnectionLeftOpen(betterproto.Message):
     """E011"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    conn_name: str = betterproto.string_field(2)
+
+
+@dataclass
+class ConnectionLeftOpenMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    conn_name: str = betterproto.string_field(3)
+    data: "ConnectionLeftOpen" = betterproto.message_field(2)
 
 
 @dataclass
 class Rollback(betterproto.Message):
     """E012"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    conn_name: str = betterproto.string_field(2)
+
+
+@dataclass
+class RollbackMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    conn_name: str = betterproto.string_field(3)
+    data: "Rollback" = betterproto.message_field(2)
 
 
 @dataclass
 class CacheMiss(betterproto.Message):
     """E013"""
 
+    conn_name: str = betterproto.string_field(1)
+    database: str = betterproto.string_field(2)
+    schema: str = betterproto.string_field(3)
+
+
+@dataclass
+class CacheMissMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    conn_name: str = betterproto.string_field(2)
-    database: str = betterproto.string_field(3)
-    schema: str = betterproto.string_field(4)
+    data: "CacheMiss" = betterproto.message_field(2)
 
 
 @dataclass
 class ListRelations(betterproto.Message):
     """E014"""
 
+    database: str = betterproto.string_field(1)
+    schema: str = betterproto.string_field(2)
+    relations: List["ReferenceKeyMsg"] = betterproto.message_field(3)
+
+
+@dataclass
+class ListRelationsMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    database: str = betterproto.string_field(2)
-    schema: str = betterproto.string_field(3)
-    relations: List["ReferenceKeyMsg"] = betterproto.message_field(4)
+    data: "ListRelations" = betterproto.message_field(2)
 
 
 @dataclass
 class ConnectionUsed(betterproto.Message):
     """E015"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    conn_type: str = betterproto.string_field(2)
+    conn_name: str = betterproto.string_field(3)
+
+
+@dataclass
+class ConnectionUsedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    conn_type: str = betterproto.string_field(3)
-    conn_name: str = betterproto.string_field(4)
+    data: "ConnectionUsed" = betterproto.message_field(2)
 
 
 @dataclass
 class SQLQuery(betterproto.Message):
     """E016"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    conn_name: str = betterproto.string_field(2)
+    sql: str = betterproto.string_field(3)
+
+
+@dataclass
+class SQLQueryMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    conn_name: str = betterproto.string_field(3)
-    sql: str = betterproto.string_field(4)
+    data: "SQLQuery" = betterproto.message_field(2)
 
 
 @dataclass
 class SQLQueryStatus(betterproto.Message):
     """E017"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    status: str = betterproto.string_field(2)
+    elapsed: float = betterproto.float_field(3)
+
+
+@dataclass
+class SQLQueryStatusMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    status: str = betterproto.string_field(3)
-    elapsed: float = betterproto.float_field(4)
+    data: "SQLQueryStatus" = betterproto.message_field(2)
 
 
 @dataclass
 class SQLCommit(betterproto.Message):
     """E018"""
 
+    conn_name: str = betterproto.string_field(1)
+
+
+@dataclass
+class SQLCommitMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    conn_name: str = betterproto.string_field(3)
+    data: "SQLCommit" = betterproto.message_field(2)
 
 
 @dataclass
 class ColTypeChange(betterproto.Message):
     """E019"""
 
+    orig_type: str = betterproto.string_field(1)
+    new_type: str = betterproto.string_field(2)
+    table: "ReferenceKeyMsg" = betterproto.message_field(3)
+
+
+@dataclass
+class ColTypeChangeMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    orig_type: str = betterproto.string_field(2)
-    new_type: str = betterproto.string_field(3)
-    table: "ReferenceKeyMsg" = betterproto.message_field(4)
+    data: "ColTypeChange" = betterproto.message_field(2)
 
 
 @dataclass
 class SchemaCreation(betterproto.Message):
     """E020"""
 
+    relation: "ReferenceKeyMsg" = betterproto.message_field(1)
+
+
+@dataclass
+class SchemaCreationMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    relation: "ReferenceKeyMsg" = betterproto.message_field(2)
+    data: "SchemaCreation" = betterproto.message_field(2)
 
 
 @dataclass
 class SchemaDrop(betterproto.Message):
     """E021"""
 
+    relation: "ReferenceKeyMsg" = betterproto.message_field(1)
+
+
+@dataclass
+class SchemaDropMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    relation: "ReferenceKeyMsg" = betterproto.message_field(2)
+    data: "SchemaDrop" = betterproto.message_field(2)
 
 
 @dataclass
 class UncachedRelation(betterproto.Message):
     """E022"""
 
+    dep_key: "ReferenceKeyMsg" = betterproto.message_field(1)
+    ref_key: "ReferenceKeyMsg" = betterproto.message_field(2)
+
+
+@dataclass
+class UncachedRelationMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    dep_key: "ReferenceKeyMsg" = betterproto.message_field(2)
-    ref_key: "ReferenceKeyMsg" = betterproto.message_field(3)
+    data: "UncachedRelation" = betterproto.message_field(2)
 
 
 @dataclass
 class AddLink(betterproto.Message):
     """E023"""
 
+    dep_key: "ReferenceKeyMsg" = betterproto.message_field(1)
+    ref_key: "ReferenceKeyMsg" = betterproto.message_field(2)
+
+
+@dataclass
+class AddLinkMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    dep_key: "ReferenceKeyMsg" = betterproto.message_field(2)
-    ref_key: "ReferenceKeyMsg" = betterproto.message_field(3)
+    data: "AddLink" = betterproto.message_field(2)
 
 
 @dataclass
 class AddRelation(betterproto.Message):
     """E024"""
 
+    relation: "ReferenceKeyMsg" = betterproto.message_field(1)
+
+
+@dataclass
+class AddRelationMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    relation: "ReferenceKeyMsg" = betterproto.message_field(2)
+    data: "AddRelation" = betterproto.message_field(2)
 
 
 @dataclass
 class DropMissingRelation(betterproto.Message):
     """E025"""
 
+    relation: "ReferenceKeyMsg" = betterproto.message_field(1)
+
+
+@dataclass
+class DropMissingRelationMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    relation: "ReferenceKeyMsg" = betterproto.message_field(2)
+    data: "DropMissingRelation" = betterproto.message_field(2)
 
 
 @dataclass
 class DropCascade(betterproto.Message):
     """E026"""
 
+    dropped: "ReferenceKeyMsg" = betterproto.message_field(1)
+    consequences: List["ReferenceKeyMsg"] = betterproto.message_field(2)
+
+
+@dataclass
+class DropCascadeMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    dropped: "ReferenceKeyMsg" = betterproto.message_field(2)
-    consequences: List["ReferenceKeyMsg"] = betterproto.message_field(3)
+    data: "DropCascade" = betterproto.message_field(2)
 
 
 @dataclass
 class DropRelation(betterproto.Message):
     """E027"""
 
+    dropped: "ReferenceKeyMsg" = betterproto.message_field(1)
+
+
+@dataclass
+class DropRelationMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    dropped: "ReferenceKeyMsg" = betterproto.message_field(2)
+    data: "DropRelation" = betterproto.message_field(2)
 
 
 @dataclass
 class UpdateReference(betterproto.Message):
     """E028"""
 
+    old_key: "ReferenceKeyMsg" = betterproto.message_field(1)
+    new_key: "ReferenceKeyMsg" = betterproto.message_field(2)
+    cached_key: "ReferenceKeyMsg" = betterproto.message_field(3)
+
+
+@dataclass
+class UpdateReferenceMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    old_key: "ReferenceKeyMsg" = betterproto.message_field(2)
-    new_key: "ReferenceKeyMsg" = betterproto.message_field(3)
-    cached_key: "ReferenceKeyMsg" = betterproto.message_field(4)
+    data: "UpdateReference" = betterproto.message_field(2)
 
 
 @dataclass
 class TemporaryRelation(betterproto.Message):
     """E029"""
 
+    key: "ReferenceKeyMsg" = betterproto.message_field(1)
+
+
+@dataclass
+class TemporaryRelationMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    key: "ReferenceKeyMsg" = betterproto.message_field(2)
+    data: "TemporaryRelation" = betterproto.message_field(2)
 
 
 @dataclass
 class RenameSchema(betterproto.Message):
     """E030"""
 
+    old_key: "ReferenceKeyMsg" = betterproto.message_field(1)
+    new_key: "ReferenceKeyMsg" = betterproto.message_field(2)
+
+
+@dataclass
+class RenameSchemaMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    old_key: "ReferenceKeyMsg" = betterproto.message_field(2)
-    new_key: "ReferenceKeyMsg" = betterproto.message_field(3)
+    data: "RenameSchema" = betterproto.message_field(2)
 
 
 @dataclass
 class DumpBeforeAddGraph(betterproto.Message):
     """E031"""
 
-    info: "EventInfo" = betterproto.message_field(1)
     dump: Dict[str, "ListOfStrings"] = betterproto.map_field(
-        2, betterproto.TYPE_STRING, betterproto.TYPE_MESSAGE
+        1, betterproto.TYPE_STRING, betterproto.TYPE_MESSAGE
     )
+
+
+@dataclass
+class DumpBeforeAddGraphMsg(betterproto.Message):
+    info: "EventInfo" = betterproto.message_field(1)
+    data: "DumpBeforeAddGraph" = betterproto.message_field(2)
 
 
 @dataclass
 class DumpAfterAddGraph(betterproto.Message):
     """E032"""
 
-    info: "EventInfo" = betterproto.message_field(1)
     dump: Dict[str, "ListOfStrings"] = betterproto.map_field(
-        2, betterproto.TYPE_STRING, betterproto.TYPE_MESSAGE
+        1, betterproto.TYPE_STRING, betterproto.TYPE_MESSAGE
     )
+
+
+@dataclass
+class DumpAfterAddGraphMsg(betterproto.Message):
+    info: "EventInfo" = betterproto.message_field(1)
+    data: "DumpAfterAddGraph" = betterproto.message_field(2)
 
 
 @dataclass
 class DumpBeforeRenameSchema(betterproto.Message):
     """E033"""
 
-    info: "EventInfo" = betterproto.message_field(1)
     dump: Dict[str, "ListOfStrings"] = betterproto.map_field(
-        2, betterproto.TYPE_STRING, betterproto.TYPE_MESSAGE
+        1, betterproto.TYPE_STRING, betterproto.TYPE_MESSAGE
     )
+
+
+@dataclass
+class DumpBeforeRenameSchemaMsg(betterproto.Message):
+    info: "EventInfo" = betterproto.message_field(1)
+    data: "DumpBeforeRenameSchema" = betterproto.message_field(2)
 
 
 @dataclass
 class DumpAfterRenameSchema(betterproto.Message):
     """E034"""
 
-    info: "EventInfo" = betterproto.message_field(1)
     dump: Dict[str, "ListOfStrings"] = betterproto.map_field(
-        2, betterproto.TYPE_STRING, betterproto.TYPE_MESSAGE
+        1, betterproto.TYPE_STRING, betterproto.TYPE_MESSAGE
     )
+
+
+@dataclass
+class DumpAfterRenameSchemaMsg(betterproto.Message):
+    info: "EventInfo" = betterproto.message_field(1)
+    data: "DumpAfterRenameSchema" = betterproto.message_field(2)
 
 
 @dataclass
 class AdapterImportError(betterproto.Message):
     """E035"""
 
+    exc: str = betterproto.string_field(1)
+
+
+@dataclass
+class AdapterImportErrorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    exc: str = betterproto.string_field(2)
+    data: "AdapterImportError" = betterproto.message_field(2)
 
 
 @dataclass
 class PluginLoadError(betterproto.Message):
     """E036"""
 
+    exc_info: str = betterproto.string_field(1)
+
+
+@dataclass
+class PluginLoadErrorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    exc_info: str = betterproto.string_field(2)
+    data: "PluginLoadError" = betterproto.message_field(2)
 
 
 @dataclass
 class NewConnectionOpening(betterproto.Message):
     """E037"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    connection_state: str = betterproto.string_field(2)
+
+
+@dataclass
+class NewConnectionOpeningMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    connection_state: str = betterproto.string_field(3)
+    data: "NewConnectionOpening" = betterproto.message_field(2)
 
 
 @dataclass
 class CodeExecution(betterproto.Message):
     """E038"""
 
+    conn_name: str = betterproto.string_field(1)
+    code_content: str = betterproto.string_field(2)
+
+
+@dataclass
+class CodeExecutionMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    conn_name: str = betterproto.string_field(2)
-    code_content: str = betterproto.string_field(3)
+    data: "CodeExecution" = betterproto.message_field(2)
 
 
 @dataclass
 class CodeExecutionStatus(betterproto.Message):
     """E039"""
 
+    status: str = betterproto.string_field(1)
+    elapsed: float = betterproto.float_field(2)
+
+
+@dataclass
+class CodeExecutionStatusMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    status: str = betterproto.string_field(2)
-    elapsed: float = betterproto.float_field(3)
+    data: "CodeExecutionStatus" = betterproto.message_field(2)
 
 
 @dataclass
 class CatalogGenerationError(betterproto.Message):
     """E040"""
 
+    exc: str = betterproto.string_field(1)
+
+
+@dataclass
+class CatalogGenerationErrorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    exc: str = betterproto.string_field(2)
+    data: "CatalogGenerationError" = betterproto.message_field(2)
 
 
 @dataclass
 class WriteCatalogFailure(betterproto.Message):
     """E041"""
 
+    num_exceptions: int = betterproto.int32_field(1)
+
+
+@dataclass
+class WriteCatalogFailureMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    num_exceptions: int = betterproto.int32_field(2)
+    data: "WriteCatalogFailure" = betterproto.message_field(2)
 
 
 @dataclass
 class CatalogWritten(betterproto.Message):
     """E042"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class CatalogWrittenMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "CatalogWritten" = betterproto.message_field(2)
 
 
 @dataclass
 class CannotGenerateDocs(betterproto.Message):
     """E043"""
 
+    pass
+
+
+@dataclass
+class CannotGenerateDocsMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "CannotGenerateDocs" = betterproto.message_field(2)
 
 
 @dataclass
 class BuildingCatalog(betterproto.Message):
     """E044"""
 
+    pass
+
+
+@dataclass
+class BuildingCatalogMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "BuildingCatalog" = betterproto.message_field(2)
 
 
 @dataclass
 class DatabaseErrorRunningHook(betterproto.Message):
     """E045"""
 
+    hook_type: str = betterproto.string_field(1)
+
+
+@dataclass
+class DatabaseErrorRunningHookMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    hook_type: str = betterproto.string_field(2)
+    data: "DatabaseErrorRunningHook" = betterproto.message_field(2)
 
 
 @dataclass
 class HooksRunning(betterproto.Message):
     """E046"""
 
+    num_hooks: int = betterproto.int32_field(1)
+    hook_type: str = betterproto.string_field(2)
+
+
+@dataclass
+class HooksRunningMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    num_hooks: int = betterproto.int32_field(2)
-    hook_type: str = betterproto.string_field(3)
+    data: "HooksRunning" = betterproto.message_field(2)
 
 
 @dataclass
 class HookFinished(betterproto.Message):
     """E047"""
 
-    info: "EventInfo" = betterproto.message_field(1)
-    stat_line: str = betterproto.string_field(2)
-    execution: str = betterproto.string_field(3)
-    execution_time: float = betterproto.float_field(4)
+    stat_line: str = betterproto.string_field(1)
+    execution: str = betterproto.string_field(2)
+    execution_time: float = betterproto.float_field(3)
 
 
 @dataclass
-class ParseCmdStart(betterproto.Message):
+class HookFinishedMsg(betterproto.Message):
+    info: "EventInfo" = betterproto.message_field(1)
+    data: "HookFinished" = betterproto.message_field(2)
+
+
+@dataclass
+class ParseCmdOut(betterproto.Message):
     """I001"""
 
-    info: "EventInfo" = betterproto.message_field(1)
+    msg: str = betterproto.string_field(1)
 
 
 @dataclass
-class ParseCmdCompiling(betterproto.Message):
-    """I002"""
-
+class ParseCmdOutMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-
-
-@dataclass
-class ParseCmdWritingManifest(betterproto.Message):
-    """I003"""
-
-    info: "EventInfo" = betterproto.message_field(1)
-
-
-@dataclass
-class ParseCmdDone(betterproto.Message):
-    """I004"""
-
-    info: "EventInfo" = betterproto.message_field(1)
-
-
-@dataclass
-class ManifestDependenciesLoaded(betterproto.Message):
-    """I005"""
-
-    info: "EventInfo" = betterproto.message_field(1)
-
-
-@dataclass
-class ManifestLoaderCreated(betterproto.Message):
-    """I006"""
-
-    info: "EventInfo" = betterproto.message_field(1)
-
-
-@dataclass
-class ManifestLoaded(betterproto.Message):
-    """I007"""
-
-    info: "EventInfo" = betterproto.message_field(1)
-
-
-@dataclass
-class ManifestChecked(betterproto.Message):
-    """I008"""
-
-    info: "EventInfo" = betterproto.message_field(1)
-
-
-@dataclass
-class ManifestFlatGraphBuilt(betterproto.Message):
-    """I009"""
-
-    info: "EventInfo" = betterproto.message_field(1)
-
-
-@dataclass
-class ParseCmdPerfInfoPath(betterproto.Message):
-    """I010"""
-
-    info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "ParseCmdOut" = betterproto.message_field(2)
 
 
 @dataclass
 class GenericTestFileParse(betterproto.Message):
     """I011"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class GenericTestFileParseMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "GenericTestFileParse" = betterproto.message_field(2)
 
 
 @dataclass
 class MacroFileParse(betterproto.Message):
     """I012"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class MacroFileParseMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "MacroFileParse" = betterproto.message_field(2)
 
 
 @dataclass
 class PartialParsingExceptionProcessingFile(betterproto.Message):
     """I014"""
 
+    file: str = betterproto.string_field(1)
+
+
+@dataclass
+class PartialParsingExceptionProcessingFileMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    file: str = betterproto.string_field(2)
+    data: "PartialParsingExceptionProcessingFile" = betterproto.message_field(2)
 
 
 @dataclass
 class PartialParsingException(betterproto.Message):
     """I016"""
 
-    info: "EventInfo" = betterproto.message_field(1)
     exc_info: Dict[str, str] = betterproto.map_field(
-        2, betterproto.TYPE_STRING, betterproto.TYPE_STRING
+        1, betterproto.TYPE_STRING, betterproto.TYPE_STRING
     )
+
+
+@dataclass
+class PartialParsingExceptionMsg(betterproto.Message):
+    info: "EventInfo" = betterproto.message_field(1)
+    data: "PartialParsingException" = betterproto.message_field(2)
 
 
 @dataclass
 class PartialParsingSkipParsing(betterproto.Message):
     """I017"""
 
+    pass
+
+
+@dataclass
+class PartialPArsingSkipParsingMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "PartialParsingSkipParsing" = betterproto.message_field(2)
 
 
 @dataclass
 class UnableToPartialParse(betterproto.Message):
     """I024"""
 
+    reason: str = betterproto.string_field(1)
+
+
+@dataclass
+class UnableToPartialParseMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    reason: str = betterproto.string_field(2)
+    data: "UnableToPartialParse" = betterproto.message_field(2)
 
 
 @dataclass
 class PartialParsingNotEnabled(betterproto.Message):
     """I028"""
 
+    pass
+
+
+@dataclass
+class PartialParsingNotEnabledMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "PartialParsingNotEnabled" = betterproto.message_field(2)
 
 
 @dataclass
 class ParsedFileLoadFailed(betterproto.Message):
     """I029"""
 
+    path: str = betterproto.string_field(1)
+    exc: str = betterproto.string_field(2)
+    exc_info: str = betterproto.string_field(3)
+
+
+@dataclass
+class ParsedFileLoadFailedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
-    exc: str = betterproto.string_field(3)
-    exc_info: str = betterproto.string_field(4)
+    data: "ParsedFileLoadFailed" = betterproto.message_field(2)
 
 
 @dataclass
 class StaticParserCausedJinjaRendering(betterproto.Message):
     """I031"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class StaticParserCausedJinjaRenderingMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "StaticParserCausedJinjaRendering" = betterproto.message_field(2)
 
 
 @dataclass
 class UsingExperimentalParser(betterproto.Message):
     """I032"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class UsingExperimentalParserMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "UsingExperimentalParser" = betterproto.message_field(2)
 
 
 @dataclass
 class SampleFullJinjaRendering(betterproto.Message):
     """I033"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class SampleFullJinjaRenderingMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "SampleFullJinjaRendering" = betterproto.message_field(2)
 
 
 @dataclass
 class StaticParserFallbackJinjaRendering(betterproto.Message):
     """I034"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class StaticParserFallbackJinjaRenderingMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "StaticParserFallbackJinjaRendering" = betterproto.message_field(2)
 
 
 @dataclass
 class StaticParsingMacroOverrideDetected(betterproto.Message):
     """I035"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class StaticParsingMacroOverrideDetectedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "StaticParsingMacroOverrideDetected" = betterproto.message_field(2)
 
 
 @dataclass
 class StaticParserSuccess(betterproto.Message):
     """I036"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class StaticParserSuccessMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "StaticParserSuccess" = betterproto.message_field(2)
 
 
 @dataclass
 class StaticParserFailure(betterproto.Message):
     """I037"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class StaticParserFailureMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "StaticParserFailure" = betterproto.message_field(2)
 
 
 @dataclass
 class ExperimentalParserSuccess(betterproto.Message):
     """I038"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class ExperimentalParserSuccessMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "ExperimentalParserSuccess" = betterproto.message_field(2)
 
 
 @dataclass
 class ExperimentalParserFailure(betterproto.Message):
     """I039"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class ExperimentalParserFailureMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "ExperimentalParserFailure" = betterproto.message_field(2)
 
 
 @dataclass
 class PartialParsingEnabled(betterproto.Message):
     """I040"""
 
+    deleted: int = betterproto.int32_field(1)
+    added: int = betterproto.int32_field(2)
+    changed: int = betterproto.int32_field(3)
+
+
+@dataclass
+class PartialParsingEnabledMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    deleted: int = betterproto.int32_field(2)
-    added: int = betterproto.int32_field(3)
-    changed: int = betterproto.int32_field(4)
+    data: "PartialParsingEnabled" = betterproto.message_field(2)
 
 
 @dataclass
 class PartialParsingFile(betterproto.Message):
     """I041"""
 
+    file_id: str = betterproto.string_field(1)
+    operation: str = betterproto.string_field(2)
+
+
+@dataclass
+class PartialParsingFileMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    file_id: str = betterproto.string_field(2)
-    operation: str = betterproto.string_field(3)
+    data: "PartialParsingFile" = betterproto.message_field(2)
 
 
 @dataclass
 class InvalidDisabledTargetInTestNode(betterproto.Message):
     """I050"""
 
+    resource_type_title: str = betterproto.string_field(1)
+    unique_id: str = betterproto.string_field(2)
+    original_file_path: str = betterproto.string_field(3)
+    target_kind: str = betterproto.string_field(4)
+    target_name: str = betterproto.string_field(5)
+    target_package: str = betterproto.string_field(6)
+
+
+@dataclass
+class InvalidDisabledTargetInTestNodeMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    resource_type_title: str = betterproto.string_field(2)
-    unique_id: str = betterproto.string_field(3)
-    original_file_path: str = betterproto.string_field(4)
-    target_kind: str = betterproto.string_field(5)
-    target_name: str = betterproto.string_field(6)
-    target_package: str = betterproto.string_field(7)
+    data: "InvalidDisabledTargetInTestNode" = betterproto.message_field(2)
 
 
 @dataclass
 class UnusedResourceConfigPath(betterproto.Message):
     """I051"""
 
+    unused_config_paths: List[str] = betterproto.string_field(1)
+
+
+@dataclass
+class UnusedResourceConfigPathMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    unused_config_paths: List[str] = betterproto.string_field(2)
+    data: "UnusedResourceConfigPath" = betterproto.message_field(2)
 
 
 @dataclass
 class SeedIncreased(betterproto.Message):
     """I052"""
 
+    package_name: str = betterproto.string_field(1)
+    name: str = betterproto.string_field(2)
+
+
+@dataclass
+class SeedIncreasedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    package_name: str = betterproto.string_field(2)
-    name: str = betterproto.string_field(3)
+    data: "SeedIncreased" = betterproto.message_field(2)
 
 
 @dataclass
 class SeedExceedsLimitSamePath(betterproto.Message):
     """I053"""
 
+    package_name: str = betterproto.string_field(1)
+    name: str = betterproto.string_field(2)
+
+
+@dataclass
+class SeedExceedsLimitSamePathMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    package_name: str = betterproto.string_field(2)
-    name: str = betterproto.string_field(3)
+    data: "SeedExceedsLimitSamePath" = betterproto.message_field(2)
 
 
 @dataclass
 class SeedExceedsLimitAndPathChanged(betterproto.Message):
     """I054"""
 
+    package_name: str = betterproto.string_field(1)
+    name: str = betterproto.string_field(2)
+
+
+@dataclass
+class SeedExceedsLimitAndPathChangedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    package_name: str = betterproto.string_field(2)
-    name: str = betterproto.string_field(3)
+    data: "SeedExceedsLimitAndPathChanged" = betterproto.message_field(2)
 
 
 @dataclass
 class SeedExceedsLimitChecksumChanged(betterproto.Message):
     """I055"""
 
+    package_name: str = betterproto.string_field(1)
+    name: str = betterproto.string_field(2)
+    checksum_name: str = betterproto.string_field(3)
+
+
+@dataclass
+class SeedExceedsLimitChecksumChangedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    package_name: str = betterproto.string_field(2)
-    name: str = betterproto.string_field(3)
-    checksum_name: str = betterproto.string_field(4)
+    data: "SeedExceedsLimitChecksumChanged" = betterproto.message_field(2)
 
 
 @dataclass
 class UnusedTables(betterproto.Message):
     """I056"""
 
+    unused_tables: List[str] = betterproto.string_field(1)
+
+
+@dataclass
+class UnusedTablesMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    unused_tables: List[str] = betterproto.string_field(2)
+    data: "UnusedTables" = betterproto.message_field(2)
 
 
 @dataclass
 class WrongResourceSchemaFile(betterproto.Message):
     """I057"""
 
+    patch_name: str = betterproto.string_field(1)
+    resource_type: str = betterproto.string_field(2)
+    plural_resource_type: str = betterproto.string_field(3)
+    yaml_key: str = betterproto.string_field(4)
+    file_path: str = betterproto.string_field(5)
+
+
+@dataclass
+class WrongResourceSchemaFileMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    patch_name: str = betterproto.string_field(2)
-    resource_type: str = betterproto.string_field(3)
-    plural_resource_type: str = betterproto.string_field(4)
-    yaml_key: str = betterproto.string_field(5)
-    file_path: str = betterproto.string_field(6)
+    data: "WrongResourceSchemaFile" = betterproto.message_field(2)
 
 
 @dataclass
 class NoNodeForYamlKey(betterproto.Message):
     """I058"""
 
-    info: "EventInfo" = betterproto.message_field(1)
-    patch_name: str = betterproto.string_field(2)
-    yaml_key: str = betterproto.string_field(3)
-    file_path: str = betterproto.string_field(4)
+    patch_name: str = betterproto.string_field(1)
+    yaml_key: str = betterproto.string_field(2)
+    file_path: str = betterproto.string_field(3)
 
 
 @dataclass
-class MacroPatchNotFound(betterproto.Message):
+class NoNodeForYamlKeyMsg(betterproto.Message):
+    info: "EventInfo" = betterproto.message_field(1)
+    data: "NoNodeForYamlKey" = betterproto.message_field(2)
+
+
+@dataclass
+class MacroNotFoundForPatch(betterproto.Message):
     """I059"""
 
+    patch_name: str = betterproto.string_field(1)
+
+
+@dataclass
+class MacroNotFoundForPatchMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    patch_name: str = betterproto.string_field(2)
+    data: "MacroNotFoundForPatch" = betterproto.message_field(2)
 
 
 @dataclass
 class NodeNotFoundOrDisabled(betterproto.Message):
     """I060"""
 
+    original_file_path: str = betterproto.string_field(1)
+    unique_id: str = betterproto.string_field(2)
+    resource_type_title: str = betterproto.string_field(3)
+    target_name: str = betterproto.string_field(4)
+    target_kind: str = betterproto.string_field(5)
+    target_package: str = betterproto.string_field(6)
+    disabled: str = betterproto.string_field(7)
+
+
+@dataclass
+class NodeNotFoundOrDisabledMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    original_file_path: str = betterproto.string_field(2)
-    unique_id: str = betterproto.string_field(3)
-    resource_type_title: str = betterproto.string_field(4)
-    target_name: str = betterproto.string_field(5)
-    target_kind: str = betterproto.string_field(6)
-    target_package: str = betterproto.string_field(7)
-    disabled: str = betterproto.string_field(8)
+    data: "NodeNotFoundOrDisabled" = betterproto.message_field(2)
 
 
 @dataclass
 class JinjaLogWarning(betterproto.Message):
     """I061"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    msg: str = betterproto.string_field(2)
+
+
+@dataclass
+class JinjaLogWarningMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    msg: str = betterproto.string_field(3)
+    data: "JinjaLogWarning" = betterproto.message_field(2)
 
 
 @dataclass
 class GitSparseCheckoutSubdirectory(betterproto.Message):
     """M001"""
 
+    subdir: str = betterproto.string_field(1)
+
+
+@dataclass
+class GitSparseCheckoutSubdirectoryMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    subdir: str = betterproto.string_field(2)
+    data: "GitSparseCheckoutSubdirectory" = betterproto.message_field(2)
 
 
 @dataclass
 class GitProgressCheckoutRevision(betterproto.Message):
     """M002"""
 
+    revision: str = betterproto.string_field(1)
+
+
+@dataclass
+class GitProgressCheckoutRevisionMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    revision: str = betterproto.string_field(2)
+    data: "GitProgressCheckoutRevision" = betterproto.message_field(2)
 
 
 @dataclass
 class GitProgressUpdatingExistingDependency(betterproto.Message):
     """M003"""
 
+    dir: str = betterproto.string_field(1)
+
+
+@dataclass
+class GitProgressUpdatingExistingDependencyMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    dir: str = betterproto.string_field(2)
+    data: "GitProgressUpdatingExistingDependency" = betterproto.message_field(2)
 
 
 @dataclass
 class GitProgressPullingNewDependency(betterproto.Message):
     """M004"""
 
+    dir: str = betterproto.string_field(1)
+
+
+@dataclass
+class GitProgressPullingNewDependencyMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    dir: str = betterproto.string_field(2)
+    data: "GitProgressPullingNewDependency" = betterproto.message_field(2)
 
 
 @dataclass
 class GitNothingToDo(betterproto.Message):
     """M005"""
 
+    sha: str = betterproto.string_field(1)
+
+
+@dataclass
+class GitNothingToDoMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    sha: str = betterproto.string_field(2)
+    data: "GitNothingToDo" = betterproto.message_field(2)
 
 
 @dataclass
 class GitProgressUpdatedCheckoutRange(betterproto.Message):
     """M006"""
 
+    start_sha: str = betterproto.string_field(1)
+    end_sha: str = betterproto.string_field(2)
+
+
+@dataclass
+class GitProgressUpdatedCheckoutRangeMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    start_sha: str = betterproto.string_field(2)
-    end_sha: str = betterproto.string_field(3)
+    data: "GitProgressUpdatedCheckoutRange" = betterproto.message_field(2)
 
 
 @dataclass
 class GitProgressCheckedOutAt(betterproto.Message):
     """M007"""
 
+    end_sha: str = betterproto.string_field(1)
+
+
+@dataclass
+class GitProgressCheckedOutAtMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    end_sha: str = betterproto.string_field(2)
+    data: "GitProgressCheckedOutAt" = betterproto.message_field(2)
 
 
 @dataclass
 class RegistryProgressGETRequest(betterproto.Message):
     """M008"""
 
+    url: str = betterproto.string_field(1)
+
+
+@dataclass
+class RegistryProgressGETRequestMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    url: str = betterproto.string_field(2)
+    data: "RegistryProgressGETRequest" = betterproto.message_field(2)
 
 
 @dataclass
 class RegistryProgressGETResponse(betterproto.Message):
     """M009"""
 
+    url: str = betterproto.string_field(1)
+    resp_code: int = betterproto.int32_field(2)
+
+
+@dataclass
+class RegistryProgressGETResponseMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    url: str = betterproto.string_field(2)
-    resp_code: int = betterproto.int32_field(3)
+    data: "RegistryProgressGETResponse" = betterproto.message_field(2)
 
 
 @dataclass
 class SelectorReportInvalidSelector(betterproto.Message):
     """M010"""
 
+    valid_selectors: str = betterproto.string_field(1)
+    spec_method: str = betterproto.string_field(2)
+    raw_spec: str = betterproto.string_field(3)
+
+
+@dataclass
+class SelectorReportInvalidSelectorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    valid_selectors: str = betterproto.string_field(2)
-    spec_method: str = betterproto.string_field(3)
-    raw_spec: str = betterproto.string_field(4)
+    data: "SelectorReportInvalidSelector" = betterproto.message_field(2)
 
 
 @dataclass
 class JinjaLogInfo(betterproto.Message):
     """M011"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    msg: str = betterproto.string_field(2)
+
+
+@dataclass
+class JinjaLogInfoMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    msg: str = betterproto.string_field(3)
+    data: "JinjaLogInfo" = betterproto.message_field(2)
 
 
 @dataclass
 class JinjaLogDebug(betterproto.Message):
     """M012"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    msg: str = betterproto.string_field(2)
+
+
+@dataclass
+class JinjaLogDebugMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    msg: str = betterproto.string_field(3)
+    data: "JinjaLogDebug" = betterproto.message_field(2)
 
 
 @dataclass
 class DepsNoPackagesFound(betterproto.Message):
     """M013"""
 
+    pass
+
+
+@dataclass
+class DepsNoPackagesFoundMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "DepsNoPackagesFound" = betterproto.message_field(2)
 
 
 @dataclass
 class DepsStartPackageInstall(betterproto.Message):
     """M014"""
 
+    package_name: str = betterproto.string_field(1)
+
+
+@dataclass
+class DepsStartPackageInstallMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    package_name: str = betterproto.string_field(2)
+    data: "DepsStartPackageInstall" = betterproto.message_field(2)
 
 
 @dataclass
 class DepsInstallInfo(betterproto.Message):
     """M015"""
 
+    version_name: str = betterproto.string_field(1)
+
+
+@dataclass
+class DepsInstallInfoMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    version_name: str = betterproto.string_field(2)
+    data: "DepsInstallInfo" = betterproto.message_field(2)
 
 
 @dataclass
 class DepsUpdateAvailable(betterproto.Message):
     """M016"""
 
+    version_latest: str = betterproto.string_field(1)
+
+
+@dataclass
+class DepsUpdateAvailableMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    version_latest: str = betterproto.string_field(2)
+    data: "DepsUpdateAvailable" = betterproto.message_field(2)
 
 
 @dataclass
 class DepsUpToDate(betterproto.Message):
     """M017"""
 
+    pass
+
+
+@dataclass
+class DepsUpToDateMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "DepsUpToDate" = betterproto.message_field(2)
 
 
 @dataclass
 class DepsListSubdirectory(betterproto.Message):
     """M018"""
 
+    subdirectory: str = betterproto.string_field(1)
+
+
+@dataclass
+class DepsListSubdirectoryMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    subdirectory: str = betterproto.string_field(2)
+    data: "DepsListSubdirectory" = betterproto.message_field(2)
 
 
 @dataclass
 class DepsNotifyUpdatesAvailable(betterproto.Message):
     """M019"""
 
+    packages: "ListOfStrings" = betterproto.message_field(1)
+
+
+@dataclass
+class DepsNotifyUpdatesAvailableMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    packages: "ListOfStrings" = betterproto.message_field(2)
+    data: "DepsNotifyUpdatesAvailable" = betterproto.message_field(2)
 
 
 @dataclass
 class RetryExternalCall(betterproto.Message):
     """M020"""
 
+    attempt: int = betterproto.int32_field(1)
+    max: int = betterproto.int32_field(2)
+
+
+@dataclass
+class RetryExternalCallMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    attempt: int = betterproto.int32_field(2)
-    max: int = betterproto.int32_field(3)
+    data: "RetryExternalCall" = betterproto.message_field(2)
 
 
 @dataclass
 class RecordRetryException(betterproto.Message):
     """M021"""
 
+    exc: str = betterproto.string_field(1)
+
+
+@dataclass
+class RecordRetryExceptionMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    exc: str = betterproto.string_field(2)
+    data: "RecordRetryException" = betterproto.message_field(2)
 
 
 @dataclass
 class RegistryIndexProgressGETRequest(betterproto.Message):
     """M022"""
 
+    url: str = betterproto.string_field(1)
+
+
+@dataclass
+class RegistryIndexProgressGETRequestMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    url: str = betterproto.string_field(2)
+    data: "RegistryIndexProgressGETRequest" = betterproto.message_field(2)
 
 
 @dataclass
 class RegistryIndexProgressGETResponse(betterproto.Message):
     """M023"""
 
+    url: str = betterproto.string_field(1)
+    resp_code: int = betterproto.int32_field(2)
+
+
+@dataclass
+class RegistryIndexProgressGETResponseMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    url: str = betterproto.string_field(2)
-    resp_code: int = betterproto.int32_field(3)
+    data: "RegistryIndexProgressGETResponse" = betterproto.message_field(2)
 
 
 @dataclass
 class RegistryResponseUnexpectedType(betterproto.Message):
     """M024"""
 
+    response: str = betterproto.string_field(1)
+
+
+@dataclass
+class RegistryResponseUnexpectedTypeMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    response: str = betterproto.string_field(2)
+    data: "RegistryResponseUnexpectedType" = betterproto.message_field(2)
 
 
 @dataclass
 class RegistryResponseMissingTopKeys(betterproto.Message):
     """M025"""
 
+    response: str = betterproto.string_field(1)
+
+
+@dataclass
+class RegistryResponseMissingTopKeysMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    response: str = betterproto.string_field(2)
+    data: "RegistryResponseMissingTopKeys" = betterproto.message_field(2)
 
 
 @dataclass
 class RegistryResponseMissingNestedKeys(betterproto.Message):
     """M026"""
 
+    response: str = betterproto.string_field(1)
+
+
+@dataclass
+class RegistryResponseMissingNestedKeysMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    response: str = betterproto.string_field(2)
+    data: "RegistryResponseMissingNestedKeys" = betterproto.message_field(2)
 
 
 @dataclass
 class RegistryResponseExtraNestedKeys(betterproto.Message):
     """m027"""
 
+    response: str = betterproto.string_field(1)
+
+
+@dataclass
+class RegistryResponseExtraNestedKeysMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    response: str = betterproto.string_field(2)
+    data: "RegistryResponseExtraNestedKeys" = betterproto.message_field(2)
 
 
 @dataclass
 class DepsSetDownloadDirectory(betterproto.Message):
     """M028"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class DepsSetDownloadDirectoryMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "DepsSetDownloadDirectory" = betterproto.message_field(2)
 
 
 @dataclass
 class DepsUnpinned(betterproto.Message):
     """M029"""
 
+    revision: str = betterproto.string_field(1)
+    git: str = betterproto.string_field(2)
+
+
+@dataclass
+class DepsUnpinnedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    revision: str = betterproto.string_field(2)
-    git: str = betterproto.string_field(3)
+    data: "DepsUnpinned" = betterproto.message_field(2)
 
 
 @dataclass
 class NoNodesForSelectionCriteria(betterproto.Message):
     """M030"""
 
+    spec_raw: str = betterproto.string_field(1)
+
+
+@dataclass
+class NoNodesForSelectionCriteriaMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    spec_raw: str = betterproto.string_field(2)
+    data: "NoNodesForSelectionCriteria" = betterproto.message_field(2)
 
 
 @dataclass
 class RunningOperationCaughtError(betterproto.Message):
     """Q001"""
 
+    exc: str = betterproto.string_field(1)
+
+
+@dataclass
+class RunningOperationCaughtErrorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    exc: str = betterproto.string_field(2)
+    data: "RunningOperationCaughtError" = betterproto.message_field(2)
 
 
 @dataclass
 class CompileComplete(betterproto.Message):
     """Q002"""
 
+    pass
+
+
+@dataclass
+class CompileCompleteMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "CompileComplete" = betterproto.message_field(2)
 
 
 @dataclass
 class FreshnessCheckComplete(betterproto.Message):
     """Q003"""
 
+    pass
+
+
+@dataclass
+class FreshnessCheckCompleteMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "FreshnessCheckComplete" = betterproto.message_field(2)
 
 
 @dataclass
 class SeedHeader(betterproto.Message):
     """Q004"""
 
+    header: str = betterproto.string_field(1)
+
+
+@dataclass
+class SeedHeaderMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    header: str = betterproto.string_field(2)
+    data: "SeedHeader" = betterproto.message_field(2)
 
 
 @dataclass
 class SeedHeaderSeparator(betterproto.Message):
     """Q005"""
 
+    len_header: int = betterproto.int32_field(1)
+
+
+@dataclass
+class SeedHeaderSeparatorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    len_header: int = betterproto.int32_field(2)
+    data: "SeedHeaderSeparator" = betterproto.message_field(2)
 
 
 @dataclass
 class SQLRunnerException(betterproto.Message):
     """Q006"""
 
+    exc: str = betterproto.string_field(1)
+    exc_info: str = betterproto.string_field(2)
+
+
+@dataclass
+class SQLRunnerExceptionMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    exc: str = betterproto.string_field(2)
-    exc_info: str = betterproto.string_field(3)
+    data: "SQLRunnerException" = betterproto.message_field(2)
 
 
 @dataclass
 class LogTestResult(betterproto.Message):
     """Q007"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    name: str = betterproto.string_field(2)
+    status: str = betterproto.string_field(3)
+    index: int = betterproto.int32_field(4)
+    num_models: int = betterproto.int32_field(5)
+    execution_time: float = betterproto.float_field(6)
+    num_failures: int = betterproto.int32_field(7)
+
+
+@dataclass
+class LogTestResultMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    name: str = betterproto.string_field(3)
-    status: str = betterproto.string_field(4)
-    index: int = betterproto.int32_field(5)
-    num_models: int = betterproto.int32_field(6)
-    execution_time: float = betterproto.float_field(7)
-    num_failures: int = betterproto.int32_field(8)
+    data: "LogTestResult" = betterproto.message_field(2)
 
 
 @dataclass
 class LogStartLine(betterproto.Message):
     """Q011"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    description: str = betterproto.string_field(2)
+    index: int = betterproto.int32_field(3)
+    total: int = betterproto.int32_field(4)
+
+
+@dataclass
+class LogStartLineMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    description: str = betterproto.string_field(3)
-    index: int = betterproto.int32_field(4)
-    total: int = betterproto.int32_field(5)
+    data: "LogStartLine" = betterproto.message_field(2)
 
 
 @dataclass
 class LogModelResult(betterproto.Message):
     """Q012"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    description: str = betterproto.string_field(2)
+    status: str = betterproto.string_field(3)
+    index: int = betterproto.int32_field(4)
+    total: int = betterproto.int32_field(5)
+    execution_time: int = betterproto.int32_field(6)
+
+
+@dataclass
+class LogModelResultMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    description: str = betterproto.string_field(3)
-    status: str = betterproto.string_field(4)
-    index: int = betterproto.int32_field(5)
-    total: int = betterproto.int32_field(6)
-    execution_time: int = betterproto.int32_field(7)
+    data: "LogModelResult" = betterproto.message_field(2)
 
 
 @dataclass
 class LogSnapshotResult(betterproto.Message):
     """Q015"""
 
-    info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    description: str = betterproto.string_field(3)
-    status: str = betterproto.string_field(4)
-    index: int = betterproto.int32_field(5)
-    total: int = betterproto.int32_field(6)
-    execution_time: float = betterproto.float_field(7)
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    description: str = betterproto.string_field(2)
+    status: str = betterproto.string_field(3)
+    index: int = betterproto.int32_field(4)
+    total: int = betterproto.int32_field(5)
+    execution_time: float = betterproto.float_field(6)
     cfg: Dict[str, str] = betterproto.map_field(
-        8, betterproto.TYPE_STRING, betterproto.TYPE_STRING
+        7, betterproto.TYPE_STRING, betterproto.TYPE_STRING
     )
+
+
+@dataclass
+class LogSnapshotResultMsg(betterproto.Message):
+    info: "EventInfo" = betterproto.message_field(1)
+    data: "LogSnapshotResult" = betterproto.message_field(2)
 
 
 @dataclass
 class LogSeedResult(betterproto.Message):
     """Q016"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    status: str = betterproto.string_field(2)
+    result_message: str = betterproto.string_field(3)
+    index: int = betterproto.int32_field(4)
+    total: int = betterproto.int32_field(5)
+    execution_time: float = betterproto.float_field(6)
+    schema: str = betterproto.string_field(7)
+    relation: str = betterproto.string_field(8)
+
+
+@dataclass
+class LogSeedResultMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    status: str = betterproto.string_field(3)
-    result_message: str = betterproto.string_field(4)
-    index: int = betterproto.int32_field(5)
-    total: int = betterproto.int32_field(6)
-    execution_time: float = betterproto.float_field(7)
-    schema: str = betterproto.string_field(8)
-    relation: str = betterproto.string_field(9)
+    data: "LogSeedResult" = betterproto.message_field(2)
 
 
 @dataclass
 class LogFreshnessResult(betterproto.Message):
     """Q018"""
 
+    status: str = betterproto.string_field(1)
+    node_info: "NodeInfo" = betterproto.message_field(2)
+    index: int = betterproto.int32_field(3)
+    total: int = betterproto.int32_field(4)
+    execution_time: float = betterproto.float_field(5)
+    source_name: str = betterproto.string_field(6)
+    table_name: str = betterproto.string_field(7)
+
+
+@dataclass
+class LogFreshnessResultMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    status: str = betterproto.string_field(2)
-    node_info: "NodeInfo" = betterproto.message_field(3)
-    index: int = betterproto.int32_field(4)
-    total: int = betterproto.int32_field(5)
-    execution_time: float = betterproto.float_field(6)
-    source_name: str = betterproto.string_field(7)
-    table_name: str = betterproto.string_field(8)
+    data: "LogFreshnessResult" = betterproto.message_field(2)
 
 
 @dataclass
 class LogCancelLine(betterproto.Message):
     """Q022"""
 
+    conn_name: str = betterproto.string_field(1)
+
+
+@dataclass
+class LogCancelLineMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    conn_name: str = betterproto.string_field(2)
+    data: "LogCancelLine" = betterproto.message_field(2)
 
 
 @dataclass
 class DefaultSelector(betterproto.Message):
     """Q023"""
 
+    name: str = betterproto.string_field(1)
+
+
+@dataclass
+class DefaultSelectorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    name: str = betterproto.string_field(2)
+    data: "DefaultSelector" = betterproto.message_field(2)
 
 
 @dataclass
 class NodeStart(betterproto.Message):
     """Q024"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+
+
+@dataclass
+class NodeStartMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
+    data: "NodeStart" = betterproto.message_field(2)
 
 
 @dataclass
 class NodeFinished(betterproto.Message):
     """Q025"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    run_result: "RunResultMsg" = betterproto.message_field(2)
+
+
+@dataclass
+class NodeFinishedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    run_result: "RunResultMsg" = betterproto.message_field(4)
+    data: "NodeFinished" = betterproto.message_field(2)
 
 
 @dataclass
 class QueryCancelationUnsupported(betterproto.Message):
     """Q026"""
 
+    type: str = betterproto.string_field(1)
+
+
+@dataclass
+class QueryCancelationUnsupportedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    type: str = betterproto.string_field(2)
+    data: "QueryCancelationUnsupported" = betterproto.message_field(2)
 
 
 @dataclass
 class ConcurrencyLine(betterproto.Message):
     """Q027"""
 
+    num_threads: int = betterproto.int32_field(1)
+    target_name: str = betterproto.string_field(2)
+    node_count: int = betterproto.int32_field(3)
+
+
+@dataclass
+class ConcurrencyLineMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    num_threads: int = betterproto.int32_field(2)
-    target_name: str = betterproto.string_field(3)
-    node_count: int = betterproto.int32_field(4)
+    data: "ConcurrencyLine" = betterproto.message_field(2)
 
 
 @dataclass
 class WritingInjectedSQLForNode(betterproto.Message):
     """Q029"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+
+
+@dataclass
+class WritingInjectedSQLForNodeMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
+    data: "WritingInjectedSQLForNode" = betterproto.message_field(2)
 
 
 @dataclass
 class NodeCompiling(betterproto.Message):
     """Q030"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+
+
+@dataclass
+class NodeCompilingMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
+    data: "NodeCompiling" = betterproto.message_field(2)
 
 
 @dataclass
 class NodeExecuting(betterproto.Message):
     """Q031"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+
+
+@dataclass
+class NodeExecutingMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
+    data: "NodeExecuting" = betterproto.message_field(2)
 
 
 @dataclass
 class LogHookStartLine(betterproto.Message):
     """Q032"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    statement: str = betterproto.string_field(2)
+    index: int = betterproto.int32_field(3)
+    total: int = betterproto.int32_field(4)
+
+
+@dataclass
+class LogHookStartLineMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    statement: str = betterproto.string_field(3)
-    index: int = betterproto.int32_field(4)
-    total: int = betterproto.int32_field(5)
+    data: "LogHookStartLine" = betterproto.message_field(2)
 
 
 @dataclass
 class LogHookEndLine(betterproto.Message):
     """Q033"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    statement: str = betterproto.string_field(2)
+    status: str = betterproto.string_field(3)
+    index: int = betterproto.int32_field(4)
+    total: int = betterproto.int32_field(5)
+    execution_time: float = betterproto.float_field(6)
+
+
+@dataclass
+class LogHookEndLineMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    statement: str = betterproto.string_field(3)
-    status: str = betterproto.string_field(4)
-    index: int = betterproto.int32_field(5)
-    total: int = betterproto.int32_field(6)
-    execution_time: float = betterproto.float_field(7)
+    data: "LogHookEndLine" = betterproto.message_field(2)
 
 
 @dataclass
 class SkippingDetails(betterproto.Message):
     """Q034"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    resource_type: str = betterproto.string_field(2)
+    schema: str = betterproto.string_field(3)
+    node_name: str = betterproto.string_field(4)
+    index: int = betterproto.int32_field(5)
+    total: int = betterproto.int32_field(6)
+
+
+@dataclass
+class SkippingDetailsMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    resource_type: str = betterproto.string_field(3)
-    schema: str = betterproto.string_field(4)
-    node_name: str = betterproto.string_field(5)
-    index: int = betterproto.int32_field(6)
-    total: int = betterproto.int32_field(7)
+    data: "SkippingDetails" = betterproto.message_field(2)
 
 
 @dataclass
 class NothingToDo(betterproto.Message):
     """Q035"""
 
+    pass
+
+
+@dataclass
+class NothingToDoMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "NothingToDo" = betterproto.message_field(2)
 
 
 @dataclass
 class RunningOperationUncaughtError(betterproto.Message):
     """Q036"""
 
+    exc: str = betterproto.string_field(1)
+
+
+@dataclass
+class RunningOperationUncaughtErrorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    exc: str = betterproto.string_field(2)
+    data: "RunningOperationUncaughtError" = betterproto.message_field(2)
 
 
 @dataclass
 class EndRunResult(betterproto.Message):
     """Q037"""
 
+    results: List["RunResultMsg"] = betterproto.message_field(1)
+    elapsed_time: float = betterproto.float_field(2)
+    generated_at: datetime = betterproto.message_field(3)
+    success: bool = betterproto.bool_field(4)
+
+
+@dataclass
+class EndRunResultMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    results: List["RunResultMsg"] = betterproto.message_field(2)
-    elapsed_time: float = betterproto.float_field(3)
-    generated_at: datetime = betterproto.message_field(4)
-    success: bool = betterproto.bool_field(5)
+    data: "EndRunResult" = betterproto.message_field(2)
 
 
 @dataclass
 class NoNodesSelected(betterproto.Message):
     """Q038"""
 
+    pass
+
+
+@dataclass
+class NoNodesSelectedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "NoNodesSelected" = betterproto.message_field(2)
 
 
 @dataclass
 class CatchableExceptionOnRun(betterproto.Message):
     """W002"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    exc: str = betterproto.string_field(2)
+    exc_info: str = betterproto.string_field(3)
+
+
+@dataclass
+class CatchableExceptionOnRunMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    exc: str = betterproto.string_field(3)
-    exc_info: str = betterproto.string_field(4)
+    data: "CatchableExceptionOnRun" = betterproto.message_field(2)
 
 
 @dataclass
 class InternalExceptionOnRun(betterproto.Message):
     """W003"""
 
+    build_path: str = betterproto.string_field(1)
+    exc: str = betterproto.string_field(2)
+
+
+@dataclass
+class InternalExceptionOnRunMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    build_path: str = betterproto.string_field(2)
-    exc: str = betterproto.string_field(3)
+    data: "InternalExceptionOnRun" = betterproto.message_field(2)
 
 
 @dataclass
 class GenericExceptionOnRun(betterproto.Message):
     """W004"""
 
+    build_path: str = betterproto.string_field(1)
+    unique_id: str = betterproto.string_field(2)
+    exc: str = betterproto.string_field(3)
+
+
+@dataclass
+class GenericExceptionOnRunMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    build_path: str = betterproto.string_field(2)
-    unique_id: str = betterproto.string_field(3)
-    exc: str = betterproto.string_field(4)
+    data: "GenericExceptionOnRun" = betterproto.message_field(2)
 
 
 @dataclass
 class NodeConnectionReleaseError(betterproto.Message):
     """W005"""
 
+    node_name: str = betterproto.string_field(1)
+    exc: str = betterproto.string_field(2)
+    exc_info: str = betterproto.string_field(3)
+
+
+@dataclass
+class NodeConnectionReleaseErrorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_name: str = betterproto.string_field(2)
-    exc: str = betterproto.string_field(3)
-    exc_info: str = betterproto.string_field(4)
+    data: "NodeConnectionReleaseError" = betterproto.message_field(2)
 
 
 @dataclass
 class FoundStats(betterproto.Message):
     """W006"""
 
+    stat_line: str = betterproto.string_field(1)
+
+
+@dataclass
+class FoundStatsMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    stat_line: str = betterproto.string_field(2)
+    data: "FoundStats" = betterproto.message_field(2)
 
 
 @dataclass
 class MainKeyboardInterrupt(betterproto.Message):
     """Z001"""
 
+    pass
+
+
+@dataclass
+class MainKeyboardInterruptMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "MainKeyboardInterrupt" = betterproto.message_field(2)
 
 
 @dataclass
 class MainEncounteredError(betterproto.Message):
     """Z002"""
 
+    exc: str = betterproto.string_field(1)
+
+
+@dataclass
+class MainEncounteredErrorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    exc: str = betterproto.string_field(2)
+    data: "MainEncounteredError" = betterproto.message_field(2)
 
 
 @dataclass
 class MainStackTrace(betterproto.Message):
     """Z003"""
 
+    stack_trace: str = betterproto.string_field(1)
+
+
+@dataclass
+class MainStackTraceMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    stack_trace: str = betterproto.string_field(2)
+    data: "MainStackTrace" = betterproto.message_field(2)
 
 
 @dataclass
 class SystemErrorRetrievingModTime(betterproto.Message):
     """Z004"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class SystemErrorRetrievingModTimeMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "SystemErrorRetrievingModTime" = betterproto.message_field(2)
 
 
 @dataclass
 class SystemCouldNotWrite(betterproto.Message):
     """Z005"""
 
+    path: str = betterproto.string_field(1)
+    reason: str = betterproto.string_field(2)
+    exc: str = betterproto.string_field(3)
+
+
+@dataclass
+class SystemCouldNotWriteMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
-    reason: str = betterproto.string_field(3)
-    exc: str = betterproto.string_field(4)
+    data: "SystemCouldNotWrite" = betterproto.message_field(2)
 
 
 @dataclass
 class SystemExecutingCmd(betterproto.Message):
     """Z006"""
 
+    cmd: List[str] = betterproto.string_field(1)
+
+
+@dataclass
+class SystemExecutingCmdMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    cmd: List[str] = betterproto.string_field(2)
+    data: "SystemExecutingCmd" = betterproto.message_field(2)
+
+
+@dataclass
+class SystemStdOut(betterproto.Message):
+    """Z007"""
+
+    bmsg: bytes = betterproto.bytes_field(1)
 
 
 @dataclass
 class SystemStdOutMsg(betterproto.Message):
-    """Z007"""
-
     info: "EventInfo" = betterproto.message_field(1)
-    bmsg: bytes = betterproto.bytes_field(2)
+    data: "SystemStdOut" = betterproto.message_field(2)
+
+
+@dataclass
+class SystemStdErr(betterproto.Message):
+    """Z008"""
+
+    bmsg: bytes = betterproto.bytes_field(1)
 
 
 @dataclass
 class SystemStdErrMsg(betterproto.Message):
-    """Z008"""
-
     info: "EventInfo" = betterproto.message_field(1)
-    bmsg: bytes = betterproto.bytes_field(2)
+    data: "SystemStdErr" = betterproto.message_field(2)
 
 
 @dataclass
 class SystemReportReturnCode(betterproto.Message):
     """Z009"""
 
+    returncode: int = betterproto.int32_field(1)
+
+
+@dataclass
+class SystemReportReturnCodeMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    returncode: int = betterproto.int32_field(2)
+    data: "SystemReportReturnCode" = betterproto.message_field(2)
 
 
 @dataclass
 class TimingInfoCollected(betterproto.Message):
     """Z010"""
 
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    timing_info: "TimingInfoMsg" = betterproto.message_field(2)
+
+
+@dataclass
+class TimingInfoCollectedMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    node_info: "NodeInfo" = betterproto.message_field(2)
-    timing_info: "TimingInfoMsg" = betterproto.message_field(3)
+    data: "TimingInfoCollected" = betterproto.message_field(2)
 
 
 @dataclass
 class LogDebugStackTrace(betterproto.Message):
     """Z011"""
 
+    exc_info: str = betterproto.string_field(1)
+
+
+@dataclass
+class LogDebugStackTraceMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    exc_info: str = betterproto.string_field(2)
+    data: "LogDebugStackTrace" = betterproto.message_field(2)
 
 
 @dataclass
 class CheckCleanPath(betterproto.Message):
     """Z012"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class CheckCleanPathMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "CheckCleanPath" = betterproto.message_field(2)
 
 
 @dataclass
 class ConfirmCleanPath(betterproto.Message):
     """Z013"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class ConfirmCleanPathMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "ConfirmCleanPath" = betterproto.message_field(2)
 
 
 @dataclass
 class ProtectedCleanPath(betterproto.Message):
     """Z014"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class ProtectedCleanPathMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "ProtectedCleanPath" = betterproto.message_field(2)
 
 
 @dataclass
 class FinishedCleanPaths(betterproto.Message):
     """Z015"""
 
+    pass
+
+
+@dataclass
+class FinishedCleanPathsMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "FinishedCleanPaths" = betterproto.message_field(2)
 
 
 @dataclass
 class OpenCommand(betterproto.Message):
     """Z016"""
 
+    open_cmd: str = betterproto.string_field(1)
+    profiles_dir: str = betterproto.string_field(2)
+
+
+@dataclass
+class OpenCommandMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    open_cmd: str = betterproto.string_field(2)
-    profiles_dir: str = betterproto.string_field(3)
+    data: "OpenCommand" = betterproto.message_field(2)
 
 
 @dataclass
 class EmptyLine(betterproto.Message):
     """Z017"""
 
+    pass
+
+
+@dataclass
+class EmptyLineMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "EmptyLine" = betterproto.message_field(2)
 
 
 @dataclass
 class ServingDocsPort(betterproto.Message):
     """Z018"""
 
+    address: str = betterproto.string_field(1)
+    port: int = betterproto.int32_field(2)
+
+
+@dataclass
+class ServingDocsPortMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    address: str = betterproto.string_field(2)
-    port: int = betterproto.int32_field(3)
+    data: "ServingDocsPort" = betterproto.message_field(2)
 
 
 @dataclass
 class ServingDocsAccessInfo(betterproto.Message):
     """Z019"""
 
+    port: str = betterproto.string_field(1)
+
+
+@dataclass
+class ServingDocsAccessInfoMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    port: str = betterproto.string_field(2)
+    data: "ServingDocsAccessInfo" = betterproto.message_field(2)
 
 
 @dataclass
 class ServingDocsExitInfo(betterproto.Message):
     """Z020"""
 
+    pass
+
+
+@dataclass
+class ServingDocsExitInfoMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "ServingDocsExitInfo" = betterproto.message_field(2)
 
 
 @dataclass
 class RunResultWarning(betterproto.Message):
     """Z021"""
 
+    resource_type: str = betterproto.string_field(1)
+    node_name: str = betterproto.string_field(2)
+    path: str = betterproto.string_field(3)
+
+
+@dataclass
+class RunResultWarningMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    resource_type: str = betterproto.string_field(2)
-    node_name: str = betterproto.string_field(3)
-    path: str = betterproto.string_field(4)
+    data: "RunResultWarning" = betterproto.message_field(2)
 
 
 @dataclass
 class RunResultFailure(betterproto.Message):
     """Z022"""
 
+    resource_type: str = betterproto.string_field(1)
+    node_name: str = betterproto.string_field(2)
+    path: str = betterproto.string_field(3)
+
+
+@dataclass
+class RunResultFailureMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    resource_type: str = betterproto.string_field(2)
-    node_name: str = betterproto.string_field(3)
-    path: str = betterproto.string_field(4)
+    data: "RunResultFailure" = betterproto.message_field(2)
 
 
 @dataclass
 class StatsLine(betterproto.Message):
     """Z023"""
 
-    info: "EventInfo" = betterproto.message_field(1)
     stats: Dict[str, int] = betterproto.map_field(
-        2, betterproto.TYPE_STRING, betterproto.TYPE_INT32
+        1, betterproto.TYPE_STRING, betterproto.TYPE_INT32
     )
+
+
+@dataclass
+class StatsLineMsg(betterproto.Message):
+    info: "EventInfo" = betterproto.message_field(1)
+    data: "StatsLine" = betterproto.message_field(2)
 
 
 @dataclass
 class RunResultError(betterproto.Message):
     """Z024"""
 
+    msg: str = betterproto.string_field(1)
+
+
+@dataclass
+class RunResultErrorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    msg: str = betterproto.string_field(2)
+    data: "RunResultError" = betterproto.message_field(2)
 
 
 @dataclass
 class RunResultErrorNoMessage(betterproto.Message):
     """Z025"""
 
+    status: str = betterproto.string_field(1)
+
+
+@dataclass
+class RunResultErrorNoMessageMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    status: str = betterproto.string_field(2)
+    data: "RunResultErrorNoMessage" = betterproto.message_field(2)
 
 
 @dataclass
 class SQLCompiledPath(betterproto.Message):
     """Z026"""
 
+    path: str = betterproto.string_field(1)
+
+
+@dataclass
+class SQLCompiledPathMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    path: str = betterproto.string_field(2)
+    data: "SQLCompiledPath" = betterproto.message_field(2)
 
 
 @dataclass
 class CheckNodeTestFailure(betterproto.Message):
     """Z027"""
 
+    relation_name: str = betterproto.string_field(1)
+
+
+@dataclass
+class CheckNodeTestFailureMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    relation_name: str = betterproto.string_field(2)
+    data: "CheckNodeTestFailure" = betterproto.message_field(2)
 
 
 @dataclass
 class FirstRunResultError(betterproto.Message):
     """Z028"""
 
+    msg: str = betterproto.string_field(1)
+
+
+@dataclass
+class FirstRunResultErrorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    msg: str = betterproto.string_field(2)
+    data: "FirstRunResultError" = betterproto.message_field(2)
 
 
 @dataclass
 class AfterFirstRunResultError(betterproto.Message):
     """Z029"""
 
+    msg: str = betterproto.string_field(1)
+
+
+@dataclass
+class AfterFirstRunResultErrorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    msg: str = betterproto.string_field(2)
+    data: "AfterFirstRunResultError" = betterproto.message_field(2)
 
 
 @dataclass
 class EndOfRunSummary(betterproto.Message):
     """Z030"""
 
+    num_errors: int = betterproto.int32_field(1)
+    num_warnings: int = betterproto.int32_field(2)
+    keyboard_interrupt: bool = betterproto.bool_field(3)
+
+
+@dataclass
+class EndOfRunSummaryMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    num_errors: int = betterproto.int32_field(2)
-    num_warnings: int = betterproto.int32_field(3)
-    keyboard_interrupt: bool = betterproto.bool_field(4)
+    data: "EndOfRunSummary" = betterproto.message_field(2)
 
 
 @dataclass
 class LogSkipBecauseError(betterproto.Message):
     """Z034"""
 
+    schema: str = betterproto.string_field(1)
+    relation: str = betterproto.string_field(2)
+    index: int = betterproto.int32_field(3)
+    total: int = betterproto.int32_field(4)
+
+
+@dataclass
+class LogSkipBecauseErrorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    schema: str = betterproto.string_field(2)
-    relation: str = betterproto.string_field(3)
-    index: int = betterproto.int32_field(4)
-    total: int = betterproto.int32_field(5)
+    data: "LogSkipBecauseError" = betterproto.message_field(2)
 
 
 @dataclass
 class EnsureGitInstalled(betterproto.Message):
     """Z036"""
 
+    pass
+
+
+@dataclass
+class EnsureGitInstalledMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "EnsureGitInstalled" = betterproto.message_field(2)
 
 
 @dataclass
 class DepsCreatingLocalSymlink(betterproto.Message):
     """Z037"""
 
+    pass
+
+
+@dataclass
+class DepsCreatingLocalSymlinkMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "DepsCreatingLocalSymlink" = betterproto.message_field(2)
 
 
 @dataclass
 class DepsSymlinkNotAvailable(betterproto.Message):
     """Z038"""
 
+    pass
+
+
+@dataclass
+class DepsSymlinkNotAvailableMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "DepsSymlinkNotAvailable" = betterproto.message_field(2)
 
 
 @dataclass
 class DisableTracking(betterproto.Message):
     """Z039"""
 
+    pass
+
+
+@dataclass
+class DisableTrackingMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "DisableTracking" = betterproto.message_field(2)
 
 
 @dataclass
 class SendingEvent(betterproto.Message):
     """Z040"""
 
+    kwargs: str = betterproto.string_field(1)
+
+
+@dataclass
+class SendingEventMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    kwargs: str = betterproto.string_field(2)
+    data: "SendingEvent" = betterproto.message_field(2)
 
 
 @dataclass
 class SendEventFailure(betterproto.Message):
     """Z041"""
 
+    pass
+
+
+@dataclass
+class SendEventFailureMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "SendEventFailure" = betterproto.message_field(2)
 
 
 @dataclass
 class FlushEvents(betterproto.Message):
     """Z042"""
 
+    pass
+
+
+@dataclass
+class FlushEventsMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "FlushEvents" = betterproto.message_field(2)
 
 
 @dataclass
 class FlushEventsFailure(betterproto.Message):
     """Z043"""
 
+    pass
+
+
+@dataclass
+class FlushEventsFailureMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
+    data: "FlushEventsFailure" = betterproto.message_field(2)
 
 
 @dataclass
 class TrackingInitializeFailure(betterproto.Message):
     """Z044"""
 
+    exc_info: str = betterproto.string_field(1)
+
+
+@dataclass
+class TrackingInitializeFailureMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    exc_info: str = betterproto.string_field(2)
+    data: "TrackingInitializeFailure" = betterproto.message_field(2)
 
 
 @dataclass
 class RunResultWarningMessage(betterproto.Message):
     """Z046"""
 
+    msg: str = betterproto.string_field(1)
+
+
+@dataclass
+class RunResultWarningMessageMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    msg: str = betterproto.string_field(2)
+    data: "RunResultWarningMessage" = betterproto.message_field(2)
 
 
 @dataclass
 class IntegrationTestInfo(betterproto.Message):
     """T001"""
 
+    msg: str = betterproto.string_field(1)
+
+
+@dataclass
+class IntegrationTestInfoMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    msg: str = betterproto.string_field(2)
+    data: "IntegrationTestInfo" = betterproto.message_field(2)
 
 
 @dataclass
 class IntegrationTestDebug(betterproto.Message):
     """T002"""
 
+    msg: str = betterproto.string_field(1)
+
+
+@dataclass
+class IntegrationTestDebugMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    msg: str = betterproto.string_field(2)
+    data: "IntegrationTestDebug" = betterproto.message_field(2)
 
 
 @dataclass
 class IntegrationTestWarn(betterproto.Message):
     """T003"""
 
+    msg: str = betterproto.string_field(1)
+
+
+@dataclass
+class IntegrationTestWarnMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    msg: str = betterproto.string_field(2)
+    data: "IntegrationTestWarn" = betterproto.message_field(2)
 
 
 @dataclass
 class IntegrationTestError(betterproto.Message):
     """T004"""
 
+    msg: str = betterproto.string_field(1)
+
+
+@dataclass
+class IntegrationTestErrorMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    msg: str = betterproto.string_field(2)
+    data: "IntegrationTestError" = betterproto.message_field(2)
 
 
 @dataclass
 class IntegrationTestException(betterproto.Message):
     """T005"""
 
+    msg: str = betterproto.string_field(1)
+
+
+@dataclass
+class IntegrationTestExceptionMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    msg: str = betterproto.string_field(2)
+    data: "IntegrationTestException" = betterproto.message_field(2)
 
 
 @dataclass
 class UnitTestInfo(betterproto.Message):
     """T006"""
 
+    msg: str = betterproto.string_field(1)
+
+
+@dataclass
+class UnitTestInfoMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    msg: str = betterproto.string_field(2)
+    data: "UnitTestInfo" = betterproto.message_field(2)

--- a/core/dbt/events/proto_types.py
+++ b/core/dbt/events/proto_types.py
@@ -1242,7 +1242,7 @@ class PartialParsingSkipParsing(betterproto.Message):
 
 
 @dataclass
-class PartialPArsingSkipParsingMsg(betterproto.Message):
+class PartialParsingSkipParsingMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
     data: "PartialParsingSkipParsing" = betterproto.message_field(2)
 

--- a/core/dbt/events/proto_types.py
+++ b/core/dbt/events/proto_types.py
@@ -759,7 +759,8 @@ class SQLQueryStatusMsg(betterproto.Message):
 class SQLCommit(betterproto.Message):
     """E018"""
 
-    conn_name: str = betterproto.string_field(1)
+    node_info: "NodeInfo" = betterproto.message_field(1)
+    conn_name: str = betterproto.string_field(2)
 
 
 @dataclass

--- a/core/dbt/events/types.proto
+++ b/core/dbt/events/types.proto
@@ -960,7 +960,7 @@ message PartialParsingExceptionMsg {
 message PartialParsingSkipParsing {
 }
 
-message PartialPArsingSkipParsingMsg {
+message PartialParsingSkipParsingMsg {
     EventInfo info = 1;
     PartialParsingSkipParsing data = 2;
 }

--- a/core/dbt/events/types.proto
+++ b/core/dbt/events/types.proto
@@ -69,607 +69,900 @@ message GenericMessage {
 
 // A001
 message MainReportVersion {
+    string version = 1;
+    int32 log_version = 2;
+}
+
+message MainReportVersionMsg {
     EventInfo info = 1;
-    string version = 2;
-    int32 log_version = 3;
+    MainReportVersion data = 2;
 }
 
 // A002
 message MainReportArgs {
+    map<string, string> args = 1;
+}
+
+message MainReportArgsMsg {
     EventInfo info = 1;
-    map<string, string> args = 2;
+    MainReportArgs data = 2;
 }
 
 // A003
 message MainTrackingUserState {
+    string user_state = 1;
+}
+
+message MainTrackingUserStateMsg {
     EventInfo info = 1;
-    string user_state = 2;
+    MainTrackingUserState data = 2;
 }
 
 // A004
 message MergedFromState {
+    int32 num_merged = 1;
+    repeated string sample = 2;
+}
+
+message MergedFromStateMsg {
     EventInfo info = 1;
-    int32 num_merged = 2;
-    repeated string sample = 3;
+    MergedFromState data = 2;
 }
 
 // A005
 message MissingProfileTarget {
+    string profile_name = 1;
+    string target_name = 2;
+}
+
+message MissingProfileTargetMsg {
     EventInfo info = 1;
-    string profile_name = 2;
-    string target_name = 3;
+    MissingProfileTarget data = 2;
 }
 
 // Skipped A006, A007
 
 // A008
 message InvalidVarsYAML {
+}
+
+message InvalidVarsYAMLMsg {
     EventInfo info = 1;
+    InvalidVarsYAML data = 2;
 }
 
 // A009
 message DbtProjectError {
+}
+
+message DbtProjectErrorMsg {
     EventInfo info = 1;
+    DbtProjectError data = 2;
 }
 
 // A010
 message DbtProjectErrorException {
+    string exc = 1;
+}
+
+message DbtProjectErrorExceptionMsg {
     EventInfo info = 1;
-    string exc = 2;
+    DbtProjectErrorException data = 2;
 }
 
 // A011
 message DbtProfileError {
+}
+
+message DbtProfileErrorMsg {
     EventInfo info = 1;
+    DbtProfileError data = 2;
 }
 
 // A012
 message DbtProfileErrorException {
+    string exc = 1;
+}
+
+message DbtProfileErrorExceptionMsg {
     EventInfo info = 1;
-    string exc = 2;
+    DbtProfileErrorException data = 2;
 }
 
 // A013
 message ProfileListTitle {
+}
+
+message ProfileListTitleMsg {
     EventInfo info = 1;
+    ProfileListTitle data = 2;
 }
 
 // A014
 message ListSingleProfile {
+    string profile = 1;
+}
+
+message ListSingleProfileMsg {
     EventInfo info = 1;
-    string profile = 2;
+    ListSingleProfile data = 2;
 }
 
 // A015
 message NoDefinedProfiles {
+}
+
+message NoDefinedProfilesMsg {
     EventInfo info = 1;
+    NoDefinedProfiles data = 2;
 }
 
 // A016
 message ProfileHelpMessage {
+}
+
+message ProfileHelpMessageMsg {
     EventInfo info = 1;
+    ProfileHelpMessage data = 2;
 }
 
 // A017
 message StarterProjectPath {
+    string dir = 1;
+}
+
+message StarterProjectPathMsg {
     EventInfo info = 1;
-    string dir = 2;
+    StarterProjectPath data = 2;
 }
 
 // A018
 message ConfigFolderDirectory {
+    string dir = 1;
+}
+
+message ConfigFolderDirectoryMsg {
     EventInfo info = 1;
-    string dir = 2;
+    ConfigFolderDirectory data = 2;
 }
 
 // A019
 message NoSampleProfileFound {
+    string adapter = 1;
+}
+
+message NoSampleProfileFoundMsg {
     EventInfo info = 1;
-    string adapter = 2;
+    NoSampleProfileFound data = 2;
 }
 
 // A020
 message ProfileWrittenWithSample {
+    string name = 1;
+    string path = 2;
+}
+
+message ProfileWrittenWithSampleMsg {
     EventInfo info = 1;
-    string name = 2;
-    string path = 3;
+    ProfileWrittenWithSample data = 2;
 }
 
 // A021
 message ProfileWrittenWithTargetTemplateYAML {
+    string name = 1;
+    string path = 2;
+}
+
+message ProfileWrittenWithTargetTemplateYAMLMsg {
     EventInfo info = 1;
-    string name = 2;
-    string path = 3;
+    ProfileWrittenWithTargetTemplateYAMLMsg data = 2;
 }
 
 // A022
 message ProfileWrittenWithProjectTemplateYAML {
+    string name = 1;
+    string path = 2;
+}
+
+message ProfileWrittenWithProjectTemplateYAMLMsg {
     EventInfo info = 1;
-    string name = 2;
-    string path = 3;
+    ProfileWrittenWithProjectTemplateYAML data = 2;
 }
 
 // A023
 message SettingUpProfile {
+}
+
+message SettingUpProfileMsg {
     EventInfo info = 1;
+    SettingUpProfile data = 2;
 }
 
 // A024
 message InvalidProfileTemplateYAML {
+}
+
+message InvalidProfileTemplateYAMLMsg {
     EventInfo info = 1;
+    InvalidProfileTemplateYAML data = 2;
 }
 
 // A025
 message ProjectNameAlreadyExists {
+    string name = 1;
+}
+
+message ProjectNameAlreadyExistsMsg {
     EventInfo info = 1;
-    string name = 2;
+    ProjectNameAlreadyExists data = 2;
 }
 
 // A026
 message ProjectCreated {
+    string project_name = 1;
+    string docs_url = 2;
+    string slack_url = 3;
+}
+
+message ProjectCreatedMsg {
     EventInfo info = 1;
-    string project_name = 2;
-    string docs_url = 3;
-    string slack_url = 4;
+    ProjectCreated data = 2;
 }
 
 // D - Deprecation
 
 // D001
 message PackageRedirectDeprecation {
+    string old_name = 1;
+    string new_name = 2;
+}
+
+message PackageRedirectDeprecationMsg {
     EventInfo info = 1;
-    string old_name = 2;
-    string new_name = 3;
+    PackageRedirectDeprecation data = 2;
 }
 
 // D002
 message PackageInstallPathDeprecation {
+}
+
+message PackageInstallPathDeprecationMsg {
     EventInfo info = 1;
+    PackageInstallPathDeprecation data = 2;
 }
 
 // D003
 message ConfigSourcePathDeprecation {
+    string deprecated_path = 1;
+    string exp_path = 2;
+}
+
+message ConfigSourcePathDeprecationMsg {
     EventInfo info = 1;
-    string deprecated_path = 2;
-    string exp_path = 3;
+    ConfigSourcePathDeprecation data = 2;
 }
 
 // D004
 message ConfigDataPathDeprecation {
+    string deprecated_path = 1;
+    string exp_path = 2;
+}
+
+message ConfigDataPathDeprecationMsg {
     EventInfo info = 1;
-    string deprecated_path = 2;
-    string exp_path = 3;
+    ConfigDataPathDeprecation data = 2;
 }
 
 //D005
 message AdapterDeprecationWarning {
+    string old_name = 1;
+    string new_name = 2;
+}
+
+message AdapterDeprecationWarningMsg {
     EventInfo info = 1;
-    string old_name = 2;
-    string new_name = 3;
+    AdapterDeprecationWarning data = 2;
 }
 
 //D006
 message MetricAttributesRenamed {
+    string metric_name = 1;
+}
+
+message MetricAttributesRenamedMsg {
     EventInfo info = 1;
-    string metric_name = 2;
+    MetricAttributesRenamed data = 2;
 }
 
 //D007
 message ExposureNameDeprecation {
+    string exposure = 1;
+}
+
+message ExposureNameDeprecationMsg {
     EventInfo info = 1;
-    string exposure = 2;
+    ExposureNameDeprecation data = 2;
 }
 
 // E - DB Adapter
 
 // E001
 message AdapterEventDebug {
+    NodeInfo node_info = 1;
+    string name = 2;
+    string base_msg = 3;
+    repeated string args = 4;
+}
+
+message AdapterEventDebugMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string name = 3;
-    string base_msg = 4;
-    repeated string args = 5;
+    AdapterEventDebug data = 2;
 }
 
 // E002
 message AdapterEventInfo {
+    NodeInfo node_info = 1;
+    string name = 2;
+    string base_msg = 3;
+    repeated string args = 4;
+}
+
+message AdapterEventInfoMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string name = 3;
-    string base_msg = 4;
-    repeated string args = 5;
+    AdapterEventInfo data = 2;
 }
 
 // E003
 message AdapterEventWarning {
+    NodeInfo node_info = 1;
+    string name = 2;
+    string base_msg = 3;
+    repeated string args = 4;
+}
+
+message AdapterEventWarningMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string name = 3;
-    string base_msg = 4;
-    repeated string args = 5;
+    AdapterEventWarning data = 2;
 }
 
 // E004
 message AdapterEventError {
+    NodeInfo node_info = 1;
+    string name = 2;
+    string base_msg = 3;
+    repeated string args = 4;
+    string exc_info = 5;
+}
+
+message AdapterEventErrorMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string name = 3;
-    string base_msg = 4;
-    repeated string args = 5;
-    string exc_info = 6;
+    AdapterEventError data = 2;
 }
 
 // E005
 message NewConnection {
+    NodeInfo node_info = 1;
+    string conn_type = 2;
+    string conn_name = 3;
+}
+
+message NewConnectionMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string conn_type = 3;
-    string conn_name = 4;
+    NewConnection data = 2;
 }
 
 // E006
 message ConnectionReused {
+    string conn_name = 1;
+}
+
+message ConnectionReusedMsg {
     EventInfo info = 1;
-    string conn_name = 2;
+    ConnectionReused data = 2;
 }
 
 // E007
 message ConnectionLeftOpenInCleanup {
+    string conn_name = 1;
+}
+
+message ConnectionLeftOpenInCleanupMsg {
     EventInfo info = 1;
-    string conn_name = 2;
+    ConnectionLeftOpen data = 2;
 }
 
 // E008
 message ConnectionClosedInCleanup {
+    string conn_name = 1;
+}
+
+message ConnectionClosedInCleanupMsg {
     EventInfo info = 1;
-    string conn_name = 2;
+    ConnectionClosedInCleanup data = 2;
 }
 
 // E009
 message RollbackFailed {
+    NodeInfo node_info = 1;
+    string conn_name = 2;
+    string exc_info = 3;
+}
+
+message RollbackFailedMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string conn_name = 3;
-    string exc_info = 4;
+    RollbackFailed data = 2;
 }
 
 // E010
 message ConnectionClosed {
+    NodeInfo node_info = 1;
+    string conn_name = 2;
+}
+
+message ConnectionClosedMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string conn_name = 3;
+    ConnectionClosed data = 2;
 }
 
 // E011
 message ConnectionLeftOpen {
+    NodeInfo node_info = 1;
+    string conn_name = 2;
+}
+
+message ConnectionLeftOpenMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string conn_name = 3;
+    ConnectionLeftOpen data = 2;
 }
 
 // E012
 message Rollback {
+    NodeInfo node_info = 1;
+    string conn_name = 2;
+}
+
+message RollbackMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string conn_name = 3;
+    Rollback data = 2;
 }
 
 // E013
 message CacheMiss {
+    string conn_name = 1;
+    string database = 2;
+    string schema = 3;
+}
+
+message CacheMissMsg {
     EventInfo info = 1;
-    string conn_name = 2;
-    string database = 3;
-    string schema = 4;
+    CacheMiss data = 2;
 }
 
 // E014
 message ListRelations {
+    string database = 1;
+    string schema = 2;
+    repeated ReferenceKeyMsg relations = 3;
+}
+
+message ListRelationsMsg {
     EventInfo info = 1;
-    string database = 2;
-    string schema = 3;
-    repeated ReferenceKeyMsg relations = 4;
+    ListRelations data = 2;
 }
 
 // E015
 message ConnectionUsed {
+    NodeInfo node_info = 1;
+    string conn_type = 2;
+    string conn_name = 3;
+}
+
+message ConnectionUsedMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string conn_type = 3;
-    string conn_name = 4;
+    ConnectionUsed data = 2;
 }
 
 // E016
 message SQLQuery {
+    NodeInfo node_info = 1;
+    string conn_name = 2;
+    string sql = 3;
+}
+
+message SQLQueryMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string conn_name = 3;
-    string sql = 4;
+    SQLQuery data = 2;
 }
 
 // E017
 message SQLQueryStatus {
-    EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string status = 3;
-    float elapsed = 4;
-}
-
-// E018
-message SQLCommit {
-    EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string conn_name = 3;
-}
-
-// E019
-message ColTypeChange {
-    EventInfo info = 1;
-    string orig_type = 2;
-    string new_type = 3;
-    ReferenceKeyMsg table = 4;
-}
-
-// E020
-message SchemaCreation {
-    EventInfo info = 1;
-    ReferenceKeyMsg relation = 2;
-}
-
-// E021
-message SchemaDrop {
-    EventInfo info = 1;
-    ReferenceKeyMsg relation = 2;
-}
-
-// E022
-message UncachedRelation {
-    EventInfo info = 1;
-    ReferenceKeyMsg dep_key = 2;
-    ReferenceKeyMsg ref_key = 3;
-}
-
-// E023
-message AddLink {
-    EventInfo info = 1;
-    ReferenceKeyMsg dep_key = 2;
-    ReferenceKeyMsg ref_key = 3;
-}
-
-// E024
-message AddRelation {
-    EventInfo info = 1;
-    ReferenceKeyMsg relation = 2;
-}
-
-// E025
-message DropMissingRelation {
-    EventInfo info = 1;
-    ReferenceKeyMsg relation = 2;
-}
-
-// E026
-message DropCascade {
-    EventInfo info = 1;
-    ReferenceKeyMsg dropped = 2;
-    repeated ReferenceKeyMsg consequences = 3;
-}
-
-// E027
-message DropRelation {
-    EventInfo info = 1;
-    ReferenceKeyMsg dropped = 2;
-}
-
-// E028
-message UpdateReference {
-    EventInfo info = 1;
-    ReferenceKeyMsg old_key = 2;
-    ReferenceKeyMsg new_key = 3;
-    ReferenceKeyMsg cached_key = 4;
-}
-
-// E029
-message TemporaryRelation {
-    EventInfo info = 1;
-    ReferenceKeyMsg key = 2;
-}
-
-// E030
-message RenameSchema {
-    EventInfo info = 1;
-    ReferenceKeyMsg old_key = 2;
-    ReferenceKeyMsg new_key = 3;
-}
-
-// E031
-message DumpBeforeAddGraph {
-    EventInfo info = 1;
-    map<string, ListOfStrings> dump = 2;
-}
-
-// E032
-message DumpAfterAddGraph {
-    EventInfo info = 1;
-    map<string, ListOfStrings> dump = 2;
-}
-
-// E033
-message DumpBeforeRenameSchema {
-    EventInfo info = 1;
-    map<string, ListOfStrings> dump = 2;
-}
-
-// E034
-message DumpAfterRenameSchema {
-    EventInfo info = 1;
-    map<string, ListOfStrings> dump = 2;
-}
-
-// E035
-message AdapterImportError {
-    EventInfo info = 1;
-    string exc = 2;
-}
-
-// E036
-message PluginLoadError {
-    EventInfo info = 1;
-    string exc_info = 2;
-}
-
-// E037
-message NewConnectionOpening {
-    EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string connection_state = 3;
-}
-
-// E038
-message CodeExecution {
-    EventInfo info = 1;
-    string conn_name = 2;
-    string code_content = 3;
-}
-
-// E039
-message CodeExecutionStatus {
-    EventInfo info = 1;
+    NodeInfo node_info = 1;
     string status = 2;
     float elapsed = 3;
 }
 
+message SQLQueryStatusMsg {
+    EventInfo info = 1;
+    SQLQueryStatus data = 2;
+}
+
+// E018
+message SQLCommit {
+    string conn_name = 1;
+}
+
+message SQLCommitMsg {
+    EventInfo info = 1;
+    SQLCommit data = 2;
+}
+
+// E019
+message ColTypeChange {
+    string orig_type = 1;
+    string new_type = 2;
+    ReferenceKeyMsg table = 3;
+}
+
+message ColTypeChangeMsg {
+    EventInfo info = 1;
+    ColTypeChange data = 2;
+}
+
+// E020
+message SchemaCreation {
+    ReferenceKeyMsg relation = 1;
+}
+
+message SchemaCreationMsg {
+    EventInfo info = 1;
+    SchemaCreation data = 2;
+}
+
+// E021
+message SchemaDrop {
+    ReferenceKeyMsg relation = 1;
+}
+
+message SchemaDropMsg {
+    EventInfo info = 1;
+    SchemaDrop data = 2;
+}
+
+// E022
+message UncachedRelation {
+    ReferenceKeyMsg dep_key = 1;
+    ReferenceKeyMsg ref_key = 2;
+}
+
+message UncachedRelationMsg {
+    EventInfo info = 1;
+    UncachedRelation data = 2;
+}
+
+// E023
+message AddLink {
+    ReferenceKeyMsg dep_key = 1;
+    ReferenceKeyMsg ref_key = 2;
+}
+
+message AddLinkMsg {
+    EventInfo info = 1;
+    AddLink data = 2;
+}
+
+// E024
+message AddRelation {
+    ReferenceKeyMsg relation = 1;
+}
+
+message AddRelationMsg {
+    EventInfo info = 1;
+    AddRelation data = 2;
+}
+
+// E025
+message DropMissingRelation {
+    ReferenceKeyMsg relation = 1;
+}
+
+message DropMissingRelationMsg {
+    EventInfo info = 1;
+    DropMissingRelation data = 2;
+}
+
+// E026
+message DropCascade {
+    ReferenceKeyMsg dropped = 1;
+    repeated ReferenceKeyMsg consequences = 2;
+}
+
+message DropCascadeMsg {
+    EventInfo info = 1;
+    DropCascade data = 2;
+}
+
+// E027
+message DropRelation {
+    ReferenceKeyMsg dropped = 1;
+}
+
+message DropRelationMsg {
+    EventInfo info = 1;
+    DropRelation data = 2;
+}
+
+// E028
+message UpdateReference {
+    ReferenceKeyMsg old_key = 1;
+    ReferenceKeyMsg new_key = 2;
+    ReferenceKeyMsg cached_key = 3;
+}
+
+message UpdateReferenceMsg {
+    EventInfo info = 1;
+    UpdateReference data = 2;
+}
+
+// E029
+message TemporaryRelation {
+    ReferenceKeyMsg key = 1;
+}
+
+message TemporaryRelationMsg {
+    EventInfo info = 1;
+    TemporaryRelation data = 2;
+}
+
+// E030
+message RenameSchema {
+    ReferenceKeyMsg old_key = 1;
+    ReferenceKeyMsg new_key = 2;
+}
+
+message RenameSchemaMsg {
+    EventInfo info = 1;
+    RenameSchema data = 2;
+}
+
+// E031
+message DumpBeforeAddGraph {
+    map<string, ListOfStrings> dump = 1;
+}
+
+message DumpBeforeAddGraphMsg {
+    EventInfo info = 1;
+    DumpBeforeAddGraph data = 2;
+}
+
+// E032
+message DumpAfterAddGraph {
+    map<string, ListOfStrings> dump = 1;
+}
+
+message DumpAfterAddGraphMsg {
+    EventInfo info = 1;
+    DumpAfterAddGraph data = 2;
+}
+
+// E033
+message DumpBeforeRenameSchema {
+    map<string, ListOfStrings> dump = 1;
+}
+
+message DumpBeforeRenameSchemaMsg {
+    EventInfo info = 1;
+    DumpBeforeRenameSchema data = 2;
+}
+
+// E034
+message DumpAfterRenameSchema {
+    map<string, ListOfStrings> dump = 1;
+}
+
+message DumpAfterRenameSchemaMsg {
+    EventInfo info = 1;
+    DumpAfterRenameSchema data = 2;
+}
+
+// E035
+message AdapterImportError {
+    string exc = 1;
+}
+
+message AdapterImportErrorMsg {
+    EventInfo info = 1;
+    AdapterImportError data = 2;
+}
+
+// E036
+message PluginLoadError {
+    string exc_info = 1;
+}
+
+message PluginLoadErrorMsg {
+    EventInfo info = 1;
+    PluginLoadError data = 2;
+}
+
+// E037
+message NewConnectionOpening {
+    NodeInfo node_info = 1;
+    string connection_state = 2;
+}
+
+message NewConnectionOpeningMsg {
+    EventInfo info = 1;
+    NewConnectionOpening data = 2;
+}
+
+// E038
+message CodeExecution {
+    string conn_name = 1;
+    string code_content = 2;
+}
+
+message CodeExecutionMsg {
+    EventInfo info = 1;
+    CodeExecution data = 2;
+}
+
+// E039
+message CodeExecutionStatus {
+    string status = 1;
+    float elapsed = 2;
+}
+
+message CodeExecutionStatusMsg {
+    EventInfo info = 1;
+    CodeExecutionStatus data = 2;
+}
+
 // E040
 message CatalogGenerationError {
+    string exc = 1;
+}
+
+message CatalogGenerationErrorMsg {
     EventInfo info = 1;
-    string exc = 2;
+    CatalogGenerationError data = 2;
 }
 
 // E041
 message WriteCatalogFailure {
+    int32 num_exceptions = 1;
+}
+
+message WriteCatalogFailureMsg {
     EventInfo info = 1;
-    int32 num_exceptions = 2;
+    WriteCatalogFailure data = 2;
 }
 
 // E042
 message CatalogWritten {
+    string path = 1;
+}
+
+message CatalogWrittenMsg {
     EventInfo info = 1;
-    string path = 2;
+    CatalogWritten data = 2;
 }
 
 // E043
 message CannotGenerateDocs {
+}
+
+message CannotGenerateDocsMsg {
     EventInfo info = 1;
+    CannotGenerateDocs data = 2;
 }
 
 // E044
 message BuildingCatalog {
+}
+
+message BuildingCatalogMsg {
     EventInfo info = 1;
+    BuildingCatalog data = 2;
 }
 
 // E045
 message DatabaseErrorRunningHook {
+    string hook_type = 1;
+}
+
+message DatabaseErrorRunningHookMsg {
     EventInfo info = 1;
-    string hook_type = 2;
+    DatabaseErrorRunningHook data = 2;
 }
 
 // E046
 message HooksRunning {
+    int32 num_hooks = 1;
+    string hook_type = 2;
+}
+
+message HooksRunningMsg {
     EventInfo info = 1;
-    int32 num_hooks = 2;
-    string hook_type = 3;
+    HooksRunning data = 2;
 }
 
 // E047
 message HookFinished {
+    string stat_line = 1;
+    string execution = 2;
+    float execution_time = 3;
+}
+
+message HookFinishedMsg {
     EventInfo info = 1;
-    string stat_line = 2;
-    string execution = 3;
-    float execution_time = 4;
+    HookFinished data = 2;
 }
 
 
 // I - Project parsing
 
 // I001
-message ParseCmdStart {
-    EventInfo info = 1;
+message ParseCmdOut {
+    string msg = 1;
 }
 
-// I002
-message ParseCmdCompiling {
+message ParseCmdOutMsg {
     EventInfo info = 1;
+    ParseCmdOut data = 2;
 }
 
-// I003
-message ParseCmdWritingManifest {
-    EventInfo info = 1;
-}
+// Skipping I002, I003, I004, I005, I006, I007, I008, I009, I010
 
-// I004
-message ParseCmdDone {
-    EventInfo info = 1;
-}
-
-// I005
-message ManifestDependenciesLoaded {
-    EventInfo info = 1;
-}
-
-// I006
-message ManifestLoaderCreated {
-    EventInfo info = 1;
-}
-
-// I007
-message ManifestLoaded {
-    EventInfo info = 1;
-}
-
-// I008
-message ManifestChecked {
-    EventInfo info = 1;
-}
-
-// I009
-message ManifestFlatGraphBuilt {
-    EventInfo info = 1;
-}
-
-// I010
-message ParseCmdPerfInfoPath {
-    EventInfo info = 1;
-    string path = 2;
-}
 
 // I011
 message GenericTestFileParse {
+    string path = 1;
+}
+
+message GenericTestFileParseMsg {
     EventInfo info = 1;
-    string path = 2;
+    GenericTestFileParse data = 2;
 }
 
 // I012
 message MacroFileParse {
+    string path = 1;
+}
+
+message MacroFileParseMsg {
     EventInfo info = 1;
-    string path = 2;
+    MacroFileParse data = 2;
 }
 
 // Skipping I013
 
 // I014
 message PartialParsingExceptionProcessingFile {
+    string file = 1;
+}
+
+message PartialParsingExceptionProcessingFileMsg {
     EventInfo info = 1;
-    string file = 2;
+    PartialParsingExceptionProcessingFile data = 2;
 }
 
 // I016
 message PartialParsingException {
+    map<string, string> exc_info = 1;
+}
+
+message PartialParsingExceptionMsg {
     EventInfo info = 1;
-    map<string, string> exc_info = 2;
+    PartialParsingException data = 2;
 }
 
 // I017
 message PartialParsingSkipParsing {
+}
+
+message PartialPArsingSkipParsingMsg {
     EventInfo info = 1;
+    PartialParsingSkipParsing data = 2;
 }
 
 
@@ -678,8 +971,12 @@ message PartialParsingSkipParsing {
 
 // I024
 message UnableToPartialParse {
+    string reason = 1;
+}
+
+message UnableToPartialParseMsg {
     EventInfo info = 1;
-    string reason = 2;
+    UnableToPartialParse data = 2;
 }
 
 // Skipped I025, I026, I027
@@ -687,15 +984,23 @@ message UnableToPartialParse {
 
 // I028
 message PartialParsingNotEnabled {
+}
+
+message PartialParsingNotEnabledMsg {
     EventInfo info = 1;
+    PartialParsingNotEnabled data = 2;
 }
 
 // I029
 message ParsedFileLoadFailed {
+    string path = 1;
+    string exc = 2;
+    string exc_info = 3;
+}
+
+message ParsedFileLoadFailedMsg {
     EventInfo info = 1;
-    string path = 2;
-    string exc = 3;
-    string exc_info = 4;
+    ParsedFileLoadFailed data = 2;
 }
 
 // Skipping I030
@@ -703,406 +1008,646 @@ message ParsedFileLoadFailed {
 
 // I031
 message StaticParserCausedJinjaRendering {
+    string path = 1;
+}
+
+message StaticParserCausedJinjaRenderingMsg {
     EventInfo info = 1;
-    string path = 2;
+    StaticParserCausedJinjaRendering data = 2;
 }
 
 // I032
 message UsingExperimentalParser {
+    string path = 1;
+}
+
+message UsingExperimentalParserMsg {
     EventInfo info = 1;
-    string path = 2;
+    UsingExperimentalParser data = 2;
 }
 
 // I033
 message SampleFullJinjaRendering {
+    string path = 1;
+}
+
+message SampleFullJinjaRenderingMsg {
     EventInfo info = 1;
-    string path = 2;
+    SampleFullJinjaRendering data = 2;
 }
 
 // I034
 message StaticParserFallbackJinjaRendering {
+    string path = 1;
+}
+
+message StaticParserFallbackJinjaRenderingMsg {
     EventInfo info = 1;
-    string path = 2;
+    StaticParserFallbackJinjaRendering data = 2;
 }
 
 // I035
 message StaticParsingMacroOverrideDetected {
+    string path = 1;
+}
+
+message StaticParsingMacroOverrideDetectedMsg {
     EventInfo info = 1;
-    string path = 2;
+    StaticParsingMacroOverrideDetected data = 2;
 }
 
 // I036
 message StaticParserSuccess {
+    string path = 1;
+}
+
+message StaticParserSuccessMsg {
     EventInfo info = 1;
-    string path = 2;
+    StaticParserSuccess data = 2;
 }
 
 // I037
 message StaticParserFailure {
+    string path = 1;
+}
+
+message StaticParserFailureMsg {
     EventInfo info = 1;
-    string path = 2;
+    StaticParserFailure data = 2;
 }
 
 // I038
 message ExperimentalParserSuccess {
+    string path = 1;
+}
+
+message ExperimentalParserSuccessMsg {
     EventInfo info = 1;
-    string path = 2;
+    ExperimentalParserSuccess data = 2;
 }
 
 // I039
 message ExperimentalParserFailure {
+    string path = 1;
+}
+
+message ExperimentalParserFailureMsg {
     EventInfo info = 1;
-    string path = 2;
+    ExperimentalParserFailure data = 2;
 }
 
 // I040
 message PartialParsingEnabled {
+    int32 deleted = 1;
+    int32 added = 2;
+    int32 changed = 3;
+}
+
+message PartialParsingEnabledMsg {
     EventInfo info = 1;
-    int32 deleted = 2;
-    int32 added = 3;
-    int32 changed = 4;
+    PartialParsingEnabled data = 2;
 }
 
 // I041
 message PartialParsingFile {
+    string file_id = 1;
+    string operation = 2;
+}
+
+message PartialParsingFileMsg {
     EventInfo info = 1;
-    string file_id = 2;
-    string operation = 3;
+    PartialParsingFile data = 2;
 }
 
 // Skipped I042, I043, I044, I045, I046, I047, I048, I049
 
 // I050
 message InvalidDisabledTargetInTestNode {
+    string resource_type_title = 1;
+    string unique_id = 2;
+    string original_file_path = 3;
+    string target_kind = 4;
+    string target_name = 5;
+    string target_package = 6;
+}
+
+message InvalidDisabledTargetInTestNodeMsg {
     EventInfo info = 1;
-    string resource_type_title = 2;
-    string unique_id = 3;
-    string original_file_path = 4;
-    string target_kind = 5;
-    string target_name = 6;
-    string target_package = 7;
+    InvalidDisabledTargetInTestNode data = 2;
 }
 
 // I051
 message UnusedResourceConfigPath {
+    repeated string unused_config_paths = 1;
+}
+
+message UnusedResourceConfigPathMsg {
     EventInfo info = 1;
-    repeated string unused_config_paths = 2;
+    UnusedResourceConfigPath data = 2;
 }
 
 // I052
 message SeedIncreased {
+    string package_name = 1;
+    string name = 2;
+}
+
+message SeedIncreasedMsg {
     EventInfo info = 1;
-    string package_name = 2;
-    string name = 3;
+    SeedIncreased data = 2;
 }
 
 // I053
 message SeedExceedsLimitSamePath {
+    string package_name = 1;
+    string name = 2;
+}
+
+message SeedExceedsLimitSamePathMsg {
     EventInfo info = 1;
-    string package_name = 2;
-    string name = 3;
+    SeedExceedsLimitSamePath data = 2;
 }
 
 // I054
 message SeedExceedsLimitAndPathChanged {
+    string package_name = 1;
+    string name = 2;
+}
+
+message SeedExceedsLimitAndPathChangedMsg {
     EventInfo info = 1;
-    string package_name = 2;
-    string name = 3;
+    SeedExceedsLimitAndPathChanged data = 2;
 }
 
 // I055
 message SeedExceedsLimitChecksumChanged {
+    string package_name = 1;
+    string name = 2;
+    string checksum_name = 3;
+}
+
+message SeedExceedsLimitChecksumChangedMsg {
     EventInfo info = 1;
-    string package_name = 2;
-    string name = 3;
-    string checksum_name = 4;
+    SeedExceedsLimitChecksumChanged data = 2;
 }
 
 // I056
 message UnusedTables {
+    repeated string unused_tables = 1;
+}
+
+message UnusedTablesMsg {
     EventInfo info = 1;
-    repeated string unused_tables = 2;
+    UnusedTables data = 2;
 }
 
 // I057
 message WrongResourceSchemaFile {
+    string patch_name = 1;
+    string resource_type = 2;
+    string plural_resource_type = 3;
+    string yaml_key = 4;
+    string file_path = 5;
+}
+
+message WrongResourceSchemaFileMsg {
     EventInfo info = 1;
-    string patch_name = 2;
-    string resource_type = 3;
-    string plural_resource_type = 4;
-    string yaml_key = 5;
-    string file_path = 6;
+    WrongResourceSchemaFile data = 2;
 }
 
 // I058
 message NoNodeForYamlKey {
+    string patch_name = 1;
+    string yaml_key = 2;
+    string file_path = 3;
+}
+
+message NoNodeForYamlKeyMsg {
     EventInfo info = 1;
-    string patch_name = 2;
-    string yaml_key = 3;
-    string file_path = 4;
+    NoNodeForYamlKey data = 2;
 }
 
 // I059
-message MacroPatchNotFound {
+message MacroNotFoundForPatch {
+    string patch_name = 1;
+}
+
+message MacroNotFoundForPatchMsg {
     EventInfo info = 1;
-    string patch_name = 2;
+    MacroNotFoundForPatch data = 2;
 }
 
 // I060
 message NodeNotFoundOrDisabled {
+    string original_file_path = 1;
+    string unique_id = 2;
+    string resource_type_title = 3;
+    string target_name = 4;
+    string target_kind = 5;
+    string target_package = 6;
+    string disabled = 7;
+}
+
+message NodeNotFoundOrDisabledMsg {
     EventInfo info = 1;
-    string original_file_path = 2;
-    string unique_id = 3;
-    string resource_type_title = 4;
-    string target_name = 5;
-    string target_kind = 6;
-    string target_package = 7;
-    string disabled = 8;
+    NodeNotFoundOrDisabled data = 2;
 }
 
 // I061
 message JinjaLogWarning {
+    NodeInfo node_info = 1;
+    string msg = 2;
+}
+
+message JinjaLogWarningMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string msg = 3;
+    JinjaLogWarning data = 2;
 }
 
 // M - Deps generation
 
 // M001
 message GitSparseCheckoutSubdirectory {
+    string subdir = 1;
+}
+
+message GitSparseCheckoutSubdirectoryMsg {
     EventInfo info = 1;
-    string subdir = 2;
+    GitSparseCheckoutSubdirectory data = 2;
 }
 
 // M002
 message GitProgressCheckoutRevision {
+    string revision = 1;
+}
+
+message GitProgressCheckoutRevisionMsg {
     EventInfo info = 1;
-    string revision = 2;
+    GitProgressCheckoutRevision data = 2;
 }
 
 // M003
 message GitProgressUpdatingExistingDependency {
+    string dir = 1;
+}
+
+message GitProgressUpdatingExistingDependencyMsg {
     EventInfo info = 1;
-    string dir = 2;
+    GitProgressUpdatingExistingDependency data = 2;
 }
 
 // M004
 message GitProgressPullingNewDependency {
+    string dir = 1;
+}
+
+message GitProgressPullingNewDependencyMsg {
     EventInfo info = 1;
-    string dir = 2;
+    GitProgressPullingNewDependency data = 2;
 }
 
 // M005
 message GitNothingToDo {
+    string sha = 1;
+}
+
+message GitNothingToDoMsg {
     EventInfo info = 1;
-    string sha = 2;
+    GitNothingToDo data = 2;
 }
 
 // M006
 message GitProgressUpdatedCheckoutRange {
+    string start_sha = 1;
+    string end_sha = 2;
+}
+
+message GitProgressUpdatedCheckoutRangeMsg {
     EventInfo info = 1;
-    string start_sha = 2;
-    string end_sha = 3;
+    GitProgressUpdatedCheckoutRange data = 2;
 }
 
 // M007
 message GitProgressCheckedOutAt {
+    string end_sha = 1;
+}
+
+message GitProgressCheckedOutAtMsg {
     EventInfo info = 1;
-    string end_sha = 2;
+    GitProgressCheckedOutAt data = 2;
 }
 
 // M008
 message RegistryProgressGETRequest {
+    string url = 1;
+}
+
+message RegistryProgressGETRequestMsg {
     EventInfo info = 1;
-    string url = 2;
+    RegistryProgressGETRequest data = 2;
 }
 
 // M009
 message RegistryProgressGETResponse {
+    string url = 1;
+    int32 resp_code = 2;
+}
+
+message RegistryProgressGETResponseMsg {
     EventInfo info = 1;
-    string url = 2;
-    int32 resp_code = 3;
+    RegistryProgressGETResponse data = 2;
 }
 
 // M010
 message SelectorReportInvalidSelector {
+    string valid_selectors = 1;
+    string spec_method = 2;
+    string raw_spec = 3;
+}
+
+message SelectorReportInvalidSelectorMsg {
     EventInfo info = 1;
-    string valid_selectors = 2;
-    string spec_method = 3;
-    string raw_spec = 4;
+    SelectorReportInvalidSelector data = 2;
 }
 
 // M011
 message JinjaLogInfo {
+    NodeInfo node_info = 1;
+    string msg = 2;
+}
+
+message  JinjaLogInfoMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string msg = 3;
+     JinjaLogInfo data = 2;
 }
 
 // M012
 message JinjaLogDebug {
+    NodeInfo node_info = 1;
+    string msg = 2;
+}
+
+message JinjaLogDebugMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string msg = 3;
+    JinjaLogDebug data = 2;
 }
 
 // M013
 message DepsNoPackagesFound {
+}
+
+message DepsNoPackagesFoundMsg {
     EventInfo info = 1;
+    DepsNoPackagesFound data = 2;
 }
 
 // M014
 message DepsStartPackageInstall {
+    string package_name = 1;
+}
+
+message DepsStartPackageInstallMsg {
     EventInfo info = 1;
-    string package_name = 2;
+    DepsStartPackageInstall data = 2;
 }
 
 // M015
 message DepsInstallInfo {
+    string version_name = 1;
+}
+
+message DepsInstallInfoMsg {
     EventInfo info = 1;
-    string version_name = 2;
+    DepsInstallInfo data = 2;
 }
 
 // M016
 message DepsUpdateAvailable {
+    string version_latest = 1;
+}
+
+message DepsUpdateAvailableMsg {
     EventInfo info = 1;
-    string version_latest = 2;
+    DepsUpdateAvailable data = 2;
 }
 
 // M017
 message DepsUpToDate {
+}
+
+message DepsUpToDateMsg {
     EventInfo info = 1;
+    DepsUpToDate data = 2;
 }
 
 // M018
 message DepsListSubdirectory {
+    string subdirectory = 1;
+}
+
+message DepsListSubdirectoryMsg {
     EventInfo info = 1;
-    string subdirectory = 2;
+    DepsListSubdirectory data = 2;
 }
 
 // M019
 message DepsNotifyUpdatesAvailable {
+    ListOfStrings packages = 1;
+}
+
+message DepsNotifyUpdatesAvailableMsg {
     EventInfo info = 1;
-    ListOfStrings packages = 2;
+    DepsNotifyUpdatesAvailable data = 2;
 }
 
 // M020
 message RetryExternalCall {
+    int32 attempt = 1;
+    int32 max = 2;
+}
+
+message RetryExternalCallMsg {
     EventInfo info = 1;
-    int32 attempt = 2;
-    int32 max = 3;
+    RetryExternalCall data = 2;
 }
 
 // M021
 message RecordRetryException {
+    string exc = 1;
+}
+
+message RecordRetryExceptionMsg {
     EventInfo info = 1;
-    string exc = 2;
+    RecordRetryException data = 2;
 }
 
 // M022
 message RegistryIndexProgressGETRequest {
+    string url = 1;
+}
+
+message RegistryIndexProgressGETRequestMsg {
     EventInfo info = 1;
-    string url = 2;
+    RegistryIndexProgressGETRequest data = 2;
 }
 
 // M023
 message RegistryIndexProgressGETResponse {
+    string url = 1;
+    int32 resp_code = 2;
+}
+
+message RegistryIndexProgressGETResponseMsg {
     EventInfo info = 1;
-    string url = 2;
-    int32 resp_code = 3;
+    RegistryIndexProgressGETResponse data = 2;
 }
 
 // M024
 message RegistryResponseUnexpectedType {
+    string response = 1;
+}
+
+message RegistryResponseUnexpectedTypeMsg {
     EventInfo info = 1;
-    string response = 2;
+    RegistryResponseUnexpectedType data = 2;
 }
 
 // M025
 message RegistryResponseMissingTopKeys {
+    string response = 1;
+}
+
+message RegistryResponseMissingTopKeysMsg {
     EventInfo info = 1;
-    string response = 2;
+    RegistryResponseMissingTopKeys data = 2;
 }
 
 // M026
 message RegistryResponseMissingNestedKeys {
+    string response = 1;
+}
+
+message RegistryResponseMissingNestedKeysMsg {
     EventInfo info = 1;
-    string response = 2;
+    RegistryResponseMissingNestedKeys data = 2;
 }
 
 // m027
 message RegistryResponseExtraNestedKeys {
+    string response = 1;
+}
+
+message RegistryResponseExtraNestedKeysMsg {
     EventInfo info = 1;
-    string response = 2;
+    RegistryResponseExtraNestedKeys data = 2;
 }
 
 // M028
 message DepsSetDownloadDirectory {
+    string path = 1;
+}
+
+message DepsSetDownloadDirectoryMsg {
     EventInfo info = 1;
-    string path = 2;
+    DepsSetDownloadDirectory data = 2;
 }
 
 // M029
 message DepsUnpinned {
+    string revision = 1;
+    string git = 2;
+}
+
+message DepsUnpinnedMsg {
     EventInfo info = 1;
-    string revision = 2;
-    string git = 3;
+    DepsUnpinned data = 2;
 }
 
 // M030
 message NoNodesForSelectionCriteria {
+    string spec_raw = 1;
+}
+
+message NoNodesForSelectionCriteriaMsg {
     EventInfo info = 1;
-    string spec_raw = 2;
+    NoNodesForSelectionCriteria data = 2;
 }
 
 // Q - Node execution
 
 // Q001
 message RunningOperationCaughtError {
+    string exc = 1;
+}
+
+message RunningOperationCaughtErrorMsg {
     EventInfo info = 1;
-    string exc = 2;
+    RunningOperationCaughtError data = 2;
 }
 
 // Q002
 message CompileComplete {
+}
+
+message CompileCompleteMsg {
     EventInfo info = 1;
+    CompileComplete data = 2;
 }
 
 // Q003
 message FreshnessCheckComplete {
+}
+
+message FreshnessCheckCompleteMsg {
     EventInfo info = 1;
+    FreshnessCheckComplete data = 2;
 }
 
 // Q004
 message SeedHeader {
+    string header = 1;
+}
+
+message SeedHeaderMsg {
     EventInfo info = 1;
-    string header = 2;
+    SeedHeader data = 2;
 }
 
 // Q005
 message SeedHeaderSeparator {
+    int32 len_header = 1;
+}
+
+message SeedHeaderSeparatorMsg {
     EventInfo info = 1;
-    int32 len_header = 2;
+    SeedHeaderSeparator data = 2;
 }
 
 // Q006
 message SQLRunnerException {
+    string exc = 1;
+    string exc_info = 2;
+}
+
+message SQLRunnerExceptionMsg {
     EventInfo info = 1;
-    string exc = 2;
-    string exc_info = 3;
+    SQLRunnerException data = 2;
 }
 
 // Q007
 message LogTestResult {
+    NodeInfo node_info = 1;
+    string name = 2;
+    string status = 3;
+    int32 index = 4;
+    int32 num_models = 5;
+    float execution_time = 6;
+    int32 num_failures = 7;
+}
+
+message LogTestResultMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string name = 3;
-    string status = 4;
-    int32 index = 5;
-    int32 num_models = 6;
-    float execution_time = 7;
-    int32 num_failures = 8;
+    LogTestResult data = 2;
 }
 
 
@@ -1111,63 +1656,83 @@ message LogTestResult {
 
 // Q011
 message LogStartLine {
+    NodeInfo node_info = 1;
+    string description = 2;
+    int32 index = 3;
+    int32 total = 4;
+}
+
+message LogStartLineMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string description = 3;
-    int32 index = 4;
-    int32 total = 5;
+    LogStartLine data = 2;
 }
 
 // Q012
 message LogModelResult {
+    NodeInfo node_info = 1;
+    string description = 2;
+    string status = 3;
+    int32 index = 4;
+    int32 total = 5;
+    int32 execution_time = 6;
+}
+
+message LogModelResultMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string description = 3;
-    string status = 4;
-    int32 index = 5;
-    int32 total = 6;
-    int32 execution_time = 7;
+    LogModelResult data = 2;
 }
 
 // skipped Q013, Q014
 
 // Q015
 message LogSnapshotResult {
+    NodeInfo node_info = 1;
+    string description = 2;
+    string status = 3;
+    int32 index = 4;
+    int32 total = 5;
+    float execution_time = 6;
+    map<string, string> cfg = 7;
+}
+
+message LogSnapshotResultMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string description = 3;
-    string status = 4;
-    int32 index = 5;
-    int32 total = 6;
-    float execution_time = 7;
-    map<string, string> cfg = 8;
+    LogSnapshotResult data = 2;
 }
 
 // Q016
 message LogSeedResult {
+    NodeInfo node_info = 1;
+    string status = 2;
+    string result_message = 3;
+    int32 index = 4;
+    int32 total = 5;
+    float execution_time = 6;
+    string schema = 7;
+    string relation = 8;
+}
+
+message LogSeedResultMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string status = 3;
-    string result_message = 4;
-    int32 index = 5;
-    int32 total = 6;
-    float execution_time = 7;
-    string schema = 8;
-    string relation = 9;
+    LogSeedResult data = 2;
 }
 
 // Skipped Q017
 
 // Q018
 message LogFreshnessResult {
+    string status = 1;
+    NodeInfo node_info = 2;
+    int32 index = 3;
+    int32 total = 4;
+    float execution_time = 5;
+    string source_name = 6;
+    string table_name = 7;
+}
+
+message LogFreshnessResultMsg {
     EventInfo info = 1;
-    string status = 2;
-    NodeInfo node_info = 3;
-    int32 index = 4;
-    int32 total = 5;
-    float execution_time = 6;
-    string source_name = 7;
-    string table_name = 8;
+    LogFreshnessResult data = 2;
 }
 
 
@@ -1176,117 +1741,181 @@ message LogFreshnessResult {
 
 // Q022
 message LogCancelLine {
+    string conn_name = 1;
+}
+
+message LogCancelLineMsg {
     EventInfo info = 1;
-    string conn_name = 2;
+    LogCancelLine data = 2;
 }
 
 // Q023
 message DefaultSelector {
+    string name = 1;
+}
+
+message DefaultSelectorMsg {
     EventInfo info = 1;
-    string name = 2;
+    DefaultSelector data = 2;
 }
 
 // Q024
 message NodeStart {
+    NodeInfo node_info = 1;
+}
+
+message NodeStartMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
+    NodeStart data = 2;
 }
 
 // Q025
 message NodeFinished {
+    NodeInfo node_info = 1;
+    RunResultMsg run_result = 2;
+}
+
+message NodeFinishedMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    RunResultMsg run_result = 4;
+    NodeFinished data = 2;
 }
 
 // Q026
 message QueryCancelationUnsupported {
+    string type = 1;
+}
+
+message QueryCancelationUnsupportedMsg {
     EventInfo info = 1;
-    string type = 2;
+    QueryCancelationUnsupported data = 2;
 }
 
 // Q027
 message ConcurrencyLine {
+    int32 num_threads = 1;
+    string target_name = 2;
+    int32 node_count = 3;
+}
+
+message ConcurrencyLineMsg {
     EventInfo info = 1;
-    int32 num_threads = 2;
-    string target_name = 3;
-    int32 node_count = 4;
+    ConcurrencyLine data = 2;
 }
 
 // Skipped Q028
 
 // Q029
 message WritingInjectedSQLForNode {
+    NodeInfo node_info = 1;
+}
+
+message WritingInjectedSQLForNodeMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
+    WritingInjectedSQLForNode data = 2;
 }
 
 // Q030
 message NodeCompiling {
+    NodeInfo node_info = 1;
+}
+
+message NodeCompilingMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
+    NodeCompiling data = 2;
 }
 
 // Q031
 message NodeExecuting {
+    NodeInfo node_info = 1;
+}
+
+message NodeExecutingMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
+    NodeExecuting data = 2;
 }
 
 // Q032
 message LogHookStartLine {
+    NodeInfo node_info = 1;
+    string statement = 2;
+    int32 index = 3;
+    int32 total = 4;
+}
+
+message LogHookStartLineMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string statement = 3;
-    int32 index = 4;
-    int32 total = 5;
+    LogHookStartLine data = 2;
 }
 
 // Q033
 message LogHookEndLine {
+    NodeInfo node_info = 1;
+    string statement = 2;
+    string status = 3;
+    int32 index = 4;
+    int32 total = 5;
+    float execution_time = 6;
+}
+
+message LogHookEndLineMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string statement = 3;
-    string status = 4;
-    int32 index = 5;
-    int32 total = 6;
-    float execution_time = 7;
+    LogHookEndLine data = 2;
 }
 
 // Q034
 message SkippingDetails {
+    NodeInfo node_info = 1;
+    string resource_type = 2;
+    string schema = 3;
+    string node_name = 4;
+    int32 index = 5;
+    int32 total = 6;
+}
+
+message SkippingDetailsMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string resource_type = 3;
-    string schema = 4;
-    string node_name = 5;
-    int32 index = 6;
-    int32 total = 7;
+    SkippingDetails data = 2;
 }
 
 // Q035
 message NothingToDo {
+}
+
+message NothingToDoMsg {
     EventInfo info = 1;
+    NothingToDo data = 2;
 }
 
 // Q036
 message RunningOperationUncaughtError {
+    string exc = 1;
+}
+
+message RunningOperationUncaughtErrorMsg {
     EventInfo info = 1;
-    string exc = 2;
+    RunningOperationUncaughtError data = 2;
 }
 
 // Q037
 message EndRunResult {
+    repeated RunResultMsg results = 1;
+    float elapsed_time = 2;
+    google.protobuf.Timestamp generated_at = 3;
+    bool success = 4;
+}
+
+message EndRunResultMsg {
     EventInfo info = 1;
-    repeated RunResultMsg results = 2;
-    float elapsed_time = 3;
-    google.protobuf.Timestamp generated_at = 4;
-    bool success = 5;
+    EndRunResult data = 2;
 }
 
 // Q038
 message NoNodesSelected {
+}
+
+message NoNodesSelectedMsg {
     EventInfo info = 1;
+    NoNodesSelected data = 2;
 }
 
 // W - Node testing
@@ -1295,330 +1924,538 @@ message NoNodesSelected {
 
 // W002
 message CatchableExceptionOnRun {
+    NodeInfo node_info = 1;
+    string exc = 2;
+    string exc_info = 3;
+}
+
+message CatchableExceptionOnRunMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    string exc = 3;
-    string exc_info = 4;
+    CatchableExceptionOnRun data = 2;
 }
 
 // W003
 message InternalExceptionOnRun {
+    string build_path = 1;
+    string exc = 2;
+}
+
+message InternalExceptionOnRunMsg {
     EventInfo info = 1;
-    string build_path = 2;
-    string exc = 3;
+    InternalExceptionOnRun data = 2;
 }
 
 // W004
 message GenericExceptionOnRun {
+    string build_path = 1;
+    string unique_id = 2;
+    string exc = 3;
+}
+
+message GenericExceptionOnRunMsg {
     EventInfo info = 1;
-    string build_path = 2;
-    string unique_id = 3;
-    string exc = 4;
+    GenericExceptionOnRun data = 2;
 }
 
 // W005
 message NodeConnectionReleaseError {
+    string node_name = 1;
+    string exc = 2;
+    string exc_info = 3;
+}
+
+message NodeConnectionReleaseErrorMsg {
     EventInfo info = 1;
-    string node_name = 2;
-    string exc = 3;
-    string exc_info = 4;
+    NodeConnectionReleaseError data = 2;
 }
 
 // W006
 message FoundStats {
+    string stat_line = 1;
+}
+
+message FoundStatsMsg {
     EventInfo info = 1;
-    string stat_line = 2;
+    FoundStats data = 2;
 }
 
 // Z - Misc
 
 // Z001
 message MainKeyboardInterrupt {
+}
+
+message MainKeyboardInterruptMsg {
     EventInfo info = 1;
+    MainKeyboardInterrupt data = 2;
 }
 
 // Z002
 message MainEncounteredError {
+    string exc = 1;
+}
+
+message MainEncounteredErrorMsg {
     EventInfo info = 1;
-    string exc = 2;
+    MainEncounteredError data = 2;
 }
 
 // Z003
 message MainStackTrace {
+    string stack_trace = 1;
+}
+
+message MainStackTraceMsg {
     EventInfo info = 1;
-    string stack_trace = 2;
+    MainStackTrace data = 2;
 }
 
 // Z004
 message SystemErrorRetrievingModTime {
+    string path = 1;
+}
+
+message SystemErrorRetrievingModTimeMsg {
     EventInfo info = 1;
-    string path = 2;
+    SystemErrorRetrievingModTime data = 2;
 }
 
 // Z005
 message SystemCouldNotWrite {
+    string path = 1;
+    string reason = 2;
+    string exc = 3;
+}
+
+message SystemCouldNotWriteMsg {
     EventInfo info = 1;
-    string path = 2;
-    string reason = 3;
-    string exc = 4;
+    SystemCouldNotWrite data = 2;
 }
 
 // Z006
 message SystemExecutingCmd {
+    repeated string cmd = 1;
+}
+
+message SystemExecutingCmdMsg {
     EventInfo info = 1;
-    repeated string cmd = 2;
+    SystemExecutingCmd data = 2;
 }
 
 // Z007
+message SystemStdOut{
+    bytes bmsg = 1;
+}
+
 message SystemStdOutMsg {
     EventInfo info = 1;
-    bytes bmsg = 2;
+    SystemStdOut data = 2;
 }
 
 // Z008
+message SystemStdErr {
+    bytes bmsg = 1;
+}
+
 message SystemStdErrMsg {
     EventInfo info = 1;
-    bytes bmsg = 2;
+    SystemStdErr data = 2;
 }
 
 // Z009
 message SystemReportReturnCode {
+    int32 returncode = 1;
+}
+
+message SystemReportReturnCodeMsg {
     EventInfo info = 1;
-    int32 returncode = 2;
+    SystemReportReturnCode data = 2;
 }
 
 // Z010
 message TimingInfoCollected {
+    NodeInfo node_info = 1;
+    TimingInfoMsg timing_info = 2;
+}
+
+message TimingInfoCollectedMsg {
     EventInfo info = 1;
-    NodeInfo node_info = 2;
-    TimingInfoMsg timing_info = 3;
+    TimingInfoCollected data = 2;
 }
 
 // Z011
 message LogDebugStackTrace {
+    string exc_info = 1;
+}
+
+message LogDebugStackTraceMsg {
     EventInfo info = 1;
-    string exc_info = 2;
+    LogDebugStackTrace data = 2;
 }
 
 // Z012
 message CheckCleanPath {
+    string path = 1;
+}
+
+message CheckCleanPathMsg {
     EventInfo info = 1;
-    string path = 2;
+    CheckCleanPath data = 2;
 }
 
 // Z013
 message ConfirmCleanPath {
+    string path = 1;
+}
+
+message ConfirmCleanPathMsg {
     EventInfo info = 1;
-    string path = 2;
+    ConfirmCleanPath data = 2;
 }
 
 // Z014
 message ProtectedCleanPath {
+    string path = 1;
+}
+
+message ProtectedCleanPathMsg {
     EventInfo info = 1;
-    string path = 2;
+    ProtectedCleanPath data = 2;
 }
 
 // Z015
 message FinishedCleanPaths {
+}
+
+message FinishedCleanPathsMsg {
     EventInfo info = 1;
+    FinishedCleanPaths data = 2;
 }
 
 // Z016
 message OpenCommand {
+    string open_cmd = 1;
+    string profiles_dir = 2;
+}
+
+message OpenCommandMsg {
     EventInfo info = 1;
-    string open_cmd = 2;
-    string profiles_dir = 3;
+    OpenCommand data = 2;
 }
 
 // Z017
 message EmptyLine {
+}
+
+message EmptyLineMsg {
     EventInfo info = 1;
+    EmptyLine data = 2;
 }
 
 // Z018
 message ServingDocsPort {
+    string address = 1;
+    int32 port = 2;
+}
+
+message ServingDocsPortMsg {
     EventInfo info = 1;
-    string address = 2;
-    int32 port = 3;
+    ServingDocsPort data = 2;
 }
 
 // Z019
 message ServingDocsAccessInfo {
+    string port = 1;
+}
+
+message ServingDocsAccessInfoMsg {
     EventInfo info = 1;
-    string port = 2;
+    ServingDocsAccessInfo data = 2;
 }
 
 // Z020
 message ServingDocsExitInfo {
+}
+
+message ServingDocsExitInfoMsg {
     EventInfo info = 1;
+    ServingDocsExitInfo data = 2;
 }
 
 // Z021
 message RunResultWarning {
+    string resource_type = 1;
+    string node_name = 2;
+    string path = 3;
+}
+
+message RunResultWarningMsg {
     EventInfo info = 1;
-    string resource_type = 2;
-    string node_name = 3;
-    string path = 4;
+    RunResultWarning data = 2;
 }
 
 // Z022
 message RunResultFailure {
+    string resource_type = 1;
+    string node_name = 2;
+    string path = 3;
+}
+
+message RunResultFailureMsg {
     EventInfo info = 1;
-    string resource_type = 2;
-    string node_name = 3;
-    string path = 4;
+    RunResultFailure data = 2;
 }
 
 // Z023
 message StatsLine {
+    map<string, int32> stats = 1;
+}
+
+message StatsLineMsg {
     EventInfo info = 1;
-    map<string, int32> stats = 2;
+    StatsLine data = 2;
 }
 
 // Z024
 message RunResultError {
+    string msg = 1;
+}
+
+message RunResultErrorMsg {
     EventInfo info = 1;
-    string msg = 2;
+    RunResultError data = 2;
 }
 
 // Z025
 message RunResultErrorNoMessage {
+    string status = 1;
+}
+
+message RunResultErrorNoMessageMsg {
     EventInfo info = 1;
-    string status = 2;
+    RunResultErrorNoMessage data = 2;
 }
 
 // Z026
 message SQLCompiledPath {
+    string path = 1;
+}
+
+message SQLCompiledPathMsg {
     EventInfo info = 1;
-    string path = 2;
+    SQLCompiledPath data = 2;
 }
 
 // Z027
 message CheckNodeTestFailure {
+    string relation_name = 1;
+}
+
+message CheckNodeTestFailureMsg {
     EventInfo info = 1;
-    string relation_name = 2;
+    CheckNodeTestFailure data = 2;
 }
 
 // Z028
 message FirstRunResultError {
+    string msg = 1;
+}
+
+message FirstRunResultErrorMsg {
     EventInfo info = 1;
-    string msg = 2;
+    FirstRunResultError data = 2;
 }
 
 // Z029
 message AfterFirstRunResultError {
+    string msg = 1;
+}
+
+message AfterFirstRunResultErrorMsg {
     EventInfo info = 1;
-    string msg = 2;
+    AfterFirstRunResultError data = 2;
 }
 
 // Z030
 message EndOfRunSummary {
+    int32 num_errors = 1;
+    int32 num_warnings = 2;
+    bool keyboard_interrupt = 3;
+}
+
+message EndOfRunSummaryMsg {
     EventInfo info = 1;
-    int32 num_errors = 2;
-    int32 num_warnings = 3;
-    bool keyboard_interrupt = 4;
+    EndOfRunSummary data = 2;
 }
 
 // Skipped Z031, Z032, Z033
 
 // Z034
 message LogSkipBecauseError {
+    string schema = 1;
+    string relation = 2;
+    int32 index = 3;
+    int32 total = 4;
+}
+
+message LogSkipBecauseErrorMsg {
     EventInfo info = 1;
-    string schema = 2;
-    string relation = 3;
-    int32 index = 4;
-    int32 total = 5;
+    LogSkipBecauseError data = 2;
 }
 
 // Z036
 message EnsureGitInstalled {
+}
+
+message EnsureGitInstalledMsg {
     EventInfo info = 1;
+    EnsureGitInstalled data = 2;
 }
 
 // Z037
 message DepsCreatingLocalSymlink {
+}
+
+message DepsCreatingLocalSymlinkMsg {
     EventInfo info = 1;
+    DepsCreatingLocalSymlink data = 2;
 }
 
 // Z038
 message DepsSymlinkNotAvailable {
+}
+
+message DepsSymlinkNotAvailableMsg {
     EventInfo info = 1;
+    DepsSymlinkNotAvailable data = 2;
 }
 
 // Z039
 message DisableTracking {
+}
+
+message DisableTrackingMsg {
     EventInfo info = 1;
+    DisableTracking data = 2;
 }
 
 // Z040
 message SendingEvent {
+    string kwargs = 1;
+}
+
+message SendingEventMsg {
     EventInfo info = 1;
-    string kwargs = 2;
+    SendingEvent data = 2;
 }
 
 // Z041
 message SendEventFailure {
+}
+
+message SendEventFailureMsg {
     EventInfo info = 1;
+    SendEventFailure data = 2;
 }
 
 // Z042
 message FlushEvents {
+}
+
+message FlushEventsMsg {
     EventInfo info = 1;
+    FlushEvents data = 2;
 }
 
 // Z043
 message FlushEventsFailure {
+}
+
+message FlushEventsFailureMsg {
     EventInfo info = 1;
+    FlushEventsFailure data = 2;
 }
 
 // Z044
 message TrackingInitializeFailure {
+    string exc_info = 1;
+}
+
+message TrackingInitializeFailureMsg {
     EventInfo info = 1;
-    string exc_info = 2;
+    TrackingInitializeFailure data = 2;
 }
 
 // Skipped Z045
 
 // Z046
 message RunResultWarningMessage {
+    string msg = 1;
+}
+
+message RunResultWarningMessageMsg {
     EventInfo info = 1;
-    string msg = 2;
+    RunResultWarningMessage data = 2;
 }
 
 // T - Integration tests
 
 // T001
 message IntegrationTestInfo {
+    string msg = 1;
+}
+
+message IntegrationTestInfoMsg {
     EventInfo info = 1;
-    string msg = 2;
+    IntegrationTestInfo data = 2;
 }
 
 // T002
 message IntegrationTestDebug {
+    string msg = 1;
+}
+
+message IntegrationTestDebugMsg {
     EventInfo info = 1;
-    string msg = 2;
+    IntegrationTestDebug data = 2;
 }
 
 // T003
 message IntegrationTestWarn {
+    string msg = 1;
+}
+
+message IntegrationTestWarnMsg {
     EventInfo info = 1;
-    string msg = 2;
+    IntegrationTestWarn data = 2;
 }
 
 // T004
 message IntegrationTestError {
+    string msg = 1;
+}
+
+message IntegrationTestErrorMsg {
     EventInfo info = 1;
-    string msg = 2;
+    IntegrationTestError data = 2;
 }
 
 // T005
 message IntegrationTestException {
+    string msg = 1;
+}
+
+message IntegrationTestExceptionMsg {
     EventInfo info = 1;
-    string msg = 2;
+    IntegrationTestException data = 2;
 }
 
 // T006
 message UnitTestInfo {
+    string msg = 1;
+}
+
+message UnitTestInfoMsg {
     EventInfo info = 1;
-    string msg = 2;
+    UnitTestInfo data = 2;
 }

--- a/core/dbt/events/types.proto
+++ b/core/dbt/events/types.proto
@@ -588,7 +588,8 @@ message SQLQueryStatusMsg {
 
 // E018
 message SQLCommit {
-    string conn_name = 1;
+    NodeInfo node_info = 1;
+    string conn_name = 2;
 }
 
 message SQLCommitMsg {

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -756,7 +756,7 @@ class PluginLoadError(DebugLevel, pt.PluginLoadError):  # noqa
         return "E036"
 
     def message(self):
-        pass
+        return f"{self.exc_info}"
 
 
 @dataclass

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -11,6 +11,7 @@ from dbt.events.base_types import (
     Cache,
     AdapterEventStringFunctor,
     EventStringFunctor,
+    EventLevel,
 )
 from dbt.events.format import format_fancy_output_line, pluralize
 
@@ -1645,17 +1646,16 @@ class LogTestResult(DynamicLevel, pt.LogTestResult):
     @classmethod
     def status_to_level(cls, status):
         # The statuses come from TestStatus
-        # TODO should this return EventLevel enum instead?
         level_lookup = {
-            "fail": "error",
-            "pass": "info",
-            "warn": "warn",
-            "error": "error",
+            "fail": EventLevel.ERROR,
+            "pass": EventLevel.INFO,
+            "warn": EventLevel.WARN,
+            "error": EventLevel.ERROR,
         }
         if status in level_lookup:
             return level_lookup[status]
         else:
-            return "info"
+            return EventLevel.INFO
 
 
 # Skipped Q008, Q009, Q010
@@ -1777,15 +1777,15 @@ class LogFreshnessResult(DynamicLevel, pt.LogFreshnessResult):
         # The statuses come from FreshnessStatus
         # TODO should this return EventLevel enum instead?
         level_lookup = {
-            "runtime error": "error",
-            "pass": "info",
-            "warn": "warn",
-            "error": "error",
+            "runtime error": EventLevel.ERROR,
+            "pass": EventLevel.INFO,
+            "warn": EventLevel.WARN,
+            "error": EventLevel.ERROR,
         }
         if status in level_lookup:
             return level_lookup[status]
         else:
-            return "info"
+            return EventLevel.INFO
 
 
 # Skipped Q019, Q020, Q021

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -867,93 +867,15 @@ class HookFinished(InfoLevel, pt.HookFinished):
 
 
 @dataclass
-class ParseCmdStart(InfoLevel, pt.ParseCmdStart):
+class ParseCmdOut(InfoLevel, pt.ParseCmdOut):
     def code(self):
         return "I001"
 
     def message(self) -> str:
-        return "Start parsing."
+        return self.msg
 
 
-@dataclass
-class ParseCmdCompiling(InfoLevel, pt.ParseCmdCompiling):
-    def code(self):
-        return "I002"
-
-    def message(self) -> str:
-        return "Compiling."
-
-
-@dataclass
-class ParseCmdWritingManifest(InfoLevel, pt.ParseCmdWritingManifest):
-    def code(self):
-        return "I003"
-
-    def message(self) -> str:
-        return "Writing manifest."
-
-
-@dataclass
-class ParseCmdDone(InfoLevel, pt.ParseCmdDone):
-    def code(self):
-        return "I004"
-
-    def message(self) -> str:
-        return "Done."
-
-
-@dataclass
-class ManifestDependenciesLoaded(InfoLevel, pt.ManifestDependenciesLoaded):
-    def code(self):
-        return "I005"
-
-    def message(self) -> str:
-        return "Dependencies loaded"
-
-
-@dataclass
-class ManifestLoaderCreated(InfoLevel, pt.ManifestLoaderCreated):
-    def code(self):
-        return "I006"
-
-    def message(self) -> str:
-        return "ManifestLoader created"
-
-
-@dataclass
-class ManifestLoaded(InfoLevel, pt.ManifestLoaded):
-    def code(self):
-        return "I007"
-
-    def message(self) -> str:
-        return "Manifest loaded"
-
-
-@dataclass
-class ManifestChecked(InfoLevel, pt.ManifestChecked):
-    def code(self):
-        return "I008"
-
-    def message(self) -> str:
-        return "Manifest checked"
-
-
-@dataclass
-class ManifestFlatGraphBuilt(InfoLevel, pt.ManifestFlatGraphBuilt):
-    def code(self):
-        return "I009"
-
-    def message(self) -> str:
-        return "Flat graph built"
-
-
-@dataclass
-class ParseCmdPerfInfoPath(InfoLevel, pt.ParseCmdPerfInfoPath):
-    def code(self):
-        return "I010"
-
-    def message(self) -> str:
-        return f"Performance info: {self.path}"
+# Skipping I002, I003, I004, I005, I006, I007, I008, I009, I010
 
 
 @dataclass
@@ -1290,7 +1212,7 @@ class NoNodeForYamlKey(WarnLevel, pt.NoNodeForYamlKey):
 
 
 @dataclass
-class MacroPatchNotFound(WarnLevel, pt.MacroPatchNotFound):
+class MacroNotFoundForPatch(WarnLevel, pt.MacroNotFoundForPatch):
     def code(self):
         return "I059"
 
@@ -2164,7 +2086,7 @@ class SystemExecutingCmd(DebugLevel, pt.SystemExecutingCmd):
 
 
 @dataclass
-class SystemStdOutMsg(DebugLevel, pt.SystemStdOutMsg):
+class SystemStdOut(DebugLevel, pt.SystemStdOut):
     def code(self):
         return "Z007"
 
@@ -2173,7 +2095,7 @@ class SystemStdOutMsg(DebugLevel, pt.SystemStdOutMsg):
 
 
 @dataclass
-class SystemStdErrMsg(DebugLevel, pt.SystemStdErrMsg):
+class SystemStdErr(DebugLevel, pt.SystemStdErr):
     def code(self):
         return "Z008"
 

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -68,7 +68,7 @@ from dbt.exceptions import (
     YamlParseListFailure,
 )
 from dbt.events.functions import warn_or_error
-from dbt.events.types import WrongResourceSchemaFile, NoNodeForYamlKey, MacroPatchNotFound
+from dbt.events.types import WrongResourceSchemaFile, NoNodeForYamlKey, MacroNotFoundForPatch
 from dbt.node_types import NodeType
 from dbt.parser.base import SimpleParser
 from dbt.parser.search import FileBlock
@@ -957,7 +957,7 @@ class MacroPatchParser(NonSourceParser[UnparsedMacroUpdate, ParsedMacroPatch]):
         unique_id = f"macro.{patch.package_name}.{patch.name}"
         macro = self.manifest.macros.get(unique_id)
         if not macro:
-            warn_or_error(MacroPatchNotFound(patch_name=patch.name))
+            warn_or_error(MacroNotFoundForPatch(patch_name=patch.name))
             return
         if macro.patch_path:
             package_name, existing_file_path = macro.patch_path.split("://")

--- a/core/dbt/task/freshness.py
+++ b/core/dbt/task/freshness.py
@@ -16,7 +16,7 @@ from dbt.contracts.results import (
     FreshnessStatus,
 )
 from dbt.exceptions import RuntimeException, InternalException
-from dbt.events.functions import fire_event, info
+from dbt.events.functions import fire_event
 from dbt.events.types import (
     FreshnessCheckComplete,
     LogStartLine,
@@ -56,7 +56,6 @@ class FreshnessRunner(BaseRunner):
         level = LogFreshnessResult.status_to_level(str(result.status))
         fire_event(
             LogFreshnessResult(
-                info=info(level=level),
                 status=result.status,
                 source_name=source_name,
                 table_name=table_name,
@@ -64,7 +63,8 @@ class FreshnessRunner(BaseRunner):
                 total=self.num_nodes,
                 execution_time=result.execution_time,
                 node_info=self.node.node_info,
-            )
+            ),
+            level=level,
         )
 
     def error_result(self, node, message, start_time, timing_info):

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -27,7 +27,7 @@ from dbt.exceptions import (
     RuntimeException,
     ValidationException,
 )
-from dbt.events.functions import fire_event, get_invocation_id, info
+from dbt.events.functions import fire_event, get_invocation_id
 from dbt.events.types import (
     DatabaseErrorRunningHook,
     EmptyLine,
@@ -38,6 +38,7 @@ from dbt.events.types import (
     LogHookEndLine,
     LogHookStartLine,
 )
+from dbt.events.base_types import EventLevel
 from dbt.logger import (
     TextOnly,
     HookMetadata,
@@ -186,10 +187,10 @@ class ModelRunner(CompileRunner):
         description = self.describe_node()
         if result.status == NodeStatus.Error:
             status = result.status
-            level = "error"
+            level = EventLevel.ERROR
         else:
             status = result.message
-            level = "info"
+            level = EventLevel.INFO
         fire_event(
             LogModelResult(
                 description=description,
@@ -198,8 +199,8 @@ class ModelRunner(CompileRunner):
                 total=self.num_nodes,
                 execution_time=result.execution_time,
                 node_info=self.node.node_info,
-                info=info(level=level),
-            )
+            ),
+            level=level,
         )
 
     def before_execute(self):

--- a/core/dbt/task/seed.py
+++ b/core/dbt/task/seed.py
@@ -9,7 +9,7 @@ from dbt.contracts.results import RunStatus
 from dbt.exceptions import InternalException
 from dbt.graph import ResourceTypeSelector
 from dbt.logger import TextOnly
-from dbt.events.functions import fire_event, info
+from dbt.events.functions import fire_event
 from dbt.events.types import (
     SeedHeader,
     SeedHeaderSeparator,
@@ -17,6 +17,7 @@ from dbt.events.types import (
     LogSeedResult,
     LogStartLine,
 )
+from dbt.events.base_types import EventLevel
 from dbt.node_types import NodeType
 from dbt.contracts.results import NodeStatus
 
@@ -46,10 +47,9 @@ class SeedRunner(ModelRunner):
 
     def print_result_line(self, result):
         model = result.node
-        level = "error" if result.status == NodeStatus.Error else "info"
+        level = EventLevel.ERROR if result.status == NodeStatus.Error else EventLevel.INFO
         fire_event(
             LogSeedResult(
-                info=info(level=level),
                 status=result.status,
                 result_message=result.message,
                 index=self.node_index,
@@ -58,7 +58,8 @@ class SeedRunner(ModelRunner):
                 schema=self.node.schema,
                 relation=model.alias,
                 node_info=model.node_info,
-            )
+            ),
+            level=level,
         )
 
 

--- a/core/dbt/task/snapshot.py
+++ b/core/dbt/task/snapshot.py
@@ -1,7 +1,8 @@
 from .run import ModelRunner, RunTask
 
 from dbt.exceptions import InternalException
-from dbt.events.functions import fire_event, info
+from dbt.events.functions import fire_event
+from dbt.events.base_types import EventLevel
 from dbt.events.types import LogSnapshotResult
 from dbt.graph import ResourceTypeSelector
 from dbt.node_types import NodeType
@@ -15,10 +16,9 @@ class SnapshotRunner(ModelRunner):
     def print_result_line(self, result):
         model = result.node
         cfg = model.config.to_dict(omit_none=True)
-        level = "error" if result.status == NodeStatus.Error else "info"
+        level = EventLevel.ERROR if result.status == NodeStatus.Error else EventLevel.INFO
         fire_event(
             LogSnapshotResult(
-                info=info(level=level),
                 status=result.status,
                 description=self.get_node_representation(),
                 cfg=cfg,
@@ -26,7 +26,8 @@ class SnapshotRunner(ModelRunner):
                 total=self.num_nodes,
                 execution_time=result.execution_time,
                 node_info=model.node_info,
-            )
+            ),
+            level=level,
         )
 
 

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -16,7 +16,7 @@ from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.results import TestStatus, PrimitiveDict, RunResult
 from dbt.context.providers import generate_runtime_model_context
 from dbt.clients.jinja import MacroGenerator
-from dbt.events.functions import fire_event, info
+from dbt.events.functions import fire_event
 from dbt.events.types import (
     LogTestResult,
     LogStartLine,
@@ -68,14 +68,14 @@ class TestRunner(CompileRunner):
         fire_event(
             LogTestResult(
                 name=model.name,
-                info=info(level=LogTestResult.status_to_level(str(result.status))),
                 status=str(result.status),
                 index=self.node_index,
                 num_models=self.num_nodes,
                 execution_time=result.execution_time,
                 node_info=model.node_info,
                 num_failures=result.failures,
-            )
+            ),
+            level=LogTestResult.status_to_level(str(result.status)),
         )
 
     def print_start_line(self):

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -1150,8 +1150,8 @@ class TestRuntimeConfigWithConfigs(BaseConfigTest):
             project.warn_for_unused_resource_config_paths(self.used, [])
             warn_or_error_patch.assert_called_once()
             event = warn_or_error_patch.call_args[0][0]
-            assert event.info.name == 'UnusedResourceConfigPath'
-            msg = event.info.msg
+            assert type(event).__name__ == 'UnusedResourceConfigPath'
+            msg = event.message()
             expected_msg = "- models.my_test_project.baz"
             assert expected_msg in msg
 

--- a/test/unit/test_graph_selector_methods.py
+++ b/test/unit/test_graph_selector_methods.py
@@ -973,8 +973,8 @@ def test_select_state_changed_seed_checksum_path_to_path(manifest, previous_stat
         assert not search_manifest_using_method(manifest, method, 'modified')
         warn_or_error_patch.assert_called_once()
         event = warn_or_error_patch.call_args[0][0]
-        assert event.info.name == 'SeedExceedsLimitSamePath'
-        msg = event.info.msg
+        assert type(event).__name__ == 'SeedExceedsLimitSamePath'
+        msg = event.message()
         assert msg.startswith('Found a seed (pkg.seed) >1MB in size')
     with mock.patch('dbt.contracts.graph.nodes.warn_or_error') as warn_or_error_patch:
         assert not search_manifest_using_method(manifest, method, 'new')
@@ -990,8 +990,8 @@ def test_select_state_changed_seed_checksum_sha_to_path(manifest, previous_state
             manifest, method, 'modified') == {'seed'}
         warn_or_error_patch.assert_called_once()
         event = warn_or_error_patch.call_args[0][0]
-        assert event.info.name == 'SeedIncreased'
-        msg = event.info.msg
+        assert type(event).__name__ == 'SeedIncreased'
+        msg = event.message()
         assert msg.startswith('Found a seed (pkg.seed) >1MB in size')
     with mock.patch('dbt.contracts.graph.nodes.warn_or_error') as warn_or_error_patch:
         assert not search_manifest_using_method(manifest, method, 'new')

--- a/tests/functional/logging/test_logging.py
+++ b/tests/functional/logging/test_logging.py
@@ -34,6 +34,7 @@ def test_basic(project, logs_dir):
         if "[debug]" in log_line:
             continue
         log_dct = json.loads(log_line)
+        log_data = log_dct["data"]
         log_event = log_dct['info']['name']
         if log_event == "NodeStart":
             node_start = True
@@ -41,11 +42,11 @@ def test_basic(project, logs_dir):
             node_finished = True
         if node_start and not node_finished:
             if log_event == 'NodeExecuting':
-                assert "node_info" in log_dct
+                assert "node_info" in log_data
             if log_event == "JinjaLogDebug":
-                assert "node_info" in log_dct
+                assert "node_info" in log_data
             if log_event == "SQLQuery":
-                assert "node_info" in log_dct
+                assert "node_info" in log_data
             if log_event == "TimingInfoCollected":
-                assert "node_info" in log_dct
-                assert "timing_info" in log_dct
+                assert "node_info" in log_data
+                assert "timing_info" in log_data

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,7 +1,8 @@
 # flake8: noqa
 from dbt.events.test_types import UnitTestInfo
 from dbt.events import AdapterLogger
-from dbt.events.functions import event_to_json, LOG_VERSION, event_to_dict
+from dbt.events.functions import msg_to_json, LOG_VERSION, msg_to_dict
+from dbt.events.base_types import msg_from_base_event
 from dbt.events.types import *
 from dbt.events.test_types import *
 
@@ -100,43 +101,6 @@ class TestEventCodes:
                 code not in all_codes
             ), f"{code} is assigned more than once. Check types.py for duplicates."
             all_codes.add(code)
-
-
-def MockNode():
-    return ModelNode(
-        alias="model_one",
-        name="model_one",
-        database="dbt",
-        schema="analytics",
-        resource_type=NodeType.Model,
-        unique_id="model.root.model_one",
-        fqn=["root", "model_one"],
-        package_name="root",
-        original_file_path="model_one.sql",
-        root_path="/usr/src/app",
-        refs=[],
-        sources=[],
-        depends_on=DependsOn(),
-        config=NodeConfig.from_dict(
-            {
-                "enabled": True,
-                "materialized": "view",
-                "persist_docs": {},
-                "post-hook": [],
-                "pre-hook": [],
-                "vars": {},
-                "quoting": {},
-                "column_types": {},
-                "tags": [],
-            }
-        ),
-        tags=[],
-        path="model_one.sql",
-        raw_code="",
-        description="",
-        columns={},
-        checksum=FileHash.from_contents(""),
-    )
 
 
 sample_values = [
@@ -280,7 +244,7 @@ sample_values = [
     UnusedTables(unused_tables=[]),
     WrongResourceSchemaFile(patch_name="", resource_type="", file_path="", plural_resource_type=""),
     NoNodeForYamlKey(patch_name="", yaml_key="", file_path=""),
-    MacroPatchNotFound(patch_name=""),
+    MacroNotFoundForPatch(patch_name=""),
     NodeNotFoundOrDisabled(
         original_file_path="",
         unique_id="",
@@ -420,8 +384,8 @@ sample_values = [
     SystemErrorRetrievingModTime(path=""),
     SystemCouldNotWrite(path="", reason="", exc=""),
     SystemExecutingCmd(cmd=[""]),
-    SystemStdOutMsg(bmsg=b""),
-    SystemStdErrMsg(bmsg=b""),
+    SystemStdOut(bmsg=b""),
+    SystemStdErr(bmsg=b""),
     SystemReportReturnCode(returncode=0),
     TimingInfoCollected(),
     LogDebugStackTrace(),
@@ -490,9 +454,10 @@ class TestEventJSONSerialization:
 
         # if we have everything we need to test, try to serialize everything
         for event in sample_values:
-            event_dict = event_to_dict(event)
+            msg = msg_from_base_event(event)
+            msg_dict = msg_to_dict(msg)
             try:
-                event_json = event_to_json(event)
+                msg_json = msg_to_json(msg)
             except Exception as e:
                 raise Exception(f"{event} is not serializable to json. Originating exception: {e}")
 

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -243,16 +243,7 @@ sample_values = [
     HookFinished(stat_line="", execution="", execution_time=0),
 
     # I - Project parsing ======================
-    ParseCmdStart(),
-    ParseCmdCompiling(),
-    ParseCmdWritingManifest(),
-    ParseCmdDone(),
-    ManifestDependenciesLoaded(),
-    ManifestLoaderCreated(),
-    ManifestLoaded(),
-    ManifestChecked(),
-    ManifestFlatGraphBuilt(),
-    ParseCmdPerfInfoPath(path=""),
+    ParseCmdOut(msg="testing"),
     GenericTestFileParse(path=""),
     MacroFileParse(path=""),
     PartialParsingExceptionProcessingFile(file=""),

--- a/tests/unit/test_proto_events.py
+++ b/tests/unit/test_proto_events.py
@@ -1,4 +1,3 @@
-import sys
 from dbt.events.types import (
     MainReportVersion,
     MainReportArgs,
@@ -8,8 +7,9 @@ from dbt.events.types import (
     LogStartLine,
     LogTestResult,
 )
-from dbt.events.functions import event_to_dict, LOG_VERSION, reset_metadata_vars, info
-from dbt.events import proto_types as pl
+from dbt.events.functions import msg_to_dict, LOG_VERSION, reset_metadata_vars
+from dbt.events import proto_types as pt
+from dbt.events.base_types import msg_from_base_event, EventLevel
 from dbt.version import installed
 
 
@@ -20,63 +20,71 @@ def test_events():
 
     # A001 event
     event = MainReportVersion(version=str(installed), log_version=LOG_VERSION)
-    event_dict = event_to_dict(event)
-    event_json = event.to_json()
-    serialized = bytes(event)
+    msg = msg_from_base_event(event)
+    msg_dict = msg_to_dict(msg)
+    msg_json = msg.to_json()
+    serialized = bytes(msg)
     assert "Running with dbt=" in str(serialized)
-    assert set(event_dict.keys()) == {"version", "info", "log_version"}
-    assert set(event_dict["info"].keys()) == info_keys
-    assert event_json
-    assert event.info.code == "A001"
+    assert set(msg_dict.keys()) == {"info", "data"}
+    assert set(msg_dict["data"].keys()) == {"version", "log_version"}
+    assert set(msg_dict["info"].keys()) == info_keys
+    assert msg_json
+    assert msg.info.code == "A001"
 
     # Extract EventInfo from serialized message
-    generic_event = pl.GenericMessage().parse(serialized)
+    generic_event = pt.GenericMessage().parse(serialized)
     assert generic_event.info.code == "A001"
     # get the message class for the real message from the generic message
-    message_class = getattr(sys.modules["dbt.events.proto_types"], generic_event.info.name)
-    new_event = message_class().parse(serialized)
-    assert new_event.info.code == event.info.code
-    assert new_event.version == event.version
+    message_class = getattr(pt, f"{generic_event.info.name}Msg")
+    new_msg = message_class().parse(serialized)
+    assert new_msg.info.code == msg.info.code
+    assert new_msg.data.version == msg.data.version
 
     # A002 event
     event = MainReportArgs(args={"one": "1", "two": "2"})
-    event_dict = event_to_dict(event)
-    event_json = event.to_json()
+    msg = msg_from_base_event(event)
+    msg_dict = msg_to_dict(msg)
+    msg_json = msg.to_json()
 
-    assert set(event_dict.keys()) == {"info", "args"}
-    assert set(event_dict["info"].keys()) == info_keys
-    assert event_json
-    assert event.info.code == "A002"
+    assert set(msg_dict.keys()) == {"info", "data"}
+    assert set(msg_dict["data"].keys()) == {"args"}
+    assert set(msg_dict["info"].keys()) == info_keys
+    assert msg_json
+    assert msg.info.code == "A002"
 
 
 def test_exception_events():
     event = RollbackFailed(conn_name="test", exc_info="something failed")
-    event_dict = event_to_dict(event)
-    event_json = event.to_json()
-    assert set(event_dict.keys()) == {"info", "conn_name", "exc_info"}
-    assert set(event_dict["info"].keys()) == info_keys
-    assert event_json
-    assert event.info.code == "E009"
+    msg = msg_from_base_event(event)
+    msg_dict = msg_to_dict(msg)
+    print(f"msg_dict: {msg_dict}")
+    msg_json = msg.to_json()
+    assert set(msg_dict.keys()) == {"info", "data"}
+    assert set(msg_dict["data"].keys()) == {"conn_name", "exc_info"}
+    assert set(msg_dict["info"].keys()) == info_keys
+    assert msg_json
+    assert msg.info.code == "E009"
 
     event = PluginLoadError(exc_info="something failed")
-    event_dict = event_to_dict(event)
-    event_json = event.to_json()
-    assert set(event_dict.keys()) == {"info", "exc_info"}
-    assert set(event_dict["info"].keys()) == info_keys
-    assert event_json
-    assert event.info.code == "E036"
-    # This event has no "msg"/"message"
-    assert event.info.msg is None
+    msg = msg_from_base_event(event)
+    msg_dict = msg_to_dict(msg)
+    msg_json = msg.to_json()
+    assert set(msg_dict["data"].keys()) == {"exc_info"}
+    assert set(msg_dict["info"].keys()) == info_keys
+    assert msg_json
+    assert msg.info.code == "E036"
+    assert msg.info.msg == "something failed"
 
     # Z002 event
     event = MainEncounteredError(exc="Rollback failed")
-    event_dict = event_to_dict(event)
-    event_json = event.to_json()
+    msg = msg_from_base_event(event)
+    msg_dict = msg_to_dict(msg)
+    msg_json = msg.to_json()
 
-    assert set(event_dict.keys()) == {"info", "exc"}
-    assert set(event_dict["info"].keys()) == info_keys
-    assert event_json
-    assert event.info.code == "Z002"
+    assert set(msg_dict["data"].keys()) == {"exc"}
+    assert set(msg_dict["info"].keys()) == info_keys
+    assert msg_json
+    assert msg.info.code == "Z002"
 
 
 def test_node_info_events():
@@ -94,7 +102,7 @@ def test_node_info_events():
         description="some description",
         index=123,
         total=111,
-        node_info=pl.NodeInfo(**node_info),
+        node_info=pt.NodeInfo(**node_info),
     )
     assert event
     assert event.node_info.node_path == "some_path"
@@ -107,18 +115,19 @@ def test_extra_dict_on_event(monkeypatch):
     reset_metadata_vars()
 
     event = MainReportVersion(version=str(installed), log_version=LOG_VERSION)
-    event_dict = event_to_dict(event)
-    assert set(event_dict["info"].keys()) == info_keys
-    assert event.info.extra == {"env_key": "env_value"}
-    serialized = bytes(event)
+    msg = msg_from_base_event(event)
+    msg_dict = msg_to_dict(msg)
+    assert set(msg_dict["info"].keys()) == info_keys
+    assert msg.info.extra == {"env_key": "env_value"}
+    serialized = bytes(msg)
 
     # Extract EventInfo from serialized message
-    generic_event = pl.GenericMessage().parse(serialized)
+    generic_event = pt.GenericMessage().parse(serialized)
     assert generic_event.info.code == "A001"
     # get the message class for the real message from the generic message
-    message_class = getattr(sys.modules["dbt.events.proto_types"], generic_event.info.name)
-    new_event = message_class().parse(serialized)
-    assert new_event.info.extra == event.info.extra
+    message_class = getattr(pt, f"{generic_event.info.name}Msg")
+    new_msg = message_class().parse(serialized)
+    assert new_msg.info.extra == msg.info.extra
 
     # clean up
     reset_metadata_vars()
@@ -127,11 +136,11 @@ def test_extra_dict_on_event(monkeypatch):
 def test_dynamic_level_events():
     event = LogTestResult(
         name="model_name",
-        info=info(level=LogTestResult.status_to_level("pass")),
         status="pass",
         index=1,
         num_models=3,
         num_failures=0
     )
-    assert event
-    assert event.info.level == "info"
+    msg = msg_from_base_event(event, level=EventLevel.INFO)
+    assert msg
+    assert msg.info.level == "info"

--- a/tests/unit/test_proto_events.py
+++ b/tests/unit/test_proto_events.py
@@ -57,7 +57,6 @@ def test_exception_events():
     event = RollbackFailed(conn_name="test", exc_info="something failed")
     msg = msg_from_base_event(event)
     msg_dict = msg_to_dict(msg)
-    print(f"msg_dict: {msg_dict}")
     msg_json = msg.to_json()
     assert set(msg_dict.keys()) == {"info", "data"}
     assert set(msg_dict["data"].keys()) == {"conn_name", "exc_info"}


### PR DESCRIPTION
resolves #6311

### Description

Reorganize structured logging events to have two top keys, "data" and "info", where "data" contains the specific pieces of information for this particular event and "info" contains the common standard logging information.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
