### PR TITLE
CT-2707: Populate metric input measures

### DIFF
--- a/.changes/unreleased/Under the Hood-20230628-142006.yaml
+++ b/.changes/unreleased/Under the Hood-20230628-142006.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Populate metric input measures
+time: 2023-06-28T14:20:06.022738-07:00
+custom:
+  Author: QMalcolm
+  Issue: "7884"

--- a/tests/functional/metrics/fixtures.py
+++ b/tests/functional/metrics/fixtures.py
@@ -50,10 +50,8 @@ metrics:
     description: "The average tenure per person"
     type: ratio
     type_params:
-      numerator:
-        name: years_tenure
-      denominator:
-        name: people
+      numerator: collective_tenure
+      denominator: number_of_people
 
   - name: average_tenure_plus_one
     label: "Average tenure, plus 1"

--- a/tests/functional/metrics/fixtures.py
+++ b/tests/functional/metrics/fixtures.py
@@ -96,6 +96,24 @@ metrics:
         filter: "{{dimension('loves_dbt')}} is true"
       window: 14 days
 
+  - name: average_tenure
+    label: Average Tenure
+    description: The average tenure of our people
+    type: ratio
+    type_params:
+      numerator: collective_tenure
+      denominator: number_of_people
+
+  - name: average_tenure_minus_people
+    label: Average Tenure minus People
+    description: Well this isn't really useful is it?
+    type: derived
+    type_params:
+      expr: average_tenure - number_of_people
+      metrics:
+        - average_tenure
+        - number_of_people
+
 """
 
 invalid_models_people_metrics_yml = """

--- a/tests/functional/metrics/test_metric_configs.py
+++ b/tests/functional/metrics/test_metric_configs.py
@@ -122,11 +122,19 @@ class TestDisabledMetricRef(MetricConfigTests):
         assert "metric.test.number_of_people" in manifest.metrics
         assert "metric.test.collective_tenure" in manifest.metrics
         assert "model.test.people_metrics" in manifest.nodes
+        assert "metric.test.average_tenure" in manifest.metrics
+        assert "metric.test.average_tenure_minus_people" in manifest.metrics
 
         new_enabled_config = {
             "metrics": {
                 "test": {
                     "number_of_people": {
+                        "enabled": False,
+                    },
+                    "average_tenure_minus_people": {
+                        "enabled": False,
+                    },
+                    "average_tenure": {
                         "enabled": False,
                     },
                 }

--- a/tests/functional/metrics/test_metric_configs.py
+++ b/tests/functional/metrics/test_metric_configs.py
@@ -36,7 +36,7 @@ class TestMetricEnabledConfigProjectLevel(MetricConfigTests):
     def project_config_update(self):
         return {
             "metrics": {
-                "number_of_people": {
+                "average_tenure_minus_people": {
                     "enabled": True,
                 },
             }
@@ -45,12 +45,12 @@ class TestMetricEnabledConfigProjectLevel(MetricConfigTests):
     def test_enabled_metric_config_dbt_project(self, project):
         run_dbt(["parse"])
         manifest = get_manifest(project.project_root)
-        assert "metric.test.number_of_people" in manifest.metrics
+        assert "metric.test.average_tenure_minus_people" in manifest.metrics
 
         new_enabled_config = {
             "metrics": {
                 "test": {
-                    "number_of_people": {
+                    "average_tenure_minus_people": {
                         "enabled": False,
                     },
                 }
@@ -59,7 +59,7 @@ class TestMetricEnabledConfigProjectLevel(MetricConfigTests):
         update_config_file(new_enabled_config, project.project_root, "dbt_project.yml")
         run_dbt(["parse"])
         manifest = get_manifest(project.project_root)
-        assert "metric.test.number_of_people" not in manifest.metrics
+        assert "metric.test.average_tenure_minus_people" not in manifest.metrics
         assert "metric.test.collective_tenure" in manifest.metrics
 
 


### PR DESCRIPTION
resolves #7884 

### Description

We weren't populating `MetricNode.type_params.input_measures` and now we do! It was problematic that we weren't populating the `input_measures` because the semantic layer depends on this field to be populated in order to properly generate queries. Now we populate it, and life is good (tests included 🙂)!

### Demo

<a href="https://www.loom.com/share/1e6533198b944664a6083587bc3c8e9f">
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/1e6533198b944664a6083587bc3c8e9f-with-play.gif">
  </a>


### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
