### PR TITLE
Submaterializations

### DIFF
--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -234,6 +234,7 @@ def docs_serve(ctx, **kwargs):
 # dbt compile
 @cli.command("compile")
 @click.pass_context
+@p.submaterialization
 @p.defer
 @p.exclude
 @p.favor_state
@@ -272,6 +273,7 @@ def compile(ctx, **kwargs):
 # dbt debug
 @cli.command("debug")
 @click.pass_context
+@p.submaterialization
 @p.config_dir
 @p.profile
 @p.profiles_dir_exists_false
@@ -335,6 +337,7 @@ def init(ctx, **kwargs):
 # dbt list
 @cli.command("list")
 @click.pass_context
+@p.submaterialization
 @p.exclude
 @p.indirect_selection
 @p.models
@@ -400,6 +403,7 @@ def parse(ctx, **kwargs):
 # dbt run
 @cli.command("run")
 @click.pass_context
+@p.submaterialization
 @p.defer
 @p.favor_state
 @p.exclude
@@ -432,7 +436,6 @@ def run(ctx, **kwargs):
     results = task.run()
     success = task.interpret_results(results)
     return results, success
-
 
 # dbt run operation
 @cli.command("run-operation")

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -375,6 +375,12 @@ store_failures = click.option(
     is_flag=True,
 )
 
+submaterialization = click.option(
+    "--submaterialization",
+    envvar=None,
+    help="Which submaterialization to select and/or run"
+)
+
 target = click.option(
     "--target", "-t", envvar=None, help="Which target to load for the given profile"
 )

--- a/core/dbt/graph/selector.py
+++ b/core/dbt/graph/selector.py
@@ -315,4 +315,8 @@ class ResourceTypeSelector(NodeSelector):
         self.resource_types: Set[NodeType] = set(resource_types)
 
     def node_is_match(self, node):
+        if self.submaterialization is not None:
+            if node.config is not None and node.config.get('submaterializations') is not None and self.submaterialization in node.config.get('submaterializations'):
+                return node.resource_type in self.resource_types
+            return False
         return node.resource_type in self.resource_types

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -48,6 +48,7 @@ class MethodName(StrEnum):
     Result = "result"
     SourceStatus = "source_status"
     Wildcard = "wildcard"
+    SubMaterialization = "submaterialization"
 
 
 def is_selected_node(
@@ -205,6 +206,12 @@ class QualifiedNameSelectorMethod(SelectorMethod):
             if self.node_is_match(selector, real_node.fqn):
                 yield node
 
+class SubMaterializationSelectorMethod(SelectorMethod):
+    def search(self, included_nodes: Set[UniqueId], selector: str) -> Iterator[UniqueId]:
+        """yields nodes from included that have the specified tag"""
+        for node, real_node in self.all_nodes(included_nodes):
+            if real_node.config.get('submaterializations') and any(fnmatch(sub, selector) for sub in real_node.config.get('submaterializations')):
+                yield node
 
 class TagSelectorMethod(SelectorMethod):
     def search(self, included_nodes: Set[UniqueId], selector: str) -> Iterator[UniqueId]:
@@ -651,6 +658,7 @@ class MethodManager:
         MethodName.Metric: MetricSelectorMethod,
         MethodName.Result: ResultSelectorMethod,
         MethodName.SourceStatus: SourceStatusSelectorMethod,
+        MethodName.SubMaterialization: SubMaterializationSelectorMethod,
     }
 
     def __init__(
@@ -660,6 +668,10 @@ class MethodManager:
     ):
         self.manifest = manifest
         self.previous_state = previous_state
+        self.submaterialization = None
+
+    def set_submaterialization(self, submaterialization):
+        self.submaterialization = submaterialization
 
     def get_method(self, method: MethodName, method_arguments: List[str]) -> SelectorMethod:
 

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -57,6 +57,8 @@ class ListTask(GraphRunnableTask):
 
     def _iterate_selected_nodes(self):
         selector = self.get_node_selector()
+        if self.config.submaterialization:
+            selector.set_submaterialization(self.config.submaterialization)
         spec = self.get_selection_spec()
         nodes = sorted(selector.get_selected(spec))
         if not nodes:

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -248,13 +248,17 @@ class ModelRunner(CompileRunner):
     def execute(self, model, manifest):
         context = generate_runtime_model_context(model, self.config, manifest)
 
+        materialized = model.get_materialization()
+        if self.config.submaterialization is not None:
+            materialized = materialized + '_' + self.config.submaterialization
+
         materialization_macro = manifest.find_materialization_macro_by_name(
-            self.config.project_name, model.get_materialization(), self.adapter.type()
+            self.config.project_name, materialized, self.adapter.type()
         )
 
         if materialization_macro is None:
             raise MissingMaterializationError(
-                materialization=model.get_materialization(), adapter_type=self.adapter.type()
+                materialization=materialized, adapter_type=self.adapter.type()
             )
 
         if "config" not in context:

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -75,6 +75,10 @@ class GraphRunnableTask(ConfiguredTask):
         self._raise_next_tick = None
         self.previous_state: Optional[PreviousState] = None
         self.set_previous_state()
+        if self.args.submaterialization is not None:
+            self.config.submaterialization = self.args.submaterialization
+        else:
+            self.config.submaterialization = None
 
     def set_previous_state(self):
         if self.args.state is not None:
@@ -124,6 +128,8 @@ class GraphRunnableTask(ConfiguredTask):
 
     def get_graph_queue(self) -> GraphQueue:
         selector = self.get_node_selector()
+        if self.config.submaterialization:
+            selector.set_submaterialization(self.config.submaterialization)
         spec = self.get_selection_spec()
         return selector.get_graph_queue(spec)
 


### PR DESCRIPTION
resolves #7122

### Description

In my company, we have a need to run operations on our materialized tables such as user deletion requests.  The dbt run-operation is single threaded and doesn't take advantage of the node yml structure.  Other submaterializations might be things like 'clone' which just implements snowflake's clone feature.

I was thinking that an improvement would be to (for a particular model)

```yaml
materialized: incremental
submaterializations:
  - user_delete
  - clone
```

Another model might be

```yaml
materialized: table
submaterializations:
  - user_delete
```

Materializations named incremental_user_delete and table_user_delete could be created to match above

And it could be run using

```dbt run --submaterialization user_delete ...```

or 

```dbt ls --submaterialization user_delete ...```

(also compile, parse)

Any model which has the submaterialization would respond to the above run and it would use the dag order / threads to run the operation.

https://getdbt.slack.com/archives/C50NEBJGG/p1677938569851409

Also supports --select submaterialization:<name> syntax.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
