### PR TITLE
[BACKPORT 1.4.latest] Fix state comparison with disabled exposure (or metric)

### DIFF
--- a/.changes/unreleased/Fixes-20230213-211257.yaml
+++ b/.changes/unreleased/Fixes-20230213-211257.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix disabled definition in WritableManifest
+time: 2023-02-13T21:12:57.618759-05:00
+custom:
+  Author: gshank
+  Issue: "6752"

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1181,7 +1181,7 @@ class WritableManifest(ArtifactMixin):
     selectors: Mapping[UniqueID, Any] = field(
         metadata=dict(description=("The selectors defined in selectors.yml"))
     )
-    disabled: Optional[Mapping[UniqueID, List[ResultNode]]] = field(
+    disabled: Optional[Mapping[UniqueID, List[GraphMemberNode]]] = field(
         metadata=dict(description="A mapping of the disabled nodes in the target")
     )
     parent_map: Optional[NodeEdgeMap] = field(


### PR DESCRIPTION
Backport #6961 to 1.4.latest
