### PR TITLE
Readd exp_path for config deprecation warnings

### DIFF
--- a/.changes/unreleased/Fixes-20230506-180900.yaml
+++ b/.changes/unreleased/Fixes-20230506-180900.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix warning messages for deprecated dbt_project.yml configs
+time: 2023-05-06T18:09:00.361961+02:00
+custom:
+  Author: jtcohen6
+  Issue: "7424"

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -315,10 +315,10 @@ class PartialProject(RenderComponents):
             # this field is no longer supported, but many projects may specify it with the default value
             # if so, let's only raise this deprecation warning if they set a custom value
             if not default_value or project_dict[deprecated_path] != default_value:
-                deprecations.warn(
-                    f"project-config-{deprecated_path}",
-                    deprecated_path=deprecated_path,
-                )
+                kwargs = {"deprecated_path": deprecated_path}
+                if expected_path:
+                    kwargs.update({"exp_path": expected_path})
+                deprecations.warn(f"project-config-{deprecated_path}", **kwargs)
 
     def create_project(self, rendered: RenderComponents) -> "Project":
         unrendered = RenderComponents(

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -280,7 +280,7 @@ class ConfigSourcePathDeprecation(WarnLevel):
 
     def message(self):
         description = (
-            f"The `{self.deprecated_path}` config has been renamed to `{self.exp_path}`."
+            f"The `{self.deprecated_path}` config has been renamed to `{self.exp_path}`. "
             "Please update your `dbt_project.yml` configuration to reflect this change."
         )
         return line_wrap_message(warning_tag(f"Deprecated functionality\n\n{description}"))
@@ -292,7 +292,7 @@ class ConfigDataPathDeprecation(WarnLevel):
 
     def message(self):
         description = (
-            f"The `{self.deprecated_path}` config has been renamed to `{self.exp_path}`."
+            f"The `{self.deprecated_path}` config has been renamed to `{self.exp_path}`. "
             "Please update your `dbt_project.yml` configuration to reflect this change."
         )
         return line_wrap_message(warning_tag(f"Deprecated functionality\n\n{description}"))


### PR DESCRIPTION
resolves #7424

(and also adds a space)

:tophat: 

```yml
# dbt_project.yml
name: my_dbt_project

source-paths: ["models"]
data-paths: ["seeds"]
target-path: "custom_target"
log-path: "custom_logs"
```
```
$ dbt --no-partial-parse parse
16:05:08  Running with dbt=1.6.0-a1
16:05:08  [WARNING]: Deprecated functionality
The `source-paths` config has been renamed to `model-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
16:05:08  [WARNING]: Deprecated functionality
The `data-paths` config has been renamed to `seed-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
16:05:08  [WARNING]: Deprecated functionality
The `log-path` config in `dbt_project.yml` has been deprecated, and will no
longer be supported in a future version of dbt-core. If you wish to write dbt
logs to a custom directory, please use the --log-path CLI flag or DBT_LOG_PATH
env var instead.
16:05:08  [WARNING]: Deprecated functionality
The `target-path` config in `dbt_project.yml` has been deprecated, and will no
longer be supported in a future version of dbt-core. If you wish to write dbt
artifacts to a custom directory, please use the --target-path CLI flag or
DBT_TARGET_PATH env var instead.
16:05:11  Performance info: custom_target/perf_info.json
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- ~This PR includes tests, or tests are not required/relevant for this PR~
- ~I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR~
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
