### PR TITLE
Test hologram#51 (remove top pin for `jsonschema`)

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,7 @@ docutils
 flake8
 flaky
 freezegun==0.3.12
+git+https://github.com/dbt-labs/hologram.git@pr/51#egg=hologram
 ipdb
 mypy==0.981
 pip-tools


### PR DESCRIPTION
resolves #6775

### Description

Run tests in CI with https://github.com/dbt-labs/hologram/pull/50 (no `jsonschema` pin)

```
$ pip install --upgrade jsonschema -r dev-requirements.txt -r editable-requirements.txt
...
$ pip freeze | grep 'hologram'
hologram @ git+https://github.com/dbt-labs/hologram.git@e4f5741c544b58e028f35296b09b3c7cdd40c4a7
$ pip freeze | grep 'jsonschema'
jsonschema==4.17.3
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- ~I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR~
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
