### PR TITLE
Ct 2393 document file descriptor workaround

### DIFF
--- a/.changes/unreleased/Under the Hood-20230412-152923.yaml
+++ b/.changes/unreleased/Under the Hood-20230412-152923.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Note file descriptor limit issues when running tests
+time: 2023-04-12T15:29:23.615538-04:00
+custom:
+  Author: ezraerb
+  Issue: ct-2393

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,9 @@ make integration
 > These make targets assume you have a local installation of a recent version of [`tox`](https://tox.readthedocs.io/en/latest/) for unit/integration testing and pre-commit for code quality checks,
 > unless you use choose a Docker container to run tests. Run `make help` for more info.
 
+> Running functional tests can fail with repeated errors opening files and other resources.
+> If this occurs, check directory permissions and the limit on open file descriptors. The latter needs to be at least 8000.
+
 Check out the other targets in the Makefile to see other commonly used test
 suites.
 


### PR DESCRIPTION
resolves #7316

### Description

Running db-core integration tests requires thousands of file descriptors. This exceeds the soft limit on some OSes. For example, the default soft limit on file descriptors for recent versions of MacOS is only 256. The changes note the signs of the problem and how to work around it by increasing the limit. The ticket will be left open for the future investigation of why so many file descriptors are needed to run tests.

### Checklist

- [X ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ X] I have run this code in development and it appears to resolve the stated issue
- [ X] This PR includes tests, or tests are not required/relevant for this PR
- [X ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
