### PR TITLE
remove `+nightly` from version parsing

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,7 +6,7 @@ parse = (?P<major>[\d]+) # major version number
 	(((?P<prekind>a|b|rc) # optional pre-release type
 	?(?P<num>[\d]+?)) # optional pre-release version number
 	\.?(?P<nightly>[a-z0-9]+)? # optional nightly release indicator
-	)? # expected matches: `1.5.0`, `1.5.0a1`, `1.5.0a1.dev123457+nightly`, expected failures: `1`, `1.5`, `1.5.2-a1`, `text1.5.0`
+	)? # expected matches: `1.5.0`, `1.5.0a1`, `1.5.0a1.dev123457`, expected failures: `1`, `1.5`, `1.5.2-a1`, `text1.5.0`
 serialize =
 	{major}.{minor}.{patch}{prekind}{num}.{nightly}
 	{major}.{minor}.{patch}{prekind}{num}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,11 +1,11 @@
 [bumpversion]
-current_version = 1.5.0a1
+current_version = 1.5.0a1.dev02132023
 parse = (?P<major>[\d]+) # major version number
 	\.(?P<minor>[\d]+) # minor version number
 	\.(?P<patch>[\d]+) # patch version number
 	(((?P<prekind>a|b|rc) # optional pre-release type
 	?(?P<num>[\d]+?)) # optional pre-release version number
-	\.?(?P<nightly>[a-z0-9]+\+[a-z]+)? # optional nightly release indicator
+	\.?(?P<nightly>[a-z0-9]+)? # optional nightly release indicator
 	)? # expected matches: `1.5.0`, `1.5.0a1`, `1.5.0a1.dev123457+nightly`, expected failures: `1`, `1.5`, `1.5.2-a1`, `text1.5.0`
 serialize =
 	{major}.{minor}.{patch}{prekind}{num}.{nightly}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.0a1.dev02132023
+current_version = 1.5.0a1
 parse = (?P<major>[\d]+) # major version number
 	\.(?P<minor>[\d]+) # minor version number
 	\.(?P<patch>[\d]+) # patch version number


### PR DESCRIPTION
resolves #6906 

### Description

The regex check got lost somewhere and `versionbump` apparently breaks silently if a part of the version definition cannot be found.  Only the `.bumpversion.cfg` was bumped and no other files.  This was only an issue with version including part of the nightly version pieces (`.dev<date>`)

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
