### PR TITLE
(Minimal alternative) Honor `--skip-profile-setup` parameter when inside an existing project

### DIFF
--- a/.changes/unreleased/Fixes-20230511-140441.yaml
+++ b/.changes/unreleased/Fixes-20230511-140441.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Honor `--skip-profile-setup` parameter when inside an existing project
+time: 2023-05-11T14:04:41.382181-06:00
+custom:
+  Author: dbeatty10
+  Issue: "7594"

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -258,6 +258,11 @@ class InitTask(BaseTask):
         if in_project:
             # When dbt init is run inside an existing project,
             # just setup the user's profile.
+
+            # Ask for adapter only if skip_profile_setup flag is not provided.
+            if self.args.skip_profile_setup:
+                return
+
             fire_event(SettingUpProfile())
             profile_name = self.get_profile_name_from_current_project()
             if not self.check_if_can_write_profile(profile_name=profile_name):


### PR DESCRIPTION
resolves #7594

### Description

This resolves the problem with a minimal code change that preserves the current style.

An alternative PR will be raised that is intended to solve the same problem, but with more code changes. Up to the reviewer to choose which is more fruitful to pursue further.

### Test cases

There are a **lot** of separate cases to test here, and I'm not sure which are already covered (or not). Although I don't view this PR as adding tests for any of the tests below, enumerating all them for clarity.

Cases:
1. In a project
      1. Skip profiles → `return`
      1. Not skip profiles
            1. Profile name already exists and not okay to overwrite → `return`
            1. Profile name does not already exist or okay to overwrite
                  1. profile_template.yml exists
                        1. profile_template.yml is invalid → `return`
                        2. profile_template.yml is valid
                            - create profile
                            - → `return`
                  2. profile_template.yml does not exist
                        1. No adapters exist → `return`
                        1. At least one adapter exists
                            - interactive prompt
                            - create profile
                            - → `return`
2. Not in a project
    1. Specified project name already exists → `return`
    2. Specified project name does not already exist
        1. Skip profiles → `return`
        1. Not skip profiles
            1. Profile name already exists and not okay to overwrite → `return`
            1. Profile name does not already exist or okay to overwrite
                1. No adapters exist → `return`
                1. At least one adapter exists
                    - interactive prompt
                    - create profile
                    - → `return`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] Docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
