### PR TITLE
Updating incremental merge WHERE condition to handle nullable fields …

### DIFF
--- a/.changes/unreleased/Fixes-20230511-142935.yaml
+++ b/.changes/unreleased/Fixes-20230511-142935.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix incremental merge to use an `is null` check to allow for handling of nullable
+  fields in the unique_key
+time: 2023-05-11T14:29:35.400734+01:00
+custom:
+  Author: amardatar
+  Issue: "7597"

--- a/core/dbt/include/global_project/macros/materializations/models/incremental/merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/models/incremental/merge.sql
@@ -62,12 +62,12 @@
 
     {% if unique_key %}
         {% if unique_key is sequence and unique_key is not string %}
-            delete from {{target }}
+            delete from {{ target }}
             using {{ source }}
             where (
                 {% for key in unique_key %}
-                    {{ source }}.{{ key }} = {{ target }}.{{ key }}
-                    {{ "and " if not loop.last}}
+                    ({{ source }}.{{ key }} = {{ target }}.{{ key }} or ({{ source }}.{{ key }} is null and {{ target }}.{{ key }} is null))
+                    {{ "and " if not loop.last }}
                 {% endfor %}
                 {% if incremental_predicates %}
                     {% for predicate in incremental_predicates %}


### PR DESCRIPTION
…with an appropriate null comparison.

resolves dbt-labs/dbt-adapters#159 

### Description

This is a proposed resolution to dbt-labs/dbt-adapters#159 which updates the check in the WHERE condition of the DELETE statement of an incremental merge, to use an additional  `{{ target }}.{{ key }} is null and {{ source }}.{{ key }} is null` check to handle nulls.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
