### PR TITLE
Windows MemoryError on CI runs

### DIFF
--- a/.changes/unreleased/Under the Hood-20230519-153059.yaml
+++ b/.changes/unreleased/Under the Hood-20230519-153059.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Break up integration tests as a short term fix for Windows CI runs
+time: 2023-05-19T15:30:59.138043-04:00
+custom:
+  Author: mikealfare
+  Issue: "7668"

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,8 @@ passenv =
   POSTGRES_TEST_*
   PYTEST_ADDOPTS
 commands =
-  {envpython} -m pytest --cov=core {posargs} tests/functional
+  {envpython} -m pytest --cov=core {posargs} tests/functional -k "not tests/functional/graph_selection"
+  {envpython} -m pytest --cov=core {posargs} tests/functional/graph_selection
   {envpython} -m pytest --cov=core {posargs} tests/adapter
 
 deps =


### PR DESCRIPTION
resolves #7668

### Description

Break out the largest subdirectory from `tests/functional` as a separate execution in pytest so that the memory is dumped and freed up in between the runs. This allows us to run tests again while we figure out how to resolve the larger issue.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
