### PR TITLE
CT 2346 fix read and check versions

### DIFF
--- a/.changes/unreleased/Fixes-20230331-170417.yaml
+++ b/.changes/unreleased/Fixes-20230331-170417.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix handling of artifacts in read_and_check_versions
+time: 2023-03-31T17:04:17.068698-04:00
+custom:
+  Author: gshank
+  Issue: "7252"

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1231,10 +1231,11 @@ class WritableManifest(ArtifactMixin):
 
     @classmethod
     def upgrade_schema_version(cls, data):
-        # This is specific to manifests, so call this from ArtifactMixin code
+        """This overrides the "upgrade_schema_version" call in VersionedSchema (via
+        ArtifactMixin) to modify the dictionary passed in from earlier versions of the manifest."""
         if get_manifest_schema_version(data) <= 8:
             data = upgrade_manifest_json(data)
-        return cls.from_dict(data)  # type: ignore
+        return cls.from_dict(data)
 
     def __post_serialize__(self, dct):
         for unique_id, node in dct["nodes"].items():

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -37,6 +37,7 @@ from dbt.contracts.graph.nodes import (
     BaseNode,
 )
 from dbt.contracts.graph.unparsed import SourcePatch
+from dbt.contracts.graph.manifest_upgrade import upgrade_manifest_json
 from dbt.contracts.files import SourceFile, SchemaSourceFile, FileHash, AnySourceFile
 from dbt.contracts.util import BaseArtifactMetadata, SourceKey, ArtifactMixin, schema_version
 from dbt.dataclass_schema import dbtClassMixin
@@ -1228,11 +1229,25 @@ class WritableManifest(ArtifactMixin):
             ("manifest", 8),
         ]
 
+    @classmethod
+    def upgrade_schema_version(cls, data):
+        # This is specific to manifests, so call this from ArtifactMixin code
+        if get_manifest_schema_version(data) <= 8:
+            data = upgrade_manifest_json(data)
+        return cls.from_dict(data)  # type: ignore
+
     def __post_serialize__(self, dct):
         for unique_id, node in dct["nodes"].items():
             if "config_call_dict" in node:
                 del node["config_call_dict"]
         return dct
+
+
+def get_manifest_schema_version(dct: dict) -> int:
+    schema_version = dct.get("metadata", {}).get("dbt_schema_version", None)
+    if not schema_version:
+        raise ValueError("Manifest doesn't have schema version")
+    return int(schema_version.split(".")[-2][-1])
 
 
 def _check_duplicates(value: BaseNode, src: Mapping[str, BaseNode]):

--- a/core/dbt/contracts/graph/manifest_upgrade.py
+++ b/core/dbt/contracts/graph/manifest_upgrade.py
@@ -1,0 +1,110 @@
+from dbt import deprecations
+from dbt.dataclass_schema import ValidationError
+
+
+# we renamed these properties in v1.3
+# this method allows us to be nice to the early adopters
+def rename_metric_attr(data: dict, raise_deprecation_warning: bool = False) -> dict:
+    metric_name = data["name"]
+    if raise_deprecation_warning and (
+        "sql" in data.keys()
+        or "type" in data.keys()
+        or data.get("calculation_method") == "expression"
+    ):
+        deprecations.warn("metric-attr-renamed", metric_name=metric_name)
+    duplicated_attribute_msg = """\n
+The metric '{}' contains both the deprecated metric property '{}'
+and the up-to-date metric property '{}'. Please remove the deprecated property.
+"""
+    if "sql" in data.keys():
+        if "expression" in data.keys():
+            raise ValidationError(
+                duplicated_attribute_msg.format(metric_name, "sql", "expression")
+            )
+        else:
+            data["expression"] = data.pop("sql")
+    if "type" in data.keys():
+        if "calculation_method" in data.keys():
+            raise ValidationError(
+                duplicated_attribute_msg.format(metric_name, "type", "calculation_method")
+            )
+        else:
+            calculation_method = data.pop("type")
+            data["calculation_method"] = calculation_method
+    # we also changed "type: expression" -> "calculation_method: derived"
+    if data.get("calculation_method") == "expression":
+        data["calculation_method"] = "derived"
+    return data
+
+
+def rename_sql_attr(node_content: dict) -> dict:
+    if "raw_sql" in node_content:
+        node_content["raw_code"] = node_content.pop("raw_sql")
+    if "compiled_sql" in node_content:
+        node_content["compiled_code"] = node_content.pop("compiled_sql")
+    node_content["language"] = "sql"
+    return node_content
+
+
+def upgrade_node_content(node_content):
+    rename_sql_attr(node_content)
+    if node_content["resource_type"] != "seed" and "root_path" in node_content:
+        del node_content["root_path"]
+
+
+def upgrade_seed_content(node_content):
+    # Remove compilation related attributes
+    for attr_name in (
+        "language",
+        "refs",
+        "sources",
+        "metrics",
+        "compiled_path",
+        "compiled",
+        "compiled_code",
+        "extra_ctes_injected",
+        "extra_ctes",
+        "relation_name",
+    ):
+        if attr_name in node_content:
+            del node_content[attr_name]
+        # In v1.4, we switched SeedNode.depends_on from DependsOn to MacroDependsOn
+        node_content.get("depends_on", {}).pop("nodes", None)
+
+
+def upgrade_manifest_json(manifest: dict) -> dict:
+    for node_content in manifest.get("nodes", {}).values():
+        upgrade_node_content(node_content)
+        if node_content["resource_type"] == "seed":
+            upgrade_seed_content(node_content)
+    for disabled in manifest.get("disabled", {}).values():
+        # There can be multiple disabled nodes for the same unique_id
+        # so make sure all the nodes get the attr renamed
+        for node_content in disabled:
+            upgrade_node_content(node_content)
+            if node_content["resource_type"] == "seed":
+                upgrade_seed_content(node_content)
+    # add group key
+    if "groups" not in manifest:
+        manifest["groups"] = {}
+    if "group_map" not in manifest:
+        manifest["group_map"] = {}
+    for metric_content in manifest.get("metrics", {}).values():
+        # handle attr renames + value translation ("expression" -> "derived")
+        metric_content = rename_metric_attr(metric_content)
+        if "root_path" in metric_content:
+            del metric_content["root_path"]
+    for exposure_content in manifest.get("exposures", {}).values():
+        if "root_path" in exposure_content:
+            del exposure_content["root_path"]
+    for source_content in manifest.get("sources", {}).values():
+        if "root_path" in source_content:
+            del source_content["root_path"]
+    for macro_content in manifest.get("macros", {}).values():
+        if "root_path" in macro_content:
+            del macro_content["root_path"]
+    for doc_content in manifest.get("docs", {}).values():
+        if "root_path" in doc_content:
+            del doc_content["root_path"]
+        doc_content["resource_type"] = "doc"
+    return manifest

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -6,8 +6,8 @@ from dbt.contracts.util import (
     AdditionalPropertiesMixin,
     Mergeable,
     Replaceable,
-    rename_metric_attr,
 )
+from dbt.contracts.graph.manifest_upgrade import rename_metric_attr
 
 # trigger the PathEncoder
 import dbt.helper_types  # noqa:F401

--- a/core/dbt/contracts/util.py
+++ b/core/dbt/contracts/util.py
@@ -231,6 +231,9 @@ class VersionedSchema(dbtClassMixin):
 
     @classmethod
     def upgrade_schema_version(cls, data):
+        """This will modify the data (dictionary) passed in to match the current
+        artifact schema code, if necessary. This is the default method, which
+        just returns the instantiated object via from_dict."""
         return cls.from_dict(data)
 
 

--- a/core/dbt/contracts/util.py
+++ b/core/dbt/contracts/util.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from typing import List, Tuple, ClassVar, Type, TypeVar, Dict, Any, Optional
 
 from dbt.clients.system import write_json, read_json
-from dbt import deprecations
 from dbt.exceptions import (
     DbtInternalError,
     DbtRuntimeError,
@@ -186,121 +185,6 @@ def schema_version(name: str, version: int):
     return inner
 
 
-def get_manifest_schema_version(dct: dict) -> int:
-    schema_version = dct.get("metadata", {}).get("dbt_schema_version", None)
-    if not schema_version:
-        raise ValueError("Manifest doesn't have schema version")
-    return int(schema_version.split(".")[-2][-1])
-
-
-# we renamed these properties in v1.3
-# this method allows us to be nice to the early adopters
-def rename_metric_attr(data: dict, raise_deprecation_warning: bool = False) -> dict:
-    metric_name = data["name"]
-    if raise_deprecation_warning and (
-        "sql" in data.keys()
-        or "type" in data.keys()
-        or data.get("calculation_method") == "expression"
-    ):
-        deprecations.warn("metric-attr-renamed", metric_name=metric_name)
-    duplicated_attribute_msg = """\n
-The metric '{}' contains both the deprecated metric property '{}'
-and the up-to-date metric property '{}'. Please remove the deprecated property.
-"""
-    if "sql" in data.keys():
-        if "expression" in data.keys():
-            raise ValidationError(
-                duplicated_attribute_msg.format(metric_name, "sql", "expression")
-            )
-        else:
-            data["expression"] = data.pop("sql")
-    if "type" in data.keys():
-        if "calculation_method" in data.keys():
-            raise ValidationError(
-                duplicated_attribute_msg.format(metric_name, "type", "calculation_method")
-            )
-        else:
-            calculation_method = data.pop("type")
-            data["calculation_method"] = calculation_method
-    # we also changed "type: expression" -> "calculation_method: derived"
-    if data.get("calculation_method") == "expression":
-        data["calculation_method"] = "derived"
-    return data
-
-
-def rename_sql_attr(node_content: dict) -> dict:
-    if "raw_sql" in node_content:
-        node_content["raw_code"] = node_content.pop("raw_sql")
-    if "compiled_sql" in node_content:
-        node_content["compiled_code"] = node_content.pop("compiled_sql")
-    node_content["language"] = "sql"
-    return node_content
-
-
-def upgrade_node_content(node_content):
-    rename_sql_attr(node_content)
-    if node_content["resource_type"] != "seed" and "root_path" in node_content:
-        del node_content["root_path"]
-
-
-def upgrade_seed_content(node_content):
-    # Remove compilation related attributes
-    for attr_name in (
-        "language",
-        "refs",
-        "sources",
-        "metrics",
-        "compiled_path",
-        "compiled",
-        "compiled_code",
-        "extra_ctes_injected",
-        "extra_ctes",
-        "relation_name",
-    ):
-        if attr_name in node_content:
-            del node_content[attr_name]
-        # In v1.4, we switched SeedNode.depends_on from DependsOn to MacroDependsOn
-        node_content.get("depends_on", {}).pop("nodes", None)
-
-
-def upgrade_manifest_json(manifest: dict) -> dict:
-    for node_content in manifest.get("nodes", {}).values():
-        upgrade_node_content(node_content)
-        if node_content["resource_type"] == "seed":
-            upgrade_seed_content(node_content)
-    for disabled in manifest.get("disabled", {}).values():
-        # There can be multiple disabled nodes for the same unique_id
-        # so make sure all the nodes get the attr renamed
-        for node_content in disabled:
-            upgrade_node_content(node_content)
-            if node_content["resource_type"] == "seed":
-                upgrade_seed_content(node_content)
-    # add group key
-    if "groups" not in manifest:
-        manifest["groups"] = {}
-    if "group_map" not in manifest:
-        manifest["group_map"] = {}
-    for metric_content in manifest.get("metrics", {}).values():
-        # handle attr renames + value translation ("expression" -> "derived")
-        metric_content = rename_metric_attr(metric_content)
-        if "root_path" in metric_content:
-            del metric_content["root_path"]
-    for exposure_content in manifest.get("exposures", {}).values():
-        if "root_path" in exposure_content:
-            del exposure_content["root_path"]
-    for source_content in manifest.get("sources", {}).values():
-        if "root_path" in source_content:
-            del source_content["root_path"]
-    for macro_content in manifest.get("macros", {}).values():
-        if "root_path" in macro_content:
-            del macro_content["root_path"]
-    for doc_content in manifest.get("docs", {}).values():
-        if "root_path" in doc_content:
-            del doc_content["root_path"]
-        doc_content["resource_type"] = "doc"
-    return manifest
-
-
 # This is used in the ArtifactMixin and RemoteResult classes
 @dataclasses.dataclass
 class VersionedSchema(dbtClassMixin):
@@ -342,9 +226,12 @@ class VersionedSchema(dbtClassMixin):
                         expected=str(cls.dbt_schema_version),
                         found=previous_schema_version,
                     )
-        if get_manifest_schema_version(data) <= 8:
-            data = upgrade_manifest_json(data)
-        return cls.from_dict(data)  # type: ignore
+
+        return cls.upgrade_schema_version(data)
+
+    @classmethod
+    def upgrade_schema_version(cls, data):
+        return cls.from_dict(data)
 
 
 T = TypeVar("T", bound="ArtifactMixin")


### PR DESCRIPTION
resolves #7252


### Description

The code to fix older versions of manifest.json was also being called for sources.json and run_results.json, which is incorrect. Refactor to only call it for manifests.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
