### PR TITLE
Check for existing_relation immediately prior to renaming

### DIFF
--- a/core/dbt/include/global_project/macros/materializations/models/table/table.sql
+++ b/core/dbt/include/global_project/macros/materializations/models/table/table.sql
@@ -33,7 +33,12 @@
 
   -- cleanup
   {% if existing_relation is not none %}
-      {{ adapter.rename_relation(existing_relation, backup_relation) }}
+     /* Do the equivalent of rename_if_exists. 'existing_relation' could have been dropped
+        since the variable was first set. */
+    {% set existing_relation = load_cached_relation(existing_relation) %}
+    {% if existing_relation is not none %}
+        {{ adapter.rename_relation(existing_relation, backup_relation) }}
+    {% endif %}
   {% endif %}
 
   {{ adapter.rename_relation(intermediate_relation, target_relation) }}

--- a/core/dbt/include/global_project/macros/materializations/models/view/view.sql
+++ b/core/dbt/include/global_project/macros/materializations/models/view/view.sql
@@ -45,7 +45,12 @@
   -- cleanup
   -- move the existing view out of the way
   {% if existing_relation is not none %}
-    {{ adapter.rename_relation(existing_relation, backup_relation) }}
+     /* Do the equivalent of rename_if_exists. 'existing_relation' could have been dropped
+        since the variable was first set. */
+    {% set existing_relation = load_cached_relation(existing_relation) %}
+    {% if existing_relation is not none %}
+        {{ adapter.rename_relation(existing_relation, backup_relation) }}
+    {% endif %}
   {% endif %}
   {{ adapter.rename_relation(intermediate_relation, target_relation) }}
 


### PR DESCRIPTION
resolves #7781

### Problem

Original pull request rearranged the test and didn't fail in 1000 iterations, but it still failed in a backport, so this pull request reduces the race window by checking for the existence of a relation immediately prior to renaming it.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
