### PR TITLE
Allow ProjectDependency to have extra fields

### DIFF
--- a/.changes/unreleased/Fixes-20230609-121930.yaml
+++ b/.changes/unreleased/Fixes-20230609-121930.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Allow project dependencies to use miscellaneous keys
+time: 2023-06-09T12:19:30.469487-05:00
+custom:
+  Author: emmyoop
+  Issue: "7497"

--- a/core/dbt/contracts/publication.py
+++ b/core/dbt/contracts/publication.py
@@ -1,18 +1,25 @@
-from typing import Optional, List, Dict, Any
+from typing import Any, Dict, List, Optional
 from datetime import datetime
-from dbt.dataclass_schema import dbtClassMixin
+
 
 from dataclasses import dataclass, field
 
-from dbt.contracts.util import BaseArtifactMetadata, ArtifactMixin, schema_version
+from dbt.contracts.util import (
+    AdditionalPropertiesMixin,
+    ArtifactMixin,
+    BaseArtifactMetadata,
+    schema_version,
+)
 from dbt.contracts.graph.unparsed import NodeVersion
 from dbt.contracts.graph.nodes import ManifestOrPublicNode
-from dbt.node_types import NodeType, AccessType
+from dbt.dataclass_schema import dbtClassMixin, ExtensibleDbtClassMixin
+from dbt.node_types import AccessType, NodeType
 
 
 @dataclass
-class ProjectDependency(dbtClassMixin):
+class ProjectDependency(AdditionalPropertiesMixin, ExtensibleDbtClassMixin):
     name: str
+    _extra: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/tests/functional/multi_project/test_publication.py
+++ b/tests/functional/multi_project/test_publication.py
@@ -7,7 +7,7 @@ from dbt.tests.util import (
     run_dbt_and_capture,
     get_logging_events,
 )
-from dbt.contracts.publication import PublicationArtifact, PublicModel
+from dbt.contracts.publication import ProjectDependency, PublicationArtifact, PublicModel
 from dbt.exceptions import (
     PublicationConfigNotFound,
     TargetNotFoundError,
@@ -43,6 +43,7 @@ models:
 dependencies_yml = """
 projects:
     - name: marketing
+      custom_field: some value
 """
 
 marketing_pub_json = """
@@ -155,6 +156,14 @@ class TestPublicationArtifacts:
         publication_dict = pub_available_events[0]["data"]["pub_artifact"]
         publication = PublicationArtifact.from_dict(publication_dict)
         assert publication.dependencies == ["marketing"]
+
+        # check project_dependencies in manifest
+        project_dependencies = manifest.project_dependencies
+        assert project_dependencies
+        project_dependency = project_dependencies.projects[0]
+        assert isinstance(project_dependency, ProjectDependency)
+        assert project_dependency.name == "marketing"
+        assert "custom_field" in project_dependency._extra
 
         # source_node, target_model_name, target_model_package, target_model_version, current_project, node_package
         resolved_node = manifest.resolve_ref(None, "fct_one", "marketing", None, "test", "test")


### PR DESCRIPTION
resolves #7497 

### Description

Make ProjectDependency a config that allows miscellaneous keys by using `AdditionalPropertiesMixin`.  Also added a test for project_dependencies.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
