### PR TITLE
Remove pin of sqlparse, minor refactoring, add tests

### DIFF
--- a/.changes/unreleased/Fixes-20230621-185452.yaml
+++ b/.changes/unreleased/Fixes-20230621-185452.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove limitation on use of sqlparse 0.4.4
+time: 2023-06-21T18:54:52.246578-04:00
+custom:
+  Author: gshank
+  Issue: "7515"

--- a/core/setup.py
+++ b/core/setup.py
@@ -68,9 +68,8 @@ setup(
         "pathspec>=0.9,<0.12",
         "isodate>=0.6,<0.7",
         # ----
-        # There is a difficult-to-reproduce bug in sqlparse==0.4.4 for ephemeral model compilation
-        # For context: dbt-core#7396 + dbt-core#7515
-        "sqlparse>=0.2.3,<0.4.4",
+        # There was a pin to below 0.4.4 for a while due to a bug in Ubuntu/sqlparse 0.4.4
+        "sqlparse>=0.2.3",
         # ----
         # These are major-version-0 packages also maintained by dbt-labs. Accept patches.
         "dbt-extractor~=0.4.1",

--- a/tests/functional/compile/test_compile.py
+++ b/tests/functional/compile/test_compile.py
@@ -1,10 +1,11 @@
 import json
 import pathlib
 import pytest
+import re
 
 from dbt.cli.main import dbtRunner
 from dbt.exceptions import DbtRuntimeError, TargetNotFoundError
-from dbt.tests.util import run_dbt, run_dbt_and_capture
+from dbt.tests.util import run_dbt, run_dbt_and_capture, read_file
 from tests.functional.compile.fixtures import (
     first_model_sql,
     second_model_sql,
@@ -17,9 +18,13 @@ from tests.functional.compile.fixtures import (
 )
 
 
-def get_lines(model_name):
-    from dbt.tests.util import read_file
+def norm_whitespace(string):
+    _RE_COMBINE_WHITESPACE = re.compile(r"\s+")
+    string = _RE_COMBINE_WHITESPACE.sub(" ", string).strip()
+    return string
 
+
+def get_lines(model_name):
     f = read_file("target", "compiled", "test", "models", model_name + ".sql")
     return [line for line in f.splitlines() if line]
 
@@ -90,21 +95,22 @@ class TestEphemeralModels:
     def test_no_selector(self, project):
         run_dbt(["compile"])
 
-        assert get_lines("first_ephemeral_model") == ["select 1 as fun"]
-        assert get_lines("second_ephemeral_model") == [
-            "with __dbt__cte__first_ephemeral_model as (",
-            "select 1 as fun",
-            ")select * from __dbt__cte__first_ephemeral_model",
-        ]
-        assert get_lines("third_ephemeral_model") == [
-            "with __dbt__cte__first_ephemeral_model as (",
-            "select 1 as fun",
-            "),  __dbt__cte__second_ephemeral_model as (",
-            "select * from __dbt__cte__first_ephemeral_model",
-            ")select * from __dbt__cte__second_ephemeral_model",
-            "union all",
-            "select 2 as fun",
-        ]
+        sql = read_file("target", "compiled", "test", "models", "first_ephemeral_model.sql")
+        assert norm_whitespace(sql) == norm_whitespace("select 1 as fun")
+        sql = read_file("target", "compiled", "test", "models", "second_ephemeral_model.sql")
+        expected_sql = """with __dbt__cte__first_ephemeral_model as (
+            select 1 as fun
+            ) select * from __dbt__cte__first_ephemeral_model"""
+        assert norm_whitespace(sql) == norm_whitespace(expected_sql)
+        sql = read_file("target", "compiled", "test", "models", "third_ephemeral_model.sql")
+        expected_sql = """with __dbt__cte__first_ephemeral_model as (
+            select 1 as fun
+            ),  __dbt__cte__second_ephemeral_model as (
+            select * from __dbt__cte__first_ephemeral_model
+            ) select * from __dbt__cte__second_ephemeral_model
+            union all
+            select 2 as fun"""
+        assert norm_whitespace(sql) == norm_whitespace(expected_sql)
 
     def test_with_recursive_cte(self, project):
         run_dbt(["compile"])
@@ -112,7 +118,7 @@ class TestEphemeralModels:
         assert get_lines("with_recursive_model") == [
             "with recursive  __dbt__cte__first_ephemeral_model as (",
             "select 1 as fun",
-            "),t(n) as (",
+            "), t(n) as (",
             "    select * from __dbt__cte__first_ephemeral_model",
             "  union all",
             "    select n+1 from t where n < 100",

--- a/tests/unit/test_inject_ctes.py
+++ b/tests/unit/test_inject_ctes.py
@@ -1,0 +1,197 @@
+from dbt.compilation import inject_ctes_into_sql
+from dbt.contracts.graph.nodes import InjectedCTE
+import re
+
+
+def norm_whitespace(string):
+    _RE_COMBINE_WHITESPACE = re.compile(r"\s+")
+    string = _RE_COMBINE_WHITESPACE.sub(" ", string).strip()
+    return string
+
+
+def test_inject_ctes_simple1():
+    starting_sql = "select * from __dbt__cte__base"
+    ctes = [
+        InjectedCTE(
+            id="model.test.base",
+            sql=" __dbt__cte__base as (\n\n\nselect * from test16873767336887004702_test_ephemeral.seed\n)",
+        )
+    ]
+    expected_sql = """with __dbt__cte__base as (
+        select * from test16873767336887004702_test_ephemeral.seed
+        ) select * from __dbt__cte__base"""
+
+    generated_sql = inject_ctes_into_sql(starting_sql, ctes)
+    assert norm_whitespace(generated_sql) == norm_whitespace(expected_sql)
+
+
+def test_inject_ctes_simple2():
+    starting_sql = "select * from __dbt__cte__ephemeral_level_two"
+    ctes = [
+        InjectedCTE(
+            id="model.test.ephemeral_level_two",
+            sql=' __dbt__cte__ephemeral_level_two as (\n\nselect * from "dbt"."test16873757769710148165_test_ephemeral"."source_table"\n)',
+        )
+    ]
+    expected_sql = """with __dbt__cte__ephemeral_level_two as (
+        select * from "dbt"."test16873757769710148165_test_ephemeral"."source_table"
+        ) select * from __dbt__cte__ephemeral_level_two"""
+
+    generated_sql = inject_ctes_into_sql(starting_sql, ctes)
+    assert norm_whitespace(generated_sql) == norm_whitespace(expected_sql)
+
+
+def test_inject_ctes_multiple_ctes():
+
+    starting_sql = "select * from __dbt__cte__ephemeral"
+    ctes = [
+        InjectedCTE(
+            id="model.test.ephemeral_level_two",
+            sql=' __dbt__cte__ephemeral_level_two as (\n\nselect * from "dbt"."test16873735573223965828_test_ephemeral"."source_table"\n)',
+        ),
+        InjectedCTE(
+            id="model.test.ephemeral",
+            sql=" __dbt__cte__ephemeral as (\n\nselect * from __dbt__cte__ephemeral_level_two\n)",
+        ),
+    ]
+    expected_sql = """with __dbt__cte__ephemeral_level_two as (
+            select * from "dbt"."test16873735573223965828_test_ephemeral"."source_table"
+        ),  __dbt__cte__ephemeral as (
+            select * from __dbt__cte__ephemeral_level_two
+        ) select * from __dbt__cte__ephemeral"""
+
+    generated_sql = inject_ctes_into_sql(starting_sql, ctes)
+    assert norm_whitespace(generated_sql) == norm_whitespace(expected_sql)
+
+
+def test_inject_ctes_multiple_ctes_more_complex():
+    starting_sql = """select * from __dbt__cte__female_only
+        union all
+        select * from "dbt"."test16873757723266827902_test_ephemeral"."double_dependent" where gender = 'Male'"""
+    ctes = [
+        InjectedCTE(
+            id="model.test.base",
+            sql=" __dbt__cte__base as (\n\n\nselect * from test16873757723266827902_test_ephemeral.seed\n)",
+        ),
+        InjectedCTE(
+            id="model.test.base_copy",
+            sql=" __dbt__cte__base_copy as (\n\n\nselect * from __dbt__cte__base\n)",
+        ),
+        InjectedCTE(
+            id="model.test.female_only",
+            sql=" __dbt__cte__female_only as (\n\n\nselect * from __dbt__cte__base_copy where gender = 'Female'\n)",
+        ),
+    ]
+    expected_sql = """with __dbt__cte__base as (
+            select * from test16873757723266827902_test_ephemeral.seed
+        ),  __dbt__cte__base_copy as (
+            select * from __dbt__cte__base
+        ),  __dbt__cte__female_only as (
+            select * from __dbt__cte__base_copy where gender = 'Female'
+        ) select * from __dbt__cte__female_only
+        union all
+        select * from "dbt"."test16873757723266827902_test_ephemeral"."double_dependent" where gender = 'Male'"""
+
+    generated_sql = inject_ctes_into_sql(starting_sql, ctes)
+    assert norm_whitespace(generated_sql) == norm_whitespace(expected_sql)
+
+
+def test_inject_ctes_starting_with1():
+    starting_sql = """
+       with internal_cte as (select * from sessions)
+       select * from internal_cte
+    """
+    ctes = [
+        InjectedCTE(
+            id="cte_id_1",
+            sql="__dbt__cte__ephemeral as (select * from table)",
+        ),
+        InjectedCTE(
+            id="cte_id_2",
+            sql="__dbt__cte__events as (select id, type from events)",
+        ),
+    ]
+    expected_sql = """with __dbt__cte__ephemeral as (select * from table),
+       __dbt__cte__events as (select id, type from events),
+       internal_cte as (select * from sessions)
+       select * from internal_cte"""
+
+    generated_sql = inject_ctes_into_sql(starting_sql, ctes)
+    assert norm_whitespace(generated_sql) == norm_whitespace(expected_sql)
+
+
+def test_inject_ctes_starting_with2():
+    starting_sql = """with my_other_cool_cte as (
+        select id, name from __dbt__cte__ephemeral
+        where id > 1000
+    )
+    select name, id from my_other_cool_cte"""
+    ctes = [
+        InjectedCTE(
+            id="model.singular_tests_ephemeral.ephemeral",
+            sql=' __dbt__cte__ephemeral as (\n\n\nwith my_cool_cte as (\n  select name, id from "dbt"."test16873917221900185954_test_singular_tests_ephemeral"."base"\n)\nselect id, name from my_cool_cte where id is not null\n)',
+        )
+    ]
+    expected_sql = """with  __dbt__cte__ephemeral as (
+        with my_cool_cte as (
+          select name, id from "dbt"."test16873917221900185954_test_singular_tests_ephemeral"."base"
+        )
+        select id, name from my_cool_cte where id is not null
+        ), my_other_cool_cte as (
+            select id, name from __dbt__cte__ephemeral
+            where id > 1000
+        )
+        select name, id from my_other_cool_cte"""
+
+    generated_sql = inject_ctes_into_sql(starting_sql, ctes)
+    assert norm_whitespace(generated_sql) == norm_whitespace(expected_sql)
+
+
+def test_inject_ctes_comment_with():
+    # Test injection with a comment containing "with"
+    starting_sql = """
+        --- This is sql with a comment
+        select * from __dbt__cte__base
+    """
+    ctes = [
+        InjectedCTE(
+            id="model.test.base",
+            sql=" __dbt__cte__base as (\n\n\nselect * from test16873767336887004702_test_ephemeral.seed\n)",
+        )
+    ]
+    expected_sql = """with __dbt__cte__base as (
+        select * from test16873767336887004702_test_ephemeral.seed
+        ) --- This is sql with a comment
+        select * from __dbt__cte__base"""
+
+    generated_sql = inject_ctes_into_sql(starting_sql, ctes)
+    assert norm_whitespace(generated_sql) == norm_whitespace(expected_sql)
+
+
+def test_inject_ctes_with_recursive():
+    # Test injection with "recursive" keyword
+    starting_sql = """
+        with recursive t(n) as (
+            select * from __dbt__cte__first_ephemeral_model
+          union all
+            select n+1 from t where n < 100
+        )
+        select sum(n) from t
+    """
+    ctes = [
+        InjectedCTE(
+            id="model.test.first_ephemeral_model",
+            sql=" __dbt__cte__first_ephemeral_model as (\n\nselect 1 as fun\n)",
+        )
+    ]
+    expected_sql = """with recursive  __dbt__cte__first_ephemeral_model as (
+        select 1 as fun
+        ), t(n) as (
+            select * from __dbt__cte__first_ephemeral_model
+          union all
+            select n+1 from t where n < 100
+        )
+        select sum(n) from t
+    """
+    generated_sql = inject_ctes_into_sql(starting_sql, ctes)
+    assert norm_whitespace(generated_sql) == norm_whitespace(expected_sql)


### PR DESCRIPTION
resolves #7515


### Description

At one point we were getting failures from a combination of Ubuntu and sqlparse 0.4.4. That looks like it was probably an issue with Ubuntu and is no longer happening, so we're removing the pin to below sqlparse 0.4.4.

In addition the "inject_ctes_into_sql" method has been made a separate function for testability, and additional tests and comments have been added.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
