### PR TITLE
[CT-2822]  Fix `NonAdditiveDimension` Implementation

### DIFF
--- a/.changes/unreleased/Fixes-20230712-172037.yaml
+++ b/.changes/unreleased/Fixes-20230712-172037.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix typo in `NonAdditiveDimension` implementation
+time: 2023-07-12T17:20:37.089887-07:00
+custom:
+  Author: QMalcolm
+  Issue: "8088"

--- a/core/dbt/contracts/graph/semantic_models.py
+++ b/core/dbt/contracts/graph/semantic_models.py
@@ -128,7 +128,7 @@ class MeasureAggregationParameters(dbtClassMixin):
 class NonAdditiveDimension(dbtClassMixin):
     name: str
     window_choice: AggregationType
-    window_grouples: List[str]
+    window_groupings: List[str]
 
 
 @dataclass

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -689,7 +689,7 @@ class UnparsedEntity(dbtClassMixin):
 class UnparsedNonAdditiveDimension(dbtClassMixin):
     name: str
     window_choice: str  # AggregationType enum
-    window_grouples: List[str]
+    window_groupings: List[str]
 
 
 @dataclass

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -486,7 +486,7 @@ class SemanticModelParser(YamlReader):
             return NonAdditiveDimension(
                 name=unparsed.name,
                 window_choice=AggregationType(unparsed.window_choice),
-                window_grouples=unparsed.window_grouples,
+                window_groupings=unparsed.window_groupings,
             )
         else:
             return None

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -7,7 +7,13 @@ from dbt.contracts.graph.nodes import (
     SemanticModel,
     WhereFilter,
 )
-from dbt.contracts.graph.semantic_models import Dimension, DimensionTypeParams, Entity, Measure
+from dbt.contracts.graph.semantic_models import (
+    Dimension,
+    DimensionTypeParams,
+    Entity,
+    Measure,
+    NonAdditiveDimension,
+)
 from dbt.node_types import NodeType
 from dbt_semantic_interfaces.protocols import (
     Dimension as DSIDimension,
@@ -20,7 +26,11 @@ from dbt_semantic_interfaces.protocols import (
     SemanticModel as DSISemanticModel,
     WhereFilter as DSIWhereFilter,
 )
+from dbt_semantic_interfaces.protocols.measure import (
+    NonAdditiveDimensionParameters as DSINonAdditiveDimensionParameters,
+)
 from dbt_semantic_interfaces.type_enums import (
+    AggregationType,
     DimensionType,
     EntityType,
     MetricType,
@@ -71,6 +81,11 @@ class RuntimeCheckableMetricTypeParams(DSIMetricTypeParams, Protocol):
 
 @runtime_checkable
 class RuntimeCheckableWhereFilter(DSIWhereFilter, Protocol):
+    pass
+
+
+@runtime_checkable
+class RuntimeCheckableNonAdditiveDimension(DSINonAdditiveDimensionParameters, Protocol):
     pass
 
 
@@ -172,3 +187,12 @@ def test_metric_input_measure():
 def test_metric_type_params_satisfies_protocol():
     type_params = MetricTypeParams()
     assert isinstance(type_params, RuntimeCheckableMetricTypeParams)
+
+
+def test_non_additive_dimension_satisfies_protocol():
+    non_additive_dimension = NonAdditiveDimension(
+        name="dimension_name",
+        window_choice=AggregationType.MIN,
+        window_grouples=["entity_name"],
+    )
+    assert isinstance(non_additive_dimension, RuntimeCheckableNonAdditiveDimension)

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -193,6 +193,6 @@ def test_non_additive_dimension_satisfies_protocol():
     non_additive_dimension = NonAdditiveDimension(
         name="dimension_name",
         window_choice=AggregationType.MIN,
-        window_grouples=["entity_name"],
+        window_groupings=["entity_name"],
     )
     assert isinstance(non_additive_dimension, RuntimeCheckableNonAdditiveDimension)


### PR DESCRIPTION
resolves #8088 

### Problem

The `NonAddtiveDimension` class had a typo, `window_grouples`. I am unsure how `window_grouples` came to be, but it needs to be `window_groupings`. The issue this was causing can be seen in #8088 

### Solution

Fix the attribute name

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
