### PR TITLE
CT 2510 Throw error for duplicate versioned and non versioned model names

### DIFF
--- a/.changes/unreleased/Fixes-20230509-165007.yaml
+++ b/.changes/unreleased/Fixes-20230509-165007.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Throw error for duplicated versioned and unversioned models
+time: 2023-05-09T16:50:07.530882-04:00
+custom:
+  Author: gshank
+  Issue: "7487"

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -2201,7 +2201,8 @@ Since these resources have the same name, dbt will be unable to find the correct
 when looking for ref({self.versioned_node.name}).
 
 To fix this, change the name of the unversioned resource:
-- {self.unversioned_node.unique_id} ({self.unversioned_node.original_file_path})
+{self.unversioned_node.unique_id} ({self.unversioned_node.original_file_path})
+or add the unversioned model to the versions in {self.versioned_node.patch_path}
     """.strip()
         return msg
 

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -2187,6 +2187,25 @@ To fix this, change the name of one of these resources:
         return msg
 
 
+class DuplicateVersionedUnversionedError(ParsingError):
+    def __init__(self, versioned_node, unversioned_node):
+        self.versioned_node = versioned_node
+        self.unversioned_node = unversioned_node
+        super().__init__(msg=self.get_message())
+
+    def get_message(self) -> str:
+        msg = f"""
+dbt found versioned and unversioned models with the name "{self.versioned_node.name}".
+
+Since these resources have the same name, dbt will be unable to find the correct resource
+when looking for ref({self.versioned_node.name}).
+
+To fix this, change the name of the unversioned resource:
+- {self.unversioned_node.unique_id} ({self.unversioned_node.original_file_path})
+    """.strip()
+        return msg
+
+
 class PropertyYMLError(CompilationError):
     def __init__(self, path: str, issue: str):
         self.path = path

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -2198,9 +2198,9 @@ class DuplicateVersionedUnversionedError(ParsingError):
 dbt found versioned and unversioned models with the name "{self.versioned_node.name}".
 
 Since these resources have the same name, dbt will be unable to find the correct resource
-when looking for ref({self.versioned_node.name}).
+when looking for ref('{self.versioned_node.name}').
 
-To fix this, change the name of the unversioned resource:
+To fix this, change the name of the unversioned resource
 {self.unversioned_node.unique_id} ({self.unversioned_node.original_file_path})
 or add the unversioned model to the versions in {self.versioned_node.patch_path}
     """.strip()

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1262,17 +1262,18 @@ def _check_resource_uniqueness(
     config: RuntimeConfig,
 ) -> None:
     alias_resources: Dict[str, ManifestNode] = {}
-    versioned_resources: Dict[str, ManifestNode] = {}
-    unversioned_resources: Dict[str, ManifestNode] = {}
+    name_resources: Dict[str, Dict] = {}
 
     for resource, node in manifest.nodes.items():
         if not node.is_relational:
             continue
 
+        if node.package_name not in name_resources:
+            name_resources[node.package_name] = {"ver": {}, "unver": {}}
         if node.is_versioned:
-            versioned_resources[node.name] = node
+            name_resources[node.package_name]["ver"][node.name] = node
         else:
-            unversioned_resources[node.name] = node
+            name_resources[node.package_name]["unver"][node.name] = node
 
         # the full node name is really defined by the adapter's relation
         relation_cls = get_relation_class_by_name(config.credentials.type)
@@ -1287,16 +1288,17 @@ def _check_resource_uniqueness(
 
         alias_resources[full_node_name] = node
 
-    intersection_versioned = set(versioned_resources.keys()).intersection(
-        set(unversioned_resources.keys())
-    )
-    if intersection_versioned:
-        for name in intersection_versioned:
-            versioned_node = versioned_resources[name]
-            unversioned_node = unversioned_resources[name]
-            raise dbt.exceptions.DuplicateVersionedUnversionedError(
-                versioned_node, unversioned_node
-            )
+    for ver_unver_dict in name_resources.values():
+        versioned_names = ver_unver_dict["ver"].keys()
+        unversioned_names = ver_unver_dict["unver"].keys()
+        intersection_versioned = set(versioned_names).intersection(set(unversioned_names))
+        if intersection_versioned:
+            for name in intersection_versioned:
+                versioned_node = ver_unver_dict["ver"][name]
+                unversioned_node = ver_unver_dict["unver"][name]
+                raise dbt.exceptions.DuplicateVersionedUnversionedError(
+                    versioned_node, unversioned_node
+                )
 
 
 def _warn_for_unused_resource_config_paths(manifest: Manifest, config: RuntimeConfig) -> None:

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1294,7 +1294,9 @@ def _check_resource_uniqueness(
         for name in intersection_versioned:
             versioned_node = versioned_resources[name]
             unversioned_node = unversioned_resources[name]
-            raise dbt.exceptions.DuplicateResourceNameError(versioned_node, unversioned_node)
+            raise dbt.exceptions.DuplicateVersionedUnversionedError(
+                versioned_node, unversioned_node
+            )
 
 
 def _warn_for_unused_resource_config_paths(manifest: Manifest, config: RuntimeConfig) -> None:

--- a/tests/functional/partial_parsing/test_partial_parsing.py
+++ b/tests/functional/partial_parsing/test_partial_parsing.py
@@ -71,7 +71,7 @@ from tests.functional.partial_parsing.fixtures import (
     groups_schema_yml_two_groups_private_orders_invalid_access,
 )
 
-from dbt.exceptions import CompilationError, ParsingError
+from dbt.exceptions import CompilationError, ParsingError, DuplicateResourceNameError
 from dbt.contracts.files import ParseFileType
 from dbt.contracts.results import TestStatus
 import re
@@ -358,6 +358,14 @@ class TestVersionedModels:
         write_file(model_two_sql, project.project_root, "models", "model_one_different.sql")
         results = run_dbt(["--partial-parse", "run"])
         assert len(results) == 3
+        manifest = get_manifest(project.project_root)
+        assert len(manifest.nodes) == 3
+        print(f"--- nodes: {manifest.nodes.keys()}")
+
+        # create a new model_one in model_one.sql and re-parse
+        write_file(model_one_sql, project.project_root, "models", "model_one.sql")
+        with pytest.raises(DuplicateResourceNameError):
+            run_dbt(["parse"])
 
 
 class TestSources:

--- a/tests/functional/partial_parsing/test_partial_parsing.py
+++ b/tests/functional/partial_parsing/test_partial_parsing.py
@@ -71,7 +71,7 @@ from tests.functional.partial_parsing.fixtures import (
     groups_schema_yml_two_groups_private_orders_invalid_access,
 )
 
-from dbt.exceptions import CompilationError, ParsingError, DuplicateResourceNameError
+from dbt.exceptions import CompilationError, ParsingError, DuplicateVersionedUnversionedError
 from dbt.contracts.files import ParseFileType
 from dbt.contracts.results import TestStatus
 import re
@@ -364,7 +364,7 @@ class TestVersionedModels:
 
         # create a new model_one in model_one.sql and re-parse
         write_file(model_one_sql, project.project_root, "models", "model_one.sql")
-        with pytest.raises(DuplicateResourceNameError):
+        with pytest.raises(DuplicateVersionedUnversionedError):
             run_dbt(["parse"])
 
 


### PR DESCRIPTION
resolves #7487

### Description

The _check_resource_uniqueness method in core/dbt/parser/manifest.py has been modified to check for non-versioned models with the same "name" as versioned models.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
