### PR TITLE
Fix event level regression

### DIFF
--- a/.changes/unreleased/Fixes-20230109-161254.yaml
+++ b/.changes/unreleased/Fixes-20230109-161254.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Restore historical behavior of certain disabled test messages, so that they
+  are at the less obtrusive debug level, rather than the warning level.
+time: 2023-01-09T16:12:54.064875-05:00
+custom:
+  Author: peterallenwebb
+  Issue: "6501"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1092,7 +1092,7 @@ class PartialParsingFile(DebugLevel, pt.PartialParsingFile):
 
 
 @dataclass
-class InvalidDisabledTargetInTestNode(WarnLevel, pt.InvalidDisabledTargetInTestNode):
+class InvalidDisabledTargetInTestNode(DebugLevel, pt.InvalidDisabledTargetInTestNode):
     def code(self):
         return "I050"
 


### PR DESCRIPTION
resolves #6501 

### Description

This change modifies the way the InvalidDisabledTargetInTestNode event is fired, so that the level in 1.4 matches dbt's historical behavior. Since InvalidDisabledTargetInTestNode was created by combining two separate events which had different levels, the new event is sometimes fired at the debug level and other times at the warning level.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
