### PR TITLE
Ensure that same_contract is called for state:modified

### DIFF
--- a/.changes/unreleased/Fixes-20230405-182927.yaml
+++ b/.changes/unreleased/Fixes-20230405-182927.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Ensure same_contract is called for state:modified
+time: 2023-04-05T18:29:27.369084-04:00
+custom:
+  Author: gshank
+  Issue: "7282"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -430,13 +430,16 @@ class ParsedNode(NodeInfoMixin, ParsedNodeMandatory, SerializableType):
         if old is None:
             return False
 
+        # Need to ensure that same_contract is called because it
+        # could throw an error
+        same_contract = self.same_contract(old)
         return (
             self.same_body(old)
             and self.same_config(old)
             and self.same_persisted_description(old)
             and self.same_fqn(old)
             and self.same_database_representation(old)
-            and self.same_contract(old)
+            and same_contract
             and True
         )
 


### PR DESCRIPTION
resolves #7282

### Description

Breaking changes in a contract throws an error for state:modified. Since the comparison methods did not throw errors before, the node "same_contents" method did an "and" of the comparison methods, which will shortcircuit calling any other methods after a "False" is encountered.  Explicitly call the "same_contract" method to ensure it's always called.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
