### PR TITLE
change `exposure_content` to `source_content`

### DIFF
--- a/.changes/unreleased/Fixes-20230125-191739.yaml
+++ b/.changes/unreleased/Fixes-20230125-191739.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: '[Regression] exposure_content referenced incorrectly'
+time: 2023-01-25T19:17:39.942081-05:00
+custom:
+  Author: Mathyoub
+  Issue: "6738"

--- a/core/dbt/contracts/util.py
+++ b/core/dbt/contracts/util.py
@@ -283,7 +283,7 @@ def upgrade_manifest_json(manifest: dict) -> dict:
         if "root_path" in exposure_content:
             del exposure_content["root_path"]
     for source_content in manifest.get("sources", {}).values():
-        if "root_path" in exposure_content:
+        if "root_path" in source_content:
             del source_content["root_path"]
     for macro_content in manifest.get("macros", {}).values():
         if "root_path" in macro_content:


### PR DESCRIPTION
resolves #6738 

### Description

`exposure_content` was incorrectly referenced instead of `source_content` this will cause `dbt deps` to fail in certain scenarios.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
