### PR TITLE
wrap deprecation warnings in warn_or_error calls

### DIFF
--- a/.changes/unreleased/Fixes-20230718-125518.yaml
+++ b/.changes/unreleased/Fixes-20230718-125518.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Enable converting deprecation warnings to errors
+time: 2023-07-18T12:55:18.03914-04:00
+custom:
+  Author: michelleark
+  Issue: "8130"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1153,10 +1153,11 @@ class DeprecatedModel(WarnLevel):
 
     def message(self) -> str:
         version = ".v" + self.model_version if self.model_version else ""
-        return (
+        msg = (
             f"Model {self.model_name}{version} has passed its deprecation date of {self.deprecation_date}. "
             "This model should be disabled or removed."
         )
+        return warning_tag(msg)
 
 
 class UpcomingReferenceDeprecation(WarnLevel):
@@ -1178,7 +1179,7 @@ class UpcomingReferenceDeprecation(WarnLevel):
             )
             msg = msg + coda
 
-        return msg
+        return warning_tag(msg)
 
 
 class DeprecatedReference(WarnLevel):
@@ -1200,7 +1201,7 @@ class DeprecatedReference(WarnLevel):
             )
             msg = msg + coda
 
-        return msg
+        return warning_tag(msg)
 
 
 class UnsupportedConstraintMaterialization(WarnLevel):

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -562,7 +562,7 @@ class ManifestLoader:
                     node.deprecation_date
                     and node.deprecation_date < datetime.datetime.now().astimezone()
                 ):
-                    fire_event(
+                    warn_or_error(
                         DeprecatedModel(
                             model_name=node.name,
                             model_version=version_to_str(node.version),
@@ -581,7 +581,7 @@ class ManifestLoader:
                         else:
                             event_cls = UpcomingReferenceDeprecation
 
-                        fire_event(
+                        warn_or_error(
                             event_cls(
                                 model_name=node.name,
                                 ref_model_package=resolved_ref.package_name,

--- a/tests/functional/deprecations/model_deprecations.py
+++ b/tests/functional/deprecations/model_deprecations.py
@@ -1,6 +1,9 @@
 import pytest
 
+from dbt.exceptions import EventCompilationError
 from dbt.cli.main import dbtRunner
+from dbt.tests.util import run_dbt
+
 
 deprecated_model__yml = """
 version: 2
@@ -41,6 +44,14 @@ class TestModelDeprecationWarning:
         assert len(matches) == 1
         assert matches[0].data.model_name == "my_model"
 
+    def test_deprecation_warning_error(self, project):
+        with pytest.raises(EventCompilationError):
+            run_dbt(["--warn-error", "parse"])
+
+    def test_deprecation_warning_error_options(self, project):
+        with pytest.raises(EventCompilationError):
+            run_dbt(["--warn-error-options", '{"include": ["DeprecatedModel"]}', "parse"])
+
 
 class TestReferenceDeprecatingWarning:
     @pytest.fixture(scope="class")
@@ -59,6 +70,16 @@ class TestReferenceDeprecatingWarning:
         assert matches[0].data.model_name == "my_dependant_model"
         assert matches[0].data.ref_model_name == "my_model"
 
+    def test_deprecation_warning_error(self, project):
+        with pytest.raises(EventCompilationError):
+            run_dbt(["--warn-error", "parse"])
+
+    def test_deprecation_warning_error_options(self, project):
+        with pytest.raises(EventCompilationError):
+            run_dbt(
+                ["--warn-error-options", '{"include": ["UpcomingReferenceDeprecation"]}', "parse"]
+            )
+
 
 class TestReferenceDeprecatedWarning:
     @pytest.fixture(scope="class")
@@ -76,3 +97,11 @@ class TestReferenceDeprecatedWarning:
         assert len(matches) == 1
         assert matches[0].data.model_name == "my_dependant_model"
         assert matches[0].data.ref_model_name == "my_model"
+
+    def test_deprecation_warning_error(self, project):
+        with pytest.raises(EventCompilationError):
+            run_dbt(["--warn-error", "parse"])
+
+    def test_deprecation_warning_error_options(self, project):
+        with pytest.raises(EventCompilationError):
+            run_dbt(["--warn-error-options", '{"include": ["DeprecatedReference"]}', "parse"])


### PR DESCRIPTION
resolves #8130
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  https://github.com/dbt-labs/docs.getdbt.com/issues/3745

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

Unable to convert deprecation warnings to errors through `--warn-error` or `--warn-error-options`.

I also noticed the deprecation warnings were not formatted with the `[WARN]` message

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
* call `fire_event` via `warn_or_error` instead of directly for deprecation warnings
  *  this is a pretty easy mistake to make, follow-on tech_debt issue: https://github.com/dbt-labs/dbt-core/issues/8133
* wrap exception messages in `warning_tag`
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX



:tophat: Formatting:  
```sh
❯ dbt parse
21:35:18  Running with dbt=1.7.0-a1
21:35:18  target not specified in profile 'postgres', using 'default'
21:35:19  Registered adapter: postgres=1.7.0-a1
21:35:19  [WARNING]: While compiling 'my_model_ref': Found a reference to my_model, which is slated for deprecation on '2024-01-01T00:00:00-05:00'. 
21:35:19  Performance info: /Users/michelleark/src/jaffle_shop/target/perf_info.json
```
:tophat: --warn-error
```sh
dbt --warn-error parse
21:35:37  Running with dbt=1.7.0-a1
21:35:37  target not specified in profile 'postgres', using 'default'
21:35:37  Registered adapter: postgres=1.7.0-a1
21:35:37  Encountered an error:
Compilation Error
  [WARNING]: While compiling 'my_model_ref': Found a reference to my_model, which is slated for deprecation on '2024-01-01T00:00:00-05:00'. 
```

:tophat: --warn-error-options
```
❯ dbt --warn-error-options '{"include":["DeprecatedReference"]}' parse
21:36:21  Running with dbt=1.7.0-a1
21:36:21  target not specified in profile 'postgres', using 'default'
21:36:22  Registered adapter: postgres=1.7.0-a1
21:36:22  [WARNING]: While compiling 'my_model_ref': Found a reference to my_model, which is slated for deprecation on '2024-01-01T00:00:00-05:00'. 
21:36:22  Performance info: /Users/michelleark/src/jaffle_shop/target/perf_info.json
```