### PR TITLE
add target-path to more cli commands that use it.

### DIFF
--- a/.changes/unreleased/Fixes-20230516-152644.yaml
+++ b/.changes/unreleased/Fixes-20230516-152644.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add --target-path to more CLI subcommands
+time: 2023-05-16T15:26:44.557072-04:00
+custom:
+  Author: dwreeves
+  Issue: "7646"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -213,6 +213,7 @@ def build(ctx, **kwargs):
 @p.profiles_dir
 @p.project_dir
 @p.target
+@p.target_path
 @p.vars
 @requires.postflight
 @requires.preflight
@@ -284,6 +285,7 @@ def docs_generate(ctx, **kwargs):
 @p.profiles_dir
 @p.project_dir
 @p.target
+@p.target_path
 @p.vars
 @requires.postflight
 @requires.preflight
@@ -477,6 +479,7 @@ def init(ctx, **kwargs):
 @p.state
 @p.deprecated_state
 @p.target
+@p.target_path
 @p.vars
 @requires.postflight
 @requires.preflight
@@ -577,6 +580,7 @@ def run(ctx, **kwargs):
 @p.profiles_dir
 @p.project_dir
 @p.target
+@p.target_path
 @p.vars
 @requires.postflight
 @requires.preflight
@@ -691,6 +695,7 @@ def source(ctx, **kwargs):
 @p.state
 @p.deprecated_state
 @p.target
+@p.target_path
 @p.threads
 @p.vars
 @requires.postflight


### PR DESCRIPTION
resolves #7646

### Description

Related to my previous PR #7419 and issue #7418.

There are additional subcommands that do not have `--target-path` as an option, even though they create a `target/` folder when one does not exist. Because we (at our company with our dbt setup) do not have our target set up in `${PWD}/target`, and we specify the `--target-path` via the CLI, this ends up being an annoyance.

In particular, we were using dbt 1.1.x and ran into this as a regression for the command `dbt run-operation`. However, I went through the rest of the CLI and added `--target-path` for everything that met the following criteria:

- `${PWD}/target/` does not exist.
- I run `dbt [subcommand]`.
- After the command executes, `${PWD}/target/` does exist.

I also validated this against source code, e.g. `GraphRunnableTask` uses `self.config.target_path`, so all subclasses of this should have a `--target-path`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
