### PR TITLE
update regex to match all iterations

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,11 @@
 [bumpversion]
 current_version = 1.5.0a1
 
+# `parse` allows parsing the version into the parts we need to check.  There are some
+# unnamed groups and that's okay because they do not need to be audited.  If any part
+# of the version passed in does not match the regex, it will fail.
 # expected matches: `1.5.0`, `1.5.0a1`, `1.5.0a1.dev123457+nightly`
-# excepted failures: `1`, `1.5`, `1.5.2-a1`
+# excepted failures: `1`, `1.5`, `1.5.2-a1`, `text1.5.0`
 parse = (?P<major>[\d]+) # major version number
 	\.(?P<minor>[\d]+) # minor version number
 	\.(?P<patch>[\d]+) # patch version number

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,12 +1,14 @@
 [bumpversion]
 current_version = 1.5.0a1
-parse = (?P<major>\d+)
-	\.(?P<minor>\d+)
-	\.(?P<patch>\d+)
-	((?P<prekind>a|b|rc)
-	(?P<pre>\d+)  # pre-release version num
-	)(\.(?P<nightly>[a-z..0-9]+)
+parse = (?P<major>[\d]+)
+	\.(?P<minor>[\d]+)
+	\.(?P<patch>[\d]+)
+	(((?P<prekind>a|b|rc)
+	?(?P<pre>[\d]+?))
+	\.?(?P<nightly>[a-z..0-9]+\+[a-z]+)?
 	)?
+
+
 serialize =
 	{major}.{minor}.{patch}{prekind}{pre}.{nightly}
 	{major}.{minor}.{patch}{prekind}{pre}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,11 +1,14 @@
 [bumpversion]
 current_version = 1.5.0a1
-parse = (?P<major>[\d]+)
-	\.(?P<minor>[\d]+)
-	\.(?P<patch>[\d]+)
-	(((?P<prekind>a|b|rc)
-	?(?P<num>[\d]+?))
-	\.?(?P<nightly>[a-z..0-9]+\+[a-z]+)?
+
+# expected matches: `1.5.0`, `1.5.0a1`, `1.5.0a1.dev123457+nightly`
+# excepted failures: `1`, `1.5`, `1.5.2-a1`
+parse = (?P<major>[\d]+) # major version number
+	\.(?P<minor>[\d]+) # minor version number
+	\.(?P<patch>[\d]+) # patch version number
+	(((?P<prekind>a|b|rc) # optional pre-release type
+	?(?P<num>[\d]+?)) # optional pre-release version number
+	\.?(?P<nightly>[a-z0-9]+\+[a-z]+)? # optional nightly release indicator
 	)?
 serialize =
 	{major}.{minor}.{patch}{prekind}{num}.{nightly}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,14 +4,12 @@ parse = (?P<major>[\d]+)
 	\.(?P<minor>[\d]+)
 	\.(?P<patch>[\d]+)
 	(((?P<prekind>a|b|rc)
-	?(?P<pre>[\d]+?))
+	?(?P<num>[\d]+?))
 	\.?(?P<nightly>[a-z..0-9]+\+[a-z]+)?
 	)?
-
-
 serialize =
-	{major}.{minor}.{patch}{prekind}{pre}.{nightly}
-	{major}.{minor}.{patch}{prekind}{pre}
+	{major}.{minor}.{patch}{prekind}{num}.{nightly}
+	{major}.{minor}.{patch}{prekind}{num}
 	{major}.{minor}.{patch}
 commit = False
 tag = False
@@ -25,7 +23,7 @@ values =
 	rc
 	final
 
-[bumpversion:part:pre]
+[bumpversion:part:num]
 first_value = 1
 
 [bumpversion:part:nightly]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ current_version = 1.5.0a1
 
 # `parse` allows parsing the version into the parts we need to check.  There are some
 # unnamed groups and that's okay because they do not need to be audited.  If any part
-# of the version passed in does not match the regex, it will fail.
+# of the version passed and does not match the regex, it will fail.
 # expected matches: `1.5.0`, `1.5.0a1`, `1.5.0a1.dev123457+nightly`
 # excepted failures: `1`, `1.5`, `1.5.2-a1`, `text1.5.0`
 parse = (?P<major>[\d]+) # major version number


### PR DESCRIPTION
### Description
The existing regex (new since nightly releases were added) had a bug and did not recognize versions without any kind of prerelease (ie. `1.5.0`).  

This change passes for the following
- `1.5.0`
- `1.5.0a1`
- `1.5.0a1.dev123457+nightly`

and fails for
- `1.5`
- `1`
- `1.5.2-a1`

Tested with release [here](https://github.com/dbt-labs/dbt-core/actions/runs/4069752682)

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
