### PR TITLE
[DO NOT MERGE] Cleanup main after cutting new emily.test branch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.0b8
+current_version = 1.7.0a1
 parse = (?P<major>[\d]+) # major version number
 	\.(?P<minor>[\d]+) # minor version number
 	\.(?P<patch>[\d]+) # patch version number
@@ -10,7 +10,7 @@ parse = (?P<major>[\d]+) # major version number
 	( # optional nightly release indicator
 	\.(?P<nightly>dev[0-9]+) # ex: .dev02142023
 	)? # expected matches: `1.15.0`, `1.5.0a11`, `1.5.0a1.dev123`, `1.5.0.dev123457`, expected failures: `1`, `1.5`, `1.5.2-a1`, `text1.5.0`
-serialize =
+serialize = 
 	{major}.{minor}.{patch}{prekind}{num}.{nightly}
 	{major}.{minor}.{patch}.{nightly}
 	{major}.{minor}.{patch}{prekind}{num}
@@ -21,7 +21,7 @@ tag = False
 [bumpversion:part:prekind]
 first_value = a
 optional_value = final
-values =
+values = 
 	a
 	b
 	rc

--- a/.changes/unreleased/Docs-20230702-130158.yaml
+++ b/.changes/unreleased/Docs-20230702-130158.yaml
@@ -1,6 +1,0 @@
-kind: Docs
-body: Fix broken links in `CONTRIBUTING.md`.
-time: 2023-07-02T13:01:58.622569-04:00
-custom:
-  Author: gem7318
-  Issue: "8018"

--- a/.changes/unreleased/Fixes-20230628-144125.yaml
+++ b/.changes/unreleased/Fixes-20230628-144125.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Inline query emit proper error message
-time: 2023-06-28T14:41:25.699046-07:00
-custom:
-  Author: ChenyuLInx
-  Issue: "7940"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@
 - [@trouze](https://github.com/trouze) ([#7564](https://github.com/dbt-labs/dbt-core/issues/7564))
 - [@willbryant](https://github.com/willbryant) ([#7350](https://github.com/dbt-labs/dbt-core/issues/7350))
 
-
 ## dbt-core 1.6.0-b7 - June 28, 2023
 
 ### Features
@@ -282,3 +281,4 @@ For information on prior major and minor releases, see their changelogs:
 * [0.13](https://github.com/dbt-labs/dbt-core/blob/0.13.latest/CHANGELOG.md)
 * [0.12](https://github.com/dbt-labs/dbt-core/blob/0.12.latest/CHANGELOG.md)
 * [0.11 and earlier](https://github.com/dbt-labs/dbt-core/blob/0.11.latest/CHANGELOG.md)
+

--- a/core/dbt/version.py
+++ b/core/dbt/version.py
@@ -232,5 +232,5 @@ def _get_adapter_plugin_names() -> Iterator[str]:
             yield plugin_name
 
 
-__version__ = "1.6.0b8"
+__version__ = "1.7.0a1"
 installed = get_installed_version()

--- a/core/setup.py
+++ b/core/setup.py
@@ -25,7 +25,7 @@ with open(os.path.join(this_directory, "README.md")) as f:
 
 
 package_name = "dbt-core"
-package_version = "1.6.0b8"
+package_version = "1.7.0a1"
 description = """With dbt, data analysts and engineers can build analytics \
 the way engineers build applications."""
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,12 +14,12 @@ FROM --platform=$build_for python:3.11.2-slim-bullseye as base
 # N.B. The refs updated automagically every release via bumpversion
 # N.B. dbt-postgres is currently found in the core codebase so a value of dbt-core@<some_version> is correct
 
-ARG dbt_core_ref=dbt-core@v1.6.0b8
-ARG dbt_postgres_ref=dbt-core@v1.6.0b8
-ARG dbt_redshift_ref=dbt-redshift@v1.6.0b8
-ARG dbt_bigquery_ref=dbt-bigquery@v1.6.0b8
-ARG dbt_snowflake_ref=dbt-snowflake@v1.6.0b8
-ARG dbt_spark_ref=dbt-spark@v1.6.0b8
+ARG dbt_core_ref=dbt-core@v1.7.0a1
+ARG dbt_postgres_ref=dbt-core@v1.7.0a1
+ARG dbt_redshift_ref=dbt-redshift@v1.7.0a1
+ARG dbt_bigquery_ref=dbt-bigquery@v1.7.0a1
+ARG dbt_snowflake_ref=dbt-snowflake@v1.7.0a1
+ARG dbt_spark_ref=dbt-spark@v1.7.0a1
 # special case args
 ARG dbt_spark_version=all
 ARG dbt_third_party

--- a/plugins/postgres/dbt/adapters/postgres/__version__.py
+++ b/plugins/postgres/dbt/adapters/postgres/__version__.py
@@ -1,1 +1,1 @@
-version = "1.6.0b8"
+version = "1.7.0a1"

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -41,7 +41,7 @@ def _dbt_psycopg2_name():
 
 
 package_name = "dbt-postgres"
-package_version = "1.6.0b8"
+package_version = "1.7.0a1"
 description = """The postgres adapter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/tests/adapter/dbt/tests/adapter/__version__.py
+++ b/tests/adapter/dbt/tests/adapter/__version__.py
@@ -1,1 +1,1 @@
-version = "1.6.0b8"
+version = "1.7.0a1"

--- a/tests/adapter/setup.py
+++ b/tests/adapter/setup.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 package_name = "dbt-tests-adapter"
-package_version = "1.6.0b8"
+package_version = "1.7.0a1"
 description = """The dbt adapter tests for adapter plugins"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
All adapter PRs will fail CI until the dbt-core PR has been merged due to release version conflicts. The workflow that generated this PR also created a new branch: emily.test