### PR TITLE
Backport to 1.4.latest: Fix a regression in the behavior of the -q/--quiet cli param…

### DIFF
--- a/.changes/unreleased/Fixes-20230207-143544.yaml
+++ b/.changes/unreleased/Fixes-20230207-143544.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix regression of --quiet cli parameter behavior
+time: 2023-02-07T14:35:44.160163-05:00
+custom:
+  Author: peterallenwebb
+  Issue: "6749"

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -18,6 +18,14 @@ LOG_VERSION = 3
 metadata_vars: Optional[Dict[str, str]] = None
 
 
+# The "fallback" logger is used as a stop-gap so that console logging works before the logging
+# configuration is fully loaded.
+def setup_fallback_logger(use_legacy: bool, level: EventLevel) -> None:
+    cleanup_event_logger()
+    config = _get_logbook_log_config(level) if use_legacy else _get_stdout_config(level)
+    EVENT_MANAGER.add_logger(config)
+
+
 def setup_event_logger(log_path: str, level_override: Optional[EventLevel] = None):
     cleanup_event_logger()
     make_log_dir_if_missing(log_path)
@@ -113,9 +121,7 @@ def cleanup_event_logger():
 # currently fire before logs can be configured by setup_event_logger(), we
 # create a default configuration with default settings and no file output.
 EVENT_MANAGER: EventManager = EventManager()
-EVENT_MANAGER.add_logger(
-    _get_logbook_log_config() if flags.ENABLE_LEGACY_LOGGER else _get_stdout_config()
-)
+setup_fallback_logger(bool(flags.ENABLE_LEGACY_LOGGER), EventLevel.INFO)
 
 
 # This global, and the following two functions for capturing stdout logs are


### PR DESCRIPTION

resolves #6749

### Description

Backports the main branch to the 1.4.latest.

This change addresses a regression which caused dbt to write non-error messages to the console, even when the -q/--quiet flag was used. This happened when the messages were logged before the final log configuration was available. This fix aims to set the log level to error-only as soon as the cli parameters are parsed and -q/--quiet is detected.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
