### PR TITLE
Backport #7647 to v1.5.x

### DIFF
--- a/.changes/unreleased/Fixes-20230516-152644.yaml
+++ b/.changes/unreleased/Fixes-20230516-152644.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add --target-path to more CLI subcommands
+time: 2023-05-16T15:26:44.557072-04:00
+custom:
+  Author: dwreeves
+  Issue: "7646"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -213,6 +213,7 @@ def build(ctx, **kwargs):
 @p.profiles_dir
 @p.project_dir
 @p.target
+@p.target_path
 @p.vars
 @requires.postflight
 @requires.preflight
@@ -283,6 +284,7 @@ def docs_generate(ctx, **kwargs):
 @p.profiles_dir
 @p.project_dir
 @p.target
+@p.target_path
 @p.vars
 @requires.postflight
 @requires.preflight
@@ -476,6 +478,7 @@ def init(ctx, **kwargs):
 @p.state
 @p.deprecated_state
 @p.target
+@p.target_path
 @p.vars
 @requires.postflight
 @requires.preflight
@@ -576,6 +579,7 @@ def run(ctx, **kwargs):
 @p.profiles_dir
 @p.project_dir
 @p.target
+@p.target_path
 @p.vars
 @requires.postflight
 @requires.preflight
@@ -690,6 +694,7 @@ def source(ctx, **kwargs):
 @p.state
 @p.deprecated_state
 @p.target
+@p.target_path
 @p.threads
 @p.vars
 @requires.postflight


### PR DESCRIPTION
resolves #7953

Backports #7647 to 1.5.latest (automated GHA didn't pick up the `backport 1.5.latest` for some reason)