### PR TITLE
Persist timing info for failed nodes

### DIFF
--- a/.changes/unreleased/Fixes-20230413-133157.yaml
+++ b/.changes/unreleased/Fixes-20230413-133157.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Persist timing info in run results for failed nodes
+time: 2023-04-13T13:31:57.938847-05:00
+custom:
+  Author: stu-k
+  Issue: "5476"

--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -21,13 +21,14 @@ import agate
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import (
-    Union,
+    Any,
+    Callable,
     Dict,
     List,
-    Optional,
-    Any,
     NamedTuple,
+    Optional,
     Sequence,
+    Union,
 )
 
 from dbt.clients.system import write_json
@@ -56,15 +57,17 @@ class TimingInfo(dbtClassMixin):
 
 # This is a context manager
 class collect_timing_info:
-    def __init__(self, name: str):
+    def __init__(self, name: str, callback: Callable[[TimingInfo], None] = None):
         self.timing_info = TimingInfo(name=name)
+        self.callback = callback
 
     def __enter__(self):
         self.timing_info.begin()
-        return self.timing_info
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.timing_info.end()
+        if self.callback is not None:
+            self.callback(self.timing_info)
         # Note: when legacy logger is removed, we can remove the following line
         with TimingProcessor(self.timing_info):
             fire_event(

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -318,12 +318,11 @@ class BaseRunner(metaclass=ABCMeta):
                     node_info=ctx.node.node_info,
                 )
             )
-            with collect_timing_info("compile") as timing_info:
+            with collect_timing_info("compile", ctx.timing.append):
                 # if we fail here, we still have a compiled node to return
                 # this has the benefit of showing a build path for the errant
                 # model
                 ctx.node = self.compile(manifest)
-            ctx.timing.append(timing_info)
 
             # for ephemeral nodes, we only want to compile, not run
             if not ctx.node.is_ephemeral_model or self.run_ephemeral_models:
@@ -333,11 +332,9 @@ class BaseRunner(metaclass=ABCMeta):
                         node_info=ctx.node.node_info,
                     )
                 )
-                with collect_timing_info("execute") as timing_info:
+                with collect_timing_info("execute", ctx.timing.append):
                     result = self.run(ctx.node, manifest)
                     ctx.node = result.node
-
-                ctx.timing.append(timing_info)
 
         return result
 
@@ -403,7 +400,7 @@ class BaseRunner(metaclass=ABCMeta):
 
         if error is not None:
             # we could include compile time for runtime errors here
-            result = self.error_result(ctx.node, error, started, [])
+            result = self.error_result(ctx.node, error, started, ctx.timing)
         elif result is not None:
             result = self.from_run_result(result, started, ctx.timing)
         else:


### PR DESCRIPTION
resolves #5476

### Description

Since pythons' context managers `__exit__` method still runs if the code they wrap throws an exception, added a callback to the `collect_timing_info` context manager to handle persisting the timing info for failed nodes to `ctx.timing`.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
