### PR TITLE
partial parse file path

### DIFF
--- a/.changes/unreleased/Under the Hood-20230706-175507.yaml
+++ b/.changes/unreleased/Under the Hood-20230706-175507.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add option to specify partial parse file
+time: 2023-07-06T17:55:07.525287-07:00
+custom:
+  Author: ChenyuLInx
+  Issue: "7911"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -138,6 +138,7 @@ class dbtRunner:
 @p.log_path
 @p.macro_debugging
 @p.partial_parse
+@p.partial_parse_file_path
 @p.populate_cache
 @p.print
 @p.printer_width

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -239,6 +239,15 @@ partial_parse = click.option(
     default=True,
 )
 
+partial_parse_file_path = click.option(
+    "--partial-parse-file-path",
+    envvar="DBT_PARTIAL_PARSE_FILE_PATH",
+    help="Internal flag for path to partial_parse.manifest file.",
+    default=None,
+    hidden=True,
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+)
+
 populate_cache = click.option(
     "--populate-cache/--no-populate-cache",
     envvar="DBT_POPULATE_CACHE",

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -840,10 +840,13 @@ class ManifestLoader:
         return False
 
     def read_manifest_for_partial_parse(self) -> Optional[Manifest]:
-        if not get_flags().PARTIAL_PARSE:
+        flags = get_flags()
+        if not flags.PARTIAL_PARSE:
             fire_event(PartialParsingNotEnabled())
             return None
-        path = os.path.join(self.root_project.project_target_path, PARTIAL_PARSE_FILE_NAME)
+        path = flags.partial_parse_file_path or os.path.join(
+            self.root_project.project_target_path, PARTIAL_PARSE_FILE_NAME
+        )
 
         reparse_reason = None
 

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -844,7 +844,7 @@ class ManifestLoader:
         if not flags.PARTIAL_PARSE:
             fire_event(PartialParsingNotEnabled())
             return None
-        path = flags.partial_parse_file_path or os.path.join(
+        path = flags.PARTIAL_PARSE_FILE_PATH or os.path.join(
             self.root_project.project_target_path, PARTIAL_PARSE_FILE_NAME
         )
 

--- a/tests/unit/test_parse_manifest.py
+++ b/tests/unit/test_parse_manifest.py
@@ -108,14 +108,16 @@ class TestLoader(unittest.TestCase):
 class TestPartialParse(unittest.TestCase):
     @patch("dbt.parser.manifest.ManifestLoader.build_manifest_state_check")
     @patch("dbt.parser.manifest.os.path.exists")
-    def test_partial_parse_file_path(self, patched_os_exist, patched_state_check):
+    @patch("dbt.parser.manifest.open")
+    def test_partial_parse_file_path(self, patched_open, patched_os_exist, patched_state_check):
         mock_project = MagicMock(RuntimeConfig)
         mock_project.project_target_path = "mock_target_path"
+        patched_os_exist.return_value = True
         set_from_args(Namespace(), {})
         ManifestLoader(mock_project, {})
         # by default we use the project_target_path
-        patched_os_exist.assert_called_with("mock_target_path/partial_parse.msgpack")
+        patched_open.assert_called_with("mock_target_path/partial_parse.msgpack", "rb")
         set_from_args(Namespace(partial_parse_file_path="specified_partial_parse_path"), {})
         ManifestLoader(mock_project, {})
         # if specified in flags, we use the specified path
-        patched_os_exist.assert_called_with("specified_partial_parse_path")
+        patched_open.assert_called_with("specified_partial_parse_path", "rb")

--- a/tests/unit/test_parse_manifest.py
+++ b/tests/unit/test_parse_manifest.py
@@ -1,12 +1,16 @@
 import unittest
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+from argparse import Namespace
 
 from .utils import config_from_parts_or_dicts, normalize
 
 from dbt.contracts.files import SourceFile, FileHash, FilePath
 from dbt.contracts.graph.manifest import Manifest, ManifestStateCheck
 from dbt.parser import manifest
+from dbt.parser.manifest import ManifestLoader
+from dbt.config import RuntimeConfig
+from dbt.flags import set_from_args
 
 
 class MatchingHash(FileHash):
@@ -99,3 +103,19 @@ class TestLoader(unittest.TestCase):
             project_root=normalize(self.root_project_config.project_root),
         )
         return SourceFile(path=path, checksum=checksum)
+
+
+class TestPartialParse(unittest.TestCase):
+    @patch("dbt.parser.manifest.ManifestLoader.build_manifest_state_check")
+    @patch("dbt.parser.manifest.os.path.exists")
+    def test_partial_parse_file_path(self, patched_os_exist, patched_state_check):
+        mock_project = MagicMock(RuntimeConfig)
+        mock_project.project_target_path = "mock_target_path"
+        set_from_args(Namespace(), {})
+        ManifestLoader(mock_project, {})
+        # by default we use the project_target_path
+        patched_os_exist.assert_called_with("mock_target_path/partial_parse.msgpack")
+        set_from_args(Namespace(partial_parse_file_path="specified_partial_parse_path"), {})
+        ManifestLoader(mock_project, {})
+        # if specified in flags, we use the specified path
+        patched_os_exist.assert_called_with("specified_partial_parse_path")


### PR DESCRIPTION
resolves #7911

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
This adds the ability to specify a env var,  cli args(hidden), kwargs in dbtRunner to specify a path file to partial parse file.

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
