### PR TITLE
Do not rewrite `manifest.json` during `docs serve` command

### DIFF
--- a/.changes/unreleased/Fixes-20230508-142518.yaml
+++ b/.changes/unreleased/Fixes-20230508-142518.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Do not rewrite manifest.json during 'docs serve' command
+time: 2023-05-08T14:25:18.376379-04:00
+custom:
+  Author: jtcohen6
+  Issue: "7553"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -290,13 +290,11 @@ def docs_generate(ctx, **kwargs):
 @requires.profile
 @requires.project
 @requires.runtime_config
-@requires.manifest
 def docs_serve(ctx, **kwargs):
     """Serve the documentation website for your project"""
     task = ServeTask(
         ctx.obj["flags"],
         ctx.obj["runtime_config"],
-        ctx.obj["manifest"],
     )
 
     results = task.run()


### PR DESCRIPTION
resolves #7553

### Description

- Currently, because `dbt docs serve` "requires" a manifest, it will re-parse the project and (over)write `manifest.json`
- This has the effect of overwriting the _compiled_ manifest just produced by `dbt docs generate`
- We don't actually need a manifest for any of the functionality in `dbt docs serve`! dbt just expects it to exist, in the `target/` path, in already serialized (JSON) form.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- ~This PR includes tests, or tests are not required/relevant for this PR~
- ~I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR~
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
