### PR TITLE
CT 2026 test proto serialization of logging events

### DIFF
--- a/.changes/unreleased/Under the Hood-20230216-143252.yaml
+++ b/.changes/unreleased/Under the Hood-20230216-143252.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Test binary serialization of logging events
+time: 2023-02-16T14:32:52.524225-05:00
+custom:
+  Author: gshank
+  Issue: "6852"

--- a/.github/workflows/structured-logging-schema-check.yml
+++ b/.github/workflows/structured-logging-schema-check.yml
@@ -30,6 +30,8 @@ jobs:
       LOG_DIR: "/home/runner/work/dbt-core/dbt-core/logs"
       # tells integration tests to output into json format
       DBT_LOG_FORMAT: "json"
+      # tell eventmgr to convert logging events into bytes
+      DBT_TEST_BINARY_SERIALIZATION: "true"
       # Additional test users
       DBT_TEST_USER_1: dbt_test_user_1
       DBT_TEST_USER_2: dbt_test_user_2

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -47,7 +47,7 @@ from dbt.events.types import (
 from dbt.events.contextvars import set_contextvars
 from dbt.flags import get_flags
 from dbt.node_types import ModelLanguage, NodeType
-from dbt.utils import cast_dict_to_dict_of_strings, cast_to_str
+from dbt.utils import cast_dict_to_dict_of_strings
 
 
 from .model_config import (
@@ -221,7 +221,7 @@ class NodeInfoMixin:
             "materialized": self.config.get("materialized"),
             "node_status": str(self._event_status.get("node_status")),
             "node_started_at": self._event_status.get("started_at"),
-            "node_finished_at": cast_to_str(self._event_status.get("finished_at")),
+            "node_finished_at": self._event_status.get("finished_at"),
             "meta": meta_stringified,
         }
         node_info_msg = NodeInfo(**node_info)

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -47,7 +47,7 @@ from dbt.events.types import (
 from dbt.events.contextvars import set_contextvars
 from dbt.flags import get_flags
 from dbt.node_types import ModelLanguage, NodeType
-from dbt.utils import cast_dict_to_dict_of_strings
+from dbt.utils import cast_dict_to_dict_of_strings, cast_to_str
 
 
 from .model_config import (
@@ -221,7 +221,7 @@ class NodeInfoMixin:
             "materialized": self.config.get("materialized"),
             "node_status": str(self._event_status.get("node_status")),
             "node_started_at": self._event_status.get("started_at"),
-            "node_finished_at": self._event_status.get("finished_at"),
+            "node_finished_at": cast_to_str(self._event_status.get("finished_at")),
             "meta": meta_stringified,
         }
         node_info_msg = NodeInfo(**node_info)

--- a/core/dbt/events/adapter_endpoint.py
+++ b/core/dbt/events/adapter_endpoint.py
@@ -17,38 +17,38 @@ class AdapterLogger:
 
     def debug(self, msg, *args):
         event = AdapterEventDebug(
-            name=self.name, base_msg=msg, args=args, node_info=get_node_info()
+            name=self.name, base_msg=msg, args=list(args), node_info=get_node_info()
         )
         fire_event(event)
 
     def info(self, msg, *args):
         event = AdapterEventInfo(
-            name=self.name, base_msg=msg, args=args, node_info=get_node_info()
+            name=self.name, base_msg=msg, args=list(args), node_info=get_node_info()
         )
         fire_event(event)
 
     def warning(self, msg, *args):
         event = AdapterEventWarning(
-            name=self.name, base_msg=msg, args=args, node_info=get_node_info()
+            name=self.name, base_msg=msg, args=list(args), node_info=get_node_info()
         )
         fire_event(event)
 
     def error(self, msg, *args):
         event = AdapterEventError(
-            name=self.name, base_msg=msg, args=args, node_info=get_node_info()
+            name=self.name, base_msg=msg, args=list(args), node_info=get_node_info()
         )
         fire_event(event)
 
     # The default exc_info=True is what makes this method different
     def exception(self, msg, *args):
         event = AdapterEventError(
-            name=self.name, base_msg=msg, args=args, node_info=get_node_info()
+            name=self.name, base_msg=msg, args=list(args), node_info=get_node_info()
         )
         event.exc_info = traceback.format_exc()
         fire_event(event)
 
     def critical(self, msg, *args):
         event = AdapterEventError(
-            name=self.name, base_msg=msg, args=args, node_info=get_node_info()
+            name=self.name, base_msg=msg, args=list(args), node_info=get_node_info()
         )
         fire_event(event)

--- a/core/dbt/events/proto_types.py
+++ b/core/dbt/events/proto_types.py
@@ -264,7 +264,7 @@ class ProfileWrittenWithTargetTemplateYAML(betterproto.Message):
 @dataclass
 class ProfileWrittenWithTargetTemplateYAMLMsg(betterproto.Message):
     info: "EventInfo" = betterproto.message_field(1)
-    data: "ProfileWrittenWithTargetTemplateYAMLMsg" = betterproto.message_field(2)
+    data: "ProfileWrittenWithTargetTemplateYAML" = betterproto.message_field(2)
 
 
 @dataclass
@@ -1817,7 +1817,7 @@ class LogModelResult(betterproto.Message):
     status: str = betterproto.string_field(3)
     index: int = betterproto.int32_field(4)
     total: int = betterproto.int32_field(5)
-    execution_time: int = betterproto.int32_field(6)
+    execution_time: float = betterproto.float_field(6)
 
 
 @dataclass

--- a/core/dbt/events/types.proto
+++ b/core/dbt/events/types.proto
@@ -207,7 +207,7 @@ message ProfileWrittenWithTargetTemplateYAML {
 
 message ProfileWrittenWithTargetTemplateYAMLMsg {
     EventInfo info = 1;
-    ProfileWrittenWithTargetTemplateYAMLMsg data = 2;
+    ProfileWrittenWithTargetTemplateYAML data = 2;
 }
 
 // A022
@@ -1449,7 +1449,7 @@ message LogModelResult {
     string status = 3;
     int32 index = 4;
     int32 total = 5;
-    int32 execution_time = 6;
+    float execution_time = 6;
 }
 
 message LogModelResultMsg {

--- a/core/dbt/task/snapshot.py
+++ b/core/dbt/task/snapshot.py
@@ -7,6 +7,7 @@ from dbt.events.types import LogSnapshotResult
 from dbt.graph import ResourceTypeSelector
 from dbt.node_types import NodeType
 from dbt.contracts.results import NodeStatus
+from dbt.utils import cast_dict_to_dict_of_strings
 
 
 class SnapshotRunner(ModelRunner):
@@ -21,7 +22,7 @@ class SnapshotRunner(ModelRunner):
             LogSnapshotResult(
                 status=result.status,
                 description=self.get_node_representation(),
-                cfg=cfg,
+                cfg=cast_dict_to_dict_of_strings(cfg),
                 index=self.node_index,
                 total=self.num_nodes,
                 execution_time=result.execution_time,

--- a/tests/functional/timezones/test_timezones.py
+++ b/tests/functional/timezones/test_timezones.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-from freezegun import freeze_time
 
 from dbt.tests.util import run_dbt
 
@@ -54,7 +53,8 @@ class TestTimezones:
             schema=project.test_schema
         )
 
-    @freeze_time("2022-01-01 03:00:00", tz_offset=0)
+    # This test used to use freeze_time, but that doesn't work
+    # with our timestamp fields in proto messages.
     def test_run_started_at(self, project, query):
         results = run_dbt(["run"])
 
@@ -63,5 +63,5 @@ class TestTimezones:
         result = project.run_sql(query, fetch="all")[0]
         est, utc = result
 
-        assert utc == "2022-01-01 03:00:00+00:00"
-        assert est == "2021-12-31 22:00:00-05:00"
+        assert "+00:00" in utc
+        assert "-05:00" in est

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -401,18 +401,31 @@ class TestEventJSONSerialization:
             assert type(event) != type
 
         # if we have everything we need to test, try to serialize everything
+        count = 0
         for event in sample_values:
             msg = msg_from_base_event(event)
+            print(f"--- msg: {msg.info.name}")
+            # Serialize to dictionary
             try:
                 msg_to_dict(msg)
             except Exception as e:
                 raise Exception(
                     f"{event} can not be converted to a dict. Originating exception: {e}"
                 )
+            # Serialize to json
             try:
                 msg_to_json(msg)
             except Exception as e:
                 raise Exception(f"{event} is not serializable to json. Originating exception: {e}")
+            # Serialize to binary
+            try:
+                bytes(msg)
+            except Exception as e:
+                raise Exception(
+                    f"{event} is not serializable to binary protobuf. Originating exception: {e}"
+                )
+            count += 1
+        print(f"--- Found {count} events")
 
 
 T = TypeVar("T")


### PR DESCRIPTION
resolves #6852

### Description

Protobuf serialization is pickier about datatypes than Python and json serialization, so we are implementing some automated tests to ensure that serialization to binary works, even though we don't have a binary logger at this time.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
