### PR TITLE
Replace stringified `meta` field with the actual `meta` field.

### DIFF
--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -46,8 +46,6 @@ from dbt.events.types import (
 from dbt.events.contextvars import set_contextvars
 from dbt import flags
 from dbt.node_types import ModelLanguage, NodeType
-from dbt.utils import cast_dict_to_dict_of_strings
-
 
 from .model_config import (
     NodeConfig,
@@ -207,8 +205,6 @@ class NodeInfoMixin:
 
     @property
     def node_info(self):
-        meta = getattr(self, "meta", {})
-        meta_stringified = cast_dict_to_dict_of_strings(meta)
         node_info = {
             "node_path": getattr(self, "path", None),
             "node_name": getattr(self, "name", None),
@@ -218,7 +214,7 @@ class NodeInfoMixin:
             "node_status": str(self._event_status.get("node_status")),
             "node_started_at": self._event_status.get("started_at"),
             "node_finished_at": self._event_status.get("finished_at"),
-            "meta": meta_stringified,
+            "meta": getattr(self, "meta", {}),
         }
         node_info_msg = NodeInfo(**node_info)
         return node_info_msg

--- a/tests/functional/logging/test_meta_logging.py
+++ b/tests/functional/logging/test_meta_logging.py
@@ -39,6 +39,6 @@ def test_meta(project, logs_dir):
         if node_path == "model1.sql":
             assert node_info["meta"] == {}
         elif node_path == "model2.sql":
-            assert node_info["meta"] == {"owners": "['team1', 'team2']"}
+            assert node_info["meta"] == {"owners": ["team1", "team2"]}
         elif node_path == "model3.sql":
-            assert node_info["meta"] == {"key": "1"}
+            assert node_info["meta"] == {"key": 1}


### PR DESCRIPTION
resolves #6803

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

Replaces the stringifyed `meta` field with the actual `meta` field. 

Logging before:
```
 "meta": {"owners": "['team1', 'team2']"}
```

Logging after:
```
"meta": {"owners": ["team1", "team2"]}
```

In the original PR, there was some concern about logging without stringifying, but I've tested it (manually and with a functional test) and it works.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
