### PR TITLE
Allow missing `profiles.yml` for `dbt deps` and `dbt init`

### DIFF
--- a/.changes/unreleased/Fixes-20230508-072929.yaml
+++ b/.changes/unreleased/Fixes-20230508-072929.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Allow missing `profiles.yml` for `dbt deps` and `dbt init`
+time: 2023-05-08T07:29:29.873793-06:00
+custom:
+  Author: dbeatty10
+  Issue: "7511"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -424,7 +424,7 @@ def debug(ctx, **kwargs):
 @cli.command("deps")
 @click.pass_context
 @p.profile
-@p.profiles_dir_exists_false
+@p.profiles_dir
 @p.project_dir
 @p.target
 @p.vars
@@ -446,7 +446,7 @@ def deps(ctx, **kwargs):
 # for backwards compatibility, accept 'project_name' as an optional positional argument
 @click.argument("project_name", required=False)
 @p.profile
-@p.profiles_dir_exists_false
+@p.profiles_dir
 @p.project_dir
 @p.skip_profile_setup
 @p.target

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -424,7 +424,7 @@ def debug(ctx, **kwargs):
 @cli.command("deps")
 @click.pass_context
 @p.profile
-@p.profiles_dir
+@p.profiles_dir_exists_false
 @p.project_dir
 @p.target
 @p.vars
@@ -446,7 +446,7 @@ def deps(ctx, **kwargs):
 # for backwards compatibility, accept 'project_name' as an optional positional argument
 @click.argument("project_name", required=False)
 @p.profile
-@p.profiles_dir
+@p.profiles_dir_exists_false
 @p.project_dir
 @p.skip_profile_setup
 @p.target

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -293,6 +293,8 @@ profiles_dir = click.option(
 )
 
 # `dbt debug` uses this because it implements custom behaviour for non-existent profiles.yml directories
+# `dbt deps` does not load a profile at all
+# `dbt init` will write profiles.yml if it doesn't yet exist
 profiles_dir_exists_false = click.option(
     "--profiles-dir",
     envvar="DBT_PROFILES_DIR",

--- a/tests/functional/profiles/test_profile_dir.py
+++ b/tests/functional/profiles/test_profile_dir.py
@@ -98,22 +98,6 @@ class TestProfilesMayNotExist:
     def test_deps(self, project):
         run_dbt(["deps", "--profiles-dir", "does_not_exist"])
 
-    def test_init(self, project):
-        # Use the parent directory to avoid this bug: https://github.com/dbt-labs/dbt-core/issues/7594
-        # Okay to have a non-zero exit code as long as it doesn't raise an exception
-        run_dbt(
-            [
-                "init",
-                "my_project",
-                "--skip-profile-setup",
-                "--profiles-dir",
-                "does_not_exist",
-                "--project-dir",
-                "..",
-            ],
-            expect_pass=None,
-        )
-
 
 class TestProfiles:
     def dbt_debug(self, project_dir_cli_arg=None, profiles_dir_cli_arg=None):

--- a/tests/functional/profiles/test_profile_dir.py
+++ b/tests/functional/profiles/test_profile_dir.py
@@ -9,6 +9,7 @@ from argparse import Namespace
 import dbt.flags as flags
 
 from dbt.tests.util import (
+    run_dbt,
     run_dbt_and_capture,
     write_file,
     rm_file,
@@ -87,6 +88,29 @@ def environ(env):
                 del os.environ[key]
             else:
                 os.environ[key] = value
+
+
+class TestProfilesMayNotExist:
+    def test_debug(self, project):
+        # The database will not be able to connect; expect neither a pass or a failure (but not an exception)
+        run_dbt(["debug", "--profiles-dir", "does_not_exist"], expect_pass=None)
+
+    def test_deps(self, project):
+        run_dbt(["deps", "--profiles-dir", "does_not_exist"])
+
+    def test_init(self, project):
+        # Use the parent directory to avoid the this bug: https://github.com/dbt-labs/dbt-core/issues/7594
+        run_dbt(
+            [
+                "init",
+                "my_project",
+                "--skip-profile-setup",
+                "--profiles-dir",
+                "does_not_exist",
+                "--project-dir",
+                "..",
+            ]
+        )
 
 
 class TestProfiles:

--- a/tests/functional/profiles/test_profile_dir.py
+++ b/tests/functional/profiles/test_profile_dir.py
@@ -99,7 +99,8 @@ class TestProfilesMayNotExist:
         run_dbt(["deps", "--profiles-dir", "does_not_exist"])
 
     def test_init(self, project):
-        # Use the parent directory to avoid the this bug: https://github.com/dbt-labs/dbt-core/issues/7594
+        # Use the parent directory to avoid this bug: https://github.com/dbt-labs/dbt-core/issues/7594
+        # Okay to have a non-zero exit code as long as it doesn't raise an exception
         run_dbt(
             [
                 "init",
@@ -109,7 +110,8 @@ class TestProfilesMayNotExist:
                 "does_not_exist",
                 "--project-dir",
                 "..",
-            ]
+            ],
+            expect_pass=None,
         )
 
 


### PR DESCRIPTION
resolves #7511

### Description

#### Options considered
We considered four different approaches:
1. Leave all behavior as-is for 1.5 and add a note to the [migration guide](https://docs.getdbt.com/guides/migration/versions/upgrading-to-v1.5) so folks know how to make updates
1. Use `type=click.Path(exists=False)` to ignore path validation
1. Give `dbt deps` it's own custom version of the `--profiles-dir` parameter that ignores path validation (similar to Option 2 above)
1. Remove [`@p.profiles_dir`](https://github.com/dbt-labs/dbt-core/blob/fd7306643fd3a98e3232cbc15bf50eb2f3733603/core/dbt/cli/main.py#L427) from `dbt deps`

#### Initial decision

The [initial decision](https://github.com/dbt-labs/dbt-core/issues/7511#issuecomment-1538277269) by @jtcohen6 was:
- Option 2: switch the parameter to `type=click.Path(exists=False)` to turn off this validation for all commands.

#### New decision

But during implementation, I discovered an alternative click option named `profiles_dir_exists_false` that has that behavior (which was added for `dbt debug`), so I chose to re-use that in order to preserve validation for the rest of the subcommands.

During code review, it would be easy to go back to the initial decision if we want to.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] Docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
