### PR TITLE
CT-2322/improve contracts error message

### DIFF
--- a/.changes/unreleased/Features-20230325-192830.yaml
+++ b/.changes/unreleased/Features-20230325-192830.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Added prettier printing to ContractError class
+time: 2023-03-25T19:28:30.171461-07:00
+custom:
+  Author: kentkr
+  Issue: "7209"

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -2136,7 +2136,7 @@ class ContractError(CompilationError):
             "Please ensure the name, data_type, and number of columns in your `yml` file "
             "match the columns in your SQL file.\n"
             # separate column headers by 20 spaces
-            f"{'yaml col:' : <20} {'sql col:' : <20} {'issue:' : <20}\n"
+            f"{'sql col:' : <20} {'yaml col:' : <20} {'issue:' : <20}\n"
         )
 
         # list of ordered matches (or not matches) for printing

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -2132,7 +2132,7 @@ class ContractError(CompilationError):
 
     def get_message(self) -> str:
         msg = (
-            "Contracts are enabled for this model. "
+            "This model has an enforced contract that failed.\n"
             "Please ensure the name, data_type, and number of columns in your `yml` file "
             "match the columns in your SQL file.\n"
             f"Schema File Columns: {self.yaml_columns}\n"

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -2135,9 +2135,22 @@ class ContractError(CompilationError):
             "This model has an enforced contract that failed.\n"
             "Please ensure the name, data_type, and number of columns in your `yml` file "
             "match the columns in your SQL file.\n"
-            f"Schema File Columns: {self.yaml_columns}\n"
-            f"SQL File Columns: {self.sql_columns}"
+            # separate column headers by 20 spaces
+            f"{'yaml col:' : <20} sql col:\n"
         )
+
+        # print columns pretty
+        # split yaml and sql strings into list
+        yaml_list = self.yaml_columns.split(', ')
+        sql_list = self.sql_columns.split(', ')
+        # make sure lists are the same length, add empty string if not
+        yaml_list += ['']*(len(sql_list) - len(yaml_list))
+        sql_list += ['']*(len(yaml_list) - len(sql_list))
+        # for each col
+        for i in range(len(yaml_list)):
+            # separate yaml and sql columns by 20 spaces, append to message
+            msg += f"{yaml_list[i] : <20} {sql_list[i]}\n"
+
         return msg
 
 

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -2136,11 +2136,7 @@ class ContractError(CompilationError):
             "Please ensure the name, data_type, and number of columns in your `yml` file "
             "match the columns in your SQL file.\n"
             # separate column headers by 20 spaces
-<<<<<<< HEAD
             f"{'sql col:' : <20} {'yaml col:' : <20} {'issue:' : <20}\n"
-=======
-            f"{'yaml col:' : <20} {'sql col:' : <20} {'issue:' : <20}\n"
->>>>>>> 86a614f034bb7e9985ad3d398a84bc3b4b8ce45b
         )
 
         # list of ordered matches (or not matches) for printing

--- a/core/dbt/include/global_project/macros/materializations/models/table/columns_spec_ddl.sql
+++ b/core/dbt/include/global_project/macros/materializations/models/table/columns_spec_ddl.sql
@@ -43,7 +43,7 @@
   {%- set string_yaml_columns = stringify_formatted_columns(yaml_columns) -%}
 
   {%- if sql_columns|length != yaml_columns|length -%}
-    {%- do exceptions.raise_contract_error(string_yaml_columns, string_sql_columns) -%}
+    {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}
   {%- endif -%}
 
   {%- for sql_col in sql_columns -%}
@@ -56,11 +56,11 @@
     {%- endfor -%}
     {%- if not yaml_col -%}
       {#-- Column with name not found in yaml #}
-      {%- do exceptions.raise_contract_error(string_yaml_columns, string_sql_columns) -%}
+      {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}
     {%- endif -%}
     {%- if sql_col['formatted'] != yaml_col[0]['formatted'] -%}
       {#-- Column data types don't match #}
-      {%- do exceptions.raise_contract_error(string_yaml_columns, string_sql_columns) -%}
+      {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}
     {%- endif -%}
   {%- endfor -%}
 


### PR DESCRIPTION
resolves #7209 

### Description

If a model has a contract error dbt currently prints the yaml columns and sql columns, respectively, as a single string with delimited column names and data type. This is hard to read. The changes made here split the strings and print the yaml and sql columns side by side.

Note that the columns are printed in the order that they are listed in the model or in the yaml file. So columns may not line up correctly. Because of this I decided not to add an extra column that checks if the two columns are the same, a feature requested in the original issue. 

I'm not all that familiar with OOP and don't know how `self.yaml_columns` (and sql columns) is inherited or where it comes from. But surely it can be inherited as something other than a delimited string. If it was a dict (`{col : data_type}`) it'd be easier to compare and print in an ordered format. That may be more effort than its worth. @jtcohen6 any suggestions?

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
