### PR TITLE
1.4 regression: Check if status has node attribute

### DIFF
--- a/.changes/unreleased/Fixes-20230208-110551.yaml
+++ b/.changes/unreleased/Fixes-20230208-110551.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Ensure results from hooks contain nodes when processing them
+time: 2023-02-08T11:05:51.952494-06:00
+custom:
+  Author: emmyoop
+  Issue: "6796"

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -443,7 +443,7 @@ class RunTask(CompileTask):
         database_schema_set: Set[Tuple[Optional[str], str]] = {
             (r.node.database, r.node.schema)
             for r in results
-            if r.node.is_relational
+            if (hasattr(r, "node") and r.node.is_relational)
             and r.status not in (NodeStatus.Error, NodeStatus.Fail, NodeStatus.Skipped)
         }
 

--- a/tests/functional/hooks/fixtures.py
+++ b/tests/functional/hooks/fixtures.py
@@ -1,3 +1,31 @@
+macros_missing_column = """
+{% macro export_table_check() %}
+
+    {% set table = 'test_column' %}
+
+    {% set query %}
+        SELECT column_name
+        FROM {{ref(table)}}
+        LIMIT 1
+    {% endset %}
+
+    {%- if flags.WHICH in ('run', 'build') -%}
+        {% set results = run_query(query) %}
+        {% if execute %}
+            {%- if results.rows -%}
+                {{ exceptions.raise_compiler_error("ON_RUN_START_CHECK_NOT_PASSED: Data already exported. DBT Run aborted.") }}
+            {% else -%}
+                {{ log("No data found in " ~ table ~ " for current day and runtime region. Proceeding...", true) }}
+            {%- endif -%}
+        {%- endif -%}
+    {%- endif -%}
+{% endmacro %}
+"""
+
+models__missing_column = """
+select 1 as col
+"""
+
 macros__before_and_after = """
 {% macro custom_run_hook(state, target, run_started_at, invocation_id) %}
 


### PR DESCRIPTION
resolves #6796 

### Description

In 1.4 we began appending a `BaseResult` to the `node_results` [here](https://github.com/dbt-labs/dbt-core/blob/df64511feb8d27be89a049f2c72a566b520ca1ed/core/dbt/task/run.py#L400-L408).  Since `BaseResult` doesn't have a node attribute it started to cause uncaught exceptions.  This checks that there is a node attribute when cycling through the results.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
