### PR TITLE
Reset invocation_id Between Commands

### DIFF
--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -9,7 +9,7 @@ from dbt.cli.exceptions import (
 from dbt.cli.flags import Flags
 from dbt.config import RuntimeConfig
 from dbt.config.runtime import load_project, load_profile, UnsetProfile
-from dbt.events.functions import setup_event_logger, fire_event, LOG_VERSION
+from dbt.events.functions import fire_event, LOG_VERSION, set_invocation_id, setup_event_logger
 from dbt.events.types import (
     CommandCompleted,
     MainReportVersion,
@@ -48,6 +48,8 @@ def preflight(func):
         # Logging
         # N.B. Legacy logger is not supported
         callabcks = ctx.obj.get("callbacks", [])
+
+        set_invocation_id()
         setup_event_logger(flags=flags, callbacks=callabcks)
 
         # Now that we have our logger, fire away!

--- a/tests/unit/test_invocation_id.py
+++ b/tests/unit/test_invocation_id.py
@@ -1,0 +1,24 @@
+from dbt.cli.main import dbtRunner
+
+
+class TestInvocationId:
+    def test_invocation_id(self):
+        """Runs dbt programmatically twice, checking that invocation_id is
+        consistent within an invocation, but changes for the second invocation."""
+
+        runner = dbtRunner()
+
+        # Run once...
+        first_ids = set()
+        runner.callbacks = [lambda e: first_ids.add(e.info.invocation_id)]
+        runner.invoke(["debug"])
+
+        # ...run twice...
+        second_ids = set()
+        runner.callbacks = [lambda e: second_ids.add(e.info.invocation_id)]
+        runner.invoke(["debug"])
+
+        # ...check that the results were nice.
+        assert len(first_ids) == 1  # There was one consistent invocation_id for first run...
+        assert len(second_ids) == 1  # ...as well as the second...
+        assert len(first_ids.intersection(second_ids)) == 0


### PR DESCRIPTION
resolves #7197 

### Description

Reset invocation_id between command invocations.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
