### PR TITLE
fix: avoid dbtRunner default callbacks being shared across instances 

### DIFF
--- a/.changes/unreleased/Fixes-20230405-124315.yaml
+++ b/.changes/unreleased/Fixes-20230405-124315.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: avoid dbtRunner default callbacks being shared across instances
+time: 2023-04-05T12:43:15.418016-04:00
+custom:
+  Author: chamini2
+  Issue: "7278"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -40,11 +40,14 @@ class dbtRunner:
         project: Project = None,
         profile: Profile = None,
         manifest: Manifest = None,
-        callbacks: List[Callable[[EventMsg], None]] = [],
+        callbacks: List[Callable[[EventMsg], None]] = None,
     ):
         self.project = project
         self.profile = profile
         self.manifest = manifest
+
+        if callbacks is None:
+            callbacks = []
         self.callbacks = callbacks
 
     def invoke(self, args: List[str]) -> Tuple[Optional[List], bool]:


### PR DESCRIPTION
resolves #7278

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

default the callbacks argument of dbtRunner to None and create a new list as the default every time it runs.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
