### PR TITLE
Remove unnecessary "version" keys in partial parsing pp_dict

### DIFF
--- a/.changes/unreleased/Fixes-20230329-111451.yaml
+++ b/.changes/unreleased/Fixes-20230329-111451.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix partial parsing error due to not requiring "version"
+time: 2023-03-29T11:14:51.734378-04:00
+custom:
+  Author: gshank
+  Issue: "7236"

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -577,13 +577,7 @@ class PartialParsing:
         new_schema_file = deepcopy(self.new_files[file_id])
         saved_yaml_dict = saved_schema_file.dict_from_yaml
         new_yaml_dict = new_schema_file.dict_from_yaml
-        if "version" in new_yaml_dict:
-            # despite the fact that this goes in the saved_schema_file, it
-            # should represent the new yaml dictionary, and should produce
-            # an error if the updated yaml file doesn't have a version
-            saved_schema_file.pp_dict = {"version": new_yaml_dict["version"]}
-        else:
-            saved_schema_file.pp_dict = {}
+        saved_schema_file.pp_dict = {}
         self.handle_schema_file_changes(saved_schema_file, saved_yaml_dict, new_yaml_dict)
 
         # copy from new schema_file to saved_schema_file to preserve references
@@ -806,8 +800,8 @@ class PartialParsing:
 
     # Merge a patch file into the pp_dict in a schema file
     def merge_patch(self, schema_file, key, patch):
-        if not schema_file.pp_dict:
-            schema_file.pp_dict = {"version": schema_file.dict_from_yaml["version"]}
+        if schema_file.pp_dict is None:
+            schema_file.pp_dict = {}
         pp_dict = schema_file.pp_dict
         if key not in pp_dict:
             pp_dict[key] = [patch]

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -502,9 +502,9 @@ class SchemaParser(SimpleParser[GenericTestBlock, GenericTestNode]):
 
     def parse_file(self, block: FileBlock, dct: Dict = None) -> None:
         assert isinstance(block.file, SchemaSourceFile)
-        if not dct:
-            dct = yaml_from_file(block.file)
 
+        # If partially parsing, dct should be from pp_dict, otherwise
+        # dict_from_yaml
         if dct:
             # contains the FileBlock and the data (dictionary)
             yaml_block = YamlBlock.from_file_block(block, dct)

--- a/tests/functional/partial_parsing/fixtures.py
+++ b/tests/functional/partial_parsing/fixtures.py
@@ -26,7 +26,6 @@ seeds:
 """
 
 local_dependency__models__schema_yml = """
-version: 2
 sources:
   - name: seed_source
     schema: "{{ var('schema_override', target.schema) }}"
@@ -56,12 +55,10 @@ local_dependency__seeds__seed_csv = """id
 """
 
 empty_schema_with_version_yml = """
-version: 2
 
 """
 
 schema_sources5_yml = """
-version: 2
 
 sources:
   - name: seed_sources
@@ -135,7 +132,6 @@ from source_data
 """
 
 schema_sources4_yml = """
-version: 2
 
 sources:
   - name: seed_sources
@@ -169,7 +165,6 @@ seeds:
 """
 
 env_var_schema_yml = """
-version: 2
 
 models:
     - name: model_one
@@ -189,7 +184,6 @@ empty_schema_yml = """
 """
 
 schema_models_c_yml = """
-version: 2
 
 sources:
   - name: seed_source
@@ -207,7 +201,6 @@ sources:
 """
 
 env_var_sources_yml = """
-version: 2
 sources:
   - name: seed_sources
     schema: "{{ target.schema }}"
@@ -258,7 +251,6 @@ from validation_errors
 """
 
 schema_sources1_yml = """
-version: 2
 sources:
   - name: seed_sources
     schema: "{{ target.schema }}"
@@ -279,7 +271,6 @@ sources:
 """
 
 schema_sources3_yml = """
-version: 2
 
 sources:
   - name: seed_sources
@@ -316,7 +307,6 @@ select * from customers
 """
 
 schema_sources2_yml = """
-version: 2
 
 sources:
   - name: seed_sources
@@ -354,7 +344,6 @@ select 'blue' as fun
 """
 
 my_metric_yml = """
-version: 2
 metrics:
   - name: new_customers
     label: New Customers
@@ -381,7 +370,6 @@ metrics:
 """
 
 env_var_schema2_yml = """
-version: 2
 
 models:
     - name: model_one
@@ -416,7 +404,6 @@ select 1 as fun
 """
 
 env_var_schema3_yml = """
-version: 2
 
 models:
     - name: model_one
@@ -441,7 +428,6 @@ exposures:
 """
 
 env_var_metrics_yml = """
-version: 2
 
 metrics:
 
@@ -598,7 +584,6 @@ custom_schema_tests1_sql = """
 """
 
 people_metrics_yml = """
-version: 2
 
 metrics:
 
@@ -665,7 +650,6 @@ from source_data
 """
 
 models_schema2b_yml = """
-version: 2
 
 models:
     - name: model_one
@@ -680,7 +664,6 @@ models:
 """
 
 env_var_macros_yml = """
-version: 2
 macros:
     - name: do_something
       description: "This is a test macro"
@@ -691,7 +674,6 @@ macros:
 """
 
 models_schema4_yml = """
-version: 2
 
 models:
     - name: model_one
@@ -713,7 +695,6 @@ select 1 as notfun
 """
 
 generic_test_schema_yml = """
-version: 2
 
 models:
   - name: orders
@@ -754,7 +735,6 @@ from source_data
 """
 
 macros_yml = """
-version: 2
 macros:
     - name: do_something
       description: "This is a test macro"
@@ -773,7 +753,6 @@ test_color_sql = """
 """
 
 models_schema2_yml = """
-version: 2
 
 models:
     - name: model_one
@@ -798,7 +777,6 @@ gsm_override2_sql = """
 """
 
 models_schema3_yml = """
-version: 2
 
 models:
     - name: model_one
@@ -843,7 +821,6 @@ from validation_errors
 """
 
 env_var_model_test_yml = """
-version: 2
 models:
   - name: model_color
     columns:
@@ -879,7 +856,6 @@ ref_override2_sql = """
 """
 
 models_schema1_yml = """
-version: 2
 
 models:
     - name: model_one
@@ -889,7 +865,6 @@ models:
 
 macros_schema_yml = """
 
-version: 2
 
 models:
     - name: model_a
@@ -944,7 +919,6 @@ select * from {{ ref('orders') }}
 """
 
 models_schema4b_yml = """
-version: 2
 
 models:
     - name: model_one
@@ -970,7 +944,6 @@ test_macro_sql = """
 """
 
 people_metrics2_yml = """
-version: 2
 
 metrics:
 
@@ -1004,7 +977,6 @@ metrics:
 """
 
 generic_schema_yml = """
-version: 2
 
 models:
   - name: orders
@@ -1018,7 +990,6 @@ models:
 
 
 groups_schema_yml_one_group = """
-version: 2
 
 groups:
   - name: test_group
@@ -1032,7 +1003,6 @@ models:
 
 
 groups_schema_yml_two_groups = """
-version: 2
 
 groups:
   - name: test_group
@@ -1048,7 +1018,6 @@ models:
 """
 
 groups_schema_yml_one_group_model_in_group2 = """
-version: 2
 
 groups:
   - name: test_group
@@ -1063,7 +1032,6 @@ models:
 """
 
 groups_schema_yml_two_groups_edited = """
-version: 2
 
 groups:
   - name: test_group
@@ -1127,7 +1095,6 @@ sources_tests2_sql = """
 """
 
 people_metrics3_yml = """
-version: 2
 
 metrics:
 


### PR DESCRIPTION
resolves #7236

### Description

Remove unnecessary "version" keys from constructed pp_dict in partial parsing. Also required removing fallback to load yaml from file with empty dict.  Removed "version: 2" from the partial parsing fixtures.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
