### PR TITLE
Make version configs optional

### DIFF
--- a/.changes/unreleased/Features-20230227-091316.yaml
+++ b/.changes/unreleased/Features-20230227-091316.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: make version configs optional
+time: 2023-02-27T09:13:16.104386-06:00
+custom:
+  Author: dave-connors-3
+  Issue: "7054"

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -499,7 +499,7 @@ class PartialProject(RenderComponents):
     ) -> "PartialProject":
         project_root = os.path.normpath(project_root)
         project_dict = load_raw_project(project_root)
-        config_version = project_dict.get("config-version", 1)
+        config_version = project_dict.get("config-version", 2)
         if config_version != 2:
             raise DbtProjectError(
                 f"Invalid config version: {config_version}, expected 2",

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -184,7 +184,7 @@ BANNED_PROJECT_NAMES = {
 @dataclass
 class Project(HyphenatedDbtClassMixin, Replaceable):
     name: Identifier
-    config_version: int
+    config_version: Optional[int] = 2
     version: Optional[Union[SemverString, float]] = None
     project_root: Optional[str] = None
     source_paths: Optional[List[str]] = None

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -2078,13 +2078,6 @@ class PropertyYMLError(CompilationError):
         return msg
 
 
-class PropertyYMLMissingVersionError(PropertyYMLError):
-    def __init__(self, path: str):
-        self.path = path
-        self.issue = f"the yml property file {self.path} is missing a version tag"
-        super().__init__(self.path, self.issue)
-
-
 class PropertyYMLVersionNotIntError(PropertyYMLError):
     def __init__(self, path: str, version: Any):
         self.path = path

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -63,7 +63,6 @@ from dbt.exceptions import (
     TestConfigError,
     ParsingError,
     PropertyYMLInvalidTagError,
-    PropertyYMLMissingVersionError,
     PropertyYMLVersionNotIntError,
     DbtValidationError,
     YamlLoadError,
@@ -576,10 +575,7 @@ class SchemaParser(SimpleParser[GenericTestBlock, GenericTestNode]):
 
 
 def check_format_version(file_path, yaml_dct) -> None:
-    if "version" not in yaml_dct:
-        raise PropertyYMLMissingVersionError(file_path)
-
-    version = yaml_dct["version"]
+    version = yaml_dct.get("version", 2)
     # if it's not an integer, the version is malformed, or not
     # set. Either way, only 'version: 2' is supported.
     if not isinstance(version, int):

--- a/core/dbt/tests/fixtures/project.py
+++ b/core/dbt/tests/fixtures/project.py
@@ -174,10 +174,16 @@ def project_config_update():
     return {}
 
 
+# Data used to remove keys from project configs
+@pytest.fixture(scope="class")
+def project_config_remove():
+    return []
+
+
 # Combines the project_config_update dictionary with project_config defaults to
 # produce a project_yml config and write it out as dbt_project.yml
 @pytest.fixture(scope="class")
-def dbt_project_yml(project_root, project_config_update, logs_dir):
+def dbt_project_yml(project_root, project_config_update, project_config_remove, logs_dir):
     project_config = {
         "config-version": 2,
         "name": "test",
@@ -190,6 +196,9 @@ def dbt_project_yml(project_root, project_config_update, logs_dir):
         elif isinstance(project_config_update, str):
             updates = yaml.safe_load(project_config_update)
             project_config.update(updates)
+    if project_config_remove:
+        for key in project_config_remove:
+            project_config.pop(key, None)
     write_file(yaml.safe_dump(project_config), project_root, "dbt_project.yml")
     return project_config
 

--- a/tests/functional/basic/test_project.py
+++ b/tests/functional/basic/test_project.py
@@ -3,6 +3,39 @@ from dbt.tests.util import run_dbt, update_config_file
 from dbt.exceptions import ProjectContractError
 
 
+simple_model_sql = """
+select true as my_column
+"""
+
+simple_model_yml = """
+models:
+  - name: simple_model
+    description: "is sythentic data ok? my column:"
+    columns:
+      - name: my_column
+        description: asked and answered
+"""
+
+
+class TestSchemaYmlVersionMissing:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"simple_model.sql": simple_model_sql, "simple_model.yml": simple_model_yml}
+
+    def test_empty_version(self, project):
+        run_dbt(["run"], expect_pass=True)
+
+
+class TestProjectConfigVersionMissing:
+    # default dbt_project.yml has config-version: 2
+    @pytest.fixture(scope="class")
+    def project_config_remove(self):
+        return ["config-version"]
+
+    def test_empty_version(self, project):
+        run_dbt(["run"], expect_pass=True)
+
+
 class TestProjectYamlVersionMissing:
     # default dbt_project.yml does not fill version
 


### PR DESCRIPTION
resolves #7054

### Description

This makes the `version: 2` config in resource `schema.yml` files and the `config-version: 2` in `dbt_project.yml` files optional for end users. 

More than open to feedback, especially on the testing setup. Needed to add some ability to remove keys from the project config dictionary, which felt a little code-smelly. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
