### PR TITLE
Add "other" relation to reffable node classes

### DIFF
--- a/.changes/unreleased/Under the Hood-20230515-152107.yaml
+++ b/.changes/unreleased/Under the Hood-20230515-152107.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add other relation to reffable nodes
+time: 2023-05-15T15:21:07.808892-05:00
+custom:
+  Author: stu-k
+  Issue: "7550"

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1316,6 +1316,8 @@ class WritableManifest(ArtifactMixin):
         for unique_id, node in dct["nodes"].items():
             if "config_call_dict" in node:
                 del node["config_call_dict"]
+            if "state_relation" in node:
+                del node["state_relation"]
         return dct
 
 

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -287,6 +287,10 @@ class ParsedNodeMandatory(GraphNode, HasRelationMetadata, Replaceable):
     checksum: FileHash
     config: NodeConfig = field(default_factory=NodeConfig)
 
+    @property
+    def identifier(self):
+        return self.alias
+
 
 # This needs to be in all ManifestNodes and also in SourceDefinition,
 # because of "source freshness"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -271,14 +271,18 @@ class DependsOn(MacroDependsOn):
 
 
 @dataclass
-class ParsedNodeMandatory(GraphNode, HasRelationMetadata, Replaceable):
+class RelationalNode(HasRelationMetadata):
     alias: str
-    checksum: FileHash
-    config: NodeConfig = field(default_factory=NodeConfig)
 
     @property
     def identifier(self):
         return self.alias
+
+
+@dataclass
+class ParsedNodeMandatory(GraphNode, RelationalNode, Replaceable):
+    checksum: FileHash
+    config: NodeConfig = field(default_factory=NodeConfig)
 
 
 # This needs to be in all ManifestNodes and also in SourceDefinition,
@@ -615,6 +619,7 @@ class ModelNode(CompiledNode):
     constraints: List[ModelLevelConstraint] = field(default_factory=list)
     version: Optional[NodeVersion] = None
     latest_version: Optional[NodeVersion] = None
+    state_relation: Optional[RelationalNode] = None
 
     @property
     def is_latest_version(self) -> bool:
@@ -797,6 +802,7 @@ class SeedNode(ParsedNode):  # No SQLDefaults!
     # and we need the root_path to load the seed later
     root_path: Optional[str] = None
     depends_on: MacroDependsOn = field(default_factory=MacroDependsOn)
+    state_relation: Optional[RelationalNode] = None
 
     def same_seeds(self, other: "SeedNode") -> bool:
         # for seeds, we check the hashes. If the hashes are different types,
@@ -995,6 +1001,7 @@ class IntermediateSnapshotNode(CompiledNode):
 class SnapshotNode(CompiledNode):
     resource_type: NodeType = field(metadata={"restrict": [NodeType.Snapshot]})
     config: SnapshotConfig
+    state_relation: Optional[RelationalNode] = None
 
 
 # ====================================

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -271,8 +271,10 @@ class DependsOn(MacroDependsOn):
 
 
 @dataclass
-class RelationalNode(HasRelationMetadata):
+class StateRelation(dbtClassMixin):
     alias: str
+    database: Optional[str]
+    schema: str
 
     @property
     def identifier(self):
@@ -280,7 +282,8 @@ class RelationalNode(HasRelationMetadata):
 
 
 @dataclass
-class ParsedNodeMandatory(GraphNode, RelationalNode, Replaceable):
+class ParsedNodeMandatory(GraphNode, HasRelationMetadata, Replaceable):
+    alias: str
     checksum: FileHash
     config: NodeConfig = field(default_factory=NodeConfig)
 
@@ -619,7 +622,7 @@ class ModelNode(CompiledNode):
     constraints: List[ModelLevelConstraint] = field(default_factory=list)
     version: Optional[NodeVersion] = None
     latest_version: Optional[NodeVersion] = None
-    state_relation: Optional[RelationalNode] = None
+    state_relation: Optional[StateRelation] = None
 
     @property
     def is_latest_version(self) -> bool:
@@ -802,7 +805,7 @@ class SeedNode(ParsedNode):  # No SQLDefaults!
     # and we need the root_path to load the seed later
     root_path: Optional[str] = None
     depends_on: MacroDependsOn = field(default_factory=MacroDependsOn)
-    state_relation: Optional[RelationalNode] = None
+    state_relation: Optional[StateRelation] = None
 
     def same_seeds(self, other: "SeedNode") -> bool:
         # for seeds, we check the hashes. If the hashes are different types,
@@ -1001,7 +1004,7 @@ class IntermediateSnapshotNode(CompiledNode):
 class SnapshotNode(CompiledNode):
     resource_type: NodeType = field(metadata={"restrict": [NodeType.Snapshot]})
     config: SnapshotConfig
-    state_relation: Optional[RelationalNode] = None
+    state_relation: Optional[StateRelation] = None
 
 
 # ====================================

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -230,7 +230,7 @@ REQUIRED_MACRO_KEYS = REQUIRED_QUERY_HEADER_KEYS | {
     "submit_python_job",
     "dbt_metadata_envs",
 }
-REQUIRED_MODEL_KEYS = REQUIRED_MACRO_KEYS | {"this", "compiled_code"}
+REQUIRED_MODEL_KEYS = REQUIRED_MACRO_KEYS | {"this", "compiled_code", "state_relation"}
 MAYBE_KEYS = frozenset({"debug"})
 
 

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -230,7 +230,7 @@ REQUIRED_MACRO_KEYS = REQUIRED_QUERY_HEADER_KEYS | {
     "submit_python_job",
     "dbt_metadata_envs",
 }
-REQUIRED_MODEL_KEYS = REQUIRED_MACRO_KEYS | {"this", "compiled_code", "state_relation"}
+REQUIRED_MODEL_KEYS = REQUIRED_MACRO_KEYS | {"this", "compiled_code"}
 MAYBE_KEYS = frozenset({"debug"})
 
 

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -93,6 +93,7 @@ REQUIRED_PARSED_NODE_KEYS = frozenset(
         "version",
         "latest_version",
         "constraints",
+        "state_relation",
     }
 )
 


### PR DESCRIPTION
resolves #7550

### Description

As part of `dbt clone` #7256, we need to add an additional field to reffable nodes (i.e. `ModelNode`, `SeedNode`, `SnapshotNode`). This field holds a relation to another node that will be used later in the `dbt clone` project to be exposed in a jinja context to enable the `clone` materialization. The name `state_relation` is very general and we do not need to use this name.

This code is taken from [an existing draft PR](https://github.com/dbt-labs/dbt-core/pull/7258) that Jeremy has up.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
