### PR TITLE
[CT-2343] [Bug] snapshot with custom datatypes breaks when source table is regenerated

### DIFF
--- a/.changes/unreleased/Fixes-20230425-155445.yaml
+++ b/.changes/unreleased/Fixes-20230425-155445.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: '[CT-2343] [Bug] snapshot with custom datatypes breaks when source table is
+  regenerated'
+time: 2023-04-25T15:54:45.1782743+01:00
+custom:
+  Author: benorourke
+  Issue: "7248"

--- a/plugins/postgres/dbt/include/postgres/macros/adapters.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/adapters.sql
@@ -59,10 +59,7 @@
 {% macro postgres__get_columns_in_relation(relation) -%}
   {% call statement('get_columns_in_relation', fetch_result=True) %}
       select
-          case
-            when (data_type = 'USER-DEFINED') then udt_name
-            else column_name
-          end as column_name,
+          column_name,
           case
             when (data_type = 'USER-DEFINED') then concat(udt_schema || '.' || udt_name)
             else data_type

--- a/plugins/postgres/dbt/include/postgres/macros/adapters.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/adapters.sql
@@ -59,8 +59,14 @@
 {% macro postgres__get_columns_in_relation(relation) -%}
   {% call statement('get_columns_in_relation', fetch_result=True) %}
       select
-          column_name,
-          data_type,
+          case
+            when (data_type = 'USER-DEFINED') then udt_name
+            else column_name
+          end as column_name,
+          case
+            when (data_type = 'USER-DEFINED') then concat(udt_schema || '.' || udt_name)
+            else data_type
+          end as data_type,
           character_maximum_length,
           numeric_precision,
           numeric_scale


### PR DESCRIPTION
Resolves dbt-labs/dbt-postgres#13 

> [!IMPORTANT]  
> The contents of this PR should be compared with https://github.com/dbt-labs/dbt-core/pull/9433 since they both touch on the same code and could easily overwrite each other. Ideally, both of them will functional tests so that one doesn't undo the other by accident.


### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->
The macro [postgres__get_columns_in_relation](https://github.com/dbt-labs/dbt-core/blob/87e25e8692197c093e9be2c0df5fe38dea48eec5/plugins/postgres/dbt/include/postgres/macros/adapters.sql#L59), which is called when the snapshot checks for any column changes, selects data_type from the information_schema. For any UDT this will return USER-DEFINED. We can instead conditionally select udt_name to get the name of the enum.

This pull request modifies the macro postgres__get_columns_in_relation to resolve udt names along with their schema, resulting in a successful snapshot build for source tables containing a UDT.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
