### PR TITLE
[CT-2594]  Fix serialization of `warn_error_options` on Contexts

### DIFF
--- a/.changes/unreleased/Fixes-20230720-161513.yaml
+++ b/.changes/unreleased/Fixes-20230720-161513.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Ensure `warn_error_options` get serialized in `invocation_args_dict`
+time: 2023-07-20T16:15:13.761813-07:00
+custom:
+  Author: QMalcolm
+  Issue: "7694"

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -17,6 +17,7 @@ from pathlib import PosixPath, WindowsPath
 
 from contextlib import contextmanager
 from dbt.events.types import RetryExternalCall, RecordRetryException
+from dbt.helper_types import WarnErrorOptions
 from dbt import flags
 from enum import Enum
 from typing_extensions import Protocol
@@ -654,6 +655,9 @@ def args_to_dict(args):
         # this was required for a test case
         if isinstance(var_args[key], PosixPath) or isinstance(var_args[key], WindowsPath):
             var_args[key] = str(var_args[key])
+        if isinstance(var_args[key], WarnErrorOptions):
+            var_args[key] = var_args[key].to_dict()
+
         dict_args[key] = var_args[key]
     return dict_args
 

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -424,6 +424,9 @@ def test_invocation_args_to_dict_in_macro_runtime_context(
     # Comes from unit/utils.py config_from_parts_or_dicts method
     assert ctx["invocation_args_dict"]["profile_dir"] == "/dev/null"
 
+    assert isinstance(ctx["invocation_args_dict"]["warn_error_options"], Dict)
+    assert ctx["invocation_args_dict"]["warn_error_options"] == {"include": [], "exclude": []}
+
 
 def test_model_parse_context(config_postgres, manifest_fx, get_adapter, get_include_paths):
     ctx = providers.generate_parser_model_context(


### PR DESCRIPTION
resolves #7694 

### Problem

In core 1.5 the`warn_error_options` property within the `invocation_args_dict` began simply stringifying the `WarnErrorOptions` python object as described in #7694. This is problematic because that makes it harder to deserialize. This PR ensures that the `WarnErrorOptions` get dict-ified for the `invocation_args_dict`

### Solution

Specifically dict-iying the `WarnErrorOptions` in `args_to_dict`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
