### PR TITLE
Handling column names having `/` while altering the table

### DIFF
--- a/core/dbt/include/global_project/macros/adapters/columns.sql
+++ b/core/dbt/include/global_project/macros/adapters/columns.sql
@@ -75,11 +75,11 @@
      alter {{ relation.type }} {{ relation }}
 
             {% for column in add_columns %}
-               add column {{ column.name }} {{ column.data_type }}{{ ',' if not loop.last }}
+               add column "{{ column.name }}" {{ column.data_type }}{{ ',' if not loop.last }}
             {% endfor %}{{ ',' if add_columns and remove_columns }}
 
             {% for column in remove_columns %}
-                drop column {{ column.name }}{{ ',' if not loop.last }}
+                drop column "{{ column.name }}" {{ ',' if not loop.last }}
             {% endfor %}
 
   {%- endset -%}


### PR DESCRIPTION
When we have "/" in a column name, this macro is throwing error post load while trying to alter the table for add or drop a column. If the column name is included in "" then this is handled, which works for normal column names as well.

resolves https://github.com/dbt-labs/dbt-adapters/issues/63

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

Alter statements from DBT for the columns with / in the name are failing. Columns with / in the name need to be in double quotes when the alter statements are executed to add the constraints, or new columns to the table.
ERROR_MESSAGE
SQL compilation error:
syntax error line 3 at position 12 unexpected '/'.
image

Fix
Modified global macro to add proper quoiting to the column names during alter table statement.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
