### PR TITLE
compile inline query doesn't add node

### DIFF
--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -143,6 +143,7 @@ class CompileTask(GraphRunnableTask):
         # remove inline node from manifest
         if self._inline_node_id:
             self.manifest.nodes.pop(self._inline_node_id)
+            self._inline_node_id = None
         super().after_run(adapter, results)
 
     def _handle_result(self, result):

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -40,6 +40,10 @@ class CompileRunner(BaseRunner):
 
 
 class CompileTask(GraphRunnableTask):
+    # We add a new inline node to the manifest during initialization
+    # it should be removed before the task is complete
+    _inline_node_id = None
+
     def raise_on_first_error(self):
         return True
 
@@ -130,8 +134,16 @@ class CompileTask(GraphRunnableTask):
             )
             sql_node = block_parser.parse_remote(self.args.inline, "inline_query")
             process_node(self.config, self.manifest, sql_node)
+            # keep track of the node added to the manifest
+            self._inline_node_id = sql_node.unique_id
 
         super()._runtime_initialize()
+
+    def after_run(self, adapter, results):
+        # remove inline node from manifest
+        if self._inline_node_id:
+            self.manifest.nodes.pop(self._inline_node_id)
+        super().after_run(adapter, results)
 
     def _handle_result(self, result):
         super()._handle_result(result)


### PR DESCRIPTION
Related to https://github.com/dbt-labs/dbt-core/issues/6358
When compile a inline node, we add one additional node to the manifest. That node should be removed when compile is done.

~~I tried but couldn't find a way to add a test for this. was hoping to have one function to remove the line node and validate it is being called when running inline query but couldn't mock because dbt.task.compile is not a package.~~
Didin't try hard enough last time, added test