### PR TITLE
Cleanup main after cutting new er/testing branch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.0a1
+current_version = 1.9.9
 parse = (?P<major>[\d]+) # major version number
 	\.(?P<minor>[\d]+) # minor version number
 	\.(?P<patch>[\d]+) # patch version number
@@ -7,7 +7,7 @@ parse = (?P<major>[\d]+) # major version number
 	?(?P<num>[\d]+?)) # optional pre-release version number
 	\.?(?P<nightly>[a-z0-9]+)? # optional nightly release indicator
 	)? # expected matches: `1.5.0`, `1.5.0a1`, `1.5.0a1.dev123457`, expected failures: `1`, `1.5`, `1.5.2-a1`, `text1.5.0`
-serialize =
+serialize = 
 	{major}.{minor}.{patch}{prekind}{num}.{nightly}
 	{major}.{minor}.{patch}{prekind}{num}
 	{major}.{minor}.{patch}
@@ -17,7 +17,7 @@ tag = False
 [bumpversion:part:prekind]
 first_value = a
 optional_value = final
-values =
+values = 
 	a
 	b
 	rc

--- a/.changes/unreleased/Dependencies-20230206-000926.yaml
+++ b/.changes/unreleased/Dependencies-20230206-000926.yaml
@@ -1,6 +1,0 @@
-kind: "Dependencies"
-body: "Bump ubuntu from 22.04 to 23.04"
-time: 2023-02-06T00:09:26.00000Z
-custom:
-  Author: dependabot[bot]
-  PR: 6865

--- a/.changes/unreleased/Dependencies-20230215-091759.yaml
+++ b/.changes/unreleased/Dependencies-20230215-091759.yaml
@@ -1,6 +1,0 @@
-kind: Dependencies
-body: Revert hoisting dbt.cli.main into the dbt.name namespace
-time: 2023-02-15T09:17:59.04148-08:00
-custom:
-  Author: aranke
-  PR: ''

--- a/.changes/unreleased/Docs-20230207-123807.yaml
+++ b/.changes/unreleased/Docs-20230207-123807.yaml
@@ -1,6 +1,0 @@
-kind: Docs
-body: update link to installation instructions
-time: 2023-02-07T12:38:07.336783-05:00
-custom:
-  Author: ryancharris
-  Issue: None

--- a/.changes/unreleased/Docs-20230209-082901.yaml
+++ b/.changes/unreleased/Docs-20230209-082901.yaml
@@ -1,6 +1,0 @@
-kind: Docs
-body: Fix JSON path to overview docs
-time: 2023-02-09T08:29:01.432616-07:00
-custom:
-  Author: halvorlu
-  Issue: "366"

--- a/.changes/unreleased/Features-20221118-141120.yaml
+++ b/.changes/unreleased/Features-20221118-141120.yaml
@@ -1,8 +1,0 @@
-kind: Features
-body: Data type constraints are now native to SQL table materializations. Enforce
-  columns are specific data types and not null depending on database functionality.
-time: 2022-11-18T14:11:20.868062-08:00
-custom:
-  Author: sungchun12
-  Issue: "6079"
-  PR: "6271"

--- a/.changes/unreleased/Features-20230107-003157.yaml
+++ b/.changes/unreleased/Features-20230107-003157.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Have dbt debug spit out structured json logs with flags enabled.
-time: 2023-01-07T00:31:57.516063-08:00
-custom:
-  Author: versusfacit
-  Issue: "5353"

--- a/.changes/unreleased/Features-20230118-233801.yaml
+++ b/.changes/unreleased/Features-20230118-233801.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: add adapter_response to dbt test and freshness result
-time: 2023-01-18T23:38:01.857342+08:00
-custom:
-  Author: aezomz
-  Issue: "2964"

--- a/.changes/unreleased/Features-20230120-112921.yaml
+++ b/.changes/unreleased/Features-20230120-112921.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Improve error message for packages missing `dbt_project.yml`
-time: 2023-01-20T11:29:21.509967-07:00
-custom:
-  Author: dbeatty10
-  Issue: "6663"

--- a/.changes/unreleased/Features-20230126-154716.yaml
+++ b/.changes/unreleased/Features-20230126-154716.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Adjust makefile to have clearer instructions for CI env var changes.
-time: 2023-01-26T15:47:16.887327-08:00
-custom:
-  Author: versusfacit
-  Issue: "6689"

--- a/.changes/unreleased/Features-20230127-162812.yaml
+++ b/.changes/unreleased/Features-20230127-162812.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Stand-alone Python module for PostgresColumn
-time: 2023-01-27T16:28:12.212427-08:00
-custom:
-  Author: nssalian
-  Issue: "6772"

--- a/.changes/unreleased/Features-20230209-092059.yaml
+++ b/.changes/unreleased/Features-20230209-092059.yaml
@@ -1,7 +1,0 @@
-kind: Features
-body: Exposure owner requires one of name or email keys, and accepts additional arbitrary
-  keys
-time: 2023-02-09T09:20:59.300272-05:00
-custom:
-  Author: michelleark
-  Issue: "6833"

--- a/.changes/unreleased/Features-20230209-093409.yaml
+++ b/.changes/unreleased/Features-20230209-093409.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Parse 'group' resource
-time: 2023-02-09T09:34:09.547006-05:00
-custom:
-  Author: michelleark
-  Issue: "6921"

--- a/.changes/unreleased/Fixes-20230123-132814.yaml
+++ b/.changes/unreleased/Fixes-20230123-132814.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: add merge_exclude_columns adapter tests
-time: 2023-01-23T13:28:14.808748-06:00
-custom:
-  Author: dave-connors-3
-  Issue: "6699"

--- a/.changes/unreleased/Fixes-20230124-115837.yaml
+++ b/.changes/unreleased/Fixes-20230124-115837.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Include adapter_response in NodeFinished run_result log event
-time: 2023-01-24T11:58:37.74179-05:00
-custom:
-  Author: gshank
-  Issue: "6703"

--- a/.changes/unreleased/Fixes-20230124-141943.yaml
+++ b/.changes/unreleased/Fixes-20230124-141943.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Sort cli vars before hashing for partial parsing
-time: 2023-01-24T14:19:43.333628-05:00
-custom:
-  Author: gshank
-  Issue: "6710"

--- a/.changes/unreleased/Fixes-20230125-191739.yaml
+++ b/.changes/unreleased/Fixes-20230125-191739.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: '[Regression] exposure_content referenced incorrectly'
-time: 2023-01-25T19:17:39.942081-05:00
-custom:
-  Author: Mathyoub
-  Issue: "6738"

--- a/.changes/unreleased/Fixes-20230201-154418.yaml
+++ b/.changes/unreleased/Fixes-20230201-154418.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Remove pin on packaging and stop using it for prerelease comparisons
-time: 2023-02-01T15:44:18.279158-05:00
-custom:
-  Author: gshank
-  Issue: "6834"

--- a/.changes/unreleased/Fixes-20230203-135557.yaml
+++ b/.changes/unreleased/Fixes-20230203-135557.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Readd depends_on.macros to SeedNode, to support seeds with hooks calling macros
-time: 2023-02-03T13:55:57.853715+01:00
-custom:
-  Author: jtcohen6
-  Issue: "6806"

--- a/.changes/unreleased/Fixes-20230207-143544.yaml
+++ b/.changes/unreleased/Fixes-20230207-143544.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Fix regression of --quiet cli parameter behavior
-time: 2023-02-07T14:35:44.160163-05:00
-custom:
-  Author: peterallenwebb
-  Issue: "6749"

--- a/.changes/unreleased/Fixes-20230208-110551.yaml
+++ b/.changes/unreleased/Fixes-20230208-110551.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Ensure results from hooks contain nodes when processing them
-time: 2023-02-08T11:05:51.952494-06:00
-custom:
-  Author: emmyoop
-  Issue: "6796"

--- a/.changes/unreleased/Fixes-20230208-154935.yaml
+++ b/.changes/unreleased/Fixes-20230208-154935.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Always flush stdout after logging
-time: 2023-02-08T15:49:35.175874-05:00
-custom:
-  Author: peterallenwebb
-  Issue: "6901"

--- a/.changes/unreleased/Fixes-20230210-103028.yaml
+++ b/.changes/unreleased/Fixes-20230210-103028.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Reapply logging fixes which were accidentally reverted
-time: 2023-02-10T10:30:28.179997-05:00
-custom:
-  Author: peterallenwebb
-  Issue: "6936"

--- a/.changes/unreleased/Fixes-20230210-194157.yaml
+++ b/.changes/unreleased/Fixes-20230210-194157.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Set relation_name in test nodes at compile time
-time: 2023-02-10T19:41:57.386766-05:00
-custom:
-  Author: gshank
-  Issue: "6930"

--- a/.changes/unreleased/Fixes-20230213-130522.yaml
+++ b/.changes/unreleased/Fixes-20230213-130522.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Readd initialization events, --log-cache-events in new CLI
-time: 2023-02-13T13:05:22.989477+01:00
-custom:
-  Author: jtcohen6
-  Issue: "6933"

--- a/.changes/unreleased/Fixes-20230213-170723.yaml
+++ b/.changes/unreleased/Fixes-20230213-170723.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Fix previous state tests and disabled exposures, metrics
-time: 2023-02-13T17:07:23.185679-05:00
-custom:
-  Author: gshank
-  Issue: 6752 6753

--- a/.changes/unreleased/Fixes-20230215-104536.yaml
+++ b/.changes/unreleased/Fixes-20230215-104536.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Make use of hashlib.md5() FIPS compliant
-time: 2023-02-15T10:45:36.755797+01:00
-custom:
-  Author: nielspardon
-  Issue: "6900"

--- a/.changes/unreleased/Under the Hood-20230111-145143.yaml
+++ b/.changes/unreleased/Under the Hood-20230111-145143.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: '[CT-921] dbt compile works in click'
-time: 2023-01-11T14:51:43.324107-08:00
-custom:
-  Author: aranke
-  Issue: "5545"

--- a/.changes/unreleased/Under the Hood-20230113-132513.yaml
+++ b/.changes/unreleased/Under the Hood-20230113-132513.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Fix use of ConnectionReused logging event
-time: 2023-01-13T13:25:13.023168-05:00
-custom:
-  Author: gshank
-  Issue: "6168"

--- a/.changes/unreleased/Under the Hood-20230113-150700.yaml
+++ b/.changes/unreleased/Under the Hood-20230113-150700.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Port docs tests to pytest
-time: 2023-01-13T15:07:00.477038-05:00
-custom:
-  Author: peterallenwebb
-  Issue: "6573"

--- a/.changes/unreleased/Under the Hood-20230117-111737.yaml
+++ b/.changes/unreleased/Under the Hood-20230117-111737.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Update deprecated github action command
-time: 2023-01-17T11:17:37.046095-06:00
-custom:
-  Author: davidbloss
-  Issue: "6153"

--- a/.changes/unreleased/Under the Hood-20230117-162505.yaml
+++ b/.changes/unreleased/Under the Hood-20230117-162505.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: dbt snapshot works in click
-time: 2023-01-17T16:25:05.973769-08:00
-custom:
-  Author: ChenyuLInx
-  Issue: "5554"

--- a/.changes/unreleased/Under the Hood-20230117-213729.yaml
+++ b/.changes/unreleased/Under the Hood-20230117-213729.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: dbt list working with click
-time: 2023-01-17T21:37:29.91632-05:00
-custom:
-  Author: michelleark
-  Issue: "5549"

--- a/.changes/unreleased/Under the Hood-20230119-105304.yaml
+++ b/.changes/unreleased/Under the Hood-20230119-105304.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Add dbt run-operation to click CLI
-time: 2023-01-19T10:53:04.154871+01:00
-custom:
-  Author: jtcohen6
-  Issue: "5552"

--- a/.changes/unreleased/Under the Hood-20230119-205650.yaml
+++ b/.changes/unreleased/Under the Hood-20230119-205650.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: dbt build working with new click framework
-time: 2023-01-19T20:56:50.50549-05:00
-custom:
-  Author: michelleark
-  Issue: "5541"

--- a/.changes/unreleased/Under the Hood-20230119-211040.yaml
+++ b/.changes/unreleased/Under the Hood-20230119-211040.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: dbt docs generate works with new click framework
-time: 2023-01-19T21:10:40.698851-05:00
-custom:
-  Author: michelleark
-  Issue: "5543"

--- a/.changes/unreleased/Under the Hood-20230120-172254.yaml
+++ b/.changes/unreleased/Under the Hood-20230120-172254.yaml
@@ -1,7 +1,0 @@
-kind: Under the Hood
-body: Replaced the EmptyLine event with a more general Formatting event, and added
-  a Note event.
-time: 2023-01-20T17:22:54.45828-05:00
-custom:
-  Author: peterallenwebb
-  Issue: "6481"

--- a/.changes/unreleased/Under the Hood-20230122-215235.yaml
+++ b/.changes/unreleased/Under the Hood-20230122-215235.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Small optimization on manifest parsing benefitting large DAGs
-time: 2023-01-22T21:52:35.549814+01:00
-custom:
-  Author: boxysean
-  Issue: "6697"

--- a/.changes/unreleased/Under the Hood-20230124-153553.yaml
+++ b/.changes/unreleased/Under the Hood-20230124-153553.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Revised and simplified various structured logging events
-time: 2023-01-24T15:35:53.065356-05:00
-custom:
-  Author: peterallenwebb
-  Issue: 6664 6665 6666

--- a/.changes/unreleased/Under the Hood-20230124-175110.yaml
+++ b/.changes/unreleased/Under the Hood-20230124-175110.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: dbt init works with click
-time: 2023-01-24T17:51:10.74065-05:00
-custom:
-  Author: michelleark
-  Issue: "5548"

--- a/.changes/unreleased/Under the Hood-20230125-041136.yaml
+++ b/.changes/unreleased/Under the Hood-20230125-041136.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: '[CT-920][CT-1900] Create Click CLI runner and use it to fix dbt docs commands'
-time: 2023-01-25T04:11:36.57506-08:00
-custom:
-  Author: aranke
-  Issue: 5544 6722

--- a/.changes/unreleased/Under the Hood-20230125-102606.yaml
+++ b/.changes/unreleased/Under the Hood-20230125-102606.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Migrate debug task to click
-time: 2023-01-25T10:26:06.735994-06:00
-custom:
-  Author: stu-k
-  Issue: "5546"

--- a/.changes/unreleased/Under the Hood-20230126-135939.yaml
+++ b/.changes/unreleased/Under the Hood-20230126-135939.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: ' Optimized GraphQueue to remove graph analysis bottleneck in large dags.'
-time: 2023-01-26T13:59:39.518345-05:00
-custom:
-  Author: peterallenwebb
-  Issue: "6759"

--- a/.changes/unreleased/Under the Hood-20230126-143102.yaml
+++ b/.changes/unreleased/Under the Hood-20230126-143102.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Implement --version for click cli
-time: 2023-01-26T14:31:02.740282-06:00
-custom:
-  Author: stu-k
-  Issue: "6757"

--- a/.changes/unreleased/Under the Hood-20230126-164741.yaml
+++ b/.changes/unreleased/Under the Hood-20230126-164741.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: '[CT-1841] Convert custom target test to Pytest'
-time: 2023-01-26T16:47:41.198714-08:00
-custom:
-  Author: aranke
-  Issue: "6638"

--- a/.changes/unreleased/Under the Hood-20230130-153306.yaml
+++ b/.changes/unreleased/Under the Hood-20230130-153306.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Remove BigQuery-specific btye abbreviations
-time: 2023-01-30T15:33:06.28965-07:00
-custom:
-  Author: dbeatty10
-  Issue: "6741"

--- a/.changes/unreleased/Under the Hood-20230130-175752.yaml
+++ b/.changes/unreleased/Under the Hood-20230130-175752.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: "Enables the new Click Cli on the commandline! \U0001F680"
-time: 2023-01-30T17:57:52.65626-06:00
-custom:
-  Author: iknox-fa
-  Issue: "6784"

--- a/.changes/unreleased/Under the Hood-20230130-180917.yaml
+++ b/.changes/unreleased/Under the Hood-20230130-180917.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: warn_error/warn_error_options mutual exclusivity in click
-time: 2023-01-30T18:09:17.240662-05:00
-custom:
-  Author: michelleark
-  Issue: "6579"

--- a/.changes/unreleased/Under the Hood-20230131-141806.yaml
+++ b/.changes/unreleased/Under the Hood-20230131-141806.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Lazily call --version
-time: 2023-01-31T14:18:06.02312-06:00
-custom:
-  Author: stu-k
-  Issue: "6812"

--- a/.changes/unreleased/Under the Hood-20230203-143551.yaml
+++ b/.changes/unreleased/Under the Hood-20230203-143551.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Moving simple_seed to adapter zone to help adapter test conversions
-time: 2023-02-03T14:35:51.481856-08:00
-custom:
-  Author: nssalian
-  Issue: CT-1959

--- a/.changes/unreleased/Under the Hood-20230207-165111.yaml
+++ b/.changes/unreleased/Under the Hood-20230207-165111.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: flags.THREADS defaults to None
-time: 2023-02-07T16:51:11.011984-05:00
-custom:
-  Author: michelleark
-  Issue: "6887"

--- a/.changes/unreleased/Under the Hood-20230210-084647.yaml
+++ b/.changes/unreleased/Under the Hood-20230210-084647.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Fixing target type exposure error
-time: 2023-02-10T08:46:47.72936-06:00
-custom:
-  Author: callum-mcdata
-  Issue: "6928"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@ For information on prior major and minor releases, see their changelogs:
 * [0.13](https://github.com/dbt-labs/dbt-core/blob/0.13.latest/CHANGELOG.md)
 * [0.12](https://github.com/dbt-labs/dbt-core/blob/0.12.latest/CHANGELOG.md)
 * [0.11 and earlier](https://github.com/dbt-labs/dbt-core/blob/0.11.latest/CHANGELOG.md)
+

--- a/core/dbt/version.py
+++ b/core/dbt/version.py
@@ -232,5 +232,5 @@ def _get_adapter_plugin_names() -> Iterator[str]:
             yield plugin_name
 
 
-__version__ = "1.5.0a1"
+__version__ = "1.9.9"
 installed = get_installed_version()

--- a/core/setup.py
+++ b/core/setup.py
@@ -25,7 +25,7 @@ with open(os.path.join(this_directory, "README.md")) as f:
 
 
 package_name = "dbt-core"
-package_version = "1.5.0a1"
+package_version = "1.9.9"
 description = """With dbt, data analysts and engineers can build analytics \
 the way engineers build applications."""
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,12 +14,12 @@ FROM --platform=$build_for python:3.10.7-slim-bullseye as base
 # N.B. The refs updated automagically every release via bumpversion
 # N.B. dbt-postgres is currently found in the core codebase so a value of dbt-core@<some_version> is correct
 
-ARG dbt_core_ref=dbt-core@v1.5.0a1
-ARG dbt_postgres_ref=dbt-core@v1.5.0a1
-ARG dbt_redshift_ref=dbt-redshift@v1.5.0a1
-ARG dbt_bigquery_ref=dbt-bigquery@v1.5.0a1
-ARG dbt_snowflake_ref=dbt-snowflake@v1.5.0a1
-ARG dbt_spark_ref=dbt-spark@v1.5.0a1
+ARG dbt_core_ref=dbt-core@v1.9.9
+ARG dbt_postgres_ref=dbt-core@v1.9.9
+ARG dbt_redshift_ref=dbt-redshift@v1.9.9
+ARG dbt_bigquery_ref=dbt-bigquery@v1.9.9
+ARG dbt_snowflake_ref=dbt-snowflake@v1.9.9
+ARG dbt_spark_ref=dbt-spark@v1.9.9
 # special case args
 ARG dbt_spark_version=all
 ARG dbt_third_party

--- a/plugins/postgres/dbt/adapters/postgres/__version__.py
+++ b/plugins/postgres/dbt/adapters/postgres/__version__.py
@@ -1,1 +1,1 @@
-version = "1.5.0a1"
+version = "1.9.9"

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -41,7 +41,7 @@ def _dbt_psycopg2_name():
 
 
 package_name = "dbt-postgres"
-package_version = "1.5.0a1"
+package_version = "1.9.9"
 description = """The postgres adapter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/tests/adapter/dbt/tests/adapter/__version__.py
+++ b/tests/adapter/dbt/tests/adapter/__version__.py
@@ -1,1 +1,1 @@
-version = "1.5.0a1"
+version = "1.9.9"

--- a/tests/adapter/setup.py
+++ b/tests/adapter/setup.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 package_name = "dbt-tests-adapter"
-package_version = "1.5.0a1"
+package_version = "1.9.9"
 description = """The dbt adapter tests for adapter plugins"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
All adapter PRs will fail CI until the dbt-core PR has been merged due to release version conflicts. The workflow that generated this PR also created a new branch: er/testing