### PR TITLE
if need_swap then rename from existing - not target

### DIFF
--- a/core/dbt/include/global_project/macros/materializations/models/incremental/incremental.sql
+++ b/core/dbt/include/global_project/macros/materializations/models/incremental/incremental.sql
@@ -62,7 +62,7 @@
   {% endcall %}
 
   {% if need_swap %}
-      {% do adapter.rename_relation(target_relation, backup_relation) %}
+      {% do adapter.rename_relation(existing_relation, backup_relation) %}
       {% do adapter.rename_relation(intermediate_relation, target_relation) %}
       {% do to_drop.append(backup_relation) %}
   {% endif %}


### PR DESCRIPTION
resolves #7267

### Description

in incremental.sql defaullt macro - use existing_model instead of target model - in order to reflect the correct type(table/view) of the existing model - in case materialization changes from view to incrmental.
 
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
