### PR TITLE
[CT-2696]  Skip jinia parsing of metric filters

### DIFF
--- a/.changes/unreleased/Fixes-20230615-142949.yaml
+++ b/.changes/unreleased/Fixes-20230615-142949.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Skip jinja parsing of metric filters
+time: 2023-06-15T14:29:49.900201-07:00
+custom:
+  Author: QMalcolm
+  Issue: "7864"

--- a/core/dbt/parser/schema_renderer.py
+++ b/core/dbt/parser/schema_renderer.py
@@ -67,7 +67,7 @@ class SchemaYamlRenderer(BaseRenderer):
             elif self._is_norender_key(keypath[0:]):
                 return False
         elif self.key == "metrics":
-            # back compat: "expression" is new name, "sql" is old name
+            # This ensures all key paths that end in 'filter' for a metric are skipped
             if keypath[-1] == "filter":
                 return False
             elif self._is_norender_key(keypath[0:]):

--- a/core/dbt/parser/schema_renderer.py
+++ b/core/dbt/parser/schema_renderer.py
@@ -68,7 +68,7 @@ class SchemaYamlRenderer(BaseRenderer):
                 return False
         elif self.key == "metrics":
             # back compat: "expression" is new name, "sql" is old name
-            if keypath[0] in ("expression", "sql"):
+            if keypath[-1] == "filter":
                 return False
             elif self._is_norender_key(keypath[0:]):
                 return False

--- a/tests/functional/duplicates/test_duplicate_metric.py
+++ b/tests/functional/duplicates/test_duplicate_metric.py
@@ -25,7 +25,7 @@ metrics:
     type_params:
       measure:
         name: "years_tenure"
-        filter: "loves_dbt is true"
+        filter: "{{dimension('loves_dbt')}} is true"
 """
 
 

--- a/tests/functional/metrics/fixtures.py
+++ b/tests/functional/metrics/fixtures.py
@@ -43,7 +43,7 @@ metrics:
     type_params:
       measure:
         name: "years_tenure"
-        filter: "loves_dbt is true"
+        filter: "{{dimension('loves_dbt')}} is true"
 
   - name: average_tenure
     label: "Average tenure"
@@ -86,7 +86,7 @@ metrics:
     type_params:
       measure:
         name: years_tenure
-        filter: "loves_dbt is true"
+        filter: "{{dimension('loves_dbt')}} is true"
 
   - name: collective_window
     label: "Collective window"
@@ -95,7 +95,7 @@ metrics:
     type_params:
       measure:
         name: years_tenure
-        filter: "loves_dbt is true"
+        filter: "{{dimension('loves_dbt')}} is true"
       window: 14 days
 
 """
@@ -377,7 +377,7 @@ metrics:
     type_params:
       measure:
         name: years_tenure
-        filter: "loves_dbt is true"
+        filter: "{{dimension('loves_dbt')}} is true"
 
 """
 
@@ -404,7 +404,7 @@ metrics:
     type_params:
       measure:
         name: years_tenure
-        filter: "loves_dbt is true"
+        filter: "{{dimension('loves_dbt')}} is true"
 
 """
 

--- a/tests/functional/partial_parsing/fixtures.py
+++ b/tests/functional/partial_parsing/fixtures.py
@@ -353,7 +353,7 @@ metrics:
     type_params:
       measure:
         name: customers
-        filter: "loves_dbt is true"
+        filter: "{{dimension('loves_dbt')}} is true"
     +meta:
         is_okr: True
     tags:
@@ -441,7 +441,7 @@ metrics:
     type_params:
       measure:
         name: years_tenure
-        filter: "loves_dbt is true"
+        filter: "{{dimension('loves_dbt')}} is true"
 
 """
 
@@ -588,7 +588,7 @@ metrics:
     type_params:
       measure:
         name: years_tenure
-        filter: "loves_dbt is true"
+        filter: "{{dimension('loves_dbt')}} is true"
 
 """
 
@@ -977,7 +977,7 @@ metrics:
     type_params:
       measure:
         name: years_tenure
-        filter: "loves_dbt is true"
+        filter: "{{dimension('loves_dbt')}} is true"
 
 """
 

--- a/tests/unit/test_yaml_renderer.py
+++ b/tests/unit/test_yaml_renderer.py
@@ -99,22 +99,20 @@ class TestYamlRendering(unittest.TestCase):
         self.assertEqual(dct, expected)
 
     def test__metrics(self):
-        context = {"my_time_grains": "[day]"}
+        context = {"metric_name_end": "_metric"}
         renderer = SchemaYamlRenderer(context, "metrics")
 
         dct = {
-            "name": "my_source",
+            "name": "test{{ metric_name_end }}",
             "description": "{{ docs('my_doc') }}",
-            "expression": "select {{ var('my_var') }} from my_table",
-            "time_grains": "{{ my_time_grains }}",
+            "filter": "{{ dimension('my_dim') }} = false",
         }
         # We expect the expression and description will not be rendered, but
         # other fields will be
         expected = {
-            "name": "my_source",
+            "name": "test_metric",
             "description": "{{ docs('my_doc') }}",
-            "expression": "select {{ var('my_var') }} from my_table",
-            "time_grains": "[day]",
+            "filter": "{{ dimension('my_dim') }} = false",
         }
         dct = renderer.render_data(dct)
         self.assertEqual(dct, expected)


### PR DESCRIPTION
resolves #7864 

### Description

We were trying to jinja parse the `filter` properties on metric nodes. However we want to leave the `{{dimension(...)}}` of the filter string for MetricFlow to resolve in it's own way

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
