### PR TITLE
format exception from dbtPlugin.initialize

### DIFF
--- a/.changes/unreleased/Under the Hood-20230719-163334.yaml
+++ b/.changes/unreleased/Under the Hood-20230719-163334.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: format exception from dbtPlugin.initialize
+time: 2023-07-19T16:33:34.586377-04:00
+custom:
+  Author: michelleark
+  Issue: "8152"

--- a/core/dbt/plugins/manager.py
+++ b/core/dbt/plugins/manager.py
@@ -29,8 +29,11 @@ class dbtPlugin:
         self.project_name = project_name
         try:
             self.initialize()
+        except DbtRuntimeError as e:
+            # Remove the first line of DbtRuntimeError to avoid redundant "Runtime Error" line
+            raise DbtRuntimeError("\n".join(str(e).split("\n")[1:]))
         except Exception as e:
-            raise DbtRuntimeError(f"initialize: {e}")
+            raise DbtRuntimeError(str(e))
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/8152
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  N/A

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
Any exception from a dbtPlugin.initialize method (an expected occurrence) is pretty verbose and exposes unnecessary details about the plugin method, e.g: 

```sh
❯ dbt run
20:30:47  Running with dbt=1.7.0-a1
20:30:47  target not specified in profile 'postgres', using 'default'
20:30:47  Encountered an error:
Runtime Error
  initialize: Runtime Error
    custom error message
```
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
Apply formatting to handled exceptions from dbtPlugin.initialize to be more inline with what a user would expect from a regular user-facing dbt-core exception - remove duplicate lines, mention of method name.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
