### PR TITLE
Ct-2690  Support dbt-semantic-interfaces 0.1.0dev5

### DIFF
--- a/.changes/unreleased/Under the Hood-20230615-163217.yaml
+++ b/.changes/unreleased/Under the Hood-20230615-163217.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Upgrade to dbt-semantic-interfaces v0.1.0dev5
+time: 2023-06-15T16:32:17.602189-07:00
+custom:
+  Author: QMalcolm
+  Issue: "7853"

--- a/core/setup.py
+++ b/core/setup.py
@@ -70,7 +70,7 @@ setup(
         "cffi>=1.9,<2.0.0",
         "pyyaml>=5.3",
         "urllib3~=1.0",
-        "dbt-semantic-interfaces==0.1.0.dev3",
+        "dbt-semantic-interfaces==0.1.0.dev5",
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
resolves #7853 

### Description

This is a fairly simple upgrade. Literally it's just pointing at the
the new versions. The v3 schemas are directly compatible with v5 because
there were no protocol level changes from v3 to v5. All the changers were
updates to tools MetricFlow uses from DSI, not tools that we ourselves
are using in core (yet).

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
