### PR TITLE
finish message rename in types.proto

### DIFF
--- a/core/dbt/config/utils.py
+++ b/core/dbt/config/utils.py
@@ -9,7 +9,7 @@ from dbt.config import Profile, Project, read_user_config
 from dbt.config.renderer import DbtProjectYamlRenderer, ProfileRenderer
 from dbt.events.functions import fire_event
 from dbt.events.types import InvalidOptionYAML
-from dbt.exceptions import DbtValidationError, OptionNotYamlDict
+from dbt.exceptions import DbtValidationError, OptionNotYamlDictError
 
 
 def parse_cli_vars(var_string: str) -> Dict[str, Any]:
@@ -23,7 +23,7 @@ def parse_cli_yaml_string(var_string: str, cli_option_name: str) -> Dict[str, An
         if var_type is dict:
             return cli_vars
         else:
-            raise OptionNotYamlDict(var_type, cli_option_name)
+            raise OptionNotYamlDictError(var_type, cli_option_name)
     except DbtValidationError:
         fire_event(InvalidOptionYAML(option_name=cli_option_name))
         raise

--- a/core/dbt/events/proto_types.py
+++ b/core/dbt/events/proto_types.py
@@ -164,7 +164,7 @@ class MissingProfileTargetMsg(betterproto.Message):
 class InvalidOptionYAML(betterproto.Message):
     """A008"""
 
-    pass
+    option_name: str = betterproto.string_field(1)
 
 
 @dataclass

--- a/core/dbt/events/proto_types.py
+++ b/core/dbt/events/proto_types.py
@@ -47,7 +47,9 @@ class NodeInfo(betterproto.Message):
     node_status: str = betterproto.string_field(6)
     node_started_at: str = betterproto.string_field(7)
     node_finished_at: str = betterproto.string_field(8)
-    meta: str = betterproto.string_field(9)
+    meta: Dict[str, str] = betterproto.map_field(
+        9, betterproto.TYPE_STRING, betterproto.TYPE_STRING
+    )
 
 
 @dataclass
@@ -162,7 +164,7 @@ class MissingProfileTargetMsg(betterproto.Message):
 class InvalidOptionYAML(betterproto.Message):
     """A008"""
 
-    option_name: str = betterproto.string_field(1)
+    pass
 
 
 @dataclass

--- a/core/dbt/events/types.proto
+++ b/core/dbt/events/types.proto
@@ -125,6 +125,7 @@ message MissingProfileTargetMsg {
 
 // A008
 message InvalidOptionYAML {
+    string option_name = 1;
 }
 
 message InvalidOptionYAMLMsg {

--- a/core/dbt/events/types.proto
+++ b/core/dbt/events/types.proto
@@ -124,12 +124,12 @@ message MissingProfileTargetMsg {
 // Skipped A006, A007
 
 // A008
-message InvalidVarsYAML {
+message InvalidOptionYAML {
 }
 
-message InvalidVarsYAMLMsg {
+message InvalidOptionYAMLMsg {
     EventInfo info = 1;
-    InvalidVarsYAML data = 2;
+    InvalidOptionYAML data = 2;
 }
 
 // A009

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -1703,7 +1703,7 @@ class UninstalledPackagesFoundError(CompilationError):
         return msg
 
 
-class OptionNotYamlDict(CompilationError):
+class OptionNotYamlDictError(CompilationError):
     def __init__(self, var_type, option_name):
         self.var_type = var_type
         self.option_name = option_name


### PR DESCRIPTION
relates to #6520 

### Description

Renames InvalidVarsYAML -> InvalidOptionYAML in types.proto to match types.py and callsite.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
