### PR TITLE
Check length of escaped strings in the adapter test

### DIFF
--- a/.changes/unreleased/Under the Hood-20230110-145648.yaml
+++ b/.changes/unreleased/Under the Hood-20230110-145648.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Check length of escaped strings in the adapter test
+time: 2023-01-10T14:56:48.044198-07:00
+custom:
+  Author: dbeatty10
+  Issue: "6566"

--- a/tests/adapter/dbt/tests/adapter/utils/fixture_escape_single_quotes.py
+++ b/tests/adapter/dbt/tests/adapter/utils/fixture_escape_single_quotes.py
@@ -1,15 +1,15 @@
 # escape_single_quotes
 
 models__test_escape_single_quotes_quote_sql = """
-select '{{ escape_single_quotes("they're") }}' as actual, 'they''re' as expected union all
-select '{{ escape_single_quotes("they are") }}' as actual, 'they are' as expected
+select '{{ escape_single_quotes("they're") }}' as actual, {{ length(string_literal(escape_single_quotes("they're"))) }} as actual_length, 'they''re' as expected, 7 as expected_length union all
+select '{{ escape_single_quotes("they are") }}' as actual, {{ length(string_literal(escape_single_quotes("they are"))) }} as actual_length, 'they are' as expected, 8 as expected_length
 """
 
 
 # The expected literal is 'they\'re'. The second backslash is to escape it from Python.
 models__test_escape_single_quotes_backslash_sql = """
-select '{{ escape_single_quotes("they're") }}' as actual, 'they\\'re' as expected union all
-select '{{ escape_single_quotes("they are") }}' as actual, 'they are' as expected
+select '{{ escape_single_quotes("they're") }}' as actual, {{ length(string_literal(escape_single_quotes("they're"))) }} as actual_length, 'they\\'re' as expected, 7 as expected_length union all
+select '{{ escape_single_quotes("they are") }}' as actual, {{ length(string_literal(escape_single_quotes("they are"))) }} as actual_length, 'they are' as expected, 8 as expected_length
 """
 
 
@@ -21,4 +21,7 @@ models:
       - assert_equal:
           actual: actual
           expected: expected
+      - assert_equal:
+          actual: actual_length
+          expected: expected_length
 """

--- a/tests/adapter/dbt/tests/adapter/utils/fixture_escape_single_quotes.py
+++ b/tests/adapter/dbt/tests/adapter/utils/fixture_escape_single_quotes.py
@@ -1,15 +1,37 @@
 # escape_single_quotes
 
 models__test_escape_single_quotes_quote_sql = """
-select '{{ escape_single_quotes("they're") }}' as actual, {{ length(string_literal(escape_single_quotes("they're"))) }} as actual_length, 'they''re' as expected, 7 as expected_length union all
-select '{{ escape_single_quotes("they are") }}' as actual, {{ length(string_literal(escape_single_quotes("they are"))) }} as actual_length, 'they are' as expected, 8 as expected_length
+select
+  '{{ escape_single_quotes("they're") }}' as actual,
+  'they''re' as expected,
+  {{ length(string_literal(escape_single_quotes("they're"))) }} as actual_length,
+  7 as expected_length
+
+union all
+
+select
+  '{{ escape_single_quotes("they are") }}' as actual,
+  'they are' as expected,
+  {{ length(string_literal(escape_single_quotes("they are"))) }} as actual_length,
+  8 as expected_length
 """
 
 
 # The expected literal is 'they\'re'. The second backslash is to escape it from Python.
 models__test_escape_single_quotes_backslash_sql = """
-select '{{ escape_single_quotes("they're") }}' as actual, {{ length(string_literal(escape_single_quotes("they're"))) }} as actual_length, 'they\\'re' as expected, 7 as expected_length union all
-select '{{ escape_single_quotes("they are") }}' as actual, {{ length(string_literal(escape_single_quotes("they are"))) }} as actual_length, 'they are' as expected, 8 as expected_length
+select
+  '{{ escape_single_quotes("they're") }}' as actual,
+  'they\\'re' as expected,
+  {{ length(string_literal(escape_single_quotes("they're"))) }} as actual_length,
+  7 as expected_length
+
+union all
+
+select
+  '{{ escape_single_quotes("they are") }}' as actual,
+  'they are' as expected,
+  {{ length(string_literal(escape_single_quotes("they are"))) }} as actual_length,
+  8 as expected_length
 """
 
 


### PR DESCRIPTION
resolves #6566

See the following PRs for context and validation that it doesn't break any dbt Labs adapters:
- https://github.com/dbt-labs/dbt-core/pull/6567
- https://github.com/dbt-labs/dbt-spark/pull/586
- https://github.com/dbt-labs/dbt-redshift/pull/260
- https://github.com/dbt-labs/dbt-bigquery/pull/462
- https://github.com/dbt-labs/dbt-snowflake/pull/386

### Description

Adapter maintainers can choose to extend one of the following pytests (which are expected to be mutually exclusive):
- BaseEscapeSingleQuotesQuote
- BaseEscapeSingleQuotesBackslash

We've observed [at least one case](https://github.com/dbt-labs/dbt-spark/issues/572) where the adapter made the wrong choice but the test passed. This PR aims to trigger a CI failure if the wrong choice is made accidentally, and I validated that is does so [here](https://github.com/dbt-labs/dbt-spark/pull/586).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
