### PR TITLE
Ignore parent tests added edges for build selection

### DIFF
--- a/.changes/unreleased/Fixes-20230421-172428.yaml
+++ b/.changes/unreleased/Fixes-20230421-172428.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: dbt build selection of tests' descendants
+time: 2023-04-21T17:24:28.335866975+02:00
+custom:
+  Author: b-luu
+  Issue: "7289"

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -474,7 +474,7 @@ class Compiler:
                     # is a subset of all upstream nodes of the current node,
                     # add an edge from the upstream test to the current node.
                     if test_depends_on.issubset(upstream_nodes):
-                        linker.graph.add_edge(upstream_test, node_id)
+                        linker.graph.add_edge(upstream_test, node_id, edge_type="parent_test")
 
     def compile(self, manifest: Manifest, write=True, add_test_edges=False) -> Graph:
         self.initialize()

--- a/core/dbt/graph/graph.py
+++ b/core/dbt/graph/graph.py
@@ -34,9 +34,7 @@ class Graph:
             for _, child in nx.bfs_edges(filtered_graph, node, reverse=True, depth_limit=max_depth)
         }
 
-    def descendants(
-        self, node: UniqueId, max_depth: Optional[int] = None, include_tests_children: bool = False
-    ) -> Set[UniqueId]:
+    def descendants(self, node: UniqueId, max_depth: Optional[int] = None) -> Set[UniqueId]:
         """Returns all nodes reachable from `node` in `graph`"""
         if not self.graph.has_node(node):
             raise DbtInternalError(f"Node {node} not found in the graph!")

--- a/tests/functional/build/fixtures.py
+++ b/tests/functional/build/fixtures.py
@@ -206,6 +206,27 @@ models:
           - not_null
 """
 
+models_triple_blocking__test_yml = """
+version: 2
+
+models:
+  - name: model_a
+    columns:
+      - name: id
+        tests:
+          - not_null
+  - name: model_b
+    columns:
+      - name: id
+        tests:
+          - not_null
+  - name: model_c
+    columns:
+      - name: id
+        tests:
+          - not_null
+"""
+
 models_interdependent__model_a_sql = """
 select 1 as id
 """

--- a/tests/functional/build/test_build.py
+++ b/tests/functional/build/test_build.py
@@ -196,3 +196,18 @@ class TestInterdependentModelsFail:
         actual = [str(r.status) for r in results]
         expected = ["error"] * 4 + ["skipped"] * 7 + ["pass"] * 2 + ["success"] * 3
         assert sorted(actual) == sorted(expected)
+
+
+class TestDownstreamSelection:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_a.sql": models_simple_blocking__model_a_sql,
+            "model_b.sql": models_simple_blocking__model_b_sql,
+            "test.yml": models_simple_blocking__test_yml,
+        }
+
+    def test_downstream_selection(self, project):
+        """Ensure that selecting test+ does not select model_a's other children"""
+        results = run_dbt(["build", "--select", "model_a not_null_model_a_id+"], expect_pass=True)
+        assert len(results) == 2

--- a/tests/functional/build/test_build.py
+++ b/tests/functional/build/test_build.py
@@ -18,6 +18,7 @@ from tests.functional.build.fixtures import (
     models_simple_blocking__model_a_sql,
     models_simple_blocking__model_b_sql,
     models_simple_blocking__test_yml,
+    models_triple_blocking__test_yml,
     models_interdependent__test_yml,
     models_interdependent__model_a_sql,
     models_interdependent__model_b_sql,
@@ -211,3 +212,19 @@ class TestDownstreamSelection:
         """Ensure that selecting test+ does not select model_a's other children"""
         results = run_dbt(["build", "--select", "model_a not_null_model_a_id+"], expect_pass=True)
         assert len(results) == 2
+
+
+class TestLimitedUpstreamSelection:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_a.sql": models_interdependent__model_a_sql,
+            "model_b.sql": models_interdependent__model_b_sql,
+            "model_c.sql": models_interdependent__model_c_sql,
+            "test.yml": models_triple_blocking__test_yml,
+        }
+
+    def test_limited_upstream_selection(self, project):
+        """Ensure that selecting 1+model_c only selects up to model_b (+ tests of both)"""
+        results = run_dbt(["build", "--select", "1+model_c"], expect_pass=True)
+        assert len(results) == 4

--- a/tests/functional/defer_state/test_run_results_state.py
+++ b/tests/functional/defer_state/test_run_results_state.py
@@ -240,9 +240,9 @@ class TestBuildRunResultsState(BaseRunResultsState):
         results = run_dbt(
             ["build", "--select", "result:warn+", "--state", "./state"], expect_pass=True
         )
-        assert len(results) == 2  # includes table_model to be run
+        assert len(results) == 1
         nodes = set([elem.node.name for elem in results])
-        assert nodes == {"table_model", "unique_view_model_id"}
+        assert nodes == {"unique_view_model_id"}
 
         results = run_dbt(["ls", "--select", "result:warn+", "--state", "./state"])
         assert len(results) == 1

--- a/tests/functional/defer_state/test_run_results_state.py
+++ b/tests/functional/defer_state/test_run_results_state.py
@@ -216,9 +216,9 @@ class TestBuildRunResultsState(BaseRunResultsState):
         results = run_dbt(
             ["build", "--select", "result:fail+", "--state", "./state"], expect_pass=False
         )
-        assert len(results) == 2
+        assert len(results) == 1
         nodes = set([elem.node.name for elem in results])
-        assert nodes == {"table_model", "unique_view_model_id"}
+        assert nodes == {"unique_view_model_id"}
 
         results = run_dbt(["ls", "--select", "result:fail+", "--state", "./state"])
         assert len(results) == 1
@@ -483,12 +483,11 @@ class TestConcurrentSelectionBuildRunResultsState(BaseRunResultsState):
             ],
             expect_pass=False,
         )
-        assert len(results) == 5
+        assert len(results) == 4
         nodes = set([elem.node.name for elem in results])
         assert nodes == {
             "error_model",
             "downstream_of_error_model",
             "table_model_modified_example",
-            "table_model",
             "unique_view_model_id",
         }


### PR DESCRIPTION
resolves #7289 #5193

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Removes the added tests edges (specific to build task) for children and/or parent selection.
This allows to avoid selecting any other nodes that aren't selected with the other dbt commands (list, run, ...).
The added tests edges are still respected for the GraphQueue to follow the execution.
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, ~~or tests are not required/relevant for this PR~~
- [x] ~~I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or~~ docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
