### PR TITLE
Improved Semantic Model Measure Percentile defaults

### DIFF
--- a/.changes/unreleased/Fixes-20230614-145954.yaml
+++ b/.changes/unreleased/Fixes-20230614-145954.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Update `use_discrete_percentile` and `use_approximate_percentile` to be non
+  optional and default to `False`
+time: 2023-06-14T14:59:54.042341-07:00
+custom:
+  Author: QMalcolm
+  Issue: "7866"

--- a/core/dbt/contracts/graph/semantic_models.py
+++ b/core/dbt/contracts/graph/semantic_models.py
@@ -120,8 +120,8 @@ class Entity(dbtClassMixin):
 @dataclass
 class MeasureAggregationParameters(dbtClassMixin):
     percentile: Optional[float] = None
-    use_discrete_percentile: Optional[bool] = None
-    use_approximate_percentile: Optional[bool] = None
+    use_discrete_percentile: bool = False
+    use_approximate_percentile: bool = False
 
 
 @dataclass

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -29,6 +29,18 @@ semantic_models:
       - name: has_revenue
         expr: true
         agg: sum_boolean
+      - name: discrete_order_value_p99
+        expr: order_total
+        agg: percentile
+        agg_params:
+          percentile: 0.99
+          use_discrete_percentile: True
+          use_approximate_percentile: False
+      - name: test_agg_params_optional_are_empty
+        expr: order_total
+        agg: percentile
+        agg_params:
+          percentile: 0.99
 
     dimensions:
       - name: ds
@@ -71,7 +83,7 @@ class TestSemanticModelParsing:
             semantic_model.node_relation.relation_name
             == f'"dbt"."{project.test_schema}"."fct_revenue"'
         )
-        assert len(semantic_model.measures) == 3
+        assert len(semantic_model.measures) == 5
 
     @pytest.mark.skip("Restore this test when partial parsing is implemented.")
     def test_semantic_model_partial_parsing(self, project):


### PR DESCRIPTION
resolves #7866 

### Description

Here we're updating `use_discrete_percentile` and `use_approximate_percentile` to be non optional and default to `False`. This was a mistake in our implementation of the MeasureAggregationParams. We had defined them as optional and defaulting to `None`. However, as the protocol states, they cannot be `None`, they must be a boolean value. Thus now we now ensure them.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
