### PR TITLE
Fix date serialization regression by adopting fixed mashumaro version

### DIFF
--- a/.changes/unreleased/Fixes-20230110-124132.yaml
+++ b/.changes/unreleased/Fixes-20230110-124132.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Bump mashumuro version to get regression fix and add unit test to verify that
+  fix.
+time: 2023-01-10T12:41:32.339631-05:00
+custom:
+  Author: peterallenwebb
+  Issue: "6428"

--- a/core/setup.py
+++ b/core/setup.py
@@ -54,7 +54,7 @@ setup(
         "hologram>=0.0.14,<=0.0.15",
         "isodate>=0.6,<0.7",
         "logbook>=1.5,<1.6",
-        "mashumaro[msgpack]==3.2",
+        "mashumaro[msgpack]==3.3.1",
         "minimal-snowplow-tracker==0.0.2",
         "networkx>=2.3,<2.8.1;python_version<'3.8'",
         "networkx>=2.3,<3;python_version>='3.8'",

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -5,6 +5,7 @@ from dbt.events.functions import msg_to_json, LOG_VERSION, msg_to_dict
 from dbt.events.base_types import msg_from_base_event
 from dbt.events.types import *
 from dbt.events.test_types import *
+from dbt.contracts.results import TimingInfo
 
 from dbt.events.base_types import (
     BaseEvent,
@@ -464,3 +465,12 @@ class TestEventJSONSerialization:
 
 
 T = TypeVar("T")
+
+
+def test_date_serialization():
+    ti = TimingInfo("test")
+    ti.begin()
+    ti.end()
+    ti_dict = ti.to_dict()
+    assert ti_dict["started_at"].endswith("Z")
+    assert ti_dict["completed_at"].endswith("Z")


### PR DESCRIPTION
resolves #6428 

### Description

Working with mashumaro, we resolved a regression their versions 3.2 and 3.3, which we now adopt by updating our requirement to version 3.3.1. This resolves the regression we saw in DBT as a result of the mashumaro regression.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
