### PR TITLE
CT-2160: Fix logbook (legacy logging) regression

### DIFF
--- a/.changes/unreleased/Fixes-20230222-133304.yaml
+++ b/.changes/unreleased/Fixes-20230222-133304.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix regression in logbook log output
+time: 2023-02-22T13:33:04.017149-05:00
+custom:
+  Author: peterallenwebb
+  Issue: "7028"

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -102,6 +102,7 @@ def _get_logbook_log_config(level: Optional[EventLevel] = None) -> LoggerConfig:
     config.name = "logbook_log"
     config.filter = NoFilter if flags.LOG_CACHE_EVENTS else lambda e: not isinstance(e.data, Cache)
     config.logger = GLOBAL_LOGGER
+    config.output_stream = None
     return config
 
 


### PR DESCRIPTION
resolves #7028

### Description

This change fixes an issue which resulted in dbt directing logs to a standard Python, rather than a logbook logger, when the DBT_ENABLE_LEGACY_LOGGER flag was set.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
