### PR TITLE
remove entire changes folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,6 @@
 /.github/                       @dbt-labs/guild-oss-tooling
 .bumpversion.cfg                @dbt-labs/guild-oss-tooling
 
-/.changes/                      @dbt-labs/guild-oss-tooling
 .changie.yaml                   @dbt-labs/guild-oss-tooling
 
 pre-commit-config.yaml          @dbt-labs/guild-oss-tooling


### PR DESCRIPTION
### Description

Removes the `/.changes` directory from CODEOWNERS.  Right now the guild is added as a reviewer on any with that contains a changelog, which is wrong.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
