### PR TITLE
Add time spine table configuration to semantic manifest

### DIFF
--- a/.changes/unreleased/Features-20230629-172524.yaml
+++ b/.changes/unreleased/Features-20230629-172524.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Store time_spline table configuration in semantic manifest
+time: 2023-06-29T17:25:24.265366-04:00
+custom:
+  Author: gshank
+  Issue: "7938"

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -50,6 +50,7 @@ from dbt.exceptions import (
     DuplicateMacroInPackageError,
     DuplicateMaterializationNameError,
     AmbiguousResourceNameRefError,
+    ParsingError,
 )
 from dbt.helper_types import PathSet
 from dbt.events.functions import fire_event
@@ -62,6 +63,13 @@ import dbt.utils
 from dbt_semantic_interfaces.implementations.metric import PydanticMetric
 from dbt_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
+from dbt_semantic_interfaces.implementations.project_configuration import (
+    PydanticProjectConfiguration,
+)
+from dbt_semantic_interfaces.implementations.time_spine_table_configuration import (
+    PydanticTimeSpineTableConfiguration,
+)
+from dbt_semantic_interfaces.type_enums import TimeGranularity
 
 NodeEdgeMap = Dict[str, List[str]]
 PackageName = str
@@ -982,7 +990,12 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
 
     @property
     def pydantic_semantic_manifest(self) -> PydanticSemanticManifest:
-        pydantic_semantic_manifest = PydanticSemanticManifest(metrics=[], semantic_models=[])
+        project_config = PydanticProjectConfiguration(
+            time_spine_table_configurations=[],
+        )
+        pydantic_semantic_manifest = PydanticSemanticManifest(
+            metrics=[], semantic_models=[], project_configuration=project_config
+        )
 
         for semantic_model in self.semantic_models.values():
             pydantic_semantic_manifest.semantic_models.append(
@@ -991,6 +1004,25 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
 
         for metric in self.metrics.values():
             pydantic_semantic_manifest.metrics.append(PydanticMetric.parse_obj(metric.to_dict()))
+
+        # Look for time-spine table model and create time spine table configuration
+        if self.semantic_models:
+            # Get model for time_spine_table
+            time_spine_model_name = "metricflow_time_spine"
+            model = self.ref_lookup.find(time_spine_model_name, None, None, self)
+            if not model:
+                raise ParsingError(
+                    "Semantic models require a 'metricflow_time_spine' model. See Metricflow docs."
+                )
+            # Create time_spine_table_config, set it in project_config, and add to semantic manifest
+            time_spine_table_config = PydanticTimeSpineTableConfiguration(
+                location=model.relation_name,
+                column_name="date_day",
+                grain=TimeGranularity.DAY,
+            )
+            pydantic_semantic_manifest.project_configuration.time_spine_table_configurations = [
+                time_spine_table_config
+            ]
 
         return pydantic_semantic_manifest
 

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1012,7 +1012,7 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
             model = self.ref_lookup.find(time_spine_model_name, None, None, self)
             if not model:
                 raise ParsingError(
-                    "Semantic models require a 'metricflow_time_spine' model. See Metricflow docs."
+                    "The semantic layer requires a 'metricflow_time_spine' model in the project, but none was found. Guidance on creating this model can be found on our docs site (https://docs.getdbt.com/docs/build/metricflow-time-spine)"
                 )
             # Create time_spine_table_config, set it in project_config, and add to semantic manifest
             time_spine_table_config = PydanticTimeSpineTableConfiguration(

--- a/core/setup.py
+++ b/core/setup.py
@@ -78,7 +78,7 @@ setup(
         "minimal-snowplow-tracker~=0.0.2",
         # DSI is under active development, so we're pinning to specific dev versions for now.
         # TODO: Before RC/final release, update to use ~= pinning.
-        "dbt-semantic-interfaces==0.1.0.dev7",
+        "dbt-semantic-interfaces==0.1.0.dev8",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
         "packaging>20.9",

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -130,7 +130,6 @@ class TestSemanticModelParsing:
         semantic_model = manifest.semantic_models["semantic_model.test.revenue"]
         assert semantic_model.dimensions[0].type_params.time_granularity == TimeGranularity.WEEK
 
-    @pytest.mark.skip(reason="Tracking in https://github.com/dbt-labs/dbt-core/issues/7977")
     def test_semantic_model_deleted_partial_parsing(self, project):
         # First, use the default schema.yml to define our semantic model, and
         # run the dbt parse command


### PR DESCRIPTION
resolves #7938

### Description

If semantic_models exist, look for metricflow_time_spine model and store information in the semantic manifest. If semantic models exist and no time_spine model is found, throw an error.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
