### PR TITLE
CT 1886 include adapter_response in NodeFinished log message

### DIFF
--- a/.changes/unreleased/Fixes-20230124-115837.yaml
+++ b/.changes/unreleased/Fixes-20230124-115837.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Include adapter_response in NodeFinished run_result log event
+time: 2023-01-24T11:58:37.74179-05:00
+custom:
+  Author: gshank
+  Issue: "6703"

--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -13,7 +13,7 @@ from dbt.events.types import TimingInfoCollected
 from dbt.events.proto_types import RunResultMsg, TimingInfoMsg
 from dbt.events.contextvars import get_node_info
 from dbt.logger import TimingProcessor
-from dbt.utils import lowercase, cast_to_str, cast_to_int
+from dbt.utils import lowercase, cast_to_str, cast_to_int, cast_dict_to_dict_of_strings
 from dbt.dataclass_schema import dbtClassMixin, StrEnum
 
 import agate
@@ -130,7 +130,6 @@ class BaseResult(dbtClassMixin):
         return data
 
     def to_msg(self):
-        # TODO: add more fields
         msg = RunResultMsg()
         msg.status = str(self.status)
         msg.message = cast_to_str(self.message)
@@ -138,7 +137,7 @@ class BaseResult(dbtClassMixin):
         msg.execution_time = self.execution_time
         msg.num_failures = cast_to_int(self.failures)
         msg.timing_info = [ti.to_msg() for ti in self.timing]
-        # adapter_response
+        msg.adapter_response = cast_dict_to_dict_of_strings(self.adapter_response)
         return msg
 
 

--- a/tests/functional/logging/test_logging.py
+++ b/tests/functional/logging/test_logging.py
@@ -44,6 +44,7 @@ def test_basic(project, logs_dir):
             node_start = True
         if log_event == "NodeFinished":
             node_finished = True
+            assert log_data["run_result"]["adapter_response"]
         if node_start and not node_finished:
             if log_event == "NodeExecuting":
                 assert "node_info" in log_data


### PR DESCRIPTION
resolves #6703


### Description

Include adapter_response dictionary as a dictionary of strings in the NodeFinished log event.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
