### PR TITLE
ExposureOwner: Rename to Owner, accept additional fields, require one of 'name' or 'email'

### DIFF
--- a/.changes/unreleased/Features-20230209-092059.yaml
+++ b/.changes/unreleased/Features-20230209-092059.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Exposure owner requires one of name or email keys, and accepts additional arbitrary
+  keys
+time: 2023-02-09T09:20:59.300272-05:00
+custom:
+  Author: michelleark
+  Issue: "6833"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -28,7 +28,7 @@ from dbt.contracts.graph.unparsed import (
     UnparsedSourceTableDefinition,
     UnparsedColumn,
     TestDef,
-    ExposureOwner,
+    Owner,
     ExposureType,
     MaturityType,
     MetricFilter,
@@ -892,7 +892,7 @@ class SourceDefinition(NodeInfoMixin, ParsedSourceMandatory):
 @dataclass
 class Exposure(GraphNode):
     type: ExposureType
-    owner: ExposureOwner
+    owner: Owner
     resource_type: NodeType = field(metadata={"restrict": [NodeType.Exposure]})
     description: str = ""
     label: Optional[str] = None

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -424,8 +424,8 @@ class MaturityType(StrEnum):
 
 
 @dataclass
-class ExposureOwner(dbtClassMixin, Replaceable):
-    email: str
+class Owner(AdditionalPropertiesAllowed, Replaceable):
+    email: Optional[str] = None
     name: Optional[str] = None
 
 
@@ -433,7 +433,7 @@ class ExposureOwner(dbtClassMixin, Replaceable):
 class UnparsedExposure(dbtClassMixin, Replaceable):
     name: str
     type: ExposureType
-    owner: ExposureOwner
+    owner: Owner
     description: str = ""
     label: Optional[str] = None
     maturity: Optional[MaturityType] = None
@@ -450,6 +450,9 @@ class UnparsedExposure(dbtClassMixin, Replaceable):
             # name can only contain alphanumeric chars and underscores
             if not (re.match(r"[\w-]+$", data["name"])):
                 deprecations.warn("exposure-name", exposure=data["name"])
+
+        if data["owner"].get("name") is None and data["owner"].get("email") is None:
+            raise ValidationError("Exposure owner must have at least one of 'name' or 'email'.")
 
 
 @dataclass

--- a/test/unit/test_contracts_graph_parsed.py
+++ b/test/unit/test_contracts_graph_parsed.py
@@ -30,7 +30,7 @@ from dbt.contracts.graph.nodes import (
     SourceDefinition,
     Documentation,
     HookNode,
-    ExposureOwner,
+    Owner,
     TestMetadata,
 )
 from dbt.contracts.graph.unparsed import (
@@ -2142,7 +2142,7 @@ def basic_parsed_exposure_object():
         package_name='test',
         path='models/something.yml',
         original_file_path='models/something.yml',
-        owner=ExposureOwner(email='test@example.com'),
+        owner=Owner(email='test@example.com'),
         description='',
         meta={},
         tags=[],
@@ -2195,7 +2195,7 @@ def complex_parsed_exposure_object():
         name='my_exposure',
         resource_type=NodeType.Exposure,
         type=ExposureType.Analysis,
-        owner=ExposureOwner(email='test@example.com', name='A Name'),
+        owner=Owner(email='test@example.com', name='A Name'),
         maturity=MaturityType.Low,
         url='https://example.com/analyses/1',
         description='my description',

--- a/test/unit/test_contracts_graph_unparsed.py
+++ b/test/unit/test_contracts_graph_unparsed.py
@@ -6,7 +6,7 @@ from dbt.contracts.graph.unparsed import (
     UnparsedNode, UnparsedRunHook, UnparsedMacro, Time, TimePeriod,
     FreshnessThreshold, Quoting, UnparsedSourceDefinition,
     UnparsedSourceTableDefinition, UnparsedDocumentationFile, UnparsedColumn,
-    UnparsedNodeUpdate, Docs, UnparsedExposure, MaturityType, ExposureOwner,
+    UnparsedNodeUpdate, Docs, UnparsedExposure, MaturityType, Owner,
     ExposureType, UnparsedMetric, MetricFilter, MetricTime, MetricTimePeriod
 )
 from dbt.contracts.results import FreshnessStatus
@@ -584,7 +584,9 @@ class TestUnparsedExposure(ContractTestCase):
             'name': 'my_exposure',
             'type': 'dashboard',
             'owner': {
+                'name': 'example',
                 'email': 'name@example.com',
+                'slack': '#channel'
             },
             'maturity': 'medium',
             'meta': {'tool': 'my_tool'},
@@ -602,7 +604,7 @@ class TestUnparsedExposure(ContractTestCase):
         exposure = self.ContractType(
             name='my_exposure',
             type=ExposureType.Dashboard,
-            owner=ExposureOwner(email='name@example.com'),
+            owner=Owner(name='example', email='name@example.com', _extra={'slack': '#channel'}),
             maturity=MaturityType.Medium,
             url='https://example.com/dashboards/1',
             description='A exposure',
@@ -652,6 +654,7 @@ class TestUnparsedExposure(ContractTestCase):
     def test_bad_owner_missing_things(self):
         tst = self.get_ok_dict()
         del tst['owner']['email']
+        del tst['owner']['name']
         self.assert_fails_validation(tst)
 
         del tst['owner']

--- a/test/unit/test_graph_selector_methods.py
+++ b/test/unit/test_graph_selector_methods.py
@@ -23,7 +23,7 @@ from dbt.contracts.graph.nodes import (
     ColumnInfo,
 )
 from dbt.contracts.graph.manifest import Manifest
-from dbt.contracts.graph.unparsed import ExposureType, ExposureOwner, MetricFilter,MetricTime
+from dbt.contracts.graph.unparsed import ExposureType, Owner, MetricFilter,MetricTime
 from dbt.contracts.state import PreviousState
 from dbt.node_types import NodeType
 from dbt.graph.selector_methods import (
@@ -330,7 +330,7 @@ def make_exposure(pkg, name, path=None, fqn_extras=None, owner=None):
         fqn_extras = []
 
     if owner is None:
-        owner = ExposureOwner(email='test@example.com')
+        owner = Owner(email='test@example.com')
 
     fqn = [pkg, 'exposures'] + fqn_extras + [name]
     return Exposure(

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -27,7 +27,7 @@ from dbt.contracts.graph.nodes import (
 
 from dbt.contracts.graph.unparsed import (
     ExposureType,
-    ExposureOwner,
+    Owner,
     MaturityType,
     MetricFilter,
     MetricTime
@@ -83,7 +83,7 @@ class ManifestTest(unittest.TestCase):
             'exposure.root.my_exposure': Exposure(
                 name='my_exposure',
                 type=ExposureType.Dashboard,
-                owner=ExposureOwner(email='some@email.com'),
+                owner=Owner(email='some@email.com'),
                 resource_type=NodeType.Exposure,
                 description='Test description',
                 maturity=MaturityType.High,


### PR DESCRIPTION
resolves #6833


<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)

🎩 some sanity testing: 

`dbt compile` succeeds: 
```yml
exposures:
  - name: weekly_jaffle_report
    type: dashboard
    owner:
      email: data@jaffleshop.com
```

```yml
exposures:
  - name: weekly_jaffle_report
    type: dashboard
    owner:
      email: data@jaffleshop.com
      slack: channel
```

`dbt compile` fails with `Parsing Error`, "Exposure owner must have at least one of 'name' or 'email'."
```yml
exposures:
  - name: weekly_jaffle_report
    type: dashboard
    owner:
      slack: channel
```

