### PR TITLE
Add run-operation to click CLI (#5552)

### DIFF
--- a/.changes/unreleased/Under the Hood-20230119-105304.yaml
+++ b/.changes/unreleased/Under the Hood-20230119-105304.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add dbt run-operation to click CLI
+time: 2023-01-19T10:53:04.154871+01:00
+custom:
+  Author: jtcohen6
+  Issue: "5552"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -261,6 +261,8 @@ def deps(ctx, **kwargs):
 # dbt init
 @cli.command("init")
 @click.pass_context
+# for backwards compatibility, accept 'project_name' as an optional positional argument
+@click.argument("project_name", required=False)
 @p.profile
 @p.profiles_dir
 @p.project_dir
@@ -269,7 +271,7 @@ def deps(ctx, **kwargs):
 @p.vars
 @requires.preflight
 def init(ctx, **kwargs):
-    """Initialize a new DBT project."""
+    """Initialize a new dbt project."""
     click.echo(f"`{inspect.stack()[0][3]}` called\n flags: {ctx.obj['flags']}")
     return None, True
 
@@ -364,8 +366,8 @@ def run(ctx, **kwargs):
 
 # dbt run operation
 @cli.command("run-operation")
-@click.argument("macro")
 @click.pass_context
+@click.argument("macro")
 @p.args
 @p.profile
 @p.profiles_dir

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -18,6 +18,7 @@ from dbt.task.snapshot import SnapshotTask
 from dbt.task.seed import SeedTask
 from dbt.task.list import ListTask
 from dbt.task.freshness import FreshnessTask
+from dbt.task.run_operation import RunOperationTask
 
 
 # CLI invocation
@@ -363,6 +364,7 @@ def run(ctx, **kwargs):
 
 # dbt run operation
 @cli.command("run-operation")
+@click.argument("macro")
 @click.pass_context
 @p.args
 @p.profile
@@ -371,10 +373,16 @@ def run(ctx, **kwargs):
 @p.target
 @p.vars
 @requires.preflight
+@requires.profile
+@requires.project
 def run_operation(ctx, **kwargs):
     """Run the named macro with any supplied arguments."""
-    click.echo(f"`{inspect.stack()[0][3]}` called\n flags: {ctx.obj['flags']}")
-    return None, True
+    config = RuntimeConfig.from_parts(ctx.obj["project"], ctx.obj["profile"], ctx.obj["flags"])
+    task = RunOperationTask(ctx.obj["flags"], config)
+
+    results = task.run()
+    success = task.interpret_results(results)
+    return results, success
 
 
 # dbt seed

--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Dict, Any
 import traceback
 
 import agate
@@ -8,7 +7,6 @@ from .runnable import ManifestTask
 
 import dbt.exceptions
 from dbt.adapters.factory import get_adapter
-from dbt.config.utils import parse_cli_vars
 from dbt.contracts.results import RunOperationResultsArtifact
 from dbt.exceptions import InternalException
 from dbt.events.functions import fire_event
@@ -29,14 +27,6 @@ class RunOperationTask(ManifestTask):
 
         return package_name, macro_name
 
-    def _get_kwargs(self) -> Dict[str, Any]:
-        # N.B. parse_cli_vars is embedded into the param when using click.
-        # replace this with:
-        # return self.args.args
-        # when this task is refactored for click
-        # or remove the function completely as it's basically a noop
-        return parse_cli_vars(self.args.args)
-
     def compile_manifest(self) -> None:
         if self.manifest is None:
             raise InternalException("manifest was None in compile_manifest")
@@ -45,7 +35,7 @@ class RunOperationTask(ManifestTask):
         adapter = get_adapter(self.config)
 
         package_name, macro_name = self._get_macro_parts()
-        macro_kwargs = self._get_kwargs()
+        macro_kwargs = self.args.args
 
         with adapter.connection_named("macro_{}".format(macro_name)):
             adapter.clear_transaction()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -23,7 +23,8 @@ class TestCLI:
     def test_unhidden_params_have_help_texts(self):
         def run_test(command):
             for param in command.params:
-                if not param.hidden:
+                # arguments can't have help text
+                if not isinstance(param, click.Argument) and not param.hidden:
                     assert param.help is not None
             if type(command) is click.Group:
                 for command in command.commands.values():


### PR DESCRIPTION
resolves #5552

Sorry, just couldn't let others have all the fun...

### L'engagement

- Add `RunOperationTask` to click CLI
- Add `macro` positional argument

### Le tour

Borrowing 63870d5953e5c355293ae9387dfb77cc2d74b597 locally, to avoid the error `Object of type SpawnContext is not JSON serializable`:

```
$ python3 -m pytest tests/functional/run_operations/
==================================== test session starts ====================================
platform darwin -- Python 3.10.9, pytest-7.2.0, pluggy-1.0.0
rootdir: /Users/jerco/dev/product/dbt-core, configfile: pytest.ini
plugins: csv-3.0.0, logbook-1.2.0, xdist-3.1.0, flaky-3.7.0, mock-3.10.0, dotenv-0.5.2, cov-4.0.0
collected 10 items

tests/functional/run_operations/test_run_operations.py ..........                     [100%]

==================================== 10 passed in 8.47s =====================================
```

### 🎩 Le prestige

```sql
{% macro say_hello(whomst="world", strong=False) %}
    {{ print("Hello " ~ whomst ~ (" !" if strong else "")) }}
{% endmacro %}
```

```bash
$ python3 -m dbt.cli.main run-operation say_hello
Hello world
$ python3 -m dbt.cli.main run-operation project_funway.say_hello
Hello world
$ python3 -m dbt.cli.main run-operation say_hello --args 'whomst: Jeremy'
Hello Jeremy
$ python3 -m dbt.cli.main run-operation say_hello --args '{"whomst": "Wisconsin", "strong": true}'
Hello Wisconsin !
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
