### PR TITLE
type + fix typo in ModelNodeArgs.unique_id

### DIFF
--- a/.changes/unreleased/Fixes-20230629-120321.yaml
+++ b/.changes/unreleased/Fixes-20230629-120321.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix typo in ModelNodeArgs
+time: 2023-06-29T12:03:21.179283-04:00
+custom:
+  Author: michelleark
+  Issue: "7991"

--- a/core/dbt/contracts/graph/node_args.py
+++ b/core/dbt/contracts/graph/node_args.py
@@ -23,9 +23,9 @@ class ModelNodeArgs:
     enabled: bool = True
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         unique_id = f"{NodeType.Model}.{self.package_name}.{self.name}"
         if self.version:
-            unique_id = f"{unique_id}.{self.verison}"
+            unique_id = f"{unique_id}.{self.version}"
 
         return unique_id


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/7991

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
🤦 - mypy didn't initially detect this issue because the `unique_id` method signature was not typed.

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
