### PR TITLE
CT 2483 duplicate depends on nodes

### DIFF
--- a/.changes/unreleased/Fixes-20230424-173404.yaml
+++ b/.changes/unreleased/Fixes-20230424-173404.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Use "add_node" to update depends_on.nodes
+time: 2023-04-24T17:34:04.37479-04:00
+custom:
+  Author: gshank
+  Issue: "7453"

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -498,25 +498,6 @@ MaybeNonSource = Optional[Union[ManifestNode, Disabled[ManifestNode]]]
 T = TypeVar("T", bound=GraphMemberNode)
 
 
-def _update_into(dest: MutableMapping[str, T], new_item: T):
-    """Update dest to overwrite whatever is at dest[new_item.unique_id] with
-    new_itme. There must be an existing value to overwrite, and the two nodes
-    must have the same original file path.
-    """
-    unique_id = new_item.unique_id
-    if unique_id not in dest:
-        raise dbt.exceptions.DbtRuntimeError(
-            f"got an update_{new_item.resource_type} call with an "
-            f"unrecognized {new_item.resource_type}: {new_item.unique_id}"
-        )
-    existing = dest[unique_id]
-    if new_item.original_file_path != existing.original_file_path:
-        raise dbt.exceptions.DbtRuntimeError(
-            f"cannot update a {new_item.resource_type} to have a new file path!"
-        )
-    dest[unique_id] = new_item
-
-
 # This contains macro methods that are in both the Manifest
 # and the MacroManifest
 class MacroMethods:
@@ -671,18 +652,6 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
     def __post_deserialize__(cls, obj):
         obj._lock = MP_CONTEXT.Lock()
         return obj
-
-    def update_exposure(self, new_exposure: Exposure):
-        _update_into(self.exposures, new_exposure)
-
-    def update_metric(self, new_metric: Metric):
-        _update_into(self.metrics, new_metric)
-
-    def update_node(self, new_node: ManifestNode):
-        _update_into(self.nodes, new_node)
-
-    def update_source(self, new_source: SourceDefinition):
-        _update_into(self.sources, new_source)
 
     def build_flat_graph(self):
         """This attribute is used in context.common by each node, so we want to

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1228,7 +1228,7 @@ def _process_refs_for_exposure(manifest: Manifest, current_project: str, exposur
 
         target_model_id = target_model.unique_id
 
-        exposure.depends_on.nodes.append(target_model_id)
+        exposure.depends_on.add_node(target_model_id)
 
 
 def _process_refs_for_metric(manifest: Manifest, current_project: str, metric: Metric):
@@ -1407,7 +1407,7 @@ def _process_sources_for_exposure(manifest: Manifest, current_project: str, expo
             )
             continue
         target_source_id = target_source.unique_id
-        exposure.depends_on.nodes.append(target_source_id)
+        exposure.depends_on.add_node(target_source_id)
 
 
 def _process_sources_for_metric(manifest: Manifest, current_project: str, metric: Metric):
@@ -1429,7 +1429,7 @@ def _process_sources_for_metric(manifest: Manifest, current_project: str, metric
             )
             continue
         target_source_id = target_source.unique_id
-        metric.depends_on.nodes.append(target_source_id)
+        metric.depends_on.add_node(target_source_id)
 
 
 def _process_sources_for_node(manifest: Manifest, current_project: str, node: ManifestNode):
@@ -1457,7 +1457,7 @@ def _process_sources_for_node(manifest: Manifest, current_project: str, node: Ma
             )
             continue
         target_source_id = target_source.unique_id
-        node.depends_on.nodes.append(target_source_id)
+        node.depends_on.add_node(target_source_id)
 
 
 # This is called in task.rpc.sql_commands when a "dynamic" node is

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1229,7 +1229,6 @@ def _process_refs_for_exposure(manifest: Manifest, current_project: str, exposur
         target_model_id = target_model.unique_id
 
         exposure.depends_on.nodes.append(target_model_id)
-        manifest.update_exposure(exposure)
 
 
 def _process_refs_for_metric(manifest: Manifest, current_project: str, metric: Metric):
@@ -1280,8 +1279,7 @@ def _process_refs_for_metric(manifest: Manifest, current_project: str, metric: M
 
         target_model_id = target_model.unique_id
 
-        metric.depends_on.nodes.append(target_model_id)
-        manifest.update_metric(metric)
+        metric.depends_on.add_node(target_model_id)
 
 
 def _process_metrics_for_node(
@@ -1330,7 +1328,7 @@ def _process_metrics_for_node(
 
         target_metric_id = target_metric.unique_id
 
-        node.depends_on.nodes.append(target_metric_id)
+        node.depends_on.add_node(target_metric_id)
 
 
 def _process_refs_for_node(manifest: Manifest, current_project: str, node: ManifestNode):
@@ -1387,12 +1385,7 @@ def _process_refs_for_node(manifest: Manifest, current_project: str, node: Manif
 
         target_model_id = target_model.unique_id
 
-        node.depends_on.nodes.append(target_model_id)
-        # TODO: I think this is extraneous, node should already be the same
-        # as manifest.nodes[node.unique_id] (we're mutating node here, not
-        # making a new one)
-        # Q: could we stop doing this?
-        manifest.update_node(node)
+        node.depends_on.add_node(target_model_id)
 
 
 def _process_sources_for_exposure(manifest: Manifest, current_project: str, exposure: Exposure):
@@ -1415,7 +1408,6 @@ def _process_sources_for_exposure(manifest: Manifest, current_project: str, expo
             continue
         target_source_id = target_source.unique_id
         exposure.depends_on.nodes.append(target_source_id)
-        manifest.update_exposure(exposure)
 
 
 def _process_sources_for_metric(manifest: Manifest, current_project: str, metric: Metric):
@@ -1438,7 +1430,6 @@ def _process_sources_for_metric(manifest: Manifest, current_project: str, metric
             continue
         target_source_id = target_source.unique_id
         metric.depends_on.nodes.append(target_source_id)
-        manifest.update_metric(metric)
 
 
 def _process_sources_for_node(manifest: Manifest, current_project: str, node: ManifestNode):
@@ -1467,7 +1458,6 @@ def _process_sources_for_node(manifest: Manifest, current_project: str, node: Ma
             continue
         target_source_id = target_source.unique_id
         node.depends_on.nodes.append(target_source_id)
-        manifest.update_node(node)
 
 
 # This is called in task.rpc.sql_commands when a "dynamic" node is

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -37,7 +37,7 @@ from dbt.events.types import (
     NothingToDo,
 )
 from dbt.events.contextvars import log_contextvars
-from dbt.contracts.graph.nodes import SourceDefinition, ResultNode
+from dbt.contracts.graph.nodes import ResultNode
 from dbt.contracts.results import NodeStatus, RunExecutionResult, RunningStatus
 from dbt.contracts.state import PreviousState
 from dbt.exceptions import (
@@ -294,11 +294,6 @@ class GraphRunnableTask(ConfiguredTask):
 
         if self.manifest is None:
             raise DbtInternalError("manifest was None in _handle_result")
-
-        if isinstance(node, SourceDefinition):
-            self.manifest.update_source(node)
-        else:
-            self.manifest.update_node(node)
 
         if result.status in self.MARK_DEPENDENT_ERRORS_STATUSES:
             if is_ephemeral:

--- a/tests/functional/artifacts/expected_manifest.py
+++ b/tests/functional/artifacts/expected_manifest.py
@@ -1602,9 +1602,6 @@ def expected_versions_manifest(project):
                     "macros": [],
                     "nodes": [
                         "model.test.versioned_model.v2",
-                        "model.test.versioned_model.v2",
-                        "model.test.versioned_model.v2",
-                        "model.test.versioned_model.v2",
                         "model.test.versioned_model.v1",
                     ],
                 },
@@ -1862,9 +1859,6 @@ def expected_versions_manifest(project):
             "model.test.versioned_model.v2": [
                 "exposure.test.notebook_exposure",
                 "model.test.ref_versioned_model",
-                "model.test.ref_versioned_model",
-                "model.test.ref_versioned_model",
-                "model.test.ref_versioned_model",
                 "test.test.unique_versioned_model_v2_first_name.998430d28e",
             ],
             "model.test.ref_versioned_model": [],
@@ -1878,9 +1872,6 @@ def expected_versions_manifest(project):
             "model.test.versioned_model.v2": [],
             "model.test.ref_versioned_model": [
                 "model.test.versioned_model.v1",
-                "model.test.versioned_model.v2",
-                "model.test.versioned_model.v2",
-                "model.test.versioned_model.v2",
                 "model.test.versioned_model.v2",
             ],
             "exposure.test.notebook_exposure": ["model.test.versioned_model.v2"],


### PR DESCRIPTION
resolves #7453


### Description

In some circumstances we ended up with duplicates node unique_ids in depends_on.nodes. Use "add_node" method to check for existence of a unique_id before adding.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
