### PR TITLE
Adding a new column is not a breaking contract change

### DIFF
--- a/.changes/unreleased/Fixes-20230412-133438.yaml
+++ b/.changes/unreleased/Fixes-20230412-133438.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Adding a new column is not a breaking contract change
+time: 2023-04-12T13:34:38.231881+02:00
+custom:
+  Author: jtcohen6
+  Issue: "7332"

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -207,9 +207,9 @@ class CompilationError(DbtRuntimeError):
             )
 
 
-class ModelContractError(DbtRuntimeError):
+class ContractBreakingChangeError(DbtRuntimeError):
     CODE = 10016
-    MESSAGE = "Contract Error"
+    MESSAGE = "Breaking Change to Contract"
 
     def __init__(self, reasons, node=None):
         self.reasons = reasons
@@ -217,12 +217,14 @@ class ModelContractError(DbtRuntimeError):
 
     @property
     def type(self):
-        return "Contract"
+        return "Breaking Change to Contract"
 
     def message(self):
         return (
-            f"There is a breaking change in the model contract because {self.reasons}; "
-            "you may need to create a new version. See: https://docs.getdbt.com/docs/collaborate/publish/model-versions"
+            "While comparing to previous project state, dbt detected a breaking change to an enforced contract."
+            f"\n\n{self.reasons}\n\n"
+            "Consider making an additive (non-breaking) change instead, if possible.\n"
+            "Otherwise, create a new model version: https://docs.getdbt.com/docs/collaborate/publish/model-versions"
         )
 
 

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -211,8 +211,12 @@ class ContractBreakingChangeError(DbtRuntimeError):
     CODE = 10016
     MESSAGE = "Breaking Change to Contract"
 
-    def __init__(self, reasons, node=None):
-        self.reasons = reasons
+    def __init__(
+        self, contract_enforced_disabled, columns_removed, column_type_changes, node=None
+    ):
+        self.contract_enforced_disabled = contract_enforced_disabled
+        self.columns_removed = columns_removed
+        self.column_type_changes = column_type_changes
         super().__init__(self.message(), node)
 
     @property
@@ -220,9 +224,25 @@ class ContractBreakingChangeError(DbtRuntimeError):
         return "Breaking Change to Contract"
 
     def message(self):
+        breaking_changes = []
+        if self.contract_enforced_disabled:
+            breaking_changes.append("The contract's enforcement has been disabled.")
+        if self.columns_removed:
+            columns_removed_str = "\n  - ".join(self.columns_removed)
+            breaking_changes.append(f"Columns were removed: \n - {columns_removed_str}")
+        if self.column_type_changes:
+            column_type_changes_str = "\n  - ".join(
+                [f"{c[0]} ({c[1]} -> {c[2]})" for c in self.column_type_changes]
+            )
+            breaking_changes.append(
+                f"Columns with data_type changes: \n - {column_type_changes_str}"
+            )
+
+        reasons = "\n\n".join(breaking_changes)
+
         return (
             "While comparing to previous project state, dbt detected a breaking change to an enforced contract."
-            f"\n\n{self.reasons}\n\n"
+            f"\n\n{reasons}\n\n"
             "Consider making an additive (non-breaking) change instead, if possible.\n"
             "Otherwise, create a new model version: https://docs.getdbt.com/docs/collaborate/publish/model-versions"
         )

--- a/tests/functional/defer_state/fixtures.py
+++ b/tests/functional/defer_state/fixtures.py
@@ -102,6 +102,29 @@ models:
         data_type: text
 """
 
+disabled_contract_schema_yml = """
+version: 2
+models:
+  - name: view_model
+    columns:
+      - name: id
+        tests:
+          - unique:
+              severity: error
+          - not_null
+      - name: name
+  - name: table_model
+    columns:
+      - name: id
+        data_type: integer
+        tests:
+          - unique:
+              severity: error
+          - not_null
+      - name: name
+        data_type: text
+"""
+
 exposures_yml = """
 version: 2
 exposures:

--- a/tests/functional/defer_state/test_modified_state.py
+++ b/tests/functional/defer_state/test_modified_state.py
@@ -385,11 +385,15 @@ class TestModifiedBodyAndContract:
 
         # Should raise even without specifying state:modified.contract
         with pytest.raises(ContractBreakingChangeError):
-            results = run_dbt(["run", "--models", "state:modified", "--state", "./state"])
+            results = run_dbt(["run", "-s", "state:modified", "--state", "./state"])
 
         # Change both body and contract in a *non-breaking* way (= adding a new column)
         write_file(modified_my_model_non_breaking_yml, "models", "my_model.yml")
         write_file(modified_my_model_non_breaking_sql, "models", "my_model.sql")
 
         # Should pass
-        run_dbt(["run", "--models", "state:modified", "--state", "./state"])
+        run_dbt(["run", "-s", "state:modified", "--state", "./state"])
+
+        # The model's contract has changed, even if non-breaking, so it should be selected by 'state:modified.contract'
+        results = run_dbt(["list", "-s", "state:modified.contract", "--state", "./state"])
+        assert results == ["test.my_model"]

--- a/tests/functional/defer_state/test_modified_state.py
+++ b/tests/functional/defer_state/test_modified_state.py
@@ -20,6 +20,7 @@ from tests.functional.defer_state.fixtures import (
     infinite_macros_sql,
     contract_schema_yml,
     modified_contract_schema_yml,
+    disabled_contract_schema_yml,
 )
 
 
@@ -307,6 +308,11 @@ class TestChangedContract(BaseModifiedState):
 
         # Go back to schema file without contract. Should raise an error.
         write_file(schema_yml, "models", "schema.yml")
+        with pytest.raises(ContractBreakingChangeError):
+            results = run_dbt(["run", "--models", "state:modified.contract", "--state", "./state"])
+
+        # Now disable the contract. Should raise an error.
+        write_file(disabled_contract_schema_yml, "models", "schema.yml")
         with pytest.raises(ContractBreakingChangeError):
             results = run_dbt(["run", "--models", "state:modified.contract", "--state", "./state"])
 


### PR DESCRIPTION
resolves #7332

### Description

If there's a mismatch in the `checksum`, then we need to dig into _why_ to understand if the change is actually breaking. I'm not sure if this is the most performant way to do it, but it yields the intended functionality.

---

I also renamed the exception from `ModelContractError` to `ContractBreakingChangeError`, and reworked the message that we display to users:
```
$ dbt ls -s state:modified --state state/
11:31:16  Running with dbt=1.5.0-b5
11:31:17  Found 2 models, 0 tests, 0 snapshots, 1 analysis, 536 macros, 0 operations, 1 seed file, 0 sources, 0 exposures, 0 metrics, 0 groups
11:31:17  Encountered an error:
Breaking Change to Contract Error in model sometable (models/sometable.sql)
  While comparing to previous project state, dbt detected a breaking change to an enforced contract.

  The contract's enforcement has been disabled.

  Columns were removed:
   - order_name

  Columns with data_type changes:
   - order_id (number -> int)

  Consider making an additive (non-breaking) change instead, if possible.
  Otherwise, create a new model version: https://docs.getdbt.com/docs/collaborate/publish/model-versions
```

I first did this with fancier string formatting within `CompiledNode.same_contract`, but I added another commit that took the approach of storing more structured information on `ContractBreakingChangeError`, and pretty-formatting the message there.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
