### PR TITLE
Update CODEOWNERS to include the OSS Tooling Guild

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,8 +13,22 @@
 # the core team as a whole will be assigned
 *       @dbt-labs/core
 
-# Changes to GitHub configurations including Actions
-/.github/ @leahwicz
+### OSS Tooling Guild
+
+/.github/                       @dbt-labs/guild-oss-tooling
+.bumpversion.cfg                @dbt-labs/guild-oss-tooling
+
+/.changes/                      @dbt-labs/guild-oss-tooling
+.changie.yaml                   @dbt-labs/guild-oss-tooling
+
+pre-commit-config.yaml          @dbt-labs/guild-oss-tooling
+pytest.ini                      @dbt-labs/guild-oss-tooling
+tox.ini                         @dbt-labs/guild-oss-tooling
+
+pyproject.toml                  @dbt-labs/guild-oss-tooling
+requirements.txt                @dbt-labs/guild-oss-tooling
+dev_requirements.txt            @dbt-labs/guild-oss-tooling
+/core/setup.py                  @dbt-labs/guild-oss-tooling
 
 ### LANGUAGE
 
@@ -71,7 +85,7 @@
 # Perf regression testing framework
 # This excludes the test project files itself since those aren't specific
 # framework changes (excluded by not setting an owner next to it- no owner)
-/performance @nathaniel-may
+/performance                    @nathaniel-may
 /performance/projects
 
 ### ARTIFACTS

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@ pyproject.toml                  @dbt-labs/guild-oss-tooling
 requirements.txt                @dbt-labs/guild-oss-tooling
 dev_requirements.txt            @dbt-labs/guild-oss-tooling
 /core/setup.py                  @dbt-labs/guild-oss-tooling
+/core/MANIFEST.in               @dbt-labs/guild-oss-tooling
 
 ### LANGUAGE
 
@@ -74,6 +75,7 @@ dev_requirements.txt            @dbt-labs/guild-oss-tooling
 
 # Postgres plugin
 /plugins/                       @dbt-labs/core-adapters
+/plugins/postgres/setup.py      @dbt-labs/core-adapters @dbt-labs/guild-oss-tooling
 
 # Functional tests for adapter plugins
 /tests/adapter                  @dbt-labs/core-adapters


### PR DESCRIPTION
### Description

Add the OSS Tooling Guild to CODEOWNERS.  Once we settle on all the files we need to replicate this in the adapter repos.  They review should not required but this will help keep us aware of changes made.  

Should also add this to, in the least:

`dbt-labs/actions`
`dbt-labs/dbt-release`
`dbt-labs/homebrew-dbt`

Open to any changes to my proposal.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
