### PR TITLE
Eliminate the NodeRelation class in favor of reusing DeferRelation

### DIFF
--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -97,7 +97,7 @@ from dbt.contracts.graph.nodes import (
     ManifestNode,
     ResultNode,
     ModelNode,
-    NodeRelation,
+    DeferRelation,
 )
 from dbt.contracts.graph.unparsed import NodeVersion
 from dbt.contracts.util import Writable
@@ -1094,10 +1094,10 @@ class ManifestLoader:
         # might have alias/schema/database fields that are updated by yaml config.
         if semantic_model.depends_on_nodes[0]:
             refd_node = self.manifest.nodes[semantic_model.depends_on_nodes[0]]
-            semantic_model.node_relation = NodeRelation(
+            semantic_model.node_relation = DeferRelation(
                 relation_name=refd_node.relation_name,
                 alias=refd_node.alias,
-                schema_name=refd_node.schema,
+                schema=refd_node.schema,
                 database=refd_node.database,
             )
 

--- a/schemas/dbt/manifest/v10.json
+++ b/schemas/dbt/manifest/v10.json
@@ -5156,7 +5156,7 @@
         "node_relation": {
           "oneOf": [
             {
-              "$ref": "#/definitions/NodeRelation"
+              "$ref": "#/definitions/DeferRelation"
             },
             {
               "type": "null"
@@ -5216,19 +5216,19 @@
         }
       },
       "additionalProperties": false,
-      "description": "SemanticModel(name: str, resource_type: dbt.node_types.NodeType, package_name: str, path: str, original_file_path: str, unique_id: str, fqn: List[str], model: str, node_relation: Union[dbt.contracts.graph.nodes.NodeRelation, NoneType], description: Union[str, NoneType] = None, defaults: Union[dbt.contracts.graph.semantic_models.Defaults, NoneType] = None, entities: Sequence[dbt.contracts.graph.semantic_models.Entity] = <factory>, measures: Sequence[dbt.contracts.graph.semantic_models.Measure] = <factory>, dimensions: Sequence[dbt.contracts.graph.semantic_models.Dimension] = <factory>, metadata: Union[dbt.contracts.graph.semantic_models.SourceFileMetadata, NoneType] = None)"
+      "description": "SemanticModel(name: str, resource_type: dbt.node_types.NodeType, package_name: str, path: str, original_file_path: str, unique_id: str, fqn: List[str], model: str, node_relation: Union[dbt.contracts.graph.nodes.DeferRelation, NoneType], description: Union[str, NoneType] = None, defaults: Union[dbt.contracts.graph.semantic_models.Defaults, NoneType] = None, entities: Sequence[dbt.contracts.graph.semantic_models.Entity] = <factory>, measures: Sequence[dbt.contracts.graph.semantic_models.Measure] = <factory>, dimensions: Sequence[dbt.contracts.graph.semantic_models.Dimension] = <factory>, metadata: Union[dbt.contracts.graph.semantic_models.SourceFileMetadata, NoneType] = None)"
     },
-    "NodeRelation": {
+    "DeferRelation": {
       "type": "object",
       "required": [
         "alias",
-        "schema_name"
+        "schema"
       ],
       "properties": {
         "alias": {
           "type": "string"
         },
-        "schema_name": {
+        "schema": {
           "type": "string"
         },
         "database": {
@@ -5243,7 +5243,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "NodeRelation(alias: str, schema_name: str, database: Union[str, NoneType] = None)"
+      "description": "DeferRelation(alias: str, schema: str, database: Union[str, NoneType] = None)"
     },
     "Defaults": {
       "type": "object",


### PR DESCRIPTION
resolves #7823

### Problem

Changes the name of a field expected by MetricFlow from `schema_name` to `schema` in order to keep plumbing as simple as possible.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
