### PR TITLE
[Backport] [CT-2063] Ensure flush() called after write() for console log output

### DIFF
--- a/.changes/unreleased/Fixes-20230208-154935.yaml
+++ b/.changes/unreleased/Fixes-20230208-154935.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Always flush stdout after logging
+time: 2023-02-08T15:49:35.175874-05:00
+custom:
+  Author: peterallenwebb
+  Issue: "6901"


### PR DESCRIPTION
resolves #6901

### Description

This is a backport to 1.4.latest of a fix to log flushing behavior.

The equivalent PR for main was #6909 .

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
