### PR TITLE
Use IEC standard abbreviations (GiB, TiB, etc)

### DIFF
--- a/.changes/unreleased/Fixes-20230125-180056.yaml
+++ b/.changes/unreleased/Fixes-20230125-180056.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Use IEC standard abbreviations (GiB, TiB, etc)
-time: 2023-01-25T18:00:56.653435-07:00
-custom:
-  Author: dbeatty10
-  Issue: "6741"

--- a/.changes/unreleased/Fixes-20230125-180056.yaml
+++ b/.changes/unreleased/Fixes-20230125-180056.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Use IEC standard abbreviations (GiB, TiB, etc)
+time: 2023-01-25T18:00:56.653435-07:00
+custom:
+  Author: dbeatty10
+  Issue: "6741"

--- a/.changes/unreleased/Under the Hood-20230130-153306.yaml
+++ b/.changes/unreleased/Under the Hood-20230130-153306.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove BigQuery-specific btye abbreviations
+time: 2023-01-30T15:33:06.28965-07:00
+custom:
+  Author: dbeatty10
+  Issue: "6741"

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -453,26 +453,6 @@ class classproperty(object):
         return self.func(objtype)
 
 
-def format_bytes(num_bytes):
-    for unit in ["Bytes", "KiB", "MiB", "GiB", "TiB", "PiB"]:
-        if abs(num_bytes) < 1024.0:
-            return f"{num_bytes:3.1f} {unit}"
-        num_bytes /= 1024.0
-
-    num_bytes *= 1024.0
-    return f"{num_bytes:3.1f} {unit}"
-
-
-def format_rows_number(rows_number):
-    for unit in ["", "k", "m", "b", "t"]:
-        if abs(rows_number) < 1000.0:
-            return f"{rows_number:3.1f}{unit}".strip()
-        rows_number /= 1000.0
-
-    rows_number *= 1000.0
-    return f"{rows_number:3.1f}{unit}".strip()
-
-
 class ConnectingExecutor(concurrent.futures.Executor):
     def submit_connected(self, adapter, conn_name, func, *args, **kwargs):
         def connected(conn_name, func, *args, **kwargs):

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -454,7 +454,7 @@ class classproperty(object):
 
 
 def format_bytes(num_bytes):
-    for unit in ["Bytes", "KB", "MB", "GB", "TB", "PB"]:
+    for unit in ["Bytes", "KiB", "MiB", "GiB", "TiB", "PiB"]:
         if abs(num_bytes) < 1024.0:
             return f"{num_bytes:3.1f} {unit}"
         num_bytes /= 1024.0

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -145,14 +145,14 @@ class TestBytesFormatting(unittest.TestCase):
         self.assertEqual(dbt.utils.format_bytes(-1), '-1.0 Bytes')
         self.assertEqual(dbt.utils.format_bytes(0), '0.0 Bytes')
         self.assertEqual(dbt.utils.format_bytes(20), '20.0 Bytes')
-        self.assertEqual(dbt.utils.format_bytes(1030), '1.0 KB')
-        self.assertEqual(dbt.utils.format_bytes(1024**2*1.5), '1.5 MB')
-        self.assertEqual(dbt.utils.format_bytes(1024**3*52.6), '52.6 GB')
-        self.assertEqual(dbt.utils.format_bytes(1024**4*128), '128.0 TB')
-        self.assertEqual(dbt.utils.format_bytes(1024**5), '1.0 PB')
-        self.assertEqual(dbt.utils.format_bytes(1024**5*31.4), '31.4 PB')
-        self.assertEqual(dbt.utils.format_bytes(1024**6), '1024.0 PB')
-        self.assertEqual(dbt.utils.format_bytes(1024**6*42), '43008.0 PB')
+        self.assertEqual(dbt.utils.format_bytes(1030), '1.0 KiB')
+        self.assertEqual(dbt.utils.format_bytes(1024**2*1.5), '1.5 MiB')
+        self.assertEqual(dbt.utils.format_bytes(1024**3*52.6), '52.6 GiB')
+        self.assertEqual(dbt.utils.format_bytes(1024**4*128), '128.0 TiB')
+        self.assertEqual(dbt.utils.format_bytes(1024**5), '1.0 PiB')
+        self.assertEqual(dbt.utils.format_bytes(1024**5*31.4), '31.4 PiB')
+        self.assertEqual(dbt.utils.format_bytes(1024**6), '1024.0 PiB')
+        self.assertEqual(dbt.utils.format_bytes(1024**6*42), '43008.0 PiB')
 
 
 class TestRowsNumberFormatting(unittest.TestCase):

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -139,37 +139,6 @@ class TestDeepMap(unittest.TestCase):
             dbt.utils.deep_map_render(lambda x, _: x, {'foo': object()})
 
 
-class TestBytesFormatting(unittest.TestCase):
-
-    def test__simple_cases(self):
-        self.assertEqual(dbt.utils.format_bytes(-1), '-1.0 Bytes')
-        self.assertEqual(dbt.utils.format_bytes(0), '0.0 Bytes')
-        self.assertEqual(dbt.utils.format_bytes(20), '20.0 Bytes')
-        self.assertEqual(dbt.utils.format_bytes(1030), '1.0 KiB')
-        self.assertEqual(dbt.utils.format_bytes(1024**2*1.5), '1.5 MiB')
-        self.assertEqual(dbt.utils.format_bytes(1024**3*52.6), '52.6 GiB')
-        self.assertEqual(dbt.utils.format_bytes(1024**4*128), '128.0 TiB')
-        self.assertEqual(dbt.utils.format_bytes(1024**5), '1.0 PiB')
-        self.assertEqual(dbt.utils.format_bytes(1024**5*31.4), '31.4 PiB')
-        self.assertEqual(dbt.utils.format_bytes(1024**6), '1024.0 PiB')
-        self.assertEqual(dbt.utils.format_bytes(1024**6*42), '43008.0 PiB')
-
-
-class TestRowsNumberFormatting(unittest.TestCase):
-
-    def test__simple_cases(self):
-        self.assertEqual(dbt.utils.format_rows_number(-1), '-1.0')
-        self.assertEqual(dbt.utils.format_rows_number(0), '0.0')
-        self.assertEqual(dbt.utils.format_rows_number(20), '20.0')
-        self.assertEqual(dbt.utils.format_rows_number(1030), '1.0k')
-        self.assertEqual(dbt.utils.format_rows_number(1000**2*1.5), '1.5m')
-        self.assertEqual(dbt.utils.format_rows_number(1000**3*52.6), '52.6b')
-        self.assertEqual(dbt.utils.format_rows_number(1000**3*128), '128.0b')
-        self.assertEqual(dbt.utils.format_rows_number(1000**4), '1.0t')
-        self.assertEqual(dbt.utils.format_rows_number(1000**4*31.4), '31.4t')
-        self.assertEqual(dbt.utils.format_rows_number(1000**5*31.4), '31400.0t')  # noqa: E501
-
-
 class TestMultiDict(unittest.TestCase):
     def test_one_member(self):
         dct = {'a': 1, 'b': 2, 'c': 3}


### PR DESCRIPTION
resolves #6741
equivalent to https://github.com/dbt-labs/dbt-bigquery/pull/482

### Description

When using multiples of 1024, the IEC standard abbreviations are "GiB", "TiB", "PiB" instead of "GB", "TB", "PB" (which are for multiples of 1000).

### More info
Today I Learned (TIL), `format_bytes` (and `format_rows_number`) are defined in dbt-core but redefined in dbt-bigquery and only used in that adapter. So the dbt-core version is unused to best I can tell.

#### Context for the duplication
Removing them from dbt-core was mentioned [here](https://github.com/dbt-labs/dbt-bigquery/pull/48#discussion_r742152754) and [here](https://github.com/dbt-labs/dbt-bigquery/pull/48#discussion_r743485981) as part of the discussion for #48.

It feels to me like one of the following should have happened along with https://github.com/dbt-labs/dbt-bigquery/pull/48:
1. a simultaneous PR should have removed `format_bytes` and `format_rows_number` from dbt-core; or
2. [#48](https://github.com/dbt-labs/dbt-bigquery/pull/48) should have been added to dbt-core instead of dbt-bigquery.

As it stands, the implementations in dbt-core are unused (to the best that we can tell), but would probably need to be maintained to preserve backwards compatibility in case some unknown adapter is using them.

#### Proposal

Going forward, I'd propose that we choose one (and only one) of the following:
1. Keep separate implementations in dbt-core and dbt-bigquery (and fix the KB vs. KiB issue in both)
1. Remove the implementations in dbt-core (so they exist only in dbt-bigquery)
1. Completely move the implementation in dbt-bigquery back into dbt-core

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
