### PR TITLE
fix error message for empty/None: --warn-error-options handling

### DIFF
--- a/.changes/unreleased/Fixes-20230530-104228.yaml
+++ b/.changes/unreleased/Fixes-20230530-104228.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix empty --warn-error-options error message
+time: 2023-05-30T10:42:28.382804-04:00
+custom:
+  Author: michelleark
+  Issue: "7730"

--- a/core/dbt/cli/option_types.py
+++ b/core/dbt/cli/option_types.py
@@ -1,6 +1,6 @@
 from click import ParamType, Choice
 
-from dbt.config.utils import parse_cli_vars
+from dbt.config.utils import parse_cli_yaml_string
 from dbt.exceptions import ValidationError
 
 from dbt.helper_types import WarnErrorOptions
@@ -16,7 +16,8 @@ class YAML(ParamType):
         if not isinstance(value, str):
             self.fail(f"Cannot load YAML from type {type(value)}", param, ctx)
         try:
-            return parse_cli_vars(value)
+            param_option_name = param.opts[0] if param.opts else param.name
+            return parse_cli_yaml_string(value, param_option_name.strip("-"))
         except ValidationError:
             self.fail(f"String '{value}' is not valid YAML", param, ctx)
 

--- a/core/dbt/cli/option_types.py
+++ b/core/dbt/cli/option_types.py
@@ -1,7 +1,7 @@
 from click import ParamType, Choice
 
 from dbt.config.utils import parse_cli_yaml_string
-from dbt.exceptions import ValidationError
+from dbt.exceptions import ValidationError, DbtValidationError, OptionNotYamlDictError
 
 from dbt.helper_types import WarnErrorOptions
 
@@ -18,7 +18,7 @@ class YAML(ParamType):
         try:
             param_option_name = param.opts[0] if param.opts else param.name
             return parse_cli_yaml_string(value, param_option_name.strip("-"))
-        except ValidationError:
+        except (ValidationError, DbtValidationError, OptionNotYamlDictError):
             self.fail(f"String '{value}' is not valid YAML", param, ctx)
 
 

--- a/core/dbt/config/utils.py
+++ b/core/dbt/config/utils.py
@@ -19,6 +19,6 @@ def parse_cli_yaml_string(var_string: str, cli_option_name: str) -> Dict[str, An
             return cli_vars
         else:
             raise OptionNotYamlDictError(var_type, cli_option_name)
-    except DbtValidationError:
+    except (DbtValidationError, OptionNotYamlDictError):
         fire_event(InvalidOptionYAML(option_name=cli_option_name))
         raise

--- a/tests/unit/test_option_types.py
+++ b/tests/unit/test_option_types.py
@@ -1,0 +1,26 @@
+from click import Option, BadParameter
+import pytest
+
+from dbt.cli.option_types import YAML
+
+
+class TestYAML:
+    @pytest.mark.parametrize(
+        "raw_value,expected_converted_value",
+        [
+            ("{}", {}),
+            ("{'test_var_key': 'test_var_value'}", {"test_var_key": "test_var_value"}),
+        ],
+    )
+    def test_yaml_init(self, raw_value, expected_converted_value):
+        converted_value = YAML().convert(raw_value, Option(["--vars"]), None)
+        assert converted_value == expected_converted_value
+
+    @pytest.mark.parametrize(
+        "invalid_yaml_str",
+        ["{", ""],
+    )
+    def test_yaml_init_invalid_yaml_str(self, invalid_yaml_str):
+        with pytest.raises(BadParameter) as e:
+            YAML().convert(invalid_yaml_str, Option(["--vars"]), None)
+        assert "--vars" in e.value.format_message()


### PR DESCRIPTION
resolves #7730

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

🎩 
```sh
❯ dbt --warn-error-options '' run -s doesntexist
dbt.exceptions.OptionNotYamlDictError: Compilation Error
  The --warn-error-options argument must be a YAML dictionary, but was of type 'NoneType'
❯ dbt run -s doesntexist --vars ''
...
dbt.exceptions.OptionNotYamlDictError: Compilation Error
  The --vars argument must be a YAML dictionary, but was of type 'NoneType'
```
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
