### PR TITLE
[CT-2860] Add IAM Authentication to dbt-postgres

### DIFF
--- a/.changes/unreleased/Features-20230722-201041.yaml
+++ b/.changes/unreleased/Features-20230722-201041.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: add IAM Authentication to dbt-postgres
+time: 2023-07-22T20:10:41.9286694+02:00
+custom:
+  Author: christopherscholz
+  Issue: "8186"

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -73,6 +73,8 @@ setup(
         "{}~=2.8".format(DBT_PSYCOPG2_NAME),
         # installed via dbt-core, but referenced directly, don't pin to avoid version conflicts with dbt-core
         "agate",
+        # pinned version, which works with dbt-redshift
+        "boto3~=1.26.157",
     ],
     zip_safe=False,
     classifiers=[

--- a/tests/unit/test_postgres_adapter.py
+++ b/tests/unit/test_postgres_adapter.py
@@ -497,6 +497,17 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
         with self.assertRaises(DbtConfigError):
             DebugTask.validate_connection(self.target_dict)
 
+    def test_debug_connection_iam_ok(self):
+        del self.target_dict["pass"]
+        self.target_dict["method"] = "iam"
+        with self.assertRaises(DbtConfigError):
+            DebugTask.validate_connection(self.target_dict)
+
+    def test_debug_connection_iam_fail_nopass(self):
+        self.target_dict["method"] = "iam"
+        with self.assertRaises(DbtConfigError):
+            DebugTask.validate_connection(self.target_dict)
+
     def test_connection_fail_select(self):
         self.mock_execute.side_effect = DatabaseError()
         with self.assertRaises(DbtConfigError):


### PR DESCRIPTION
resolves dbt-labs/dbt-postgres#14
docs [#3798](https://github.com/dbt-labs/docs.getdbt.com/issues/3798)

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

It is not possible to use AWS IAM Authentication with dbt-postgres.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

This adds IAM Authentication to dbt-postgres in order to connect to Amazon RDS Aurora PostgreSQL and Amazon RDS for PostgreSQL.
It does it in the same fashion as dbt-redshift. It is refactoring the connection function by providing it through a connection factory.

The following profile configurations change
- `password` becomes optional
- `method` is added: default `database`; options: `database`, `iam`
- `iam_profile` is added: default `None`, used to overwrite default AWS IAM profile
- `region is` added: default `None`, used to overwrite default AWS Region

If `iam` is chosen as `method`, then before connecting to the PostgreSQL db using `psycopg2.connect`, it would
- open boto3 session
- create rds client
- get the auth token by calling `generate_db_auth_token` and pass it to kwargs as password

if `method` is not set or set to `database`, the current password connection is used

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
