### PR TITLE
Upgrade core to support dbt-semantic-interfaces `0.1.0dev7`

### DIFF
--- a/.changes/unreleased/Under the Hood-20230619-135201.yaml
+++ b/.changes/unreleased/Under the Hood-20230619-135201.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Move from dbt-semantic-intefaces 0.1.0dev5 to 0.1.0dev7
+time: 2023-06-19T13:52:01.947206-07:00
+custom:
+  Author: QMalcolm
+  Issue: "7898"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1333,18 +1333,12 @@ class MetricInput(dbtClassMixin):
 class MetricTypeParams(dbtClassMixin):
     measure: Optional[MetricInputMeasure] = None
     input_measures: List[MetricInputMeasure] = field(default_factory=list)
-    numerator: Optional[MetricInputMeasure] = None
-    denominator: Optional[MetricInputMeasure] = None
+    numerator: Optional[MetricInput] = None
+    denominator: Optional[MetricInput] = None
     expr: Optional[str] = None
     window: Optional[MetricTimeWindow] = None
     grain_to_date: Optional[TimeGranularity] = None
     metrics: Optional[List[MetricInput]] = None
-
-    def numerator_measure_reference(self) -> Optional[MeasureReference]:
-        return self.numerator.measure_reference() if self.numerator else None
-
-    def denominator_measure_reference(self) -> Optional[MeasureReference]:
-        return self.denominator.measure_reference() if self.denominator else None
 
 
 @dataclass

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1307,7 +1307,7 @@ class MetricInputMeasure(dbtClassMixin):
     def measure_reference(self) -> MeasureReference:
         return MeasureReference(element_name=self.name)
 
-    def post_aggregation_measure_referenc(self) -> MeasureReference:
+    def post_aggregation_measure_reference(self) -> MeasureReference:
         return MeasureReference(element_name=self.alias or self.name)
 
 
@@ -1327,6 +1327,9 @@ class MetricInput(dbtClassMixin):
 
     def as_reference(self) -> DSIMetricReference:
         return DSIMetricReference(element_name=self.name)
+
+    def post_aggregation_reference(self) -> DSIMetricReference:
+        return DSIMetricReference(element_name=self.alias or self.name)
 
 
 @dataclass

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -53,8 +53,7 @@ from dbt_semantic_interfaces.references import (
     SemanticModelReference,
 )
 from dbt_semantic_interfaces.references import MetricReference as DSIMetricReference
-from dbt_semantic_interfaces.type_enums.metric_type import MetricType
-from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.type_enums import MetricType, TimeGranularity
 
 from .model_config import (
     NodeConfig,

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1332,7 +1332,7 @@ class MetricInput(dbtClassMixin):
 @dataclass
 class MetricTypeParams(dbtClassMixin):
     measure: Optional[MetricInputMeasure] = None
-    measures: Optional[List[MetricInputMeasure]] = None
+    input_measures: List[MetricInputMeasure] = field(default_factory=list)
     numerator: Optional[MetricInputMeasure] = None
     denominator: Optional[MetricInputMeasure] = None
     expr: Optional[str] = None
@@ -1388,16 +1388,7 @@ class Metric(GraphNode):
 
     @property
     def input_measures(self) -> List[MetricInputMeasure]:
-        tp = self.type_params
-        res = tp.measures or []
-        if tp.measure:
-            res.append(tp.measure)
-        if tp.numerator:
-            res.append(tp.numerator)
-        if tp.denominator:
-            res.append(tp.denominator)
-
-        return res
+        return self.type_params.input_measures
 
     @property
     def measure_references(self) -> List[MeasureReference]:

--- a/core/dbt/contracts/graph/semantic_models.py
+++ b/core/dbt/contracts/graph/semantic_models.py
@@ -6,10 +6,12 @@ from dbt_semantic_interfaces.references import (
     MeasureReference,
     TimeDimensionReference,
 )
-from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
-from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
-from dbt_semantic_interfaces.type_enums.entity_type import EntityType
-from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.type_enums import (
+    AggregationType,
+    DimensionType,
+    EntityType,
+    TimeGranularity,
+)
 from typing import List, Optional
 
 

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -616,8 +616,8 @@ class UnparsedMetricInput(dbtClassMixin):
 @dataclass
 class UnparsedMetricTypeParams(dbtClassMixin):
     measure: Optional[Union[UnparsedMetricInputMeasure, str]] = None
-    numerator: Optional[Union[UnparsedMetricInputMeasure, str]] = None
-    denominator: Optional[Union[UnparsedMetricInputMeasure, str]] = None
+    numerator: Optional[Union[UnparsedMetricInput, str]] = None
+    denominator: Optional[Union[UnparsedMetricInput, str]] = None
     expr: Optional[str] = None
     window: Optional[str] = None
     grain_to_date: Optional[str] = None  # str is really a TimeGranularity Enum

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -616,7 +616,6 @@ class UnparsedMetricInput(dbtClassMixin):
 @dataclass
 class UnparsedMetricTypeParams(dbtClassMixin):
     measure: Optional[Union[UnparsedMetricInputMeasure, str]] = None
-    measures: Optional[List[Union[UnparsedMetricInputMeasure, str]]] = None
     numerator: Optional[Union[UnparsedMetricInputMeasure, str]] = None
     denominator: Optional[Union[UnparsedMetricInputMeasure, str]] = None
     expr: Optional[str] = None

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -282,13 +282,16 @@ class MetricParser(YamlReader):
 
         return MetricTypeParams(
             measure=self._get_optional_input_measure(type_params.measure),
-            measures=self._get_input_measures(type_params.measures),
             numerator=self._get_optional_input_measure(type_params.numerator),
             denominator=self._get_optional_input_measure(type_params.denominator),
             expr=type_params.expr,
             window=self._get_time_window(type_params.window),
             grain_to_date=grain_to_date,
             metrics=self._get_metric_inputs(type_params.metrics),
+            # TODO This is a compiled list of measure/numerator/denominator as
+            # well as the `input_measures` of included metrics. We're planning
+            # on doing this as part of CT-2707
+            # input_measures=?,
         )
 
     def parse_metric(self, unparsed: UnparsedMetric):

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -43,11 +43,13 @@ from dbt.context.context_config import (
 )
 from dbt.clients.jinja import get_rendered
 from dbt.dataclass_schema import ValidationError
-from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
-from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
-from dbt_semantic_interfaces.type_enums.entity_type import EntityType
-from dbt_semantic_interfaces.type_enums.metric_type import MetricType
-from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.type_enums import (
+    AggregationType,
+    DimensionType,
+    EntityType,
+    MetricType,
+    TimeGranularity,
+)
 from typing import List, Optional, Union
 
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -70,7 +70,7 @@ setup(
         "cffi>=1.9,<2.0.0",
         "pyyaml>=5.3",
         "urllib3~=1.0",
-        "dbt-semantic-interfaces==0.1.0.dev5",
+        "dbt-semantic-interfaces==0.1.0.dev7",
     ],
     zip_safe=False,
     classifiers=[

--- a/tests/unit/test_contracts_graph_parsed.py
+++ b/tests/unit/test_contracts_graph_parsed.py
@@ -46,7 +46,7 @@ from dbt import flags
 from argparse import Namespace
 
 from dbt.dataclass_schema import ValidationError
-from dbt_semantic_interfaces.type_enums.metric_type import MetricType
+from dbt_semantic_interfaces.type_enums import MetricType
 from .utils import (
     ContractTestCase,
     assert_symmetric,

--- a/tests/unit/test_graph_selector_methods.py
+++ b/tests/unit/test_graph_selector_methods.py
@@ -49,7 +49,7 @@ from dbt.graph.selector_methods import (
 )
 import dbt.exceptions
 import dbt.contracts.graph.nodes
-from dbt_semantic_interfaces.type_enums.metric_type import MetricType
+from dbt_semantic_interfaces.type_enums import MetricType
 from .utils import replace_config
 
 

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -39,7 +39,7 @@ from dbt.events.functions import reset_metadata_vars
 from dbt.exceptions import AmbiguousResourceNameRefError
 from dbt.flags import set_from_args
 from dbt.node_types import NodeType
-from dbt_semantic_interfaces.type_enums.metric_type import MetricType
+from dbt_semantic_interfaces.type_enums import MetricType
 
 from .utils import (
     MockMacro,

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -8,11 +8,13 @@ from dbt.contracts.graph.nodes import (
 )
 from dbt.contracts.graph.semantic_models import Dimension, DimensionTypeParams, Entity, Measure
 from dbt.node_types import NodeType
-from dbt_semantic_interfaces.protocols.dimension import Dimension as DSIDimension
-from dbt_semantic_interfaces.protocols.entity import Entity as DSIEntitiy
-from dbt_semantic_interfaces.protocols.measure import Measure as DSIMeasure
-from dbt_semantic_interfaces.protocols.metric import Metric as DSIMetric
-from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel as DSISemanticModel
+from dbt_semantic_interfaces.protocols import (
+    Dimension as DSIDimension,
+    Entity as DSIEntitiy,
+    Measure as DSIMeasure,
+    Metric as DSIMetric,
+    SemanticModel as DSISemanticModel,
+)
 from dbt_semantic_interfaces.type_enums import (
     DimensionType,
     EntityType,

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -1,5 +1,6 @@
 from dbt.contracts.graph.nodes import (
     Metric,
+    MetricInput,
     MetricInputMeasure,
     MetricTypeParams,
     NodeRelation,
@@ -13,6 +14,8 @@ from dbt_semantic_interfaces.protocols import (
     Entity as DSIEntitiy,
     Measure as DSIMeasure,
     Metric as DSIMetric,
+    MetricInput as DSIMetricInput,
+    MetricInputMeasure as DSIMetricInputMeasure,
     MetricTypeParams as DSIMetricTypeParams,
     SemanticModel as DSISemanticModel,
 )
@@ -47,6 +50,16 @@ class RuntimeCheckableMeasure(DSIMeasure, Protocol):
 
 @runtime_checkable
 class RuntimeCheckableMetric(DSIMetric, Protocol):
+    pass
+
+
+@runtime_checkable
+class RuntimeCheckableMetricInput(DSIMetricInput, Protocol):
+    pass
+
+
+@runtime_checkable
+class RuntimeCheckableMetricInputMeasure(DSIMetricInputMeasure, Protocol):
     pass
 
 
@@ -131,6 +144,16 @@ def test_metric_node_satisfies_protocol():
         ),
     )
     assert isinstance(metric, RuntimeCheckableMetric)
+
+
+def test_metric_input():
+    metric_input = MetricInput(name="a_metric_input")
+    assert isinstance(metric_input, RuntimeCheckableMetricInput)
+
+
+def test_metric_input_measure():
+    metric_input_measure = MetricInputMeasure(name="a_metric_input_measure")
+    assert isinstance(metric_input_measure, RuntimeCheckableMetricInputMeasure)
 
 
 def test_metric_type_params_satisfies_protocol():

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -13,6 +13,7 @@ from dbt_semantic_interfaces.protocols import (
     Entity as DSIEntitiy,
     Measure as DSIMeasure,
     Metric as DSIMetric,
+    MetricTypeParams as DSIMetricTypeParams,
     SemanticModel as DSISemanticModel,
 )
 from dbt_semantic_interfaces.type_enums import (
@@ -46,6 +47,11 @@ class RuntimeCheckableMeasure(DSIMeasure, Protocol):
 
 @runtime_checkable
 class RuntimeCheckableMetric(DSIMetric, Protocol):
+    pass
+
+
+@runtime_checkable
+class RuntimeCheckableMetricTypeParams(DSIMetricTypeParams, Protocol):
     pass
 
 
@@ -125,3 +131,8 @@ def test_metric_node_satisfies_protocol():
         ),
     )
     assert isinstance(metric, RuntimeCheckableMetric)
+
+
+def test_metric_type_params_satisfies_protocol():
+    type_params = MetricTypeParams()
+    assert isinstance(type_params, RuntimeCheckableMetricTypeParams)

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -13,10 +13,12 @@ from dbt_semantic_interfaces.protocols.entity import Entity as DSIEntitiy
 from dbt_semantic_interfaces.protocols.measure import Measure as DSIMeasure
 from dbt_semantic_interfaces.protocols.metric import Metric as DSIMetric
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel as DSISemanticModel
-from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
-from dbt_semantic_interfaces.type_enums.entity_type import EntityType
-from dbt_semantic_interfaces.type_enums.metric_type import MetricType
-from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.type_enums import (
+    DimensionType,
+    EntityType,
+    MetricType,
+    TimeGranularity,
+)
 from typing import Protocol, runtime_checkable
 
 


### PR DESCRIPTION
resolves #7898 

### Description

We recently upgraded core to support dbt-semantic-interfaces `0.1.0dev5`. Since then we've released `0.1.0.dev6` and `0.1.0dev7` of that package. This PR upgrades us to `0.1.0dev7`.

Notable changes

- Metric `numerator` and `denominator` type params are now `MetricInput`s instead of `MetricInputMeasure`s
- Metric `measures` have been removed and replaced with `input_measures`
  - Populating this field is the subject of #7884
- Additional helper method `post_aggregation_reference` on `MetricInput` implementations
- Better import paths for type enums provided by DSI
- Better import paths for protocols provided by DSI

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
