### PR TITLE
Update validate sql test classes to new nomenclature

### DIFF
--- a/.changes/unreleased/Fixes-20230711-234737.yaml
+++ b/.changes/unreleased/Fixes-20230711-234737.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Update DryRunMethod test classes ValidateSqlMethod naming
+time: 2023-07-11T23:47:37.9525-04:00
+custom:
+  Author: tlento
+  Issue: "7839"

--- a/tests/adapter/dbt/tests/adapter/utils/test_validate_sql.py
+++ b/tests/adapter/dbt/tests/adapter/utils/test_validate_sql.py
@@ -6,20 +6,20 @@ from dbt.adapters.base.impl import BaseAdapter
 from dbt.exceptions import DbtRuntimeError, InvalidConnectionError
 
 
-class BaseDryRunMethod:
-    """Tests the behavior of the dry run method for the relevant adapters.
+class BaseValidateSqlMethod:
+    """Tests the behavior of the validate_sql method for the relevant adapters.
 
     The valid and invalid SQL should work with most engines by default, but
     both inputs can be overridden as needed for a given engine to get the correct
     behavior.
 
-    The base method is meant to throw the appropriate custom exception when dry_run
+    The base method is meant to throw the appropriate custom exception when validate_sql
     fails.
     """
 
     @pytest.fixture(scope="class")
     def valid_sql(self) -> str:
-        """Returns a valid statement for issuing as a dry run query.
+        """Returns a valid statement for issuing as a validate_sql query.
 
         Ideally this would be checkable for non-execution. For example, we could use a
         CREATE TABLE statement with an assertion that no table was created. However,
@@ -33,7 +33,7 @@ class BaseDryRunMethod:
 
     @pytest.fixture(scope="class")
     def invalid_sql(self) -> str:
-        """Returns an invalid statement for issuing a bad dry run query."""
+        """Returns an invalid statement for issuing a bad validate_sql query."""
 
         return "Let's run some invalid SQL and see if we get an error!"
 
@@ -45,18 +45,18 @@ class BaseDryRunMethod:
         base exception for adapters to throw."""
         return DbtRuntimeError
 
-    def test_valid_dry_run(self, adapter: BaseAdapter, valid_sql: str) -> None:
-        """Executes a dry run query on valid SQL. No news is good news."""
+    def test_validate_sql_success(self, adapter: BaseAdapter, valid_sql: str) -> None:
+        """Executes validate_sql on valid SQL. No news is good news."""
         with adapter.connection_named("test_valid_sql_validation"):
             adapter.validate_sql(valid_sql)
 
-    def test_invalid_dry_run(
+    def test_validate_sql_failure(
         self,
         adapter: BaseAdapter,
         invalid_sql: str,
         expected_exception: Type[Exception],
     ) -> None:
-        """Executes a dry run query on invalid SQL, expecting the exception."""
+        """Executes validate_sql on invalid SQL, expecting the exception."""
         with pytest.raises(expected_exception=expected_exception) as excinfo:
             with adapter.connection_named("test_invalid_sql_validation"):
                 adapter.validate_sql(invalid_sql)
@@ -71,5 +71,5 @@ class BaseDryRunMethod:
             ) from excinfo.value
 
 
-class TestDryRunMethod(BaseDryRunMethod):
+class TestValidateSqlMethod(BaseValidateSqlMethod):
     pass


### PR DESCRIPTION
resolves # 7839

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
The original implementation of validate_sql was called dry_run,
but in the rename the test classes and much of their associated
documentation still retained the old naming.

This is mainly cosmetic, but since these test classes will be
imported into adapter repositories we should fix this now before
the wrong name proliferates.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
Renamed the relevant symbols and updated docblocks as needed

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
