### PR TITLE
Update the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,9 +30,9 @@ docs dbt-labs/docs.getdbt.com/#
 
 - [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
 - [ ] I have run this code in development and it appears to resolve the stated issue
-Tests - choose one:
+  Tests - choose one:
 - [ ] This PR includes tests
 - [ ] Tests are not required or are not relevant for this PR
-Interfaces - choose one:
+  Interfaces - choose one:
 - [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)
 - [ ] This PR has already received feedback and approval from Product or DX.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 resolves #  
-docs dbt-labs/docs.getdbt.com/#  
+[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  
 
 <!---
   Include the number of the issue addressed by this PR above if applicable.
@@ -8,7 +8,8 @@ docs dbt-labs/docs.getdbt.com/#
 
   Include the number of the docs issue that was opened for this issue. If
   this change has no user-facing implications, "N/A" suffices instead. New
-  docs tickets can be created[here](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose).
+  docs tickets can be created by clicking the link above or by going to
+  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
 -->
 
 ### Problem

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,30 +1,34 @@
 resolves #
+docs dbt-labs/docs.getdbt.com/#
 
 <!---
   Include the number of the issue addressed by this PR above if applicable.
   PRs for code changes without an associated issue *will not be merged*.
   See CONTRIBUTING.md for more information.
+
+  Include the number of the docs issue that was opened for this issue. If
+  this change has no user-facing implications, "N/A" suffices instead. New
+  docs tickets can be created[here](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose).
 -->
 
-### Description
+### Problem
 
 <!---
-  Describe the Pull Request here. Add any references and info to help reviewers
-  understand your changes. Include any tradeoffs you considered.
+  Describe the problem this PR is solving. What is the application state
+  before this PR is merged?
 -->
 
-### Interface Changes
+### Solution
 
 <!---
-  Describe the changes made in this PR to any user interfaces, and their
-  expected impact on users. 
+  Describe the way this PR solves the above problem. Add as much detail as you
+  can to help reviewers understand your changes. Include any alternatives and
+  tradeoffs you considered.
 -->
 
 ### Checklist
 
 - [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
-- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
-- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
-- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
+- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,13 @@ resolves #
   understand your changes. Include any tradeoffs you considered.
 -->
 
+### Interface Changes
+
+<!---
+  Describe the changes made in this PR to any user interfaces, and their
+  expected impact on users. 
+-->
+
 ### Checklist
 
 - [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,11 +28,11 @@ docs dbt-labs/docs.getdbt.com/#
 
 ### Checklist
 
-- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
-- [ ] I have run this code in development and it appears to resolve the stated issue
-  Tests - choose one:
-- [ ] This PR includes tests
-- [ ] Tests are not required or are not relevant for this PR
-  Interfaces - choose one:
-- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)
-- [ ] This PR has already received feedback and approval from Product or DX.
+- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
+- [ ] I have run this code in development and it appears to resolve the stated issue  
+Tests - choose one:  
+- [ ] This PR includes tests  
+- [ ] Tests are not required or are not relevant for this PR  
+Interfaces - choose one:  
+- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)  
+- [ ] This PR has already received feedback and approval from Product or DX.  

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ resolves #
   PRs for code changes without an associated issue *will not be merged*.
   See CONTRIBUTING.md for more information.
 
-  Include the number of the docs issue that was opened for this issue. If
+  Include the number of the docs issue that was opened for this PR. If
   this change has no user-facing implications, "N/A" suffices instead. New
   docs tickets can be created by clicking the link above or by going to
   https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
-resolves #
-docs dbt-labs/docs.getdbt.com/#
+resolves #  
+docs dbt-labs/docs.getdbt.com/#  
 
 <!---
   Include the number of the issue addressed by this PR above if applicable.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,9 +30,9 @@ docs dbt-labs/docs.getdbt.com/#
 
 - [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
 - [ ] I have run this code in development and it appears to resolve the stated issue
-- Tests - choose one:
-    - [ ] This PR includes tests
-    - [ ] Tests are not required or are not relevant for this PR
-- Interfaces - choose one:
-    - [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)
-    - [ ] This PR has already received feedback and approval from Product or DX.
+Tests - choose one:
+- [ ] This PR includes tests
+- [ ] Tests are not required or are not relevant for this PR
+Interfaces - choose one:
+- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)
+- [ ] This PR has already received feedback and approval from Product or DX.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,5 +30,9 @@ docs dbt-labs/docs.getdbt.com/#
 
 - [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
 - [ ] I have run this code in development and it appears to resolve the stated issue
-- [ ] This PR includes tests, or tests are not required/relevant for this PR
-- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX.
+- Tests - choose one:
+    - [ ] This PR includes tests
+    - [ ] Tests are not required or are not relevant for this PR
+- Interfaces - choose one:
+    - [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)
+    - [ ] This PR has already received feedback and approval from Product or DX.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,9 +30,5 @@ docs dbt-labs/docs.getdbt.com/#
 
 - [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
 - [ ] I have run this code in development and it appears to resolve the stated issue  
-Tests - choose one:  
-- [ ] This PR includes tests  
-- [ ] Tests are not required or are not relevant for this PR  
-Interfaces - choose one:  
-- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)  
-- [ ] This PR has already received feedback and approval from Product or DX.  
+- [ ] This PR includes tests, or tests are not required/relevant for this PR
+- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX


### PR DESCRIPTION
### Description

The goal is to minimize the items in the checklist so it is easier to abide by, and to add clear reminders for opening docs tickets and getting explicit approval from Product/DX for interface changes.

Let's discuss the proposed change here, and if we agree to merge I'll open identical PRs against the adapter repos.

### Changes
- Removed changie checklist item because it is a required branch protection and automation responds with instructive PR comments
- Removed CLA checklist item because it is a required branch protection and automation responds with instructive PR comments
- Removed docs checklist item in favor of adding a place to link the open docs tickets at the top
- Added Product/DX approval checklist item to remind contributors to call out interface changes specifically
- Split "Description" header into "Problem" and "Solution".
