### PR TITLE
Add types to `quote`

### DIFF
--- a/.changes/unreleased/Fixes-20230510-162347.yaml
+++ b/.changes/unreleased/Fixes-20230510-162347.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add types to `quote`
+time: 2023-05-10T16:23:47.691015+02:00
+custom:
+  Author: Fokko
+  Issue: "7584"

--- a/core/dbt/adapters/sql/impl.py
+++ b/core/dbt/adapters/sql/impl.py
@@ -197,7 +197,7 @@ class SQLAdapter(BaseAdapter):
             )
         return relations
 
-    def quote(self, identifier):
+    def quote(self, identifier: str) -> str:
         return '"{}"'.format(identifier)
 
     def list_schemas(self, database: str) -> List[str]:


### PR DESCRIPTION
### Description

I noticed this when working on types for `dbt-spark`.

This is equivalent to the signature of the method that it's overriding:

```python
    @available
    @classmethod
    @abc.abstractmethod
    def quote(cls, identifier: str) -> str:
        """Quote the given identifier, as appropriate for the database."""
        raise NotImplementedError("`quote` is not implemented for this adapter!")
```

resolves dbt-labs/dbt-adapters#153


<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
