### PR TITLE
Made project version optional (default None)

### DIFF
--- a/.changes/unreleased/Features-20230124-135550.yaml
+++ b/.changes/unreleased/Features-20230124-135550.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Make project version optional
+time: 2023-01-24T13:55:50.86071024-08:00
+custom:
+  Author: seub
+  Issue: "6603"

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -525,7 +525,7 @@ class VarProvider:
 @dataclass
 class Project:
     project_name: str
-    version: Union[SemverString, float]
+    version: Optional[Union[SemverString, float]]
     project_root: str
     profile_name: Optional[str]
     model_paths: List[str]

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -184,8 +184,8 @@ BANNED_PROJECT_NAMES = {
 @dataclass
 class Project(HyphenatedDbtClassMixin, Replaceable):
     name: Identifier
-    version: Union[SemverString, float]
     config_version: int
+    version: Optional[Union[SemverString, float]] = None
     project_root: Optional[str] = None
     source_paths: Optional[List[str]] = None
     model_paths: Optional[List[str]] = None

--- a/core/dbt/tests/fixtures/project.py
+++ b/core/dbt/tests/fixtures/project.py
@@ -181,7 +181,6 @@ def dbt_project_yml(project_root, project_config_update, logs_dir):
     project_config = {
         "config-version": 2,
         "name": "test",
-        "version": "0.1.0",
         "profile": "test",
         "log-path": logs_dir,
     }

--- a/tests/functional/basic/test_project.py
+++ b/tests/functional/basic/test_project.py
@@ -1,0 +1,31 @@
+import pytest
+from dbt.tests.util import run_dbt, update_config_file
+from dbt.exceptions import ProjectContractError
+
+
+class TestProjectYamlVersionMissing:
+    # default dbt_project.yml does not fill version
+
+    def test_empty_version(self, project):
+        run_dbt(["run"], expect_pass=True)
+
+
+class TestProjectYamlVersionValid:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"version": "1.0.0"}
+
+    def test_valid_version(self, project):
+        run_dbt(["run"], expect_pass=True)
+
+
+class TestProjectYamlVersionInvalid:
+    def test_invalid_version(self, project):
+        # we need to run it so the project gets set up first, otherwise we hit the semver error in setting up the test project
+        run_dbt()
+        update_config_file({"version": "invalid"}, "dbt_project.yml")
+        with pytest.raises(ProjectContractError) as excinfo:
+            run_dbt()
+        assert "at path ['version']: 'invalid' is not valid under any of the given schemas" in str(
+            excinfo.value
+        )


### PR DESCRIPTION
resolves #6603 

### Description

This MR makes the project version optional.

I changed `Project.version` to `Optional` (default `None`) in core/dbt/config and core/dbt/contracts. 

(This change was suggested by @jtcohen6 in the issue #6603)

This config was not being used by dbt, so I believe no further changes are needed. `make test` and `make integration` both passed.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
    - https://github.com/dbt-labs/docs.getdbt.com/issues/2747
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
