### PR TITLE
Allow enabling DEBUG logs for databricks-sql-connector

### DIFF
--- a/.changes/unreleased/Under the Hood-20230613-143433.yaml
+++ b/.changes/unreleased/Under the Hood-20230613-143433.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Setting DBT_DATABRICKS_CONNECTOR_DEBUG_LOGGING to True enables debug logs for
+  databricks-sql-connector.
+time: 2023-06-13T14:34:33.923627-05:00
+custom:
+  Author: susodapop
+  Issue: "7859"

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -499,6 +499,7 @@ def _env_log_level(var_name: str) -> int:
 
 LOG_LEVEL_GOOGLE = _env_log_level("DBT_GOOGLE_DEBUG_LOGGING")
 LOG_LEVEL_SNOWFLAKE = _env_log_level("DBT_SNOWFLAKE_CONNECTOR_DEBUG_LOGGING")
+LOG_LEVEL_DATABRICKS = _env_log_level("DBT_DATABRICKS_CONNECTOR_DEBUG_LOGGING")
 LOG_LEVEL_BOTOCORE = _env_log_level("DBT_BOTOCORE_DEBUG_LOGGING")
 LOG_LEVEL_HTTP = _env_log_level("DBT_HTTP_DEBUG_LOGGING")
 LOG_LEVEL_WERKZEUG = _env_log_level("DBT_WERKZEUG_DEBUG_LOGGING")
@@ -508,6 +509,7 @@ logging.getLogger("requests").setLevel(LOG_LEVEL_HTTP)
 logging.getLogger("urllib3").setLevel(LOG_LEVEL_HTTP)
 logging.getLogger("google").setLevel(LOG_LEVEL_GOOGLE)
 logging.getLogger("snowflake.connector").setLevel(LOG_LEVEL_SNOWFLAKE)
+logging.getLogger("databricks.sql").setLevel(LOG_LEVEL_DATABRICKS)
 
 logging.getLogger("parsedatetime").setLevel(logging.ERROR)
 logging.getLogger("werkzeug").setLevel(LOG_LEVEL_WERKZEUG)


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

This change allows us to turn on `DEBUG` level logs for `databricks-sql-connector` when invoked from dbt.

Regarding documentation updates: I'm going to open a PR for dbt-databricks that includes more fine-grained control over the logs from databricks-sql-connector. The doc update for this PR will be included at that time.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
