### PR TITLE
Remove volume declaration

### DIFF
--- a/.changes/unreleased/Fixes-20230711-141432.yaml
+++ b/.changes/unreleased/Fixes-20230711-141432.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove `VOLUME` declaration within Dockerfile
+time: 2023-07-11T14:14:32.117718-06:00
+custom:
+  Author: alexrosenfeld10
+  Issue: "4784"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,6 @@ RUN python -m pip install --upgrade pip setuptools wheel --no-cache-dir
 
 # Set docker basics
 WORKDIR /usr/app/dbt/
-VOLUME /usr/app
 ENTRYPOINT ["dbt"]
 
 ##


### PR DESCRIPTION
resolves #4784

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

Immutable deploys are super important so you know exactly what you're getting every time you ship code, and running `dbt deps` should persist the generated `dbt_packages` in the final resulting image.  This means the deps are bundled in the image at build time. That way if anything is down (like the servers where the dbt dependencies are hosted), the image still has everything it needs inside it to start up.

Currently, running `dbt deps` inside a Dockerfile has no effect on the final resulting image. This is because any files created in a docker `VOLUME` as a result of a `RUN` command during the build process aren't allowed to persist. Furthermore, it is not possible to override a `VOLUME` directive after one has been set.

### Solution

The main pain point is the `VOLUME directive`, and this PR simply removes it.

Removing it should be relatively straight-forward for existing users, and there should be few affected by removing this directive. Specifying the `--volume` flag to a container runtime (e.g. `docker run --volume /opt/dbt:/usr/app`) is always allowed and will create a volume binding even though no `VOLUME` directive is set in the Dockerfile. So, if the `VOLUME` directive is not already been set in the Dockerfile, mounting dbt sources from an external source should work just fine.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
