### PR TITLE
Validate public models are not materialized as ephemeral

### DIFF
--- a/.changes/unreleased/Features-20230605-222039.yaml
+++ b/.changes/unreleased/Features-20230605-222039.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: ' Validate public models are not materialized as ephemeral'
+time: 2023-06-05T22:20:39.382019-04:00
+custom:
+  Author: michelleark
+  Issue: "7226"

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -1254,12 +1254,15 @@ class DbtReferenceError(ParsingError):
 
 
 class InvalidAccessTypeError(ParsingError):
-    def __init__(self, unique_id: str, field_value: str):
+    def __init__(self, unique_id: str, field_value: str, materialization: Optional[str] = None):
         self.unique_id = unique_id
         self.field_value = field_value
-        msg = (
-            f"Node {self.unique_id} has an invalid value ({self.field_value}) for the access field"
+        self.materialization = materialization
+
+        with_materialization = (
+            f"with '{self.materialization}' materialization " if self.materialization else ""
         )
+        msg = f"Node {self.unique_id} {with_materialization}has an invalid value ({self.field_value}) for the access field"
         super().__init__(msg=msg)
 
 


### PR DESCRIPTION
resolves #7226 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

🎩 
```sql
-- my_model.sql
{{ config(materialized='ephemeral') }}
```

```yml
models:
  - name: my_model
    access: public
```
will lead to: 

```sh 
❯ dbt parse
02:19:30  Encountered an error:
Parsing Error
  Node model.jaffle_shop.my_model with 'ephemeral' materialization has an invalid value (public) for the access field
```
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR: https://github.com/dbt-labs/docs.getdbt.com/issues/3475
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
