### PR TITLE
add env vars for datadog ci visibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,13 @@ defaults:
   run:
     shell: bash
 
+env:
+  DD_CIVISIBILITY_AGENTLESS_ENABLED: true
+  DD_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+  DD_SITE: datadoghq.com
+  DD_ENV: ci
+  DD_SERVICE: dbt-core
+
 jobs:
   code-quality:
     name: code-quality

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,13 +33,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  DD_CIVISIBILITY_AGENTLESS_ENABLED: true
-  DD_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-  DD_SITE: datadoghq.com
-  DD_ENV: ci
-  DD_SERVICE: dbt-core
-
 jobs:
   code-quality:
     name: code-quality
@@ -138,6 +131,11 @@ jobs:
       DBT_TEST_USER_1: dbt_test_user_1
       DBT_TEST_USER_2: dbt_test_user_2
       DBT_TEST_USER_3: dbt_test_user_3
+      DD_CIVISIBILITY_AGENTLESS_ENABLED: true
+      DD_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      DD_SITE: datadoghq.com
+      DD_ENV: ci
+      DD_SERVICE: ${{ github.event.repository.name }}
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
           tox --version
 
       - name: Run tests
-        run: tox
+        run: tox --ddtrace
 
       - name: Get current date
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
           tox --version
 
       - name: Run tests
-        run: tox --ddtrace
+        run: tox -- --ddtrace
 
       - name: Get current date
         if: always()

--- a/.github/workflows/test-repeater.yml
+++ b/.github/workflows/test-repeater.yml
@@ -75,6 +75,11 @@ jobs:
       DBT_TEST_USER_1: dbt_test_user_1
       DBT_TEST_USER_2: dbt_test_user_2
       DBT_TEST_USER_3: dbt_test_user_3
+      DD_CIVISIBILITY_AGENTLESS_ENABLED: true
+      DD_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      DD_SITE: datadoghq.com
+      DD_ENV: ci
+      DD_SERVICE: ${{ github.event.repository.name }}
 
     steps:
       - name: "Checkout code"
@@ -116,7 +121,7 @@ jobs:
           for ((i=1; i<=${{ inputs.num_runs_per_batch }}; i++))
           do
             echo "Running pytest iteration $i..."
-            python -m pytest ${{ inputs.test_path }}
+            python -m pytest ${{ inputs.test_path }} --ddtrace
             exit_code=$?
 
             if [[ $exit_code -eq 0 ]]; then

--- a/.github/workflows/test-repeater.yml
+++ b/.github/workflows/test-repeater.yml
@@ -121,7 +121,7 @@ jobs:
           for ((i=1; i<=${{ inputs.num_runs_per_batch }}; i++))
           do
             echo "Running pytest iteration $i..."
-            python -m pytest ${{ inputs.test_path }} --ddtrace
+            python -m pytest --ddtrace ${{ inputs.test_path }}
             exit_code=$?
 
             if [[ $exit_code -eq 0 ]]; then

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 black==23.3.0
 bumpversion
+ddtrace
 docutils
 flake8
 flaky

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,8 @@ passenv =
   DBT_*
   POSTGRES_TEST_*
   PYTEST_ADDOPTS
+  DD_SERVICE
+  DD_ENV
 commands =
   {envpython} -m pytest --cov=core {posargs} tests/functional -k "not tests/functional/graph_selection"
   {envpython} -m pytest --cov=core {posargs} tests/functional/graph_selection


### PR DESCRIPTION
resolves #8081 
~~[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#~~ n/a

### Problem

Datadog not ingesting test data for flaky test visibility

### Solution

Adds env vars to turn on test visibility in datadog.  [Datadog docs](https://docs.datadoghq.com/continuous_integration/tests/python/?tab=cloudciprovideragentless#compatibility)

Updates the tox command to include the `--ddtrace` flag only when running in CI.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
