### PR TITLE
Copy dir if symlink fails

### DIFF
--- a/.changes/unreleased/Fixes-20230424-210734.yaml
+++ b/.changes/unreleased/Fixes-20230424-210734.yaml
@@ -3,4 +3,4 @@ body: Copy dir during `dbt deps` if symlink fails
 time: 2023-04-24T21:07:34.336797+05:30
 custom:
   Author: anjutiwari
-  Issue: "7428" "8223"
+  Issue: "7428 8223"

--- a/.changes/unreleased/Fixes-20230424-210734.yaml
+++ b/.changes/unreleased/Fixes-20230424-210734.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Copy dir during `dbt deps` if symlink fails
+time: 2023-04-24T21:07:34.336797+05:30
+custom:
+  Author: anjutiwari
+  Issue: "7428" "8223"

--- a/core/dbt/deps/local.py
+++ b/core/dbt/deps/local.py
@@ -51,19 +51,15 @@ class LocalPinnedPackage(LocalPackageMixin, PinnedPackage):
         src_path = self.resolve_path(project)
         dest_path = self.get_installation_path(project, renderer)
 
-        can_create_symlink = system.supports_symlinks()
-
         if system.path_exists(dest_path):
             if not system.path_is_symlink(dest_path):
                 system.rmdir(dest_path)
             else:
                 system.remove_file(dest_path)
-
-        if can_create_symlink:
+        try:
             fire_event(DepsCreatingLocalSymlink())
             system.make_symlink(src_path, dest_path)
-
-        else:
+        except OSError:
             fire_event(DepsSymlinkNotAvailable())
             shutil.copytree(src_path, dest_path)
 


### PR DESCRIPTION
resolves #7428
resolves #8223

### Description

dbt deps command fails to run in databricks DBFS. Copy dir in case if any symlink fails with expection 

### Checklist
- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
