### PR TITLE
[BACKPORT to 1.5.latest] Remove pin of sqlparse to below 0.4.4

### DIFF
--- a/.changes/unreleased/Fixes-20230621-185452.yaml
+++ b/.changes/unreleased/Fixes-20230621-185452.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove limitation on use of sqlparse 0.4.4
+time: 2023-06-21T18:54:52.246578-04:00
+custom:
+  Author: gshank
+  Issue: "7515"

--- a/core/setup.py
+++ b/core/setup.py
@@ -58,7 +58,7 @@ setup(
         "networkx>=2.3,<2.8.1;python_version<'3.8'",
         "networkx>=2.3,<3;python_version>='3.8'",
         "packaging>20.9",
-        "sqlparse>=0.2.3,<0.4.4",
+        "sqlparse>=0.2.3",
         "dbt-extractor~=0.4.1",
         "typing-extensions>=3.7.4",
         "werkzeug>=1,<3",


### PR DESCRIPTION
Backport 7993 to 1.5.latest.

This just includes the change to core/setup.py, since the other changes in 7993 were commenting and tests and don't need to be backported.