### PR TITLE
feat: move `--profile` and `--target` to global config

### DIFF
--- a/.changes/unreleased/Features-20230622-122252.yaml
+++ b/.changes/unreleased/Features-20230622-122252.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Move `--profile` and `--target` to global config, as well as allow these flags
+  to be set by environment variables (`DBT_TARGET` and `DBT_PROFILE`)
+time: 2023-06-22T12:22:52.491092-04:00
+custom:
+  Author: rexledesma
+  Issue: "7798"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -142,11 +142,13 @@ class dbtRunner:
 @p.populate_cache
 @p.print
 @p.printer_width
+@p.profile
 @p.quiet
 @p.record_timing_info
 @p.send_anonymous_usage_stats
 @p.single_threaded
 @p.static_parser
+@p.target
 @p.use_colors
 @p.use_colors_file
 @p.use_experimental_parser

--- a/tests/unit/test_cli_flags.py
+++ b/tests/unit/test_cli_flags.py
@@ -344,6 +344,40 @@ class TestFlags:
         assert flags.USE_COLORS is True
         assert flags.USE_COLORS_FILE is False
 
+    @pytest.mark.parametrize(
+        "cli_profile, flag_profile",
+        [
+            (None, None),
+            ("profile", "profile"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "cli_target, flag_target",
+        [
+            (None, None),
+            ("target", "target"),
+        ],
+    )
+    def test_profile_settings_interaction(
+        self, cli_profile, cli_target, flag_profile, flag_target
+    ):
+        cli_params = []
+
+        if cli_profile is not None:
+            cli_params += ["--profile", cli_profile]
+
+        if cli_target is not None:
+            cli_params += ["--target", cli_target]
+
+        cli_params += ["run"]
+
+        context = self.make_dbt_context("run", cli_params)
+
+        flags = Flags(context, None)
+
+        assert flags.PROFILE == flag_profile
+        assert flags.TARGET == flag_target
+
     def test_duplicate_flags_raises_error(self):
         parent_context = self.make_dbt_context("parent", ["--version-check"])
         context = self.make_dbt_context("child", ["--version-check"], parent_context)


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/7798.

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

Move `--target` and `--profile` command line flags to global config. Also, allow these flags to be set by environment variable (`DBT_TARGET`, and `DBT_PROFILE`).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
