### PR TITLE
Fix changelog entry for 5989/6432

### DIFF
--- a/.changes/1.4.0/Fixes-20221213-112620.yaml
+++ b/.changes/1.4.0/Fixes-20221213-112620.yaml
@@ -3,4 +3,4 @@ body: '[CT-1284] Change Python model default materialization to table'
 time: 2022-12-13T11:26:20.550017-08:00
 custom:
   Author: aranke
-  Issue: "6345"
+  Issue: "5989"


### PR DESCRIPTION
This also happened in https://github.com/dbt-labs/dbt-core/pull/6496. I haven't been doing any exhaustive checking, just some spot-checking here or there while working on docs for v1.4.

Now that we're only linking to the issue, rather than both the issue + the PR—if we get one link wrong, it's the _only_ link we're showing in the changelog / release notes. It's not a huge deal, but it could be misleading for some community members.

Is there any automation that could help us here? Or just an additional manual check during review? E.g. https://github.com/dbt-labs/dbt-core/pull/6432 was linked to #5989 in the PR description (+ therefore also GitHub "Development" flow).