### PR TITLE
Use function for datetime in CommandCompleted and throw error when testing

### DIFF
--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -11,6 +11,7 @@ from dbt.events.types import (
     MainReportArgs,
     MainTrackingUserState,
 )
+from dbt.events.helpers import get_json_string_utcnow
 from dbt.exceptions import DbtProjectError
 from dbt.parser.manifest import ManifestLoader, write_manifest
 from dbt.profiler import profiler
@@ -18,7 +19,6 @@ from dbt.tracking import active_user, initialize_from_flags, track_run
 from dbt.utils import cast_dict_to_dict_of_strings
 
 from click import Context
-import datetime
 from functools import update_wrapper
 import time
 
@@ -69,7 +69,7 @@ def preflight(func):
                 CommandCompleted(
                     command=ctx.command_path,
                     success=success,
-                    completed_at=datetime.datetime.utcnow(),
+                    completed_at=get_json_string_utcnow(),
                     elapsed=time.perf_counter() - start_func,
                 )
             )
@@ -80,7 +80,7 @@ def preflight(func):
                 CommandCompleted(
                     command=ctx.command_path,
                     success=False,
-                    completed_at=datetime.datetime.utcnow(),
+                    completed_at=get_json_string_utcnow(),
                     elapsed=time.perf_counter() - start_func,
                 )
             )

--- a/core/dbt/events/base_types.py
+++ b/core/dbt/events/base_types.py
@@ -74,8 +74,13 @@ class BaseEvent:
             from dbt.events.types import Note
             from dbt.events.functions import fire_event
 
-            fire_event(Note(msg=f"[{class_name}]: Unable to parse dict {kwargs}"))
-            self.pb_msg = msg_cls()
+            error_msg = f"[{class_name}]: Unable to parse dict {kwargs}"
+            # If we're testing throw an error so that we notice failures
+            if "pytest" in sys.modules:
+                raise Exception(error_msg)
+            else:
+                fire_event(Note(msg=error_msg))
+                self.pb_msg = msg_cls()
 
     def __setattr__(self, key, value):
         if key == "pb_msg":

--- a/tests/functional/logging/test_logging.py
+++ b/tests/functional/logging/test_logging.py
@@ -76,29 +76,7 @@ def test_invalid_event_value(project, logs_dir):
         fire_event(InvalidOptionYAML("testing"))
 
     # Provide invalid type to "option_name"
-    fire_event(InvalidOptionYAML(option_name=1))
+    with pytest.raises(Exception) as excinfo:
+        fire_event(InvalidOptionYAML(option_name=1))
 
-    log_file = read_file(logs_dir, "dbt.log")
-    invalid_kwarg_event = None
-    invalid_kwarg_note = None
-    for log_line in log_file.split("\n"):
-        # skip empty lines
-        if len(log_line) == 0:
-            continue
-        # The adapter logging also shows up, so skip non-json lines
-        if "[debug]" in log_line:
-            continue
-        log_dct = json.loads(log_line)
-        if log_dct["info"]["name"] == "InvalidOptionYAML":
-            invalid_kwarg_event = log_dct
-        if log_dct["info"]["name"] == "Note":
-            invalid_kwarg_note = log_dct
-    assert invalid_kwarg_event
-    assert (
-        invalid_kwarg_event["info"]["msg"] == "The YAML provided in the -- argument is not valid."
-    )
-    assert invalid_kwarg_note
-    assert (
-        invalid_kwarg_note["info"]["msg"]
-        == "[InvalidOptionYAML]: Unable to parse dict {'option_name': 1}"
-    )
+    assert str(excinfo.value) == "[InvalidOptionYAML]: Unable to parse dict {'option_name': 1}"

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,7 +1,6 @@
 import re
 from typing import TypeVar
 
-from datetime import datetime
 from dbt.contracts.results import TimingInfo
 from dbt.events import AdapterLogger, types
 from dbt.events.base_types import (
@@ -15,6 +14,7 @@ from dbt.events.base_types import (
     msg_from_base_event,
 )
 from dbt.events.functions import msg_to_dict, msg_to_json
+from dbt.events.helpers import get_json_string_utcnow
 from dbt.flags import set_from_args
 from argparse import Namespace
 
@@ -331,7 +331,9 @@ sample_values = [
     types.NoNodesSelected(),
     types.DepsUnpinned(revision="", git=""),
     types.NoNodesForSelectionCriteria(spec_raw=""),
-    types.CommandCompleted(command="", success=True, elapsed=0.1, completed_at=datetime.utcnow()),
+    types.CommandCompleted(
+        command="", success=True, elapsed=0.1, completed_at=get_json_string_utcnow()
+    ),
     # W - Node testing ======================
     types.CatchableExceptionOnRun(exc=""),
     types.InternalErrorOnRun(build_path="", exc=""),


### PR DESCRIPTION

### Description

Use utility function "get_json_string_utcnow" to set the time in the CommandCompleted message. Throw errors when testing and unable to parse the kwarg dictionary in the logging event base class.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
