### PR TITLE
Remove `create_metric` as a public facing `SemanticModel.Measure` property

### DIFF
--- a/.changes/unreleased/Fixes-20230711-083213.yaml
+++ b/.changes/unreleased/Fixes-20230711-083213.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Remove `create_metric` as a `SemanticModel.Measure` property because it currently
+  doesn't do anything
+time: 2023-07-11T08:32:13.158779-07:00
+custom:
+  Author: QMalcolm
+  Issue: "8064"

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -697,7 +697,6 @@ class UnparsedMeasure(dbtClassMixin):
     name: str
     agg: str  # actually an enum
     description: Optional[str] = None
-    create_metric: bool = False
     expr: Optional[Union[str, bool, int]] = None
     agg_params: Optional[MeasureAggregationParameters] = None
     non_additive_dimension: Optional[UnparsedNonAdditiveDimension] = None

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -499,7 +499,6 @@ class SemanticModelParser(YamlReader):
                     name=unparsed.name,
                     agg=AggregationType(unparsed.agg),
                     description=unparsed.description,
-                    create_metric=unparsed.create_metric,
                     expr=str(unparsed.expr) if unparsed.expr is not None else None,
                     agg_params=unparsed.agg_params,
                     non_additive_dimension=self._get_non_additive_dimension(


### PR DESCRIPTION
resolves #8064

### Description

We do want to have the `create_metric` property because it is incredibly useful when hooked up (reduces a fair mount of YAML that people have to write for the semantic layer). However, at this time it is not hooked up, and we don't have time to hook it up before the code freeze for 1.6.0rc of core. As it doesn't do anything at this time, we shouldn't allow people to specify it, because it won't do what one would expect. We plan on making the implementation of `create_metric` a priority for 1.7 of core.

The eventual support of `create_metric` is tracked by #7504

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
