### PR TITLE
Feature/drop relation/ct 2581

### DIFF
--- a/.changes/unreleased/Features-20230515-122304.yaml
+++ b/.changes/unreleased/Features-20230515-122304.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Update drop_relation macro to allow for configuration of drop statement separately
+  from object name
+time: 2023-05-15T12:23:04.177141-04:00
+custom:
+  Author: mikealfare
+  Issue: "7625"

--- a/core/dbt/include/global_project/macros/adapters/drop_relation.sql
+++ b/core/dbt/include/global_project/macros/adapters/drop_relation.sql
@@ -19,26 +19,26 @@
 
 {% macro drop_table(relation) -%}
   {{ return(adapter.dispatch('drop_table', 'dbt')(relation)) }}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro default__drop_table(relation) -%}
     drop table if exists {{ relation }} cascade
-{% endmacro %}
+{%- endmacro %}
 
 
 {% macro drop_view(relation) -%}
   {{ return(adapter.dispatch('drop_view', 'dbt')(relation)) }}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro default__drop_view(relation) -%}
     drop view if exists {{ relation }} cascade
-{% endmacro %}
+{%- endmacro %}
 
 
 {% macro drop_materialized_view(relation) -%}
   {{ return(adapter.dispatch('drop_materialized_view', 'dbt')(relation)) }}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro default__drop_materialized_view(relation) -%}
     drop materialized view if exists {{ relation }} cascade
-{% endmacro %}
+{%- endmacro %}

--- a/core/dbt/include/global_project/macros/adapters/drop_relation.sql
+++ b/core/dbt/include/global_project/macros/adapters/drop_relation.sql
@@ -7,7 +7,7 @@
         {%- if relation.is_table -%}
             {{- drop_table(relation) -}}
         {%- elif relation.is_view -%}
-            {{- drop_table(relation) -}}
+            {{- drop_view(relation) -}}
         {%- elif relation.is_materialized_view -%}
             {{- drop_materialized_view(relation) -}}
         {%- else -%}

--- a/core/dbt/include/global_project/macros/adapters/drop_relation.sql
+++ b/core/dbt/include/global_project/macros/adapters/drop_relation.sql
@@ -1,0 +1,44 @@
+{% macro drop_relation(relation) -%}
+    {{ return(adapter.dispatch('drop_relation', 'dbt')(relation)) }}
+{% endmacro %}
+
+{% macro default__drop_relation(relation) -%}
+    {% call statement('drop_relation', auto_begin=False) -%}
+        {%- if relation.is_table -%}
+            {{- drop_table(relation) -}}
+        {%- elif relation.is_view -%}
+            {{- drop_table(relation) -}}
+        {%- elif relation.is_materialized_view -%}
+            {{- drop_materialized_view(relation) -}}
+        {%- else -%}
+            drop {{ relation.type }} if exists {{ relation }} cascade
+        {%- endif -%}
+    {%- endcall %}
+{% endmacro %}
+
+
+{% macro drop_table(relation) -%}
+  {{ return(adapter.dispatch('drop_table', 'dbt')(relation)) }}
+{% endmacro %}
+
+{% macro default__drop_table(relation) -%}
+    drop table if exists {{ relation }} cascade
+{% endmacro %}
+
+
+{% macro drop_view(relation) -%}
+  {{ return(adapter.dispatch('drop_view', 'dbt')(relation)) }}
+{% endmacro %}
+
+{% macro default__drop_view(relation) -%}
+    drop view if exists {{ relation }} cascade
+{% endmacro %}
+
+
+{% macro drop_materialized_view(relation) -%}
+  {{ return(adapter.dispatch('drop_materialized_view', 'dbt')(relation)) }}
+{% endmacro %}
+
+{% macro default__drop_materialized_view(relation) -%}
+    drop materialized view if exists {{ relation }} cascade
+{% endmacro %}

--- a/core/dbt/include/global_project/macros/adapters/relation.sql
+++ b/core/dbt/include/global_project/macros/adapters/relation.sql
@@ -31,16 +31,6 @@
     {{ return(backup_relation) }}
 {% endmacro %}
 
-{% macro drop_relation(relation) -%}
-  {{ return(adapter.dispatch('drop_relation', 'dbt')(relation)) }}
-{% endmacro %}
-
-{% macro default__drop_relation(relation) -%}
-  {% call statement('drop_relation', auto_begin=False) -%}
-    drop {{ relation.type }} if exists {{ relation }} cascade
-  {%- endcall %}
-{% endmacro %}
-
 
 {% macro truncate_relation(relation) -%}
   {{ return(adapter.dispatch('truncate_relation', 'dbt')(relation)) }}


### PR DESCRIPTION
resolves #7625

### Description

Allow for a more configurable `drop_relation()` macro; preserve backwards compatibility.

- create `adapters/drop_relation.sql`
- update `drop_relation()` to condition on `relation.type` and dispatch to the appropriate macro
- create `drop_table()`, `drop_view()`, and `drop_materialized_view()`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
