### PR TITLE
CT-1928: dbtRunner to EventManager callback support

### DIFF
--- a/.changes/unreleased/Features-20230322-124615.yaml
+++ b/.changes/unreleased/Features-20230322-124615.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support setting of callbacks for programmatic uses of `dbtRunner`
+time: 2023-03-22T12:46:15.877884-07:00
+custom:
+  Author: QMalcolm
+  Issue: "6763"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -1,11 +1,12 @@
 from copy import copy
-from typing import List, Tuple, Optional
+from typing import Callable, List, Tuple, Optional
 
 import click
 from dbt.cli import requires, params as p
 from dbt.config.project import Project
 from dbt.config.profile import Profile
 from dbt.contracts.graph.manifest import Manifest
+from dbt.events.base_types import EventMsg
 from dbt.task.clean import CleanTask
 from dbt.task.compile import CompileTask
 from dbt.task.deps import DepsTask
@@ -34,11 +35,16 @@ class dbtInternalException(Exception):
 # Programmatic invocation
 class dbtRunner:
     def __init__(
-        self, project: Project = None, profile: Profile = None, manifest: Manifest = None
+        self,
+        project: Project = None,
+        profile: Profile = None,
+        manifest: Manifest = None,
+        callbacks: List[Callable[[EventMsg], None]] = [],
     ):
         self.project = project
         self.profile = profile
         self.manifest = manifest
+        self.callbacks = callbacks
 
     def invoke(self, args: List[str]) -> Tuple[Optional[List], bool]:
         try:
@@ -47,6 +53,7 @@ class dbtRunner:
                 "project": self.project,
                 "profile": self.profile,
                 "manifest": self.manifest,
+                "callbacks": self.callbacks,
             }
             return cli.invoke(dbt_ctx)
         except click.exceptions.Exit as e:

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -33,7 +33,8 @@ def preflight(func):
 
         # Logging
         # N.B. Legacy logger is not supported
-        setup_event_logger(flags)
+        callabcks = ctx.obj.get("callbacks", [])
+        setup_event_logger(flags=flags, callbacks=callabcks)
 
         # Now that we have our logger, fire away!
         fire_event(MainReportVersion(version=str(installed_version), log_version=LOG_VERSION))

--- a/core/dbt/events/eventmgr.py
+++ b/core/dbt/events/eventmgr.py
@@ -215,12 +215,8 @@ class EventManager:
         self.loggers.append(logger)
 
     def add_callbacks(self, callbacks: List[Callable[[EventMsg], None]]):
-        """Helper for bulk adding a sequence of Callbacks to the EventManager"""
+        """Helper for adding a sequence of Callbacks to the EventManager"""
         self.callbacks.extend(callbacks)
-
-    def add_callback(self, callback: Callable[[EventMsg], None]):
-        """Helper which adds a singular Callback to the EventManager"""
-        self.callbacks.append(callback)
 
     def flush(self):
         for logger in self.loggers:

--- a/core/dbt/events/eventmgr.py
+++ b/core/dbt/events/eventmgr.py
@@ -214,6 +214,14 @@ class EventManager:
         logger.event_manager = self
         self.loggers.append(logger)
 
+    def add_callbacks(self, callbacks: List[Callable[[EventMsg], None]]):
+        """Helper for bulk adding a sequence of Callbacks to the EventManager"""
+        self.callbacks.extend(callbacks)
+
+    def add_callback(self, callback: Callable[[EventMsg], None]):
+        """Helper which adds a singular Callback to the EventManager"""
+        self.callbacks.append(callback)
+
     def flush(self):
         for logger in self.loggers:
             logger.flush()

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -10,7 +10,7 @@ from functools import partial
 import json
 import os
 import sys
-from typing import Callable, Dict, Optional, TextIO
+from typing import Callable, Dict, List, Optional, TextIO
 import uuid
 
 
@@ -18,9 +18,10 @@ LOG_VERSION = 3
 metadata_vars: Optional[Dict[str, str]] = None
 
 
-def setup_event_logger(flags) -> None:
+def setup_event_logger(flags, callbacks: List[Callable[[EventMsg], None]] = []) -> None:
     cleanup_event_logger()
     make_log_dir_if_missing(flags.LOG_PATH)
+    EVENT_MANAGER.add_callbacks(callbacks=callbacks)
 
     if ENABLE_LEGACY_LOGGER:
         EVENT_MANAGER.add_logger(

--- a/tests/unit/test_dbt_runner.py
+++ b/tests/unit/test_dbt_runner.py
@@ -1,6 +1,7 @@
 import pytest
 
 from dbt.cli.main import dbtRunner, dbtUsageException
+from unittest import mock
 
 
 class TestDbtRunner:
@@ -26,3 +27,11 @@ class TestDbtRunner:
 
     def test_invoke_version(self, dbt: dbtRunner) -> None:
         dbt.invoke(["--version"])
+
+    def test_callbacks(self) -> None:
+        mock_callback = mock.MagicMock()
+        dbt = dbtRunner(callbacks=[mock_callback])
+        # the `debug` command is one of the few commands wherein you don't need
+        # to have a project to run it and it will emit events
+        dbt.invoke(["debug"])
+        mock_callback.assert_called()


### PR DESCRIPTION
resolves #6763 

# Description
We need to be able to set callbacks for the `EventManager` when using the `dbtRunner` for programmatic implementations, as described in [CT-1928](https://github.com/dbt-labs/dbt-core/issues/6763). The way it works is on instantiation of `dbtRunner` one can now provide `callbacks`. These callbacks are for the `EventLogger`. When `invoke` is called on a `dbtRunner`, the `callbacks` are added to the cli context object. In the preflight decorator these callbacks are extracted from the cli context and then passed to the `setup_event_logger`, finally `setup_event_logger` ensures the callbacks are added to the global `EVENT_MANAGER`.

<a href="https://www.loom.com/share/2e9fb9999f9849c7ba9f1cc1d51febb3">
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/2e9fb9999f9849c7ba9f1cc1d51febb3-with-play.gif">
</a>


## Problems
This implementation has two problems: DevEx and Global State Shenanigans

### DevEx Gripe
To make this work we had to set `callbacks` on the cli context `obj`. This `obj` is basically a grab bag of stuff which may or may not exist, and may or may not be necessary. It would be nice to have a more explicit passing of parameters so that it's clearer where and why they are necessary

### `EVENT_MANAGER` Global State Shenanigans
Every invocation of the CLI shares the same `EventManager`, which is the global `EVENT_MANAGER`. This isn't problematic so long as only one invocation is running at a time. However, as soon as there are two or more invocations at a time (I don't think we currently support this?) things will start breaking. Things will start breaking because `setup_event_logger` is destructive and called during every invocation. Specifically it clears the existing loggers and callbacks associated with the `EVENT_MANAGER`. Though even if this didn't happen, the global `EVENT_MANAGER` would still be problematic because `setup_event_logger` would be adding extra callbacks to other unrelated invocations 🫠

Loom video coming soon™️ 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)


[CT-1928]: https://dbtlabs.atlassian.net/browse/CT-1928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ