### PR TITLE
CT-2049: Add CommandCompleted event

### DIFF
--- a/.changes/unreleased/Under the Hood-20230316-123305.yaml
+++ b/.changes/unreleased/Under the Hood-20230316-123305.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add CommandCompleted event, and fire it upon completion of every command
+time: 2023-03-16T12:33:05.696752-07:00
+custom:
+  Author: QMalcolm
+  Issue: "6878"

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -62,16 +62,29 @@ def preflight(func):
 
         start_func = time.perf_counter()
 
-        (results, success) = func(*args, **kwargs)
+        try:
+            (results, success) = func(*args, **kwargs)
 
-        fire_event(
-            CommandCompleted(
-                command=ctx.command_path,
-                success=success,
-                completed_at=datetime.datetime.utcnow(),
-                elapsed=time.perf_counter() - start_func,
+            fire_event(
+                CommandCompleted(
+                    command=ctx.command_path,
+                    success=success,
+                    completed_at=datetime.datetime.utcnow(),
+                    elapsed=time.perf_counter() - start_func,
+                )
             )
-        )
+        # Bare except because we really do want to catch ALL exceptions,
+        # i.e. we want to fire this event in ALL cases.
+        except:  # noqa
+            fire_event(
+                CommandCompleted(
+                    command=ctx.command_path,
+                    success=False,
+                    completed_at=datetime.datetime.utcnow(),
+                    elapsed=time.perf_counter() - start_func,
+                )
+            )
+            raise
 
         return (results, success)
 

--- a/core/dbt/events/proto_types.py
+++ b/core/dbt/events/proto_types.py
@@ -2185,6 +2185,22 @@ class NoNodesSelectedMsg(betterproto.Message):
 
 
 @dataclass
+class CommandCompleted(betterproto.Message):
+    """Q039"""
+
+    command: str = betterproto.string_field(1)
+    success: bool = betterproto.bool_field(2)
+    completed_at: datetime = betterproto.message_field(3)
+    elapsed: float = betterproto.float_field(4)
+
+
+@dataclass
+class CommandCompletedMsg(betterproto.Message):
+    info: "EventInfo" = betterproto.message_field(1)
+    data: "CommandCompleted" = betterproto.message_field(2)
+
+
+@dataclass
 class CatchableExceptionOnRun(betterproto.Message):
     """W002"""
 

--- a/core/dbt/events/types.proto
+++ b/core/dbt/events/types.proto
@@ -1747,6 +1747,19 @@ message NoNodesSelectedMsg {
     NoNodesSelected data = 2;
 }
 
+// Q039
+message CommandCompleted {
+    string command = 1;
+    bool success = 2;
+    google.protobuf.Timestamp completed_at = 3;
+    float elapsed = 4;
+}
+
+message CommandCompletedMsg {
+    EventInfo info = 1;
+    CommandCompleted data = 2;
+}
+
 // W - Node testing
 
 // Skipped W001

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1827,6 +1827,16 @@ class NoNodesSelected(WarnLevel, pt.NoNodesSelected):
         return "No nodes selected!"
 
 
+@dataclass
+class CommandCompleted(InfoLevel, pt.CommandCompleted):
+    def code(self):
+        return "Q039"
+
+    def message(self) -> str:
+        status = "succeeded" if self.success else "failed"
+        return f"Command `{self.command}` {status} at {self.completed_at} after {self.elapsed:0.2f} seconds"
+
+
 # =======================================================
 # W - Node testing
 # =======================================================

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1828,7 +1828,7 @@ class NoNodesSelected(WarnLevel, pt.NoNodesSelected):
 
 
 @dataclass
-class CommandCompleted(InfoLevel, pt.CommandCompleted):
+class CommandCompleted(DebugLevel, pt.CommandCompleted):
     def code(self):
         return "Q039"
 

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,6 +1,7 @@
 import re
 from typing import TypeVar
 
+from datetime import datetime
 from dbt.contracts.results import TimingInfo
 from dbt.events import AdapterLogger, test_types, types
 from dbt.events.base_types import (
@@ -326,6 +327,7 @@ sample_values = [
     types.NoNodesSelected(),
     types.DepsUnpinned(revision="", git=""),
     types.NoNodesForSelectionCriteria(spec_raw=""),
+    types.CommandCompleted(command="", success=True, elapsed=0.1, completed_at=datetime.utcnow()),
     # W - Node testing ======================
     types.CatchableExceptionOnRun(exc=""),
     types.InternalErrorOnRun(build_path="", exc=""),


### PR DESCRIPTION
resolves #6878 

### Description

[CT-2049](https://github.com/dbt-labs/dbt-core/issues/6878) outlines a desire to have an event that is output on completion of any and every command. This PR adds that functionality. Below is a demo of the functionality in a loom video (clicking will redirect you to loom)

<a href="https://www.loom.com/share/661cb790b6524c4b87ecd90ca3520f00">
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/661cb790b6524c4b87ecd90ca3520f00-with-play.gif">
</a>

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)


[CT-2049]: https://dbtlabs.atlassian.net/browse/CT-2049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ