### PR TITLE
Reformat `tests/`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,4 +9,4 @@ ignore =
     E203 # makes Flake8 work like black
     E741
     E501 # long line checking is done in black
-exclude = test
+exclude = test/

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -272,7 +272,7 @@ class TestBuilder(Generic[Testable]):
                         column_name=column_name,
                         name=self.name,
                         key=key,
-                        err_msg=e.msg
+                        err_msg=e.msg,
                     )
 
             if value is not None:

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -91,9 +91,7 @@ class TestRunner(CompileRunner):
     def before_execute(self):
         self.print_start_line()
 
-    def execute_test(
-        self, test: TestNode, manifest: Manifest
-    ) -> TestResultData:
+    def execute_test(self, test: TestNode, manifest: Manifest) -> TestResultData:
         context = generate_runtime_model_context(test, self.config, manifest)
 
         materialization_macro = manifest.find_materialization_macro_by_name(
@@ -101,7 +99,9 @@ class TestRunner(CompileRunner):
         )
 
         if materialization_macro is None:
-            raise MissingMaterializationError(materialization=test.get_materialization(), adapter_type=self.adapter.type())
+            raise MissingMaterializationError(
+                materialization=test.get_materialization(), adapter_type=self.adapter.type()
+            )
 
         if "config" not in context:
             raise DbtInternalError(

--- a/core/dbt/tests/fixtures/project.py
+++ b/core/dbt/tests/fixtures/project.py
@@ -249,7 +249,9 @@ def clean_up_logging():
 # otherwise this will fail. So to test errors in those areas, you need to copy the files
 # into the project in the tests instead of putting them in the fixtures.
 @pytest.fixture(scope="class")
-def adapter(unique_schema, project_root, profiles_root, profiles_yml, dbt_project_yml, clean_up_logging):
+def adapter(
+    unique_schema, project_root, profiles_root, profiles_yml, dbt_project_yml, clean_up_logging
+):
     # The profiles.yml and dbt_project.yml should already be written out
     args = Namespace(
         profiles_dir=str(profiles_root), project_dir=str(project_root), target=None, profile=None

--- a/core/dbt/tests/util.py
+++ b/core/dbt/tests/util.py
@@ -12,7 +12,12 @@ from dbt.adapters.factory import Adapter
 from dbt.main import handle_and_check
 from dbt.logger import log_manager
 from dbt.contracts.graph.manifest import Manifest
-from dbt.events.functions import fire_event, capture_stdout_logs, stop_capture_stdout_logs, reset_metadata_vars
+from dbt.events.functions import (
+    fire_event,
+    capture_stdout_logs,
+    stop_capture_stdout_logs,
+    reset_metadata_vars,
+)
 from dbt.events.test_types import IntegrationTestDebug
 
 # =============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,6 @@ namespace_packages = true
 
 [tool.black]
 # TODO: remove global exclusion of tests when testing overhaul is complete
-force-exclude = 'test'
+force-exclude = 'test/'
 line-length = 99
 target-version = ['py38']

--- a/tests/adapter/dbt/tests/adapter/aliases/test_aliases.py
+++ b/tests/adapter/dbt/tests/adapter/aliases/test_aliases.py
@@ -50,10 +50,7 @@ class BaseAliases:
 
     @pytest.fixture(scope="class")
     def macros(self):
-        return {
-            "cast.sql": MACROS__CAST_SQL,
-            "expect_value.sql": MACROS__EXPECT_VALUE_SQL
-        }
+        return {"cast.sql": MACROS__CAST_SQL, "expect_value.sql": MACROS__EXPECT_VALUE_SQL}
 
     def test_alias_model_name(self, project):
         results = run_dbt(["run"])
@@ -71,10 +68,7 @@ class BaseAliasErrors:
 
     @pytest.fixture(scope="class")
     def macros(self):
-        return {
-            "cast.sql": MACROS__CAST_SQL,
-            "expect_value.sql": MACROS__EXPECT_VALUE_SQL
-        }
+        return {"cast.sql": MACROS__CAST_SQL, "expect_value.sql": MACROS__EXPECT_VALUE_SQL}
 
     @pytest.fixture(scope="class")
     def models(self):
@@ -100,10 +94,7 @@ class BaseSameAliasDifferentSchemas:
 
     @pytest.fixture(scope="class")
     def macros(self):
-        return {
-            "cast.sql": MACROS__CAST_SQL,
-            "expect_value.sql": MACROS__EXPECT_VALUE_SQL
-        }
+        return {"cast.sql": MACROS__CAST_SQL, "expect_value.sql": MACROS__EXPECT_VALUE_SQL}
 
     @pytest.fixture(scope="class")
     def models(self):
@@ -130,19 +121,14 @@ class BaseSameAliasDifferentDatabases:
             "models": {
                 "test": {
                     "alias": "duped_alias",
-                    "model_b": {
-                        "schema": unique_schema + "_alt"
-                    },
+                    "model_b": {"schema": unique_schema + "_alt"},
                 },
             },
         }
 
     @pytest.fixture(scope="class")
     def macros(self):
-        return {
-            "cast.sql": MACROS__CAST_SQL,
-            "expect_value.sql": MACROS__EXPECT_VALUE_SQL
-        }
+        return {"cast.sql": MACROS__CAST_SQL, "expect_value.sql": MACROS__EXPECT_VALUE_SQL}
 
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/adapter/dbt/tests/adapter/basic/test_table_materialization.py
+++ b/tests/adapter/dbt/tests/adapter/basic/test_table_materialization.py
@@ -70,14 +70,13 @@ select * from {{ this.schema }}.seed
 
 
 class BaseTableMaterialization:
-
     @pytest.fixture(scope="class")
     def seeds(self):
         return {"seed.csv": seeds__seed_csv}
 
     @pytest.fixture(scope="class")
     def models(self):
-        return {'materialized.sql': model_sql}
+        return {"materialized.sql": model_sql}
 
     def test_table_materialization_sort_dist_no_op(self, project):
         # basic table materialization test, sort and dist is not supported by postgres so the result table would still be same as input

--- a/tests/adapter/dbt/tests/adapter/dbt_debug/test_dbt_debug.py
+++ b/tests/adapter/dbt/tests/adapter/dbt_debug/test_dbt_debug.py
@@ -21,7 +21,7 @@ class BaseDebug:
     def assertGotValue(self, linepat, result):
         found = False
         output = self.capsys.readouterr().out
-        for line in output.split('\n'):
+        for line in output.split("\n"):
             if linepat.match(line):
                 found = True
                 assert result in line
@@ -41,10 +41,7 @@ class BaseDebug:
 class BaseDebugProfileVariable(BaseDebug):
     @pytest.fixture(scope="class")
     def project_config_update(self):
-        return {
-            "config-version": 2,
-            "profile": '{{ "te" ~ "st" }}'
-        }
+        return {"config-version": 2, "profile": '{{ "te" ~ "st" }}'}
 
 
 class TestDebugPostgres(BaseDebug):
@@ -70,7 +67,6 @@ class TestDebugProfileVariablePostgres(BaseDebugProfileVariable):
 
 
 class TestDebugInvalidProjectPostgres(BaseDebug):
-
     def test_empty_project(self, project):
         with open("dbt_project.yml", "w") as f:  # noqa: F841
             pass
@@ -96,9 +92,7 @@ class TestDebugInvalidProjectPostgres(BaseDebug):
 
     def test_invalid_project_outside_current_dir(self, project):
         # create a dbt_project.yml
-        project_config = {
-            "invalid-key": "not a valid key in this project"
-        }
+        project_config = {"invalid-key": "not a valid key in this project"}
         os.makedirs("custom", exist_ok=True)
         with open("custom/dbt_project.yml", "w") as f:
             yaml.safe_dump(project_config, f, default_flow_style=True)

--- a/tests/adapter/dbt/tests/adapter/incremental/test_incremental_predicates.py
+++ b/tests/adapter/dbt/tests/adapter/incremental/test_incremental_predicates.py
@@ -64,10 +64,8 @@ class BaseIncrementalPredicates:
     def project_config_update(self):
         return {
             "models": {
-                "+incremental_predicates": [
-                    "id != 2"
-                ],
-                "+incremental_strategy": "delete+insert"
+                "+incremental_predicates": ["id != 2"],
+                "+incremental_strategy": "delete+insert",
             }
         }
 
@@ -123,16 +121,21 @@ class BaseIncrementalPredicates:
             inc_test_model_count=1,
             seed_rows=seed_rows,
             opt_model_count=opt_model_count,
-            relation=relation
+            relation=relation,
         )
 
     # no unique_key test
     def test__incremental_predicates(self, project):
         """seed should match model after two incremental runs"""
 
-        expected_fields = self.get_expected_fields(relation="expected_delete_insert_incremental_predicates", seed_rows=4)
+        expected_fields = self.get_expected_fields(
+            relation="expected_delete_insert_incremental_predicates", seed_rows=4
+        )
         test_case_fields = self.get_test_fields(
-            project, seed="expected_delete_insert_incremental_predicates", incremental_model="delete_insert_incremental_predicates", update_sql_file=None
+            project,
+            seed="expected_delete_insert_incremental_predicates",
+            incremental_model="delete_insert_incremental_predicates",
+            update_sql_file=None,
         )
         self.check_scenario_correctness(expected_fields, test_case_fields, project)
 
@@ -144,11 +147,4 @@ class TestIncrementalPredicatesDeleteInsert(BaseIncrementalPredicates):
 class TestPredicatesDeleteInsert(BaseIncrementalPredicates):
     @pytest.fixture(scope="class")
     def project_config_update(self):
-        return {
-            "models": {
-                "+predicates": [
-                    "id != 2"
-                ],
-                "+incremental_strategy": "delete+insert"
-            }
-        }
+        return {"models": {"+predicates": ["id != 2"], "+incremental_strategy": "delete+insert"}}

--- a/tests/adapter/dbt/tests/adapter/relations/test_changing_relation_type.py
+++ b/tests/adapter/dbt/tests/adapter/relations/test_changing_relation_type.py
@@ -1,5 +1,3 @@
-
-
 from typing import List, Optional
 import pytest
 
@@ -20,12 +18,10 @@ select '{{ var("materialized") }}' as materialization
 class BaseChangeRelationTypeValidator:
     @pytest.fixture(scope="class")
     def models(self):
-        return {
-            "model_mc_modelface.sql": _DEFAULT_CHANGE_RELATION_TYPE_MODEL
-        }
+        return {"model_mc_modelface.sql": _DEFAULT_CHANGE_RELATION_TYPE_MODEL}
 
     def _run_and_check_materialization(self, materialization, extra_args: Optional[List] = None):
-        run_args = ["run", '--vars', f'materialized: {materialization}']
+        run_args = ["run", "--vars", f"materialized: {materialization}"]
         if extra_args:
             run_args.extend(extra_args)
         results = run_dbt(run_args)
@@ -33,11 +29,11 @@ class BaseChangeRelationTypeValidator:
         assert len(results) == 1
 
     def test_changing_materialization_changes_relation_type(self, project):
-        self._run_and_check_materialization('view')
-        self._run_and_check_materialization('table')
-        self._run_and_check_materialization('view')
-        self._run_and_check_materialization('incremental')
-        self._run_and_check_materialization('table', extra_args=['--full-refresh'])
+        self._run_and_check_materialization("view")
+        self._run_and_check_materialization("table")
+        self._run_and_check_materialization("view")
+        self._run_and_check_materialization("incremental")
+        self._run_and_check_materialization("table", extra_args=["--full-refresh"])
 
 
 class TestChangeRelationTypes(BaseChangeRelationTypeValidator):

--- a/tests/functional/artifacts/expected_manifest.py
+++ b/tests/functional/artifacts/expected_manifest.py
@@ -1061,9 +1061,7 @@ def expected_references_manifest(project):
                 "unique_id": "seed.test.seed",
                 "checksum": checksum_file(seed_path),
                 "unrendered_config": get_unrendered_seed_config(),
-                "relation_name": '"{0}"."{1}".seed'.format(
-                    project.database, my_schema_name
-                ),
+                "relation_name": '"{0}"."{1}".seed'.format(project.database, my_schema_name),
             },
             "snapshot.test.snapshot_seed": {
                 "alias": "snapshot_seed",
@@ -1244,9 +1242,7 @@ def expected_references_manifest(project):
                 "unique_id": "doc.test.table_info",
             },
             "doc.test.view_summary": {
-                "block_contents": (
-                    "A view of the summary of the ephemeral copy of the seed data"
-                ),
+                "block_contents": ("A view of the summary of the ephemeral copy of the seed data"),
                 "resource_type": "doc",
                 "name": "view_summary",
                 "original_file_path": docs_path,

--- a/tests/functional/colors/test_colors.py
+++ b/tests/functional/colors/test_colors.py
@@ -16,7 +16,7 @@ def models():
 
 @pytest.fixture(scope="class")
 def project_config_update():
-    return {'config-version': 2}
+    return {"config-version": 2}
 
 
 class TestColors:

--- a/tests/functional/configs/test_configs.py
+++ b/tests/functional/configs/test_configs.py
@@ -1,4 +1,3 @@
-
 from hologram import ValidationError
 import pytest
 import os
@@ -94,7 +93,11 @@ class TestInvalidSeedsMaterializationProj(object):
 class TestInvalidSeedsMaterializationSchema(object):
     def test_seeds_materialization_schema_config(self, project):
         seeds_dir = os.path.join(project.project_root, "seeds")
-        write_file("version: 2\nseeds:\n  - name: myseed\n    config:\n      materialized: table", seeds_dir, "schema.yml")
+        write_file(
+            "version: 2\nseeds:\n  - name: myseed\n    config:\n      materialized: table",
+            seeds_dir,
+            "schema.yml",
+        )
         write_file("id1, id2\n1, 2", seeds_dir, "myseed.csv")
 
         with pytest.raises(ValidationError):
@@ -116,7 +119,11 @@ class TestInvalidSnapshotsMaterializationProj(object):
 class TestInvalidSnapshotsMaterializationSchema(object):
     def test_snapshots_materialization_schema_config(self, project):
         snapshots_dir = os.path.join(project.project_root, "snapshots")
-        write_file("version: 2\nsnapshots:\n  - name: mysnapshot\n    config:\n      materialized: table", snapshots_dir, "schema.yml")
+        write_file(
+            "version: 2\nsnapshots:\n  - name: mysnapshot\n    config:\n      materialized: table",
+            snapshots_dir,
+            "schema.yml",
+        )
         write_file(simple_snapshot, snapshots_dir, "mysnapshot.sql")
 
         with pytest.raises(ValidationError):

--- a/tests/functional/context_methods/test_builtin_functions.py
+++ b/tests/functional/context_methods/test_builtin_functions.py
@@ -112,7 +112,17 @@ class TestContextBuiltins:
         expected = "invocation_result: {'debug': True, 'log_format': 'json', 'write_json': True, 'use_colors': True, 'printer_width': 80, 'version_check': True, 'partial_parse': True, 'static_parser': True, 'profiles_dir': "
         assert expected in str(result)
 
-        expected = ("'send_anonymous_usage_stats': False", "'quiet': False", "'no_print': False", "'cache_selected_only': False", "'macro': 'validate_invocation'", "'args': '{my_variable: test_variable}'", "'which': 'run-operation'", "'rpc_method': 'run-operation'", "'indirect_selection': 'eager'")
+        expected = (
+            "'send_anonymous_usage_stats': False",
+            "'quiet': False",
+            "'no_print': False",
+            "'cache_selected_only': False",
+            "'macro': 'validate_invocation'",
+            "'args': '{my_variable: test_variable}'",
+            "'which': 'run-operation'",
+            "'rpc_method': 'run-operation'",
+            "'indirect_selection': 'eager'",
+        )
         for element in expected:
             assert element in str(result)
 

--- a/tests/functional/context_methods/test_custom_env_vars.py
+++ b/tests/functional/context_methods/test_custom_env_vars.py
@@ -27,7 +27,9 @@ class TestCustomVarInLogs:
         del os.environ["DBT_ENV_CUSTOM_ENV_SOME_VAR"]
 
     def test_extra_filled(self, project):
-        _, log_output = run_dbt_and_capture(['--log-format=json', 'deps'],)
+        _, log_output = run_dbt_and_capture(
+            ["--log-format=json", "deps"],
+        )
         logs = parse_json_logs(log_output)
         for log in logs:
-            assert log['info'].get('extra') == {"SOME_VAR": "value"}
+            assert log["info"].get("extra") == {"SOME_VAR": "value"}

--- a/tests/functional/custom_aliases/test_custom_aliases.py
+++ b/tests/functional/custom_aliases/test_custom_aliases.py
@@ -7,18 +7,14 @@ from tests.functional.custom_aliases.fixtures import (
     model2_sql,
     macros_sql,
     macros_config_sql,
-    schema_yml
+    schema_yml,
 )
 
 
 class TestAliases:
     @pytest.fixture(scope="class")
     def models(self):
-        return {
-            "model1.sql": model1_sql,
-            "model2.sql": model2_sql,
-            "schema.yml": schema_yml
-        }
+        return {"model1.sql": model1_sql, "model2.sql": model2_sql, "schema.yml": schema_yml}
 
     @pytest.fixture(scope="class")
     def macros(self):
@@ -27,21 +23,17 @@ class TestAliases:
         }
 
     def test_customer_alias_name(self, project):
-        results = run_dbt(['run'])
+        results = run_dbt(["run"])
         assert len(results) == 2
 
-        results = run_dbt(['test'])
+        results = run_dbt(["test"])
         assert len(results) == 2
 
 
 class TestAliasesWithConfig:
     @pytest.fixture(scope="class")
     def models(self):
-        return {
-            "model1.sql": model1_sql,
-            "model2.sql": model2_sql,
-            "schema.yml": schema_yml
-        }
+        return {"model1.sql": model1_sql, "model2.sql": model2_sql, "schema.yml": schema_yml}
 
     @pytest.fixture(scope="class")
     def macros(self):
@@ -50,8 +42,8 @@ class TestAliasesWithConfig:
         }
 
     def test_customer_alias_name(self, project):
-        results = run_dbt(['run'])
+        results = run_dbt(["run"])
         assert len(results) == 2
 
-        results = run_dbt(['test'])
+        results = run_dbt(["test"])
         assert len(results) == 2

--- a/tests/functional/cycles/test_cycles.py
+++ b/tests/functional/cycles/test_cycles.py
@@ -36,10 +36,7 @@ select * from {{ ref('model_e') }}
 class TestSimpleCycle:
     @pytest.fixture(scope="class")
     def models(self):
-        return {
-            "model_a.sql": model_a_sql,
-            "model_b.sql": model_b_sql
-        }
+        return {"model_a.sql": model_a_sql, "model_b.sql": model_b_sql}
 
     def test_simple_cycle(self, project):
         with pytest.raises(RuntimeError) as exc:

--- a/tests/functional/exit_codes/fixtures.py
+++ b/tests/functional/exit_codes/fixtures.py
@@ -74,5 +74,5 @@ class BaseConfigProject:
             "bad.sql": bad_sql,
             "dupe.sql": dupe_sql,
             "good.sql": good_sql,
-            "schema.yml": schema_yml
+            "schema.yml": schema_yml,
         }

--- a/tests/functional/exit_codes/test_exit_codes.py
+++ b/tests/functional/exit_codes/test_exit_codes.py
@@ -1,17 +1,13 @@
 import pytest
 
 import dbt.exceptions
-from dbt.tests.util import (
-    check_table_does_exist,
-    check_table_does_not_exist,
-    run_dbt
-)
+from dbt.tests.util import check_table_does_exist, check_table_does_not_exist, run_dbt
 from tests.functional.exit_codes.fixtures import (
     BaseConfigProject,
     snapshots_bad_sql,
     snapshots_good_sql,
     data_seed_bad_csv,
-    data_seed_good_csv
+    data_seed_good_csv,
 )
 
 
@@ -21,38 +17,38 @@ class TestExitCodes(BaseConfigProject):
         return {"g.sql": snapshots_good_sql}
 
     def test_exit_code_run_succeed(self, project):
-        results = run_dbt(['run', '--model', 'good'])
+        results = run_dbt(["run", "--model", "good"])
         assert len(results) == 1
-        check_table_does_exist(project.adapter, 'good')
+        check_table_does_exist(project.adapter, "good")
 
     def test_exit_code_run_fail(self, project):
-        results = run_dbt(['run', '--model', 'bad'], expect_pass=False)
+        results = run_dbt(["run", "--model", "bad"], expect_pass=False)
         assert len(results) == 1
-        check_table_does_not_exist(project.adapter, 'bad')
+        check_table_does_not_exist(project.adapter, "bad")
 
     def test_schema_test_pass(self, project):
-        results = run_dbt(['run', '--model', 'good'])
+        results = run_dbt(["run", "--model", "good"])
         assert len(results) == 1
 
-        results = run_dbt(['test', '--model', 'good'])
+        results = run_dbt(["test", "--model", "good"])
         assert len(results) == 1
 
     def test_schema_test_fail(self, project):
-        results = run_dbt(['run', '--model', 'dupe'])
+        results = run_dbt(["run", "--model", "dupe"])
         assert len(results) == 1
 
-        results = run_dbt(['test', '--model', 'dupe'], expect_pass=False)
+        results = run_dbt(["test", "--model", "dupe"], expect_pass=False)
         assert len(results) == 1
 
     def test_compile(self, project):
-        results = run_dbt(['compile'])
+        results = run_dbt(["compile"])
         assert len(results) == 7
 
     def test_snapshot_pass(self, project):
         run_dbt(["run", "--model", "good"])
-        results = run_dbt(['snapshot'])
+        results = run_dbt(["snapshot"])
         assert len(results) == 1
-        check_table_does_exist(project.adapter, 'good_snapshot')
+        check_table_does_exist(project.adapter, "good_snapshot")
 
 
 class TestExitCodesSnapshotFail(BaseConfigProject):
@@ -61,12 +57,12 @@ class TestExitCodesSnapshotFail(BaseConfigProject):
         return {"b.sql": snapshots_bad_sql}
 
     def test_snapshot_fail(self, project):
-        results = run_dbt(['run', '--model', 'good'])
+        results = run_dbt(["run", "--model", "good"])
         assert len(results) == 1
 
-        results = run_dbt(['snapshot'], expect_pass=False)
+        results = run_dbt(["snapshot"], expect_pass=False)
         assert len(results) == 1
-        check_table_does_not_exist(project.adapter, 'good_snapshot')
+        check_table_does_not_exist(project.adapter, "good_snapshot")
 
 
 class TestExitCodesDeps:
@@ -75,14 +71,14 @@ class TestExitCodesDeps:
         return {
             "packages": [
                 {
-                    'git': 'https://github.com/dbt-labs/dbt-integration-project',
-                    'revision': 'dbt/1.0.0',
+                    "git": "https://github.com/dbt-labs/dbt-integration-project",
+                    "revision": "dbt/1.0.0",
                 }
             ]
         }
 
     def test_deps(self, project):
-        results = run_dbt(['deps'])
+        results = run_dbt(["deps"])
         assert results is None
 
 
@@ -92,15 +88,15 @@ class TestExitCodesDepsFail:
         return {
             "packages": [
                 {
-                    'git': 'https://github.com/dbt-labs/dbt-integration-project',
-                    'revision': 'bad-branch',
+                    "git": "https://github.com/dbt-labs/dbt-integration-project",
+                    "revision": "bad-branch",
                 },
             ]
         }
 
     def test_deps_fail(self, project):
         with pytest.raises(dbt.exceptions.GitCheckoutError) as exc:
-            run_dbt(['deps'])
+            run_dbt(["deps"])
         expected_msg = "Error checking out spec='bad-branch'"
         assert expected_msg in str(exc.value)
 
@@ -111,7 +107,7 @@ class TestExitCodesSeed:
         return {"good.csv": data_seed_good_csv}
 
     def test_seed(self, project):
-        results = run_dbt(['seed'])
+        results = run_dbt(["seed"])
         assert len(results) == 1
 
 
@@ -121,4 +117,4 @@ class TestExitCodesSeedFail:
         return {"bad.csv": data_seed_bad_csv}
 
     def test_seed(self, project):
-        run_dbt(['seed'], expect_pass=False)
+        run_dbt(["seed"], expect_pass=False)

--- a/tests/functional/exposures/fixtures.py
+++ b/tests/functional/exposures/fixtures.py
@@ -1,4 +1,3 @@
-
 models_sql = """
 select 1 as id
 """

--- a/tests/functional/exposures/test_exposure_configs.py
+++ b/tests/functional/exposures/test_exposure_configs.py
@@ -12,7 +12,7 @@ from tests.functional.exposures.fixtures import (
     enabled_yaml_level_exposure_yml,
     invalid_config_exposure_yml,
     source_schema_yml,
-    metrics_schema_yml
+    metrics_schema_yml,
 )
 
 

--- a/tests/functional/exposures/test_exposures.py
+++ b/tests/functional/exposures/test_exposures.py
@@ -6,7 +6,7 @@ from tests.functional.exposures.fixtures import (
     second_model_sql,
     simple_exposure_yml,
     source_schema_yml,
-    metrics_schema_yml
+    metrics_schema_yml,
 )
 
 
@@ -37,8 +37,8 @@ class TestBasicExposures:
         manifest = get_manifest(project.project_root)
         exposure_depends_on = manifest.exposures["exposure.test.simple_exposure"].depends_on.nodes
         expected_exposure_depends_on = [
-            'source.test.test_source.test_table',
-            'model.test.model',
-            'metric.test.metric'
+            "source.test.test_source.test_table",
+            "model.test.model",
+            "metric.test.metric",
         ]
         assert sorted(exposure_depends_on) == sorted(expected_exposure_depends_on)

--- a/tests/functional/external_reference/test_external_reference.py
+++ b/tests/functional/external_reference/test_external_reference.py
@@ -24,16 +24,16 @@ class TestExternalReference:
         return {"model.sql": external_model_sql}
 
     def test_external_reference(self, project, unique_schema):
-        external_schema = unique_schema + 'z'
+        external_schema = unique_schema + "z"
         project.run_sql(f'create schema "{external_schema}"')
         project.run_sql(f'create table "{external_schema}"."external" (id integer)')
         project.run_sql(f'insert into "{external_schema}"."external" values (1), (2)')
 
-        results = run_dbt(['run'])
+        results = run_dbt(["run"])
         assert len(results) == 1
 
         # running it again should succeed
-        results = run_dbt(['run'])
+        results = run_dbt(["run"])
         assert len(results) == 1
 
 
@@ -45,13 +45,15 @@ class TestExternalDependency:
         return {"model.sql": model_sql}
 
     def test_external_reference(self, project, unique_schema):
-        results = run_dbt(['run'])
+        results = run_dbt(["run"])
         assert len(results) == 1
 
-        external_schema = unique_schema + 'z'
+        external_schema = unique_schema + "z"
         project.run_sql(f'create schema "{external_schema}"')
-        project.run_sql(f'create view "{external_schema}"."external" as (select * from {unique_schema}.model)')
+        project.run_sql(
+            f'create view "{external_schema}"."external" as (select * from {unique_schema}.model)'
+        )
 
         # running it again should succeed
-        results = run_dbt(['run'])
+        results = run_dbt(["run"])
         assert len(results) == 1

--- a/tests/functional/incremental_schema_tests/fixtures.py
+++ b/tests/functional/incremental_schema_tests/fixtures.py
@@ -1,4 +1,3 @@
-
 #
 # Properties
 #

--- a/tests/functional/incremental_schema_tests/test_incremental_schema.py
+++ b/tests/functional/incremental_schema_tests/test_incremental_schema.py
@@ -41,21 +41,16 @@ class TestIncrementalSchemaChange:
         return {
             "incremental_sync_remove_only.sql": _MODELS__INCREMENTAL_SYNC_REMOVE_ONLY,
             "incremental_ignore.sql": _MODELS__INCREMENTAL_IGNORE,
-            "incremental_sync_remove_only_target.sql":
-                _MODELS__INCREMENTAL_SYNC_REMOVE_ONLY_TARGET,
+            "incremental_sync_remove_only_target.sql": _MODELS__INCREMENTAL_SYNC_REMOVE_ONLY_TARGET,
             "incremental_ignore_target.sql": _MODELS__INCREMENTAL_IGNORE_TARGET,
             "incremental_fail.sql": _MODELS__INCREMENTAL_FAIL,
             "incremental_sync_all_columns.sql": _MODELS__INCREMENTAL_SYNC_ALL_COLUMNS,
-            "incremental_append_new_columns_remove_one.sql":
-                _MODELS__INCREMENTAL_APPEND_NEW_COLUMNS_REMOVE_ONE,
+            "incremental_append_new_columns_remove_one.sql": _MODELS__INCREMENTAL_APPEND_NEW_COLUMNS_REMOVE_ONE,
             "model_a.sql": _MODELS__A,
-            "incremental_append_new_columns_target.sql":
-                _MODELS__INCREMENTAL_APPEND_NEW_COLUMNS_TARGET,
+            "incremental_append_new_columns_target.sql": _MODELS__INCREMENTAL_APPEND_NEW_COLUMNS_TARGET,
             "incremental_append_new_columns.sql": _MODELS__INCREMENTAL_APPEND_NEW_COLUMNS,
-            "incremental_sync_all_columns_target.sql":
-                _MODELS__INCREMENTAL_SYNC_ALL_COLUMNS_TARGET,
-            "incremental_append_new_columns_remove_one_target.sql":
-                _MODELS__INCREMENTAL_APPEND_NEW_COLUMNS_REMOVE_ONE_TARGET,
+            "incremental_sync_all_columns_target.sql": _MODELS__INCREMENTAL_SYNC_ALL_COLUMNS_TARGET,
+            "incremental_append_new_columns_remove_one_target.sql": _MODELS__INCREMENTAL_APPEND_NEW_COLUMNS_REMOVE_ONE_TARGET,
         }
 
     @pytest.fixture(scope="class")
@@ -63,26 +58,19 @@ class TestIncrementalSchemaChange:
         return {
             "select_from_incremental.sql": _TESTS__SELECT_FROM_INCREMENTAL_IGNORE,
             "select_from_a.sql": _TESTS__SELECT_FROM_A,
-            "select_from_incremental_append_new_columns_target.sql":
-                _TESTS__SELECT_FROM_INCREMENTAL_APPEND_NEW_COLUMNS_TARGET,
-            "select_from_incremental_sync_all_columns.sql":
-                _TESTS__SELECT_FROM_INCREMENTAL_SYNC_ALL_COLUMNS,
-            "select_from_incremental_sync_all_columns_target.sql":
-                _TESTS__SELECT_FROM_INCREMENTAL_SYNC_ALL_COLUMNS_TARGET,
-            "select_from_incremental_ignore_target.sql":
-                _TESTS__SELECT_FROM_INCREMENTAL_IGNORE_TARGET,
-            "select_from_incremental_append_new_columns.sql":
-                _TESTS__SELECT_FROM_INCREMENTAL_APPEND_NEW_COLUMNS,
+            "select_from_incremental_append_new_columns_target.sql": _TESTS__SELECT_FROM_INCREMENTAL_APPEND_NEW_COLUMNS_TARGET,
+            "select_from_incremental_sync_all_columns.sql": _TESTS__SELECT_FROM_INCREMENTAL_SYNC_ALL_COLUMNS,
+            "select_from_incremental_sync_all_columns_target.sql": _TESTS__SELECT_FROM_INCREMENTAL_SYNC_ALL_COLUMNS_TARGET,
+            "select_from_incremental_ignore_target.sql": _TESTS__SELECT_FROM_INCREMENTAL_IGNORE_TARGET,
+            "select_from_incremental_append_new_columns.sql": _TESTS__SELECT_FROM_INCREMENTAL_APPEND_NEW_COLUMNS,
         }
 
-    def run_twice_and_assert(
-        self, include, compare_source, compare_target, project
-    ):
+    def run_twice_and_assert(self, include, compare_source, compare_target, project):
 
         # dbt run (twice)
-        run_args = ['run']
+        run_args = ["run"]
         if include:
-            run_args.extend(('--select', include))
+            run_args.extend(("--select", include))
         results_one = run_dbt(run_args)
         assert len(results_one) == 3
 
@@ -92,33 +80,33 @@ class TestIncrementalSchemaChange:
         check_relations_equal(project.adapter, [compare_source, compare_target])
 
     def run_incremental_append_new_columns(self, project):
-        select = 'model_a incremental_append_new_columns incremental_append_new_columns_target'
-        compare_source = 'incremental_append_new_columns'
-        compare_target = 'incremental_append_new_columns_target'
+        select = "model_a incremental_append_new_columns incremental_append_new_columns_target"
+        compare_source = "incremental_append_new_columns"
+        compare_target = "incremental_append_new_columns_target"
         self.run_twice_and_assert(select, compare_source, compare_target, project)
 
     def run_incremental_append_new_columns_remove_one(self, project):
-        select = 'model_a incremental_append_new_columns_remove_one incremental_append_new_columns_remove_one_target'
-        compare_source = 'incremental_append_new_columns_remove_one'
-        compare_target = 'incremental_append_new_columns_remove_one_target'
+        select = "model_a incremental_append_new_columns_remove_one incremental_append_new_columns_remove_one_target"
+        compare_source = "incremental_append_new_columns_remove_one"
+        compare_target = "incremental_append_new_columns_remove_one_target"
         self.run_twice_and_assert(select, compare_source, compare_target, project)
 
     def run_incremental_sync_all_columns(self, project):
-        select = 'model_a incremental_sync_all_columns incremental_sync_all_columns_target'
-        compare_source = 'incremental_sync_all_columns'
-        compare_target = 'incremental_sync_all_columns_target'
+        select = "model_a incremental_sync_all_columns incremental_sync_all_columns_target"
+        compare_source = "incremental_sync_all_columns"
+        compare_target = "incremental_sync_all_columns_target"
         self.run_twice_and_assert(select, compare_source, compare_target, project)
 
     def run_incremental_sync_remove_only(self, project):
-        select = 'model_a incremental_sync_remove_only incremental_sync_remove_only_target'
-        compare_source = 'incremental_sync_remove_only'
-        compare_target = 'incremental_sync_remove_only_target'
+        select = "model_a incremental_sync_remove_only incremental_sync_remove_only_target"
+        compare_source = "incremental_sync_remove_only"
+        compare_target = "incremental_sync_remove_only_target"
         self.run_twice_and_assert(select, compare_source, compare_target, project)
 
     def test_run_incremental_ignore(self, project):
-        select = 'model_a incremental_ignore incremental_ignore_target'
-        compare_source = 'incremental_ignore'
-        compare_target = 'incremental_ignore_target'
+        select = "model_a incremental_ignore incremental_ignore_target"
+        compare_source = "incremental_ignore"
+        compare_target = "incremental_ignore_target"
         self.run_twice_and_assert(select, compare_source, compare_target, project)
 
     def test_run_incremental_append_new_columns(self, project):
@@ -130,7 +118,7 @@ class TestIncrementalSchemaChange:
         self.run_incremental_sync_remove_only(project)
 
     def test_run_incremental_fail_on_schema_change(self, project):
-        select = 'model_a incremental_fail'
-        run_dbt(['run', '--models', select, '--full-refresh'])
-        results_two = run_dbt(['run', '--models', select], expect_pass=False)
-        assert 'Compilation Error' in results_two[1].message
+        select = "model_a incremental_fail"
+        run_dbt(["run", "--models", select, "--full-refresh"])
+        results_two = run_dbt(["run", "--models", select], expect_pass=False)
+        assert "Compilation Error" in results_two[1].message

--- a/tests/functional/logging/test_logging.py
+++ b/tests/functional/logging/test_logging.py
@@ -26,7 +26,7 @@ def test_basic(project, logs_dir):
     assert log_file
     node_start = False
     node_finished = False
-    for log_line in log_file.split('\n'):
+    for log_line in log_file.split("\n"):
         # skip empty lines
         if len(log_line) == 0:
             continue
@@ -35,13 +35,13 @@ def test_basic(project, logs_dir):
             continue
         log_dct = json.loads(log_line)
         log_data = log_dct["data"]
-        log_event = log_dct['info']['name']
+        log_event = log_dct["info"]["name"]
         if log_event == "NodeStart":
             node_start = True
         if log_event == "NodeFinished":
             node_finished = True
         if node_start and not node_finished:
-            if log_event == 'NodeExecuting':
+            if log_event == "NodeExecuting":
                 assert "node_info" in log_data
             if log_event == "JinjaLogDebug":
                 assert "node_info" in log_data

--- a/tests/functional/logging/test_meta_logging.py
+++ b/tests/functional/logging/test_meta_logging.py
@@ -2,9 +2,10 @@ import pytest
 from dbt.tests.util import run_dbt, read_file
 import json
 
-model1 = 'select 1 as fun'
+model1 = "select 1 as fun"
 model2 = '{{ config(meta={"owners": ["team1", "team2"]})}} select 1 as fun'
 model3 = '{{ config(meta={"key": 1})}} select 1 as fun'
+
 
 @pytest.fixture(scope="class")  # noqa
 def models():
@@ -20,7 +21,7 @@ def test_meta(project, logs_dir):
     log_file = read_file(logs_dir, "dbt.log")
     assert log_file
 
-    for log_line in log_file.split('\n'):
+    for log_line in log_file.split("\n"):
         # skip empty lines
         if len(log_line) == 0:
             continue
@@ -34,10 +35,10 @@ def test_meta(project, logs_dir):
 
         print(f"--- log_dct: {log_dct}")
         node_info = log_dct["data"]["node_info"]
-        node_path = node_info['node_path']
+        node_path = node_info["node_path"]
         if node_path == "model1.sql":
-            assert node_info['meta'] == {}
+            assert node_info["meta"] == {}
         elif node_path == "model2.sql":
-            assert node_info['meta'] == {"owners": "['team1', 'team2']"}
+            assert node_info["meta"] == {"owners": "['team1', 'team2']"}
         elif node_path == "model3.sql":
-            assert node_info['meta'] == {"key": "1"}
+            assert node_info["meta"] == {"key": "1"}

--- a/tests/functional/metrics/test_metric_configs.py
+++ b/tests/functional/metrics/test_metric_configs.py
@@ -11,7 +11,7 @@ from tests.functional.metrics.fixtures import (
     disabled_metric_level_schema_yml,
     enabled_metric_level_schema_yml,
     models_people_metrics_sql,
-    invalid_config_metric_yml
+    invalid_config_metric_yml,
 )
 
 

--- a/tests/functional/metrics/test_metric_helper_functions.py
+++ b/tests/functional/metrics/test_metric_helper_functions.py
@@ -3,10 +3,7 @@ import pytest
 from dbt.tests.util import run_dbt, get_manifest
 from dbt.contracts.graph.metrics import ResolvedMetricReference
 
-from tests.functional.metrics.fixtures import (
-    models_people_sql,
-    basic_metrics_yml
-)
+from tests.functional.metrics.fixtures import models_people_sql, basic_metrics_yml
 
 
 class TestMetricHelperFunctions:

--- a/tests/functional/metrics/test_metrics.py
+++ b/tests/functional/metrics/test_metrics.py
@@ -21,7 +21,7 @@ from tests.functional.metrics.fixtures import (
     derived_metric_old_attr_names_yml,
     metric_without_timestamp_or_timegrains_yml,
     invalid_metric_without_timestamp_with_time_grains_yml,
-    invalid_metric_without_timestamp_with_window_yml
+    invalid_metric_without_timestamp_with_window_yml,
 )
 
 

--- a/tests/functional/persist_docs_tests/test_persist_docs.py
+++ b/tests/functional/persist_docs_tests/test_persist_docs.py
@@ -47,50 +47,44 @@ class BasePersistDocsTest:
         for comment in comments:
             assert '"with double quotes"' in comment
             assert """'''abc123'''""" in comment
-            assert '\n' in comment
-            assert 'Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting' in comment
-            assert '/* comment */' in comment
-            if os.name == 'nt':
-                assert '--\r\n' in comment or '--\n' in comment
+            assert "\n" in comment
+            assert "Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting" in comment
+            assert "/* comment */" in comment
+            if os.name == "nt":
+                assert "--\r\n" in comment or "--\n" in comment
             else:
-                assert '--\n' in comment
+                assert "--\n" in comment
 
     def _assert_has_table_comments(self, table_node):
-        table_comment = table_node['metadata']['comment']
-        assert table_comment.startswith('Table model description')
+        table_comment = table_node["metadata"]["comment"]
+        assert table_comment.startswith("Table model description")
 
-        table_id_comment = table_node['columns']['id']['comment']
-        assert table_id_comment.startswith('id Column description')
+        table_id_comment = table_node["columns"]["id"]["comment"]
+        assert table_id_comment.startswith("id Column description")
 
-        table_name_comment = table_node['columns']['name']['comment']
-        assert table_name_comment.startswith(
-            'Some stuff here and then a call to')
+        table_name_comment = table_node["columns"]["name"]["comment"]
+        assert table_name_comment.startswith("Some stuff here and then a call to")
 
-        self._assert_common_comments(
-            table_comment, table_id_comment, table_name_comment
-        )
+        self._assert_common_comments(table_comment, table_id_comment, table_name_comment)
 
     def _assert_has_view_comments(
-        self,
-        view_node,
-        has_node_comments=True,
-        has_column_comments=True
+        self, view_node, has_node_comments=True, has_column_comments=True
     ):
-        view_comment = view_node['metadata']['comment']
+        view_comment = view_node["metadata"]["comment"]
         if has_node_comments:
-            assert view_comment.startswith('View model description')
+            assert view_comment.startswith("View model description")
             self._assert_common_comments(view_comment)
         else:
             assert view_comment is None
 
-        view_id_comment = view_node['columns']['id']['comment']
+        view_id_comment = view_node["columns"]["id"]["comment"]
         if has_column_comments:
-            assert view_id_comment.startswith('id Column description')
+            assert view_id_comment.startswith("id Column description")
             self._assert_common_comments(view_id_comment)
         else:
             assert view_id_comment is None
 
-        view_name_comment = view_node['columns']['name']['comment']
+        view_name_comment = view_node["columns"]["name"]["comment"]
         assert view_name_comment is None
 
 
@@ -98,9 +92,9 @@ class TestPersistDocs(BasePersistDocsTest):
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
-            'models': {
-                'test': {
-                    '+persist_docs': {
+            "models": {
+                "test": {
+                    "+persist_docs": {
                         "relation": True,
                         "columns": True,
                     },
@@ -109,18 +103,18 @@ class TestPersistDocs(BasePersistDocsTest):
         }
 
     def test_has_comments_pglike(self, project):
-        run_dbt(['docs', 'generate'])
-        with open('target/catalog.json') as fp:
+        run_dbt(["docs", "generate"])
+        with open("target/catalog.json") as fp:
             catalog_data = json.load(fp)
-        assert 'nodes' in catalog_data
-        assert len(catalog_data['nodes']) == 4
-        table_node = catalog_data['nodes']['model.test.table_model']
+        assert "nodes" in catalog_data
+        assert len(catalog_data["nodes"]) == 4
+        table_node = catalog_data["nodes"]["model.test.table_model"]
         view_node = self._assert_has_table_comments(table_node)
 
-        view_node = catalog_data['nodes']['model.test.view_model']
+        view_node = catalog_data["nodes"]["model.test.view_model"]
         self._assert_has_view_comments(view_node)
 
-        no_docs_node = catalog_data['nodes']['model.test.no_docs_model']
+        no_docs_node = catalog_data["nodes"]["model.test.no_docs_model"]
         self._assert_has_view_comments(no_docs_node, False, False)
 
 
@@ -128,9 +122,9 @@ class TestPersistDocsColumnMissing(BasePersistDocsTest):
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
-            'models': {
-                'test': {
-                    '+persist_docs': {
+            "models": {
+                "test": {
+                    "+persist_docs": {
                         "columns": True,
                     },
                 }
@@ -146,11 +140,11 @@ class TestPersistDocsColumnMissing(BasePersistDocsTest):
         return {"schema.yml": _PROPERITES__SCHEMA_MISSING_COL}
 
     def test_postgres_missing_column(self, project):
-        run_dbt(['docs', 'generate'])
-        with open('target/catalog.json') as fp:
+        run_dbt(["docs", "generate"])
+        with open("target/catalog.json") as fp:
             catalog_data = json.load(fp)
-        assert 'nodes' in catalog_data
+        assert "nodes" in catalog_data
 
-        table_node = catalog_data['nodes']['model.test.missing_column']
-        table_id_comment = table_node['columns']['id']['comment']
-        assert table_id_comment.startswith('test id column description')
+        table_node = catalog_data["nodes"]["model.test.missing_column"]
+        table_id_comment = table_node["columns"]["id"]["comment"]
+        assert table_id_comment.startswith("test id column description")

--- a/tests/functional/postgres/test_postgres_indexes.py
+++ b/tests/functional/postgres/test_postgres_indexes.py
@@ -70,7 +70,7 @@ class TestPostgresIndex:
             results = run_dbt(["run", "--models", "incremental"] + additional_argument)
             assert len(results) == 1
 
-            indexes = self.get_indexes('incremental', project, unique_schema)
+            indexes = self.get_indexes("incremental", project, unique_schema)
             expected = [
                 {"columns": "column_a", "unique": False, "type": "hash"},
                 {"columns": "column_a, column_b", "unique": True, "type": "btree"},
@@ -78,11 +78,11 @@ class TestPostgresIndex:
             assert len(indexes) == len(expected)
 
     def test_seed(self, project, unique_schema):
-        for additional_argument in [[], [], ['--full-refresh']]:
+        for additional_argument in [[], [], ["--full-refresh"]]:
             results = run_dbt(["seed"] + additional_argument)
             assert len(results) == 1
 
-            indexes = self.get_indexes('seed', project, unique_schema)
+            indexes = self.get_indexes("seed", project, unique_schema)
             expected = [
                 {"columns": "country_code", "unique": False, "type": "hash"},
                 {"columns": "country_code, country_name", "unique": True, "type": "btree"},
@@ -94,7 +94,7 @@ class TestPostgresIndex:
             results = run_dbt(["snapshot", "--vars", f"version: {version}"])
             assert len(results) == 1
 
-            indexes = self.get_indexes('colors', project, unique_schema)
+            indexes = self.get_indexes("colors", project, unique_schema)
             expected = [
                 {"columns": "id", "unique": False, "type": "hash"},
                 {"columns": "id, color", "unique": True, "type": "btree"},
@@ -130,7 +130,7 @@ class TestPostgresIndex:
         assert len(a) == len(b)
 
 
-class TestPostgresInvalidIndex():
+class TestPostgresInvalidIndex:
     @pytest.fixture(scope="class")
     def models(self):
         return {

--- a/tests/functional/relation_names/test_relation_name.py
+++ b/tests/functional/relation_names/test_relation_name.py
@@ -40,9 +40,13 @@ class TestGeneratedDDLNameRules:
     def setup_class(self):
         self.incremental_filename = "my_name_is_51_characters_incremental_abcdefghijklmn"
         # length is 63
-        self.max_length_filename = "my_name_is_max_length_chars_abcdefghijklmnopqrstuvwxyz123456789"
+        self.max_length_filename = (
+            "my_name_is_max_length_chars_abcdefghijklmnopqrstuvwxyz123456789"
+        )
         # length is 64
-        self.over_max_length_filename = "my_name_is_one_over_max_length_chats_abcdefghijklmnopqrstuvwxyz1"
+        self.over_max_length_filename = (
+            "my_name_is_one_over_max_length_chats_abcdefghijklmnopqrstuvwxyz1"
+        )
 
         self.filename_for_backup_file = "my_name_is_52_characters_abcdefghijklmnopqrstuvwxyz0"
 
@@ -57,14 +61,10 @@ class TestGeneratedDDLNameRules:
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            f"{self.incremental_filename}.sql":
-                models__basic_incremental,
-            f"{self.filename_for_backup_file}.sql":
-                models__basic_table,
-            f"{self.max_length_filename}.sql":
-                models__basic_table,
-            f"{self.over_max_length_filename}.sql":
-                models__basic_table,
+            f"{self.incremental_filename}.sql": models__basic_incremental,
+            f"{self.filename_for_backup_file}.sql": models__basic_table,
+            f"{self.max_length_filename}.sql": models__basic_table,
+            f"{self.over_max_length_filename}.sql": models__basic_table,
         }
 
     @pytest.fixture(scope="class")
@@ -110,15 +110,17 @@ class TestGeneratedDDLNameRules:
     # 63 characters is the character limit for a table name in a postgres database
     # (assuming compiled without changes from source)
     def test_name_longer_than_63_does_not_build(self):
-        err_msg = "Relation name 'my_name_is_one_over_max"\
+        err_msg = (
+            "Relation name 'my_name_is_one_over_max"
             "_length_chats_abcdefghijklmnopqrstuvwxyz1' is longer than 63 characters"
+        )
         res = run_dbt(
             [
                 "run",
                 "-s",
                 self.over_max_length_filename,
             ],
-            expect_pass=False
+            expect_pass=False,
         )
         assert res[0].status == RunStatus.Error
         assert err_msg in res[0].message

--- a/tests/functional/run_operations/test_run_operations.py
+++ b/tests/functional/run_operations/test_run_operations.py
@@ -2,15 +2,8 @@ import os
 import pytest
 import yaml
 
-from dbt.tests.util import (
-    check_table_does_exist,
-    run_dbt
-)
-from tests.functional.run_operations.fixtures import (
-    happy_macros_sql,
-    sad_macros_sql,
-    model_sql
-)
+from dbt.tests.util import check_table_does_exist, run_dbt
+from tests.functional.run_operations.fixtures import happy_macros_sql, sad_macros_sql, model_sql
 
 
 class TestOperations:
@@ -20,10 +13,7 @@ class TestOperations:
 
     @pytest.fixture(scope="class")
     def macros(self):
-        return {
-            "happy_macros.sql": happy_macros_sql,
-            "sad_macros.sql": sad_macros_sql
-        }
+        return {"happy_macros.sql": happy_macros_sql, "sad_macros.sql": sad_macros_sql}
 
     @pytest.fixture(scope="class")
     def dbt_profile_data(self, unique_schema):
@@ -46,59 +36,57 @@ class TestOperations:
                         "threads": 4,
                         "host": "localhost",
                         "port": int(os.getenv("POSTGRES_TEST_PORT", 5432)),
-                        "user": 'noaccess',
-                        "pass": 'password',
+                        "user": "noaccess",
+                        "pass": "password",
                         "dbname": os.getenv("POSTGRES_TEST_DATABASE", "dbt"),
-                        'schema': unique_schema
-                    }
+                        "schema": unique_schema,
+                    },
                 },
                 "target": "default",
             },
         }
 
     def run_operation(self, macro, expect_pass=True, extra_args=None, **kwargs):
-        args = ['run-operation', macro]
+        args = ["run-operation", macro]
         if kwargs:
-            args.extend(('--args', yaml.safe_dump(kwargs)))
+            args.extend(("--args", yaml.safe_dump(kwargs)))
         if extra_args:
             args.extend(extra_args)
         return run_dbt(args, expect_pass=expect_pass)
 
     def test_macro_noargs(self, project):
-        self.run_operation('no_args')
-        check_table_does_exist(project.adapter, 'no_args')
+        self.run_operation("no_args")
+        check_table_does_exist(project.adapter, "no_args")
 
     def test_macro_args(self, project):
-        self.run_operation('table_name_args', table_name='my_fancy_table')
-        check_table_does_exist(project.adapter, 'my_fancy_table')
+        self.run_operation("table_name_args", table_name="my_fancy_table")
+        check_table_does_exist(project.adapter, "my_fancy_table")
 
     def test_macro_exception(self, project):
-        self.run_operation('syntax_error', False)
+        self.run_operation("syntax_error", False)
 
     def test_macro_missing(self, project):
-        self.run_operation('this_macro_does_not_exist', False)
+        self.run_operation("this_macro_does_not_exist", False)
 
     def test_cannot_connect(self, project):
-        self.run_operation('no_args',
-                           extra_args=['--target', 'noaccess'],
-                           expect_pass=False)
+        self.run_operation("no_args", extra_args=["--target", "noaccess"], expect_pass=False)
 
     def test_vacuum(self, project):
-        run_dbt(['run'])
+        run_dbt(["run"])
         # this should succeed
-        self.run_operation('vacuum', table_name='model')
+        self.run_operation("vacuum", table_name="model")
 
     def test_vacuum_ref(self, project):
-        run_dbt(['run'])
+        run_dbt(["run"])
         # this should succeed
-        self.run_operation('vacuum_ref', ref_target='model')
+        self.run_operation("vacuum_ref", ref_target="model")
 
     def test_select(self, project):
-        self.run_operation('select_something', name='world')
+        self.run_operation("select_something", name="world")
 
     def test_access_graph(self, project):
-        self.run_operation('log_graph')
+        self.run_operation("log_graph")
 
     def test_print(self, project):
         # Tests that calling the `print()` macro does not cause an exception
-        self.run_operation('print_something')
+        self.run_operation("print_something")

--- a/tests/functional/run_query/test_types.py
+++ b/tests/functional/run_query/test_types.py
@@ -29,5 +29,5 @@ class TestTypes:
         }
 
     def test_nested_types(self, project):
-        result = run_dbt(['run-operation', 'test_array_results'])
+        result = run_dbt(["run-operation", "test_array_results"])
         assert result.success

--- a/tests/functional/schema_tests/test_schema_v2_tests.py
+++ b/tests/functional/schema_tests/test_schema_v2_tests.py
@@ -1003,11 +1003,13 @@ class TestCommentedSchema:
     def test_quoted_schema_file(self, project):
         try:
             # A schema file consisting entirely of quotes should not be a problem
-            run_dbt(['parse'])
+            run_dbt(["parse"])
         except TypeError:
-            assert False, '`dbt parse` failed with a yaml file that is all comments with the same exception as 3568'
+            assert (
+                False
+            ), "`dbt parse` failed with a yaml file that is all comments with the same exception as 3568"
         except Exception:
-            assert False, '`dbt parse` failed with a yaml file that is all comments'
+            assert False, "`dbt parse` failed with a yaml file that is all comments"
 
 
 class TestWrongSpecificationBlock:

--- a/tests/functional/severity/test_severity.py
+++ b/tests/functional/severity/test_severity.py
@@ -60,10 +60,7 @@ select * from {{ ref("sample_model") }} where email is null
 
 @pytest.fixture(scope="class")
 def models():
-    return {
-        "sample_model.sql": models__sample_model_sql,
-        "schema.yml": models__schema_yml
-    }
+    return {"sample_model.sql": models__sample_model_sql, "schema.yml": models__schema_yml}
 
 
 @pytest.fixture(scope="class")
@@ -79,9 +76,9 @@ def tests():
 @pytest.fixture(scope="class")
 def project_config_update():
     return {
-        'config-version': 2,
-        'seed-paths': ['seeds'],
-        'test-paths': ['tests'],
+        "config-version": 2,
+        "seed-paths": ["seeds"],
+        "test-paths": ["tests"],
         "seeds": {
             "quote_columns": False,
         },
@@ -95,25 +92,31 @@ class TestSeverity:
         run_dbt(["run"])
 
     def test_generic_default(self, project):
-        results = run_dbt(['test', '--select', 'test_type:generic'])
+        results = run_dbt(["test", "--select", "test_type:generic"])
         assert len(results) == 2
-        assert all([r.status == 'warn' for r in results])
+        assert all([r.status == "warn" for r in results])
         assert all([r.failures == 2 for r in results])
 
     def test_generic_strict(self, project):
-        results = run_dbt(['test', '--select', 'test_type:generic', "--vars", '{"strict": True}'], expect_pass=False)
+        results = run_dbt(
+            ["test", "--select", "test_type:generic", "--vars", '{"strict": True}'],
+            expect_pass=False,
+        )
         assert len(results) == 2
-        assert all([r.status == 'fail' for r in results])
+        assert all([r.status == "fail" for r in results])
         assert all([r.failures == 2 for r in results])
 
     def test_singular_default(self, project):
-        results = run_dbt(['test', '--select', 'test_type:singular'])
+        results = run_dbt(["test", "--select", "test_type:singular"])
         assert len(results) == 1
-        assert all([r.status == 'warn' for r in results])
+        assert all([r.status == "warn" for r in results])
         assert all([r.failures == 2 for r in results])
 
     def test_singular_strict(self, project):
-        results = run_dbt(['test', '--select', 'test_type:singular', "--vars", '{"strict": True}'], expect_pass=False)
+        results = run_dbt(
+            ["test", "--select", "test_type:singular", "--vars", '{"strict": True}'],
+            expect_pass=False,
+        )
         assert len(results) == 1
-        assert all([r.status == 'fail' for r in results])
+        assert all([r.status == "fail" for r in results])
         assert all([r.failures == 2 for r in results])

--- a/tests/functional/statements/test_statements.py
+++ b/tests/functional/statements/test_statements.py
@@ -1,11 +1,7 @@
 import pathlib
 import pytest
 
-from dbt.tests.util import (
-    run_dbt,
-    check_relations_equal,
-    write_file
-)
+from dbt.tests.util import run_dbt, check_relations_equal, write_file
 from tests.functional.statements.fixtures import (
     models__statement_actual,
     seeds__statement_actual,
@@ -19,7 +15,9 @@ class TestStatements:
         # put seeds in 'seed' not 'seeds' directory
         (pathlib.Path(project.project_root) / "seed").mkdir(parents=True, exist_ok=True)
         write_file(seeds__statement_actual, project.project_root, "seed", "seed.csv")
-        write_file(seeds__statement_expected, project.project_root, "seed", "statement_expected.csv")
+        write_file(
+            seeds__statement_expected, project.project_root, "seed", "statement_expected.csv"
+        )
 
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/functional/store_test_failures_tests/test_store_test_failures.py
+++ b/tests/functional/store_test_failures_tests/test_store_test_failures.py
@@ -38,10 +38,8 @@ class StoreTestFailuresBase:
             "people.csv": seeds__people,
             "expected_accepted_values.csv": seeds__expected_accepted_values,
             "expected_failing_test.csv": seeds__expected_failing_test,
-            "expected_not_null_problematic_model_id.csv":
-                seeds__expected_not_null_problematic_model_id,
-            "expected_unique_problematic_model_id.csv":
-                seeds__expected_unique_problematic_model_id,
+            "expected_not_null_problematic_model_id.csv": seeds__expected_not_null_problematic_model_id,
+            "expected_unique_problematic_model_id.csv": seeds__expected_unique_problematic_model_id,
         }
 
     @pytest.fixture(scope="class")
@@ -59,8 +57,7 @@ class StoreTestFailuresBase:
     def models(self):
         return {
             "fine_model.sql": models__fine_model,
-            "fine_model_but_with_a_no_good_very_long_name.sql":
-                models__file_model_but_with_a_no_good_very_long_name,
+            "fine_model_but_with_a_no_good_very_long_name.sql": models__file_model_but_with_a_no_good_very_long_name,
             "problematic_model.sql": models__problematic_model,
         }
 
@@ -71,9 +68,7 @@ class StoreTestFailuresBase:
                 "quote_columns": False,
                 "test": self.column_type_overrides(),
             },
-            "tests": {
-                "+schema": TEST_AUDIT_SCHEMA_SUFFIX
-            }
+            "tests": {"+schema": TEST_AUDIT_SCHEMA_SUFFIX},
         }
 
     def column_type_overrides(self):
@@ -87,8 +82,8 @@ class StoreTestFailuresBase:
             project.adapter,
             [
                 f"{self.test_audit_schema}.unique_problematic_model_id",
-                "expected_unique_problematic_model_id"
-            ]
+                "expected_unique_problematic_model_id",
+            ],
         )
 
     def run_tests_store_failures_and_assert(self, project):
@@ -98,39 +93,59 @@ class StoreTestFailuresBase:
 
         # compare test results
         actual = [(r.status, r.failures) for r in results]
-        expected = [('pass', 0), ('pass', 0), ('pass', 0), ('pass', 0),
-                    ('fail', 2), ('fail', 2), ('fail', 2), ('fail', 10)]
+        expected = [
+            ("pass", 0),
+            ("pass", 0),
+            ("pass", 0),
+            ("pass", 0),
+            ("fail", 2),
+            ("fail", 2),
+            ("fail", 2),
+            ("fail", 10),
+        ]
         assert sorted(actual) == sorted(expected)
 
         # compare test results stored in database
-        check_relations_equal(project.adapter, [
-            f"{self.test_audit_schema}.failing_test",
-            "expected_failing_test"
-        ])
-        check_relations_equal(project.adapter, [
-            f"{self.test_audit_schema}.not_null_problematic_model_id",
-            "expected_not_null_problematic_model_id"
-        ])
-        check_relations_equal(project.adapter, [
-            f"{self.test_audit_schema}.unique_problematic_model_id",
-            "expected_unique_problematic_model_id"
-        ])
-        check_relations_equal(project.adapter, [
-            f"{self.test_audit_schema}.accepted_values_problemat"
-            "ic_mo_c533ab4ca65c1a9dbf14f79ded49b628",
-            "expected_accepted_values"
-        ])
+        check_relations_equal(
+            project.adapter, [f"{self.test_audit_schema}.failing_test", "expected_failing_test"]
+        )
+        check_relations_equal(
+            project.adapter,
+            [
+                f"{self.test_audit_schema}.not_null_problematic_model_id",
+                "expected_not_null_problematic_model_id",
+            ],
+        )
+        check_relations_equal(
+            project.adapter,
+            [
+                f"{self.test_audit_schema}.unique_problematic_model_id",
+                "expected_unique_problematic_model_id",
+            ],
+        )
+        check_relations_equal(
+            project.adapter,
+            [
+                f"{self.test_audit_schema}.accepted_values_problemat"
+                "ic_mo_c533ab4ca65c1a9dbf14f79ded49b628",
+                "expected_accepted_values",
+            ],
+        )
 
 
 class TestStoreTestFailures(StoreTestFailuresBase):
     @pytest.fixture(scope="function")
     def clean_up(self, project):
         yield
-        with project.adapter.connection_named('__test'):
-            relation = project.adapter.Relation.create(database=project.database, schema=self.test_audit_schema)
+        with project.adapter.connection_named("__test"):
+            relation = project.adapter.Relation.create(
+                database=project.database, schema=self.test_audit_schema
+            )
             project.adapter.drop_schema(relation)
 
-            relation = project.adapter.Relation.create(database=project.database, schema=project.test_schema)
+            relation = project.adapter.Relation.create(
+                database=project.database, schema=project.test_schema
+            )
             project.adapter.drop_schema(relation)
 
     def column_type_overrides(self):

--- a/tests/functional/test_selection/test_selection_expansion.py
+++ b/tests/functional/test_selection/test_selection_expansion.py
@@ -190,7 +190,13 @@ class TestSelectionExpansion:
     ):
         select = "model_a"
         exclude = "unique_model_a_fun"
-        expected = ["just_a", "cf_a_b", "cf_a_src", "relationships_model_a_fun__fun__ref_model_b_", "relationships_model_a_fun__fun__source_my_src_my_tbl_"]
+        expected = [
+            "just_a",
+            "cf_a_b",
+            "cf_a_src",
+            "relationships_model_a_fun__fun__ref_model_b_",
+            "relationships_model_a_fun__fun__source_my_src_my_tbl_",
+        ]
         indirect_selection = "buildable"
 
         self.list_tests_and_assert(select, exclude, expected, indirect_selection)

--- a/tests/functional/timezones/test_timezones.py
+++ b/tests/functional/timezones/test_timezones.py
@@ -26,20 +26,20 @@ class TestTimezones:
     @pytest.fixture(scope="class")
     def dbt_profile_data(self, unique_schema):
         return {
-            'test': {
-                'outputs': {
-                    'dev': {
-                        'type': 'postgres',
-                        'threads': 1,
-                        'host': 'localhost',
+            "test": {
+                "outputs": {
+                    "dev": {
+                        "type": "postgres",
+                        "threads": 1,
+                        "host": "localhost",
                         "port": int(os.getenv("POSTGRES_TEST_PORT", 5432)),
                         "user": os.getenv("POSTGRES_TEST_USER", "root"),
                         "pass": os.getenv("POSTGRES_TEST_PASS", "password"),
                         "dbname": os.getenv("POSTGRES_TEST_DATABASE", "dbt"),
-                        'schema': unique_schema
+                        "schema": unique_schema,
                     },
                 },
-                'target': 'dev'
+                "target": "dev",
             }
         }
 
@@ -50,16 +50,18 @@ class TestTimezones:
               run_started_at_est,
               run_started_at_utc
             from {schema}.timezones
-        """.format(schema=project.test_schema)
+        """.format(
+            schema=project.test_schema
+        )
 
     @freeze_time("2022-01-01 03:00:00", tz_offset=0)
     def test_run_started_at(self, project, query):
-        results = run_dbt(['run'])
+        results = run_dbt(["run"])
 
         assert len(results) == 1
 
-        result = project.run_sql(query, fetch='all')[0]
+        result = project.run_sql(query, fetch="all")[0]
         est, utc = result
 
-        assert utc == '2022-01-01 03:00:00+00:00'
-        assert est == '2021-12-31 22:00:00-05:00'
+        assert utc == "2022-01-01 03:00:00+00:00"
+        assert est == "2021-12-31 22:00:00-05:00"

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -13,13 +13,13 @@ def to_be_decorated():
 
 # simpletest that the return value is not modified
 def test_deprecated_func():
-    assert(hasattr(to_be_decorated, '__wrapped__'))
-    assert(to_be_decorated() == 5)
+    assert hasattr(to_be_decorated, "__wrapped__")
+    assert to_be_decorated() == 5
 
 
 class TestDeprecatedFunctions:
     def is_deprecated(self, func):
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         # TODO: add in log check
 
     def test_warn(self):
@@ -31,19 +31,19 @@ class TestDeprecatedExceptionFunctions:
         return func(*args)
 
     def is_deprecated(self, func):
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         # TODO: add in log check
 
     def test_missing_config(self):
         func = dbt.exceptions.missing_config
         exception = dbt.exceptions.MissingConfigError
         model = argparse.Namespace()
-        model.unique_id = ''
+        model.unique_id = ""
         name = ""
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(model, name)
 
@@ -52,12 +52,12 @@ class TestDeprecatedExceptionFunctions:
         exception = dbt.exceptions.MissingMaterializationError
         model = argparse.Namespace()
         model.config = argparse.Namespace()
-        model.config.materialized = ''
+        model.config.materialized = ""
         adapter_type = ""
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(model, adapter_type)
 
@@ -68,7 +68,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(relation)
 
@@ -85,7 +85,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(node_1, node_2, duped_name)
 
@@ -98,7 +98,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(unique_id, match_1, match_2)
 
@@ -109,7 +109,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(msg)
 
@@ -120,7 +120,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(obj)
 
@@ -131,7 +131,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(msg)
 
@@ -142,7 +142,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(msg)
 
@@ -155,7 +155,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(node, node_description, required_pkg)
 
@@ -166,7 +166,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(msg)
 
@@ -180,7 +180,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(patch_1, existing_patch_path)
 
@@ -189,7 +189,7 @@ class TestDeprecatedExceptionFunctions:
         exception = dbt.exceptions.DuplicateResourceNameError
         node_1 = argparse.Namespace()
         node_1.name = ""
-        node_1.resource_type = NodeType('model')
+        node_1.resource_type = NodeType("model")
         node_1.column_name = ""
         node_1.unique_id = ""
         node_1.original_file_path = ""
@@ -201,7 +201,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(node_1, node_2)
 
@@ -213,7 +213,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(path, issue)
 
@@ -224,7 +224,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(msg)
 
@@ -238,7 +238,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(relation, expected_type)
 
@@ -251,7 +251,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(kwargs, aliases, canonical_key)
 
@@ -267,7 +267,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(patch_1, patch_2)
 
@@ -282,7 +282,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(patch_1, existing_patch_path)
 
@@ -302,7 +302,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(node_1, node_2, namespace)
 
@@ -314,7 +314,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(target, relation)
 
@@ -326,7 +326,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(kwargs, matches)
 
@@ -337,7 +337,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(operation_name)
 
@@ -349,7 +349,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(name, argument)
 
@@ -363,7 +363,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(repo, spec, error)
 
@@ -391,7 +391,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(repo)
 
@@ -402,7 +402,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(macro_name)
 
@@ -415,7 +415,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(node, dependency)
 
@@ -431,7 +431,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(node, target_name, target_kind)
 
@@ -445,7 +445,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(model, target_doc_name, target_doc_package)
 
@@ -458,7 +458,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(model, args)
 
@@ -471,7 +471,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(model, args)
 
@@ -484,7 +484,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(model, args)
 
@@ -496,7 +496,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(return_value, macro_name)
 
@@ -510,7 +510,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(method_name, arg_name, got_value, expected_type)
 
@@ -521,7 +521,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(env_var_name)
 
@@ -532,7 +532,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(msg)
 
@@ -544,7 +544,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(typename, supported_types)
 
@@ -558,7 +558,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(patches)
 
@@ -570,7 +570,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(kwargs, matches)
 
@@ -584,7 +584,7 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(model, adapter_type)
 
@@ -597,6 +597,6 @@ class TestDeprecatedExceptionFunctions:
 
         self.is_deprecated(func)
 
-        assert(hasattr(func, '__wrapped__'))
+        assert hasattr(func, "__wrapped__")
         with pytest.raises(exception):
             func(model, target_macro_id)

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -78,10 +78,10 @@ class TestAdapterLogger:
         # ensure AdapterLogger and subclasses makes all base_msg members
         # of type string; when someone writes logger.debug(a) where a is
         # any non-string object
-        event = AdapterEventDebug(name="dbt_tests", base_msg=[1,2,3], args=(3,))
+        event = AdapterEventDebug(name="dbt_tests", base_msg=[1, 2, 3], args=(3,))
         assert isinstance(event.base_msg, str)
 
-        event = JinjaLogDebug(msg=[1,2,3])
+        event = JinjaLogDebug(msg=[1, 2, 3])
         assert isinstance(event.msg, str)
 
 
@@ -124,7 +124,6 @@ sample_values = [
     InvalidProfileTemplateYAML(),
     ProjectNameAlreadyExists(name=""),
     ProjectCreated(project_name=""),
-
     # D - Deprecations ======================
     PackageRedirectDeprecation(old_name="", new_name=""),
     PackageInstallPathDeprecation(),
@@ -134,7 +133,6 @@ sample_values = [
     MetricAttributesRenamed(metric_name=""),
     ExposureNameDeprecation(exposure=""),
     InternalDeprecation(name="", reason="", suggested_action="", version=""),
-
     # E - DB Adapter ======================
     AdapterEventDebug(),
     AdapterEventInfo(),
@@ -178,7 +176,6 @@ sample_values = [
     DatabaseErrorRunningHook(hook_type=""),
     HooksRunning(num_hooks=0, hook_type=""),
     FinishedRunningStats(stat_line="", execution="", execution_time=0),
-
     # I - Project parsing ======================
     ParseCmdOut(msg="testing"),
     GenericTestFileParse(path=""),
@@ -215,7 +212,9 @@ sample_values = [
     SeedExceedsLimitAndPathChanged(package_name="", name=""),
     SeedExceedsLimitChecksumChanged(package_name="", name="", checksum_name=""),
     UnusedTables(unused_tables=[]),
-    WrongResourceSchemaFile(patch_name="", resource_type="", file_path="", plural_resource_type=""),
+    WrongResourceSchemaFile(
+        patch_name="", resource_type="", file_path="", plural_resource_type=""
+    ),
     NoNodeForYamlKey(patch_name="", yaml_key="", file_path=""),
     MacroNotFoundForPatch(patch_name=""),
     NodeNotFoundOrDisabled(
@@ -228,9 +227,7 @@ sample_values = [
         disabled="",
     ),
     JinjaLogWarning(),
-
     # M - Deps generation ======================
-
     GitSparseCheckoutSubdirectory(subdir=""),
     GitProgressCheckoutRevision(revision=""),
     GitProgressUpdatingExistingDependency(dir=""),
@@ -259,9 +256,7 @@ sample_values = [
     RegistryResponseMissingNestedKeys(response=""),
     RegistryResponseExtraNestedKeys(response=""),
     DepsSetDownloadDirectory(path=""),
-
     # Q - Node execution ======================
-
     RunningOperationCaughtError(exc=""),
     CompileComplete(),
     FreshnessCheckComplete(),
@@ -340,17 +335,13 @@ sample_values = [
     NoNodesSelected(),
     DepsUnpinned(revision="", git=""),
     NoNodesForSelectionCriteria(spec_raw=""),
-
     # W - Node testing ======================
-
     CatchableExceptionOnRun(exc=""),
     InternalErrorOnRun(build_path="", exc=""),
     GenericExceptionOnRun(build_path="", unique_id="", exc=""),
     NodeConnectionReleaseError(node_name="", exc=""),
     FoundStats(stat_line=""),
-
     # Z - misc ======================
-
     MainKeyboardInterrupt(),
     MainEncounteredError(exc=""),
     MainStackTrace(stack_trace=""),
@@ -373,7 +364,7 @@ sample_values = [
     ServingDocsExitInfo(),
     RunResultWarning(resource_type="", node_name="", path=""),
     RunResultFailure(resource_type="", node_name="", path=""),
-    StatsLine(stats={"error": 0, "skip": 0, "pass": 0, "warn": 0,"total": 0}),
+    StatsLine(stats={"error": 0, "skip": 0, "pass": 0, "warn": 0, "total": 0}),
     RunResultError(msg=""),
     RunResultErrorNoMessage(status=""),
     SQLCompiledPath(path=""),
@@ -392,7 +383,6 @@ sample_values = [
     FlushEventsFailure(),
     TrackingInitializeFailure(),
     RunResultWarningMessage(),
-
     # T - tests ======================
     IntegrationTestInfo(),
     IntegrationTestDebug(),
@@ -400,10 +390,7 @@ sample_values = [
     IntegrationTestError(),
     IntegrationTestException(),
     UnitTestInfo(),
-
 ]
-
-
 
 
 class TestEventJSONSerialization:

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -13,15 +13,13 @@ from dbt.exceptions import EventCompilationError
         ('{"include": "all"}', True),
         ('{"include": [NoNodesForSelectionCriteria]}', True),
         ('{"include": []}', False),
-        ('{}', False),
+        ("{}", False),
         ('{"include": [MainTrackingUserState]}', False),
         ('{"include": "all", "exclude": [NoNodesForSelectionCriteria]}', False),
     ],
 )
 def test_warn_or_error_warn_error_options(warn_error_options, expect_compilation_exception):
-    args = Namespace(
-        warn_error_options=warn_error_options
-    )
+    args = Namespace(warn_error_options=warn_error_options)
     flags.set_from_args(args, {})
     if expect_compilation_exception:
         with pytest.raises(EventCompilationError):
@@ -38,9 +36,7 @@ def test_warn_or_error_warn_error_options(warn_error_options, expect_compilation
     ],
 )
 def test_warn_or_error_warn_error(warn_error, expect_compilation_exception):
-    args = Namespace(
-        warn_error=warn_error
-    )
+    args = Namespace(warn_error=warn_error)
     flags.set_from_args(args, {})
     if expect_compilation_exception:
         with pytest.raises(EventCompilationError):

--- a/tests/unit/test_helper_types.py
+++ b/tests/unit/test_helper_types.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from dbt.helper_types import IncludeExclude, WarnErrorOptions
@@ -21,7 +20,7 @@ class TestIncludeExclude:
             ("*", ["ItemA"], False),
             (["ItemA"], [], True),
             (["ItemA", "ItemB"], [], True),
-        ]
+        ],
     )
     def test_includes(self, include, exclude, expected_includes):
         include_exclude = IncludeExclude(include=include, exclude=exclude)

--- a/tests/unit/test_proto_events.py
+++ b/tests/unit/test_proto_events.py
@@ -13,7 +13,18 @@ from dbt.events.base_types import msg_from_base_event, EventLevel
 from dbt.version import installed
 
 
-info_keys = {"name", "code", "msg", "level", "invocation_id", "pid", "thread", "ts", "extra", "category"}
+info_keys = {
+    "name",
+    "code",
+    "msg",
+    "level",
+    "invocation_id",
+    "pid",
+    "thread",
+    "ts",
+    "extra",
+    "category",
+}
 
 
 def test_events():
@@ -87,7 +98,13 @@ def test_exception_events():
 
 
 def test_node_info_events():
-    meta_dict = {"string-key1": ["value1", 2], "string-key2": {"nested-dict-key": "value2"}, 1: "value-from-non-string-key", "string-key3": 1, "string-key4": ["string1", 1, "string2", 2]}
+    meta_dict = {
+        "string-key1": ["value1", 2],
+        "string-key2": {"nested-dict-key": "value2"},
+        1: "value-from-non-string-key",
+        "string-key3": 1,
+        "string-key4": ["string1", 1, "string2", 2],
+    }
     node_info = {
         "node_path": "some_path",
         "node_name": "some_name",
@@ -136,13 +153,7 @@ def test_extra_dict_on_event(monkeypatch):
 
 
 def test_dynamic_level_events():
-    event = LogTestResult(
-        name="model_name",
-        status="pass",
-        index=1,
-        num_models=3,
-        num_failures=0
-    )
+    event = LogTestResult(name="model_name", status="pass", index=1, num_models=3, num_failures=0)
     msg = msg_from_base_event(event, level=EventLevel.INFO)
     assert msg
     assert msg.info.level == "info"


### PR DESCRIPTION
resolves #6621

### Description

1. bc3704aa0b0c5b8388854827b00c791f87e1765e: Update `black` + `flake8` configs to include `tests/` directory. The previous regex was overly aggressive, and even caused `black` to skip over files in `core/` that were related to `dbt test` functionality :)
2. ea1abe8d623ee9834d8eb424718ff98f11f2dda4: Run `pre-commit` + commit changes

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- ~I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)~