### PR TITLE
use timezone with no DST in test

### DIFF
--- a/tests/functional/timezones/test_timezones.py
+++ b/tests/functional/timezones/test_timezones.py
@@ -4,6 +4,7 @@ import pytest
 from dbt.tests.util import run_dbt
 
 
+# Canada/Saskatchewan does not observe DST so the time diff won't change depending on when it is in the year
 model_sql = """
 {{
     config(
@@ -12,7 +13,7 @@ model_sql = """
 }}
 
 select
-    '{{ run_started_at.astimezone(modules.pytz.timezone("America/New_York")) }}' as run_started_at_est,
+    '{{ run_started_at.astimezone(modules.pytz.timezone("Canada/Saskatchewan")) }}' as run_started_at_saskatchewan,
     '{{ run_started_at }}' as run_started_at_utc
 """
 
@@ -46,7 +47,7 @@ class TestTimezones:
     def query(self, project):
         return """
             select
-              run_started_at_est,
+              run_started_at_saskatchewan,
               run_started_at_utc
             from {schema}.timezones
         """.format(
@@ -61,7 +62,7 @@ class TestTimezones:
         assert len(results) == 1
 
         result = project.run_sql(query, fetch="all")[0]
-        est, utc = result
+        saskatchewan, utc = result
 
         assert "+00:00" in utc
-        assert "-05:00" in est
+        assert "-06:00" in saskatchewan


### PR DESCRIPTION
resolves none

### Description

Test is failing in core due to daylight savings time.  This updates the timezone we use to one that does not observe daylight savings so this test will pass all year.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
