### PR TITLE
Resolve SemanticModel refs in the same way as other refs

### DIFF
--- a/.changes/unreleased/Under the Hood-20230616-155749.yaml
+++ b/.changes/unreleased/Under the Hood-20230616-155749.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Resolve SemanticModel ref is the same way as other refs
+time: 2023-06-16T15:57:49.245262-04:00
+custom:
+  Author: gshank
+  Issue: "7822"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -32,13 +32,13 @@ from dbt.contracts.graph.manifest import Manifest, Disabled
 from dbt.contracts.graph.nodes import (
     Macro,
     Exposure,
-    Metric,
     SeedNode,
     SourceDefinition,
     Resource,
     ManifestNode,
     RefArgs,
     AccessType,
+    SemanticModel,
 )
 from dbt.contracts.graph.metrics import MetricReference, ResolvedMetricReference
 from dbt.contracts.graph.unparsed import NodeVersion
@@ -1538,7 +1538,8 @@ def generate_parse_exposure(
     }
 
 
-class MetricRefResolver(BaseResolver):
+# applies to SemanticModels
+class SemanticModelRefResolver(BaseResolver):
     def __call__(self, *args, **kwargs) -> str:
         package = None
         if len(args) == 1:
@@ -1551,34 +1552,30 @@ class MetricRefResolver(BaseResolver):
         version = kwargs.get("version") or kwargs.get("v")
         self.validate_args(name, package, version)
 
+        # "model" here is any node
         self.model.refs.append(RefArgs(package=package, name=name, version=version))
         return ""
 
     def validate_args(self, name, package, version):
         if not isinstance(name, str):
             raise ParsingError(
-                f"In a metrics section in {self.model.original_file_path} "
+                f"In a semantic model or metrics section in {self.model.original_file_path} "
                 "the name argument to ref() must be a string"
             )
 
 
-def generate_parse_metrics(
-    metric: Metric,
+# used for semantic models
+def generate_parse_semantic_models(
+    semantic_model: SemanticModel,
     config: RuntimeConfig,
     manifest: Manifest,
     package_name: str,
 ) -> Dict[str, Any]:
     project = config.load_dependencies()[package_name]
     return {
-        "ref": MetricRefResolver(
+        "ref": SemanticModelRefResolver(
             None,
-            metric,
-            project,
-            manifest,
-        ),
-        "metric": ParseMetricResolver(
-            None,
-            metric,
+            semantic_model,
             project,
             manifest,
         ),

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1288,6 +1288,10 @@ class Exposure(GraphNode):
             and True
         )
 
+    @property
+    def group(self):
+        return None
+
 
 # ====================================
 # Metric node
@@ -1472,6 +1476,7 @@ class NodeRelation(dbtClassMixin):
     alias: str
     schema_name: str  # TODO: Could this be called simply "schema" so we could reuse StateRelation?
     database: Optional[str] = None
+    relation_name: Optional[str] = None
 
 
 @dataclass
@@ -1484,6 +1489,9 @@ class SemanticModel(GraphNode):
     measures: Sequence[Measure] = field(default_factory=list)
     dimensions: Sequence[Dimension] = field(default_factory=list)
     metadata: Optional[SourceFileMetadata] = None
+    depends_on: DependsOn = field(default_factory=DependsOn)
+    refs: List[RefArgs] = field(default_factory=list)
+    created_at: float = field(default_factory=lambda: time.time())
 
     @property
     def entity_references(self) -> List[LinkableElementReference]:
@@ -1533,6 +1541,10 @@ class SemanticModel(GraphNode):
     @property
     def reference(self) -> SemanticModelReference:
         return SemanticModelReference(semantic_model_name=self.name)
+
+    @property
+    def depends_on_nodes(self):
+        return self.depends_on.nodes
 
 
 # ====================================

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -62,7 +62,6 @@ from dbt.events.types import (
     DeprecatedReference,
     UpcomingReferenceDeprecation,
 )
-from dbt_extractor import py_extract_from_source  # type: ignore
 from dbt.logger import DbtProcessState
 from dbt.node_types import NodeType, AccessType
 from dbt.clients.jinja import get_rendered, MacroStack
@@ -536,7 +535,6 @@ class ManifestLoader:
             self.process_refs(self.root_project.project_name)
             self.process_docs(self.root_project)
             self.process_metrics(self.root_project)
-            self.process_semantic_models()
             self.check_valid_group_config()
             self.check_valid_access_property()
 
@@ -1159,15 +1157,20 @@ class ManifestLoader:
         for node in self.manifest.nodes.values():
             if node.created_at < self.started_at:
                 continue
-            _process_refs_for_node(self.manifest, current_project, node)
+            _process_refs(self.manifest, current_project, node)
         for exposure in self.manifest.exposures.values():
             if exposure.created_at < self.started_at:
                 continue
-            _process_refs_for_exposure(self.manifest, current_project, exposure)
+            _process_refs(self.manifest, current_project, exposure)
         for metric in self.manifest.metrics.values():
             if metric.created_at < self.started_at:
                 continue
-            _process_refs_for_metric(self.manifest, current_project, metric)
+            _process_refs(self.manifest, current_project, metric)
+        for semantic_model in self.manifest.semantic_nodes.values():
+            if semantic_model.created_at < self.started_at:
+                continue
+            _process_refs(self.manifest, current_project, semantic_model)
+            self.update_semantic_model(semantic_model)
 
     # Takes references in 'metrics' array of nodes and exposures, finds the target
     # node, and updates 'depends_on.nodes' with the unique id
@@ -1188,27 +1191,17 @@ class ManifestLoader:
                 continue
             _process_metrics_for_node(self.manifest, current_project, exposure)
 
-    def process_semantic_models(self) -> None:
-        for semantic_model in self.manifest.semantic_nodes.values():
-            if semantic_model.model:
-                statically_parsed = py_extract_from_source(f"{{{{ {semantic_model.model} }}}}")
-                if statically_parsed["refs"]:
-
-                    ref = statically_parsed["refs"][0]
-                    if len(ref) == 2:
-                        input_package_name, input_model_name = ref
-                    else:
-                        input_package_name, input_model_name = None, ref[0]
-
-                    refd_node = self.manifest.ref_lookup.find(
-                        input_model_name, input_package_name, None, self.manifest
-                    )
-                    if isinstance(refd_node, ModelNode):
-                        semantic_model.node_relation = NodeRelation(
-                            alias=refd_node.alias,
-                            schema_name=refd_node.schema,
-                            database=refd_node.database,
-                        )
+    def update_semantic_model(self, semantic_model) -> None:
+        # This has to be done at the end of parsing because the referenced model
+        # might have alias/schema/database fields that are updated by yaml config.
+        if semantic_model.depends_on_nodes[0]:
+            refd_node = self.manifest.nodes[semantic_model.depends_on_nodes[0]]
+            semantic_model.node_relation = NodeRelation(
+                relation_name=refd_node.relation_name,
+                alias=refd_node.alias,
+                schema_name=refd_node.schema,
+                database=refd_node.database,
+            )
 
     # nodes: node and column descriptions
     # sources: source and table descriptions, column descriptions
@@ -1494,9 +1487,13 @@ def _process_docs_for_metrics(context: Dict[str, Any], metric: Metric) -> None:
     metric.description = get_rendered(metric.description, context)
 
 
-def _process_refs_for_exposure(manifest: Manifest, current_project: str, exposure: Exposure):
-    """Given a manifest and exposure in that manifest, process its refs"""
-    for ref in exposure.refs:
+def _process_refs(manifest: Manifest, current_project: str, node):
+    """Given a manifest and node in that manifest, process its refs"""
+
+    if isinstance(node, SeedNode):
+        return
+
+    for ref in node.refs:
         target_model: Optional[Union[Disabled, ManifestNode]] = None
         target_model_name: str = ref.name
         target_model_package: Optional[str] = ref.package
@@ -1508,20 +1505,20 @@ def _process_refs_for_exposure(manifest: Manifest, current_project: str, exposur
             )
 
         target_model = manifest.resolve_ref(
-            exposure,
+            node,
             target_model_name,
             target_model_package,
             target_model_version,
             current_project,
-            exposure.package_name,
+            node.package_name,
         )
 
         if target_model is None or isinstance(target_model, Disabled):
             # This may raise. Even if it doesn't, we don't want to add
             # this exposure to the graph b/c there is no destination exposure
-            exposure.config.enabled = False
+            node.config.enabled = False
             invalid_target_fail_unless_test(
-                node=exposure,
+                node=node,
                 target_name=target_model_name,
                 target_kind="node",
                 target_package=target_model_package,
@@ -1531,66 +1528,25 @@ def _process_refs_for_exposure(manifest: Manifest, current_project: str, exposur
             )
 
             continue
-        elif isinstance(target_model, ModelNode) and target_model.access == AccessType.Private:
-            # Exposures do not have a group and so can never reference private models
-            raise dbt.exceptions.DbtReferenceError(
-                unique_id=exposure.unique_id,
-                ref_unique_id=target_model.unique_id,
-                group=dbt.utils.cast_to_str(target_model.group),
-            )
-
-        target_model_id = target_model.unique_id
-
-        exposure.depends_on.add_node(target_model_id)
-
-
-def _process_refs_for_metric(manifest: Manifest, current_project: str, metric: Metric):
-    """Given a manifest and a metric in that manifest, process its refs"""
-    for ref in metric.refs:
-        target_model: Optional[Union[Disabled, ManifestNode]] = None
-        target_model_name: str = ref.name
-        target_model_package: Optional[str] = ref.package
-        target_model_version: Optional[NodeVersion] = ref.version
-
-        if len(ref.positional_args) < 1 or len(ref.positional_args) > 2:
-            raise dbt.exceptions.DbtInternalError(
-                f"Refs should always be 1 or 2 arguments - got {len(ref.positional_args)}"
-            )
-
-        target_model = manifest.resolve_ref(
-            metric,
-            target_model_name,
-            target_model_package,
-            target_model_version,
-            current_project,
-            metric.package_name,
-        )
-
-        if target_model is None or isinstance(target_model, Disabled):
-            # This may raise. Even if it doesn't, we don't want to add
-            # this metric to the graph b/c there is no destination metric
-            metric.config.enabled = False
-            invalid_target_fail_unless_test(
-                node=metric,
-                target_name=target_model_name,
-                target_kind="node",
-                target_package=target_model_package,
-                target_version=target_model_version,
-                disabled=(isinstance(target_model, Disabled)),
-                should_warn_if_disabled=False,
-            )
-            continue
-        elif isinstance(target_model, ModelNode) and target_model.access == AccessType.Private:
-            if not metric.group or metric.group != target_model.group:
+        elif (
+            isinstance(target_model, ModelNode)
+            and target_model.access == AccessType.Private
+            and node.resource_type != NodeType.SqlOperation
+            and node.resource_type != NodeType.RPCCall  # TODO: rm
+        ):
+            if not node.group or node.group != target_model.group:
                 raise dbt.exceptions.DbtReferenceError(
-                    unique_id=metric.unique_id,
+                    unique_id=node.unique_id,
                     ref_unique_id=target_model.unique_id,
                     group=dbt.utils.cast_to_str(target_model.group),
                 )
 
         target_model_id = target_model.unique_id
 
-        metric.depends_on.add_node(target_model_id)
+        if target_model.is_public_node:
+            node.depends_on.add_public_node(target_model_id)
+        else:
+            node.depends_on.add_node(target_model_id)
 
 
 def _process_metrics_for_node(
@@ -1640,69 +1596,6 @@ def _process_metrics_for_node(
         target_metric_id = target_metric.unique_id
 
         node.depends_on.add_node(target_metric_id)
-
-
-def _process_refs_for_node(manifest: Manifest, current_project: str, node: ManifestNode):
-    """Given a manifest and a node in that manifest, process its refs"""
-
-    if isinstance(node, SeedNode):
-        return
-
-    for ref in node.refs:
-        target_model: Optional[Union[Disabled, ManifestNode]] = None
-        target_model_name: str = ref.name
-        target_model_package: Optional[str] = ref.package
-        target_model_version: Optional[NodeVersion] = ref.version
-
-        if len(ref.positional_args) < 1 or len(ref.positional_args) > 2:
-            raise dbt.exceptions.DbtInternalError(
-                f"Refs should always be 1 or 2 arguments - got {len(ref.positional_args)}"
-            )
-
-        target_model = manifest.resolve_ref(
-            node,
-            target_model_name,
-            target_model_package,
-            target_model_version,
-            current_project,
-            node.package_name,
-        )
-
-        if target_model is None or isinstance(target_model, Disabled):
-            # This may raise. Even if it doesn't, we don't want to add
-            # this node to the graph b/c there is no destination node
-            node.config.enabled = False
-            invalid_target_fail_unless_test(
-                node=node,
-                target_name=target_model_name,
-                target_kind="node",
-                target_package=target_model_package,
-                target_version=target_model_version,
-                disabled=(isinstance(target_model, Disabled)),
-                should_warn_if_disabled=False,
-            )
-            continue
-
-        # Handle references to models that are private, unless this is an 'ad hoc' query (SqlOperation, RPCCall)
-        elif (
-            isinstance(target_model, ModelNode)
-            and target_model.access == AccessType.Private
-            and node.resource_type != NodeType.SqlOperation
-            and node.resource_type != NodeType.RPCCall  # TODO: rm
-        ):
-            if not node.group or node.group != target_model.group:
-                raise dbt.exceptions.DbtReferenceError(
-                    unique_id=node.unique_id,
-                    ref_unique_id=target_model.unique_id,
-                    group=dbt.utils.cast_to_str(target_model.group),
-                )
-
-        target_model_id = target_model.unique_id
-
-        if target_model.is_public_node:
-            node.depends_on.add_public_node(target_model_id)
-        else:
-            node.depends_on.add_node(target_model_id)
 
 
 def remove_dependent_project_references(manifest: Manifest, publication: PublicationConfig):
@@ -1804,7 +1697,7 @@ def process_macro(config: RuntimeConfig, manifest: Manifest, macro: Macro) -> No
 def process_node(config: RuntimeConfig, manifest: Manifest, node: ManifestNode):
 
     _process_sources_for_node(manifest, config.project_name, node)
-    _process_refs_for_node(manifest, config.project_name, node)
+    _process_refs(manifest, config.project_name, node)
     ctx = generate_runtime_docs_context(config, node, manifest, config.project_name)
     _process_docs_for_node(ctx, node)
 

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -34,7 +34,8 @@ from dbt.contracts.graph.semantic_models import (
     NonAdditiveDimension,
 )
 from dbt.exceptions import DbtInternalError, YamlParseDictError, JSONValidationError
-from dbt.context.providers import generate_parse_exposure
+from dbt.context.providers import generate_parse_exposure, generate_parse_semantic_models
+
 from dbt.contracts.graph.model_config import MetricConfig, ExposureConfig
 from dbt.context.context_config import (
     BaseContextConfigGenerator,
@@ -521,6 +522,19 @@ class SemanticModelParser(YamlReader):
             defaults=unparsed.defaults,
         )
 
+        ctx = generate_parse_semantic_models(
+            parsed,
+            self.root_project,
+            self.schema_parser.manifest,
+            package_name,
+        )
+
+        if parsed.model is not None:
+            model_ref = "{{ " + parsed.model + " }}"
+            # This sets the "refs" in the SemanticModel from the MetricRefResolver in context/providers.py
+            get_rendered(model_ref, ctx, parsed)
+
+        # No ability to disable a semantic model at this time
         self.manifest.add_semantic_model(self.yaml.file, parsed)
 
     def parse(self):

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -57,3 +57,8 @@ class TestSemanticModelParsing:
         assert len(manifest.semantic_nodes) == 1
         semantic_model = manifest.semantic_nodes["semanticmodel.test.revenue"]
         assert semantic_model.node_relation.alias == "fct_revenue"
+
+        assert (
+            semantic_model.node_relation.relation_name
+            == f'"dbt"."{project.test_schema}"."fct_revenue"'
+        )


### PR DESCRIPTION
resolves #7822

### Description

Refactor SemanticModel ref resolution to work in the same way as other nodes. This includes adding several fields on the SamnticModel: created_at (for partial parsing), refs (for holding intermediate representation of the ref), and depends_on for holding the resolved unique_id of the model that's ref'd (also necessary for partial parsing.  We do a "get_rendered" on the model field to generate the "ref", calling common code to process the ref (_process_refs), and setting the fields in the NodeRelation class.

I also added relation_name to the NodeRelation class, because without something like that you have to call adapter code to get a properly quoted relation name. Let me know if there's some reason that's not necessary.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
