### PR TITLE
[BACKPORT 1.3.latest] Improved event log msg stringification

### DIFF
--- a/.changes/unreleased/Fixes-20230331-095428.yaml
+++ b/.changes/unreleased/Fixes-20230331-095428.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Improved failed event serialization handling and associated tests
+time: 2023-03-31T09:54:28.701963-07:00
+custom:
+  Author: QMalcolm
+  Issue: 7113 7108 6568

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -556,6 +556,10 @@ class BaseContext(metaclass=ContextMeta):
               {{ log("Running some_macro: " ~ arg1 ~ ", " ~ arg2) }}
             {% endmacro %}"
         """
+
+        if not isinstance(msg, str):
+            msg = str(msg)
+
         if info:
             fire_event(MacroEventInfo(msg=msg))
         else:

--- a/test/unit/test_base_context.py
+++ b/test/unit/test_base_context.py
@@ -1,3 +1,5 @@
+import os
+
 from dbt.context.base import BaseContext
 from jinja2.runtime import Undefined
 
@@ -10,3 +12,11 @@ class TestBaseContext:
             BaseContext.log(msg=Undefined(), info=True)
         except Exception as e:
             assert False, f"Logging an jinja2.Undefined object raises an exception: {e}"
+
+    def test_log_with_dbt_env_secret(self):
+        # regression test for CT-1783
+        try:
+            os.environ["DBT_ENV_SECRET_LOG_TEST"] = "cats_are_cool"
+            BaseContext.log({"fact1": "I like cats"}, info=True)
+        except Exception as e:
+            assert False, f"Logging while a `DBT_ENV_SECRET` was set raised an exception: {e}"

--- a/test/unit/test_base_context.py
+++ b/test/unit/test_base_context.py
@@ -1,0 +1,12 @@
+from dbt.context.base import BaseContext
+from jinja2.runtime import Undefined
+
+
+class TestBaseContext:
+    def test_log_jinja_undefined(self):
+        # regression test for CT-2259
+        try:
+            os.environ["DBT_ENV_SECRET_LOG_TEST"] = "cats_are_cool"
+            BaseContext.log(msg=Undefined(), info=True)
+        except Exception as e:
+            assert False, f"Logging an jinja2.Undefined object raises an exception: {e}"


### PR DESCRIPTION
resolves #7108, #6568 for 1.3.latest

### Description

This PR cherry-picks select commits from #7249, specifically: https://github.com/dbt-labs/dbt-core/pull/7249/commits/f96b84d7491a657a74411e081790100d5d45e3fe, https://github.com/dbt-labs/dbt-core/pull/7249/commits/b7f0caab0869c7a0db504ad206780cbdb538046b, https://github.com/dbt-labs/dbt-core/pull/7249/commits/a40aba2620732a1ceedfdfb6cde8c09f16bcae6c. These commits serve to add tests highlighting that #7108 and #6568 are problems in 1.3.latest. We then add https://github.com/dbt-labs/dbt-core/commit/259d50ba95055fdfbf9995ad560061844f50f51a which ensures any non string `msg` in `BaseContext.log()` gets stringified (resolving #7108 and #6568)

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)