### PR TITLE
Automate cutting new .latest branches

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -31,6 +31,7 @@ permissions:
 jobs:
   cut_branch:
     name: "Cut branch and clean up main for dbt-core"
+    # TODO: update to point at `main` once testing is complete
     uses: dbt-labs/actions/.github/workflows/cut-release-branch.yaml@er/ct-495-cleanup
     with:
       version_to_bump_main: ${{ inputs.version_to_bump_main }}

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -40,19 +40,20 @@ jobs:
   prep_work:
     runs-on: ubuntu-latest
     steps:
-      - name: Audit Version and Parse Into Parts
+      - name: Audit New Version and Parse Into Parts
         id: semver_release
         uses: dbt-labs/actions/parse-semver@v1
         with:
           version: ${{ inputs.version_to_bump_release }}
 
-      - name: Audit Version and Parse Into Parts
+      - name: Audit Existing Version and Parse Into Parts
         id: semver_main
         uses: dbt-labs/actions/parse-semver@v1
         with:
           version: ${{ inputs.version_to_bump_main }}
 
       # - name: Audit if New branch already exist?
+      # - name: Audit if old branch exist?
 
   cut_branch:
     needs: ['prep_work']
@@ -62,7 +63,7 @@ jobs:
       - name: Set branch value
         id: variables
         run: |
-          echo "::set-output name=BRANCH_NAME::release_workflow/${{ version_to_bump_release }}_version_bump"
+          echo "NEW_BRANCH_NAME=release_workflow/${{ version_to_bump_release }}_version_bump" >> GITHUB_OUTPUT
 
       - name: Cut Release Branch
         run: |
@@ -72,9 +73,9 @@ jobs:
 
       - name: Create PR branch
         run: |
-          git checkout -b ${{ steps.variables.output.BRANCH_NAME }}
-          git push origin ${{ steps.variables.output.BRANCH_NAME }}
-          git branch --set-upstream-to=origin/${{ steps.variables.output.BRANCH_NAME }} ${{ steps.variables.output.BRANCH_NAME }}
+          git checkout -b ${{ steps.variables.output.NEW_BRANCH_NAME }}
+          git push origin ${{ steps.variables.output.NEW_BRANCH_NAME }}
+          git branch --set-upstream-to=origin/${{ steps.variables.output.NEW_BRANCH_NAME }} ${{ steps.variables.output.NEW_BRANCH_NAME }}
 
       - name: Bump dependencies
         if: repo != dbt-core
@@ -86,8 +87,8 @@ jobs:
           author_name: 'Github Build Bot'
           author_email: 'buildbot@fishtownanalytics.com'
           message: 'Bumping version to ${{ inputs.version_to_bump_main }}'
-          branch: '${{ steps.variables.output.BRANCH_NAME }}'
-          push: 'origin origin/${{ steps.variables.output.BRANCH_NAME }}'
+          branch: '${{ steps.variables.output.NEW_BRANCH_NAME }}'
+          push: 'origin origin/${{ steps.variables.output.NEW_BRANCH_NAME }}'
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
@@ -95,7 +96,7 @@ jobs:
           author: 'Github Build Bot <buildbot@fishtownanalytics.com>'
           base: ${{github.ref}}
           title: 'Clean up changelogs and bump to version ${{ inputs.version_to_bump_main }}'
-          branch: '${{ steps.variables.output.BRANCH_NAME }}'
+          branch: '${{ steps.variables.output.NEW_BRANCH_NAME }}'
           labels: |
             Skip Changelog
 
@@ -112,13 +113,13 @@ jobs:
       - name: Set branch value
         id: variables
         run: |
-          echo "::set-output name=BRANCH_NAME::release_workflow/${{ version_to_bump_main }}_version_bump"
+          echo "MAIN_BRANCH_NAME=${{ main_branch_name }}" >> GITHUB_OUTPUT
 
       - name: Create PR branch
         run: |
-          git checkout -b ${{ steps.variables.output.BRANCH_NAME }}
-          git push origin ${{ steps.variables.output.BRANCH_NAME }}
-          git branch --set-upstream-to=origin/${{ steps.variables.output.BRANCH_NAME }} ${{ steps.variables.output.BRANCH_NAME }}
+          git checkout -b ${{ steps.variables.output.MAIN_BRANCH_NAME }}
+          git push origin ${{ steps.variables.output.MAIN_BRANCH_NAME }}
+          git branch --set-upstream-to=origin/${{ steps.variables.output.MAIN_BRANCH_NAME }} ${{ steps.variables.output.MAIN_BRANCH_NAME }}
 
       - name: Bump version
         run: |
@@ -133,8 +134,8 @@ jobs:
           author_name: 'Github Build Bot'
           author_email: 'buildbot@fishtownanalytics.com'
           message: 'Bumping version to ${{ inputs.version_to_bump_main }}'
-          branch: '${{ steps.variables.output.BRANCH_NAME }}'
-          push: 'origin origin/${{ steps.variables.output.BRANCH_NAME }}'
+          branch: '${{ steps.variables.output.MAIN_BRANCH_NAME }}'
+          push: 'origin origin/${{ steps.variables.output.MAIN_BRANCH_NAME }}'
 
       - name: Install Homebrew packages
         run: |

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -142,6 +142,10 @@ jobs:
           brew tap miniscruff/changie https://github.com/miniscruff/changie
           brew install changie
 
+      # Remove the directories (there will be 2) that the versioned changelogs go into
+      # Also remove the .md files
+      # then update the 0.0.0.md to add in the release branch changelog we just cut above
+      # run changie merge
       - name: Cleanup changelog
         run: |
           if [[ ${{ steps.semver.outputs.is-pre-release }} -eq 1 ]]
@@ -152,6 +156,19 @@ jobs:
           fi
           changie merge
           git status
+
+      - name: Commit changelog cleanup to branch
+        uses: EndBug/add-and-commit@v7
+        with:
+          author_name: 'Github Build Bot'
+          author_email: 'buildbot@fishtownanalytics.com'
+          message: 'Bumping version to ${{ inputs.version_to_bump_main }}'
+          branch: '${{ steps.variables.output.BRANCH_NAME }}'
+          push: 'origin origin/${{ steps.variables.output.BRANCH_NAME }}'
+
+      - name: Add testing
+        run: |
+          Update the testing matrix to include the release branch that just got cut
 
       - name: Commit changelog cleanup to branch
         uses: EndBug/add-and-commit@v7

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -1,0 +1,172 @@
+# **what?**
+#
+
+
+# **why?**
+#
+
+# **when?**
+#
+
+# Note: This should be moved into the actions repos so it can be used in all adapters as well
+
+name: Cut new release branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      main_branch_name:
+       description: 'The name of the main branch (ex. main)'
+       default: main
+       required: true
+      new_branch_name:
+       description: 'The full name of the new branch (ex. 1.5.latest)'
+       required: true
+      version_to_bump_main:
+       description: 'The alpha version main should bump to (ex. 1.6.0a1)'
+       required: true
+      version_to_bump_release:
+       description: 'The rc version main should bump to (ex. 1.5.0rc1)'
+       required: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: write
+
+jobs:
+  prep_work:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Audit Version and Parse Into Parts
+        id: semver_release
+        uses: dbt-labs/actions/parse-semver@v1
+        with:
+          version: ${{ inputs.version_to_bump_release }}
+
+      - name: Audit Version and Parse Into Parts
+        id: semver_main
+        uses: dbt-labs/actions/parse-semver@v1
+        with:
+          version: ${{ inputs.version_to_bump_main }}
+
+      # - name: Audit New branch
+
+  cut_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set branch value
+        id: variables
+        run: |
+          echo "::set-output name=BRANCH_NAME::release_workflow/${{ version_to_bump_release }}_version_bump"
+
+      - name: Cut Release Branch
+        run: |
+          git checkout -b ${{ inputs.new_branch_name }}
+          git push origin ${{ inputs.new_branch_name }}
+          git branch --set-upstream-to=origin/${{ inputs.new_branch_name }} ${{ inputs.new_branch_name }}
+
+      - name: Create PR branch
+        run: |
+          git checkout -b ${{ steps.variables.output.BRANCH_NAME }}
+          git push origin ${{ steps.variables.output.BRANCH_NAME }}
+          git branch --set-upstream-to=origin/${{ steps.variables.output.BRANCH_NAME }} ${{ steps.variables.output.BRANCH_NAME }}
+
+      - name: Bump version
+        run: |
+          source env/bin/activate
+          pip install -r dev-requirements.txt
+          env/bin/bumpversion --allow-dirty --new-version ${{ inputs.version_to_bump_release }} major
+          git status
+
+      - name: Commit version bump to branch
+        uses: EndBug/add-and-commit@v7
+        with:
+          author_name: 'Github Build Bot'
+          author_email: 'buildbot@fishtownanalytics.com'
+          message: 'Bumping version to ${{ inputs.version_to_bump_release }}'
+          branch: '${{ steps.variables.output.BRANCH_NAME }}'
+          push: 'origin origin/${{ steps.variables.output.BRANCH_NAME }}'
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          author: 'Github Build Bot <buildbot@fishtownanalytics.com>'
+          base: ${{ inputs.new_branch_name }}
+          title: 'Cut release branch and bump version to ${{ inputs.version_to_bump_release }}'
+          branch: '${{ steps.variables.output.BRANCH_NAME }}'
+          labels: |
+            Skip Changelog
+
+  cleanup_main:
+    runs-on: ubuntu-latest
+    steps:
+      - remove_changelogs
+      - version bump to alpha
+      - open PR with changes
+            # - name: Audit New branch
+      # - name: Audit New version
+      - name: Set branch value
+        id: variables
+        run: |
+          echo "::set-output name=BRANCH_NAME::release_workflow/${{ version_to_bump_main }}_version_bump"
+
+      - name: Create PR branch
+        run: |
+          git checkout -b ${{ steps.variables.output.BRANCH_NAME }}
+          git push origin ${{ steps.variables.output.BRANCH_NAME }}
+          git branch --set-upstream-to=origin/${{ steps.variables.output.BRANCH_NAME }} ${{ steps.variables.output.BRANCH_NAME }}
+
+      - name: Bump version
+        run: |
+          source env/bin/activate
+          pip install -r dev-requirements.txt
+          env/bin/bumpversion --allow-dirty --new-version ${{ inputs.version_to_bump_main }} major
+          git status
+
+      - name: Commit version bump to branch
+        uses: EndBug/add-and-commit@v7
+        with:
+          author_name: 'Github Build Bot'
+          author_email: 'buildbot@fishtownanalytics.com'
+          message: 'Bumping version to ${{ inputs.version_to_bump_main }}'
+          branch: '${{ steps.variables.output.BRANCH_NAME }}'
+          push: 'origin origin/${{ steps.variables.output.BRANCH_NAME }}'
+
+      - name: Install Homebrew packages
+        run: |
+          brew install pre-commit
+          brew tap miniscruff/changie https://github.com/miniscruff/changie
+          brew install changie
+
+      - name: Cleanup changelog
+        run: |
+          if [[ ${{ steps.semver.outputs.is-pre-release }} -eq 1 ]]
+          then
+            changie batch ${{ steps.semver.outputs.base-version }}  --move-dir '${{ steps.semver.outputs.base-version }}' --prerelease '${{ steps.semver.outputs.pre-release }}'
+          else
+            changie batch ${{ steps.semver.outputs.base-version }}  --include '${{ steps.semver.outputs.base-version }}' --remove-prereleases
+          fi
+          changie merge
+          git status
+
+      - name: Commit changelog cleanup to branch
+        uses: EndBug/add-and-commit@v7
+        with:
+          author_name: 'Github Build Bot'
+          author_email: 'buildbot@fishtownanalytics.com'
+          message: 'Bumping version to ${{ inputs.version_to_bump_main }}'
+          branch: '${{ steps.variables.output.BRANCH_NAME }}'
+          push: 'origin origin/${{ steps.variables.output.BRANCH_NAME }}'
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          author: 'Github Build Bot <buildbot@fishtownanalytics.com>'
+          base: ${{github.ref}}
+          title: 'Clean up changelogs and bump to version ${{ inputs.version_to_bump_main }}'
+          branch: '${{ steps.variables.output.BRANCH_NAME }}'
+          labels: |
+            Skip Changelog

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -21,8 +21,10 @@
 #   changelog:
 #     uses: dbt-labs/actions/.github/workflows/cut-release-branch.yml@main
 #    with:
-#      release_branch_name: 1.2.latest
-#      sha: 0e60fc1  (or nothing!)
+#      version_to_bump_main: 1.3.0a1
+#      new_branch_name: 1.2.latest
+#      dependency_bump_script_path: scripts/
+#      repository: dbt-snowflake
 #    secrets: inherit # this is only acceptable because we own the action we're calling
 #
 
@@ -36,16 +38,18 @@ name: Cut new release branch
 on:
   workflow_dispatch:
     inputs:
-      main_branch_name:
-       description: 'The name of the main branch (ex. main)'
-       default: main
-       required: true
       version_to_bump_main:
-       description: 'The alpha version main should bump to (ex. 1.6.0a1)'
-       required: true
+        description: 'The alpha version main should bump to (ex. 1.6.0a1)'
+        required: true
       new_branch_name:
-       description: 'The full name of the new branch (ex. 1.5.latest)'
-       required: true
+        description: 'The full name of the new branch (ex. 1.5.latest)'
+        required: true
+      dependency_bump_script_path:
+        description: "Path to the script to bump dependencies on the release branch"
+        required: false  # not used in dbt-core
+      repository:
+        description: "Repository to create new branch and cleanup main"
+        required: true
 
 defaults:
   run:
@@ -57,35 +61,46 @@ permissions:
 jobs:
   prep_work:
     runs-on: ubuntu-latest
+    outputs:
+      base_version: ${{ steps.semver.outputs.base-version }}
     steps:
-      - name: Audit New Version and Parse Into Parts
-        id: semver_release
-        uses: dbt-labs/actions/parse-semver@v1
-        with:
-          version: ${{ inputs.version_to_bump_release }}
+      - name: "[DEBUG] Print Inputs"
+        run: |
+          echo "Version to bump main:    ${{ inputs.version_to_bump_main }}"
+          echo "Name of branch to cut:   ${{ inputs.new_branch_name }}"
 
-      - name: Audit Existing Version and Parse Into Parts
-        id: semver_main
+      - name: Audit New Version and Parse Into Parts
+        id: semver
         uses: dbt-labs/actions/parse-semver@v1
         with:
           version: ${{ inputs.version_to_bump_main }}
 
-      # - name: Audit if New branch already exist?
-      # - name: Audit if old branch exist?
+      - name: "Checkout ${{ inputs.repository }} repository"
+        uses: actions/checkout@v4.3.0
+        with:
+          repository: ${{ inputs.repository }}
+
+      - name: "Audit if New Branch Already Exists"
+        id: check_new_branch
+        run: |
+          if git show-ref --quiet refs/heads/${{ inputs.new_branch_name }}; then
+            echo "Branch ${{ inputs.new_branch_name }} already exists.  Exiting."
+            exit 1
+          fi
 
   cut_branch:
     needs: ['prep_work']
-    if: prep_work.needs.output.branch_exists = false
     runs-on: ubuntu-latest
     steps:
-      - name: Set branch value
-        id: variables
-        run: |
-          echo "NEW_BRANCH_NAME=${{ inputs.version_to_bump_release }}" >> GITHUB_OUTPUT
+
+      - name: "Checkout ${{ inputs.repository }} repository"
+        uses: actions/checkout@v4.3.0
+        with:
+          repository: ${{ inputs.repository }}
 
       - name: Create new release branch
         run: |
-          git checkout -b ${{ steps.variables.output.NEW_BRANCH_NAME }}
+          git checkout -b ${{ inputs.new_branch_name }}
 
       - name: Bump dependencies
         if: repo != dbt-core
@@ -98,20 +113,24 @@ jobs:
         with:
           author_name: 'Github Build Bot'
           author_email: 'buildbot@fishtownanalytics.com'
-          message: 'Cutting .latest branch ${{ steps.variables.output.NEW_BRANCH_NAME }}'
-          branch: '${{ steps.variables.output.NEW_BRANCH_NAME }}'
-          push: 'origin origin/${{ steps.variables.output.NEW_BRANCH_NAME }}'
+          message: 'Cutting .latest branch ${{ inputs.new_branch_name }}'
+          branch: '${{ inputs.new_branch_name }}'
+          push: 'origin origin/${{ inputs.new_branch_name }}'
 
   cleanup_main:
-    needs: ['cut_branch']
-    if: success() # todo: does it run even if cut_branch was skipped - should it?
+    needs: [prep_work, 'cut_branch']
     runs-on: ubuntu-latest
     steps:
 
       - name: Set branch value
         id: variables
         run: |
-          echo "BRANCH_NAME=cutting_latest_branch/${{ inputs.main_branch_name }}_cleanup" >> GITHUB_OUTPUT
+          echo "BRANCH_NAME=cutting_release_branch/main_cleanup" >> GITHUB_OUTPUT
+
+      - name: "Checkout ${{ inputs.repository }} repository"
+        uses: actions/checkout@v4.3.0
+        with:
+          repository: ${{ inputs.repository }}
 
       - name: Create PR branch
         run: |
@@ -141,12 +160,7 @@ jobs:
           brew tap miniscruff/changie https://github.com/miniscruff/changie
           brew install changie
 
-      # Remove the directories (there will be 2) that the versioned changelogs go into
-      # Also remove the .md files
-      # then update the 0.0.0.md to add in the release branch changelog we just cut above
-      # run changie merge
       - name: Check if any unreleased changelog files exists
-        # if there are no changelog entries, exit!
         shell: bash
         id: unreleased_changelog_check
         run: |
@@ -160,12 +174,11 @@ jobs:
           fi
 
       - name: "Check if any prerelease changelog files exists"
-        # if there are no changelog entries, exit!
         shell: bash
         id: prerelease_changelog_check
         run: |
           git fetch origin ${{ inputs.sha }}
-          if echo grep '.changes/${{ steps.semver.outputs.base-version }}/.*.yaml'; then
+          if echo grep '.changes/${{ needs.prep_work.outputs.base_version }}/.*.yaml'; then
             echo "prerelease_exists=true" >> GITHUB_OUTPUT
             echo "Changelogs exist for this PR, delete them now"
           else
@@ -174,27 +187,26 @@ jobs:
           fi
 
       - name: "Delete unreleased Changelogs"
-        if: ${{ steps.unreleased_changelog_check.outputs.unreleased_exists }}
+        if: ${{ steps.unreleased_changelog_check.outputs.unreleased_exists }} = true
         run: |
           rm .changes/unreleased/*.yaml
 
       - name: Delete unreleased Changelogs
-        if: ${{ steps.prerelease_changelog_check.outputs.prerelease_exists }}
+        if: ${{ steps.prerelease_changelog_check.outputs.prerelease_exists }} = true
         run: |
-          rm .changes/${{ steps.semver.outputs.base-version }}/*.yaml
-          rm .changes/${{ steps.semver.outputs.base-version }}.*.md  #TODO: figure this regex
+          rm .changes/${{ needs.prep_work.outputs.base_version }}/*.yaml
+          rm .changes/${{ needs.prep_work.outputs.base_version }}.*.md  #TODO: figure this regex
 
       - name: "Cleanup CHANGELOG.md"
         run: |
           changie merge
-          git status
 
       - name: Commit changelog cleanup to branch
         uses: EndBug/add-and-commit@v7
         with:
           author_name: 'Github Build Bot'
           author_email: 'buildbot@fishtownanalytics.com'
-          message: 'Clean up changelog on ${{ inputs.main_branch_name }}'
+          message: 'Clean up changelog on main'
           branch: '${{ steps.variables.output.BRANCH_NAME }}'
           push: 'origin origin/${{ steps.variables.output.BRANCH_NAME }}'
 

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -1,11 +1,29 @@
 # **what?**
+# Cuts the `*.latest` branch, bumps dependencies on it, cleans up all files in `.changes/unreleased`
+# on main and bumps main to the next alpha..
 #
-
 
 # **why?**
-#
+# Clean up the main branch after a release branch is cut and automate cutting the release branch.
+# Generally reduces the workload of engineers and reducing error.
 
 # **when?**
+# This will run when called manually in a workflow.
+
+# Example Usage including required permissions:  TODO: update once finalized
+
+# permissions:
+#   contents: read
+#   pull-requests: write
+#
+# name: Cut Release Branch
+# jobs:
+#   changelog:
+#     uses: dbt-labs/actions/.github/workflows/cut-release-branch.yml@main
+#    with:
+#      release_branch_name: 1.2.latest
+#      sha: 0e60fc1  (or nothing!)
+#    secrets: inherit # this is only acceptable because we own the action we're calling
 #
 
 # Note: This should be moved into the actions repos so it can be used in all adapters as well
@@ -72,7 +90,7 @@ jobs:
       - name: Bump dependencies
         if: repo != dbt-core
         run: |
-          echo ruinning some script now
+          echo "running some script yet to be written now"
           # TODO: some_script because each adapter is different
 
       - name: Commit dependency change
@@ -80,7 +98,7 @@ jobs:
         with:
           author_name: 'Github Build Bot'
           author_email: 'buildbot@fishtownanalytics.com'
-          message: 'Cutting .latests branch ${{ steps.variables.output.NEW_BRANCH_NAME }}'
+          message: 'Cutting .latest branch ${{ steps.variables.output.NEW_BRANCH_NAME }}'
           branch: '${{ steps.variables.output.NEW_BRANCH_NAME }}'
           push: 'origin origin/${{ steps.variables.output.NEW_BRANCH_NAME }}'
 

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -1,37 +1,13 @@
 # **what?**
-# Cuts the `*.latest` branch, bumps dependencies on it, cleans up all files in `.changes/unreleased`
-# on main and bumps main to the next alpha..
-#
+# Cuts a new `*.latest` branch
+# Also cleans up all files in `.changes/unreleased` and `.changes/previous verion on
+# `main` and bumps `main` to the input version.
 
 # **why?**
-# Clean up the main branch after a release branch is cut and automate cutting the release branch.
-# Generally reduces the workload of engineers and reducing error.
+# Generally reduces the workload of engineers and reduces error.  Allow automation.
 
 # **when?**
-# This will run when called manually in a workflow.
-
-# Example Usage including required permissions:  TODO: update once finalized
-
-# permissions:
-#   contents: read
-#   pull-requests: write
-#
-# name: Cut Release Branch
-# jobs:
-#   changelog:
-#     uses: dbt-labs/actions/.github/workflows/cut-release-branch.yml@main
-#    with:
-#      version_to_bump_main: 1.3.0a1
-#      new_branch_name: 1.2.latest
-#      dependency_bump_script_path: scripts/
-#      repository: dbt-snowflake
-#    secrets: inherit # this is only acceptable because we own the action we're calling
-#
-
-# Note: This should be moved into the actions repos so it can be used in all adapters as well
-# string together all updates into single action
-# Should open PRs in all repos, do all adapters first then put link to all adapter PRs in the core PR talking about dependency
-# add note to eventually commit changes directly and bypass checks - same as release - when we move to this model run test action after merge
+# This will run when called manually.
 
 name: Cut new release branch
 
@@ -44,12 +20,6 @@ on:
       new_branch_name:
         description: 'The full name of the new branch (ex. 1.5.latest)'
         required: true
-      dependency_bump_script_path:
-        description: "Path to the script to bump dependencies on the release branch"
-        required: false  # not used in dbt-core
-      repository:
-        description: "Repository to create new branch and cleanup main"
-        required: true
 
 defaults:
   run:
@@ -59,163 +29,13 @@ permissions:
   contents: write
 
 jobs:
-  prep_work:
-    runs-on: ubuntu-latest
-    outputs:
-      base_version: ${{ steps.semver.outputs.base-version }}
-    steps:
-      - name: "[DEBUG] Print Inputs"
-        run: |
-          echo "Version to bump main:    ${{ inputs.version_to_bump_main }}"
-          echo "Name of branch to cut:   ${{ inputs.new_branch_name }}"
-
-      - name: Audit New Version and Parse Into Parts
-        id: semver
-        uses: dbt-labs/actions/parse-semver@v1
-        with:
-          version: ${{ inputs.version_to_bump_main }}
-
-      - name: "Checkout ${{ inputs.repository }} repository"
-        uses: actions/checkout@v4.3.0
-        with:
-          repository: ${{ inputs.repository }}
-
-      - name: "Audit if New Branch Already Exists"
-        id: check_new_branch
-        run: |
-          if git show-ref --quiet refs/heads/${{ inputs.new_branch_name }}; then
-            echo "Branch ${{ inputs.new_branch_name }} already exists.  Exiting."
-            exit 1
-          fi
-
   cut_branch:
-    needs: ['prep_work']
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: "Checkout ${{ inputs.repository }} repository"
-        uses: actions/checkout@v4.3.0
-        with:
-          repository: ${{ inputs.repository }}
-
-      - name: Create new release branch
-        run: |
-          git checkout -b ${{ inputs.new_branch_name }}
-
-      - name: Bump dependencies
-        if: repo != dbt-core
-        run: |
-          echo "running some script yet to be written now"
-          # TODO: some_script because each adapter is different
-
-      - name: Commit dependency change
-        uses: EndBug/add-and-commit@v7
-        with:
-          author_name: 'Github Build Bot'
-          author_email: 'buildbot@fishtownanalytics.com'
-          message: 'Cutting .latest branch ${{ inputs.new_branch_name }}'
-          branch: '${{ inputs.new_branch_name }}'
-          push: 'origin origin/${{ inputs.new_branch_name }}'
-
-  cleanup_main:
-    needs: [prep_work, 'cut_branch']
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Set branch value
-        id: variables
-        run: |
-          echo "BRANCH_NAME=cutting_release_branch/main_cleanup" >> GITHUB_OUTPUT
-
-      - name: "Checkout ${{ inputs.repository }} repository"
-        uses: actions/checkout@v4.3.0
-        with:
-          repository: ${{ inputs.repository }}
-
-      - name: Create PR branch
-        run: |
-          git checkout -b ${{ steps.variables.output.BRANCH_NAME }}
-          git push origin ${{ steps.variables.output.BRANCH_NAME }}
-          git branch --set-upstream-to=origin/${{ steps.variables.output.BRANCH_NAME }} ${{ steps.variables.output.BRANCH_NAME }}
-
-      - name: Bump version
-        run: |
-          source env/bin/activate
-          pip install -r dev-requirements.txt
-          env/bin/bumpversion --allow-dirty --new-version ${{ inputs.version_to_bump_main }} major
-          git status
-
-      - name: Commit version bump to branch
-        uses: EndBug/add-and-commit@v7
-        with:
-          author_name: 'Github Build Bot'
-          author_email: 'buildbot@fishtownanalytics.com'
-          message: 'Bumping version to ${{ inputs.version_to_bump_main }}'
-          branch: '${{ steps.variables.output.BRANCH_NAME }}'
-          push: 'origin origin/${{ steps.variables.output.BRANCH_NAME }}'
-
-      - name: Install Homebrew packages
-        run: |
-          brew install pre-commit
-          brew tap miniscruff/changie https://github.com/miniscruff/changie
-          brew install changie
-
-      - name: Check if any unreleased changelog files exists
-        shell: bash
-        id: unreleased_changelog_check
-        run: |
-          git fetch origin ${{ inputs.sha }}
-          if echo grep '.changes/unreleased/.*.yaml'; then
-            echo "unreleased_exists=true" >> GITHUB_OUTPUT
-            echo "Unreleased changelogs exist for this PR, they will be deleted"
-          else
-            echo "unreleased_exists=false" >> GITHUB_OUTPUT
-            echo "No unreleased changelog exists for this PR, nothing to delete"
-          fi
-
-      - name: "Check if any prerelease changelog files exists"
-        shell: bash
-        id: prerelease_changelog_check
-        run: |
-          git fetch origin ${{ inputs.sha }}
-          if echo grep '.changes/${{ needs.prep_work.outputs.base_version }}/.*.yaml'; then
-            echo "prerelease_exists=true" >> GITHUB_OUTPUT
-            echo "Changelogs exist for this PR, delete them now"
-          else
-            echo "prerelease_exists=false" >> GITHUB_OUTPUT
-            echo "No prerelease changelogs exists for this PR, nothing to delete"
-          fi
-
-      - name: "Delete unreleased Changelogs"
-        if: ${{ steps.unreleased_changelog_check.outputs.unreleased_exists }} = true
-        run: |
-          rm .changes/unreleased/*.yaml
-
-      - name: Delete unreleased Changelogs
-        if: ${{ steps.prerelease_changelog_check.outputs.prerelease_exists }} = true
-        run: |
-          rm .changes/${{ needs.prep_work.outputs.base_version }}/*.yaml
-          rm .changes/${{ needs.prep_work.outputs.base_version }}.*.md  #TODO: figure this regex
-
-      - name: "Cleanup CHANGELOG.md"
-        run: |
-          changie merge
-
-      - name: Commit changelog cleanup to branch
-        uses: EndBug/add-and-commit@v7
-        with:
-          author_name: 'Github Build Bot'
-          author_email: 'buildbot@fishtownanalytics.com'
-          message: 'Clean up changelog on main'
-          branch: '${{ steps.variables.output.BRANCH_NAME }}'
-          push: 'origin origin/${{ steps.variables.output.BRANCH_NAME }}'
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
-        with:
-          author: 'Github Build Bot <buildbot@fishtownanalytics.com>'
-          base: ${{github.ref}}
-          title: 'Clean up changelogs and bump to version ${{ inputs.version_to_bump_main }}'
-          branch: '${{ steps.variables.output.BRANCH_NAME }}'
-          labels: |
-            Skip Changelog
+    name: "Cut branch and clean up main for dbt-core"
+    uses: dbt-labs/actions/.github/workflows/cut-release-branch.yaml@er/ct-495-cleanup
+    with:
+      version_to_bump_main: ${{ inputs.version_to_bump_main }}
+      new_branch_name: ${{ inputs.new_branch_name }}
+      PR_title: "Cleanup main after cutting new ${{ inputs.new_branch_name }} branch"
+      PR_body: "All adapter PRs will fail CI until the dbt-core PR has been merged due to release version conflicts."
+    secrets:
+      FISHTOWN_BOT_PAT: ${{ secrets.FISHTOWN_BOT_PAT }}

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -9,6 +9,9 @@
 #
 
 # Note: This should be moved into the actions repos so it can be used in all adapters as well
+# string together all updates into single action
+# Should open PRs in all repos, do all adapters first then put link to all adapter PRs in the core PR talking about dependency
+# add note to eventually commit changes directly and bypass checks - same as release - when we move to this model run test action after merge
 
 name: Cut new release branch
 
@@ -19,14 +22,11 @@ on:
        description: 'The name of the main branch (ex. main)'
        default: main
        required: true
-      new_branch_name:
-       description: 'The full name of the new branch (ex. 1.5.latest)'
-       required: true
       version_to_bump_main:
        description: 'The alpha version main should bump to (ex. 1.6.0a1)'
        required: true
-      version_to_bump_release:
-       description: 'The rc version main should bump to (ex. 1.5.0rc1)'
+      new_branch_name:
+       description: 'The full name of the new branch (ex. 1.5.latest)'
        required: true
 
 defaults:
@@ -52,9 +52,11 @@ jobs:
         with:
           version: ${{ inputs.version_to_bump_main }}
 
-      # - name: Audit New branch
+      # - name: Audit if New branch already exist?
 
   cut_branch:
+    needs: ['prep_work']
+    if: prep_work.needs.output.branch_exists = false
     runs-on: ubuntu-latest
     steps:
       - name: Set branch value
@@ -74,19 +76,16 @@ jobs:
           git push origin ${{ steps.variables.output.BRANCH_NAME }}
           git branch --set-upstream-to=origin/${{ steps.variables.output.BRANCH_NAME }} ${{ steps.variables.output.BRANCH_NAME }}
 
-      - name: Bump version
-        run: |
-          source env/bin/activate
-          pip install -r dev-requirements.txt
-          env/bin/bumpversion --allow-dirty --new-version ${{ inputs.version_to_bump_release }} major
-          git status
+      - name: Bump dependencies
+        if: repo != dbt-core
+        run: some_script because each adapter is different
 
-      - name: Commit version bump to branch
+      - name: Commit dependency change
         uses: EndBug/add-and-commit@v7
         with:
           author_name: 'Github Build Bot'
           author_email: 'buildbot@fishtownanalytics.com'
-          message: 'Bumping version to ${{ inputs.version_to_bump_release }}'
+          message: 'Bumping version to ${{ inputs.version_to_bump_main }}'
           branch: '${{ steps.variables.output.BRANCH_NAME }}'
           push: 'origin origin/${{ steps.variables.output.BRANCH_NAME }}'
 
@@ -94,13 +93,15 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           author: 'Github Build Bot <buildbot@fishtownanalytics.com>'
-          base: ${{ inputs.new_branch_name }}
-          title: 'Cut release branch and bump version to ${{ inputs.version_to_bump_release }}'
+          base: ${{github.ref}}
+          title: 'Clean up changelogs and bump to version ${{ inputs.version_to_bump_main }}'
           branch: '${{ steps.variables.output.BRANCH_NAME }}'
           labels: |
             Skip Changelog
 
   cleanup_main:
+    needs: ['cut_branch']
+    if: success() # runs even if cut_branch was skipped
     runs-on: ubuntu-latest
     steps:
       - remove_changelogs

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -63,63 +63,43 @@ jobs:
       - name: Set branch value
         id: variables
         run: |
-          echo "NEW_BRANCH_NAME=release_workflow/${{ version_to_bump_release }}_version_bump" >> GITHUB_OUTPUT
+          echo "NEW_BRANCH_NAME=${{ inputs.version_to_bump_release }}" >> GITHUB_OUTPUT
 
-      - name: Cut Release Branch
-        run: |
-          git checkout -b ${{ inputs.new_branch_name }}
-          git push origin ${{ inputs.new_branch_name }}
-          git branch --set-upstream-to=origin/${{ inputs.new_branch_name }} ${{ inputs.new_branch_name }}
-
-      - name: Create PR branch
+      - name: Create new release branch
         run: |
           git checkout -b ${{ steps.variables.output.NEW_BRANCH_NAME }}
-          git push origin ${{ steps.variables.output.NEW_BRANCH_NAME }}
-          git branch --set-upstream-to=origin/${{ steps.variables.output.NEW_BRANCH_NAME }} ${{ steps.variables.output.NEW_BRANCH_NAME }}
 
       - name: Bump dependencies
         if: repo != dbt-core
-        run: some_script because each adapter is different
+        run: |
+          echo ruinning some script now
+          # TODO: some_script because each adapter is different
 
       - name: Commit dependency change
         uses: EndBug/add-and-commit@v7
         with:
           author_name: 'Github Build Bot'
           author_email: 'buildbot@fishtownanalytics.com'
-          message: 'Bumping version to ${{ inputs.version_to_bump_main }}'
+          message: 'Cutting .latests branch ${{ steps.variables.output.NEW_BRANCH_NAME }}'
           branch: '${{ steps.variables.output.NEW_BRANCH_NAME }}'
           push: 'origin origin/${{ steps.variables.output.NEW_BRANCH_NAME }}'
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
-        with:
-          author: 'Github Build Bot <buildbot@fishtownanalytics.com>'
-          base: ${{github.ref}}
-          title: 'Clean up changelogs and bump to version ${{ inputs.version_to_bump_main }}'
-          branch: '${{ steps.variables.output.NEW_BRANCH_NAME }}'
-          labels: |
-            Skip Changelog
-
   cleanup_main:
     needs: ['cut_branch']
-    if: success() # runs even if cut_branch was skipped
+    if: success() # todo: does it run even if cut_branch was skipped - should it?
     runs-on: ubuntu-latest
     steps:
-      - remove_changelogs
-      - version bump to alpha
-      - open PR with changes
-            # - name: Audit New branch
-      # - name: Audit New version
+
       - name: Set branch value
         id: variables
         run: |
-          echo "MAIN_BRANCH_NAME=${{ main_branch_name }}" >> GITHUB_OUTPUT
+          echo "BRANCH_NAME=cutting_latest_branch/${{ inputs.main_branch_name }}_cleanup" >> GITHUB_OUTPUT
 
       - name: Create PR branch
         run: |
-          git checkout -b ${{ steps.variables.output.MAIN_BRANCH_NAME }}
-          git push origin ${{ steps.variables.output.MAIN_BRANCH_NAME }}
-          git branch --set-upstream-to=origin/${{ steps.variables.output.MAIN_BRANCH_NAME }} ${{ steps.variables.output.MAIN_BRANCH_NAME }}
+          git checkout -b ${{ steps.variables.output.BRANCH_NAME }}
+          git push origin ${{ steps.variables.output.BRANCH_NAME }}
+          git branch --set-upstream-to=origin/${{ steps.variables.output.BRANCH_NAME }} ${{ steps.variables.output.BRANCH_NAME }}
 
       - name: Bump version
         run: |
@@ -134,8 +114,8 @@ jobs:
           author_name: 'Github Build Bot'
           author_email: 'buildbot@fishtownanalytics.com'
           message: 'Bumping version to ${{ inputs.version_to_bump_main }}'
-          branch: '${{ steps.variables.output.MAIN_BRANCH_NAME }}'
-          push: 'origin origin/${{ steps.variables.output.MAIN_BRANCH_NAME }}'
+          branch: '${{ steps.variables.output.BRANCH_NAME }}'
+          push: 'origin origin/${{ steps.variables.output.BRANCH_NAME }}'
 
       - name: Install Homebrew packages
         run: |
@@ -147,14 +127,47 @@ jobs:
       # Also remove the .md files
       # then update the 0.0.0.md to add in the release branch changelog we just cut above
       # run changie merge
-      - name: Cleanup changelog
+      - name: Check if any unreleased changelog files exists
+        # if there are no changelog entries, exit!
+        shell: bash
+        id: unreleased_changelog_check
         run: |
-          if [[ ${{ steps.semver.outputs.is-pre-release }} -eq 1 ]]
-          then
-            changie batch ${{ steps.semver.outputs.base-version }}  --move-dir '${{ steps.semver.outputs.base-version }}' --prerelease '${{ steps.semver.outputs.pre-release }}'
+          git fetch origin ${{ inputs.sha }}
+          if echo grep '.changes/unreleased/.*.yaml'; then
+            echo "unreleased_exists=true" >> GITHUB_OUTPUT
+            echo "Unreleased changelogs exist for this PR, they will be deleted"
           else
-            changie batch ${{ steps.semver.outputs.base-version }}  --include '${{ steps.semver.outputs.base-version }}' --remove-prereleases
+            echo "unreleased_exists=false" >> GITHUB_OUTPUT
+            echo "No unreleased changelog exists for this PR, nothing to delete"
           fi
+
+      - name: "Check if any prerelease changelog files exists"
+        # if there are no changelog entries, exit!
+        shell: bash
+        id: prerelease_changelog_check
+        run: |
+          git fetch origin ${{ inputs.sha }}
+          if echo grep '.changes/${{ steps.semver.outputs.base-version }}/.*.yaml'; then
+            echo "prerelease_exists=true" >> GITHUB_OUTPUT
+            echo "Changelogs exist for this PR, delete them now"
+          else
+            echo "prerelease_exists=false" >> GITHUB_OUTPUT
+            echo "No prerelease changelogs exists for this PR, nothing to delete"
+          fi
+
+      - name: "Delete unreleased Changelogs"
+        if: ${{ steps.unreleased_changelog_check.outputs.unreleased_exists }}
+        run: |
+          rm .changes/unreleased/*.yaml
+
+      - name: Delete unreleased Changelogs
+        if: ${{ steps.prerelease_changelog_check.outputs.prerelease_exists }}
+        run: |
+          rm .changes/${{ steps.semver.outputs.base-version }}/*.yaml
+          rm .changes/${{ steps.semver.outputs.base-version }}.*.md  #TODO: figure this regex
+
+      - name: "Cleanup CHANGELOG.md"
+        run: |
           changie merge
           git status
 
@@ -163,20 +176,7 @@ jobs:
         with:
           author_name: 'Github Build Bot'
           author_email: 'buildbot@fishtownanalytics.com'
-          message: 'Bumping version to ${{ inputs.version_to_bump_main }}'
-          branch: '${{ steps.variables.output.BRANCH_NAME }}'
-          push: 'origin origin/${{ steps.variables.output.BRANCH_NAME }}'
-
-      - name: Add testing
-        run: |
-          Update the testing matrix to include the release branch that just got cut
-
-      - name: Commit changelog cleanup to branch
-        uses: EndBug/add-and-commit@v7
-        with:
-          author_name: 'Github Build Bot'
-          author_email: 'buildbot@fishtownanalytics.com'
-          message: 'Bumping version to ${{ inputs.version_to_bump_main }}'
+          message: 'Clean up changelog on ${{ inputs.main_branch_name }}'
           branch: '${{ steps.variables.output.BRANCH_NAME }}'
           push: 'origin origin/${{ steps.variables.output.BRANCH_NAME }}'
 


### PR DESCRIPTION
resolves #5074 

### Description

Calls reusable workflow to cut new latest branch and clean up main.

I tested this in a fork and there was some weirdness with the PRs getting opened but I believe that stems from using a fork.  Since this is just calling the other workflow it is good to merge into main now since it won't need changes, the workflow in `dbt-labs/actions` would.  This will eventually need to be updated to point at the workflow on `main` instead of the branch.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
