### PR TITLE
Fix CTE insertion position when the model uses WITH RECURSIVE (#7350)

### DIFF
--- a/.changes/unreleased/Fixes-20230420-123221.yaml
+++ b/.changes/unreleased/Fixes-20230420-123221.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix CTE insertion position when the model uses WITH RECURSIVE
+time: 2023-04-20T12:32:21.432848+12:00
+custom:
+  Author: willbryant
+  Issue: "7350"

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -232,6 +232,10 @@ class Compiler:
         for token in parsed.tokens:
             if token.is_keyword and token.normalized == "WITH":
                 with_stmt = token
+            elif token.is_keyword and token.normalized == "RECURSIVE" and with_stmt is not None:
+                with_stmt = token
+                break
+            elif not token.is_whitespace and with_stmt is not None:
                 break
 
         if with_stmt is None:

--- a/tests/functional/compile/fixtures.py
+++ b/tests/functional/compile/fixtures.py
@@ -32,6 +32,16 @@ select {{
 }} as fun
 """
 
+with_recursive_model_sql = """
+{{ config(materialized = 'ephemeral') }}
+with recursive t(n) as (
+    select * from {{ ref('first_ephemeral_model') }}
+  union all
+    select n+1 from t where n < 100
+)
+select sum(n) from t;
+"""
+
 schema_yml = """
 version: 2
 

--- a/tests/functional/compile/test_compile.py
+++ b/tests/functional/compile/test_compile.py
@@ -9,6 +9,7 @@ from tests.functional.compile.fixtures import (
     first_ephemeral_model_sql,
     second_ephemeral_model_sql,
     third_ephemeral_model_sql,
+    with_recursive_model_sql,
     schema_yml,
     model_multiline_jinja,
 )
@@ -54,6 +55,7 @@ class TestEphemeralModels:
             "first_ephemeral_model.sql": first_ephemeral_model_sql,
             "second_ephemeral_model.sql": second_ephemeral_model_sql,
             "third_ephemeral_model.sql": third_ephemeral_model_sql,
+            "with_recursive_model.sql": with_recursive_model_sql,
         }
 
     def test_first_selector(self, project):
@@ -100,6 +102,20 @@ class TestEphemeralModels:
             ")select * from __dbt__cte__second_ephemeral_model",
             "union all",
             "select 2 as fun",
+        ]
+
+    def test_with_recursive_cte(self, project):
+        run_dbt(["compile"])
+
+        assert get_lines("with_recursive_model") == [
+            "with recursive  __dbt__cte__first_ephemeral_model as (",
+            "select 1 as fun",
+            "),t(n) as (",
+            "    select * from __dbt__cte__first_ephemeral_model",
+            "  union all",
+            "    select n+1 from t where n < 100",
+            ")",
+            "select sum(n) from t;",
         ]
 
 

--- a/third-party-stubs/sqlparse/sql.pyi
+++ b/third-party-stubs/sqlparse/sql.pyi
@@ -3,6 +3,7 @@ from typing import Tuple, Iterable
 class Token:
     def __init__(self, ttype, value): ...
     is_keyword: bool
+    is_whitespace: bool
     normalized: str
 
 class TokenList(Token):


### PR DESCRIPTION
resolves #7350 

### Description

If the model code uses `WITH RECURSIVE`, moves the CTEs inserted by DBT from immediately after `WITH` to be after `RECURSIVE`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
