### PR TITLE
Add --target-path to snapshot command

### DIFF
--- a/.changes/unreleased/Fixes-20230420-104254.yaml
+++ b/.changes/unreleased/Fixes-20230420-104254.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add --target-path to dbt snapshot command.
+time: 2023-04-20T10:42:54.17972-04:00
+custom:
+  Author: dwreeves
+  Issue: "7418"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -650,6 +650,7 @@ def seed(ctx, **kwargs):
 @p.state
 @p.deprecated_state
 @p.target
+@p.target_path
 @p.threads
 @p.vars
 @requires.postflight


### PR DESCRIPTION
resolves #7418

### Description

`dbt snapshot` uses the target path (since it runs a subclass of `RunTask`), but does not contain the option to specify it. This PR adds `--target-path` as a valid option for `dbt snaphot`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
