### PR TITLE
bugfix: Deps hangs when using relative paths via `--project-dir`

### DIFF
--- a/.changes/unreleased/Fixes-20230515-123654.yaml
+++ b/.changes/unreleased/Fixes-20230515-123654.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: 'Fix: Relative project paths weren''t working with deps'
+time: 2023-05-15T12:36:54.807413-05:00
+custom:
+  Author: iknox-fa
+  Issue: "7491"

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -211,7 +211,7 @@ def _windows_rmdir_readonly(func: Callable[[str], Any], path: str, exc: Tuple[An
 
 def resolve_path_from_base(path_to_resolve: str, base_path: str) -> str:
     """
-    If path-to_resolve is a relative path, create an absolute path
+    If path_to_resolve is a relative path, create an absolute path
     with base_path as the base.
 
     If path_to_resolve is an absolute path or a user path (~), just

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -1,5 +1,5 @@
 from typing import Any, Optional
-
+from pathlib import Path
 import dbt.utils
 import dbt.deprecations
 import dbt.exceptions
@@ -29,6 +29,7 @@ from dbt.config import Project
 
 class DepsTask(BaseTask):
     def __init__(self, args: Any, project: Project):
+        project.project_root = str(Path(project.project_root).resolve())
         move_to_nearest_project_dir(project.project_root)
         super().__init__(args=args, config=None, project=project)
         self.cli_vars = args.vars

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -29,6 +29,10 @@ from dbt.config import Project
 
 class DepsTask(BaseTask):
     def __init__(self, args: Any, project: Project):
+        # N.B. This is a temporary fix for a bug when using relative paths via
+        # --project-dir with deps.  A larger overhaul of our path handling methods
+        # is needed to fix this the "right" way.
+        # See GH-7651
         project.project_root = str(Path(project.project_root).resolve())
         move_to_nearest_project_dir(project.project_root)
         super().__init__(args=args, config=None, project=project)

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -34,6 +34,7 @@ class DepsTask(BaseTask):
         # is needed to fix this the "right" way.
         # See GH-7651
         project.project_root = str(Path(project.project_root).resolve())
+
         move_to_nearest_project_dir(project.project_root)
         super().__init__(args=args, config=None, project=project)
         self.cli_vars = args.vars

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -32,7 +32,7 @@ class DepsTask(BaseTask):
         # N.B. This is a temporary fix for a bug when using relative paths via
         # --project-dir with deps.  A larger overhaul of our path handling methods
         # is needed to fix this the "right" way.
-        # See GH-7651
+        # See GH-7615
         project.project_root = str(Path(project.project_root).resolve())
 
         move_to_nearest_project_dir(project.project_root)


### PR DESCRIPTION
resolves #7491
### Description
When a relative path is provided by using `--project-dir` the resolution of that path would fail in deps because we change the working directory during the task's lifecycle.  This means that we got invalid paths when trying to fetch the metadata for `LocalPinnedPackage`s because it uses `system.resolve_path_from_base` which in turn relies on `os.path.abspath` to properly resolve the full path, which it can't do correctly because said path is now resolved using a different `cwd` than when originally defined.

If you can follow that convoluted logic give yourself a pat on the back.  :)

In the long run we shouldn't do things like `os.cwd()` in our tasks, but it's pretty deeply built into how we handle the "portable" nature of things like manifests and whatnot so it's a ticket for another day.  

See #7615 for tracking larger issues around file paths.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
