### PR TITLE
Remove python 3.9 from main workflow in 1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8]
 
     env:
       TOXENV: "unit"
@@ -169,7 +169,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Remove python 3.9 from the main workflow to stop CI errors due to pytz.
