### PR TITLE
CT 2516 ensure that paths in Jinja context flags object are strings

### DIFF
--- a/.changes/unreleased/Fixes-20230522-135007.yaml
+++ b/.changes/unreleased/Fixes-20230522-135007.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Stringify flag paths for Jinja context
+time: 2023-05-22T13:50:07.897354-04:00
+custom:
+  Author: gshank
+  Issue: "7495"

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -95,6 +95,8 @@ def get_flag_dict():
 def get_flag_obj():
     new_flags = Namespace()
     for key, val in get_flag_dict().items():
+        if isinstance(val, Path):
+            val = str(val)
         setattr(new_flags, key.upper(), val)
     # The following 3 are CLI arguments only so they're not full-fledged flags,
     # but we put in flags for users.

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -3,6 +3,7 @@ from os import getenv as os_getenv
 from argparse import Namespace
 from multiprocessing import get_context
 from typing import Optional
+from pathlib import Path
 
 
 # for setting up logger for legacy logger


### PR DESCRIPTION
resolves #7495


### Description

Explicitly stringify the paths in the flags object provided by get_flag_obj.

Note: because of the way that our project test fixtures work, it was pretty impossible to recreate this in a test, and would require rewriting a bunch of the project fixtures. Since this is going to be backported, if we want a test for this it should be done separately. Fix was hand verified.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
