### PR TITLE
Do not log traceback when log format is json

### DIFF
--- a/.changes/unreleased/Fixes-20230627-224355.yaml
+++ b/.changes/unreleased/Fixes-20230627-224355.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix producing non json log when log format is json
+time: 2023-06-27T22:43:55.071123-07:00
+custom:
+  Author: ChenyuLInx
+  Issue: "7972"

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -294,7 +294,7 @@ def fire_event(e: Event) -> None:
                     STDOUT_LOG,
                     level_tag=e.level_tag(),
                     log_line=log_line,
-                    exc_info=e.exc_info,
+                    exc_info=False if flags.LOG_FORMAT == "json" else e.exc_info,
                     stack_info=e.stack_info,
                     extra=e.extra,
                 )


### PR DESCRIPTION
resolves #7972
This is only for 1.3 and pre versions of dbt-core.

When calling `logger.debug` with `exc_info` set to True, logger will actually print out the formatted log to stdout(?). We want to avoid it when we set log_format to `JSON`

Will backport to 1.2 and 1.1 and 1.0 once this is merged.