### PR TITLE
Update snapshot_merge.sql

### DIFF
--- a/core/dbt/include/global_project/macros/materializations/snapshots/snapshot_merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshots/snapshot_merge.sql
@@ -15,8 +15,8 @@
      and DBT_INTERNAL_DEST.dbt_valid_to is null
      and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')
         then update
-        set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to
-        set dbt_updated_at = DBT_INTERNAL_SOURCE.dbt_valid_to
+        set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to, 
+        dbt_updated_at = DBT_INTERNAL_SOURCE.dbt_valid_to
 
     when not matched
      and DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'

--- a/core/dbt/include/global_project/macros/materializations/snapshots/snapshot_merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshots/snapshot_merge.sql
@@ -16,6 +16,7 @@
      and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')
         then update
         set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to
+        set dbt_updated_at = DBT_INTERNAL_SOURCE.dbt_valid_to
 
     when not matched
      and DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'


### PR DESCRIPTION
resolves #7869 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
https://github.com/dbt-labs/dbt-core/issues/7869

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

This was brought up by a customer and I am kinda surprised I have never heard this before. 

[Our docs show](https://docs.getdbt.com/docs/build/snapshots)

that a row should have two fields in the existing row should be updated when the `updated_at` timestamp is changed signifying a change of some value. 

![image](https://github.com/dbt-labs/dbt-core/assets/30663534/77a6c1db-3336-4abe-9a80-a8e398e16237)

Looks like only one update is happening and the `dbt_updated_at` does not get updated.

![Screen Shot 2023-06-14 at 2 06 07 PM](https://github.com/dbt-labs/dbt-core/assets/30663534/dd03040c-c348-45db-aae8-fec79da3a97e)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
