### PR TITLE
Use Ubuntu 22.04.2 LTS (Jammy Jellyfish) since it is a long-term supported release

### DIFF
--- a/.changes/unreleased/Fixes-20230711-145311.yaml
+++ b/.changes/unreleased/Fixes-20230711-145311.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix Dockerfile.test
+time: 2023-07-11T14:53:11.454863-06:00
+custom:
+  Author: dbeatty10
+  Issue: "7352"

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -3,13 +3,13 @@
 #  See `/docker` for a generic and production-ready docker file
 ##
 
-FROM ubuntu:23.10
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    software-properties-common \
+    software-properties-common gpg-agent \
     && add-apt-repository ppa:git-core/ppa -y \
     && apt-get dist-upgrade -y \
     && apt-get install -y --no-install-recommends \
@@ -30,8 +30,8 @@ RUN apt-get update \
     unixodbc-dev \
     && add-apt-repository ppa:deadsnakes/ppa \
     && apt-get install -y \
-    python \
-    python-dev \
+    python-is-python3 \
+    python-dev-is-python3 \
     python3-pip \
     python3.8 \
     python3.8-dev \


### PR DESCRIPTION
resolves #7352
docs: N/A

### Problem

See #7352

### Solution

This PR reverts to the LTS version of Ubuntu and ensures that the gpg-agent is installed.

### Manual testing

#### Before

```shell
docker-compose run --rm test tox -e py
```

<img width="1107" alt="image" src="https://github.com/dbt-labs/dbt-core/assets/44704949/95b0d169-6483-41c4-bcf0-09b784863989">


<details>
<summary>Log output:</summary>

```
$ docker-compose run --rm test tox -e py

[+] Running 1/0
 ⠿ Container dbt-core-database-1  Running                                                                                                               0.0s
[+] Building 129.1s (5/11)                                                                                                                                   
 => [internal] load build definition from Dockerfile.test                                                                                               0.0s
 => => transferring dockerfile: 2.21kB                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                       0.0s
 => => transferring context: 34B                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/ubuntu:23.10                                                                                         2.2s
 => [1/8] FROM docker.io/library/ubuntu:23.10@sha256:8abf9cea172b86fe77d65ef1abbdb186d06d1b44858efe09a16de7e2c43f645a                                  22.4s
 => => resolve docker.io/library/ubuntu:23.10@sha256:8abf9cea172b86fe77d65ef1abbdb186d06d1b44858efe09a16de7e2c43f645a                                   0.0s
 => => sha256:8abf9cea172b86fe77d65ef1abbdb186d06d1b44858efe09a16de7e2c43f645a 1.13kB / 1.13kB                                                          0.0s
 => => sha256:15ab070a0555d8274bb60513b343130b956ff0fed9288e5b7f3071c5ef434691 424B / 424B                                                              0.0s
 => => sha256:26bf20c5602e90cfbd38fe9170c4dd275dadd670b9eec3fe694e0672f53ab28d 2.31kB / 2.31kB                                                          0.0s
 => => sha256:837d8d26a53fc170f12f00f7943b0b3acd3a96dda6f6a60334b9ecf804d6899f 26.13MB / 26.13MB                                                       20.9s
 => => extracting sha256:837d8d26a53fc170f12f00f7943b0b3acd3a96dda6f6a60334b9ecf804d6899f                                                               1.2s
 => ERROR [2/8] RUN apt-get update     && apt-get install -y --no-install-recommends     software-properties-common     && add-apt-repository ppa:gi  104.4s
------                                                                                                                                                       
 > [2/8] RUN apt-get update     && apt-get install -y --no-install-recommends     software-properties-common     && add-apt-repository ppa:git-core/ppa -y     && apt-get dist-upgrade -y     && apt-get install -y --no-install-recommends     netcat     postgresql     curl     git     ssh     software-properties-common     make     build-essential     ca-certificates     libpq-dev     libsasl2-dev     libsasl2-2     libsasl2-modules-gssapi-mit     libyaml-dev     unixodbc-dev     && add-apt-repository ppa:deadsnakes/ppa     && apt-get install -y     python     python-dev     python3-pip     python3.8     python3.8-dev     python3.8-venv     python3.9     python3.9-dev     python3.9-venv     python3.10     python3.10-dev     python3.10-venv     python3.11     python3.11-dev     python3.11-venv     && apt-get clean     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*:
#0 1.143 Get:1 http://ports.ubuntu.com/ubuntu-ports mantic InRelease [255 kB]
#0 1.918 Get:2 http://ports.ubuntu.com/ubuntu-ports mantic-updates InRelease [90.7 kB]
#0 2.140 Get:3 http://ports.ubuntu.com/ubuntu-ports mantic-backports InRelease [90.7 kB]
#0 2.319 Get:4 http://ports.ubuntu.com/ubuntu-ports mantic-security InRelease [90.7 kB]
#0 2.624 Get:5 http://ports.ubuntu.com/ubuntu-ports mantic/restricted arm64 Packages [119 kB]
#0 2.761 Get:6 http://ports.ubuntu.com/ubuntu-ports mantic/multiverse arm64 Packages [252 kB]
#0 3.146 Get:7 http://ports.ubuntu.com/ubuntu-ports mantic/universe arm64 Packages [18.5 MB]
#0 44.76 Get:8 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 Packages [1782 kB]
#0 45.90 Fetched 21.2 MB in 45s (466 kB/s)
#0 45.90 Reading package lists...
#0 46.54 Reading package lists...
#0 47.38 Building dependency tree...
#0 47.57 Reading state information...
#0 47.99 The following additional packages will be installed:
#0 47.99   adduser ca-certificates dbus dbus-bin dbus-daemon dbus-session-bus-common
#0 47.99   dbus-system-bus-common distro-info-data gir1.2-glib-2.0
#0 47.99   gir1.2-packagekitglib-1.0 gpg gpgconf iso-codes libapparmor1 libappstream4
#0 47.99   libargon2-1 libassuan0 libbrotli1 libcap2-bin libcryptsetup12
#0 47.99   libcurl3-gnutls libdbus-1-3 libdevmapper1.02.1 libduktape207 libdw1 libelf1
#0 47.99   libexpat1 libfdisk1 libgirepository-1.0-1 libglib2.0-0 libglib2.0-bin
#0 47.99   libglib2.0-data libgssapi-krb5-2 libgstreamer1.0-0 libicu72 libip4tc2
#0 47.99   libjson-c5 libk5crypto3 libkeyutils1 libkmod2 libkrb5-3 libkrb5support0
#0 47.99   libldap2 libnghttp2-14 libnsl2 libpackagekit-glib2-18 libpam-systemd
#0 47.99   libpolkit-agent-1-0 libpolkit-gobject-1-0 libpsl5 libpython3-stdlib
#0 47.99   libpython3.11-minimal libpython3.11-stdlib libreadline8 librtmp1 libsasl2-2
#0 47.99   libsasl2-modules-db libsqlite3-0 libssh-4 libssl3 libstemmer0d
#0 47.99   libsystemd-shared libtirpc-common libtirpc3 libunwind8 libxml2 libxmlb2
#0 47.99   libyaml-0-2 libzstd1 lsb-release media-types openssl packagekit polkitd
#0 47.99   python-apt-common python3 python3-apt python3-blinker python3-cffi-backend
#0 47.99   python3-cryptography python3-dbus python3-distro python3-gi python3-httplib2
#0 47.99   python3-jwt python3-launchpadlib python3-lazr.restfulclient python3-lazr.uri
#0 47.99   python3-minimal python3-oauthlib python3-pkg-resources python3-pyparsing
#0 47.99   python3-six python3-software-properties python3-wadllib python3.11
#0 47.99   python3.11-minimal readline-common sgml-base systemd systemd-sysv xml-core
#0 47.99 Suggested packages:
#0 47.99   liblocale-gettext-perl perl cron quota ecryptfs-utils
#0 47.99   default-dbus-session-bus | dbus-session-bus isoquery low-memory-monitor
#0 47.99   krb5-doc krb5-user gstreamer1.0-tools polkitd-pkla python3-doc python3-tk
#0 47.99   python3-venv python-apt-doc python-blinker-doc python-cryptography-doc
#0 47.99   python3-cryptography-vectors python-dbus-doc python3-crypto
#0 47.99   python3-testresources python3-setuptools python-pyparsing-doc
#0 47.99   python3.11-venv python3.11-doc binutils binfmt-support readline-doc
#0 47.99   sgml-base-doc systemd-container systemd-homed systemd-userdbd systemd-boot
#0 47.99   libfido2-1 libqrencode4 libtss2-esys-3.0.2-0 libtss2-mu0 libtss2-rc0
#0 47.99   debhelper
#0 47.99 Recommended packages:
#0 47.99   gnupg libpam-cap dmsetup shared-mime-info xdg-user-dirs krb5-locales
#0 47.99   libldap-common dbus-user-session publicsuffix libsasl2-modules appstream
#0 47.99   packagekit-tools python3-keyring unattended-upgrades networkd-dispatcher
#0 47.99   systemd-timesyncd | time-daemon systemd-resolved libnss-systemd
#0 48.08 The following NEW packages will be installed:
#0 48.08   adduser ca-certificates dbus dbus-bin dbus-daemon dbus-session-bus-common
#0 48.08   dbus-system-bus-common distro-info-data gir1.2-glib-2.0
#0 48.08   gir1.2-packagekitglib-1.0 gpg gpgconf iso-codes libapparmor1 libappstream4
#0 48.08   libargon2-1 libassuan0 libbrotli1 libcap2-bin libcryptsetup12
#0 48.08   libcurl3-gnutls libdbus-1-3 libdevmapper1.02.1 libduktape207 libdw1 libelf1
#0 48.08   libexpat1 libfdisk1 libgirepository-1.0-1 libglib2.0-0 libglib2.0-bin
#0 48.08   libglib2.0-data libgssapi-krb5-2 libgstreamer1.0-0 libicu72 libip4tc2
#0 48.08   libjson-c5 libk5crypto3 libkeyutils1 libkmod2 libkrb5-3 libkrb5support0
#0 48.08   libldap2 libnghttp2-14 libnsl2 libpackagekit-glib2-18 libpam-systemd
#0 48.08   libpolkit-agent-1-0 libpolkit-gobject-1-0 libpsl5 libpython3-stdlib
#0 48.08   libpython3.11-minimal libpython3.11-stdlib libreadline8 librtmp1 libsasl2-2
#0 48.08   libsasl2-modules-db libsqlite3-0 libssh-4 libssl3 libstemmer0d
#0 48.08   libsystemd-shared libtirpc-common libtirpc3 libunwind8 libxml2 libxmlb2
#0 48.08   libyaml-0-2 lsb-release media-types openssl packagekit polkitd
#0 48.08   python-apt-common python3 python3-apt python3-blinker python3-cffi-backend
#0 48.08   python3-cryptography python3-dbus python3-distro python3-gi python3-httplib2
#0 48.08   python3-jwt python3-launchpadlib python3-lazr.restfulclient python3-lazr.uri
#0 48.08   python3-minimal python3-oauthlib python3-pkg-resources python3-pyparsing
#0 48.08   python3-six python3-software-properties python3-wadllib python3.11
#0 48.08   python3.11-minimal readline-common sgml-base software-properties-common
#0 48.08   systemd systemd-sysv xml-core
#0 48.09 The following packages will be upgraded:
#0 48.09   libzstd1
#0 48.51 1 upgraded, 102 newly installed, 0 to remove and 17 not upgraded.
#0 48.51 Need to get 40.1 MB of archives.
#0 48.51 After this operation, 154 MB of additional disk space will be used.
#0 48.51 Get:1 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libssl3 arm64 3.0.9-1ubuntu1 [1761 kB]
#0 50.04 Get:2 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libpython3.11-minimal arm64 3.11.4-1 [834 kB]
#0 50.57 Get:3 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libexpat1 arm64 2.5.0-2 [72.2 kB]
#0 50.62 Get:4 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3.11-minimal arm64 3.11.4-1 [2152 kB]
#0 51.48 Get:5 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-minimal arm64 3.11.4-1 [26.6 kB]
#0 51.48 Get:6 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 media-types all 10.0.0 [25.8 kB]
#0 51.50 Get:7 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libkrb5support0 arm64 1.20.1-2 [32.6 kB]
#0 51.51 Get:8 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libk5crypto3 arm64 1.20.1-2 [84.8 kB]
#0 51.56 Get:9 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libkeyutils1 arm64 1.6.3-2 [9296 B]
#0 51.57 Get:10 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libkrb5-3 arm64 1.20.1-2 [345 kB]
#0 51.71 Get:11 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libgssapi-krb5-2 arm64 1.20.1-2 [139 kB]
#0 52.04 Get:12 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libtirpc-common all 1.3.3+ds-1 [7790 B]
#0 52.20 Get:13 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libtirpc3 arm64 1.3.3+ds-1 [82.1 kB]
#0 52.53 Get:14 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libnsl2 arm64 1.3.0-2build2 [41.4 kB]
#0 52.62 Get:15 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 readline-common all 8.2-1.3 [55.7 kB]
#0 52.68 Get:16 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libreadline8 arm64 8.2-1.3 [150 kB]
#0 52.83 Get:17 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libsqlite3-0 arm64 3.42.0-1 [662 kB]
#0 53.22 Get:18 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libpython3.11-stdlib arm64 3.11.4-1 [1880 kB]
#0 54.10 Get:19 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3.11 arm64 3.11.4-1 [572 kB]
#0 54.37 Get:20 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libpython3-stdlib arm64 3.11.4-1 [9334 B]
#0 54.39 Get:21 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3 arm64 3.11.4-1 [22.9 kB]
#0 54.41 Get:22 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libargon2-1 arm64 0~20190702+dfsg-3 [18.9 kB]
#0 54.73 Get:23 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libdevmapper1.02.1 arm64 2:1.02.185-2ubuntu1 [128 kB]
#0 55.35 Get:24 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libjson-c5 arm64 0.16-2 [32.4 kB]
#0 55.39 Get:25 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libcryptsetup12 arm64 2:2.6.1-4ubuntu1 [238 kB]
#0 55.60 Get:26 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libfdisk1 arm64 2.38.1-5ubuntu2 [140 kB]
#0 55.66 Get:27 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libzstd1 arm64 1.5.5+dfsg2-1ubuntu1 [275 kB]
#0 55.78 Get:28 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libkmod2 arm64 30+20221128-1ubuntu1 [47.7 kB]
#0 55.80 Get:29 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libapparmor1 arm64 3.0.8-1ubuntu4 [46.5 kB]
#0 55.82 Get:30 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libip4tc2 arm64 1.8.7-1ubuntu7 [19.6 kB]
#0 55.83 Get:31 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libsystemd-shared arm64 252.5-2ubuntu3 [1750 kB]
#0 56.65 Get:32 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 systemd arm64 252.5-2ubuntu3 [2906 kB]
#0 58.08 Get:33 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 systemd-sysv arm64 252.5-2ubuntu3 [11.5 kB]
#0 58.38 Get:34 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 sgml-base all 1.31 [11.4 kB]
#0 58.52 Get:35 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 adduser all 3.134ubuntu1 [136 kB]
#0 58.91 Get:36 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 openssl arm64 3.0.9-1ubuntu1 [1168 kB]
#0 59.56 Get:37 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 ca-certificates all 20230311ubuntu1 [152 kB]
#0 59.63 Get:38 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libdbus-1-3 arm64 1.14.6-1ubuntu1 [205 kB]
#0 59.71 Get:39 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 dbus-bin arm64 1.14.6-1ubuntu1 [39.0 kB]
#0 59.73 Get:40 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 dbus-session-bus-common all 1.14.6-1ubuntu1 [77.6 kB]
#0 59.76 Get:41 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 dbus-daemon arm64 1.14.6-1ubuntu1 [114 kB]
#0 59.79 Get:42 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 dbus-system-bus-common all 1.14.6-1ubuntu1 [78.7 kB]
#0 59.83 Get:43 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 dbus arm64 1.14.6-1ubuntu1 [23.8 kB]
#0 59.85 Get:44 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 distro-info-data all 0.58 [5996 B]
#0 60.12 Get:45 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libglib2.0-0 arm64 2.76.3-1ubuntu1 [1490 kB]
#0 61.46 Get:46 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libgirepository-1.0-1 arm64 1.76.1-1 [70.4 kB]
#0 61.49 Get:47 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 gir1.2-glib-2.0 arm64 1.76.1-1 [179 kB]
#0 61.55 Get:48 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 iso-codes all 4.15.0-1 [3458 kB]
#0 63.30 Get:49 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libcap2-bin arm64 1:2.66-4ubuntu1 [33.4 kB]
#0 63.31 Get:50 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libelf1 arm64 0.189-4 [56.2 kB]
#0 63.34 Get:51 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libglib2.0-data all 2.76.3-1ubuntu1 [38.8 kB]
#0 63.35 Get:52 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libicu72 arm64 72.1-3ubuntu2 [10.7 MB]
#0 68.02 Get:53 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libpam-systemd arm64 252.5-2ubuntu3 [201 kB]
#0 68.25 Get:54 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libxml2 arm64 2.9.14+dfsg-1.2 [723 kB]
#0 68.65 Get:55 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libyaml-0-2 arm64 0.2.5-1 [51.8 kB]
#0 68.94 Get:56 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 lsb-release all 12.0-1ubuntu1 [6548 B]
#0 69.07 Get:57 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python-apt-common all 2.6.0 [18.0 kB]
#0 69.10 Get:58 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-apt arm64 2.6.0 [163 kB]
#0 69.51 Get:59 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-dbus arm64 1.3.2-4build1 [98.5 kB]
#0 69.63 Get:60 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-gi arm64 3.44.1-1 [228 kB]
#0 69.74 Get:61 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-pkg-resources all 67.8.0-1 [161 kB]
#0 69.80 Get:62 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libnghttp2-14 arm64 1.54.0-1 [72.0 kB]
#0 69.83 Get:63 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libpsl5 arm64 0.21.2-1 [59.0 kB]
#0 69.87 Get:64 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libpackagekit-glib2-18 arm64 1.2.6-5 [115 kB]
#0 69.90 Get:65 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 gir1.2-packagekitglib-1.0 arm64 1.2.6-5 [25.4 kB]
#0 69.93 Get:66 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libassuan0 arm64 2.5.5-5 [35.2 kB]
#0 70.25 Get:67 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 gpgconf arm64 2.2.40-1.1ubuntu1 [95.3 kB]
#0 70.78 Get:68 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 gpg arm64 2.2.40-1.1ubuntu1 [509 kB]
#0 71.22 Get:69 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libbrotli1 arm64 1.0.9-2build8 [312 kB]
#0 71.32 Get:70 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libsasl2-modules-db arm64 2.1.28+dfsg1-1 [20.8 kB]
#0 71.32 Get:71 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libsasl2-2 arm64 2.1.28+dfsg1-1 [56.2 kB]
#0 71.35 Get:72 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libldap2 arm64 2.6.4+dfsg-1~exp1ubuntu1 [190 kB]
#0 71.43 Get:73 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 librtmp1 arm64 2.4+20151223.gitfa8646d.1-2build4 [59.2 kB]
#0 71.45 Get:74 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libssh-4 arm64 0.10.4-2 [184 kB]
#0 71.53 Get:75 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libcurl3-gnutls arm64 7.88.1-10ubuntu1 [293 kB]
#0 71.67 Get:76 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libstemmer0d arm64 2.2.0-4 [159 kB]
#0 71.73 Get:77 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libxmlb2 arm64 0.3.10-2 [63.6 kB]
#0 72.04 Get:78 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libappstream4 arm64 0.16.2-1 [214 kB]
#0 72.73 Get:79 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libduktape207 arm64 2.7.0+tests-0ubuntu2 [142 kB]
#0 72.81 Get:80 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libdw1 arm64 0.189-4 [253 kB]
#0 73.07 Get:81 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libglib2.0-bin arm64 2.76.3-1ubuntu1 [94.2 kB]
#0 73.13 Get:82 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libunwind8 arm64 1.6.2-3 [55.1 kB]
#0 73.23 Get:83 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libgstreamer1.0-0 arm64 1.22.4-1 [927 kB]
#0 73.66 Get:84 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libpolkit-gobject-1-0 arm64 122-4 [45.2 kB]
#0 73.68 Get:85 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libpolkit-agent-1-0 arm64 122-4 [16.9 kB]
#0 73.68 Get:86 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 xml-core all 0.18+nmu1 [21.6 kB]
#0 73.68 Get:87 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 polkitd arm64 122-4 [90.6 kB]
#0 73.73 Get:88 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-blinker all 1.6.2-1 [15.1 kB]
#0 74.00 Get:89 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-cffi-backend arm64 1.15.1-5build1 [80.3 kB]
#0 74.49 Get:90 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-cryptography arm64 38.0.4-3 [652 kB]
#0 75.04 Get:91 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-pyparsing all 3.1.0-1 [86.4 kB]
#0 75.10 Get:92 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-httplib2 all 0.20.4-3 [30.4 kB]
#0 75.10 Get:93 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-jwt all 2.7.0-1 [20.9 kB]
#0 75.10 Get:94 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-lazr.uri all 1.0.6-3 [13.5 kB]
#0 75.10 Get:95 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-wadllib all 1.3.6-4 [35.8 kB]
#0 75.12 Get:96 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-distro all 1.8.0-1 [17.4 kB]
#0 75.13 Get:97 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-oauthlib all 3.2.2-1 [89.7 kB]
#0 75.17 Get:98 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-six all 1.16.0-4 [12.4 kB]
#0 75.17 Get:99 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-lazr.restfulclient all 0.14.5-1 [50.7 kB]
#0 75.49 Get:100 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-launchpadlib all 1.11.0-1 [125 kB]
#0 76.13 Get:101 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 python3-software-properties all 0.99.37 [28.4 kB]
#0 76.14 Get:102 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 packagekit arm64 1.2.6-5 [424 kB]
#0 76.43 Get:103 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 software-properties-common all 0.99.37 [14.3 kB]
#0 76.60 debconf: delaying package configuration, since apt-utils is not installed
#0 76.63 Fetched 40.1 MB in 28s (1414 kB/s)
#0 76.65 Selecting previously unselected package libssl3:arm64.
(Reading database ... 4343 files and directories currently installed.)
#0 76.66 Preparing to unpack .../libssl3_3.0.9-1ubuntu1_arm64.deb ...
#0 76.67 Unpacking libssl3:arm64 (3.0.9-1ubuntu1) ...
#0 76.72 Selecting previously unselected package libpython3.11-minimal:arm64.
#0 76.72 Preparing to unpack .../libpython3.11-minimal_3.11.4-1_arm64.deb ...
#0 76.73 Unpacking libpython3.11-minimal:arm64 (3.11.4-1) ...
#0 76.81 Selecting previously unselected package libexpat1:arm64.
#0 76.81 Preparing to unpack .../libexpat1_2.5.0-2_arm64.deb ...
#0 76.81 Unpacking libexpat1:arm64 (2.5.0-2) ...
#0 76.84 Selecting previously unselected package python3.11-minimal.
#0 76.84 Preparing to unpack .../python3.11-minimal_3.11.4-1_arm64.deb ...
#0 76.84 Unpacking python3.11-minimal (3.11.4-1) ...
#0 76.91 Setting up libssl3:arm64 (3.0.9-1ubuntu1) ...
#0 76.96 Setting up libpython3.11-minimal:arm64 (3.11.4-1) ...
#0 76.97 Setting up libexpat1:arm64 (2.5.0-2) ...
#0 76.98 Setting up python3.11-minimal (3.11.4-1) ...
#0 77.37 Selecting previously unselected package python3-minimal.
(Reading database ... 4669 files and directories currently installed.)
#0 77.38 Preparing to unpack .../00-python3-minimal_3.11.4-1_arm64.deb ...
#0 77.38 Unpacking python3-minimal (3.11.4-1) ...
#0 77.40 Selecting previously unselected package media-types.
#0 77.40 Preparing to unpack .../01-media-types_10.0.0_all.deb ...
#0 77.40 Unpacking media-types (10.0.0) ...
#0 77.43 Selecting previously unselected package libkrb5support0:arm64.
#0 77.43 Preparing to unpack .../02-libkrb5support0_1.20.1-2_arm64.deb ...
#0 77.43 Unpacking libkrb5support0:arm64 (1.20.1-2) ...
#0 77.45 Selecting previously unselected package libk5crypto3:arm64.
#0 77.45 Preparing to unpack .../03-libk5crypto3_1.20.1-2_arm64.deb ...
#0 77.45 Unpacking libk5crypto3:arm64 (1.20.1-2) ...
#0 77.47 Selecting previously unselected package libkeyutils1:arm64.
#0 77.48 Preparing to unpack .../04-libkeyutils1_1.6.3-2_arm64.deb ...
#0 77.48 Unpacking libkeyutils1:arm64 (1.6.3-2) ...
#0 77.50 Selecting previously unselected package libkrb5-3:arm64.
#0 77.50 Preparing to unpack .../05-libkrb5-3_1.20.1-2_arm64.deb ...
#0 77.51 Unpacking libkrb5-3:arm64 (1.20.1-2) ...
#0 77.61 Selecting previously unselected package libgssapi-krb5-2:arm64.
#0 77.61 Preparing to unpack .../06-libgssapi-krb5-2_1.20.1-2_arm64.deb ...
#0 77.61 Unpacking libgssapi-krb5-2:arm64 (1.20.1-2) ...
#0 77.63 Selecting previously unselected package libtirpc-common.
#0 77.64 Preparing to unpack .../07-libtirpc-common_1.3.3+ds-1_all.deb ...
#0 77.64 Unpacking libtirpc-common (1.3.3+ds-1) ...
#0 77.67 Selecting previously unselected package libtirpc3:arm64.
#0 77.67 Preparing to unpack .../08-libtirpc3_1.3.3+ds-1_arm64.deb ...
#0 77.67 Unpacking libtirpc3:arm64 (1.3.3+ds-1) ...
#0 77.70 Selecting previously unselected package libnsl2:arm64.
#0 77.70 Preparing to unpack .../09-libnsl2_1.3.0-2build2_arm64.deb ...
#0 77.70 Unpacking libnsl2:arm64 (1.3.0-2build2) ...
#0 77.72 Selecting previously unselected package readline-common.
#0 77.72 Preparing to unpack .../10-readline-common_8.2-1.3_all.deb ...
#0 77.73 Unpacking readline-common (8.2-1.3) ...
#0 77.76 Selecting previously unselected package libreadline8:arm64.
#0 77.76 Preparing to unpack .../11-libreadline8_8.2-1.3_arm64.deb ...
#0 77.76 Unpacking libreadline8:arm64 (8.2-1.3) ...
#0 77.80 Selecting previously unselected package libsqlite3-0:arm64.
#0 77.80 Preparing to unpack .../12-libsqlite3-0_3.42.0-1_arm64.deb ...
#0 77.80 Unpacking libsqlite3-0:arm64 (3.42.0-1) ...
#0 77.86 Selecting previously unselected package libpython3.11-stdlib:arm64.
#0 77.86 Preparing to unpack .../13-libpython3.11-stdlib_3.11.4-1_arm64.deb ...
#0 77.86 Unpacking libpython3.11-stdlib:arm64 (3.11.4-1) ...
#0 77.97 Selecting previously unselected package python3.11.
#0 77.97 Preparing to unpack .../14-python3.11_3.11.4-1_arm64.deb ...
#0 77.97 Unpacking python3.11 (3.11.4-1) ...
#0 77.99 Selecting previously unselected package libpython3-stdlib:arm64.
#0 77.99 Preparing to unpack .../15-libpython3-stdlib_3.11.4-1_arm64.deb ...
#0 78.00 Unpacking libpython3-stdlib:arm64 (3.11.4-1) ...
#0 78.02 Setting up python3-minimal (3.11.4-1) ...
#0 78.13 Selecting previously unselected package python3.
(Reading database ... 5158 files and directories currently installed.)
#0 78.14 Preparing to unpack .../0-python3_3.11.4-1_arm64.deb ...
#0 78.14 Unpacking python3 (3.11.4-1) ...
#0 78.17 Selecting previously unselected package libargon2-1:arm64.
#0 78.17 Preparing to unpack .../1-libargon2-1_0~20190702+dfsg-3_arm64.deb ...
#0 78.17 Unpacking libargon2-1:arm64 (0~20190702+dfsg-3) ...
#0 78.20 Selecting previously unselected package libdevmapper1.02.1:arm64.
#0 78.20 Preparing to unpack .../2-libdevmapper1.02.1_2%3a1.02.185-2ubuntu1_arm64.deb ...
#0 78.20 Unpacking libdevmapper1.02.1:arm64 (2:1.02.185-2ubuntu1) ...
#0 78.22 Selecting previously unselected package libjson-c5:arm64.
#0 78.22 Preparing to unpack .../3-libjson-c5_0.16-2_arm64.deb ...
#0 78.23 Unpacking libjson-c5:arm64 (0.16-2) ...
#0 78.25 Selecting previously unselected package libcryptsetup12:arm64.
#0 78.25 Preparing to unpack .../4-libcryptsetup12_2%3a2.6.1-4ubuntu1_arm64.deb ...
#0 78.25 Unpacking libcryptsetup12:arm64 (2:2.6.1-4ubuntu1) ...
#0 78.28 Selecting previously unselected package libfdisk1:arm64.
#0 78.28 Preparing to unpack .../5-libfdisk1_2.38.1-5ubuntu2_arm64.deb ...
#0 78.28 Unpacking libfdisk1:arm64 (2.38.1-5ubuntu2) ...
#0 78.30 Preparing to unpack .../6-libzstd1_1.5.5+dfsg2-1ubuntu1_arm64.deb ...
#0 78.31 Unpacking libzstd1:arm64 (1.5.5+dfsg2-1ubuntu1) over (1.5.4+dfsg2-5) ...
#0 78.34 Setting up libzstd1:arm64 (1.5.5+dfsg2-1ubuntu1) ...
#0 78.40 Selecting previously unselected package libkmod2:arm64.
(Reading database ... 5208 files and directories currently installed.)
#0 78.40 Preparing to unpack .../libkmod2_30+20221128-1ubuntu1_arm64.deb ...
#0 78.41 Unpacking libkmod2:arm64 (30+20221128-1ubuntu1) ...
#0 78.43 Selecting previously unselected package libapparmor1:arm64.
#0 78.43 Preparing to unpack .../libapparmor1_3.0.8-1ubuntu4_arm64.deb ...
#0 78.43 Unpacking libapparmor1:arm64 (3.0.8-1ubuntu4) ...
#0 78.46 Selecting previously unselected package libip4tc2:arm64.
#0 78.46 Preparing to unpack .../libip4tc2_1.8.7-1ubuntu7_arm64.deb ...
#0 78.47 Unpacking libip4tc2:arm64 (1.8.7-1ubuntu7) ...
#0 78.49 Selecting previously unselected package libsystemd-shared:arm64.
#0 78.49 Preparing to unpack .../libsystemd-shared_252.5-2ubuntu3_arm64.deb ...
#0 78.49 Unpacking libsystemd-shared:arm64 (252.5-2ubuntu3) ...
#0 78.60 Selecting previously unselected package systemd.
#0 78.60 Preparing to unpack .../systemd_252.5-2ubuntu3_arm64.deb ...
#0 78.80 Unpacking systemd (252.5-2ubuntu3) ...
#0 79.76 Setting up libargon2-1:arm64 (0~20190702+dfsg-3) ...
#0 79.78 Setting up libdevmapper1.02.1:arm64 (2:1.02.185-2ubuntu1) ...
#0 79.80 Setting up libjson-c5:arm64 (0.16-2) ...
#0 79.81 Setting up libcryptsetup12:arm64 (2:2.6.1-4ubuntu1) ...
#0 79.83 Setting up libfdisk1:arm64 (2.38.1-5ubuntu2) ...
#0 79.84 Setting up libkmod2:arm64 (30+20221128-1ubuntu1) ...
#0 79.85 Setting up libapparmor1:arm64 (3.0.8-1ubuntu4) ...
#0 79.86 Setting up libip4tc2:arm64 (1.8.7-1ubuntu7) ...
#0 79.86 Setting up libsystemd-shared:arm64 (252.5-2ubuntu3) ...
#0 79.87 Setting up systemd (252.5-2ubuntu3) ...
#0 79.91 Created symlink /etc/systemd/system/getty.target.wants/getty@tty1.service → /lib/systemd/system/getty@.service.
#0 79.92 Created symlink /etc/systemd/system/multi-user.target.wants/remote-fs.target → /lib/systemd/system/remote-fs.target.
#0 79.93 Created symlink /etc/systemd/system/sysinit.target.wants/systemd-pstore.service → /lib/systemd/system/systemd-pstore.service.
#0 79.94 Initializing machine ID from random generator.
#0 79.96 /usr/lib/tmpfiles.d/systemd-network.conf:10: Failed to resolve user 'systemd-network': No such process
#0 79.96 /usr/lib/tmpfiles.d/systemd-network.conf:11: Failed to resolve user 'systemd-network': No such process
#0 79.96 /usr/lib/tmpfiles.d/systemd-network.conf:12: Failed to resolve user 'systemd-network': No such process
#0 79.96 /usr/lib/tmpfiles.d/systemd-network.conf:13: Failed to resolve user 'systemd-network': No such process
#0 79.96 /usr/lib/tmpfiles.d/systemd.conf:22: Failed to resolve group 'systemd-journal'.
#0 79.96 /usr/lib/tmpfiles.d/systemd.conf:23: Failed to resolve group 'systemd-journal'.
#0 79.96 /usr/lib/tmpfiles.d/systemd.conf:28: Failed to resolve group 'systemd-journal'.
#0 79.96 /usr/lib/tmpfiles.d/systemd.conf:29: Failed to resolve group 'systemd-journal'.
#0 79.96 /usr/lib/tmpfiles.d/systemd.conf:30: Failed to resolve group 'systemd-journal'.
#0 79.97 Creating group 'systemd-journal' with GID 999.
#0 79.97 Creating group 'systemd-network' with GID 998.
#0 79.97 Creating user 'systemd-network' (systemd Network Management) with UID 998 and GID 998.
#0 80.05 Selecting previously unselected package systemd-sysv.
(Reading database ... 6032 files and directories currently installed.)
#0 80.06 Preparing to unpack .../systemd-sysv_252.5-2ubuntu3_arm64.deb ...
#0 80.07 Unpacking systemd-sysv (252.5-2ubuntu3) ...
#0 80.11 Selecting previously unselected package sgml-base.
#0 80.11 Preparing to unpack .../sgml-base_1.31_all.deb ...
#0 80.12 Unpacking sgml-base (1.31) ...
#0 80.16 Selecting previously unselected package adduser.
#0 80.16 Preparing to unpack .../adduser_3.134ubuntu1_all.deb ...
#0 80.17 Unpacking adduser (3.134ubuntu1) ...
#0 80.20 Setting up adduser (3.134ubuntu1) ...
#0 80.23 Selecting previously unselected package openssl.
(Reading database ... 6132 files and directories currently installed.)
#0 80.24 Preparing to unpack .../00-openssl_3.0.9-1ubuntu1_arm64.deb ...
#0 80.24 Unpacking openssl (3.0.9-1ubuntu1) ...
#0 80.42 Selecting previously unselected package ca-certificates.
#0 80.42 Preparing to unpack .../01-ca-certificates_20230311ubuntu1_all.deb ...
#0 80.43 Unpacking ca-certificates (20230311ubuntu1) ...
#0 80.47 Selecting previously unselected package libdbus-1-3:arm64.
#0 80.47 Preparing to unpack .../02-libdbus-1-3_1.14.6-1ubuntu1_arm64.deb ...
#0 80.47 Unpacking libdbus-1-3:arm64 (1.14.6-1ubuntu1) ...
#0 80.49 Selecting previously unselected package dbus-bin.
#0 80.49 Preparing to unpack .../03-dbus-bin_1.14.6-1ubuntu1_arm64.deb ...
#0 80.50 Unpacking dbus-bin (1.14.6-1ubuntu1) ...
#0 80.52 Selecting previously unselected package dbus-session-bus-common.
#0 80.52 Preparing to unpack .../04-dbus-session-bus-common_1.14.6-1ubuntu1_all.deb ...
#0 80.52 Unpacking dbus-session-bus-common (1.14.6-1ubuntu1) ...
#0 80.56 Selecting previously unselected package dbus-daemon.
#0 80.56 Preparing to unpack .../05-dbus-daemon_1.14.6-1ubuntu1_arm64.deb ...
#0 80.57 Unpacking dbus-daemon (1.14.6-1ubuntu1) ...
#0 80.59 Selecting previously unselected package dbus-system-bus-common.
#0 80.59 Preparing to unpack .../06-dbus-system-bus-common_1.14.6-1ubuntu1_all.deb ...
#0 80.59 Unpacking dbus-system-bus-common (1.14.6-1ubuntu1) ...
#0 80.62 Selecting previously unselected package dbus.
#0 80.62 Preparing to unpack .../07-dbus_1.14.6-1ubuntu1_arm64.deb ...
#0 80.63 Unpacking dbus (1.14.6-1ubuntu1) ...
#0 80.65 Selecting previously unselected package distro-info-data.
#0 80.65 Preparing to unpack .../08-distro-info-data_0.58_all.deb ...
#0 80.65 Unpacking distro-info-data (0.58) ...
#0 80.68 Selecting previously unselected package libglib2.0-0:arm64.
#0 80.68 Preparing to unpack .../09-libglib2.0-0_2.76.3-1ubuntu1_arm64.deb ...
#0 80.68 Unpacking libglib2.0-0:arm64 (2.76.3-1ubuntu1) ...
#0 80.73 Selecting previously unselected package libgirepository-1.0-1:arm64.
#0 80.73 Preparing to unpack .../10-libgirepository-1.0-1_1.76.1-1_arm64.deb ...
#0 80.73 Unpacking libgirepository-1.0-1:arm64 (1.76.1-1) ...
#0 80.76 Selecting previously unselected package gir1.2-glib-2.0:arm64.
#0 80.76 Preparing to unpack .../11-gir1.2-glib-2.0_1.76.1-1_arm64.deb ...
#0 80.76 Unpacking gir1.2-glib-2.0:arm64 (1.76.1-1) ...
#0 80.78 Selecting previously unselected package iso-codes.
#0 80.78 Preparing to unpack .../12-iso-codes_4.15.0-1_all.deb ...
#0 80.78 Unpacking iso-codes (4.15.0-1) ...
#0 80.92 Selecting previously unselected package libcap2-bin.
#0 80.92 Preparing to unpack .../13-libcap2-bin_1%3a2.66-4ubuntu1_arm64.deb ...
#0 80.93 Unpacking libcap2-bin (1:2.66-4ubuntu1) ...
#0 80.95 Selecting previously unselected package libelf1:arm64.
#0 80.95 Preparing to unpack .../14-libelf1_0.189-4_arm64.deb ...
#0 80.95 Unpacking libelf1:arm64 (0.189-4) ...
#0 80.97 Selecting previously unselected package libglib2.0-data.
#0 80.97 Preparing to unpack .../15-libglib2.0-data_2.76.3-1ubuntu1_all.deb ...
#0 80.98 Unpacking libglib2.0-data (2.76.3-1ubuntu1) ...
#0 81.00 Selecting previously unselected package libicu72:arm64.
#0 81.00 Preparing to unpack .../16-libicu72_72.1-3ubuntu2_arm64.deb ...
#0 81.00 Unpacking libicu72:arm64 (72.1-3ubuntu2) ...
#0 81.22 Selecting previously unselected package libpam-systemd:arm64.
#0 81.22 Preparing to unpack .../17-libpam-systemd_252.5-2ubuntu3_arm64.deb ...
#0 81.23 Unpacking libpam-systemd:arm64 (252.5-2ubuntu3) ...
#0 81.25 Selecting previously unselected package libxml2:arm64.
#0 81.25 Preparing to unpack .../18-libxml2_2.9.14+dfsg-1.2_arm64.deb ...
#0 81.26 Unpacking libxml2:arm64 (2.9.14+dfsg-1.2) ...
#0 81.35 Selecting previously unselected package libyaml-0-2:arm64.
#0 81.35 Preparing to unpack .../19-libyaml-0-2_0.2.5-1_arm64.deb ...
#0 81.35 Unpacking libyaml-0-2:arm64 (0.2.5-1) ...
#0 81.37 Selecting previously unselected package lsb-release.
#0 81.37 Preparing to unpack .../20-lsb-release_12.0-1ubuntu1_all.deb ...
#0 81.38 Unpacking lsb-release (12.0-1ubuntu1) ...
#0 81.40 Selecting previously unselected package python-apt-common.
#0 81.40 Preparing to unpack .../21-python-apt-common_2.6.0_all.deb ...
#0 81.40 Unpacking python-apt-common (2.6.0) ...
#0 81.42 Selecting previously unselected package python3-apt.
#0 81.42 Preparing to unpack .../22-python3-apt_2.6.0_arm64.deb ...
#0 81.42 Unpacking python3-apt (2.6.0) ...
#0 81.45 Selecting previously unselected package python3-dbus.
#0 81.45 Preparing to unpack .../23-python3-dbus_1.3.2-4build1_arm64.deb ...
#0 81.45 Unpacking python3-dbus (1.3.2-4build1) ...
#0 81.47 Selecting previously unselected package python3-gi.
#0 81.48 Preparing to unpack .../24-python3-gi_3.44.1-1_arm64.deb ...
#0 81.48 Unpacking python3-gi (3.44.1-1) ...
#0 81.51 Selecting previously unselected package python3-pkg-resources.
#0 81.51 Preparing to unpack .../25-python3-pkg-resources_67.8.0-1_all.deb ...
#0 81.51 Unpacking python3-pkg-resources (67.8.0-1) ...
#0 81.55 Selecting previously unselected package libnghttp2-14:arm64.
#0 81.55 Preparing to unpack .../26-libnghttp2-14_1.54.0-1_arm64.deb ...
#0 81.55 Unpacking libnghttp2-14:arm64 (1.54.0-1) ...
#0 81.58 Selecting previously unselected package libpsl5:arm64.
#0 81.58 Preparing to unpack .../27-libpsl5_0.21.2-1_arm64.deb ...
#0 81.60 Unpacking libpsl5:arm64 (0.21.2-1) ...
#0 81.63 Selecting previously unselected package libpackagekit-glib2-18:arm64.
#0 81.63 Preparing to unpack .../28-libpackagekit-glib2-18_1.2.6-5_arm64.deb ...
#0 81.64 Unpacking libpackagekit-glib2-18:arm64 (1.2.6-5) ...
#0 81.66 Selecting previously unselected package gir1.2-packagekitglib-1.0.
#0 81.66 Preparing to unpack .../29-gir1.2-packagekitglib-1.0_1.2.6-5_arm64.deb ...
#0 81.66 Unpacking gir1.2-packagekitglib-1.0 (1.2.6-5) ...
#0 81.68 Selecting previously unselected package libassuan0:arm64.
#0 81.68 Preparing to unpack .../30-libassuan0_2.5.5-5_arm64.deb ...
#0 81.68 Unpacking libassuan0:arm64 (2.5.5-5) ...
#0 81.72 Selecting previously unselected package gpgconf.
#0 81.72 Preparing to unpack .../31-gpgconf_2.2.40-1.1ubuntu1_arm64.deb ...
#0 81.72 Unpacking gpgconf (2.2.40-1.1ubuntu1) ...
#0 81.75 Selecting previously unselected package gpg.
#0 81.75 Preparing to unpack .../32-gpg_2.2.40-1.1ubuntu1_arm64.deb ...
#0 81.75 Unpacking gpg (2.2.40-1.1ubuntu1) ...
#0 81.78 Selecting previously unselected package libbrotli1:arm64.
#0 81.78 Preparing to unpack .../33-libbrotli1_1.0.9-2build8_arm64.deb ...
#0 81.78 Unpacking libbrotli1:arm64 (1.0.9-2build8) ...
#0 81.80 Selecting previously unselected package libsasl2-modules-db:arm64.
#0 81.80 Preparing to unpack .../34-libsasl2-modules-db_2.1.28+dfsg1-1_arm64.deb ...
#0 81.81 Unpacking libsasl2-modules-db:arm64 (2.1.28+dfsg1-1) ...
#0 81.83 Selecting previously unselected package libsasl2-2:arm64.
#0 81.83 Preparing to unpack .../35-libsasl2-2_2.1.28+dfsg1-1_arm64.deb ...
#0 81.83 Unpacking libsasl2-2:arm64 (2.1.28+dfsg1-1) ...
#0 81.85 Selecting previously unselected package libldap2:arm64.
#0 81.85 Preparing to unpack .../36-libldap2_2.6.4+dfsg-1~exp1ubuntu1_arm64.deb ...
#0 81.85 Unpacking libldap2:arm64 (2.6.4+dfsg-1~exp1ubuntu1) ...
#0 81.88 Selecting previously unselected package librtmp1:arm64.
#0 81.89 Preparing to unpack .../37-librtmp1_2.4+20151223.gitfa8646d.1-2build4_arm64.deb ...
#0 81.89 Unpacking librtmp1:arm64 (2.4+20151223.gitfa8646d.1-2build4) ...
#0 81.92 Selecting previously unselected package libssh-4:arm64.
#0 81.92 Preparing to unpack .../38-libssh-4_0.10.4-2_arm64.deb ...
#0 81.93 Unpacking libssh-4:arm64 (0.10.4-2) ...
#0 81.95 Selecting previously unselected package libcurl3-gnutls:arm64.
#0 81.95 Preparing to unpack .../39-libcurl3-gnutls_7.88.1-10ubuntu1_arm64.deb ...
#0 81.96 Unpacking libcurl3-gnutls:arm64 (7.88.1-10ubuntu1) ...
#0 81.98 Selecting previously unselected package libstemmer0d:arm64.
#0 81.98 Preparing to unpack .../40-libstemmer0d_2.2.0-4_arm64.deb ...
#0 81.98 Unpacking libstemmer0d:arm64 (2.2.0-4) ...
#0 82.01 Selecting previously unselected package libxmlb2:arm64.
#0 82.01 Preparing to unpack .../41-libxmlb2_0.3.10-2_arm64.deb ...
#0 82.02 Unpacking libxmlb2:arm64 (0.3.10-2) ...
#0 82.05 Selecting previously unselected package libappstream4:arm64.
#0 82.05 Preparing to unpack .../42-libappstream4_0.16.2-1_arm64.deb ...
#0 82.05 Unpacking libappstream4:arm64 (0.16.2-1) ...
#0 82.08 Selecting previously unselected package libduktape207:arm64.
#0 82.08 Preparing to unpack .../43-libduktape207_2.7.0+tests-0ubuntu2_arm64.deb ...
#0 82.08 Unpacking libduktape207:arm64 (2.7.0+tests-0ubuntu2) ...
#0 82.11 Selecting previously unselected package libdw1:arm64.
#0 82.11 Preparing to unpack .../44-libdw1_0.189-4_arm64.deb ...
#0 82.11 Unpacking libdw1:arm64 (0.189-4) ...
#0 82.13 Selecting previously unselected package libglib2.0-bin.
#0 82.13 Preparing to unpack .../45-libglib2.0-bin_2.76.3-1ubuntu1_arm64.deb ...
#0 82.14 Unpacking libglib2.0-bin (2.76.3-1ubuntu1) ...
#0 82.16 Selecting previously unselected package libunwind8:arm64.
#0 82.16 Preparing to unpack .../46-libunwind8_1.6.2-3_arm64.deb ...
#0 82.17 Unpacking libunwind8:arm64 (1.6.2-3) ...
#0 82.19 Selecting previously unselected package libgstreamer1.0-0:arm64.
#0 82.19 Preparing to unpack .../47-libgstreamer1.0-0_1.22.4-1_arm64.deb ...
#0 82.20 Unpacking libgstreamer1.0-0:arm64 (1.22.4-1) ...
#0 82.28 Selecting previously unselected package libpolkit-gobject-1-0:arm64.
#0 82.28 Preparing to unpack .../48-libpolkit-gobject-1-0_122-4_arm64.deb ...
#0 82.29 Unpacking libpolkit-gobject-1-0:arm64 (122-4) ...
#0 82.33 Selecting previously unselected package libpolkit-agent-1-0:arm64.
#0 82.33 Preparing to unpack .../49-libpolkit-agent-1-0_122-4_arm64.deb ...
#0 82.33 Unpacking libpolkit-agent-1-0:arm64 (122-4) ...
#0 82.36 Selecting previously unselected package xml-core.
#0 82.37 Preparing to unpack .../50-xml-core_0.18+nmu1_all.deb ...
#0 82.37 Unpacking xml-core (0.18+nmu1) ...
#0 82.40 Selecting previously unselected package polkitd.
#0 82.40 Preparing to unpack .../51-polkitd_122-4_arm64.deb ...
#0 82.51 Unpacking polkitd (122-4) ...
#0 82.59 Selecting previously unselected package python3-blinker.
#0 82.59 Preparing to unpack .../52-python3-blinker_1.6.2-1_all.deb ...
#0 82.59 Unpacking python3-blinker (1.6.2-1) ...
#0 82.62 Selecting previously unselected package python3-cffi-backend:arm64.
#0 82.62 Preparing to unpack .../53-python3-cffi-backend_1.15.1-5build1_arm64.deb ...
#0 82.63 Unpacking python3-cffi-backend:arm64 (1.15.1-5build1) ...
#0 82.66 Selecting previously unselected package python3-cryptography.
#0 82.66 Preparing to unpack .../54-python3-cryptography_38.0.4-3_arm64.deb ...
#0 82.66 Unpacking python3-cryptography (38.0.4-3) ...
#0 82.74 Selecting previously unselected package python3-pyparsing.
#0 82.74 Preparing to unpack .../55-python3-pyparsing_3.1.0-1_all.deb ...
#0 82.75 Unpacking python3-pyparsing (3.1.0-1) ...
#0 82.85 Selecting previously unselected package python3-httplib2.
#0 82.85 Preparing to unpack .../56-python3-httplib2_0.20.4-3_all.deb ...
#0 82.87 Unpacking python3-httplib2 (0.20.4-3) ...
#0 82.93 Selecting previously unselected package python3-jwt.
#0 82.93 Preparing to unpack .../57-python3-jwt_2.7.0-1_all.deb ...
#0 82.94 Unpacking python3-jwt (2.7.0-1) ...
#0 82.96 Selecting previously unselected package python3-lazr.uri.
#0 82.96 Preparing to unpack .../58-python3-lazr.uri_1.0.6-3_all.deb ...
#0 82.97 Unpacking python3-lazr.uri (1.0.6-3) ...
#0 82.99 Selecting previously unselected package python3-wadllib.
#0 82.99 Preparing to unpack .../59-python3-wadllib_1.3.6-4_all.deb ...
#0 83.00 Unpacking python3-wadllib (1.3.6-4) ...
#0 83.03 Selecting previously unselected package python3-distro.
#0 83.03 Preparing to unpack .../60-python3-distro_1.8.0-1_all.deb ...
#0 83.03 Unpacking python3-distro (1.8.0-1) ...
#0 83.06 Selecting previously unselected package python3-oauthlib.
#0 83.06 Preparing to unpack .../61-python3-oauthlib_3.2.2-1_all.deb ...
#0 83.06 Unpacking python3-oauthlib (3.2.2-1) ...
#0 83.10 Selecting previously unselected package python3-six.
#0 83.10 Preparing to unpack .../62-python3-six_1.16.0-4_all.deb ...
#0 83.11 Unpacking python3-six (1.16.0-4) ...
#0 83.14 Selecting previously unselected package python3-lazr.restfulclient.
#0 83.14 Preparing to unpack .../63-python3-lazr.restfulclient_0.14.5-1_all.deb ...
#0 83.14 Unpacking python3-lazr.restfulclient (0.14.5-1) ...
#0 83.17 Selecting previously unselected package python3-launchpadlib.
#0 83.17 Preparing to unpack .../64-python3-launchpadlib_1.11.0-1_all.deb ...
#0 83.17 Unpacking python3-launchpadlib (1.11.0-1) ...
#0 83.24 Selecting previously unselected package python3-software-properties.
#0 83.24 Preparing to unpack .../65-python3-software-properties_0.99.37_all.deb ...
#0 83.24 Unpacking python3-software-properties (0.99.37) ...
#0 83.27 Selecting previously unselected package packagekit.
#0 83.27 Preparing to unpack .../66-packagekit_1.2.6-5_arm64.deb ...
#0 83.28 Unpacking packagekit (1.2.6-5) ...
#0 83.31 Selecting previously unselected package software-properties-common.
#0 83.32 Preparing to unpack .../67-software-properties-common_0.99.37_all.deb ...
#0 83.32 Unpacking software-properties-common (0.99.37) ...
#0 83.35 Setting up media-types (10.0.0) ...
#0 83.36 Setting up systemd-sysv (252.5-2ubuntu3) ...
#0 83.37 Setting up libkeyutils1:arm64 (1.6.3-2) ...
#0 83.37 Setting up libpsl5:arm64 (0.21.2-1) ...
#0 83.39 Setting up libicu72:arm64 (72.1-3ubuntu2) ...
#0 83.40 Setting up libyaml-0-2:arm64 (0.2.5-1) ...
#0 83.40 Setting up libglib2.0-0:arm64 (2.76.3-1ubuntu1) ...
#0 83.42 No schema files found: doing nothing.
#0 83.42 Setting up distro-info-data (0.58) ...
#0 83.44 Setting up libtirpc-common (1.3.3+ds-1) ...
#0 83.44 Setting up libxmlb2:arm64 (0.3.10-2) ...
#0 83.45 Setting up libbrotli1:arm64 (1.0.9-2build8) ...
#0 83.46 Setting up libsqlite3-0:arm64 (3.42.0-1) ...
#0 83.47 Setting up libnghttp2-14:arm64 (1.54.0-1) ...
#0 83.47 Setting up libpackagekit-glib2-18:arm64 (1.2.6-5) ...
#0 83.49 Setting up libassuan0:arm64 (2.5.5-5) ...
#0 83.49 Setting up libunwind8:arm64 (1.6.2-3) ...
#0 83.50 Setting up libkrb5support0:arm64 (1.20.1-2) ...
#0 83.51 Setting up libsasl2-modules-db:arm64 (2.1.28+dfsg1-1) ...
#0 83.51 Setting up libcap2-bin (1:2.66-4ubuntu1) ...
#0 83.52 Setting up libglib2.0-data (2.76.3-1ubuntu1) ...
#0 83.53 Setting up librtmp1:arm64 (2.4+20151223.gitfa8646d.1-2build4) ...
#0 83.55 Setting up libdbus-1-3:arm64 (1.14.6-1ubuntu1) ...
#0 83.55 Setting up libk5crypto3:arm64 (1.20.1-2) ...
#0 83.56 Setting up libsasl2-2:arm64 (2.1.28+dfsg1-1) ...
#0 83.57 Setting up python-apt-common (2.6.0) ...
#0 83.57 Setting up libduktape207:arm64 (2.7.0+tests-0ubuntu2) ...
#0 83.58 Setting up dbus-session-bus-common (1.14.6-1ubuntu1) ...
#0 83.59 Setting up libgirepository-1.0-1:arm64 (1.76.1-1) ...
#0 83.59 Setting up sgml-base (1.31) ...
#0 83.62 Setting up libkrb5-3:arm64 (1.20.1-2) ...
#0 83.63 Setting up libstemmer0d:arm64 (2.2.0-4) ...
#0 83.63 Setting up lsb-release (12.0-1ubuntu1) ...
#0 83.64 Setting up dbus-system-bus-common (1.14.6-1ubuntu1) ...
#0 83.70 Setting up openssl (3.0.9-1ubuntu1) ...
#0 83.71 Setting up libelf1:arm64 (0.189-4) ...
#0 83.72 Setting up readline-common (8.2-1.3) ...
#0 83.73 Setting up libxml2:arm64 (2.9.14+dfsg-1.2) ...
#0 83.74 Setting up libldap2:arm64 (2.6.4+dfsg-1~exp1ubuntu1) ...
#0 83.75 Setting up iso-codes (4.15.0-1) ...
#0 83.75 Setting up dbus-bin (1.14.6-1ubuntu1) ...
#0 83.76 Setting up libpolkit-gobject-1-0:arm64 (122-4) ...
#0 83.77 Setting up libdw1:arm64 (0.189-4) ...
#0 83.77 Setting up libreadline8:arm64 (8.2-1.3) ...
#0 83.78 Setting up libglib2.0-bin (2.76.3-1ubuntu1) ...
#0 83.79 Setting up dbus-daemon (1.14.6-1ubuntu1) ...
#0 83.81 Setting up ca-certificates (20230311ubuntu1) ...
#0 84.35 Updating certificates in /etc/ssl/certs...
#0 85.11 137 added, 0 removed; done.
#0 85.17 Setting up dbus (1.14.6-1ubuntu1) ...
#0 85.24 Setting up libgssapi-krb5-2:arm64 (1.20.1-2) ...
#0 85.27 Setting up gir1.2-glib-2.0:arm64 (1.76.1-1) ...
#0 85.30 Setting up libssh-4:arm64 (0.10.4-2) ...
#0 85.32 Setting up xml-core (0.18+nmu1) ...
#0 85.50 Setting up gpgconf (2.2.40-1.1ubuntu1) ...
#0 85.53 Setting up libpam-systemd:arm64 (252.5-2ubuntu3) ...
#0 85.65 Setting up libpolkit-agent-1-0:arm64 (122-4) ...
#0 85.69 Setting up gpg (2.2.40-1.1ubuntu1) ...
#0 85.72 Setting up libgstreamer1.0-0:arm64 (1.22.4-1) ...
#0 85.74 Setcap worked! gst-ptp-helper is not suid!
#0 85.76 Setting up libtirpc3:arm64 (1.3.3+ds-1) ...
#0 85.78 Setting up libcurl3-gnutls:arm64 (7.88.1-10ubuntu1) ...
#0 85.82 Setting up libappstream4:arm64 (0.16.2-1) ...
#0 85.85 Setting up gir1.2-packagekitglib-1.0 (1.2.6-5) ...
#0 85.88 Setting up libnsl2:arm64 (1.3.0-2build2) ...
#0 85.90 Setting up libpython3.11-stdlib:arm64 (3.11.4-1) ...
#0 85.92 Setting up libpython3-stdlib:arm64 (3.11.4-1) ...
#0 85.97 Setting up python3.11 (3.11.4-1) ...
#0 86.45 Setting up python3 (3.11.4-1) ...
#0 86.54 Setting up python3-six (1.16.0-4) ...
#0 86.66 Setting up python3-pyparsing (3.1.0-1) ...
#0 86.82 Setting up python3-gi (3.44.1-1) ...
#0 86.95 Setting up python3-httplib2 (0.20.4-3) ...
#0 87.06 Setting up python3-cffi-backend:arm64 (1.15.1-5build1) ...
#0 87.08 Setting up python3-blinker (1.6.2-1) ...
#0 87.20 Setting up python3-pkg-resources (67.8.0-1) ...
#0 87.35 Setting up python3-dbus (1.3.2-4build1) ...
#0 87.44 Setting up python3-distro (1.8.0-1) ...
#0 87.52 Setting up python3-jwt (2.7.0-1) ...
#0 87.62 Setting up python3-apt (2.6.0) ...
#0 87.72 Setting up python3-lazr.uri (1.0.6-3) ...
#0 87.87 Setting up python3-cryptography (38.0.4-3) ...
#0 88.05 Setting up python3-wadllib (1.3.6-4) ...
#0 88.13 Setting up python3-oauthlib (3.2.2-1) ...
#0 88.24 Setting up python3-lazr.restfulclient (0.14.5-1) ...
#0 88.33 Setting up python3-launchpadlib (1.11.0-1) ...
#0 88.42 Setting up python3-software-properties (0.99.37) ...
#0 88.52 Processing triggers for libc-bin (2.37-0ubuntu2) ...
#0 88.58 Processing triggers for sgml-base (1.31) ...
#0 88.60 Setting up polkitd (122-4) ...
#0 88.61 Creating group 'polkitd' with GID 997.
#0 88.61 Creating user 'polkitd' (polkit) with UID 997 and GID 997.
#0 88.65 invoke-rc.d: could not determine current runlevel
#0 88.65 invoke-rc.d: policy-rc.d denied execution of reload.
#0 88.74 start-stop-daemon: unable to stat /usr/libexec/polkitd (No such file or directory)
#0 88.74 Setting up packagekit (1.2.6-5) ...
#0 88.76 invoke-rc.d: could not determine current runlevel
#0 88.77 invoke-rc.d: policy-rc.d denied execution of force-reload.
#0 88.77 Failed to open connection to "system" message bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
#0 88.84 Created symlink /etc/systemd/user/sockets.target.wants/pk-debconf-helper.socket → /usr/lib/systemd/user/pk-debconf-helper.socket.
#0 88.85 Setting up software-properties-common (0.99.37) ...
#0 88.93 Processing triggers for ca-certificates (20230311ubuntu1) ...
#0 88.94 Updating certificates in /etc/ssl/certs...
#0 89.40 0 added, 0 removed; done.
#0 89.40 Running hooks in /etc/ca-certificates/update.d...
#0 89.40 done.
#0 89.41 Processing triggers for dbus (1.14.6-1ubuntu1) ...
#0 92.32 Hit:1 http://ports.ubuntu.com/ubuntu-ports mantic InRelease
#0 92.45 Hit:2 http://ports.ubuntu.com/ubuntu-ports mantic-updates InRelease
#0 92.58 Hit:3 http://ports.ubuntu.com/ubuntu-ports mantic-backports InRelease
#0 92.71 Get:4 https://ppa.launchpadcontent.net/git-core/ppa/ubuntu mantic InRelease [23.8 kB]
#0 92.76 Hit:5 http://ports.ubuntu.com/ubuntu-ports mantic-security InRelease
#0 93.71 Get:6 https://ppa.launchpadcontent.net/git-core/ppa/ubuntu mantic/main arm64 Packages [2964 B]
#0 93.76 Fetched 26.8 kB in 2s (15.4 kB/s)
#0 93.76 Reading package lists...
#0 95.59 PPA publishes dbgsym, you may need to include 'main/debug' component
#0 95.59 Repository: 'Types: deb
#0 95.59 URIs: https://ppa.launchpadcontent.net/git-core/ppa/ubuntu/
#0 95.59 Suites: mantic
#0 95.59 Components: main
#0 95.59 '
#0 95.59 Description:
#0 95.59 The most current stable version of Git for Ubuntu.
#0 95.59 
#0 95.59 For release candidates, go to https://launchpad.net/~git-core/+archive/candidate .
#0 95.59 More info: https://launchpad.net/~git-core/+archive/ubuntu/ppa
#0 95.59 Adding repository.
#0 96.24 Reading package lists...
#0 96.82 Building dependency tree...
#0 96.95 Reading state information...
#0 96.98 Calculating upgrade...
#0 97.17 The following packages will be upgraded:
#0 97.17   debianutils e2fsprogs findutils gcc-13-base libaudit-common libaudit1
#0 97.17   libcom-err2 libext2fs2 libgcc-s1 libncursesw6 libss2 libstdc++6 libtasn1-6
#0 97.17   libtinfo6 logsave ncurses-base ncurses-bin
#0 97.47 17 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
#0 97.47 Need to get 2642 kB of archives.
#0 97.47 After this operation, 17.4 kB of additional disk space will be used.
#0 97.47 Get:1 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 debianutils arm64 5.8-1 [103 kB]
#0 98.04 Get:2 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 findutils arm64 4.9.0-5 [300 kB]
#0 98.34 Get:3 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libncursesw6 arm64 6.4+20230625-1 [141 kB]
#0 98.49 Get:4 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libtinfo6 arm64 6.4+20230625-1 [104 kB]
#0 98.59 Get:5 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 ncurses-bin arm64 6.4+20230625-1 [184 kB]
#0 98.77 Get:6 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 ncurses-base all 6.4+20230625-1 [24.1 kB]
#0 98.78 Get:7 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 logsave arm64 1.47.0-1ubuntu2 [21.4 kB]
#0 98.79 Get:8 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libext2fs2 arm64 1.47.0-1ubuntu2 [221 kB]
#0 98.87 Get:9 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 e2fsprogs arm64 1.47.0-1ubuntu2 [591 kB]
#0 99.20 Get:10 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 gcc-13-base arm64 13.1.0-7ubuntu1 [42.2 kB]
#0 99.21 Get:11 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libstdc++6 arm64 13.1.0-7ubuntu1 [732 kB]
#0 100.1 Get:12 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libgcc-s1 arm64 13.1.0-7ubuntu1 [46.6 kB]
#0 100.5 Get:13 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libaudit-common all 1:3.1.1-1 [5426 B]
#0 100.6 Get:14 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libaudit1 arm64 1:3.1.1-1 [46.4 kB]
#0 100.7 Get:15 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libtasn1-6 arm64 4.19.0-3 [42.8 kB]
#0 101.0 Get:16 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libcom-err2 arm64 1.47.0-1ubuntu2 [21.5 kB]
#0 101.0 Get:17 http://ports.ubuntu.com/ubuntu-ports mantic/main arm64 libss2 arm64 1.47.0-1ubuntu2 [16.1 kB]
#0 101.2 debconf: delaying package configuration, since apt-utils is not installed
#0 101.2 Fetched 2642 kB in 4s (683 kB/s)
(Reading database ... 9160 files and directories currently installed.)
#0 101.2 Preparing to unpack .../debianutils_5.8-1_arm64.deb ...
#0 101.3 Unpacking debianutils (5.8-1) over (5.7-0.4) ...
#0 101.3 Setting up debianutils (5.8-1) ...
(Reading database ... 9160 files and directories currently installed.)
#0 101.4 Preparing to unpack .../findutils_4.9.0-5_arm64.deb ...
#0 101.4 Unpacking findutils (4.9.0-5) over (4.9.0-4ubuntu1) ...
#0 101.4 Setting up findutils (4.9.0-5) ...
(Reading database ... 9160 files and directories currently installed.)
#0 101.5 Preparing to unpack .../libncursesw6_6.4+20230625-1_arm64.deb ...
#0 101.5 Unpacking libncursesw6:arm64 (6.4+20230625-1) over (6.4-4) ...
#0 101.5 Preparing to unpack .../libtinfo6_6.4+20230625-1_arm64.deb ...
#0 101.5 Unpacking libtinfo6:arm64 (6.4+20230625-1) over (6.4-4) ...
#0 101.6 Setting up libtinfo6:arm64 (6.4+20230625-1) ...
(Reading database ... 9160 files and directories currently installed.)
#0 101.6 Preparing to unpack .../ncurses-bin_6.4+20230625-1_arm64.deb ...
#0 101.6 Unpacking ncurses-bin (6.4+20230625-1) over (6.4-4) ...
#0 101.6 Setting up ncurses-bin (6.4+20230625-1) ...
(Reading database ... 9160 files and directories currently installed.)
#0 101.7 Preparing to unpack .../ncurses-base_6.4+20230625-1_all.deb ...
#0 101.7 Unpacking ncurses-base (6.4+20230625-1) over (6.4-4) ...
#0 101.7 Setting up ncurses-base (6.4+20230625-1) ...
(Reading database ... 9158 files and directories currently installed.)
#0 101.8 Preparing to unpack .../logsave_1.47.0-1ubuntu2_arm64.deb ...
#0 101.8 Unpacking logsave (1.47.0-1ubuntu2) over (1.47.0-1ubuntu1) ...
#0 101.8 Preparing to unpack .../libext2fs2_1.47.0-1ubuntu2_arm64.deb ...
#0 101.8 Unpacking libext2fs2:arm64 (1.47.0-1ubuntu2) over (1.47.0-1ubuntu1) ...
#0 101.9 Setting up libext2fs2:arm64 (1.47.0-1ubuntu2) ...
(Reading database ... 9158 files and directories currently installed.)
#0 101.9 Preparing to unpack .../e2fsprogs_1.47.0-1ubuntu2_arm64.deb ...
#0 101.9 Unpacking e2fsprogs (1.47.0-1ubuntu2) over (1.47.0-1ubuntu1) ...
#0 102.0 Preparing to unpack .../gcc-13-base_13.1.0-7ubuntu1_arm64.deb ...
#0 102.0 Unpacking gcc-13-base:arm64 (13.1.0-7ubuntu1) over (13.1.0-6ubuntu1) ...
#0 102.0 Setting up gcc-13-base:arm64 (13.1.0-7ubuntu1) ...
(Reading database ... 9158 files and directories currently installed.)
#0 102.1 Preparing to unpack .../libstdc++6_13.1.0-7ubuntu1_arm64.deb ...
#0 102.1 Unpacking libstdc++6:arm64 (13.1.0-7ubuntu1) over (13.1.0-6ubuntu1) ...
#0 102.2 Setting up libstdc++6:arm64 (13.1.0-7ubuntu1) ...
(Reading database ... 9158 files and directories currently installed.)
#0 102.2 Preparing to unpack .../libgcc-s1_13.1.0-7ubuntu1_arm64.deb ...
#0 102.2 Unpacking libgcc-s1:arm64 (13.1.0-7ubuntu1) over (13.1.0-6ubuntu1) ...
#0 102.3 Setting up libgcc-s1:arm64 (13.1.0-7ubuntu1) ...
(Reading database ... 9158 files and directories currently installed.)
#0 102.3 Preparing to unpack .../libaudit-common_1%3a3.1.1-1_all.deb ...
#0 102.3 Unpacking libaudit-common (1:3.1.1-1) over (1:3.0.9-1) ...
#0 102.4 Setting up libaudit-common (1:3.1.1-1) ...
(Reading database ... 9158 files and directories currently installed.)
#0 102.4 Preparing to unpack .../libaudit1_1%3a3.1.1-1_arm64.deb ...
#0 102.4 Unpacking libaudit1:arm64 (1:3.1.1-1) over (1:3.0.9-1) ...
#0 102.4 Setting up libaudit1:arm64 (1:3.1.1-1) ...
(Reading database ... 9158 files and directories currently installed.)
#0 102.5 Preparing to unpack .../libtasn1-6_4.19.0-3_arm64.deb ...
#0 102.5 Unpacking libtasn1-6:arm64 (4.19.0-3) over (4.19.0-2) ...
#0 102.5 Setting up libtasn1-6:arm64 (4.19.0-3) ...
(Reading database ... 9158 files and directories currently installed.)
#0 102.5 Preparing to unpack .../libcom-err2_1.47.0-1ubuntu2_arm64.deb ...
#0 102.6 Unpacking libcom-err2:arm64 (1.47.0-1ubuntu2) over (1.47.0-1ubuntu1) ...
#0 102.6 Preparing to unpack .../libss2_1.47.0-1ubuntu2_arm64.deb ...
#0 102.6 Unpacking libss2:arm64 (1.47.0-1ubuntu2) over (1.47.0-1ubuntu1) ...
#0 102.6 Setting up libcom-err2:arm64 (1.47.0-1ubuntu2) ...
#0 102.6 Setting up libss2:arm64 (1.47.0-1ubuntu2) ...
#0 102.6 Setting up libncursesw6:arm64 (6.4+20230625-1) ...
#0 102.6 Setting up logsave (1.47.0-1ubuntu2) ...
#0 102.7 Setting up e2fsprogs (1.47.0-1ubuntu2) ...
#0 102.7 Installing new version of config file /etc/mke2fs.conf ...
#0 102.9 Processing triggers for libc-bin (2.37-0ubuntu2) ...
#0 103.0 Reading package lists...
#0 103.5 Building dependency tree...
#0 103.6 Reading state information...
#0 103.6 Package netcat is a virtual package provided by:
#0 103.6   netcat-traditional 1.10-47
#0 103.6   netcat-openbsd 1.219-1ubuntu1
#0 103.6 
#0 103.6 E: Package 'netcat' has no installation candidate
------
failed to solve: executor failed running [/bin/sh -c apt-get update     && apt-get install -y --no-install-recommends     software-properties-common     && add-apt-repository ppa:git-core/ppa -y     && apt-get dist-upgrade -y     && apt-get install -y --no-install-recommends     netcat     postgresql     curl     git     ssh     software-properties-common     make     build-essential     ca-certificates     libpq-dev     libsasl2-dev     libsasl2-2     libsasl2-modules-gssapi-mit     libyaml-dev     unixodbc-dev     && add-apt-repository ppa:deadsnakes/ppa     && apt-get install -y     python     python-dev     python3-pip     python3.8     python3.8-dev     python3.8-venv     python3.9     python3.9-dev     python3.9-venv     python3.10     python3.10-dev     python3.10-venv     python3.11     python3.11-dev     python3.11-venv     && apt-get clean     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*]: exit code: 100
```

</details>


#### After

```shell
docker-compose run --rm test tox -e py
```

<img width="1108" alt="image" src="https://github.com/dbt-labs/dbt-core/assets/44704949/5ea78028-cd7a-4f60-99a2-277fc6e2ab20">

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] 👉 The testing for this PR is manual rather than automated 😅 
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) ~or this PR has already received feedback and approval from Product or DX~
