### PR TITLE
fix MP_CONTEXT is not JSON serializable

### DIFF
--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -642,7 +642,10 @@ def args_to_dict(args):
     dict_args = {}
     # remove args keys that clutter up the dictionary
     for key in var_args:
-        if key == "cls":
+        if key.lower() in var_args and key == key.upper():
+            # skip all caped keys being introduced by Flags in dbt.cli.flags
+            continue
+        if key in ["cls", "mp_context"]:
             continue
         if var_args[key] is None:
             continue

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -643,7 +643,7 @@ def args_to_dict(args):
     # remove args keys that clutter up the dictionary
     for key in var_args:
         if key.lower() in var_args and key == key.upper():
-            # skip all caped keys being introduced by Flags in dbt.cli.flags
+            # skip all capped keys being introduced by Flags in dbt.cli.flags
             continue
         if key in ["cls", "mp_context"]:
             continue


### PR DESCRIPTION
Resolves #6509

This fixes the issue by adding logic to skip duplicated capped attributes introduced in Flags, also remove `mp_context` that is added.
Test that failed before now passes
* [x] `tests/adapter/dbt/tests/adapter/grants/test_snapshot_grants.py`
 