### PR TITLE
remove '+nightly' from release test version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,11 @@
 [bumpversion]
 current_version = 1.5.0a1
+
+# `parse` allows parsing the version into the parts we need to check.  There are some
+# unnamed groups and that's okay because they do not need to be audited.  If any part
+# of the version passed and does not match the regex, it will fail.
+# expected matches: `1.5.0`, `1.5.0a1`, `1.5.0a1.dev123457`
+# excepted failures: `1`, `1.5`, `1.5.2-a1`, `text1.5.0`
 parse = (?P<major>[\d]+) # major version number
 	\.(?P<minor>[\d]+) # minor version number
 	\.(?P<patch>[\d]+) # patch version number

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,11 +1,5 @@
 [bumpversion]
 current_version = 1.5.0a1
-
-# `parse` allows parsing the version into the parts we need to check.  There are some
-# unnamed groups and that's okay because they do not need to be audited.  If any part
-# of the version passed and does not match the regex, it will fail.
-# expected matches: `1.5.0`, `1.5.0a1`, `1.5.0a1.dev123457`
-# excepted failures: `1`, `1.5`, `1.5.2-a1`, `text1.5.0`
 parse = (?P<major>[\d]+) # major version number
 	\.(?P<minor>[\d]+) # minor version number
 	\.(?P<patch>[\d]+) # patch version number

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -68,7 +68,7 @@ jobs:
       - name: "Generate Nightly Release Version Number"
         id: nightly-release-version
         run: |
-          number="${{ steps.semver.outputs.version }}.dev${{ steps.current-date.outputs.date }}+nightly"
+          number="${{ steps.semver.outputs.version }}.dev${{ steps.current-date.outputs.date }}"
           echo "number=$number" >> $GITHUB_OUTPUT
 
       - name: "Audit Nightly Release Version And Parse Into Parts"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -98,7 +98,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       sha: ${{ needs.aggregate-release-data.outputs.commit_sha }}
-      target_branch: ${{ needs.aggregate-release-data.outputs.release-branch }}
+      target_branch: ${{ needs.aggregate-release-data.outputs.release_branch }}
       version_number: ${{ needs.aggregate-release-data.outputs.version_number }}
       build_script_path: "scripts/build-dist.sh"
       env_setup_script_path: "scripts/env-setup.sh"


### PR DESCRIPTION
resolves #6906 

### Description

Updates the nightly release test workflow to have a PEP440 compatible version and updates the bump version config accordingly.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
