### PR TITLE
fix: add pytz dependency

### DIFF
--- a/.changes/unreleased/Fixes-20230228-130318.yaml
+++ b/.changes/unreleased/Fixes-20230228-130318.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: add pytz dependency
+time: 2023-02-28T13:03:18.353468+01:00
+custom:
+  Author: sdebruyn
+  Issue: "7077"

--- a/core/setup.py
+++ b/core/setup.py
@@ -64,6 +64,7 @@ setup(
         "typing-extensions>=3.7.4",
         "werkzeug>=1,<3",
         "pathspec>=0.9,<0.11",
+        "pytz>=2015.7",
         # the following are all to match snowflake-connector-python
         "requests<3.0.0",
         "idna>=2.5,<4",

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,7 +17,6 @@ pytest-dotenv
 pytest-logbook
 pytest-mock
 pytest-xdist
-pytz
 sphinx
 tox>=3.13
 twine


### PR DESCRIPTION
resolves #7075 

### Description

dbt-core uses pytz directly. The dependency on babel guaranteed pytz to be there until now, but that dependency was recently removed. Since dbt-core uses pytz directly (in tracking), it should explicitly add a dependency on it

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
