### PR TITLE
Fix groupable node partial parsing, raise DbtReferenceError in RuntimeRefResolver

### DIFF
--- a/.changes/unreleased/Fixes-20230424-161843.yaml
+++ b/.changes/unreleased/Fixes-20230424-161843.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: fix groupable node partial parsing, raise DbtReferenceError at runtime for safety
+time: 2023-04-24T16:18:43.130637-04:00
+custom:
+  Author: MichelleArk
+  Issue: "7437"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -38,6 +38,7 @@ from dbt.contracts.graph.nodes import (
     Resource,
     ManifestNode,
     RefArgs,
+    AccessType,
 )
 from dbt.contracts.graph.metrics import MetricReference, ResolvedMetricReference
 from dbt.contracts.graph.unparsed import NodeVersion
@@ -65,11 +66,12 @@ from dbt.exceptions import (
     DbtRuntimeError,
     TargetNotFoundError,
     DbtValidationError,
+    DbtReferenceError,
 )
 from dbt.config import IsFQNResource
 from dbt.node_types import NodeType, ModelLanguage
 
-from dbt.utils import merge, AttrDict, MultiDict, args_to_dict
+from dbt.utils import merge, AttrDict, MultiDict, args_to_dict, cast_to_str
 
 from dbt import selected_resources
 
@@ -494,6 +496,17 @@ class RuntimeRefResolver(BaseRefResolver):
                 target_version=target_version,
                 disabled=isinstance(target_model, Disabled),
             )
+        elif (
+            target_model.resource_type == NodeType.Model
+            and target_model.access == AccessType.Private
+        ):
+            if not self.model.group or self.model.group != target_model.group:
+                raise DbtReferenceError(
+                    unique_id=self.model.unique_id,
+                    ref_unique_id=target_model.unique_id,
+                    group=cast_to_str(target_model.group),
+                )
+
         self.validate(target_model, target_name, target_package, target_version)
         return self.create_relation(target_model)
 

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -851,6 +851,9 @@ class PartialParsing:
                     if self.saved_files[file_id]:
                         source_file = self.saved_files[file_id]
                         self.add_to_pp_files(source_file)
+                    # if the node's group has changed - need to reparse all referencing nodes to ensure valid ref access
+                    if node.group != elem.get("group"):
+                        self.schedule_referencing_nodes_for_parsing(node.unique_id)
             # remove from patches
             schema_file.node_patches.remove(elem_unique_id)
 

--- a/tests/functional/partial_parsing/fixtures.py
+++ b/tests/functional/partial_parsing/fixtures.py
@@ -628,6 +628,11 @@ select 1 as id, 101 as user_id, 'pending' as status
 
 """
 
+orders_downstream_sql = """
+select * from {{ ref('orders') }}
+
+"""
+
 model_a_sql = """
 select 1 as fun
 
@@ -1037,6 +1042,47 @@ groups:
 
 models:
   - name: orders
+    description: "Some order data"
+"""
+
+
+groups_schema_yml_two_groups_private_orders_valid_access = """
+
+groups:
+  - name: test_group
+    owner:
+      name: test_group_owner
+  - name: test_group2
+    owner:
+      name: test_group_owner2
+
+models:
+  - name: orders
+    group: test_group
+    access: private
+    description: "Some order data"
+  - name: orders_downstream
+    group: test_group
+    description: "Some order data"
+"""
+
+groups_schema_yml_two_groups_private_orders_invalid_access = """
+
+groups:
+  - name: test_group
+    owner:
+      name: test_group_owner
+  - name: test_group2
+    owner:
+      name: test_group_owner2
+
+models:
+  - name: orders
+    group: test_group2
+    access: private
+    description: "Some order data"
+  - name: orders_downstream
+    group: test_group
     description: "Some order data"
 """
 

--- a/tests/functional/partial_parsing/test_partial_parsing.py
+++ b/tests/functional/partial_parsing/test_partial_parsing.py
@@ -55,6 +55,7 @@ from tests.functional.partial_parsing.fixtures import (
     gsm_override_sql,
     gsm_override2_sql,
     orders_sql,
+    orders_downstream_sql,
     snapshot_sql,
     snapshot2_sql,
     generic_schema_yml,
@@ -65,6 +66,8 @@ from tests.functional.partial_parsing.fixtures import (
     groups_schema_yml_two_groups,
     groups_schema_yml_two_groups_edited,
     groups_schema_yml_one_group_model_in_group2,
+    groups_schema_yml_two_groups_private_orders_valid_access,
+    groups_schema_yml_two_groups_private_orders_invalid_access,
 )
 
 from dbt.exceptions import CompilationError, ParsingError
@@ -692,6 +695,7 @@ class TestGroups:
     def models(self):
         return {
             "orders.sql": orders_sql,
+            "orders_downstream.sql": orders_downstream_sql,
             "schema.yml": groups_schema_yml_one_group,
         }
 
@@ -699,9 +703,9 @@ class TestGroups:
 
         # initial run
         results = run_dbt()
-        assert len(results) == 1
+        assert len(results) == 2
         manifest = get_manifest(project.project_root)
-        expected_nodes = ["model.test.orders"]
+        expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
         expected_groups = ["group.test.test_group"]
         assert expected_nodes == list(manifest.nodes.keys())
         assert expected_groups == list(manifest.groups.keys())
@@ -709,9 +713,9 @@ class TestGroups:
         # add group to schema
         write_file(groups_schema_yml_two_groups, project.project_root, "models", "schema.yml")
         results = run_dbt(["--partial-parse", "run"])
-        assert len(results) == 1
+        assert len(results) == 2
         manifest = get_manifest(project.project_root)
-        expected_nodes = ["model.test.orders"]
+        expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
         expected_groups = ["group.test.test_group", "group.test.test_group2"]
         assert expected_nodes == list(manifest.nodes.keys())
         assert expected_groups == list(manifest.groups.keys())
@@ -721,9 +725,9 @@ class TestGroups:
             groups_schema_yml_two_groups_edited, project.project_root, "models", "schema.yml"
         )
         results = run_dbt(["--partial-parse", "run"])
-        assert len(results) == 1
+        assert len(results) == 2
         manifest = get_manifest(project.project_root)
-        expected_nodes = ["model.test.orders"]
+        expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
         expected_groups = ["group.test.test_group", "group.test.test_group2_edited"]
         assert expected_nodes == list(manifest.nodes.keys())
         assert expected_groups == list(manifest.groups.keys())
@@ -731,9 +735,9 @@ class TestGroups:
         # delete group in schema
         write_file(groups_schema_yml_one_group, project.project_root, "models", "schema.yml")
         results = run_dbt(["--partial-parse", "run"])
-        assert len(results) == 1
+        assert len(results) == 2
         manifest = get_manifest(project.project_root)
-        expected_nodes = ["model.test.orders"]
+        expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
         expected_groups = ["group.test.test_group"]
         assert expected_nodes == list(manifest.nodes.keys())
         assert expected_groups == list(manifest.groups.keys())
@@ -741,11 +745,30 @@ class TestGroups:
         # add back second group
         write_file(groups_schema_yml_two_groups, project.project_root, "models", "schema.yml")
         results = run_dbt(["--partial-parse", "run"])
-        assert len(results) == 1
+        assert len(results) == 2
 
         # remove second group with model still configured to second group
         write_file(
             groups_schema_yml_one_group_model_in_group2,
+            project.project_root,
+            "models",
+            "schema.yml",
+        )
+        with pytest.raises(ParsingError):
+            results = run_dbt(["--partial-parse", "run"])
+
+        # add back second group, make orders private with valid ref
+        write_file(
+            groups_schema_yml_two_groups_private_orders_valid_access,
+            project.project_root,
+            "models",
+            "schema.yml",
+        )
+        results = run_dbt(["--partial-parse", "run"])
+        assert len(results) == 2
+
+        write_file(
+            groups_schema_yml_two_groups_private_orders_invalid_access,
             project.project_root,
             "models",
             "schema.yml",

--- a/tests/functional/partial_parsing/test_partial_parsing.py
+++ b/tests/functional/partial_parsing/test_partial_parsing.py
@@ -707,8 +707,8 @@ class TestGroups:
         manifest = get_manifest(project.project_root)
         expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
         expected_groups = ["group.test.test_group"]
-        assert expected_nodes == list(manifest.nodes.keys())
-        assert expected_groups == list(manifest.groups.keys())
+        assert expected_nodes == sorted(list(manifest.nodes.keys()))
+        assert expected_groups == sorted(list(manifest.groups.keys()))
 
         # add group to schema
         write_file(groups_schema_yml_two_groups, project.project_root, "models", "schema.yml")
@@ -717,8 +717,8 @@ class TestGroups:
         manifest = get_manifest(project.project_root)
         expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
         expected_groups = ["group.test.test_group", "group.test.test_group2"]
-        assert expected_nodes == list(manifest.nodes.keys())
-        assert expected_groups == list(manifest.groups.keys())
+        assert expected_nodes == sorted(list(manifest.nodes.keys()))
+        assert expected_groups == sorted(list(manifest.groups.keys()))
 
         # edit group in schema
         write_file(
@@ -729,8 +729,8 @@ class TestGroups:
         manifest = get_manifest(project.project_root)
         expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
         expected_groups = ["group.test.test_group", "group.test.test_group2_edited"]
-        assert expected_nodes == list(manifest.nodes.keys())
-        assert expected_groups == list(manifest.groups.keys())
+        assert expected_nodes == sorted(list(manifest.nodes.keys()))
+        assert expected_groups == sorted(list(manifest.groups.keys()))
 
         # delete group in schema
         write_file(groups_schema_yml_one_group, project.project_root, "models", "schema.yml")
@@ -739,8 +739,8 @@ class TestGroups:
         manifest = get_manifest(project.project_root)
         expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
         expected_groups = ["group.test.test_group"]
-        assert expected_nodes == list(manifest.nodes.keys())
-        assert expected_groups == list(manifest.groups.keys())
+        assert expected_nodes == sorted(list(manifest.nodes.keys()))
+        assert expected_groups == sorted(list(manifest.groups.keys()))
 
         # add back second group
         write_file(groups_schema_yml_two_groups, project.project_root, "models", "schema.yml")


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/7437

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Currently, modifying a private node's "group" property does not schedule its referencing nodes for re-parsing. This can lead to a scenario where a node that should not be ref-able because of its access and group settings is refable during execution. This change fixes the partial parsing issue, and raises DbtReferenceError during execution (RuntimeRefResolver) out of an abundance of caution.


<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
