### PR TITLE
Make use of hashlib.md5() FIPS compliant

### DIFF
--- a/.changes/unreleased/Fixes-20230215-104536.yaml
+++ b/.changes/unreleased/Fixes-20230215-104536.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Make use of hashlib.md5() FIPS compliant
+time: 2023-02-15T10:45:36.755797+01:00
+custom:
+  Author: nielspardon
+  Issue: "6900"

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -12,7 +12,6 @@ from typing import (
 )
 from typing_extensions import Protocol, runtime_checkable
 
-import hashlib
 import os
 
 from dbt.flags import get_flags
@@ -31,7 +30,7 @@ from dbt.graph import SelectionSpec
 from dbt.helper_types import NoValue
 from dbt.semver import VersionSpecifier, versions_compatible
 from dbt.version import get_installed_version
-from dbt.utils import MultiDict
+from dbt.utils import MultiDict, md5
 from dbt.node_types import NodeType
 from dbt.config.selectors import SelectorDict
 from dbt.contracts.project import (
@@ -678,7 +677,7 @@ class Project:
         return partial.render(renderer)
 
     def hashed_name(self):
-        return hashlib.md5(self.project_name.encode("utf-8")).hexdigest()
+        return md5(self.project_name)
 
     def get_selector(self, name: str) -> Union[SelectionSpec, bool]:
         if name not in self.selectors:

--- a/core/dbt/contracts/connection.py
+++ b/core/dbt/contracts/connection.py
@@ -1,6 +1,5 @@
 import abc
 import itertools
-import hashlib
 from dataclasses import dataclass, field
 from typing import (
     Any,
@@ -13,7 +12,7 @@ from typing import (
     Callable,
 )
 from dbt.exceptions import DbtInternalError
-from dbt.utils import translate_aliases
+from dbt.utils import translate_aliases, md5
 from dbt.events.functions import fire_event
 from dbt.events.types import NewConnectionOpening
 from dbt.events.contextvars import get_node_info
@@ -142,7 +141,7 @@ class Credentials(ExtensibleDbtClassMixin, Replaceable, metaclass=abc.ABCMeta):
         raise NotImplementedError("unique_field not implemented for base credentials class")
 
     def hashed_unique_field(self) -> str:
-        return hashlib.md5(self.unique_field.encode("utf-8")).hexdigest()
+        return md5(self.unique_field)
 
     def connection_info(self, *, with_aliases: bool = False) -> Iterable[Tuple[str, Any]]:
         """Return an ordered iterator of key/value pairs for pretty-printing."""

--- a/core/dbt/deps/git.py
+++ b/core/dbt/deps/git.py
@@ -1,5 +1,4 @@
 import os
-import hashlib
 from typing import List, Optional
 
 from dbt.clients import git, system
@@ -13,10 +12,11 @@ from dbt.deps.base import PinnedPackage, UnpinnedPackage, get_downloads_path
 from dbt.exceptions import ExecutableError, MultipleVersionGitDepsError
 from dbt.events.functions import fire_event, warn_or_error
 from dbt.events.types import EnsureGitInstalled, DepsUnpinned
+from dbt.utils import md5
 
 
 def md5sum(s: str):
-    return hashlib.md5(s.encode("latin-1")).hexdigest()
+    return md5(s, "latin-1")
 
 
 class GitPackageMixin:

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -1,4 +1,3 @@
-import hashlib
 import re
 from copy import deepcopy
 from dataclasses import dataclass
@@ -35,6 +34,7 @@ from dbt.exceptions import (
     UndefinedMacroError,
 )
 from dbt.parser.search import FileBlock
+from dbt.utils import md5
 
 
 def synthesize_generic_test_names(
@@ -72,7 +72,7 @@ def synthesize_generic_test_names(
 
     if len(full_name) >= 64:
         test_trunc_identifier = test_identifier[:30]
-        label = hashlib.md5(full_name.encode("utf-8")).hexdigest()
+        label = md5(full_name)
         short_name = "{}_{}".format(test_trunc_identifier, label)
     else:
         short_name = full_name

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -3,7 +3,6 @@ import os
 import pathlib
 
 from abc import ABCMeta, abstractmethod
-from hashlib import md5
 from typing import Iterable, Dict, Any, Union, List, Optional, Generic, TypeVar, Type
 
 from dbt.dataclass_schema import ValidationError, dbtClassMixin
@@ -80,7 +79,7 @@ from dbt.parser.generic_test_builders import (
     TestBlock,
     Testable,
 )
-from dbt.utils import get_pseudo_test_path, coerce_dict_str
+from dbt.utils import get_pseudo_test_path, coerce_dict_str, md5
 
 
 TestDef = Union[str, Dict[str, Any]]
@@ -222,8 +221,8 @@ class SchemaParser(SimpleParser[GenericTestBlock, GenericTestNode]):
                 return str(data)
 
         hashable_metadata = repr(get_hashable_md(test_metadata))
-        hash_string = "".join([name, hashable_metadata]).encode("utf-8")
-        test_hash = md5(hash_string).hexdigest()[-HASH_LENGTH:]
+        hash_string = "".join([name, hashable_metadata])
+        test_hash = md5(hash_string)[-HASH_LENGTH:]
 
         dct = {
             "alias": name,

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -10,6 +10,7 @@ import jinja2
 import json
 import os
 import requests
+import sys
 from tarfile import ReadError
 import time
 from pathlib import PosixPath, WindowsPath
@@ -252,16 +253,19 @@ def get_pseudo_hook_path(hook_name):
     return os.path.join(*path_parts)
 
 
-def md5(string):
-    return hashlib.md5(string.encode("utf-8")).hexdigest()
+def md5(string, charset="utf-8"):
+    if sys.version_info >= (3, 9):
+        return hashlib.md5(string.encode(charset), usedforsecurity=False).hexdigest()
+    else:
+        return hashlib.md5(string.encode(charset)).hexdigest()
 
 
 def get_hash(model):
-    return hashlib.md5(model.unique_id.encode("utf-8")).hexdigest()
+    return md5(model.unique_id)
 
 
 def get_hashed_contents(model):
-    return hashlib.md5(model.raw_code.encode("utf-8")).hexdigest()
+    return md5(model.raw_code)
 
 
 def flatten_nodes(dep_list):


### PR DESCRIPTION
resolves #6900

### Description

- replaces all direct usages of `hashlib.md5()` with calls to `dbt.utils.md5()`
- sets `usedforsecurity=False` when calling `hashlib.md5()`

Previously when running `make test` on a FIPS enabled system there were many test failures. With the changes of this PR both `make test` and `make integration` run through without errors on a FIPS enabled system.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
