### PR TITLE
CT 2494 check for project level dependency cycles

### DIFF
--- a/.changes/unreleased/Features-20230509-094147.yaml
+++ b/.changes/unreleased/Features-20230509-094147.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Check for project dependency cycles
+time: 2023-05-09T09:41:47.2-04:00
+custom:
+  Author: gshank
+  Issue: "7468"

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -871,6 +871,19 @@ class SecretEnvVarLocationError(ParsingError):
         return msg
 
 
+class ProjectDependencyCycleError(ParsingError):
+    def __init__(self, pub_project_name, project_name):
+        self.pub_project_name = pub_project_name
+        self.project_name = project_name
+        super().__init__(msg=self.get_message())
+
+    def get_message(self) -> str:
+        return (
+            f"A project dependency cycle has been detected. The current project {self.project_name} "
+            f"depends on {self.pub_project_name} which also depends on the current project."
+        )
+
+
 class MacroArgTypeError(CompilationError):
     def __init__(self, method_name: str, arg_name: str, got_value: Any, expected_type):
         self.method_name = method_name

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -103,7 +103,12 @@ from dbt.contracts.publication import (
     PublicModel,
     ProjectDependencies,
 )
-from dbt.exceptions import TargetNotFoundError, AmbiguousAliasError, PublicationConfigNotFound
+from dbt.exceptions import (
+    TargetNotFoundError,
+    AmbiguousAliasError,
+    PublicationConfigNotFound,
+    ProjectDependencyCycleError,
+)
 from dbt.parser.base import Parser
 from dbt.parser.analysis import AnalysisParser
 from dbt.parser.generic_test import GenericTestParser
@@ -1712,6 +1717,10 @@ def write_publication_artifact(root_project: RuntimeConfig, manifest: Manifest):
     # Get dependencies from publication dependencies
     for pub_project in manifest.publications.values():
         for project_name in pub_project.dependencies:
+            if project_name == root_project.project_name:
+                raise ProjectDependencyCycleError(
+                    pub_project_name=pub_project.project_name, project_name=project_name
+                )
             if project_name not in dependencies:
                 dependencies.append(project_name)
 


### PR DESCRIPTION
resolves #7468


### Description

When loading publication artifacts (from project in dependencies.yml) check to see if the current project is listed as a dependency and throw an error.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
