### PR TITLE
Honor `--skip-profile-setup` parameter when inside an existing project

### DIFF
--- a/.changes/unreleased/Fixes-20230511-140441.yaml
+++ b/.changes/unreleased/Fixes-20230511-140441.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Honor `--skip-profile-setup` parameter when inside an existing project
+time: 2023-05-11T14:04:41.382181-06:00
+custom:
+  Author: dbeatty10
+  Issue: "7594"

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -699,6 +699,15 @@ class UnknownGitCloningProblemError(DbtRuntimeError):
         return msg
 
 
+class NoAdaptersAvailableError(DbtRuntimeError):
+    def __init__(self):
+        super().__init__(msg=self.get_message())
+
+    def get_message(self) -> str:
+        msg = "No adapters available. Learn how to install an adapter by going to https://docs.getdbt.com/docs/supported-data-platforms#adapter-installation"
+        return msg
+
+
 class BadSpecError(DbtInternalError):
     def __init__(self, repo, revision, error):
         self.repo = repo

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -290,7 +290,8 @@ class InitTask(BaseTask):
             if project_path.exists():
                 fire_event(ProjectNameAlreadyExists(name=project_name))
                 return
-            profile_name = self.create_new_project(project_name)
+            self.create_new_project(project_name)
+            profile_name = project_name
 
         # Ask for adapter only if skip_profile_setup flag is not provided.
         if not self.args.skip_profile_setup:

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -250,11 +250,10 @@ class InitTask(BaseTask):
     def create_new_project(self, project_name: str):
         self.copy_starter_repo(project_name)
         os.chdir(project_name)
-        with open("dbt_project.yml", "r+") as f:
+        with open("dbt_project.yml", "r") as f:
             content = f"{f.read()}".format(project_name=project_name, profile_name=project_name)
-            f.seek(0)
+        with open("dbt_project.yml", "w") as f:
             f.write(content)
-            f.truncate()
         fire_event(
             ProjectCreated(
                 project_name=project_name,

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -3,7 +3,6 @@ import os
 from pathlib import Path
 import re
 import shutil
-import sys
 from typing import Optional
 
 import yaml
@@ -223,10 +222,7 @@ class InitTask(BaseTask):
         available_adapters = list(_get_adapter_plugin_names())
 
         if not len(available_adapters):
-            click.echo(
-                "No adapters available. Learn how to install an adapter by going to https://docs.getdbt.com/docs/supported-data-platforms#adapter-installation"
-            )
-            sys.exit(1)
+            raise dbt.exceptions.NoAdaptersAvailableError()
 
         prompt_msg = (
             "Which database would you like to use?\n"

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -221,7 +221,7 @@ class InitTask(BaseTask):
         """Ask the user which adapter (database) they'd like to use."""
         available_adapters = list(_get_adapter_plugin_names())
 
-        if not len(available_adapters):
+        if not available_adapters:
             raise dbt.exceptions.NoAdaptersAvailableError()
 
         prompt_msg = (

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -145,17 +145,17 @@ class InitTask(BaseTask):
         This will overwrite any profile with a matching name."""
         # Create the profile directory if it doesn't exist
         profiles_filepath = Path(get_flags().PROFILES_DIR) / Path("profiles.yml")
+
+        profiles = {profile_name: profile}
+
         if profiles_filepath.exists():
-            with open(profiles_filepath, "r+") as f:
+            with open(profiles_filepath, "r") as f:
                 profiles = yaml.safe_load(f) or {}
                 profiles[profile_name] = profile
-                f.seek(0)
-                yaml.dump(profiles, f)
-                f.truncate()
-        else:
-            profiles = {profile_name: profile}
-            with open(profiles_filepath, "w") as f:
-                yaml.dump(profiles, f)
+
+        # Write the profiles dictionary to a brand-new or pre-existing file
+        with open(profiles_filepath, "w") as f:
+            yaml.dump(profiles, f)
 
     def create_profile_from_profile_template(self, profile_template: dict, profile_name: str):
         """Create and write a profile using the supplied profile_template."""

--- a/tests/functional/init/test_init.py
+++ b/tests/functional/init/test_init.py
@@ -646,7 +646,7 @@ class TestInitProvidedProjectNameAndSkipProfileSetup(TestInitOutsideOfProjectBas
 
         # provide project name through the init command
         run_dbt(["init", project_name, "-s"])
-        manager.assert_not_called()
+        assert len(manager.mock_calls) == 0
 
         with open(os.path.join(project.project_root, project_name, "dbt_project.yml"), "r") as f:
             assert (
@@ -707,4 +707,4 @@ class TestInitInsideProjectAndSkipProfileSetup(TestInitInsideOfProjectBase):
 
         # skip interactive profile setup
         run_dbt(["init", "-s"])
-        manager.assert_not_called()
+        assert len(manager.mock_calls) == 0

--- a/tests/functional/init/test_init.py
+++ b/tests/functional/init/test_init.py
@@ -589,7 +589,7 @@ class TestInitInvalidProjectNameCLI(TestInitOutsideOfProjectBase):
         manager.prompt.side_effect = [valid_name]
         mock_get_adapter.return_value = [project.adapter.type()]
 
-        run_dbt(["init", invalid_name, "-s"])
+        run_dbt(["init", invalid_name, "--skip-profile-setup"])
         manager.assert_has_calls(
             [
                 call.prompt("Enter a name for your project (letters, digits, underscore)"),
@@ -613,7 +613,7 @@ class TestInitInvalidProjectNamePrompt(TestInitOutsideOfProjectBase):
         manager.prompt.side_effect = [invalid_name, valid_name]
         mock_get_adapter.return_value = [project.adapter.type()]
 
-        run_dbt(["init", "-s"])
+        run_dbt(["init", "--skip-profile-setup"])
         manager.assert_has_calls(
             [
                 call.prompt("Enter a name for your project (letters, digits, underscore)"),
@@ -645,7 +645,7 @@ class TestInitProvidedProjectNameAndSkipProfileSetup(TestInitOutsideOfProjectBas
         mock_get.return_value = [project.adapter.type()]
 
         # provide project name through the init command
-        run_dbt(["init", project_name, "-s"])
+        run_dbt(["init", project_name, "--skip-profile-setup"])
         assert len(manager.mock_calls) == 0
 
         with open(os.path.join(project.project_root, project_name, "dbt_project.yml"), "r") as f:
@@ -706,5 +706,5 @@ class TestInitInsideProjectAndSkipProfileSetup(TestInitInsideOfProjectBase):
         assert Path("dbt_project.yml").exists()
 
         # skip interactive profile setup
-        run_dbt(["init", "-s"])
+        run_dbt(["init", "--skip-profile-setup"])
         assert len(manager.mock_calls) == 0


### PR DESCRIPTION
resolves #7594
resolves #7662

### Description

This is an alternative PR intended to solve the same problem as https://github.com/dbt-labs/dbt-core/pull/7608 -- up to the reviewer to choose which is more fruitful to pursue further.

Differences:
1 - This PR has a refactor to [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) up the implementation. 
2 - This PR also solves an additional issue that #7608 does not solve: #7662

### Test cases

See here for a list of relevant cases https://github.com/dbt-labs/dbt-core/pull/7608

### Running locally

In order to use the workflow locally, I needed to install an adapter like this:
```shell
python -m pip install ./plugins/postgres
```

But in order to run the relevant functional test, I needed to do this:
```shell
python -m pip install -e ./plugins/postgres
pytest tests/functional/init/test_init.py
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests
- [x] Docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
