### PR TITLE
Backport 8072 1.5.latest3

### DIFF
--- a/.changes/unreleased/Fixes-20230712-164916.yaml
+++ b/.changes/unreleased/Fixes-20230712-164916.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Detect breaking contract changes to versioned models
+time: 2023-07-12T16:49:16.247718-07:00
+custom:
+  Author: michelleark
+  Issue: "8030"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -585,6 +585,11 @@ class CompiledNode(ParsedNode):
         # We don't need to construct the checksum if the model does not
         # have contract enforced, because it won't be used.
         # This needs to be executed after contract config is set
+
+        # Avoid rebuilding the checksum if it has already been set.
+        if self.contract.checksum is not None:
+            return
+
         if self.contract.enforced is True:
             contract_state = ""
             # We need to sort the columns so that order doesn't matter

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -1191,10 +1191,12 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
                 self.patch_constraints(
                     versioned_model_node, unparsed_version.constraints or target.constraints
                 )
-                versioned_model_node.build_contract_checksum()
-
                 # Includes alias recomputation
                 self.patch_node_config(versioned_model_node, versioned_model_patch)
+
+                # Need to reapply this here, in the case that 'contract: {enforced: true}' was during config-setting
+                versioned_model_node.build_contract_checksum()
+
                 source_file.append_patch(
                     versioned_model_patch.yaml_key, versioned_model_node.unique_id
                 )

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -311,6 +311,20 @@ models:
             - name: extra
 """
 
+
+MULTIPLE_TABLE_VERSIONED_MODEL_CONTRACT_ENFORCED = """
+models:
+    - name: my_model
+      config:
+        contract:
+            enforced: true
+      versions:
+        - v: 0
+          defined_in: arbitrary_file_name
+        - v: 2
+"""
+
+
 MULTIPLE_TABLE_VERSIONED_MODEL_V0 = """
 models:
     - name: my_model
@@ -751,6 +765,18 @@ class SchemaParserVersionedModels(SchemaParserTest):
         self.assertEqual(
             parsed_node_patch_v2.config, {"materialized": "view", "sql_header": "test_sql_header"}
         )
+
+    def test__parsed_versioned_models_contract_enforced(self):
+        block = self.file_block_for(
+            MULTIPLE_TABLE_VERSIONED_MODEL_CONTRACT_ENFORCED, "test_one.yml"
+        )
+        self.parser.manifest.files[block.file.file_id] = block.file
+        dct = yaml_from_file(block.file)
+        self.parser.parse_file(block, dct)
+        self.assert_has_manifest_lengths(self.parser.manifest, nodes=2)
+        for node in self.parser.manifest.nodes.values():
+            assert node.contract.enforced
+            node.build_contract_checksum.assert_called()
 
     def test__parsed_versioned_models_v0(self):
         block = self.file_block_for(MULTIPLE_TABLE_VERSIONED_MODEL_V0, "test_one.yml")

--- a/tests/functional/defer_state/fixtures.py
+++ b/tests/functional/defer_state/fixtures.py
@@ -50,17 +50,25 @@ models:
       - name: name
 """
 
-contract_schema_yml = """
+no_contract_schema_yml = """
 version: 2
 models:
-  - name: view_model
+  - name: table_model
+    config: {}
     columns:
       - name: id
+        data_type: integer
         tests:
           - unique:
               severity: error
           - not_null
       - name: name
+        data_type: text
+"""
+
+contract_schema_yml = """
+version: 2
+models:
   - name: table_model
     config:
       contract:
@@ -79,14 +87,6 @@ models:
 modified_contract_schema_yml = """
 version: 2
 models:
-  - name: view_model
-    columns:
-      - name: id
-        tests:
-          - unique:
-              severity: error
-          - not_null
-      - name: name
   - name: table_model
     config:
       contract:
@@ -105,15 +105,88 @@ models:
 disabled_contract_schema_yml = """
 version: 2
 models:
-  - name: view_model
+  - name: table_model
+    config:
+      contract:
+        enforced: False
     columns:
       - name: id
+        data_type: integer
         tests:
           - unique:
               severity: error
           - not_null
       - name: name
+        data_type: text
+"""
+
+versioned_no_contract_schema_yml = """
+version: 2
+models:
   - name: table_model
+    config: {}
+    versions:
+      - v: 1
+    columns:
+      - name: id
+        data_type: integer
+        tests:
+          - unique:
+              severity: error
+          - not_null
+      - name: name
+        data_type: text
+"""
+
+versioned_contract_schema_yml = """
+version: 2
+models:
+  - name: table_model
+    config:
+      contract:
+        enforced: True
+    versions:
+      - v: 1
+    columns:
+      - name: id
+        data_type: integer
+        tests:
+          - unique:
+              severity: error
+          - not_null
+      - name: name
+        data_type: text
+"""
+
+versioned_modified_contract_schema_yml = """
+version: 2
+models:
+  - name: table_model
+    config:
+      contract:
+        enforced: True
+    versions:
+      - v: 1
+    columns:
+      - name: id
+        data_type: integer
+        tests:
+          - unique:
+              severity: error
+          - not_null
+      - name: user_name
+        data_type: text
+"""
+
+versioned_disabled_contract_schema_yml = """
+version: 2
+models:
+  - name: table_model
+    config:
+      contract:
+        enforced: False
+    versions:
+      - v: 1
     columns:
       - name: id
         data_type: integer

--- a/tests/functional/defer_state/test_modified_state.py
+++ b/tests/functional/defer_state/test_modified_state.py
@@ -18,9 +18,14 @@ from tests.functional.defer_state.fixtures import (
     exposures_yml,
     macros_sql,
     infinite_macros_sql,
+    no_contract_schema_yml,
     contract_schema_yml,
     modified_contract_schema_yml,
     disabled_contract_schema_yml,
+    versioned_no_contract_schema_yml,
+    versioned_contract_schema_yml,
+    versioned_disabled_contract_schema_yml,
+    versioned_modified_contract_schema_yml,
 )
 
 
@@ -267,11 +272,17 @@ class TestChangedExposure(BaseModifiedState):
 
 
 class TestChangedContract(BaseModifiedState):
+    MODEL_UNIQUE_ID = "model.test.table_model"
+    CONTRACT_SCHEMA_YML = contract_schema_yml
+    MODIFIED_SCHEMA_YML = modified_contract_schema_yml
+    DISABLED_SCHEMA_YML = disabled_contract_schema_yml
+    NO_CONTRACT_SCHEMA_YML = no_contract_schema_yml
+
     def test_changed_contract(self, project):
         self.run_and_save_state()
 
         # update contract for table_model
-        write_file(contract_schema_yml, "models", "schema.yml")
+        write_file(self.CONTRACT_SCHEMA_YML, "models", "schema.yml")
 
         # This will find the table_model node modified both through a config change
         # and by a non-breaking change to contract: true
@@ -279,7 +290,7 @@ class TestChangedContract(BaseModifiedState):
         assert len(results) == 1
         assert results[0].node.name == "table_model"
         manifest = get_manifest(project.project_root)
-        model_unique_id = "model.test.table_model"
+        model_unique_id = self.MODEL_UNIQUE_ID
         model = manifest.nodes[model_unique_id]
         expected_unrendered_config = {"contract": {"enforced": True}, "materialized": "table"}
         assert model.unrendered_config == expected_unrendered_config
@@ -295,7 +306,7 @@ class TestChangedContract(BaseModifiedState):
         self.copy_state()
 
         # This should raise because a column name has changed
-        write_file(modified_contract_schema_yml, "models", "schema.yml")
+        write_file(self.MODIFIED_SCHEMA_YML, "models", "schema.yml")
         results = run_dbt(["run"], expect_pass=False)
         assert len(results) == 2
         manifest = get_manifest(project.project_root)
@@ -307,14 +318,22 @@ class TestChangedContract(BaseModifiedState):
             results = run_dbt(["run", "--models", "state:modified.contract", "--state", "./state"])
 
         # Go back to schema file without contract. Should raise an error.
-        write_file(schema_yml, "models", "schema.yml")
+        write_file(self.NO_CONTRACT_SCHEMA_YML, "models", "schema.yml")
         with pytest.raises(ContractBreakingChangeError):
             results = run_dbt(["run", "--models", "state:modified.contract", "--state", "./state"])
 
         # Now disable the contract. Should raise an error.
-        write_file(disabled_contract_schema_yml, "models", "schema.yml")
+        write_file(self.DISABLED_SCHEMA_YML, "models", "schema.yml")
         with pytest.raises(ContractBreakingChangeError):
             results = run_dbt(["run", "--models", "state:modified.contract", "--state", "./state"])
+
+
+class TestChangedContractVersioned(TestChangedContract):
+    MODEL_UNIQUE_ID = "model.test.table_model.v1"
+    CONTRACT_SCHEMA_YML = versioned_contract_schema_yml
+    MODIFIED_SCHEMA_YML = versioned_modified_contract_schema_yml
+    DISABLED_SCHEMA_YML = versioned_disabled_contract_schema_yml
+    NO_CONTRACT_SCHEMA_YML = versioned_no_contract_schema_yml
 
 
 my_model_sql = """


### PR DESCRIPTION
Backport of https://github.com/dbt-labs/dbt-core/pull/8072
- Automatic backport failed due to conflicts arising from (intentionally not backported) changes in https://github.com/dbt-labs/dbt-core/pull/7476
- Manually implemented the fix in 1.5.latest instead.

[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  
  * N/A - current documentation describes expected behaviour which was not being met for versioned models.

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
