### PR TITLE
[BACKPORT to 1.5.latest] pin click (#8050)

### DIFF
--- a/.changes/unreleased/Dependencies-20230707-104052.yaml
+++ b/.changes/unreleased/Dependencies-20230707-104052.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Pin click>=7.0,<8.1.4
+time: 2023-07-07T10:40:52.565603-05:00
+custom:
+  Author: emmyoop
+  PR: "8050"

--- a/core/setup.py
+++ b/core/setup.py
@@ -48,7 +48,8 @@ setup(
     install_requires=[
         "Jinja2==3.1.2",
         "agate>=1.6,<1.7.1",
-        "click>=7.0,<9",
+        # temporarily pinning click for mypy failures: https://github.com/pallets/click/issues/2558
+        "click>=7.0,<8.1.4",
         "colorama>=0.3.9,<0.4.7",
         "hologram>=0.0.14,<=0.0.16",
         "isodate>=0.6,<0.7",


### PR DESCRIPTION
resolves #8050 

### Description

Pin click click>=7.0,<8.1.4

This backport differs from main to reduce risk of anyone depending on a version of click~=7 since it's a previous version

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
