### PR TITLE
Add semantic_models to tracked resource counts

### DIFF
--- a/.changes/unreleased/Under the Hood-20230712-170559.yaml
+++ b/.changes/unreleased/Under the Hood-20230712-170559.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add semantic_models to resource counts
+time: 2023-07-12T17:05:59.497596+02:00
+custom:
+  Author: jtcohen6
+  Issue: "8077"

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -84,26 +84,17 @@ def _generate_stats(manifest: Manifest):
         if _node_enabled(node):
             stats[node.resource_type] += 1
 
-    for source in manifest.sources.values():
-        stats[source.resource_type] += 1
-    for exposure in manifest.exposures.values():
-        stats[exposure.resource_type] += 1
-    for metric in manifest.metrics.values():
-        stats[metric.resource_type] += 1
-    for macro in manifest.macros.values():
-        stats[macro.resource_type] += 1
-    for group in manifest.groups.values():
-        stats[group.resource_type] += 1
+    # REVIEW: Why are these counted if disabled, when nodes in the general node
+    # collection are not?
+    stats[NodeType.Source] += len(manifest.sources)
+    stats[NodeType.Exposure] += len(manifest.exposures)
+    stats[NodeType.Metric] += len(manifest.metrics)
+    stats[NodeType.Macro] += len(manifest.macros)
+    stats[NodeType.Group] += len(manifest.groups)
+    stats[NodeType.SemanticModel] += len(manifest.semantic_models)
 
     # TODO: should we be counting dimensions + entities?
-    # dimensions = set()
-    # entities = set()
-    for semantic_model in manifest.semantic_models.values():
-        stats[semantic_model.resource_type] += 1
-        # for dimension in semantic_model.dimensions:
-        #    dimensions.add(dimension.name)
-        # for entity in semantic_model.entities:
-        #    entities.add(entity.name)
+
     return stats
 
 

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -84,8 +84,7 @@ def _generate_stats(manifest: Manifest):
         if _node_enabled(node):
             stats[node.resource_type] += 1
 
-    # REVIEW: Why are these counted if disabled, when nodes in the general node
-    # collection are not?
+    # Disabled nodes don't appear in the following collections, so we don't check.
     stats[NodeType.Source] += len(manifest.sources)
     stats[NodeType.Exposure] += len(manifest.exposures)
     stats[NodeType.Metric] += len(manifest.metrics)

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -48,9 +48,10 @@ def print_compile_stats(stats):
         NodeType.Analysis: "analysis",
         NodeType.Macro: "macro",
         NodeType.Operation: "operation",
-        NodeType.Seed: "seed file",
+        NodeType.Seed: "seed",
         NodeType.Source: "source",
         NodeType.Exposure: "exposure",
+        NodeType.SemanticModel: "semantic model",
         NodeType.Metric: "metric",
         NodeType.Group: "group",
     }
@@ -63,7 +64,8 @@ def print_compile_stats(stats):
         resource_counts = {k.pluralize(): v for k, v in results.items()}
         dbt.tracking.track_resource_counts(resource_counts)
 
-    stat_line = ", ".join([pluralize(ct, names.get(t)) for t, ct in results.items() if t in names])
+    # do not include resource types that are not actually defined in the project
+    stat_line = ", ".join([pluralize(ct, names.get(t)) for t, ct in stats.items() if t in names])
 
     fire_event(FoundStats(stat_line=stat_line))
 
@@ -92,6 +94,16 @@ def _generate_stats(manifest: Manifest):
         stats[macro.resource_type] += 1
     for group in manifest.groups.values():
         stats[group.resource_type] += 1
+
+    # TODO: should we be counting dimensions + entities?
+    # dimensions = set()
+    # entities = set()
+    for semantic_model in manifest.semantic_models.values():
+        stats[semantic_model.resource_type] += 1
+        # for dimension in semantic_model.dimensions:
+        #    dimensions.add(dimension.name)
+        # for entity in semantic_model.entities:
+        #    entities.add(entity.name)
     return stats
 
 


### PR DESCRIPTION
resolves #8077
~no docs changes needed~

### Problem

We want to be reporting on & tracking the count of semantic models defined in a project

### Solution

Add `semantic_models` to the list of resources being counted

We _might_ be able to do this for `dimensions` & `entities` too, but it's a lot less nice & straighforward

### While here

Aesthetic preference: Don't include resources in the logged "stat line" that aren't actually used/defined in the project.
```
$ dbt compile
14:01:29  Running with dbt=1.6.0-b8
14:01:29  Registered adapter: postgres=1.6.0-b8
14:01:30  Found 2 models, 1 seed, 349 macros, 1 semantic model
```
versus
```
 $ dbt compile
14:01:39  Running with dbt=1.6.0-b8
14:01:39  Registered adapter: postgres=1.6.0-b8
14:01:39  Found 2 models, 0 tests, 0 snapshots, 0 analyses, 349 macros, 0 operations, 1 seed, 0 sources, 0 exposures, 1 semantic model, 0 metrics, 0 groups
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
