### PR TITLE
Set relation_name in tests at compile time

### DIFF
--- a/.changes/unreleased/Fixes-20230210-194157.yaml
+++ b/.changes/unreleased/Fixes-20230210-194157.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Set relation_name in test nodes at compile time
+time: 2023-02-10T19:41:57.386766-05:00
+custom:
+  Author: gshank
+  Issue: "6930"

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -376,7 +376,7 @@ class Compiler:
         if (
             node.resource_type == NodeType.Test
             and node.relation_name is None
-            and node.is_relational()
+            and node.is_relational
         ):
             adapter = get_adapter(self.config)
             relation_cls = adapter.Relation

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -371,6 +371,18 @@ class Compiler:
                 node,
             )
 
+        # relation_name is set at parse time, except for tests without store_failures,
+        # but cli param can turn on store_failures, so we set here.
+        if (
+            node.resource_type == NodeType.Test
+            and node.relation_name is None
+            and node.is_relational()
+        ):
+            adapter = get_adapter(self.config)
+            relation_cls = adapter.Relation
+            relation_name = str(relation_cls.create_from(self.config, node))
+            node.relation_name = relation_name
+
         node.compiled = True
 
         return node

--- a/tests/functional/artifacts/test_artifact_fields.py
+++ b/tests/functional/artifacts/test_artifact_fields.py
@@ -1,0 +1,48 @@
+import pytest
+from dbt.tests.util import run_dbt, get_manifest, get_artifact
+
+# This is a place to put specific tests for contents of artifacts that we
+# don't want to bother putting in the big artifact output test, which is
+# hard to update.
+
+my_model_sql = "select 1 as fun"
+
+schema_yml = """
+version: 2
+models:
+  - name: my_model
+    columns:
+      - name: fun
+        tests:
+          - not_null
+"""
+
+
+class TestRelationNameInTests:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "schema.yml": schema_yml,
+        }
+
+    def test_relation_name_in_tests(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        manifest = get_manifest(project.project_root)
+        test_id = "test.test.not_null_my_model_fun.bf3b032a01"
+        assert test_id in manifest.nodes
+        assert manifest.nodes[test_id].relation_name is None
+
+        results = run_dbt(["test", "--store-failures"])
+        assert len(results) == 1
+        # The relation_name for tests with previously generated manifest and
+        # store_failures passed in on the command line, will be in the manifest.json
+        # but not in the parsed manifest.
+        manifest = get_manifest(project.project_root)
+        assert manifest.nodes[test_id].relation_name is None
+        manifest_json = get_artifact(project.project_root, "target", "manifest.json")
+        assert test_id in manifest_json["nodes"]
+        relation_name = manifest_json["nodes"][test_id]["relation_name"]
+        assert relation_name
+        assert '"not_null_my_model_fun"' in relation_name


### PR DESCRIPTION
resolves #6930

### Description

After moving the setting of relation_name to parse time, test nodes do not contain relation_name when store_failures is set by cli param.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
