### PR TITLE
Rename the semantic_nodes collection to semantic_models

### DIFF
--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -179,8 +179,8 @@ class Linker:
     def link_graph(self, manifest: Manifest):
         for source in manifest.sources.values():
             self.add_node(source.unique_id)
-        for semantic_node in manifest.semantic_nodes.values():
-            self.add_node(semantic_node.unique_id)
+        for semantic_model in manifest.semantic_models.values():
+            self.add_node(semantic_model.unique_id)
 
         for node in manifest.nodes.values():
             self.link_node(node, manifest)

--- a/core/dbt/contracts/files.py
+++ b/core/dbt/contracts/files.py
@@ -228,7 +228,7 @@ class SchemaSourceFile(BaseSourceFile):
     groups: List[str] = field(default_factory=list)
     # node patches contain models, seeds, snapshots, analyses
     ndp: List[str] = field(default_factory=list)
-    semantic_nodes: List[str] = field(default_factory=list)
+    semantic_models: List[str] = field(default_factory=list)
     # any macro patches in this file by macro unique_id.
     mcp: Dict[str, str] = field(default_factory=dict)
     # any source patches in this file. The entries are package, name pairs

--- a/core/dbt/contracts/graph/manifest_upgrade.py
+++ b/core/dbt/contracts/graph/manifest_upgrade.py
@@ -102,6 +102,6 @@ def upgrade_manifest_json(manifest: dict, manifest_schema_version: int) -> dict:
         if "root_path" in doc_content:
             del doc_content["root_path"]
         doc_content["resource_type"] = "doc"
-    if "semantic_nodes" not in manifest:
-        manifest["semantic_nodes"] = {}
+    if "semantic_models" not in manifest:
+        manifest["semantic_models"] = {}
     return manifest

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1103,7 +1103,7 @@ class ManifestLoader:
             if metric.created_at < self.started_at:
                 continue
             _process_refs(self.manifest, current_project, metric)
-        for semantic_model in self.manifest.semantic_nodes.values():
+        for semantic_model in self.manifest.semantic_models.values():
             if semantic_model.created_at < self.started_at:
                 continue
             _process_refs(self.manifest, current_project, semantic_model)

--- a/schemas/dbt/manifest/v10.json
+++ b/schemas/dbt/manifest/v10.json
@@ -10,7 +10,7 @@
     "metrics",
     "groups",
     "selectors",
-    "semantic_nodes"
+    "semantic_models"
   ],
   "properties": {
     "metadata": {
@@ -203,7 +203,7 @@
       ],
       "description": "A mapping from group names to their nodes"
     },
-    "semantic_nodes": {
+    "semantic_models": {
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/SemanticModel"
@@ -212,7 +212,7 @@
     }
   },
   "additionalProperties": false,
-  "description": "WritableManifest(metadata: dbt.contracts.graph.manifest.ManifestMetadata, nodes: Mapping[str, Union[dbt.contracts.graph.nodes.AnalysisNode, dbt.contracts.graph.nodes.SingularTestNode, dbt.contracts.graph.nodes.HookNode, dbt.contracts.graph.nodes.ModelNode, dbt.contracts.graph.nodes.RPCNode, dbt.contracts.graph.nodes.SqlNode, dbt.contracts.graph.nodes.GenericTestNode, dbt.contracts.graph.nodes.SnapshotNode, dbt.contracts.graph.nodes.SeedNode]], sources: Mapping[str, dbt.contracts.graph.nodes.SourceDefinition], macros: Mapping[str, dbt.contracts.graph.nodes.Macro], docs: Mapping[str, dbt.contracts.graph.nodes.Documentation], exposures: Mapping[str, dbt.contracts.graph.nodes.Exposure], metrics: Mapping[str, dbt.contracts.graph.nodes.Metric], groups: Mapping[str, dbt.contracts.graph.nodes.Group], selectors: Mapping[str, Any], disabled: Union[Mapping[str, List[Union[dbt.contracts.graph.nodes.AnalysisNode, dbt.contracts.graph.nodes.SingularTestNode, dbt.contracts.graph.nodes.HookNode, dbt.contracts.graph.nodes.ModelNode, dbt.contracts.graph.nodes.RPCNode, dbt.contracts.graph.nodes.SqlNode, dbt.contracts.graph.nodes.GenericTestNode, dbt.contracts.graph.nodes.SnapshotNode, dbt.contracts.graph.nodes.SeedNode, dbt.contracts.graph.nodes.SourceDefinition, dbt.contracts.graph.nodes.Exposure, dbt.contracts.graph.nodes.Metric]]], NoneType], parent_map: Union[Dict[str, List[str]], NoneType], child_map: Union[Dict[str, List[str]], NoneType], group_map: Union[Dict[str, List[str]], NoneType], semantic_nodes: Mapping[str, dbt.contracts.graph.nodes.SemanticModel])",
+  "description": "WritableManifest(metadata: dbt.contracts.graph.manifest.ManifestMetadata, nodes: Mapping[str, Union[dbt.contracts.graph.nodes.AnalysisNode, dbt.contracts.graph.nodes.SingularTestNode, dbt.contracts.graph.nodes.HookNode, dbt.contracts.graph.nodes.ModelNode, dbt.contracts.graph.nodes.RPCNode, dbt.contracts.graph.nodes.SqlNode, dbt.contracts.graph.nodes.GenericTestNode, dbt.contracts.graph.nodes.SnapshotNode, dbt.contracts.graph.nodes.SeedNode]], sources: Mapping[str, dbt.contracts.graph.nodes.SourceDefinition], macros: Mapping[str, dbt.contracts.graph.nodes.Macro], docs: Mapping[str, dbt.contracts.graph.nodes.Documentation], exposures: Mapping[str, dbt.contracts.graph.nodes.Exposure], metrics: Mapping[str, dbt.contracts.graph.nodes.Metric], groups: Mapping[str, dbt.contracts.graph.nodes.Group], selectors: Mapping[str, Any], disabled: Union[Mapping[str, List[Union[dbt.contracts.graph.nodes.AnalysisNode, dbt.contracts.graph.nodes.SingularTestNode, dbt.contracts.graph.nodes.HookNode, dbt.contracts.graph.nodes.ModelNode, dbt.contracts.graph.nodes.RPCNode, dbt.contracts.graph.nodes.SqlNode, dbt.contracts.graph.nodes.GenericTestNode, dbt.contracts.graph.nodes.SnapshotNode, dbt.contracts.graph.nodes.SeedNode, dbt.contracts.graph.nodes.SourceDefinition, dbt.contracts.graph.nodes.Exposure, dbt.contracts.graph.nodes.Metric]]], NoneType], parent_map: Union[Dict[str, List[str]], NoneType], child_map: Union[Dict[str, List[str]], NoneType], group_map: Union[Dict[str, List[str]], NoneType], semantic_models: Mapping[str, dbt.contracts.graph.nodes.SemanticModel])",
   "definitions": {
     "ManifestMetadata": {
       "type": "object",

--- a/tests/functional/artifacts/expected_manifest.py
+++ b/tests/functional/artifacts/expected_manifest.py
@@ -886,7 +886,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
             "doc.test.macro_arg_info": ANY,
         },
         "disabled": {},
-        "semantic_nodes": {},
+        "semantic_models": {},
     }
 
 
@@ -1445,7 +1445,7 @@ def expected_references_manifest(project):
                 ],
             }
         },
-        "semantic_nodes": {},
+        "semantic_models": {},
     }
 
 
@@ -1924,5 +1924,5 @@ def expected_versions_manifest(project):
         },
         "disabled": {},
         "macros": {},
-        "semantic_nodes": {},
+        "semantic_models": {},
     }

--- a/tests/functional/artifacts/test_artifacts.py
+++ b/tests/functional/artifacts/test_artifacts.py
@@ -468,7 +468,7 @@ def verify_manifest(project, expected_manifest, start_time, manifest_schema_path
         "disabled",
         "exposures",
         "selectors",
-        "semantic_nodes",
+        "semantic_models",
     }
 
     assert set(manifest.keys()) == manifest_keys

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -58,8 +58,8 @@ class TestSemanticModelParsing:
         assert result.success
         assert isinstance(result.result, Manifest)
         manifest = result.result
-        assert len(manifest.semantic_nodes) == 1
-        semantic_model = manifest.semantic_nodes["semanticmodel.test.revenue"]
+        assert len(manifest.semantic_models) == 1
+        semantic_model = manifest.semantic_models["semanticmodel.test.revenue"]
         assert semantic_model.node_relation.alias == "fct_revenue"
         assert (
             semantic_model.node_relation.relation_name
@@ -83,5 +83,5 @@ class TestSemanticModelParsing:
 
         # Finally, verify that the manifest reflects the partially parsed change
         manifest = result.result
-        semantic_model = manifest.semantic_nodes["semanticmodel.test.revenue"]
+        semantic_model = manifest.semantic_models["semanticmodel.test.revenue"]
         assert semantic_model.dimensions[0].type_params.time_granularity == TimeGranularity.WEEK

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -336,7 +336,7 @@ class ManifestTest(unittest.TestCase):
             ),
         }
 
-        self.semantic_nodes = {}
+        self.semantic_models = {}
 
         for exposure in self.exposures.values():
             exposure.validate(exposure.to_dict(omit_none=True))
@@ -366,7 +366,7 @@ class ManifestTest(unittest.TestCase):
             metrics={},
             selectors={},
             metadata=ManifestMetadata(generated_at=datetime.utcnow()),
-            semantic_nodes={},
+            semantic_models={},
         )
 
         invocation_id = dbt.events.functions.EVENT_MANAGER.invocation_id
@@ -392,7 +392,7 @@ class ManifestTest(unittest.TestCase):
                 },
                 "docs": {},
                 "disabled": {},
-                "semantic_nodes": {},
+                "semantic_models": {},
             },
         )
 
@@ -476,7 +476,7 @@ class ManifestTest(unittest.TestCase):
         flat_metrics = flat_graph["metrics"]
         flat_nodes = flat_graph["nodes"]
         flat_sources = flat_graph["sources"]
-        flat_semantic_nodes = flat_graph["semantic_nodes"]
+        flat_semantic_models = flat_graph["semantic_models"]
         self.assertEqual(
             set(flat_graph),
             set(
@@ -486,7 +486,7 @@ class ManifestTest(unittest.TestCase):
                     "nodes",
                     "sources",
                     "metrics",
-                    "semantic_nodes",
+                    "semantic_models",
                 ]
             ),
         )
@@ -495,7 +495,7 @@ class ManifestTest(unittest.TestCase):
         self.assertEqual(set(flat_metrics), set(self.metrics))
         self.assertEqual(set(flat_nodes), set(self.nested_nodes))
         self.assertEqual(set(flat_sources), set(self.sources))
-        self.assertEqual(set(flat_semantic_nodes), set(self.semantic_nodes))
+        self.assertEqual(set(flat_semantic_models), set(self.semantic_models))
         for node in flat_nodes.values():
             self.assertEqual(frozenset(node), REQUIRED_PARSED_NODE_KEYS)
 
@@ -542,7 +542,7 @@ class ManifestTest(unittest.TestCase):
             metadata=metadata,
             files={},
             exposures={},
-            semantic_nodes={},
+            semantic_models={},
         )
 
         self.assertEqual(
@@ -571,7 +571,7 @@ class ManifestTest(unittest.TestCase):
                     "env": {ENV_KEY_NAME: "value"},
                 },
                 "disabled": {},
-                "semantic_nodes": {},
+                "semantic_models": {},
             },
         )
 
@@ -919,7 +919,7 @@ class MixedManifestTest(unittest.TestCase):
             metadata=metadata,
             files={},
             exposures={},
-            semantic_nodes={},
+            semantic_models={},
         )
         self.assertEqual(
             manifest.writable_manifest().to_dict(omit_none=True),
@@ -943,7 +943,7 @@ class MixedManifestTest(unittest.TestCase):
                 },
                 "docs": {},
                 "disabled": {},
-                "semantic_nodes": {},
+                "semantic_models": {},
             },
         )
 
@@ -1011,7 +1011,7 @@ class MixedManifestTest(unittest.TestCase):
             selectors={},
             files={},
             exposures={},
-            semantic_nodes={},
+            semantic_models={},
         )
         manifest.build_flat_graph()
         flat_graph = manifest.flat_graph
@@ -1025,7 +1025,7 @@ class MixedManifestTest(unittest.TestCase):
                     "metrics",
                     "nodes",
                     "sources",
-                    "semantic_nodes",
+                    "semantic_models",
                 ]
             ),
         )


### PR DESCRIPTION
resolves #7907

### Description

Rename the manifest property semantic_nodes to semantic_models for greater clarity.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
