### PR TITLE
CT 2057 Fix compilation logic for ephemeral nodes

### DIFF
--- a/.changes/unreleased/Fixes-20230221-170630.yaml
+++ b/.changes/unreleased/Fixes-20230221-170630.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix compilation logic for ephemeral nodes
+time: 2023-02-21T17:06:30.218568-05:00
+custom:
+  Author: gshank
+  Issue: "6885"

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -519,7 +519,7 @@ class Compiler:
         """This is the main entry point into this code. It's called by
         CompileRunner.compile, GenericRPCRunner.compile, and
         RunTask.get_hook_sql. It calls '_compile_code' to render
-        the node's raw_code into ompiled_code, and then calls the
+        the node's raw_code into compiled_code, and then calls the
         recursive method to "prepend" the ctes.
         """
         node = self._compile_code(node, manifest, extra_context)

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -95,7 +95,7 @@ def _generate_stats(manifest: Manifest):
 
 def _add_prepended_cte(prepended_ctes, new_cte):
     for cte in prepended_ctes:
-        if cte.id == new_cte.id:
+        if cte.id == new_cte.id and new_cte.sql:
             cte.sql = new_cte.sql
             return
     prepended_ctes.append(new_cte)
@@ -306,11 +306,11 @@ class Compiler:
                 # This is an ephemeral parsed model that we can compile.
                 # Render the raw_code and set compiled to True
                 cte_model = self._compile_code(cte_model, manifest, extra_context)
-                # recursively call this method
+                # recursively call this method, sets extra_ctes_injected to True
                 cte_model, new_prepended_ctes = self._recursively_prepend_ctes(
                     cte_model, manifest, extra_context
                 )
-                # Save compiled SQL file and sync manifest
+                # Write compiled SQL file
                 self._write_node(cte_model)
 
             _extend_prepended_ctes(prepended_ctes, new_prepended_ctes)
@@ -329,9 +329,8 @@ class Compiler:
         if not model.extra_ctes_injected:
             model._pre_injected_sql = model.compiled_code
             model.compiled_code = injected_sql
-            model.extra_ctes_injected = True
             model.extra_ctes = prepended_ctes
-            model.validate(model.to_dict(omit_none=True))
+            model.extra_ctes_injected = True
 
         return model, prepended_ctes
 

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -266,7 +266,7 @@ class Compiler:
             raise DbtRuntimeError("Cannot inject ctes into an uncompiled node", model)
 
         # extra_ctes_injected flag says that we've already recursively injected the ctes
-        if model.extra_ctes_injected and model.extra_ctes_compiled():
+        if model.extra_ctes_injected:
             return (model, model.extra_ctes)
 
         # Just to make it plain that nothing is actually injected for this case
@@ -300,11 +300,7 @@ class Compiler:
             # This model has already been compiled and extra_ctes_injected, so it's been
             # through here before. We already checked above for extra_ctes_injected, but
             # checking again because updates maybe have happened in another thread.
-            if (
-                cte_model.compiled is True
-                and cte_model.extra_ctes_injected is True
-                and cte_model.extra_ctes_compiled()
-            ):
+            if cte_model.compiled is True and cte_model.extra_ctes_injected is True:
                 new_prepended_ctes = cte_model.extra_ctes
 
             # if the cte_model isn't compiled, i.e. first time here

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -263,14 +263,16 @@ class Compiler:
         """
         if model.compiled_code is None:
             raise DbtRuntimeError("Cannot inject ctes into an unparsed node", model)
+
+        # extra_ctes_injected flag says that we've already recursively injected the ctes
         if model.extra_ctes_injected:
             return (model, model.extra_ctes)
 
         # Just to make it plain that nothing is actually injected for this case
         if not model.extra_ctes:
+            # SeedNodes don't have compilation attributes
             if not isinstance(model, SeedNode):
                 model.extra_ctes_injected = True
-            manifest.update_node(model)
             return (model, model.extra_ctes)
 
         # This stores the ctes which will all be recursively
@@ -280,7 +282,7 @@ class Compiler:
         # extra_ctes are added to the model by
         # RuntimeRefResolver.create_relation, which adds an
         # extra_cte for every model relation which is an
-        # ephemeral model.
+        # ephemeral model. InjectedCTEs have a unique_id and sql
         for cte in model.extra_ctes:
             if cte.id not in manifest.nodes:
                 raise DbtInternalError(
@@ -293,23 +295,23 @@ class Compiler:
             if not cte_model.is_ephemeral_model:
                 raise DbtInternalError(f"{cte.id} is not ephemeral")
 
-            # This model has already been compiled, so it's been
-            # through here before
-            if getattr(cte_model, "compiled", False):
+            # This model has already been compiled and extra_ctes_injected, so it's been
+            # through here before. We already checked above for extra_ctes_injected, but
+            # checking again because updates maybe have happened in another thread.
+            if cte_model.compiled is True and cte_model.extra_ctes_injected is True:
                 new_prepended_ctes = cte_model.extra_ctes
 
             # if the cte_model isn't compiled, i.e. first time here
             else:
                 # This is an ephemeral parsed model that we can compile.
-                # Compile and update the node
-                cte_model = self._compile_node(cte_model, manifest, extra_context)
+                # Render the raw_code and set compiled to True
+                cte_model = self._compile_code(cte_model, manifest, extra_context)
                 # recursively call this method
                 cte_model, new_prepended_ctes = self._recursively_prepend_ctes(
                     cte_model, manifest, extra_context
                 )
                 # Save compiled SQL file and sync manifest
                 self._write_node(cte_model)
-                manifest.sync_update_node(cte_model)
 
             _extend_prepended_ctes(prepended_ctes, new_prepended_ctes)
 
@@ -323,20 +325,21 @@ class Compiler:
             model.compiled_code,
             prepended_ctes,
         )
-        model._pre_injected_sql = model.compiled_code
-        model.compiled_code = injected_sql
-        model.extra_ctes_injected = True
-        model.extra_ctes = prepended_ctes
-        model.validate(model.to_dict(omit_none=True))
-        manifest.update_node(model)
+        # Check again before updating for multi-threading
+        if not model.extra_ctes_injected:
+            model._pre_injected_sql = model.compiled_code
+            model.compiled_code = injected_sql
+            model.extra_ctes_injected = True
+            model.extra_ctes = prepended_ctes
+            model.validate(model.to_dict(omit_none=True))
 
         return model, prepended_ctes
 
-    # Sets compiled fields in the ManifestSQLNode passed in,
+    # Sets compiled_code and compiled flag in the ManifestSQLNode passed in,
     # creates a "context" dictionary for jinja rendering,
     # and then renders the "compiled_code" using the node, the
     # raw_code and the context.
-    def _compile_node(
+    def _compile_code(
         self,
         node: ManifestSQLNode,
         manifest: Manifest,
@@ -344,16 +347,6 @@ class Compiler:
     ) -> ManifestSQLNode:
         if extra_context is None:
             extra_context = {}
-
-        data = node.to_dict(omit_none=True)
-        data.update(
-            {
-                "compiled": False,
-                "compiled_code": None,
-                "extra_ctes_injected": False,
-                "extra_ctes": [],
-            }
-        )
 
         if node.language == ModelLanguage.python:
             context = self._create_node_context(node, manifest, extra_context)
@@ -374,6 +367,8 @@ class Compiler:
                 node,
             )
 
+        node.compiled = True
+
         # relation_name is set at parse time, except for tests without store_failures,
         # but cli param can turn on store_failures, so we set here.
         if (
@@ -385,8 +380,6 @@ class Compiler:
             relation_cls = adapter.Relation
             relation_name = str(relation_cls.create_from(self.config, node))
             node.relation_name = relation_name
-
-        node.compiled = True
 
         return node
 
@@ -525,11 +518,11 @@ class Compiler:
     ) -> ManifestSQLNode:
         """This is the main entry point into this code. It's called by
         CompileRunner.compile, GenericRPCRunner.compile, and
-        RunTask.get_hook_sql. It calls '_compile_node' to convert
-        the node into a compiled node, and then calls the
+        RunTask.get_hook_sql. It calls '_compile_code' to render
+        the node's raw_code into ompiled_code, and then calls the
         recursive method to "prepend" the ctes.
         """
-        node = self._compile_node(node, manifest, extra_context)
+        node = self._compile_code(node, manifest, extra_context)
 
         node, _ = self._recursively_prepend_ctes(node, manifest, extra_context)
         if write:

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -648,24 +648,6 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         obj._lock = MP_CONTEXT.Lock()
         return obj
 
-    def sync_update_node(self, new_node: ManifestNode) -> ManifestNode:
-        """update the node with a lock. The only time we should want to lock is
-        when compiling an ephemeral ancestor of a node at runtime, because
-        multiple threads could be just-in-time compiling the same ephemeral
-        dependency, and we want them to have a consistent view of the manifest.
-
-        If the existing node is not compiled, update it with the new node and
-        return that. If the existing node is compiled, do not update the
-        manifest and return the existing node.
-        """
-        with self._lock:
-            existing = self.nodes[new_node.unique_id]
-            if getattr(existing, "compiled", False):
-                # already compiled
-                return existing
-            _update_into(self.nodes, new_node)
-            return new_node
-
     def update_exposure(self, new_exposure: Exposure):
         _update_into(self.exposures, new_exposure)
 

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -420,6 +420,15 @@ class CompiledNode(ParsedNode):
         else:
             self.extra_ctes.append(InjectedCTE(id=cte_id, sql=sql))
 
+    def extra_ctes_compiled(self):
+        if len(self.extra_ctes) == 0:
+            return True
+        compiled = True
+        for cte in self.extra_ctes:
+            if not cte.sql:
+                compiled = False
+        return compiled
+
     def __post_serialize__(self, dct):
         dct = super().__post_serialize__(dct)
         if "_pre_injected_sql" in dct:

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -414,20 +414,13 @@ class CompiledNode(ParsedNode):
         do if extra_ctes were an OrderedDict
         """
         for cte in self.extra_ctes:
+            # Because it's possible that multiple threads are compiling the
+            # node at the same time, we don't want to overwrite already compiled
+            # sql in the extra_ctes with empty sql.
             if cte.id == cte_id:
-                cte.sql = sql
                 break
         else:
             self.extra_ctes.append(InjectedCTE(id=cte_id, sql=sql))
-
-    def extra_ctes_compiled(self):
-        if len(self.extra_ctes) == 0:
-            return True
-        compiled = True
-        for cte in self.extra_ctes:
-            if not cte.sql:
-                compiled = False
-        return compiled
 
     def __post_serialize__(self, dct):
         dct = super().__post_serialize__(dct)

--- a/tests/functional/materializations/test_ephemeral_compilation.py
+++ b/tests/functional/materializations/test_ephemeral_compilation.py
@@ -1,0 +1,71 @@
+import pytest
+from dbt.tests.util import run_dbt
+
+# Note: This tests compilation only, so is a dbt Core test and not an adapter test.
+# There is some complicated logic in core/dbt/compilation.py having to do with
+# ephemeral nodes and handling multiple threads at the same time. This test
+# fails fairly regularly if that is broken, but does occasionally work (depending
+# on the order in which things are compiled). It requires multi-threading to fail.
+
+
+fct_eph_first_sql = """
+-- fct_eph_first.sql
+{{ config(materialized='ephemeral') }}
+
+with int_eph_first as(
+    select * from {{ ref('int_eph_first') }}
+)
+
+select * from int_eph_first
+"""
+
+int_eph_first_sql = """
+-- int_eph_first.sql
+{{ config(materialized='ephemeral') }}
+
+select
+    1 as first_column,
+    2 as second_column
+"""
+
+schema_yml = """
+version: 2
+
+models:
+  - name: int_eph_first
+    columns:
+      - name: first_column
+        tests:
+          - not_null
+      - name: second_column
+        tests:
+          - not_null
+
+  - name: fct_eph_first
+    columns:
+      - name: first_column
+        tests:
+          - not_null
+      - name: second_column
+        tests:
+          - not_null
+
+"""
+
+
+class TestEphemeralCompilation:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "int_eph_first.sql": int_eph_first_sql,
+            "fct_eph_first.sql": fct_eph_first_sql,
+            "schema.yml": schema_yml,
+        }
+
+    def test_ephemeral_compilation(self, project):
+        # Note: There are no models that run successfully. This testcase tests running tests.
+        results = run_dbt(["run"])
+        assert len(results) == 0
+
+        results = run_dbt(["test"])
+        len(results) == 4


### PR DESCRIPTION
resolves #6885


### Description

We removed separate Compiled classes in version 1.4. As a result some of the logic in compilation.py for handling ephemeral nodes was unnecessary and was causing problems when multi-threading.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
