### PR TITLE
Respect quoting config in dbt-py models

### DIFF
--- a/.changes/unreleased/Fixes-20230116-123645.yaml
+++ b/.changes/unreleased/Fixes-20230116-123645.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Respect quoting config for dbt.ref() + dbt.source() in dbt-py models
+time: 2023-01-16T12:36:45.63092+01:00
+custom:
+  Author: jtcohen6
+  Issue: "6103"

--- a/.changes/unreleased/Fixes-20230116-123709.yaml
+++ b/.changes/unreleased/Fixes-20230116-123709.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Respect quoting config for dbt.this() in dbt-py models
+time: 2023-01-16T12:37:09.000659+01:00
+custom:
+  Author: jtcohen6
+  Issue: "6619"

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -351,13 +351,6 @@ class Compiler:
         )
 
         if node.language == ModelLanguage.python:
-            # TODO could we also 'minify' this code at all? just aesthetic, not functional
-
-            # quoating seems like something very specific to sql so far
-            # for all python implementations we are seeing there's no quating.
-            # TODO try to find better way to do this, given that
-            original_quoting = self.config.quoting
-            self.config.quoting = {key: False for key in original_quoting.keys()}
             context = self._create_node_context(node, manifest, extra_context)
 
             postfix = jinja.get_rendered(
@@ -367,8 +360,6 @@ class Compiler:
             )
             # we should NOT jinja render the python model's 'raw code'
             node.compiled_code = f"{node.raw_code}\n\n{postfix}"
-            # restore quoting settings in the end since context is lazy evaluated
-            self.config.quoting = original_quoting
 
         else:
             context = self._create_node_context(node, manifest, extra_context)

--- a/core/dbt/include/global_project/macros/python_model/python.sql
+++ b/core/dbt/include/global_project/macros/python_model/python.sql
@@ -3,7 +3,7 @@
     {%- set ref_dict = {} -%}
     {%- for _ref in model.refs -%}
         {%- set resolved = ref(*_ref) -%}
-        {%- do ref_dict.update({_ref | join("."): resolved.quote(database=False, schema=False, identifier=False) | string}) -%}
+        {%- do ref_dict.update({_ref | join("."): resolved | string | replace('"', '\"')}) -%}
     {%- endfor -%}
 
 def ref(*args,dbt_load_df_function):
@@ -18,7 +18,7 @@ def ref(*args,dbt_load_df_function):
     {%- set source_dict = {} -%}
     {%- for _source in model.sources -%}
         {%- set resolved = source(*_source) -%}
-        {%- do source_dict.update({_source | join("."): resolved.quote(database=False, schema=False, identifier=False) | string}) -%}
+        {%- do source_dict.update({_source | join("."): resolved | string | replace('"', '\"')}) -%}
     {%- endfor -%}
 
 def source(*args, dbt_load_df_function):

--- a/core/dbt/include/global_project/macros/python_model/python.sql
+++ b/core/dbt/include/global_project/macros/python_model/python.sql
@@ -33,8 +33,8 @@ def source(*args, dbt_load_df_function):
     {% set config_dbt_used = zip(model.config.config_keys_used, model.config.config_keys_defaults) | list %}
     {%- for key, default in config_dbt_used -%}
         {# weird type testing with enum, would be much easier to write this logic in Python! #}
-        {%- if key == 'language' -%}
-          {%- set value = 'python' -%}
+        {%- if key == "language" -%}
+          {%- set value = "python" -%}
         {%- endif -%}
         {%- set value = model.config.get(key, default) -%}
         {%- do config_dict.update({key: value}) -%}
@@ -62,11 +62,12 @@ class config:
 
 class this:
     """dbt.this() or dbt.this.identifier"""
-    database = '{{ this.database }}'
-    schema = '{{ this.schema }}'
-    identifier = '{{ this.identifier }}'
+    database = "{{ this.database }}"
+    schema = "{{ this.schema }}"
+    identifier = "{{ this.identifier }}"
+    {% set this_relation_name = this | string | replace('"', '\\"') %}
     def __repr__(self):
-        return '{{ this }}'
+        return "{{ this_relation_name  }}"
 
 
 class dbtObj:


### PR DESCRIPTION
resolves #6103
resolves #6619

### Description

From our code comment:
> Quoting seems like something very specific to sql so far. For all python implementations we are seeing, there's no quoting.

Initial user feedback has proven otherwise!
- We do need to respect quoting in methods that return stringified relation names (`dbt.ref()`, `dbt.source()`, `dbt.this()`)
- Because relation names are interpolated into Python dataframe code as strings, we need to escape relation names that contain double quotes (`"`). This is principally relevant to Snowflake today, but several other data platforms also use `"` as their quoting character.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR — relevant tests in adapter repos
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
