### PR TITLE
CT-2079: Re-apply accidentally reverted logging fix

### DIFF
--- a/.changes/unreleased/Fixes-20230210-103028.yaml
+++ b/.changes/unreleased/Fixes-20230210-103028.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Reapply logging fixes which were accidentally reverted
+time: 2023-02-10T10:30:28.179997-05:00
+custom:
+  Author: peterallenwebb
+  Issue: "6936"


### PR DESCRIPTION
resolves #6936 

### Description

Re-applies fix to always flush log messages after write

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
