### PR TITLE
use cross-db macro to concat str in test

### DIFF
--- a/.changes/unreleased/Under the Hood-20230514-201733.yaml
+++ b/.changes/unreleased/Under the Hood-20230514-201733.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: cross-db string concatenation in adapter test
+time: 2023-05-14T20:17:33.314262+02:00
+custom:
+  Author: sdebruyn
+  Issue: "7621"

--- a/tests/adapter/dbt/tests/adapter/basic/files.py
+++ b/tests/adapter/dbt/tests/adapter/basic/files.py
@@ -201,7 +201,7 @@ model_ephemeral = """
 incremental_not_schema_change_sql = """
 {{ config(materialized="incremental", unique_key="user_id_current_time",on_schema_change="sync_all_columns") }}
 select
-    1 || '-' || current_timestamp as user_id_current_time,
+    {{ dbt.concat(["1", "'-'" , "current_timestamp"]) }} as user_id_current_time,
     {% if is_incremental() %}
         'thisis18characters' as platform
     {% else %}

--- a/tests/adapter/dbt/tests/adapter/basic/files.py
+++ b/tests/adapter/dbt/tests/adapter/basic/files.py
@@ -201,7 +201,7 @@ model_ephemeral = """
 incremental_not_schema_change_sql = """
 {{ config(materialized="incremental", unique_key="user_id_current_time",on_schema_change="sync_all_columns") }}
 select
-    {{ dbt.concat(["1", "'-'" , "current_timestamp"]) }} as user_id_current_time,
+    {{ dbt.concat(["1", "'-'" , dbt.current_timestamp()]) }} as user_id_current_time,
     {% if is_incremental() %}
         'thisis18characters' as platform
     {% else %}


### PR DESCRIPTION
resolves dbt-labs/dbt-adapters#155

### Description

In dbt.tests.adapter.basic.files, there is a string concatenation being done in the PostgreSQL syntax. This PR changes that to use the cross-db macro `concat` so that you don't have to override the SQL in that syntax just to make the concatenation work.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
