### PR TITLE
Fix doc link in selector.py

### DIFF
--- a/core/dbt/config/selectors.py
+++ b/core/dbt/config/selectors.py
@@ -21,7 +21,7 @@ The selectors.yml file in this project is malformed. Please double check
 the contents of this file and fix any errors before retrying.
 
 You can find more information on the syntax for this file here:
-https://docs.getdbt.com/docs/package-management
+https://docs.getdbt.com/reference/node-selection/yaml-selectors
 
 Validator Error:
 {error}


### PR DESCRIPTION
resolves #7533

### Description

Update the URL link from https://docs.getdbt.com/docs/package-management to https://docs.getdbt.com/reference/node-selection/yaml-selectors for MALFORMED_SELECTOR_ERROR variable at dbt-core/core/dbt/config
/selectors.py as instructed on the issue by [dbeatty10](https://github.com/dbeatty10).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)