### PR TITLE
Updating CODEOWNERS to consolidate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 
 # As a default for areas with no assignment,
 # the core team as a whole will be assigned
-*       @dbt-labs/core
+*       @dbt-labs/core-team
 
 ### OSS Tooling Guild
 
@@ -30,40 +30,6 @@ requirements.txt                @dbt-labs/guild-oss-tooling
 dev_requirements.txt            @dbt-labs/guild-oss-tooling
 /core/setup.py                  @dbt-labs/guild-oss-tooling
 /core/MANIFEST.in               @dbt-labs/guild-oss-tooling
-
-### LANGUAGE
-
-# Language core modules
-/core/dbt/config/               @dbt-labs/core-language
-/core/dbt/context/              @dbt-labs/core-language
-/core/dbt/contracts/            @dbt-labs/core-language
-/core/dbt/deps/                 @dbt-labs/core-language
-/core/dbt/events/               @dbt-labs/core-language  # structured logging
-/core/dbt/parser/               @dbt-labs/core-language
-
-# Language misc files
-/core/dbt/dataclass_schema.py   @dbt-labs/core-language
-/core/dbt/hooks.py              @dbt-labs/core-language
-/core/dbt/node_types.py         @dbt-labs/core-language
-/core/dbt/semver.py             @dbt-labs/core-language
-
-
-### EXECUTION
-
-# Execution core modules
-/core/dbt/graph/                @dbt-labs/core-execution
-/core/dbt/task/                 @dbt-labs/core-execution
-
-# Execution misc files
-/core/dbt/compilation.py        @dbt-labs/core-execution
-/core/dbt/flags.py              @dbt-labs/core-execution
-/core/dbt/lib.py                @dbt-labs/core-execution
-/core/dbt/main.py               @dbt-labs/core-execution
-/core/dbt/profiler.py           @dbt-labs/core-execution
-/core/dbt/selected_resources.py @dbt-labs/core-execution
-/core/dbt/tracking.py           @dbt-labs/core-execution
-/core/dbt/version.py            @dbt-labs/core-execution
-
 
 ### ADAPTERS
 


### PR DESCRIPTION
### Description
Consolidating to remove Language and Execution and instead default to the `core-team` for reviews

This will default all reviews to the Core team unless in the Adapters or OSS Guild areas.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
