### PR TITLE
Add `%` to adapter suite test cases for `persist_docs`

### DIFF
--- a/.changes/unreleased/Fixes-20230524-160648.yaml
+++ b/.changes/unreleased/Fixes-20230524-160648.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add `%` to adapter suite test cases for `persist_docs`
+time: 2023-05-24T16:06:48.477708-06:00
+custom:
+  Author: dbeatty10
+  Issue: "7698"

--- a/tests/adapter/dbt/tests/adapter/persist_docs/fixtures.py
+++ b/tests/adapter/dbt/tests/adapter/persist_docs/fixtures.py
@@ -67,6 +67,7 @@ models:
       and with 'single  quotes' as welll as other;
       '''abc123'''
       reserved -- characters
+      80% of statistics are made up on the spot
       --
       /* comment */
       Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
@@ -77,6 +78,7 @@ models:
           and with 'single  quotes' as welll as other;
           '''abc123'''
           reserved -- characters
+          80% of statistics are made up on the spot
           --
           /* comment */
           Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
@@ -90,6 +92,7 @@ models:
       and with 'single  quotes' as welll as other;
       '''abc123'''
       reserved -- characters
+      80% of statistics are made up on the spot
       --
       /* comment */
       Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
@@ -100,6 +103,7 @@ models:
           and with 'single  quotes' as welll as other;
           '''abc123'''
           reserved -- characters
+          80% of statistics are made up on the spot
           --
           /* comment */
           Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
@@ -111,6 +115,7 @@ seeds:
       and with 'single  quotes' as welll as other;
       '''abc123'''
       reserved -- characters
+      80% of statistics are made up on the spot
       --
       /* comment */
       Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
@@ -121,6 +126,7 @@ seeds:
           and with 'single  quotes' as welll as other;
           '''abc123'''
           reserved -- characters
+          80% of statistics are made up on the spot
           --
           /* comment */
           Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting

--- a/tests/adapter/dbt/tests/adapter/persist_docs/fixtures.py
+++ b/tests/adapter/dbt/tests/adapter/persist_docs/fixtures.py
@@ -13,6 +13,7 @@ name Column description "with double quotes"
 and with 'single  quotes' as welll as other;
 '''abc123'''
 reserved -- characters
+80% of statistics are made up on the spot
 --
 /* comment */
 Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting


### PR DESCRIPTION
resolves #7698

### Description

I suspect there's a bug that affects `redshift_connector` (and possibly `pg8000` too) where a [comment](https://docs.aws.amazon.com/redshift/latest/dg/r_COMMENT.html) like the following raises an error regardless if using `paramstyle = 'pyformat'` or `paramstyle = 'format'`:
```sql
  comment on table customers is '95% of customer records';
```

Added text containing `%` to the functional tests within dbt-core so that we can cover this test case in dbt-redshift and other adapters.

### Decisions to be made

It's possible that adapters maintained by dbt Labs, partners, or the community will fail certain test(s) after merging this.

It is confirmed to work fine with dbt-redshift in https://github.com/dbt-labs/dbt-redshift/pull/466.

But it is up to the reviewer if we need/want to check this branch against other adapters also before merging this PR.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests
- [x] Docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
