### PR TITLE
[CT-2821]  Support `dbt-semantic-interfaces~=0.1.0rc1`

### DIFF
--- a/.changes/unreleased/Dependencies-20230712-165219.yaml
+++ b/.changes/unreleased/Dependencies-20230712-165219.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump `dbt-semantic-interfaces` to `~=0.1.0rc1`
+time: 2023-07-12T16:52:19.748953-07:00
+custom:
+  Author: QMalcolm
+  PR: "8082"

--- a/.changes/unreleased/Fixes-20230712-172037.yaml
+++ b/.changes/unreleased/Fixes-20230712-172037.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix typo in `NonAdditiveDimension` implementation
+time: 2023-07-12T17:20:37.089887-07:00
+custom:
+  Author: QMalcolm
+  Issue: "8088"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -48,6 +48,7 @@ from dbt.events.types import (
 from dbt.events.contextvars import set_log_contextvars
 from dbt.flags import get_flags
 from dbt.node_types import ModelLanguage, NodeType, AccessType
+from dbt_semantic_interfaces.call_parameter_sets import FilterCallParameterSets
 from dbt_semantic_interfaces.references import (
     MeasureReference,
     LinkableElementReference,
@@ -56,6 +57,7 @@ from dbt_semantic_interfaces.references import (
 )
 from dbt_semantic_interfaces.references import MetricReference as DSIMetricReference
 from dbt_semantic_interfaces.type_enums import MetricType, TimeGranularity
+from dbt_semantic_interfaces.parsing.where_filter_parser import WhereFilterParser
 
 from .model_config import (
     NodeConfig,
@@ -1314,6 +1316,10 @@ class Exposure(GraphNode):
 @dataclass
 class WhereFilter(dbtClassMixin):
     where_sql_template: str
+
+    @property
+    def call_parameter_sets(self) -> FilterCallParameterSets:
+        return WhereFilterParser.parse_call_parameter_sets(self.where_sql_template)
 
 
 @dataclass

--- a/core/dbt/contracts/graph/semantic_models.py
+++ b/core/dbt/contracts/graph/semantic_models.py
@@ -128,7 +128,7 @@ class MeasureAggregationParameters(dbtClassMixin):
 class NonAdditiveDimension(dbtClassMixin):
     name: str
     window_choice: AggregationType
-    window_grouples: List[str]
+    window_groupings: List[str]
 
 
 @dataclass

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -689,7 +689,7 @@ class UnparsedEntity(dbtClassMixin):
 class UnparsedNonAdditiveDimension(dbtClassMixin):
     name: str
     window_choice: str  # AggregationType enum
-    window_grouples: List[str]
+    window_groupings: List[str]
 
 
 @dataclass

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -486,7 +486,7 @@ class SemanticModelParser(YamlReader):
             return NonAdditiveDimension(
                 name=unparsed.name,
                 window_choice=AggregationType(unparsed.window_choice),
-                window_grouples=unparsed.window_grouples,
+                window_groupings=unparsed.window_groupings,
             )
         else:
             return None

--- a/core/setup.py
+++ b/core/setup.py
@@ -78,7 +78,7 @@ setup(
         "minimal-snowplow-tracker~=0.0.2",
         # DSI is under active development, so we're pinning to specific dev versions for now.
         # TODO: Before RC/final release, update to use ~= pinning.
-        "dbt-semantic-interfaces~=0.1.0.dev10",
+        "dbt-semantic-interfaces~=0.1.0rc1",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
         "packaging>20.9",

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -7,7 +7,13 @@ from dbt.contracts.graph.nodes import (
     SemanticModel,
     WhereFilter,
 )
-from dbt.contracts.graph.semantic_models import Dimension, DimensionTypeParams, Entity, Measure
+from dbt.contracts.graph.semantic_models import (
+    Dimension,
+    DimensionTypeParams,
+    Entity,
+    Measure,
+    NonAdditiveDimension,
+)
 from dbt.node_types import NodeType
 from dbt_semantic_interfaces.protocols import (
     Dimension as DSIDimension,
@@ -20,7 +26,11 @@ from dbt_semantic_interfaces.protocols import (
     SemanticModel as DSISemanticModel,
     WhereFilter as DSIWhereFilter,
 )
+from dbt_semantic_interfaces.protocols.measure import (
+    NonAdditiveDimensionParameters as DSINonAdditiveDimensionParameters,
+)
 from dbt_semantic_interfaces.type_enums import (
+    AggregationType,
     DimensionType,
     EntityType,
     MetricType,
@@ -71,6 +81,11 @@ class RuntimeCheckableMetricTypeParams(DSIMetricTypeParams, Protocol):
 
 @runtime_checkable
 class RuntimeCheckableWhereFilter(DSIWhereFilter, Protocol):
+    pass
+
+
+@runtime_checkable
+class RuntimeCheckableNonAdditiveDimension(DSINonAdditiveDimensionParameters, Protocol):
     pass
 
 
@@ -172,3 +187,12 @@ def test_metric_input_measure():
 def test_metric_type_params_satisfies_protocol():
     type_params = MetricTypeParams()
     assert isinstance(type_params, RuntimeCheckableMetricTypeParams)
+
+
+def test_non_additive_dimension_satisfies_protocol():
+    non_additive_dimension = NonAdditiveDimension(
+        name="dimension_name",
+        window_choice=AggregationType.MIN,
+        window_groupings=["entity_name"],
+    )
+    assert isinstance(non_additive_dimension, RuntimeCheckableNonAdditiveDimension)

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -18,6 +18,7 @@ from dbt_semantic_interfaces.protocols import (
     MetricInputMeasure as DSIMetricInputMeasure,
     MetricTypeParams as DSIMetricTypeParams,
     SemanticModel as DSISemanticModel,
+    WhereFilter as DSIWhereFilter,
 )
 from dbt_semantic_interfaces.type_enums import (
     DimensionType,
@@ -65,6 +66,11 @@ class RuntimeCheckableMetricInputMeasure(DSIMetricInputMeasure, Protocol):
 
 @runtime_checkable
 class RuntimeCheckableMetricTypeParams(DSIMetricTypeParams, Protocol):
+    pass
+
+
+@runtime_checkable
+class RuntimeCheckableWhereFilter(DSIWhereFilter, Protocol):
     pass
 
 
@@ -144,6 +150,13 @@ def test_metric_node_satisfies_protocol():
         ),
     )
     assert isinstance(metric, RuntimeCheckableMetric)
+
+
+def test_where_filter_satisfies_protocol():
+    where_filter = WhereFilter(
+        where_sql_template="{{ dimension('dimension_name') }} AND {{ time_dimension('time_dimension_name', 'month') }} AND {{ entity('entity_name') }}"
+    )
+    assert isinstance(where_filter, RuntimeCheckableWhereFilter)
 
 
 def test_metric_input():


### PR DESCRIPTION
resolves #8082

### Problem

We need to move to DSI 0.1.0rc versions prior to RC of dbt-core

### Solution

Update dependency on DSI to `dbt-semantic-interfaces~=0.1.0rc1` and make any necessary changes

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
