### PR TITLE
[CT-1483] Backport #8181 to 1.6.latest

### DIFF
--- a/.changes/unreleased/Fixes-20230720-170112.yaml
+++ b/.changes/unreleased/Fixes-20230720-170112.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Stop detecting materialization macros based on macro name
+time: 2023-07-20T17:01:12.496238-07:00
+custom:
+  Author: QMalcolm
+  Issue: "6231"

--- a/core/dbt/parser/macros.py
+++ b/core/dbt/parser/macros.py
@@ -81,7 +81,7 @@ class MacroParser(BaseParser[Macro]):
             name: str = macro.name.replace(MACRO_PREFIX, "")
             node = self.parse_macro(block, base_node, name)
             # get supported_languages for materialization macro
-            if "materialization" in name:
+            if block.block_type_name == "materialization":
                 node.supported_languages = jinja.get_supported_languages(macro)
             yield node
 

--- a/tests/functional/macros/fixtures.py
+++ b/tests/functional/macros/fixtures.py
@@ -4,6 +4,12 @@ models__dep_macro = """
 }}
 """
 
+models__materialization_macro = """
+{{
+    materialization_macro()
+}}
+"""
+
 models__with_undefined_macro = """
 {{ dispatch_to_nowhere() }}
 select 1 as id
@@ -72,6 +78,12 @@ macros__my_macros = """
 
 {% macro postgres__dispatch_to_parent() %}
     {{ return('') }}
+{% endmacro %}
+"""
+
+macros__named_materialization = """
+{% macro materialization_macro() %}
+    select 1 as foo
 {% endmacro %}
 """
 

--- a/tests/functional/macros/test_macros.py
+++ b/tests/functional/macros/test_macros.py
@@ -20,12 +20,14 @@ from tests.functional.macros.fixtures import (
     models__override_get_columns_macros,
     models__deprecated_adapter_macro_model,
     models__incorrect_dispatch,
+    models__materialization_macro,
     macros__my_macros,
     macros__no_default_macros,
     macros__override_get_columns_macros,
     macros__package_override_get_columns_macros,
     macros__deprecated_adapter_macro,
     macros__incorrect_dispatch,
+    macros__named_materialization,
 )
 
 
@@ -76,6 +78,21 @@ class TestMacros:
 
         check_relations_equal(project.adapter, ["expected_dep_macro", "dep_macro"])
         check_relations_equal(project.adapter, ["expected_local_macro", "local_macro"])
+
+
+class TestMacrosNamedMaterialization:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "models_materialization_macro.sql": models__materialization_macro,
+        }
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"macros_named_materialization.sql": macros__named_materialization}
+
+    def test_macro_with_materialization_in_name_works(self, project):
+        run_dbt(expect_pass=True)
 
 
 class TestInvalidMacros:


### PR DESCRIPTION
### Description

This is a backport of approved and merged #8181 to 1.6.latest. There's currently an issue which is stopping people from upgrading (and has been since 1.3) wherein macros that included the word `materialization` in their name, but didn't actually contain a materialization, caused an exception to be thrown. More details can be seen in [CT-1483](https://github.com/dbt-labs/dbt-core/issues/6231).

This backport was done by cherry-picking from the #8181 PR branch. Specifically `git cherry-pick 68df0f9753e9a41a2b91064a6851af7f3366af36^..3bf17598ee09254a2e0dcda398d9ee8248f3fa46`. No merge conflicts occurred, so no conflict resolutions were necessary.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX


[CT-1483]: https://dbtlabs.atlassian.net/browse/CT-1483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ