### PR TITLE
Update SemanticModel node to match DSI 0.1.0dev3 protocols

### DIFF
--- a/.changes/unreleased/Fixes-20230612-175854.yaml
+++ b/.changes/unreleased/Fixes-20230612-175854.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Update SemanticModel node to properly impelment the DSI 0.1.0dev3 SemanticModel
+  protocol spec
+time: 2023-06-12T17:58:54.289704-07:00
+custom:
+  Author: QMalcolm
+  Issue: 7833 7827

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -12,8 +12,8 @@ from dbt.dataclass_schema import dbtClassMixin, ExtensibleDbtClassMixin
 
 from dbt.clients.system import write_file
 from dbt.contracts.files import FileHash
+from dbt.contracts.graph.semantic_models import Dimension, SourceFileMetadata
 from dbt.contracts.graph.unparsed import (
-    Dimension,
     Docs,
     Entity,
     ExposureType,
@@ -552,30 +552,6 @@ class CompiledNode(ParsedNode):
     @property
     def depends_on_macros(self):
         return self.depends_on.macros
-
-
-@dataclass
-class FileSlice(dbtClassMixin, Replaceable):
-    """Provides file slice level context about what something was created from.
-
-    Implementation of the dbt-semantic-interfaces `FileSlice` protocol
-    """
-
-    filename: str
-    content: str
-    start_line_number: int
-    end_line_number: int
-
-
-@dataclass
-class SourceFileMetadata(dbtClassMixin, Replaceable):
-    """Provides file context about what something was created from.
-
-    Implementation of the dbt-semantic-interfaces `Metadata` protocol
-    """
-
-    repo_file_path: str
-    file_slice: FileSlice
 
 
 # ====================================

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -12,7 +12,13 @@ from dbt.dataclass_schema import dbtClassMixin, ExtensibleDbtClassMixin
 
 from dbt.clients.system import write_file
 from dbt.contracts.files import FileHash
-from dbt.contracts.graph.semantic_models import Dimension, Entity, Measure, SourceFileMetadata
+from dbt.contracts.graph.semantic_models import (
+    Defaults,
+    Dimension,
+    Entity,
+    Measure,
+    SourceFileMetadata,
+)
 from dbt.contracts.graph.unparsed import (
     Docs,
     ExposureType,
@@ -41,7 +47,11 @@ from dbt.events.types import (
 from dbt.events.contextvars import set_contextvars
 from dbt.flags import get_flags
 from dbt.node_types import ModelLanguage, NodeType, AccessType
-from dbt_semantic_interfaces.references import MeasureReference
+from dbt_semantic_interfaces.references import (
+    MeasureReference,
+    LinkableElementReference,
+    SemanticModelReference,
+)
 from dbt_semantic_interfaces.references import MetricReference as DSIMetricReference
 from dbt_semantic_interfaces.type_enums.metric_type import MetricType
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
@@ -677,7 +687,6 @@ class ModelNode(CompiledNode):
                 and old_value.constraints != self.columns[old_key].constraints
                 and old.materialization_enforces_constraints
             ):
-
                 for old_constraint in old_value.constraints:
                     if (
                         old_constraint not in self.columns[old_key].constraints
@@ -1467,12 +1476,63 @@ class NodeRelation(dbtClassMixin):
 
 @dataclass
 class SemanticModel(GraphNode):
-    description: Optional[str]
     model: str
     node_relation: Optional[NodeRelation]
-    entities: Sequence[Entity]
-    measures: Sequence[Measure]
-    dimensions: Sequence[Dimension]
+    description: Optional[str] = None
+    defaults: Optional[Defaults] = None
+    entities: Sequence[Entity] = field(default_factory=list)
+    measures: Sequence[Measure] = field(default_factory=list)
+    dimensions: Sequence[Dimension] = field(default_factory=list)
+    metadata: Optional[SourceFileMetadata] = None
+
+    @property
+    def entity_references(self) -> List[LinkableElementReference]:
+        return [entity.reference for entity in self.entities]
+
+    @property
+    def dimension_references(self) -> List[LinkableElementReference]:
+        return [dimension.reference for dimension in self.dimensions]
+
+    @property
+    def measure_references(self) -> List[MeasureReference]:
+        return [measure.reference for measure in self.measures]
+
+    @property
+    def has_validity_dimensions(self) -> bool:
+        return any([dim.validity_params is not None for dim in self.dimensions])
+
+    @property
+    def validity_start_dimension(self) -> Optional[Dimension]:
+        validity_start_dims = [
+            dim for dim in self.dimensions if dim.validity_params and dim.validity_params.is_start
+        ]
+        if not validity_start_dims:
+            return None
+        return validity_start_dims[0]
+
+    @property
+    def validity_end_dimension(self) -> Optional[Dimension]:
+        validity_end_dims = [
+            dim for dim in self.dimensions if dim.validity_params and dim.validity_params.is_end
+        ]
+        if not validity_end_dims:
+            return None
+        return validity_end_dims[0]
+
+    @property
+    def partitions(self) -> List[Dimension]:  # noqa: D
+        return [dim for dim in self.dimensions or [] if dim.is_partition]
+
+    @property
+    def partition(self) -> Optional[Dimension]:
+        partitions = self.partitions
+        if not partitions:
+            return None
+        return partitions[0]
+
+    @property
+    def reference(self) -> SemanticModelReference:
+        return SemanticModelReference(semantic_model_name=self.name)
 
 
 # ====================================

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -12,10 +12,9 @@ from dbt.dataclass_schema import dbtClassMixin, ExtensibleDbtClassMixin
 
 from dbt.clients.system import write_file
 from dbt.contracts.files import FileHash
-from dbt.contracts.graph.semantic_models import Dimension, SourceFileMetadata
+from dbt.contracts.graph.semantic_models import Dimension, Entity, SourceFileMetadata
 from dbt.contracts.graph.unparsed import (
     Docs,
-    Entity,
     ExposureType,
     ExternalTable,
     FreshnessThreshold,

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -12,7 +12,7 @@ from dbt.dataclass_schema import dbtClassMixin, ExtensibleDbtClassMixin
 
 from dbt.clients.system import write_file
 from dbt.contracts.files import FileHash
-from dbt.contracts.graph.semantic_models import Dimension, Entity, SourceFileMetadata
+from dbt.contracts.graph.semantic_models import Dimension, Entity, Measure, SourceFileMetadata
 from dbt.contracts.graph.unparsed import (
     Docs,
     ExposureType,
@@ -21,7 +21,6 @@ from dbt.contracts.graph.unparsed import (
     HasYamlMetadata,
     MacroArgument,
     MaturityType,
-    Measure,
     Owner,
     Quoting,
     TestDef,

--- a/core/dbt/contracts/graph/semantic_models.py
+++ b/core/dbt/contracts/graph/semantic_models.py
@@ -129,7 +129,7 @@ class Measure(dbtClassMixin):
     name: str
     agg: AggregationType
     description: Optional[str] = None
-    create_metric: Optional[bool] = False
+    create_metric: bool = False
     expr: Optional[str] = None
     agg_params: Optional[MeasureAggregationParameters] = None
     non_additive_dimension: Optional[NonAdditiveDimension] = None

--- a/core/dbt/contracts/graph/semantic_models.py
+++ b/core/dbt/contracts/graph/semantic_models.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+from dbt.dataclass_schema import dbtClassMixin
+from dbt_semantic_interfaces.references import DimensionReference, TimeDimensionReference
+from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
+from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
+from typing import Optional
+
+
+@dataclass
+class FileSlice(dbtClassMixin):
+    """Provides file slice level context about what something was created from.
+
+    Implementation of the dbt-semantic-interfaces `FileSlice` protocol
+    """
+
+    filename: str
+    content: str
+    start_line_number: int
+    end_line_number: int
+
+
+@dataclass
+class SourceFileMetadata(dbtClassMixin):
+    """Provides file context about what something was created from.
+
+    Implementation of the dbt-semantic-interfaces `Metadata` protocol
+    """
+
+    repo_file_path: str
+    file_slice: FileSlice
+
+
+@dataclass
+class DimensionValidityParams(dbtClassMixin):
+    is_start: bool = False
+    is_end: bool = False
+
+
+@dataclass
+class DimensionTypeParams(dbtClassMixin):
+    time_granularity: TimeGranularity
+    validity_params: Optional[DimensionValidityParams] = None
+
+
+@dataclass
+class Dimension(dbtClassMixin):
+    name: str
+    type: DimensionType
+    description: Optional[str] = None
+    is_partition: bool = False
+    type_params: Optional[DimensionTypeParams] = None
+    expr: Optional[str] = None
+    metadata: Optional[SourceFileMetadata] = None
+
+    @property
+    def reference(self) -> DimensionReference:
+        return DimensionReference(element_name=self.name)
+
+    @property
+    def time_dimension_reference(self) -> Optional[TimeDimensionReference]:
+        if self.type == DimensionType.TIME:
+            return TimeDimensionReference(element_name=self.name)
+        else:
+            return None
+
+    @property
+    def validity_params(self) -> Optional[DimensionValidityParams]:
+        if self.type_params:
+            return self.type_params.validity_params
+        else:
+            return None

--- a/core/dbt/contracts/graph/semantic_models.py
+++ b/core/dbt/contracts/graph/semantic_models.py
@@ -1,7 +1,12 @@
 from dataclasses import dataclass
 from dbt.dataclass_schema import dbtClassMixin
-from dbt_semantic_interfaces.references import DimensionReference, TimeDimensionReference
+from dbt_semantic_interfaces.references import (
+    DimensionReference,
+    EntityReference,
+    TimeDimensionReference,
+)
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
+from dbt_semantic_interfaces.type_enums.entity_type import EntityType
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from typing import Optional
 
@@ -28,6 +33,11 @@ class SourceFileMetadata(dbtClassMixin):
 
     repo_file_path: str
     file_slice: FileSlice
+
+
+# ====================================
+# Dimension objects
+# ====================================
 
 
 @dataclass
@@ -69,3 +79,25 @@ class Dimension(dbtClassMixin):
             return self.type_params.validity_params
         else:
             return None
+
+
+# ====================================
+# Entity objects
+# ====================================
+
+
+@dataclass
+class Entity(dbtClassMixin):
+    name: str
+    type: EntityType
+    description: Optional[str] = None
+    role: Optional[str] = None
+    expr: Optional[str] = None
+
+    @property
+    def reference(self) -> EntityReference:
+        return EntityReference(element_name=self.name)
+
+    @property
+    def is_linkable_entity_type(self) -> bool:
+        return self.type in (EntityType.PRIMARY, EntityType.UNIQUE, EntityType.NATURAL)

--- a/core/dbt/contracts/graph/semantic_models.py
+++ b/core/dbt/contracts/graph/semantic_models.py
@@ -37,6 +37,11 @@ class SourceFileMetadata(dbtClassMixin):
     file_slice: FileSlice
 
 
+@dataclass
+class Defaults(dbtClassMixin):
+    agg_time_dimension: Optional[str] = None
+
+
 # ====================================
 # Dimension objects
 # ====================================

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -4,6 +4,7 @@ import re
 from dbt import deprecations
 from dbt.node_types import NodeType
 from dbt.contracts.graph.semantic_models import (
+    Defaults,
     DimensionValidityParams,
     MeasureAggregationParameters,
 )
@@ -723,8 +724,9 @@ class UnparsedDimension(dbtClassMixin):
 @dataclass
 class UnparsedSemanticModel(dbtClassMixin):
     name: str
-    description: Optional[str]
     model: str  # looks like "ref(...)"
+    description: Optional[str] = None
+    defaults: Optional[Defaults] = None
     entities: List[UnparsedEntity] = field(default_factory=list)
     measures: List[UnparsedMeasure] = field(default_factory=list)
     dimensions: List[UnparsedDimension] = field(default_factory=list)

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -3,7 +3,10 @@ import re
 
 from dbt import deprecations
 from dbt.node_types import NodeType
-from dbt.contracts.graph.semantic_models import DimensionValidityParams
+from dbt.contracts.graph.semantic_models import (
+    DimensionValidityParams,
+    MeasureAggregationParameters,
+)
 from dbt.contracts.util import (
     AdditionalPropertiesMixin,
     Mergeable,
@@ -683,21 +686,21 @@ class UnparsedEntity(dbtClassMixin):
 
 
 @dataclass
-class MeasureAggregationParameters(dbtClassMixin):
-    percentile: Optional[float] = None
-    use_discrete_percentile: bool = False
-    use_approximate_percentile: bool = False
+class UnparsedNonAdditiveDimension(dbtClassMixin):
+    name: str
+    window_choice: str  # AggregationType enum
+    window_grouples: List[str]
 
 
 @dataclass
-class Measure(dbtClassMixin):
+class UnparsedMeasure(dbtClassMixin):
     name: str
     agg: str  # actually an enum
     description: Optional[str] = None
-    create_metric: Optional[bool] = None
+    create_metric: bool = False
     expr: Optional[str] = None
     agg_params: Optional[MeasureAggregationParameters] = None
-    non_additive_dimension: Optional[Dict[str, Any]] = None
+    non_additive_dimension: Optional[UnparsedNonAdditiveDimension] = None
     agg_time_dimension: Optional[str] = None
 
 
@@ -723,7 +726,7 @@ class UnparsedSemanticModel(dbtClassMixin):
     description: Optional[str]
     model: str  # looks like "ref(...)"
     entities: List[UnparsedEntity] = field(default_factory=list)
-    measures: List[Measure] = field(default_factory=list)
+    measures: List[UnparsedMeasure] = field(default_factory=list)
     dimensions: List[UnparsedDimension] = field(default_factory=list)
 
 

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -674,9 +674,9 @@ class UnparsedGroup(dbtClassMixin, Replaceable):
 
 
 @dataclass
-class Entity(dbtClassMixin):
+class UnparsedEntity(dbtClassMixin):
     name: str
-    type: str  # actually an enum
+    type: str  # EntityType enum
     description: Optional[str] = None
     role: Optional[str] = None
     expr: Optional[str] = None
@@ -722,7 +722,7 @@ class UnparsedSemanticModel(dbtClassMixin):
     name: str
     description: Optional[str]
     model: str  # looks like "ref(...)"
-    entities: List[Entity] = field(default_factory=list)
+    entities: List[UnparsedEntity] = field(default_factory=list)
     measures: List[Measure] = field(default_factory=list)
     dimensions: List[UnparsedDimension] = field(default_factory=list)
 

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -3,6 +3,7 @@ import re
 
 from dbt import deprecations
 from dbt.node_types import NodeType
+from dbt.contracts.graph.semantic_models import DimensionValidityParams
 from dbt.contracts.util import (
     AdditionalPropertiesMixin,
     Mergeable,
@@ -701,14 +702,19 @@ class Measure(dbtClassMixin):
 
 
 @dataclass
-class Dimension(dbtClassMixin):
+class UnparsedDimensionTypeParams(dbtClassMixin):
+    time_granularity: str  # TimeGranularity enum
+    validity_params: Optional[DimensionValidityParams] = None
+
+
+@dataclass
+class UnparsedDimension(dbtClassMixin):
     name: str
     type: str  # actually an enum
     description: Optional[str] = None
-    is_partition: Optional[bool] = False
-    type_params: Optional[Dict[str, Any]] = None
+    is_partition: bool = False
+    type_params: Optional[UnparsedDimensionTypeParams] = None
     expr: Optional[str] = None
-    # TODO metadata: Optional[Metadata] (this would actually be the YML for the dimension)
 
 
 @dataclass
@@ -718,7 +724,7 @@ class UnparsedSemanticModel(dbtClassMixin):
     model: str  # looks like "ref(...)"
     entities: List[Entity] = field(default_factory=list)
     measures: List[Measure] = field(default_factory=list)
-    dimensions: List[Dimension] = field(default_factory=list)
+    dimensions: List[UnparsedDimension] = field(default_factory=list)
 
 
 def normalize_date(d: Optional[datetime.date]) -> Optional[datetime.datetime]:

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -518,6 +518,7 @@ class SemanticModelParser(YamlReader):
             entities=self._get_entities(unparsed.entities),
             measures=self._get_measures(unparsed.measures),
             dimensions=self._get_dimensions(unparsed.dimensions),
+            defaults=unparsed.defaults,
         )
 
         self.manifest.add_semantic_model(self.yaml.file, parsed)

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -22,7 +22,6 @@ semantic_models:
         type: time
         expr: created_at
         type_params:
-          is_primary: True
           time_granularity: day
 
     entities:

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -12,6 +12,9 @@ semantic_models:
     description: This is the revenue semantic model. It should be able to use doc blocks
     model: ref('fct_revenue')
 
+    defaults:
+      agg_time_dimension: ds
+
     measures:
       - name: txn_revenue
         expr: revenue

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -1,0 +1,113 @@
+from dbt.contracts.graph.nodes import (
+    Metric,
+    MetricInputMeasure,
+    MetricTypeParams,
+    NodeRelation,
+    SemanticModel,
+    WhereFilter,
+)
+from dbt.contracts.graph.unparsed import Dimension, Entity, Measure
+from dbt.node_types import NodeType
+from dbt_semantic_interfaces.protocols.dimension import Dimension as DSIDimension
+from dbt_semantic_interfaces.protocols.entity import Entity as DSIEntitiy
+from dbt_semantic_interfaces.protocols.measure import Measure as DSIMeasure
+from dbt_semantic_interfaces.protocols.metric import Metric as DSIMetric
+from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel as DSISemanticModel
+from dbt_semantic_interfaces.type_enums.metric_type import MetricType
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class RuntimeCheckableSemanticModel(DSISemanticModel, Protocol):
+    pass
+
+
+@runtime_checkable
+class RuntimeCheckableDimension(DSIDimension, Protocol):
+    pass
+
+
+@runtime_checkable
+class RuntimeCheckableEntity(DSIEntitiy, Protocol):
+    pass
+
+
+@runtime_checkable
+class RuntimeCheckableMeasure(DSIMeasure, Protocol):
+    pass
+
+
+@runtime_checkable
+class RuntimeCheckableMetric(DSIMetric, Protocol):
+    pass
+
+
+def test_semantic_model_node_satisfies_protocol():
+    test_semantic_model = SemanticModel(
+        name="test_semantic_model",
+        description="a test semantic_model",
+        resource_type=NodeType.SemanticModel,
+        package_name="package_name",
+        path="path.to.semantic_model",
+        original_file_path="path/to/file",
+        unique_id="not_like_the_other_semantic_models",
+        fqn=["fully", "qualified", "name"],
+        model="ref('a_model')",
+        node_relation=NodeRelation(
+            alias="test_alias",
+            schema_name="test_schema_name",
+        ),
+        entities=[],
+        measures=[],
+        dimensions=[],
+    )
+    assert isinstance(test_semantic_model, RuntimeCheckableSemanticModel)
+
+
+def test_dimension_satisfies_protocol():
+    dimension = Dimension(
+        name="test_dimension",
+        description="a test dimension",
+        type="categorical",
+        type_params={},
+    )
+    assert isinstance(dimension, RuntimeCheckableDimension)
+
+
+def test_entity_satisfies_protocol():
+    entity = Entity(
+        name="test_entity", description="a test entity", type="primary", expr="id", role="a_role"
+    )
+    assert isinstance(entity, RuntimeCheckableEntity)
+
+
+def test_measure_satisfies_protocol():
+    measure = Measure(
+        name="test_measure",
+        description="a test measure",
+        agg="sum",
+        create_metric=True,
+        expr="amount",
+    )
+    assert isinstance(measure, RuntimeCheckableMeasure)
+
+
+def test_metric_node_satisfies_protocol():
+    metric = Metric(
+        name="a_metric",
+        resource_type=NodeType.Metric,
+        package_name="package_name",
+        path="path.to.semantic_model",
+        original_file_path="path/to/file",
+        unique_id="not_like_the_other_semantic_models",
+        fqn=["fully", "qualified", "name"],
+        description="a test metric",
+        label="A test metric",
+        type=MetricType.SIMPLE,
+        type_params=MetricTypeParams(
+            measure=MetricInputMeasure(
+                name="a_test_measure", filter=WhereFilter(where_sql_template="a_dimension is true")
+            )
+        ),
+    )
+    assert isinstance(metric, RuntimeCheckableMetric)

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -6,11 +6,8 @@ from dbt.contracts.graph.nodes import (
     SemanticModel,
     WhereFilter,
 )
-from dbt.contracts.graph.semantic_models import (
-    Dimension,
-    DimensionTypeParams,
-)
-from dbt.contracts.graph.unparsed import Entity, Measure
+from dbt.contracts.graph.semantic_models import Dimension, DimensionTypeParams, Entity
+from dbt.contracts.graph.unparsed import Measure
 from dbt.node_types import NodeType
 from dbt_semantic_interfaces.protocols.dimension import Dimension as DSIDimension
 from dbt_semantic_interfaces.protocols.entity import Entity as DSIEntitiy
@@ -18,6 +15,7 @@ from dbt_semantic_interfaces.protocols.measure import Measure as DSIMeasure
 from dbt_semantic_interfaces.protocols.metric import Metric as DSIMetric
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel as DSISemanticModel
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
+from dbt_semantic_interfaces.type_enums.entity_type import EntityType
 from dbt_semantic_interfaces.type_enums.metric_type import MetricType
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from typing import Protocol, runtime_checkable
@@ -84,7 +82,11 @@ def test_dimension_satisfies_protocol():
 
 def test_entity_satisfies_protocol():
     entity = Entity(
-        name="test_entity", description="a test entity", type="primary", expr="id", role="a_role"
+        name="test_entity",
+        description="a test entity",
+        type=EntityType.PRIMARY,
+        expr="id",
+        role="a_role",
     )
     assert isinstance(entity, RuntimeCheckableEntity)
 

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -6,8 +6,7 @@ from dbt.contracts.graph.nodes import (
     SemanticModel,
     WhereFilter,
 )
-from dbt.contracts.graph.semantic_models import Dimension, DimensionTypeParams, Entity
-from dbt.contracts.graph.unparsed import Measure
+from dbt.contracts.graph.semantic_models import Dimension, DimensionTypeParams, Entity, Measure
 from dbt.node_types import NodeType
 from dbt_semantic_interfaces.protocols.dimension import Dimension as DSIDimension
 from dbt_semantic_interfaces.protocols.entity import Entity as DSIEntitiy
@@ -98,6 +97,7 @@ def test_measure_satisfies_protocol():
         agg="sum",
         create_metric=True,
         expr="amount",
+        agg_time_dimension="a_time_dimension",
     )
     assert isinstance(measure, RuntimeCheckableMeasure)
 

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -6,14 +6,20 @@ from dbt.contracts.graph.nodes import (
     SemanticModel,
     WhereFilter,
 )
-from dbt.contracts.graph.unparsed import Dimension, Entity, Measure
+from dbt.contracts.graph.semantic_models import (
+    Dimension,
+    DimensionTypeParams,
+)
+from dbt.contracts.graph.unparsed import Entity, Measure
 from dbt.node_types import NodeType
 from dbt_semantic_interfaces.protocols.dimension import Dimension as DSIDimension
 from dbt_semantic_interfaces.protocols.entity import Entity as DSIEntitiy
 from dbt_semantic_interfaces.protocols.measure import Measure as DSIMeasure
 from dbt_semantic_interfaces.protocols.metric import Metric as DSIMetric
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel as DSISemanticModel
+from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
 from dbt_semantic_interfaces.type_enums.metric_type import MetricType
+from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from typing import Protocol, runtime_checkable
 
 
@@ -68,8 +74,10 @@ def test_dimension_satisfies_protocol():
     dimension = Dimension(
         name="test_dimension",
         description="a test dimension",
-        type="categorical",
-        type_params={},
+        type=DimensionType.TIME,
+        type_params=DimensionTypeParams(
+            time_granularity=TimeGranularity.DAY,
+        ),
     )
     assert isinstance(dimension, RuntimeCheckableDimension)
 


### PR DESCRIPTION
resolves #7833, #7827 

### Description

In the midst of #7769 we moved from DSI `0.1.0dev2` to `0.1.0dev3`. This led to a situation where we were parsing and defining `SemanticModel` nodes in a `0.1.0dev2` shape instead of a `0.1.0dev3` shape (more detail can be found in #7833). This was possible because we weren't doing anything to ensure that semantic layer nodes we were adding satisfied the protocols we were targeting (the focus of #7827). This PR first adds testing to ensure our semantic layer nodes satisfy the protocols, and then goes through updating the nodes (and sub objects) to pass the tests (and therefore ensure satisfaction of the protocols).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
