### PR TITLE
add param to control maxBytes for single dbt.log file

### DIFF
--- a/.changes/unreleased/Under the Hood-20230724-150654.yaml
+++ b/.changes/unreleased/Under the Hood-20230724-150654.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: A way to control maxBytes for a single dbt.log file
+time: 2023-07-24T15:06:54.263822-07:00
+custom:
+  Author: ChenyuLInx
+  Issue: "8199"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -132,6 +132,7 @@ class dbtRunner:
 @p.enable_legacy_logger
 @p.fail_fast
 @p.log_cache_events
+@p.log_file_max_bytes
 @p.log_format
 @p.log_format_file
 @p.log_level

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -174,7 +174,7 @@ use_colors_file = click.option(
 log_file_max_bytes = click.option(
     "--log-file-max-bytes",
     envvar="DBT_LOG_FILE_MAX_BYTES",
-    help="Configure the max file size in bytes for a single dbt.log file. 0 means no limit.",
+    help="Configure the max file size in bytes for a single dbt.log file, before rolling over. 0 means no limit.",
     default=10 * 1024 * 1024,  # 10mb
     type=click.INT,
     hidden=True,

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -171,6 +171,15 @@ use_colors_file = click.option(
     default=True,
 )
 
+log_file_max_bytes = click.option(
+    "--log-file-max-bytes",
+    envvar="DBT_LOG_FILE_MAX_BYTES",
+    help="Configure the max file size in bytes for a single dbt.log file. 0 means no limit.",
+    default=10 * 1024 * 1024,  # 10mb
+    type=click.INT,
+    hidden=True,
+)
+
 log_path = click.option(
     "--log-path",
     envvar="DBT_LOG_PATH",

--- a/core/dbt/events/eventmgr.py
+++ b/core/dbt/events/eventmgr.py
@@ -80,6 +80,7 @@ class LoggerConfig:
     use_colors: bool = False
     output_stream: Optional[TextIO] = None
     output_file_name: Optional[str] = None
+    output_file_max_bytes: int = 10 * 1024 * 1024  # 10 mb
     logger: Optional[Any] = None
 
 
@@ -100,7 +101,7 @@ class _Logger:
             file_handler = RotatingFileHandler(
                 filename=str(config.output_file_name),
                 encoding="utf8",
-                maxBytes=10 * 1024 * 1024,  # 10 mb
+                maxBytes=config.output_file_max_bytes,
                 backupCount=5,
             )
             self._python_logger = self._get_python_log_for_handler(file_handler)

--- a/core/dbt/events/eventmgr.py
+++ b/core/dbt/events/eventmgr.py
@@ -80,7 +80,7 @@ class LoggerConfig:
     use_colors: bool = False
     output_stream: Optional[TextIO] = None
     output_file_name: Optional[str] = None
-    output_file_max_bytes: int = 10 * 1024 * 1024  # 10 mb
+    output_file_max_bytes: Optional[int] = 10 * 1024 * 1024  # 10 mb
     logger: Optional[Any] = None
 
 
@@ -101,7 +101,7 @@ class _Logger:
             file_handler = RotatingFileHandler(
                 filename=str(config.output_file_name),
                 encoding="utf8",
-                maxBytes=config.output_file_max_bytes,
+                maxBytes=config.output_file_max_bytes,  # type: ignore
                 backupCount=5,
             )
             self._python_logger = self._get_python_log_for_handler(file_handler)

--- a/core/dbt/events/functions.py
+++ b/core/dbt/events/functions.py
@@ -68,7 +68,11 @@ def setup_event_logger(flags, callbacks: List[Callable[[EventMsg], None]] = []) 
             log_level_file = EventLevel.DEBUG if flags.DEBUG else EventLevel(flags.LOG_LEVEL_FILE)
             EVENT_MANAGER.add_logger(
                 _get_logfile_config(
-                    log_file, flags.USE_COLORS_FILE, log_file_format, log_level_file
+                    log_file,
+                    flags.USE_COLORS_FILE,
+                    log_file_format,
+                    log_level_file,
+                    flags.LOG_FILE_MAX_BYTES,
                 )
             )
 
@@ -117,7 +121,11 @@ def _stdout_filter(
 
 
 def _get_logfile_config(
-    log_path: str, use_colors: bool, line_format: LineFormat, level: EventLevel
+    log_path: str,
+    use_colors: bool,
+    line_format: LineFormat,
+    level: EventLevel,
+    log_file_max_bytes: int,
 ) -> LoggerConfig:
     return LoggerConfig(
         name="file_log",
@@ -127,6 +135,7 @@ def _get_logfile_config(
         scrubber=env_scrubber,
         filter=partial(_logfile_filter, bool(get_flags().LOG_CACHE_EVENTS), line_format),
         output_file_name=log_path,
+        output_file_max_bytes=log_file_max_bytes,
     )
 
 

--- a/core/dbt/tests/fixtures/project.py
+++ b/core/dbt/tests/fixtures/project.py
@@ -502,6 +502,7 @@ def project(
         DEBUG=False,
         LOG_CACHE_EVENTS=False,
         QUIET=False,
+        LOG_FILE_MAX_BYTES=1000000,
     )
     setup_event_logger(log_flags)
     orig_cwd = os.getcwd()

--- a/tests/unit/test_cli_flags.py
+++ b/tests/unit/test_cli_flags.py
@@ -57,6 +57,11 @@ class TestFlags:
         assert hasattr(flags, "LOG_PATH")
         assert getattr(flags, "LOG_PATH") == Path("logs")
 
+    def test_log_file_max_size_default(self, run_context):
+        flags = Flags(run_context)
+        assert hasattr(flags, "LOG_FILE_MAX_BYTES")
+        assert getattr(flags, "LOG_FILE_MAX_BYTES") == 10 * 1024 * 1024
+
     @pytest.mark.parametrize(
         "set_stats_param,do_not_track,expected_anonymous_usage_stats",
         [

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,7 +1,6 @@
 from argparse import Namespace
 import pytest
 
-
 import dbt.flags as flags
 from dbt.events.functions import msg_to_dict, warn_or_error, setup_event_logger
 from dbt.events.types import InfoLevel, NoNodesForSelectionCriteria

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,8 +1,9 @@
 from argparse import Namespace
 import pytest
 
+
 import dbt.flags as flags
-from dbt.events.functions import msg_to_dict, warn_or_error
+from dbt.events.functions import msg_to_dict, warn_or_error, setup_event_logger
 from dbt.events.types import InfoLevel, NoNodesForSelectionCriteria
 from dbt.exceptions import EventCompilationError
 
@@ -59,3 +60,13 @@ def test_msg_to_dict_handles_exceptions_gracefully():
         assert (
             False
         ), f"We expect `msg_to_dict` to gracefully handle exceptions, but it raised {exc}"
+
+
+def test_setup_event_logger_specify_max_bytes(mocker):
+    patched_file_handler = mocker.patch("dbt.events.eventmgr.RotatingFileHandler")
+    args = Namespace(log_file_max_bytes=1234567)
+    flags.set_from_args(args, {})
+    setup_event_logger(flags.get_flags())
+    patched_file_handler.assert_called_once_with(
+        filename="logs/dbt.log", encoding="utf8", maxBytes=1234567, backupCount=5
+    )

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -18,6 +18,7 @@ from dbt import tracking
 from dbt.contracts.files import SourceFile, FileHash, FilePath
 from dbt.contracts.graph.manifest import MacroManifest, ManifestStateCheck
 from dbt.graph import NodeSelector, parse_difference
+from dbt.events.functions import setup_event_logger
 
 try:
     from queue import Empty
@@ -140,6 +141,7 @@ class GraphTest(unittest.TestCase):
 
         config = config_from_parts_or_dicts(project=cfg, profile=self.profile)
         dbt.flags.set_from_args(Namespace(), config)
+        setup_event_logger(dbt.flags.get_flags())
         object.__setattr__(dbt.flags.get_flags(), "PARTIAL_PARSE", False)
         return config
 


### PR DESCRIPTION
resolves #8199

[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  


- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
