### PR TITLE
add helper function for load project/profile

### DIFF
--- a/core/dbt/lib.py
+++ b/core/dbt/lib.py
@@ -1,6 +1,5 @@
 import os
 from dbt.config.project import Project
-from dbt.config.renderer import DbtProjectYamlRenderer
 from dbt.contracts.results import RunningStatus, collect_timing_info
 from dbt.events.functions import fire_event
 from dbt.events.types import NodeCompiling, NodeExecuting
@@ -9,6 +8,8 @@ from dbt import flags
 from dbt.task.sql import SqlCompileRunner
 from dataclasses import dataclass
 from dbt.cli.resolvers import default_profiles_dir
+from dbt.config.runtime import load_profile, load_project
+from dbt.flags import set_from_args
 
 
 @dataclass
@@ -62,6 +63,12 @@ class SqlCompileRunnerNoIntrospection(SqlCompileRunner):
         return result
 
 
+def load_profile_project(project_dir, profile_name_override=None):
+    profile = load_profile(project_dir, {}, profile_name_override)
+    project = load_project(project_dir, False, profile, {})
+    return profile, project
+
+
 def get_dbt_config(project_dir, args=None, single_threaded=False):
     from dbt.config.runtime import RuntimeConfig
     import dbt.adapters.factory
@@ -74,10 +81,6 @@ def get_dbt_config(project_dir, args=None, single_threaded=False):
 
     profile_name = getattr(args, "profile", None)
 
-    profile_name = getattr(args, "profile", None)
-
-    profile_name = getattr(args, "profile", None)
-
     runtime_args = RuntimeArgs(
         project_dir=project_dir,
         profiles_dir=profiles_dir,
@@ -86,9 +89,8 @@ def get_dbt_config(project_dir, args=None, single_threaded=False):
         target=getattr(args, "target", None),
     )
 
-    profile = RuntimeConfig.collect_profile(args=runtime_args, profile_name=profile_name)
-    project_renderer = DbtProjectYamlRenderer(profile, None)
-    project = RuntimeConfig.collect_project(args=runtime_args, project_renderer=project_renderer)
+    set_from_args(runtime_args, None)
+    profile, project = load_profile_project(project_dir, profile_name)
     assert type(project) is Project
 
     config = RuntimeConfig.from_parts(project, profile, runtime_args)


### PR DESCRIPTION
resolves #

This PR added a (hacky) helper function to load project file and profile file.
It is currently used both in lib.py, and dbt-server directly
The [dbt-server direct usecase ](https://github.com/dbt-labs/dbt-server/pull/167/files)is because there's no way to programmatically specify a Project Dir right now.
We should look into remove all function here in the second phase of API-ification once we improve our programatic interface core provides.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
