### PR TITLE
Raise upper pin for hologram to 0.0.16; removed jsonschema upper pin

### DIFF
--- a/.changes/unreleased/Under the Hood-20230324-144050.yaml
+++ b/.changes/unreleased/Under the Hood-20230324-144050.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove upper pin for hologram/jsonschema
+time: 2023-03-24T14:40:50.574108-04:00
+custom:
+  Author: gshank
+  Issue: "6775"

--- a/core/setup.py
+++ b/core/setup.py
@@ -50,7 +50,7 @@ setup(
         "agate>=1.6,<1.7.1",
         "click>=7.0,<9",
         "colorama>=0.3.9,<0.4.7",
-        "hologram>=0.0.14,<=0.0.15",
+        "hologram>=0.0.14,<=0.0.16",
         "isodate>=0.6,<0.7",
         "logbook>=1.5,<1.6",
         "mashumaro[msgpack]==3.3.1",


### PR DESCRIPTION
resolves #6775

### Description

Use hologram version 0.0.16 without pin of jsonschema.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
