### PR TITLE
Test fix: `TestProfileEnvVars::test_profile_env_vars`

### DIFF
--- a/tests/functional/partial_parsing/test_pp_vars.py
+++ b/tests/functional/partial_parsing/test_pp_vars.py
@@ -330,6 +330,7 @@ class TestProfileEnvVars:
         # Change env_vars, the user doesn't exist, this should fail
         os.environ["ENV_VAR_USER"] = "fake_user"
 
+        # N.B. run_dbt_and_capture won't work here because FailedToConnectError ends the test entirely
         with pytest.raises(FailedToConnectError):
             run_dbt(["run"], expect_pass=False)
 

--- a/tests/functional/partial_parsing/test_pp_vars.py
+++ b/tests/functional/partial_parsing/test_pp_vars.py
@@ -1,30 +1,28 @@
-import pytest
+import os
+from pathlib import Path
 
-from dbt.tests.util import run_dbt, write_file, run_dbt_and_capture, get_manifest
+import pytest
+from dbt.constants import SECRET_ENV_PREFIX
+from dbt.exceptions import FailedToConnectError, ParsingError
+from dbt.tests.util import get_manifest, run_dbt, run_dbt_and_capture, write_file
 
 from tests.functional.partial_parsing.fixtures import (
-    model_color_sql,
-    env_var_model_sql,
-    env_var_schema_yml,
-    env_var_model_one_sql,
-    raw_customers_csv,
-    env_var_sources_yml,
-    test_color_sql,
-    env_var_schema2_yml,
-    env_var_schema3_yml,
     env_var_macro_sql,
     env_var_macros_yml,
-    env_var_model_test_yml,
-    people_sql,
     env_var_metrics_yml,
+    env_var_model_one_sql,
+    env_var_model_sql,
+    env_var_model_test_yml,
+    env_var_schema2_yml,
+    env_var_schema3_yml,
+    env_var_schema_yml,
+    env_var_sources_yml,
+    model_color_sql,
     model_one_sql,
+    people_sql,
+    raw_customers_csv,
+    test_color_sql,
 )
-
-
-from dbt.exceptions import ParsingError
-from dbt.constants import SECRET_ENV_PREFIX
-import os
-
 
 os.environ["DBT_PP_TEST"] = "true"
 
@@ -325,14 +323,19 @@ class TestProfileEnvVars:
         os.environ["ENV_VAR_USER"] = "root"
         os.environ["ENV_VAR_PASS"] = "password"
 
-        results = run_dbt(["run"])
+        run_dbt(["run"])
         manifest = get_manifest(project.project_root)
         env_vars_checksum = manifest.state_check.profile_env_vars_hash.checksum
 
         # Change env_vars, the user doesn't exist, this should fail
         os.environ["ENV_VAR_USER"] = "fake_user"
-        (results, log_output) = run_dbt_and_capture(["run"], expect_pass=False)
+
+        with pytest.raises(FailedToConnectError):
+            run_dbt(["run"], expect_pass=False)
+
+        log_output = Path(project.project_root, "logs", "dbt.log").read_text()
         assert "env vars used in profiles.yml have changed" in log_output
+
         manifest = get_manifest(project.project_root)
         assert env_vars_checksum != manifest.state_check.profile_env_vars_hash.checksum
 


### PR DESCRIPTION
resolves # 
https://media.tenor.com/5WTzTOGLLyEAAAAC/no-ticket-indiana-jones.gif

### Description
Fixes issue where `FailedToConnectError` errors stop test from being completed due to not using `pytest.raises`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
