### PR TITLE
fix StopIteration error when publication not found

### DIFF
--- a/.changes/unreleased/Fixes-20230526-153738.yaml
+++ b/.changes/unreleased/Fixes-20230526-153738.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: fix StopIteration error when publication for project not found
+time: 2023-05-26T15:37:38.952939-04:00
+custom:
+  Author: michelleark
+  Issue: "7711"

--- a/core/dbt/contracts/publication.py
+++ b/core/dbt/contracts/publication.py
@@ -97,8 +97,6 @@ class PublicationMandatory:
 @dataclass
 @schema_version("publication", 1)
 class PublicationArtifact(ArtifactMixin, PublicationMandatory):
-    """This represents the <project_name>_publication.json artifact"""
-
     public_models: Dict[str, PublicModel] = field(default_factory=dict)
     metadata: PublicationMetadata = field(default_factory=PublicationMetadata)
     # list of project name strings

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -243,7 +243,11 @@ class ManifestLoader:
         self.root_project: RuntimeConfig = root_project
         self.all_projects: Mapping[str, Project] = all_projects
         self.file_diff = file_diff
-        self.publications = publications
+        self.publications: Mapping[str, PublicationArtifact] = (
+            {publication.project_name: publication for publication in publications}
+            if publications
+            else {}
+        )
         self.manifest: Manifest = Manifest()
         self.new_manifest = self.manifest
         self.manifest.metadata = root_project.get_metadata()
@@ -841,11 +845,7 @@ class ManifestLoader:
 
     def load_new_public_nodes(self):
         for project in self.manifest.project_dependencies.projects:
-            publication = (
-                next(p for p in self.publications if p.project_name == project.name)
-                if self.publications
-                else None
-            )
+            publication = self.publications.get(project.name)
             if publication:
                 publication_config = PublicationConfig.from_publication(publication)
                 self.manifest.publications[project.name] = publication_config

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -845,15 +845,17 @@ class ManifestLoader:
 
     def load_new_public_nodes(self):
         for project in self.manifest.project_dependencies.projects:
-            publication = self.publications.get(project.name)
-            if publication:
-                publication_config = PublicationConfig.from_publication(publication)
-                self.manifest.publications[project.name] = publication_config
-                # Add to dictionary of public_nodes and save id in PublicationConfig
-                for public_node in publication.public_models.values():
-                    self.manifest.public_nodes[public_node.unique_id] = public_node
-            else:
+            try:
+                publication = self.publications[project.name]
+            except KeyError:
                 raise PublicationConfigNotFound(project=project.name)
+
+            publication_config = PublicationConfig.from_publication(publication)
+            self.manifest.publications[project.name] = publication_config
+
+            # Add to dictionary of public_nodes and save id in PublicationConfig
+            for public_node in publication.public_models.values():
+                self.manifest.public_nodes[public_node.unique_id] = public_node
 
     def is_partial_parsable(self, manifest: Manifest) -> Tuple[bool, Optional[str]]:
         """Compare the global hashes of the read-in parse results' values to

--- a/tests/functional/multi_project/test_publication.py
+++ b/tests/functional/multi_project/test_publication.py
@@ -133,9 +133,13 @@ class TestPublicationArtifacts:
     def test_pub_artifacts(self, project):
         write_file(dependencies_yml, "dependencies.yml")
 
-        # Dependencies lists "marketing" project, but no publication file found
+        # Dependencies lists "marketing" project, but no publications provided
         with pytest.raises(PublicationConfigNotFound):
             run_dbt(["parse"])
+
+        # Dependencies lists "marketing" project, but no "marketing" publication provided
+        with pytest.raises(PublicationConfigNotFound):
+            run_dbt(["parse"], publications=[PublicationArtifact(project_name="not_marketing")])
 
         # Provide publication and try again
         m_pub_json = marketing_pub_json.replace("test_schema", project.test_schema)


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/7711

🎩 -ed with reproduction case from issue + added new test case.

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
* represents `ManifestLoader.publications` as a dictionary mapping project name strings -> publications, instead of a flat list for more straightforward lookups downstream. 
* This feels like an internal concern to ManifestLoader. User-facing interface `dbtRunner.invoke` still makes sense as a flat list of `PublicationArtifacts` for simplicity. 


<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
