### PR TITLE
allow resources to be selected by patch path

### DIFF
--- a/.changes/unreleased/Features-20230411-084645.yaml
+++ b/.changes/unreleased/Features-20230411-084645.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: select resources by patch path
+time: 2023-04-11T08:46:45.641682-05:00
+custom:
+  Author: dave-connors-3
+  Issue: "7315"

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -312,6 +312,11 @@ class PathSelectorMethod(SelectorMethod):
             ofp = Path(real_node.original_file_path)
             if ofp in paths:
                 yield node
+            if real_node.to_dict().get('patch_path', None):
+                pfp = real_node.patch_path.split('://')[1]
+                ymlfp = Path(pfp)    
+                if ymlfp in paths:  
+                    yield node
             elif any(parent in paths for parent in ofp.parents):
                 yield node
 

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -312,10 +312,10 @@ class PathSelectorMethod(SelectorMethod):
             ofp = Path(real_node.original_file_path)
             if ofp in paths:
                 yield node
-            if real_node.to_dict().get('patch_path', None):
-                pfp = real_node.patch_path.split('://')[1]
-                ymlfp = Path(pfp)    
-                if ymlfp in paths:  
+            if hasattr(real_node, "patch_path") and real_node.patch_path:
+                pfp = real_node.patch_path.split("://")[1]
+                ymlfp = Path(pfp)
+                if ymlfp in paths:
                     yield node
             elif any(parent in paths for parent in ofp.parents):
                 yield node

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -312,8 +312,8 @@ class PathSelectorMethod(SelectorMethod):
             ofp = Path(real_node.original_file_path)
             if ofp in paths:
                 yield node
-            if hasattr(real_node, "patch_path") and real_node.patch_path:
-                pfp = real_node.patch_path.split("://")[1]
+            if hasattr(real_node, "patch_path") and real_node.patch_path:  # type: ignore
+                pfp = real_node.patch_path.split("://")[1]  # type: ignore
                 ymlfp = Path(pfp)
                 if ymlfp in paths:
                     yield node

--- a/tests/functional/graph_selection/fixtures.py
+++ b/tests/functional/graph_selection/fixtures.py
@@ -71,7 +71,7 @@ exposures:
       email: nope@example.com
 """
 
-patch_path_selection_schema_yml="""
+patch_path_selection_schema_yml = """
 version: 2
 
 models:

--- a/tests/functional/graph_selection/fixtures.py
+++ b/tests/functional/graph_selection/fixtures.py
@@ -71,6 +71,15 @@ exposures:
       email: nope@example.com
 """
 
+patch_path_selection_schema_yml="""
+version: 2
+
+models:
+  - name: subdir
+    description: submarine sandwich directory
+
+"""
+
 base_users_sql = """
 
 {{
@@ -182,6 +191,7 @@ class SelectionFixtures:
     def models(self):
         return {
             "schema.yml": schema_yml,
+            "patch_path_selection_schema.yml": patch_path_selection_schema_yml,
             "base_users.sql": base_users_sql,
             "users.sql": users_sql,
             "users_rollup.sql": users_rollup_sql,

--- a/tests/functional/graph_selection/test_graph_selection.py
+++ b/tests/functional/graph_selection/test_graph_selection.py
@@ -125,6 +125,10 @@ class TestGraphSelection(SelectionFixtures):
         check_result_nodes_by_name(results, ["nested_users", "subdir"])
         assert_correct_schemas(project)
 
+        results = run_dbt(["build", "--select", "models/patch_path_selection_schema.yml"])
+        check_result_nodes_by_name(results, ["subdir"])
+        assert_correct_schemas(project)
+
     def test_locally_qualified_name_model_with_dots(self, project):
         results = run_dbt(["run", "--select", "alternative.users"], expect_pass=False)
         check_result_nodes_by_name(results, ["alternative.users"])


### PR DESCRIPTION
resolves #7315 

### Description

This changes the selection method to allow resources to be selected when the path selector matches their patch path in addition to their original filepath. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
