### PR TITLE
Cheeky performance improvement on big DAGs

### DIFF
--- a/.changes/unreleased/Under the Hood-20230122-215235.yaml
+++ b/.changes/unreleased/Under the Hood-20230122-215235.yaml
@@ -3,4 +3,4 @@ body: Small optimization on manifest parsing benefitting large DAGs
 time: 2023-01-22T21:52:35.549814+01:00
 custom:
   Author: boxysean
-  Issue: "6322"
+  Issue: "6073"

--- a/.changes/unreleased/Under the Hood-20230122-215235.yaml
+++ b/.changes/unreleased/Under the Hood-20230122-215235.yaml
@@ -3,4 +3,4 @@ body: Small optimization on manifest parsing benefitting large DAGs
 time: 2023-01-22T21:52:35.549814+01:00
 custom:
   Author: boxysean
-  Issue: "6073"
+  Issue: "6697"

--- a/.changes/unreleased/Under the Hood-20230122-215235.yaml
+++ b/.changes/unreleased/Under the Hood-20230122-215235.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Small optimization on manifest parsing benefitting large DAGs
+time: 2023-01-22T21:52:35.549814+01:00
+custom:
+  Author: boxysean
+  Issue: "6322"

--- a/core/dbt/graph/queue.py
+++ b/core/dbt/graph/queue.py
@@ -161,7 +161,7 @@ class GraphQueue:
         queue and add them.
         """
         for node, in_degree in self.graph.in_degree():
-            if not self._already_known(node) and in_degree == 0:
+            if in_degree == 0 and not self._already_known(node):
                 self.inner.put((self._scores[node], node))
                 self.queued.add(node)
 


### PR DESCRIPTION
resolves #6697

### Description

Small optimization on manifest parsing benefitting large DAGs.

Swapping the conditions of the `if` statement as shown in 9f9608731263b7b3b3e8dfd22a9d579cb650cd54 short-circuits the relatively expensive `_already_known` method call. In a test DAG provided by my client, with 8468 models and 17103 tests, this significantly reduced calls to `_already_known` and reduced runtime in my test environment. See profiling screenshot of a `dbt compile` command:

<img width="2560" alt="Screenshot 2023-01-22 at 9 12 15 PM" src="https://user-images.githubusercontent.com/574003/213939401-d32ad906-0532-4e45-9a9c-1347ddef6390.png">

I don't know precisely what this will translate to in real-world results, but it's safe to say (1) there are fewer calls to a relatively expensive method, and (2) the logic is the same. My client reports any `dbt build` command takes 15 minutes startup time -- I hope afterwards the startup time will be between 11-12 minutes.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
