### PR TITLE
Version 0 for model works for latest_version

### DIFF
--- a/.changes/unreleased/Fixes-20230526-164727.yaml
+++ b/.changes/unreleased/Fixes-20230526-164727.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Using version 0 works when resolving single model
+time: 2023-05-26T16:47:27.6065-04:00
+custom:
+  Author: gshank
+  Issue: "7372"

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -204,7 +204,7 @@ class RefableLookup(dbtClassMixin):
                         if v.name == node.name and v.version is not None
                     ]
                 )
-                assert node.latest_version  # for mypy, whenever i may find it
+                assert node.latest_version is not None  # for mypy, whenever i may find it
                 if max_version > UnparsedVersion(node.latest_version):
                     fire_event(
                         UnpinnedRefNewVersionAvailable(

--- a/tests/functional/graph_selection/test_version_selection.py
+++ b/tests/functional/graph_selection/test_version_selection.py
@@ -109,3 +109,25 @@ class TestVersionSelection:
     def test_select_models_two_versions(self, project):
         results = run_dbt(["ls", "--models", "version:latest version:old"])
         assert sorted(results) == ["test.versioned.v1", "test.versioned.v2"]
+
+
+my_model_yml = """
+models:
+  - name: my_model
+    versions:
+      - v: 0
+"""
+
+
+class TestVersionZero:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": "select 1 as id",
+            "another.sql": "select * from {{ ref('my_model') }}",
+            "schema.yml": my_model_yml,
+        }
+
+    def test_version_zero(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 2


### PR DESCRIPTION
resolves #7372

### Description

Because of an incorrect assert statement, when version 0 is the latest zero an error was thrown. Fix the assert statement.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
