### PR TITLE
Improved Semantic expr specification handling

### DIFF
--- a/.changes/unreleased/Fixes-20230614-134933.yaml
+++ b/.changes/unreleased/Fixes-20230614-134933.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Allow semantic model measure exprs to be defined with ints and bools in yaml
+time: 2023-06-14T13:49:33.544552-07:00
+custom:
+  Author: QMalcolm
+  Issue: "7865"

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -618,7 +618,7 @@ class UnparsedMetricTypeParams(dbtClassMixin):
     measure: Optional[Union[UnparsedMetricInputMeasure, str]] = None
     numerator: Optional[Union[UnparsedMetricInput, str]] = None
     denominator: Optional[Union[UnparsedMetricInput, str]] = None
-    expr: Optional[str] = None
+    expr: Optional[Union[str, bool]] = None
     window: Optional[str] = None
     grain_to_date: Optional[str] = None  # str is really a TimeGranularity Enum
     metrics: Optional[List[Union[UnparsedMetricInput, str]]] = None
@@ -698,7 +698,7 @@ class UnparsedMeasure(dbtClassMixin):
     agg: str  # actually an enum
     description: Optional[str] = None
     create_metric: bool = False
-    expr: Optional[str] = None
+    expr: Optional[Union[str, bool, int]] = None
     agg_params: Optional[MeasureAggregationParameters] = None
     non_additive_dimension: Optional[UnparsedNonAdditiveDimension] = None
     agg_time_dimension: Optional[str] = None

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -293,7 +293,7 @@ class MetricParser(YamlReader):
             measure=self._get_optional_input_measure(type_params.measure),
             numerator=self._get_optional_metric_input(type_params.numerator),
             denominator=self._get_optional_metric_input(type_params.denominator),
-            expr=type_params.expr,
+            expr=str(type_params.expr) if type_params.expr is not None else None,
             window=self._get_time_window(type_params.window),
             grain_to_date=grain_to_date,
             metrics=self._get_metric_inputs(type_params.metrics),
@@ -500,7 +500,7 @@ class SemanticModelParser(YamlReader):
                     agg=AggregationType(unparsed.agg),
                     description=unparsed.description,
                     create_metric=unparsed.create_metric,
-                    expr=unparsed.expr,
+                    expr=str(unparsed.expr) if unparsed.expr is not None else None,
                     agg_params=unparsed.agg_params,
                     non_additive_dimension=self._get_non_additive_dimension(
                         unparsed.non_additive_dimension

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -23,6 +23,12 @@ semantic_models:
       - name: txn_revenue
         expr: revenue
         agg: sum
+      - name: sum_of_things
+        expr: 2
+        agg: sum
+      - name: has_revenue
+        expr: true
+        agg: sum_boolean
 
     dimensions:
       - name: ds
@@ -65,6 +71,7 @@ class TestSemanticModelParsing:
             semantic_model.node_relation.relation_name
             == f'"dbt"."{project.test_schema}"."fct_revenue"'
         )
+        assert len(semantic_model.measures) == 3
 
     @pytest.mark.skip("Restore this test when partial parsing is implemented.")
     def test_semantic_model_partial_parsing(self, project):


### PR DESCRIPTION
resolves #7865 

### Description

The `expr` on semantic model measures have historically in MetricFlow supported `bool` and `int` in addition to `str`. We were only supporting `str` in core which was problematic.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
