### PR TITLE
Add double to float types for columns

### DIFF
--- a/.changes/unreleased/Fixes-20230208-104230.yaml
+++ b/.changes/unreleased/Fixes-20230208-104230.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add double type to list of float column types for the column class
+time: 2023-02-08T10:42:30.918479Z
+custom:
+  Author: rlh1994
+  Issue: "6876"

--- a/core/dbt/adapters/base/column.py
+++ b/core/dbt/adapters/base/column.py
@@ -60,6 +60,7 @@ class Column:
             "float",
             "double precision",
             "float8",
+            "double",
         ]
 
     def is_integer(self) -> bool:


### PR DESCRIPTION
resolves #6876 

### Description

Adds a `double` type for float type checks, used within databricks and also as an alias in snowflake warehouses.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
