### PR TITLE
[CT-1849]  `_connection_exception_retry` handles `EOFError` exceptions

### DIFF
--- a/.changes/unreleased/Fixes-20230720-172422.yaml
+++ b/.changes/unreleased/Fixes-20230720-172422.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Update `dbt deps` download retry logic to handle `EOFError` exceptions
+time: 2023-07-20T17:24:22.969951-07:00
+custom:
+  Author: QMalcolm
+  Issue: "6653"

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -601,6 +601,7 @@ def _connection_exception_retry(fn, max_attempts: int, attempt: int = 0):
     except (
         requests.exceptions.RequestException,
         ReadError,
+        EOFError,
     ) as exc:
         if attempt <= max_attempts - 1:
             dbt.events.functions.fire_event(RecordRetryException(exc=str(exc)))

--- a/tests/unit/test_core_dbt_utils.py
+++ b/tests/unit/test_core_dbt_utils.py
@@ -28,6 +28,11 @@ class TestCoreDbtUtils(unittest.TestCase):
         connection_exception_retry(lambda: Counter._add_with_untar_exception(), 5)
         self.assertEqual(2, counter)  # 2 = original attempt returned ReadError, plus 1 retry
 
+    def test_connection_exception_retry_success_failed_eofexception(self):
+        Counter._reset()
+        connection_exception_retry(lambda: Counter._add_with_eof_exception(), 5)
+        self.assertEqual(2, counter)  # 2 = original attempt returned EOFError, plus 1 retry
+
 
 counter: int = 0
 
@@ -56,6 +61,12 @@ class Counter:
         counter += 1
         if counter < 2:
             raise tarfile.ReadError
+
+    def _add_with_eof_exception():
+        global counter
+        counter += 1
+        if counter < 2:
+            raise EOFError
 
     def _reset():
         global counter


### PR DESCRIPTION
resolves #6653

### Problem

Sometimes github has some intermittent connectivity issues. If that happens in the midst of running `dbt deps` an incomplete download occurs and a `EOFError` gets raised.

### Solution

Add `EOFError` type exceptions to the known exceptions list to retry in `_connection_exception_retry`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
