### PR TITLE
Fix inverted `--print/--no-print` flag

### DIFF
--- a/.changes/unreleased/Fixes-20230505-132545.yaml
+++ b/.changes/unreleased/Fixes-20230505-132545.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix inverted `--print/--no-print` flag
+time: 2023-05-05T13:25:45.949997-06:00
+custom:
+  Author: dbeatty10 thomasgjerdekog
+  Issue: "7517"

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -652,7 +652,7 @@ class BaseContext(metaclass=ContextMeta):
             {% endmacro %}"
         """
 
-        if not get_flags().PRINT:
+        if get_flags().PRINT:
             print(msg)
         return ""
 


### PR DESCRIPTION
resolves #7517

### Description

This flag must not have the relevant tests, or this wouldn't have been able to slip through during [this](https://github.com/dbt-labs/dbt-core/pull/6788/files#diff-bcf7b3e41dde65dcffbca817d1390f09b9c0935b4f06661738e6885d36c2b453R655-R657) re-factor. And I didn't add any relevant tests.

Maybe the reviewer would be so kind as to add them? 🙏  Will offer co-authorship as a reward 😎 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] 👈 This PR includes tests
- [x] Docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
