### PR TITLE
gitignore .user.yml and profiles.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ var/
 .mypy_cache/
 .dmypy.json
 logs/
+.user.yml
+profiles.yml
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION
resolves #  
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

running `pytest/unit` leaves behind a couple straggling files - .user.yml and profiles.yml. I'm not entirely sure which test is writing these, presumably something related to testing `dbt init` behaviour which writes a profiles.yml file.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Ideally these files are cleaned up as part of the unit test execution, but they are not written by a unit test itself (during setup, for example) and instead are a side-effect of running certain codepaths. A quick fix and robust fix is to simply .gitignore these files to avoid erroneously checking them in. 
* e.g. writing .user.yml: https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/tracking.py#L158

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
