### PR TITLE
Remove --config-dir instead of fixing #7774

### DIFF
--- a/.changes/unreleased/Fixes-20230621-030733.yaml
+++ b/.changes/unreleased/Fixes-20230621-030733.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix a bad implicit string conversion regression in debug --config-dir code.
+time: 2023-06-21T03:07:33.815966-07:00
+custom:
+  Author: versusfacit
+  Issue: "7774"

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -43,7 +43,7 @@ compile_docs = click.option(
 config_dir = click.option(
     "--config-dir",
     envvar=None,
-    help="Show the configured location for the profiles.yml file and exit",
+    help="Print a system-specific command to access the directory that the current dbt project is searching for a profiles.yml. Then, exit. This flag renders other debug step flags no-ops.",
     is_flag=True,
 )
 

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -102,13 +102,14 @@ class DebugTask(BaseTask):
             return None
         return self.project.profile_name
 
-    def path_info(self):
-        open_cmd = dbt.clients.system.open_dir_cmd()
-        fire_event(OpenCommand(open_cmd=open_cmd, profiles_dir=self.profiles_dir))
-
     def run(self) -> bool:
+        # WARN: this is a legacy workflow that is not compatible with other runtime flags
         if self.args.config_dir:
-            self.path_info()
+            fire_event(
+                OpenCommand(
+                    open_cmd=dbt.clients.system.open_dir_cmd(), profiles_dir=str(self.profiles_dir)
+                )
+            )
             return DebugRunStatus.SUCCESS.value
 
         version: str = get_installed_version().to_version_string(skip_matcher=True)


### PR DESCRIPTION
resolves #7774
### Description

So `--config-dir` is broken.

Also, it's less a flag and more a subcommand which prevents the running of any other `dbt debug` runtime. 

This PR aims to streamline the experience and remove the ambiguously-named "config" dir.

### Preferred alternative to fixing (breaking change to interface)

This may affect day to day workflows somewhat, but this flag doesn't fit in orchestrated jobs (unless you jam a square peg into a round hole). To be clear, `dbt` users **_already_** get the useful info out of `--config-dir` in the output of `dbt debug` on every run, by default.

Because it is redundant, I'd rather nix this flag and the code it relies on.

There are no tests for it, and we document it rarely (see below). [Some users reference it](https://stackoverflow.com/questions/71482406/how-to-set-location-of-profiles-yml-and-dbt-project-yml-files-in-dbt), but it causes confusion (which of these do I use and why?), and the output in `debug` already has the tools to do what we want `--config-dir` to do (i.e. show where `dbt` thinks the profile dir is). 

Even that SO post has some confusion over how to use the flag.


### Aligned with existing API

Rather than keep this as a distinct flag, we can rely on these existing ones:
<img width="1328" alt="image" src="https://github.com/dbt-labs/dbt-core/assets/67295367/914d539b-c7bb-4c9e-abda-a30c6374eb58">
and slip the profile dir info into the existing output.
<img width="380" alt="image" src="https://github.com/dbt-labs/dbt-core/assets/67295367/79a0c7d1-a795-47c3-96ca-9b63030505d2"> 
The first line in this trio so what I'm proposing in lieu of keeping `--config_dir` around.

Revised `dbt debug --help` output.

<img width="1351" alt="image" src="https://github.com/dbt-labs/dbt-core/assets/67295367/37185573-9138-4fed-987e-52c91ee522b6">

#### Appendix -- Docs references to adjust
1. https://docs.getdbt.com/docs/core/connect-data-platform/connection-profiles
2. https://docs.getdbt.com/reference/commands/debug
3. https://docs.getdbt.com/guides/best-practices/debugging-errors#failed-to-connect

We should update with guidance on how to use the existing `profiles-dir` flag and how to read the new and improved `dbt debug` output from #496 instead (i.e. a plain old `dbt debug` command will always -- even before this PR -- give you the _profiles dir + profiles file_, no separate subcommand needed). 





### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
