### PR TITLE
[WIP] Adds reuse_connections to BaseConnectionManager

### DIFF
--- a/.changes/unreleased/Features-20230510-114236.yaml
+++ b/.changes/unreleased/Features-20230510-114236.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Adds reuse_connections to BaseConnectionManager and PostgresCredentials
+time: 2023-05-10T11:42:36.914466-04:00
+custom:
+  Author: ckdake
+  Issue: "7520"

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -33,6 +33,7 @@ class PostgresCredentials(Credentials):
     sslrootcert: Optional[str] = None
     application_name: Optional[str] = "dbt"
     retries: int = 1
+    reuse_connections: Optional[bool] = False
 
     _ALIASES = {"dbname": "database", "pass": "password"}
 


### PR DESCRIPTION
resolves #7520

### Description

This is a WIP because I'm not sure the best way to test this yet, and need a hand!

This adds a `reuse_connections` configuration option to BaseConnectionManager, defaulting to `false` which is the existing behavior. This also adds `reuse_connections` as an optional (defaulting to False) attribute for Postgres databases.  When a `dbt` configuration specifies `reuse_connections: True` for a Postgres database, `dbt` will no longer close the connection to the database after every usage.

This will (revert to very old dbt behavior!) allow postgres connections to remain open for the duration of a thread, which should be for the duration of the `dbt` run. This allows a postgres connection with short-lived credentials (e.g. AWS RDS IAM credentials) to stay open without requiring a credential refresh, and saves the overhead of opening/closing connections to databases repeatedly.

The dbt snowflake adapter currently has this functionality already, it can be removed to utilize this new functionality in dbt-core. Other adapters can add support for this functionality by adding `reuse_connections` to their configuration with a sensible default. Ongoing discussion on that here: https://github.com/dbt-labs/dbt-core/issues/5489

Docs Issue: https://github.com/dbt-labs/docs.getdbt.com/issues/3356

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
