### PR TITLE
Fixing exposure error

### DIFF
--- a/.changes/unreleased/Under the Hood-20230210-084647.yaml
+++ b/.changes/unreleased/Under the Hood-20230210-084647.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Fixing target type exposure error
+time: 2023-02-10T08:46:47.72936-06:00
+custom:
+  Author: callum-mcdata
+  Issue: "6928"

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1264,7 +1264,7 @@ def _process_metrics_for_node(
             invalid_target_fail_unless_test(
                 node=node,
                 target_name=target_metric_name,
-                target_kind="source",
+                target_kind="metric",
                 target_package=target_metric_package,
                 disabled=(isinstance(target_metric, Disabled)),
             )


### PR DESCRIPTION
resolves #6928 

### Description

Resolves an issue in the manifest parsing file where we were providing a string that was the wrong node type.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
