### PR TITLE
Add thread_id context var

### DIFF
--- a/.changes/unreleased/Features-20230623-173357.yaml
+++ b/.changes/unreleased/Features-20230623-173357.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add thread_id context var
+time: 2023-06-23T17:33:57.412102-07:00
+custom:
+  Author: NiallRees
+  Issue: "7942"

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -1,6 +1,7 @@
 import json
 import os
 from typing import Any, Dict, NoReturn, Optional, Mapping, Iterable, Set, List
+import threading
 
 from dbt.flags import get_flags
 import dbt.flags as flags_module
@@ -595,6 +596,11 @@ class BaseContext(metaclass=ContextMeta):
         auditing)
         """
         return get_invocation_id()
+
+    @contextproperty
+    def thread_id(self) -> str:
+        """thread_id outputs an ID for the current thread (useful for auditing)"""
+        return threading.current_thread().name
 
     @contextproperty
     def modules(self) -> Dict[str, Any]:

--- a/tests/adapter/dbt/tests/adapter/hooks/data/seed_model.sql
+++ b/tests/adapter/dbt/tests/adapter/hooks/data/seed_model.sql
@@ -12,5 +12,6 @@ create table {schema}.on_model_hook (
     target_pass      TEXT,
     target_threads   INTEGER,
     run_started_at   TEXT,
-    invocation_id    TEXT
+    invocation_id    TEXT,
+    thread_id        TEXT
 );

--- a/tests/adapter/dbt/tests/adapter/hooks/data/seed_run.sql
+++ b/tests/adapter/dbt/tests/adapter/hooks/data/seed_run.sql
@@ -12,5 +12,6 @@ create table {schema}.on_run_hook (
     target_pass      TEXT,
     target_threads   INTEGER,
     run_started_at   TEXT,
-    invocation_id    TEXT
+    invocation_id    TEXT,
+    thread_id        TEXT,
 );

--- a/tests/adapter/dbt/tests/adapter/hooks/data/seed_run.sql
+++ b/tests/adapter/dbt/tests/adapter/hooks/data/seed_run.sql
@@ -13,5 +13,5 @@ create table {schema}.on_run_hook (
     target_threads   INTEGER,
     run_started_at   TEXT,
     invocation_id    TEXT,
-    thread_id        TEXT,
+    thread_id        TEXT
 );

--- a/tests/adapter/dbt/tests/adapter/hooks/fixtures.py
+++ b/tests/adapter/dbt/tests/adapter/hooks/fixtures.py
@@ -40,7 +40,8 @@ macros__before_and_after = """
         target_pass,
         target_threads,
         run_started_at,
-        invocation_id
+        invocation_id,
+        thread_id
    ) VALUES (
     '{{ state }}',
     '{{ target.dbname }}',
@@ -52,7 +53,8 @@ macros__before_and_after = """
     '{{ target.get("pass", "") }}',
     {{ target.threads }},
     '{{ run_started_at }}',
-    '{{ invocation_id }}'
+    '{{ invocation_id }}',
+    '{{ thread_id }}'\
    )
 
 {% endmacro %}
@@ -83,7 +85,8 @@ models__hooks_configured = """
                 target_pass,\
                 target_threads,\
                 run_started_at,\
-                invocation_id
+                invocation_id,\
+                thread_id
             ) VALUES (\
                 'start',\
                 '{{ target.dbname }}',\
@@ -95,7 +98,8 @@ models__hooks_configured = """
                 '{{ target.get(\\"pass\\", \\"\\") }}',\
                 {{ target.threads }},\
                 '{{ run_started_at }}',\
-                '{{ invocation_id }}'\
+                '{{ invocation_id }}',\
+                '{{ thread_id }}'\
         )",
         "post-hook": "\
             insert into {{this.schema}}.on_model_hook (\
@@ -109,7 +113,9 @@ models__hooks_configured = """
                 target_pass,\
                 target_threads,\
                 run_started_at,\
-                invocation_id
+                invocation_id,\
+                thread_id
+
             ) VALUES (\
                 'end',\
                 '{{ target.dbname }}',\
@@ -121,7 +127,8 @@ models__hooks_configured = """
                 '{{ target.get(\\"pass\\", \\"\\") }}',\
                 {{ target.threads }},\
                 '{{ run_started_at }}',\
-                '{{ invocation_id }}'\
+                '{{ invocation_id }}',\
+                '{{ thread_id }}'\
             )"
     })
 }}
@@ -144,7 +151,8 @@ models__hooks_error = """
                 target_pass,\
                 target_threads,\
                 run_started_at,\
-                invocation_id
+                invocation_id,\
+                thread_id
             ) VALUES (\
                 'start',\
                 '{{ target.dbname }}',\
@@ -156,7 +164,8 @@ models__hooks_error = """
                 '{{ target.get(\\"pass\\", \\"\\") }}',\
                 {{ target.threads }},\
                 '{{ run_started_at }}',\
-                '{{ invocation_id }}'
+                '{{ invocation_id }}',\
+                '{{ thread_id }}'\
         )",
         "pre-hook": "\
             insert into {{this.schema}}.on_model_hook (\
@@ -170,7 +179,8 @@ models__hooks_error = """
                 target_pass,\
                 target_threads,\
                 run_started_at,\
-                invocation_id
+                invocation_id,\
+                thread_id
             ) VALUES (\
                 'start',\
                 '{{ target.dbname }}',\
@@ -182,7 +192,8 @@ models__hooks_error = """
                 '{{ target.get(\\"pass\\", \\"\\") }}',\
                 {{ target.threads }},\
                 '{{ run_started_at }}',\
-                '{{ invocation_id }}'
+                '{{ invocation_id }}',\
+                '{{ thread_id }}'\
         )",
         "post-hook": "\
             insert into {{this.schema}}.on_model_hook (\
@@ -196,7 +207,8 @@ models__hooks_error = """
                 target_pass,\
                 target_threads,\
                 run_started_at,\
-                invocation_id
+                invocation_id,\
+                thread_id
             ) VALUES (\
                 'end',\
                 '{{ target.dbname }}',\
@@ -208,7 +220,8 @@ models__hooks_error = """
                 '{{ target.get(\\"pass\\", \\"\\") }}',\
                 {{ target.threads }},\
                 '{{ run_started_at }}',\
-                '{{ invocation_id }}'\
+                '{{ invocation_id }}',\
+                '{{ thread_id }}'\
             )"
     })
 }}
@@ -231,7 +244,8 @@ models__hooks_kwargs = """
                 target_pass,\
                 target_threads,\
                 run_started_at,\
-                invocation_id
+                invocation_id,\
+                thread_id
             ) VALUES (\
                 'start',\
                 '{{ target.dbname }}',\
@@ -243,7 +257,8 @@ models__hooks_kwargs = """
                 '{{ target.get(\\"pass\\", \\"\\") }}',\
                 {{ target.threads }},\
                 '{{ run_started_at }}',\
-                '{{ invocation_id }}'\
+                '{{ invocation_id }}',\
+                '{{ thread_id }}'\
         )",
         post_hook="\
             insert into {{this.schema}}.on_model_hook (\
@@ -257,7 +272,8 @@ models__hooks_kwargs = """
                 target_pass,\
                 target_threads,\
                 run_started_at,\
-                invocation_id\
+                invocation_id,\
+                thread_id
             ) VALUES (\
                 'end',\
                 '{{ target.dbname }}',\
@@ -269,7 +285,8 @@ models__hooks_kwargs = """
                 '{{ target.get(\\"pass\\", \\"\\") }}',\
                 {{ target.threads }},\
                 '{{ run_started_at }}',\
-                '{{ invocation_id }}'\
+                '{{ invocation_id }}',\
+                '{{ thread_id }}'\
             )"
     )
 }}
@@ -292,7 +309,8 @@ models__hooked = """
                 '{{ target.get(\\"pass\\", \\"\\") }}' as target_pass,\
                 {{ target.threads }} as target_threads,\
                 '{{ run_started_at }}' as run_started_at,\
-                '{{ invocation_id }}' as invocation_id
+                '{{ invocation_id }}' as invocation_id,\
+                '{{ thread_id }}' as thread_id
                 from {{ ref('pre') }}\
                 "
     })

--- a/tests/adapter/dbt/tests/adapter/hooks/fixtures.py
+++ b/tests/adapter/dbt/tests/adapter/hooks/fixtures.py
@@ -54,7 +54,7 @@ macros__before_and_after = """
     {{ target.threads }},
     '{{ run_started_at }}',
     '{{ invocation_id }}',
-    '{{ thread_id }}'\
+    '{{ thread_id }}'
    )
 
 {% endmacro %}
@@ -165,7 +165,7 @@ models__hooks_error = """
                 {{ target.threads }},\
                 '{{ run_started_at }}',\
                 '{{ invocation_id }}',\
-                '{{ thread_id }}'\
+                '{{ thread_id }}'
         )",
         "pre-hook": "\
             insert into {{this.schema}}.on_model_hook (\
@@ -193,7 +193,7 @@ models__hooks_error = """
                 {{ target.threads }},\
                 '{{ run_started_at }}',\
                 '{{ invocation_id }}',\
-                '{{ thread_id }}'\
+                '{{ thread_id }}'
         )",
         "post-hook": "\
             insert into {{this.schema}}.on_model_hook (\
@@ -273,7 +273,7 @@ models__hooks_kwargs = """
                 target_threads,\
                 run_started_at,\
                 invocation_id,\
-                thread_id
+                thread_id\
             ) VALUES (\
                 'end',\
                 '{{ target.dbname }}',\

--- a/tests/adapter/dbt/tests/adapter/hooks/test_model_hooks.py
+++ b/tests/adapter/dbt/tests/adapter/hooks/test_model_hooks.py
@@ -35,7 +35,8 @@ MODEL_PRE_HOOK = """
         target_pass,
         target_threads,
         run_started_at,
-        invocation_id
+        invocation_id,
+        thread_id
    ) VALUES (
     'start',
     '{{ target.dbname }}',
@@ -47,7 +48,8 @@ MODEL_PRE_HOOK = """
     '{{ target.get("pass", "") }}',
     {{ target.threads }},
     '{{ run_started_at }}',
-    '{{ invocation_id }}'
+    '{{ invocation_id }}',
+    '{{ thread_id }}'
    )
 """
 
@@ -63,7 +65,8 @@ MODEL_POST_HOOK = """
         target_pass,
         target_threads,
         run_started_at,
-        invocation_id
+        invocation_id,
+        thread_id
    ) VALUES (
     'end',
     '{{ target.dbname }}',
@@ -75,7 +78,8 @@ MODEL_POST_HOOK = """
     '{{ target.get("pass", "") }}',
     {{ target.threads }},
     '{{ run_started_at }}',
-    '{{ invocation_id }}'
+    '{{ invocation_id }}',
+    '{{ thread_id }}'
    )
 """
 
@@ -98,6 +102,7 @@ class BaseTestPrePost(object):
             "target_pass",
             "run_started_at",
             "invocation_id",
+            "thread_id",
         ]
         field_list = ", ".join(['"{}"'.format(f) for f in fields])
         query = f"select {field_list} from {project.test_schema}.on_model_hook where test_state = '{state}'"
@@ -127,6 +132,7 @@ class BaseTestPrePost(object):
             assert (
                 ctx["invocation_id"] is not None and len(ctx["invocation_id"]) > 0
             ), "invocation_id was not set"
+            assert ctx["thread_id"].startswith("Thread-")
 
 
 class TestPrePostModelHooks(BaseTestPrePost):
@@ -204,7 +210,8 @@ class TestHookRefs(BaseTestPrePost):
                         '{{ target.get(pass, "") }}' as target_pass,
                         {{ target.threads }} as target_threads,
                         '{{ run_started_at }}' as run_started_at,
-                        '{{ invocation_id }}' as invocation_id
+                        '{{ invocation_id }}' as invocation_id,
+                        '{{ thread_id }}' as thread_id
                         from {{ ref('post') }}""".strip()
                         ],
                     }

--- a/tests/adapter/dbt/tests/adapter/hooks/test_run_hooks.py
+++ b/tests/adapter/dbt/tests/adapter/hooks/test_run_hooks.py
@@ -120,7 +120,7 @@ class TestPrePostRunHooks(object):
         assert (
             ctx["invocation_id"] is not None and len(ctx["invocation_id"]) > 0
         ), "invocation_id was not set"
-        assert ctx["thread_id"].startswith("Thread-")
+        assert ctx["thread_id"].startswith("Thread-") or ctx["thread_id"] == "MainThread"
 
     def test_pre_and_post_run_hooks(self, setUp, project, dbt_profile_target):
         run_dbt(["run"])

--- a/tests/adapter/dbt/tests/adapter/hooks/test_run_hooks.py
+++ b/tests/adapter/dbt/tests/adapter/hooks/test_run_hooks.py
@@ -77,6 +77,7 @@ class TestPrePostRunHooks(object):
             "target_pass",
             "run_started_at",
             "invocation_id",
+            "thread_id",
         ]
         field_list = ", ".join(['"{}"'.format(f) for f in fields])
         query = f"select {field_list} from {project.test_schema}.on_run_hook where test_state = '{state}'"
@@ -119,6 +120,7 @@ class TestPrePostRunHooks(object):
         assert (
             ctx["invocation_id"] is not None and len(ctx["invocation_id"]) > 0
         ), "invocation_id was not set"
+        assert ctx["thread_id"].startswith("Thread-")
 
     def test_pre_and_post_run_hooks(self, setUp, project, dbt_profile_target):
         run_dbt(["run"])

--- a/tests/functional/context_methods/test_env_vars.py
+++ b/tests/functional/context_methods/test_env_vars.py
@@ -34,6 +34,7 @@ select
     -- runtime variables
     '{{ run_started_at }}' as run_started_at,
     '{{ invocation_id }}'  as invocation_id,
+    '{{ thread_id }}'  as thread_id,
 
     '{{ env_var("DBT_TEST_ENV_VAR") }}' as env_var,
     '{{ env_var("DBT_TEST_IGNORE_DEFAULT", "ignored_default_val") }}' as env_var_ignore_default,
@@ -114,6 +115,7 @@ class TestEnvVars:
             "target.pass",
             "run_started_at",
             "invocation_id",
+            "thread_id",
             "env_var",
         ]
         field_list = ", ".join(['"{}"'.format(f) for f in fields])

--- a/tests/functional/context_methods/test_secret_env_vars.py
+++ b/tests/functional/context_methods/test_secret_env_vars.py
@@ -62,6 +62,7 @@ select
     -- runtime variables
     '{{ run_started_at }}' as run_started_at,
     '{{ invocation_id }}'  as invocation_id,
+    '{{ thread_id }}'  as thread_id,
 
     '{{ env_var("DBT_TEST_ENV_VAR") }}' as env_var,
     'secret_variable' as env_var_secret, -- make sure the value itself is scrubbed from the logs

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -182,6 +182,7 @@ REQUIRED_BASE_KEYS = frozenset(
         "log",
         "run_started_at",
         "invocation_id",
+        "thread_id",
         "modules",
         "flags",
         "print",


### PR DESCRIPTION
resolves #7941

### Description

Adds a `thread_id` context var. Motive is wanting to add a `thread_id` to a query tag with the Snowflake adapter.

Would ❤️ to get this into 1.6.0 if poss.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
