### PR TITLE
Fix not equals comparison to be null-safe for adapters/utils tests

### DIFF
--- a/.changes/unreleased/Features-20230604-080052.yaml
+++ b/.changes/unreleased/Features-20230604-080052.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Cross-database null-safe equals comparison via `equals`
+time: 2023-06-04T08:00:52.537967-06:00
+custom:
+  Author: dbeatty10
+  Issue: "6997"

--- a/.changes/unreleased/Features-20230604-080052.yaml
+++ b/.changes/unreleased/Features-20230604-080052.yaml
@@ -1,6 +1,6 @@
-kind: Features
-body: Cross-database null-safe equals comparison via `equals`
+kind: Fixes
+body: Fix null-safe equals comparison via `equals`
 time: 2023-06-04T08:00:52.537967-06:00
 custom:
   Author: dbeatty10
-  Issue: "6997"
+  Issue: "7778"

--- a/tests/adapter/dbt/tests/adapter/utils/base_utils.py
+++ b/tests/adapter/dbt/tests/adapter/utils/base_utils.py
@@ -2,9 +2,11 @@ import pytest
 from dbt.tests.util import run_dbt
 
 macros__equals_sql = """
-{% macro equals(actual, expected) %}
-{# -- actual is not distinct from expected #}
-(({{ actual }} = {{ expected }}) or ({{ actual }} is null and {{ expected }} is null))
+{% macro equals(expr1, expr2) -%}
+case when (({{ expr1 }} = {{ expr2 }}) or ({{ expr1 }} is null and {{ expr2 }} is null))
+    then 0
+    else 1
+end = 0
 {% endmacro %}
 """
 

--- a/tests/adapter/dbt/tests/adapter/utils/base_utils.py
+++ b/tests/adapter/dbt/tests/adapter/utils/base_utils.py
@@ -17,6 +17,15 @@ where not {{ equals(actual, expected) }}
 {% endtest %}
 """
 
+macros__replace_empty_sql = """
+{% macro replace_empty(expr) -%}
+case
+    when {{ expr }} = 'EMPTY' then ''
+    else {{ expr }}
+end
+{% endmacro %}
+"""
+
 
 class BaseUtils:
     # setup
@@ -25,6 +34,7 @@ class BaseUtils:
         return {
             "equals.sql": macros__equals_sql,
             "test_assert_equal.sql": macros__test_assert_equal_sql,
+            "replace_empty.sql": macros__replace_empty_sql,
         }
 
     # make it possible to dynamically update the macro call with a namespace

--- a/tests/adapter/dbt/tests/adapter/utils/fixture_concat.py
+++ b/tests/adapter/dbt/tests/adapter/utils/fixture_concat.py
@@ -1,17 +1,28 @@
 # concat
 
+# https://github.com/dbt-labs/dbt-core/issues/4725
 seeds__data_concat_csv = """input_1,input_2,output
 a,b,ab
-a,,a
-,b,b
-,,
+a,EMPTY,a
+EMPTY,b,b
+EMPTY,EMPTY,EMPTY
 """
 
 
 models__test_concat_sql = """
-with data as (
+with seed_data as (
 
     select * from {{ ref('data_concat') }}
+
+),
+
+data as (
+
+    select
+        {{ replace_empty('input_1') }} as input_1,
+        {{ replace_empty('input_2') }} as input_2,
+        {{ replace_empty('output') }} as output
+    from seed_data
 
 )
 

--- a/tests/adapter/dbt/tests/adapter/utils/fixture_equals.py
+++ b/tests/adapter/dbt/tests/adapter/utils/fixture_equals.py
@@ -24,7 +24,6 @@ select *
 from data
 where
   {{ equals('x', 'y') }}
-  and expected = 'same'
 """
 
 
@@ -39,5 +38,4 @@ select *
 from data
 where
   not {{ equals('x', 'y') }}
-  and expected = 'different'
 """

--- a/tests/adapter/dbt/tests/adapter/utils/fixture_equals.py
+++ b/tests/adapter/dbt/tests/adapter/utils/fixture_equals.py
@@ -1,0 +1,43 @@
+# equals
+
+SEEDS__DATA_EQUALS_CSV = """key_name,x,y,expected
+1,1,1,same
+2,1,2,different
+3,1,null,different
+4,2,1,different
+5,2,2,same
+6,2,null,different
+7,null,1,different
+8,null,2,different
+9,null,null,same
+"""
+
+
+MODELS__EQUAL_VALUES_SQL = """
+with data as (
+
+    select * from {{ ref('data_equals') }}
+
+)
+
+select *
+from data
+where
+  {{ equals('x', 'y') }}
+  and expected = 'same'
+"""
+
+
+MODELS__NOT_EQUAL_VALUES_SQL = """
+with data as (
+
+    select * from {{ ref('data_equals') }}
+
+)
+
+select *
+from data
+where
+  not {{ equals('x', 'y') }}
+  and expected = 'different'
+"""

--- a/tests/adapter/dbt/tests/adapter/utils/fixture_hash.py
+++ b/tests/adapter/dbt/tests/adapter/utils/fixture_hash.py
@@ -1,17 +1,27 @@
 # hash
 
+# https://github.com/dbt-labs/dbt-core/issues/4725
 seeds__data_hash_csv = """input_1,output
 ab,187ef4436122d1cc2f40dc2b92f0eba0
 a,0cc175b9c0f1b6a831c399e269772661
 1,c4ca4238a0b923820dcc509a6f75849b
-,d41d8cd98f00b204e9800998ecf8427e
+EMPTY,d41d8cd98f00b204e9800998ecf8427e
 """
 
 
 models__test_hash_sql = """
-with data as (
+with seed_data as (
 
     select * from {{ ref('data_hash') }}
+
+),
+
+data as (
+
+    select
+        {{ replace_empty('input_1') }} as input_1,
+        {{ replace_empty('output') }} as output
+    from seed_data
 
 )
 

--- a/tests/adapter/dbt/tests/adapter/utils/fixture_null_compare.py
+++ b/tests/adapter/dbt/tests/adapter/utils/fixture_null_compare.py
@@ -8,7 +8,7 @@ select
 MODELS__TEST_MIXED_NULL_COMPARE_YML = """
 version: 2
 models:
-  - name: test_null_compare
+  - name: test_mixed_null_compare
     tests:
       - assert_equal:
           actual: actual

--- a/tests/adapter/dbt/tests/adapter/utils/test_equals.py
+++ b/tests/adapter/dbt/tests/adapter/utils/test_equals.py
@@ -15,19 +15,6 @@ class BaseEquals:
             "equals.sql": macros__equals_sql,
         }
 
-    # make it possible to dynamically update the macro call with a namespace
-    # (e.g.) 'dateadd', 'dbt.dateadd', 'dbt_utils.dateadd'
-    def macro_namespace(self):
-        return ""
-
-    def interpolate_macro_namespace(self, model_sql, macro_name):
-        macro_namespace = self.macro_namespace()
-        return (
-            model_sql.replace(f"{macro_name}(", f"{macro_namespace}.{macro_name}(")
-            if macro_namespace
-            else model_sql
-        )
-
     @pytest.fixture(scope="class")
     def seeds(self):
         return {
@@ -37,12 +24,8 @@ class BaseEquals:
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "equal_values.sql": self.interpolate_macro_namespace(
-                MODELS__EQUAL_VALUES_SQL, "equals"
-            ),
-            "not_equal_values.sql": self.interpolate_macro_namespace(
-                MODELS__NOT_EQUAL_VALUES_SQL, "equals"
-            ),
+            "equal_values.sql": MODELS__EQUAL_VALUES_SQL,
+            "not_equal_values.sql": MODELS__NOT_EQUAL_VALUES_SQL,
         }
 
     def test_equal_values(self, project):

--- a/tests/adapter/dbt/tests/adapter/utils/test_equals.py
+++ b/tests/adapter/dbt/tests/adapter/utils/test_equals.py
@@ -1,0 +1,71 @@
+import pytest
+from dbt.tests.adapter.utils.base_utils import macros__equals_sql
+from dbt.tests.adapter.utils.fixture_equals import (
+    SEEDS__DATA_EQUALS_CSV,
+    MODELS__EQUAL_VALUES_SQL,
+    MODELS__NOT_EQUAL_VALUES_SQL,
+)
+from dbt.tests.util import run_dbt, relation_from_name
+
+
+class BaseEquals:
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "equals.sql": macros__equals_sql,
+        }
+
+    # make it possible to dynamically update the macro call with a namespace
+    # (e.g.) 'dateadd', 'dbt.dateadd', 'dbt_utils.dateadd'
+    def macro_namespace(self):
+        return ""
+
+    def interpolate_macro_namespace(self, model_sql, macro_name):
+        macro_namespace = self.macro_namespace()
+        return (
+            model_sql.replace(f"{macro_name}(", f"{macro_namespace}.{macro_name}(")
+            if macro_namespace
+            else model_sql
+        )
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "data_equals.csv": SEEDS__DATA_EQUALS_CSV,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "equal_values.sql": self.interpolate_macro_namespace(
+                MODELS__EQUAL_VALUES_SQL, "equals"
+            ),
+            "not_equal_values.sql": self.interpolate_macro_namespace(
+                MODELS__NOT_EQUAL_VALUES_SQL, "equals"
+            ),
+        }
+
+    def test_equal_values(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+
+        # There are 9 cases total; 3 are equal and 6 are not equal
+
+        # 3 are equal
+        relation = relation_from_name(project.adapter, "equal_values")
+        result = project.run_sql(
+            f"select count(*) as num_rows from {relation} where expected = 'same'", fetch="one"
+        )
+        assert result[0] == 3
+
+        # 6 are not equal
+        relation = relation_from_name(project.adapter, "not_equal_values")
+        result = project.run_sql(
+            f"select count(*) as num_rows from {relation} where expected = 'different'",
+            fetch="one",
+        )
+        assert result[0] == 6
+
+
+class TestEquals(BaseEquals):
+    pass

--- a/tests/adapter/dbt/tests/adapter/utils/test_null_compare.py
+++ b/tests/adapter/dbt/tests/adapter/utils/test_null_compare.py
@@ -14,8 +14,8 @@ class BaseMixedNullCompare(BaseUtils):
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "test_mixed_null_compare.yml": MODELS__TEST_MIXED_NULL_COMPARE_SQL,
-            "test_mixed_null_compare.sql": MODELS__TEST_MIXED_NULL_COMPARE_YML,
+            "test_mixed_null_compare.yml": MODELS__TEST_MIXED_NULL_COMPARE_YML,
+            "test_mixed_null_compare.sql": MODELS__TEST_MIXED_NULL_COMPARE_SQL,
         }
 
     def test_build_assert_equal(self, project):
@@ -32,7 +32,7 @@ class BaseNullCompare(BaseUtils):
         }
 
 
-class TestMixedNullCompare(BaseNullCompare):
+class TestMixedNullCompare(BaseMixedNullCompare):
     pass
 
 


### PR DESCRIPTION
resolves #7778

follow-up on #7672

### Description

The bug report describes how functional tests in adapters/utils are not currently null-safe (specifically for "not equals" comparisons).

#### Main things
This pull request does two main things:
1. Implements a ["SQL standard conforming alternative"](https://modern-sql.com/feature/is-distinct-from#conforming-alterantives) to `A is not distinct from B`.
2. Implements comprehensive 🤞 tests inspired by the [Snowflake docs](https://docs.snowflake.com/en/sql-reference/functions/is-distinct-from#examples) and demo'd [here](https://github.com/dbt-labs/dbt-core/issues/7670#issuecomment-1564713670).

#### Ancillary things
This PR needed some ancillary things as well that arose with the improved `equals` comparisons:
- Fix tests for `concat` and `hash` by using empty strings ('') instead of `null`

See a combination of [three-valued logic of SQL](https://modern-sql.com/concept/three-valued-logic) and https://github.com/dbt-labs/dbt-core/issues/4725 for context why these changes were necessary and done this particular way.

### Future-facing opportunities
The code in this PR would make the implementation of #6997 as easy as possible:
1. Move the definition of the `equals` macro from `tests/adapter/dbt/tests/adapter/utils/base_utils.py` to:

    `core/dbt/include/global_project/macros/utils/equals.sql`
    ```
    {% macro equals(expr1, expr2) -%}
      {{ return(adapter.dispatch('equals', 'dbt')(expr1, expr2)) }}
    {%- endmacro %}
    
    {% macro default__equals(expr1, expr2) -%}
    case when (({{ expr1 }} = {{ expr2 }}) or ({{ expr1 }} is null and {{ expr2 }} is null))
        then 0
        else 1
    end = 0
    {%- endmacro %}
    ```
1. Remove any other code that is no longer necessary
1. Adopt this test within each adapter
1. Resolve this issue: https://github.com/dbt-labs/docs.getdbt.com/issues/3469
1. Add the new macro to the migration guide for adapter maintainers

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests 👍 
- [x] Updates to docs are not relevant
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)