### PR TITLE
[CT-2594]  Backport #8180 to 1.5.latest

### DIFF
--- a/.changes/unreleased/Fixes-20230720-161513.yaml
+++ b/.changes/unreleased/Fixes-20230720-161513.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Ensure `warn_error_options` get serialized in `invocation_args_dict`
+time: 2023-07-20T16:15:13.761813-07:00
+custom:
+  Author: QMalcolm
+  Issue: "7694"

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -17,6 +17,7 @@ from pathlib import PosixPath, WindowsPath
 
 from contextlib import contextmanager
 from dbt.events.types import RetryExternalCall, RecordRetryException
+from dbt.helper_types import WarnErrorOptions
 from dbt import flags
 from enum import Enum
 from typing_extensions import Protocol
@@ -654,6 +655,9 @@ def args_to_dict(args):
         # this was required for a test case
         if isinstance(var_args[key], PosixPath) or isinstance(var_args[key], WindowsPath):
             var_args[key] = str(var_args[key])
+        if isinstance(var_args[key], WarnErrorOptions):
+            var_args[key] = var_args[key].to_dict()
+
         dict_args[key] = var_args[key]
     return dict_args
 

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -423,6 +423,9 @@ def test_invocation_args_to_dict_in_macro_runtime_context(
     # Comes from unit/utils.py config_from_parts_or_dicts method
     assert ctx["invocation_args_dict"]["profile_dir"] == "/dev/null"
 
+    assert isinstance(ctx["invocation_args_dict"]["warn_error_options"], Dict)
+    assert ctx["invocation_args_dict"]["warn_error_options"] == {"include": [], "exclude": []}
+
 
 def test_model_parse_context(config_postgres, manifest_fx, get_adapter, get_include_paths):
     ctx = providers.generate_parser_model_context(


### PR DESCRIPTION
### Description

This is a backport of approved and merged #8180 to 1.5.latest. In `1.5` the `warn_error_options` began being serialized as just a str representation of the python `WarnErrorOptions` object. However, this is not easily deserializable. in #8180 we started converting the `WarnErrorOptions` during serialization. See [CT-2594](https://github.com/dbt-labs/dbt-core/issues/7694) for more details.

This backport was done by cherry-picking from the #8180 PR branch. Specifically `git cherry-pick 49e7a791b3b0d35db371043845209798886d5266^..99e484d1d28746be1251e14e5d950b6da641ea0b`. No merge conflicts occurred, so no conflict resolutions were necessary.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX


[CT-2594]: https://dbtlabs.atlassian.net/browse/CT-2594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ