### PR TITLE
Dynamically list all `.latest` branches for scheduled testing

### DIFF
--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -34,6 +34,9 @@ jobs:
       # Will look like '["1.0.latest", "1.2.latest"]'
       branches: ${{ toJSON(steps.generate.outputs.branch_matrix) }}
     steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
       - name: "Get all branches"
         run: |
           branches=($(git branch --format "%(refname:short)" | grep "^1.*.latest"))

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -28,38 +28,33 @@ on:
 permissions: read-all
 
 jobs:
-  generate_matrix:
+  fetch-latest-branches:
     runs-on: ubuntu-latest
+
     outputs:
-      # Will look like '["1.0.latest", "1.2.latest"]'
-      branch_matrix: ${{ toJSON(steps.generate.outputs.branch_matrix) }}
+      latest-branches: ${{ steps.get-latest-branches.outputs.repo-branches }}
+
     steps:
-      - name: Check out the repository
-        uses: actions/checkout@v3
+      - name: "Fetch dbt-core Latest Branches"
+        uses: dbt-labs/actions/fetch-repo-branches@v1.1.1
+        id: get-latest-branches
         with:
-          fetch-depth: 0
+          repo_name: ${{ inputs.package_name }}
+          organization: "dbt-labs"
+          pat: ${{ secrets.GITHUB_TOKEN }}
+          fetch_protected_branches_only: true
+          regex: "^1.[0-9]+.latest$"
+          perform_match_method: "match"
+          retries: 3
 
-      - name: "Test Step"
-        id: test_generate
+      - name: "[ANNOTATION] ${{ inputs.package_name }} - branches to test"
         run: |
-          git status
-          git branch --format "%(refname:short)"
-          git branch --format "%(refname:short)" | grep "^1.*.latest"
-
-      - name: "Get all branches"
-        id: generate
-        run: |
-          git status
-          BRANCHES=($(git branch --format "%(refname:short)" | grep "^1.*.latest"))
-          BRANCHES+="main"
-          echo "branch_matrix=$BRANCHES" >> $GITHUB_OUTPUT
-
-      - name: "[DEBUG] Check branch list"
-        run: |
-          echo ${{ steps.generate.outputs.branch_matrix }}
+          title="${{ inputs.package_name }} - branches to test"
+          message="The workflow will run tests for the following branches of the ${{ inputs.package_name }} repo: ${{ steps.get-latest-branches.outputs.repo-branches }}"
+          echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
 
   kick-off-ci:
-    needs: [generate_matrix]
+    needs: [fetch-latest-branches]
     name: Kick-off CI
     runs-on: ubuntu-latest
 
@@ -70,7 +65,9 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        branch: ${{ fromJSON(needs.generate_matrix.outputs.branch_matrix) }}
+        branch: ${{ fromJSON(needs.fetch-latest-branches.outputs.latest-branches) }}
+        include:
+          - branch: 'main'
 
     steps:
     - name: Call CI workflow for ${{ matrix.branch }} branch

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -28,7 +28,28 @@ on:
 permissions: read-all
 
 jobs:
+  generate_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      # Will look like '["1.0.latest", "1.2.latest"]'
+      branches: ${{ toJSON(steps.generate.outputs.branch_matrix) }}
+    steps:
+      - name: "Get all branches"
+        run: |
+          branches=($(git branch --format "%(refname:short)" | grep "^1.*.latest"))
+          branches+="main"
+
+      - name: "[DEBUG] Check branch list"
+        run: |
+          echo ${{ steps.generate.outputs.branch_matrix }}
+
+      - name: Generate Matrix
+        id: generate
+        run: |
+          echo "branch_matrix=BRANCHES" >> $GITHUB_OUTPUT
+
   kick-off-ci:
+    needs: [generate_matrix]
     name: Kick-off CI
     runs-on: ubuntu-latest
 
@@ -39,7 +60,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        branch: [1.0.latest, 1.1.latest, 1.2.latest, 1.3.latest, 1.4.latest, main]
+        branch: ${{ fromJSON(needs.generate_matrix.outputs.branches) }}
 
     steps:
     - name: Call CI workflow for ${{ matrix.branch }} branch

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -40,7 +40,7 @@ jobs:
           fetch-depth: 0
 
       - name: "Test Step"
-        id: generate
+        id: test_generate
         run: |
           git status
           git branch --format "%(refname:short)" | grep "^1.*.latest"

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: dbt-labs/actions/fetch-repo-branches@v1.1.1
         id: get-latest-branches
         with:
-          repo_name: ${{ inputs.package_name }}
+          repo_name: ${{ github.event.repository.name }}
           organization: "dbt-labs"
           pat: ${{ secrets.GITHUB_TOKEN }}
           fetch_protected_branches_only: true
@@ -47,11 +47,11 @@ jobs:
           perform_match_method: "match"
           retries: 3
 
-      - name: "[ANNOTATION] ${{ inputs.package_name }} - branches to test"
+      - name: "[ANNOTATION] ${{ github.event.repository.name }} - branches to test"
         run: |
-          title="${{ inputs.package_name }} - branches to test"
-          message="The workflow will run tests for the following branches of the ${{ inputs.package_name }} repo: ${{ steps.get-latest-branches.outputs.repo-branches }}"
-          echo "::notice title=${{ env.NOTIFICATION_PREFIX }}: $title::$message"
+          title="${{ github.event.repository.name }} - branches to test"
+          message="The workflow will run tests for the following branches of the ${{ github.event.repository.name }} repo: ${{ steps.get-latest-branches.outputs.repo-branches }}"
+          echo "::notice $title::$message"
 
   kick-off-ci:
     needs: [fetch-latest-branches]

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       # Will look like '["1.0.latest", "1.2.latest"]'
-      branches: ${{ toJSON(steps.generate.outputs.branch_matrix) }}
+      branch_matrix: ${{ toJSON(steps.generate.outputs.branch_matrix) }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v3
@@ -40,18 +40,16 @@ jobs:
           fetch-depth: 0
 
       - name: "Get all branches"
+        id: generate
         run: |
-          branches=($(git branch --format "%(refname:short)" | grep "^1.*.latest"))
-          branches+="main"
+          git status
+          BRANCHES=($(git branch --format "%(refname:short)" | grep "^1.*.latest"))
+          BRANCHES+="main"
+          echo "branch_matrix=$BRANCHES" >> $GITHUB_OUTPUT
 
       - name: "[DEBUG] Check branch list"
         run: |
           echo ${{ steps.generate.outputs.branch_matrix }}
-
-      - name: Generate Matrix
-        id: generate
-        run: |
-          echo "branch_matrix=BRANCHES" >> $GITHUB_OUTPUT
 
   kick-off-ci:
     needs: [generate_matrix]
@@ -65,7 +63,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        branch: ${{ fromJSON(needs.generate_matrix.outputs.branches) }}
+        branch: ${{ fromJSON(needs.generate_matrix.outputs.branch_matrix) }}
 
     steps:
     - name: Call CI workflow for ${{ matrix.branch }} branch

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: "Get all branches"
         run: |

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -43,8 +43,8 @@ jobs:
         id: test_generate
         run: |
           git status
-          git branch --format "%(refname:short)" | grep "^1.*.latest"
           git branch --format "%(refname:short)"
+          git branch --format "%(refname:short)" | grep "^1.*.latest"
 
       - name: "Get all branches"
         id: generate

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -39,6 +39,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: "Test Step"
+        id: generate
+        run: |
+          git status
+          git branch --format "%(refname:short)" | grep "^1.*.latest"
+          git branch --format "%(refname:short)"
+
       - name: "Get all branches"
         id: generate
         run: |


### PR DESCRIPTION
resolves #5773 

### Description

This auto generates the list of all `*.latest` branches (plus `main`) for our scheduled integration tests.

Eventually we would want to start removing versions once we no longer support them but this iteration does not deal with that.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
