### PR TITLE
Fix: safe remove of external nodes from nodes.depends_on

### DIFF
--- a/.changes/unreleased/Fixes-20230622-121907.yaml
+++ b/.changes/unreleased/Fixes-20230622-121907.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: 'Fix: safe remove of external nodes from nodes.depends_on'
+time: 2023-06-22T12:19:07.657855-04:00
+custom:
+  Author: michelleark
+  Issue: "7924"

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1534,7 +1534,9 @@ def _process_metrics_for_node(
 def remove_dependent_project_references(manifest, external_node_unique_id):
     for child_id in manifest.child_map[external_node_unique_id]:
         node = manifest.expect(child_id)
-        node.depends_on_nodes.remove(external_node_unique_id)
+        # child node may have been modified and already recreated its depends_on.nodes list
+        if external_node_unique_id in node.depends_on_nodes:
+            node.depends_on_nodes.remove(external_node_unique_id)
         node.created_at = time.time()
 
 

--- a/tests/functional/multi_project/test_publication.py
+++ b/tests/functional/multi_project/test_publication.py
@@ -99,6 +99,10 @@ ext_node_model_sql = """
 select * from {{ ref('marketing', 'fct_one') }}
 """
 
+ext_node_model_sql_modified = """
+select * from {{ ref('marketing', 'fct_three') }}
+"""
+
 
 class TestPublicationArtifact:
     @pytest.fixture(scope="class")
@@ -202,6 +206,14 @@ class TestPublicationArtifacts:
         # test_model_one references a missing public model
         with pytest.raises(TargetNotFoundError):
             manifest = run_dbt(["parse"], publications=publications)
+
+        # With public node changed from fct_one to fct_three, also update test_model_one's reference
+        write_file(
+            ext_node_model_sql_modified, project.project_root, "models", "test_model_one.sql"
+        )
+        manifest = run_dbt(["parse"], publications=publications)
+        # undo test_model_one changes
+        write_file(ext_node_model_sql, project.project_root, "models", "test_model_one.sql")
 
         # Add another public reference
         m_pub_json = m_pub_json.replace("fct_three", "fct_one")


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/7924

If a child node of an external node was modified — it may have already reprocessed refs / updated its `depends_on.nodes` array by the time we `remove_dependent_project_references` even though the `child_map` has not yet been updated. Fixes this case by ensuring the external node is in the depends_on list before removing it. 


<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
