### PR TITLE
Allow `--select` and `--exclude` multiple times

### DIFF
--- a/.changes/unreleased/Breaking Changes-20230314-161505.yaml
+++ b/.changes/unreleased/Breaking Changes-20230314-161505.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Allow `--select` and `--exclude` multiple times
+time: 2023-03-14T16:15:05.81741-06:00
+custom:
+  Author: dbeatty10
+  Issue: "7158"

--- a/core/dbt/cli/options.py
+++ b/core/dbt/cli/options.py
@@ -1,4 +1,6 @@
 import click
+import typing as t
+from click import Context
 
 
 # Implementation from: https://stackoverflow.com/a/48394004
@@ -42,3 +44,17 @@ class MultiOption(click.Option):
                 our_parser.process = parser_process
                 break
         return retval
+
+    def type_cast_value(self, ctx: Context, value: t.Any) -> t.Any:
+        def flatten(data):
+            if isinstance(data, tuple):
+                for x in data:
+                    yield from flatten(x)
+            else:
+                yield data
+
+        # there will be nested tuples to flatten when multiple=True
+        value = super(MultiOption, self).type_cast_value(ctx, value)
+        if value:
+            value = tuple(flatten(value))
+        return value

--- a/core/dbt/cli/options.py
+++ b/core/dbt/cli/options.py
@@ -1,6 +1,8 @@
 import click
+import inspect
 import typing as t
 from click import Context
+from dbt.cli.option_types import ChoiceTuple
 
 
 # Implementation from: https://stackoverflow.com/a/48394004
@@ -13,6 +15,19 @@ class MultiOption(click.Option):
         super(MultiOption, self).__init__(*args, **kwargs)
         self._previous_parser_process = None
         self._eat_all_parser = None
+
+        # validate that multiple=True
+        multiple = kwargs.pop("multiple", None)
+        msg = f"MultiOption named `{self.name}` must have multiple=True (rather than {multiple})"
+        assert multiple, msg
+
+        # validate that type=tuple or type=ChoiceTuple
+        option_type = kwargs.pop("type", None)
+        msg = f"MultiOption named `{self.name}` must be tuple or ChoiceTuple (rather than {option_type})"
+        if inspect.isclass(option_type):
+            assert issubclass(option_type, tuple), msg
+        else:
+            assert isinstance(option_type, ChoiceTuple), msg
 
     def add_to_parser(self, parser, ctx):
         def parser_process(value, state):

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -83,6 +83,7 @@ exclude = click.option(
     envvar=None,
     type=tuple,
     cls=MultiOption,
+    multiple=True,
     help="Specify the nodes to exclude.",
 )
 
@@ -318,6 +319,7 @@ select_attrs = {
     "envvar": None,
     "help": "Specify the nodes to include.",
     "cls": MultiOption,
+    "multiple": True,
     "type": tuple,
 }
 

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -183,7 +183,7 @@ output_keys = click.option(
         "Space-delimited listing of node properties to include as custom keys for JSON output "
         "(e.g. `--output json --output-keys name resource_type description`)"
     ),
-    type=list,
+    type=tuple,
     cls=MultiOption,
     default=[],
 )

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -185,6 +185,7 @@ output_keys = click.option(
     ),
     type=tuple,
     cls=MultiOption,
+    multiple=True,
     default=[],
 )
 
@@ -310,6 +311,7 @@ resource_type = click.option(
         case_sensitive=False,
     ),
     cls=MultiOption,
+    multiple=True,
     default=(),
 )
 

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -79,7 +79,11 @@ enable_legacy_logger = click.option(
 )
 
 exclude = click.option(
-    "--exclude", envvar=None, type=tuple, cls=MultiOption, help="Specify the nodes to exclude."
+    "--exclude",
+    envvar=None,
+    type=tuple,
+    cls=MultiOption,
+    help="Specify the nodes to exclude.",
 )
 
 fail_fast = click.option(

--- a/tests/functional/graph_selection/test_graph_selection.py
+++ b/tests/functional/graph_selection/test_graph_selection.py
@@ -163,6 +163,12 @@ class TestGraphSelection(SelectionFixtures):
         results = run_dbt(["run", "--select", "@emails_alt", "users_rollup"], expect_pass=False)
         check_result_nodes_by_name(results, ["users_rollup", "users", "emails_alt"])
 
+    def test_concat_multiple(self, project):
+        results = run_dbt(
+            ["run", "--select", "@emails_alt", "--select", "users_rollup"], expect_pass=False
+        )
+        check_result_nodes_by_name(results, ["users_rollup"])
+
     def test_concat_exclude(self, project):
         results = run_dbt(
             [
@@ -170,6 +176,22 @@ class TestGraphSelection(SelectionFixtures):
                 "--select",
                 "@emails_alt",
                 "users_rollup",
+                "--exclude",
+                "emails_alt",
+            ],
+            expect_pass=False,
+        )
+        check_result_nodes_by_name(results, ["users_rollup", "users"])
+
+    def test_concat_exclude_multiple(self, project):
+        results = run_dbt(
+            [
+                "run",
+                "--select",
+                "@emails_alt",
+                "users_rollup",
+                "--exclude",
+                "users",
                 "--exclude",
                 "emails_alt",
             ],

--- a/tests/functional/graph_selection/test_graph_selection.py
+++ b/tests/functional/graph_selection/test_graph_selection.py
@@ -167,7 +167,7 @@ class TestGraphSelection(SelectionFixtures):
         results = run_dbt(
             ["run", "--select", "@emails_alt", "--select", "users_rollup"], expect_pass=False
         )
-        check_result_nodes_by_name(results, ["users_rollup"])
+        check_result_nodes_by_name(results, ["users_rollup", "users", "emails_alt"])
 
     def test_concat_exclude(self, project):
         results = run_dbt(
@@ -197,7 +197,7 @@ class TestGraphSelection(SelectionFixtures):
             ],
             expect_pass=False,
         )
-        check_result_nodes_by_name(results, ["users_rollup", "users"])
+        check_result_nodes_by_name(results, ["users_rollup"])
 
     def test_concat_exclude_concat(self, project):
         results = run_dbt(


### PR DESCRIPTION
resolves #7158
resolves #6800

### Problem
Currently, if a user does the following, only the last selector (`users_rollup`) will be take effect and earlier ones (`users`) will not:
```shell
dbt run --select users --select users_rollup
```

Selection syntax is confusing enough as-is, and the fact that it accepts multiples but only uses the last one makes it even more confusing.

### Options

#7158 describes two options for how to move forward:
1. Combine multiple instances of `--select` as if it were a [union](https://docs.getdbt.com/reference/node-selection/set-operators#unions). Similar for `--exclude`.
1. Raise an error (with a helpful message) if more than 1 `--select` is supplied. Same thing for `--exclude`.

This PR fleshes out **option 1**.

Note: most of it would also be applicable if we choose to implement **option 2** instead.

Implicitly, there's also an **option 0** that keeps the status quo. If we choose option 0, I'd still advocate that we cherry-pick the two test cases in https://github.com/dbt-labs/dbt-core/pull/7169/commits/2824f4ac82c08c07ef46f32e05defcc44f924de4 so we can actively affirm that this is the expected and desired behavior.

### Breaking change

This is described as a breaking change in the changelog because the behavior changes for certain edge cases (see above).

### 🎩 
Our custom `MultiOption` class itself doesn't currently have any unit tests. Its main form of testing is the functional tests that depend upon it.

We expect that any parameter with MultiOption should also have (`type=tuple` or `type=ChoiceTuple`) and `multiple=True`.

Here's the exceptions that are raised when either of those expectations are violated:

Not `type=tuple` and not `type=ChoiceTuple`:
```
  File "/Users/dbeatty/projects/dbt-core/core/dbt/cli/options.py", line 28, in __init__
    assert issubclass(option_type, tuple), msg
AssertionError: MultiOption named `output_keys` must be tuple or ChoiceTuple (rather than <class 'list'>)
```

Not `multiple=True`:
```
  File "/Users/dbeatty/projects/dbt-core/core/dbt/cli/options.py", line 22, in __init__
    assert multiple, msg
AssertionError: MultiOption named `output_keys` must have multiple=True (rather than None)
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
    - https://github.com/dbt-labs/docs.getdbt.com/issues/3003
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
