### PR TITLE
Ensure that target_schema from snapshot config is promoted to node level

### DIFF
--- a/.changes/unreleased/Fixes-20230717-160652.yaml
+++ b/.changes/unreleased/Fixes-20230717-160652.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Copy target_schema from config into snapshot node
+time: 2023-07-17T16:06:52.957724-04:00
+custom:
+  Author: gshank
+  Issue: "6745"

--- a/core/dbt/contracts/graph/model_config.py
+++ b/core/dbt/contracts/graph/model_config.py
@@ -619,6 +619,8 @@ class SnapshotConfig(EmptySnapshotConfig):
     @classmethod
     def validate(cls, data):
         super().validate(data)
+        # Note: currently you can't just set these keys in schema.yml because this validation
+        # will fail when parsing the snapshot node.
         if not data.get("strategy") or not data.get("unique_key") or not data.get("target_schema"):
             raise ValidationError(
                 "Snapshots must be configured with a 'strategy', 'unique_key', "
@@ -649,6 +651,7 @@ class SnapshotConfig(EmptySnapshotConfig):
         if data.get("materialized") and data.get("materialized") != "snapshot":
             raise ValidationError("A snapshot must have a materialized value of 'snapshot'")
 
+    # Called by "calculate_node_config_dict" in ContextConfigGenerator
     def finalize_and_validate(self):
         data = self.to_dict(omit_none=True)
         self.validate(data)

--- a/core/dbt/parser/base.py
+++ b/core/dbt/parser/base.py
@@ -102,8 +102,7 @@ class RelationUpdate:
         self.package_updaters = package_updaters
         self.component = component
 
-    def __call__(self, parsed_node: Any, config_dict: Dict[str, Any]) -> None:
-        override = config_dict.get(self.component)
+    def __call__(self, parsed_node: Any, override: Optional[str]) -> None:
         if parsed_node.package_name in self.package_updaters:
             new_value = self.package_updaters[parsed_node.package_name](override, parsed_node)
         else:
@@ -280,9 +279,18 @@ class ConfiguredParser(
     def update_parsed_node_relation_names(
         self, parsed_node: IntermediateNode, config_dict: Dict[str, Any]
     ) -> None:
-        self._update_node_database(parsed_node, config_dict)
-        self._update_node_schema(parsed_node, config_dict)
-        self._update_node_alias(parsed_node, config_dict)
+
+        if parsed_node.resource_type == "snapshot":
+            if "target_database" in config_dict and config_dict["target_database"]:
+                parsed_node.database = config_dict["target_database"]
+            if "target_schema" in config_dict and config_dict["target_schema"]:
+                parsed_node.schema = config_dict["target_schema"]
+        else:
+            # These call the RelationUpdate callable to go through generate_name macros
+            self._update_node_database(parsed_node, config_dict.get("database"))
+            self._update_node_schema(parsed_node, config_dict.get("schema"))
+            self._update_node_alias(parsed_node, config_dict.get("alias"))
+
         self._update_node_relation_name(parsed_node)
 
     def update_parsed_node_config(
@@ -349,7 +357,7 @@ class ConfiguredParser(
         # do this once before we parse the node database/schema/alias, so
         # parsed_node.config is what it would be if they did nothing
         self.update_parsed_node_config_dict(parsed_node, config_dict)
-        # This updates the node database/schema/alias
+        # This updates the node database/schema/alias/relation_name
         self.update_parsed_node_relation_names(parsed_node, config_dict)
 
         # tests don't have hooks

--- a/core/dbt/parser/base.py
+++ b/core/dbt/parser/base.py
@@ -280,7 +280,7 @@ class ConfiguredParser(
         self, parsed_node: IntermediateNode, config_dict: Dict[str, Any]
     ) -> None:
 
-        if parsed_node.resource_type == "snapshot":
+        if parsed_node.resource_type == NodeType.Snapshot:
             if "target_database" in config_dict and config_dict["target_database"]:
                 parsed_node.database = config_dict["target_database"]
             if "target_schema" in config_dict and config_dict["target_schema"]:

--- a/core/dbt/parser/base.py
+++ b/core/dbt/parser/base.py
@@ -280,16 +280,17 @@ class ConfiguredParser(
         self, parsed_node: IntermediateNode, config_dict: Dict[str, Any]
     ) -> None:
 
+        # These call the RelationUpdate callable to go through generate_name macros
+        self._update_node_database(parsed_node, config_dict.get("database"))
+        self._update_node_schema(parsed_node, config_dict.get("schema"))
+        self._update_node_alias(parsed_node, config_dict.get("alias"))
+
+        # Snapshot nodes use special "target_database" and "target_schema" fields for some reason
         if parsed_node.resource_type == NodeType.Snapshot:
             if "target_database" in config_dict and config_dict["target_database"]:
                 parsed_node.database = config_dict["target_database"]
             if "target_schema" in config_dict and config_dict["target_schema"]:
                 parsed_node.schema = config_dict["target_schema"]
-        else:
-            # These call the RelationUpdate callable to go through generate_name macros
-            self._update_node_database(parsed_node, config_dict.get("database"))
-            self._update_node_schema(parsed_node, config_dict.get("schema"))
-            self._update_node_alias(parsed_node, config_dict.get("alias"))
 
         self._update_node_relation_name(parsed_node)
 

--- a/tests/functional/simple_snapshot/fixtures.py
+++ b/tests/functional/simple_snapshot/fixtures.py
@@ -96,6 +96,18 @@ snapshots:
         owner: 'a_owner'
 """
 
+models__schema_with_target_schema_yml = """
+version: 2
+snapshots:
+  - name: snapshot_actual
+    tests:
+      - mutually_exclusive_ranges
+    config:
+      meta:
+        owner: 'a_owner'
+      target_schema: schema_from_schema_yml
+"""
+
 models__ref_snapshot_sql = """
 select * from {{ ref('snapshot_actual') }}
 """

--- a/tests/functional/simple_snapshot/fixtures.py
+++ b/tests/functional/simple_snapshot/fixtures.py
@@ -281,6 +281,26 @@ snapshots_pg__snapshot_sql = """
 {% endsnapshot %}
 """
 
+snapshots_pg__snapshot_no_target_schema_sql = """
+{% snapshot snapshot_actual %}
+
+    {{
+        config(
+            target_database=var('target_database', database),
+            unique_key='id || ' ~ "'-'" ~ ' || first_name',
+            strategy='timestamp',
+            updated_at='updated_at',
+        )
+    }}
+
+    {% if var('invalidate_hard_deletes', 'false') | as_bool %}
+        {{ config(invalidate_hard_deletes=True) }}
+    {% endif %}
+
+    select * from {{target.database}}.{{target.schema}}.seed
+
+{% endsnapshot %}
+"""
 
 models_slow__gen_sql = """
 

--- a/tests/functional/simple_snapshot/test_basic_snapshot.py
+++ b/tests/functional/simple_snapshot/test_basic_snapshot.py
@@ -2,9 +2,10 @@ import os
 from datetime import datetime
 import pytz
 import pytest
-from dbt.tests.util import run_dbt, check_relations_equal, relation_from_name
+from dbt.tests.util import run_dbt, check_relations_equal, relation_from_name, write_file
 from tests.functional.simple_snapshot.fixtures import (
     models__schema_yml,
+    models__schema_with_target_schema_yml,
     models__ref_snapshot_sql,
     seeds__seed_newcol_csv,
     seeds__seed_csv,
@@ -141,8 +142,8 @@ class TestBasicTargetSchemaConfig(Basic):
 
     def test_target_schema(self, project):
         manifest = run_dbt(["parse"])
-        print(f"\n\n--- node keys: {manifest.nodes.keys()}")
         assert len(manifest.nodes) == 5
+        # ensure that the schema in the snapshot node is the same as target_schema
         snapshot_id = "snapshot.test.snapshot_actual"
         snapshot_node = manifest.nodes[snapshot_id]
         assert snapshot_node.schema == f"{project.test_schema}_alt"
@@ -150,6 +151,13 @@ class TestBasicTargetSchemaConfig(Basic):
             snapshot_node.relation_name
             == f'"{project.database}"."{project.test_schema}_alt"."snapshot_actual"'
         )
+        assert snapshot_node.meta == {"owner": "a_owner"}
+
+        # write out schema.yml file and check again
+        write_file(models__schema_with_target_schema_yml, "models", "schema.yml")
+        manifest = run_dbt(["parse"])
+        snapshot_node = manifest.nodes[snapshot_id]
+        assert snapshot_node.schema == "schema_from_schema_yml"
 
 
 class CustomNamespace:


### PR DESCRIPTION
resolves #6745 

### Problem

Snapshot target_schema and target_database were being processed when the snapshot nodes were processed, but those config fields were not being promoted  to the node level schema and database if set in config in dbt_proejct.yml or a schema yaml file.

### Solution

Added code to the "update_parsed_node_relation_names" to promote target_schema and target_database for snapshot nodes.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
