### PR TITLE
add env DBT_PROJECT_DIR support #6078

### DIFF
--- a/.changes/unreleased/Features-20230119-141156.yaml
+++ b/.changes/unreleased/Features-20230119-141156.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: add support for DBT_PROJECT_DIR env var
+time: 2023-01-19T14:11:56.638325919+01:00
+custom:
+  Author: leo-schick
+  Issue: "6078"

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -226,7 +226,7 @@ profiles_dir_exists_false = click.option(
 
 project_dir = click.option(
     "--project-dir",
-    envvar=None,
+    envvar="DBT_PROJECT_DIR",
     help="Which directory to look in for the dbt_project.yml file. Default is the current working directory and its parents.",
     default=default_project_dir,
     type=click.Path(exists=True),


### PR DESCRIPTION
resolves #6078

### Description

Adds support for `DBT_PROJECT_DIR` handy to skip having to write `dbt <verb> --project-dir ...`.

### Development test

![image](https://user-images.githubusercontent.com/67712864/213449309-21a8782e-9916-41fe-9759-56f2d679d712.png)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
