### PR TITLE
Use project directory in path selector instead of cwd

### DIFF
--- a/.changes/unreleased/Fixes-20230608-135952.yaml
+++ b/.changes/unreleased/Fixes-20230608-135952.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix path selector when using project-dir
+time: 2023-06-08T13:59:52.95775-04:00
+custom:
+  Author: gshank
+  Issue: "7819"

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -26,6 +26,7 @@ from dbt.exceptions import (
     DbtRuntimeError,
 )
 from dbt.node_types import NodeType
+from dbt.task.contextvars import cv_project_root
 
 
 SELECTOR_GLOB = "*"
@@ -324,8 +325,8 @@ class MetricSelectorMethod(SelectorMethod):
 class PathSelectorMethod(SelectorMethod):
     def search(self, included_nodes: Set[UniqueId], selector: str) -> Iterator[UniqueId]:
         """Yields nodes from included that match the given path."""
-        # use '.' and not 'root' for easy comparison
-        root = Path.cwd()
+        # get project root from contextvar
+        root = Path(cv_project_root.get())
         paths = set(p.relative_to(root) for p in root.glob(selector))
         for node, real_node in self.all_nodes(included_nodes):
             ofp = Path(real_node.original_file_path)

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -45,6 +45,7 @@ from dbt.flags import get_flags
 from dbt.graph import Graph
 from dbt.logger import log_manager
 from .printer import print_run_result_error
+from dbt.task.contextvars import cv_project_root
 
 
 class NoneConfig:
@@ -75,6 +76,7 @@ class BaseTask(metaclass=ABCMeta):
         self.args = args
         self.config = config
         self.project = config if isinstance(config, Project) else project
+        cv_project_root.set(self.config.project_root)
 
     @classmethod
     def pre_init_hook(cls, args):

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -76,7 +76,8 @@ class BaseTask(metaclass=ABCMeta):
         self.args = args
         self.config = config
         self.project = config if isinstance(config, Project) else project
-        cv_project_root.set(self.config.project_root)
+        if self.config:
+            cv_project_root.set(self.config.project_root)
 
     @classmethod
     def pre_init_hook(cls, args):

--- a/core/dbt/task/contextvars.py
+++ b/core/dbt/task/contextvars.py
@@ -1,0 +1,6 @@
+from contextvars import ContextVar
+
+# This is a place to hold common contextvars used in tasks so that we can
+# avoid circular imports.
+
+cv_project_root: ContextVar = ContextVar("project_root")

--- a/tests/functional/graph_selection/test_graph_selection.py
+++ b/tests/functional/graph_selection/test_graph_selection.py
@@ -121,11 +121,24 @@ class TestGraphSelection(SelectionFixtures):
         check_result_nodes_by_name(results, ["nested_users", "subdir", "versioned"])
         assert_correct_schemas(project)
 
-        results = run_dbt(["run", "--select", "models/test/subdir*"])
+        os.chdir(
+            project.profiles_dir
+        )  # Change to random directory to test that Path selector works with project-dir
+        results = run_dbt(
+            ["run", "--project-dir", str(project.project_root), "--select", "models/test/subdir*"]
+        )
         check_result_nodes_by_name(results, ["nested_users", "subdir", "versioned"])
         assert_correct_schemas(project)
 
-        results = run_dbt(["build", "--select", "models/patch_path_selection_schema.yml"])
+        results = run_dbt(
+            [
+                "build",
+                "--project-dir",
+                str(project.project_root),
+                "--select",
+                "models/patch_path_selection_schema.yml",
+            ]
+        )
         check_result_nodes_by_name(results, ["subdir"])
         assert_correct_schemas(project)
 


### PR DESCRIPTION
resolves #7819

### Description

As additional fallout from the same underlying issue as #7465 and #7706, the Path selector expected to be in the project directory and used "cwd" to find the correct files. Use a contextvar to store the project_root and use in the PathSelectorMethod.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
