### PR TITLE
Call `update_event_status` earlier + rename an event

### DIFF
--- a/.changes/unreleased/Fixes-20230111-134058.yaml
+++ b/.changes/unreleased/Fixes-20230111-134058.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: Call get_node_info in more event types. Rename event 'HookFinished' -> FinishedRunningStats
+body: Call update_event_status earlier for node results. Rename event 'HookFinished' -> FinishedRunningStats
 time: 2023-01-11T13:40:58.577722+01:00
 custom:
   Author: jtcohen6

--- a/.changes/unreleased/Fixes-20230111-134058.yaml
+++ b/.changes/unreleased/Fixes-20230111-134058.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Call get_node_info in more event types. Rename event 'HookFinished' -> FinishedRunningStats
+time: 2023-01-11T13:40:58.577722+01:00
+custom:
+  Author: jtcohen6
+  Issue: "6571"

--- a/core/dbt/events/proto_types.py
+++ b/core/dbt/events/proto_types.py
@@ -945,7 +945,7 @@ class HooksRunningMsg(betterproto.Message):
 
 
 @dataclass
-class HookFinished(betterproto.Message):
+class FinishedRunningStats(betterproto.Message):
     """E047"""
 
     stat_line: str = betterproto.string_field(1)
@@ -954,9 +954,9 @@ class HookFinished(betterproto.Message):
 
 
 @dataclass
-class HookFinishedMsg(betterproto.Message):
+class FinishedRunningStatsMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    data: "HookFinished" = betterproto.message_field(2)
+    data: "FinishedRunningStats" = betterproto.message_field(2)
 
 
 @dataclass

--- a/core/dbt/events/types.proto
+++ b/core/dbt/events/types.proto
@@ -747,15 +747,15 @@ message HooksRunningMsg {
 }
 
 // E047
-message HookFinished {
+message FinishedRunningStats {
     string stat_line = 1;
     string execution = 2;
     float execution_time = 3;
 }
 
-message HookFinishedMsg {
+message FinishedRunningStatsMsg {
     EventInfo info = 1;
-    HookFinished data = 2;
+    FinishedRunningStats data = 2;
 }
 
 

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -755,7 +755,7 @@ class HooksRunning(InfoLevel, pt.HooksRunning):
 
 
 @dataclass
-class HookFinished(InfoLevel, pt.HookFinished):
+class FinishedRunningStats(InfoLevel, pt.FinishedRunningStats):
     def code(self):
         return "E047"
 

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -452,6 +452,9 @@ class BaseRunner(metaclass=ABCMeta):
                     )
                 )
             else:
+                # 'skipped' nodes should not have a value for 'node_finished_at'
+                # they do have 'node_started_at', which is set in GraphRunnableTask.call_runner
+                self.node.update_event_status(node_status=RunStatus.Skipped)
                 fire_event(
                     SkippingDetails(
                         resource_type=self.node.resource_type,

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -4,6 +4,7 @@ import time
 import traceback
 from abc import ABCMeta, abstractmethod
 from typing import Type, Union, Dict, Any, Optional
+from datetime import datetime
 
 from dbt import tracking
 from dbt import flags
@@ -208,6 +209,9 @@ class BaseRunner(metaclass=ABCMeta):
             self.before_execute()
 
         result = self.safe_run(manifest)
+        self.node.update_event_status(
+            node_status=result.status, finished_at=datetime.utcnow().isoformat()
+        )
 
         if not self.node.is_ephemeral_model:
             self.after_execute(result)

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -32,7 +32,7 @@ from dbt.events.types import (
     DatabaseErrorRunningHook,
     EmptyLine,
     HooksRunning,
-    HookFinished,
+    FinishedRunningStats,
     LogModelResult,
     LogStartLine,
     LogHookEndLine,
@@ -421,7 +421,9 @@ class RunTask(CompileTask):
         with TextOnly():
             fire_event(EmptyLine())
         fire_event(
-            HookFinished(stat_line=stat_line, execution=execution, execution_time=execution_time)
+            FinishedRunningStats(
+                stat_line=stat_line, execution=execution, execution_time=execution_time
+            )
         )
 
     def before_run(self, adapter, selected_uids: AbstractSet[str]):

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -226,10 +226,6 @@ class GraphRunnableTask(ManifestTask):
             status: Dict[str, str] = {}
             try:
                 result = runner.run_with_hooks(self.manifest)
-                status = runner.get_result_status(result)
-                runner.node.update_event_status(
-                    node_status=result.status, finished_at=datetime.utcnow().isoformat()
-                )
             finally:
                 finishctx = TimestampNamed("finished_at")
                 with finishctx, DbtModelState(status):

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -177,7 +177,7 @@ sample_values = [
     BuildingCatalog(),
     DatabaseErrorRunningHook(hook_type=""),
     HooksRunning(num_hooks=0, hook_type=""),
-    HookFinished(stat_line="", execution="", execution_time=0),
+    FinishedRunningStats(stat_line="", execution="", execution_time=0),
 
     # I - Project parsing ======================
     ParseCmdOut(msg="testing"),


### PR DESCRIPTION
resolves #6571

### Description

~There are places where we were already explicitly passing in `node_info`, preceding the parity work in https://github.com/dbt-labs/dbt-core/pull/6325 — but the information was actually incorrect! This PR updates those events to call `get_node_info` instead. This is especially important for `NodeFinished`-type events, to properly update `node_status` + `node_finished_at`.~

Move `update_event_status` to a different spot in tasks, which gets called earlier, and crucially before the info-level `LogModelResult` event.

While here: rename `HookFinished` to `FinishedRunningStats`. This event has nothing to do with "hooks," as a dbt user would understand them :)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
