### PR TITLE
CT 2000 fix semver prerelease comparisons

### DIFF
--- a/.changes/unreleased/Fixes-20230201-154418.yaml
+++ b/.changes/unreleased/Fixes-20230201-154418.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove pin on packaging and stop using it for prerelease comparisons
+time: 2023-02-01T15:44:18.279158-05:00
+custom:
+  Author: gshank
+  Issue: "6834"

--- a/core/dbt/semver.py
+++ b/core/dbt/semver.py
@@ -1,9 +1,6 @@
 from dataclasses import dataclass
 import re
-import warnings
 from typing import List
-
-from packaging import version as packaging_version
 
 from dbt.exceptions import VersionsNotCompatibleError
 import dbt.utils
@@ -68,6 +65,11 @@ $
 )
 
 _VERSION_REGEX = re.compile(_VERSION_REGEX_PAT_STR, re.VERBOSE)
+
+
+def _cmp(a, b):
+    """Return negative if a<b, zero if a==b, positive if a>b."""
+    return (a > b) - (a < b)
 
 
 @dataclass
@@ -142,13 +144,19 @@ class VersionSpecifier(VersionSpecification):
                     return 1
                 if b is None:
                     return -1
-            # This suppresses the LegacyVersion deprecation warning
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", category=DeprecationWarning)
-                if packaging_version.parse(a) > packaging_version.parse(b):
+
+                # Check the prerelease component only
+                prcmp = self._nat_cmp(a, b)
+                if prcmp != 0:  # either -1 or 1
+                    return prcmp
+                # else is equal and will fall through
+
+            else:  # major/minor/patch, should all be numbers
+                if a > b:
                     return 1
-                elif packaging_version.parse(a) < packaging_version.parse(b):
+                elif a < b:
                     return -1
+                # else is equal and will fall through
 
         equal = (
             self.matcher == Matchers.GREATER_THAN_OR_EQUAL
@@ -211,6 +219,29 @@ class VersionSpecifier(VersionSpecification):
     @property
     def is_exact(self):
         return self.matcher == Matchers.EXACT
+
+    @classmethod
+    def _nat_cmp(cls, a, b):
+        def cmp_prerelease_tag(a, b):
+            if isinstance(a, int) and isinstance(b, int):
+                return _cmp(a, b)
+            elif isinstance(a, int):
+                return -1
+            elif isinstance(b, int):
+                return 1
+            else:
+                return _cmp(a, b)
+
+        a, b = a or "", b or ""
+        a_parts, b_parts = a.split("."), b.split(".")
+        a_parts = [int(x) if re.match(r"^\d+$", x) else x for x in a_parts]
+        b_parts = [int(x) if re.match(r"^\d+$", x) else x for x in b_parts]
+        for sub_a, sub_b in zip(a_parts, b_parts):
+            cmp_result = cmp_prerelease_tag(sub_a, sub_b)
+            if cmp_result != 0:
+                return cmp_result
+        else:
+            return _cmp(len(a), len(b))
 
 
 @dataclass

--- a/core/setup.py
+++ b/core/setup.py
@@ -58,7 +58,7 @@ setup(
         "minimal-snowplow-tracker==0.0.2",
         "networkx>=2.3,<2.8.1;python_version<'3.8'",
         "networkx>=2.3,<3;python_version>='3.8'",
-        "packaging>=20.9,<22.0",
+        "packaging>20.9",
         "sqlparse>=0.2.3,<0.5",
         "dbt-extractor~=0.4.1",
         "typing-extensions>=3.7.4",

--- a/test/unit/test_semver.py
+++ b/test/unit/test_semver.py
@@ -201,12 +201,16 @@ class TestSemver(unittest.TestCase):
             '1.1.0')
 
     def test__filter_installable(self):
-        assert filter_installable(
+        installable = filter_installable(
             ['1.1.0',  '1.2.0a1', '1.0.0','2.1.0-alpha','2.2.0asdf','2.1.0','2.2.0','2.2.0-fishtown-beta','2.2.0-2'],
             install_prerelease=True
-        ) == ['1.0.0', '1.1.0', '1.2.0a1','2.1.0-alpha','2.1.0','2.2.0asdf','2.2.0-fishtown-beta','2.2.0-2','2.2.0']
+        )
+        expected = ['1.0.0', '1.1.0', '1.2.0a1','2.1.0-alpha','2.1.0','2.2.0-2','2.2.0asdf','2.2.0-fishtown-beta','2.2.0']
+        assert installable == expected
 
-        assert filter_installable(
+        installable = filter_installable(
             ['1.1.0',  '1.2.0a1', '1.0.0','2.1.0-alpha','2.2.0asdf','2.1.0','2.2.0','2.2.0-fishtown-beta'],
             install_prerelease=False
-        ) == ['1.0.0', '1.1.0','2.1.0','2.2.0']
+        )
+        expected = ['1.0.0', '1.1.0','2.1.0','2.2.0']
+        assert installable == expected


### PR DESCRIPTION
resolves #6834

### Description

In semver.py we were using packaging.version.parse to parse the prerelease portion of versions, but since that version parsing is incompatible with SemVer, it started failing once the LegacyVersion fallback was removed.

This removes the dependency on packaging and subsitutes some comparison code specifically for prepreleases, so that we can remove the pin on packaging.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
