### PR TITLE
Ensure flush() after logging write()

### DIFF
--- a/.changes/unreleased/Fixes-20230208-154935.yaml
+++ b/.changes/unreleased/Fixes-20230208-154935.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Always flush stdout after logging
+time: 2023-02-08T15:49:35.175874-05:00
+custom:
+  Author: peterallenwebb
+  Issue: "6901"


### PR DESCRIPTION
resolves #6901

### Description

This change restores some of the pre-1.4 console logging behavior. It ensures that flush() is called immediately after every console log write, and does so by using a Python log and StreamHandler to write to stdout, rather than writing to it directly. That is how 1.3 wrote to the console.

It would have been possible to simply add a flush() call after every write(), but my inspection of the StreamHandler class revealed that it adds locking behavior around the flush() call. I don't want to learn the reasons for that lock the hard way, or try to implement locking code in a patch release.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
