### PR TITLE
Update Core for Latest dbt-extractor with Version Parsing

### DIFF
--- a/.changes/unreleased/Under the Hood-20230725-102609.yaml
+++ b/.changes/unreleased/Under the Hood-20230725-102609.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Ref expressions with version can now be processed by the latest version of the
+  high-performance dbt-extractor library.
+time: 2023-07-25T10:26:09.902878-04:00
+custom:
+  Author: peterallenwebb
+  Issue: "7688"

--- a/core/dbt/parser/models.py
+++ b/core/dbt/parser/models.py
@@ -497,12 +497,10 @@ class ModelParser(SimpleSQLParser[ModelNode]):
         # set refs and sources on the node object
         refs: List[RefArgs] = []
         for ref in statically_parsed["refs"]:
-            if len(ref) == 1:
-                package, name = None, ref[0]
-            else:
-                package, name = ref
-
-            refs.append(RefArgs(package=package, name=name))
+            name = ref.get("name")
+            package = ref.get("package")
+            version = ref.get("version")
+            refs.append(RefArgs(name, package, version))
 
         node.refs += refs
         node.sources += statically_parsed["sources"]

--- a/core/setup.py
+++ b/core/setup.py
@@ -73,7 +73,7 @@ setup(
         "sqlparse>=0.2.3",
         # ----
         # These are major-version-0 packages also maintained by dbt-labs. Accept patches.
-        "dbt-extractor~=0.4.1",
+        "dbt-extractor~=0.5.0",
         "hologram~=0.0.16",  # includes transitive dependencies on python-dateutil and jsonschema
         "minimal-snowplow-tracker~=0.0.2",
         # DSI is under active development, so we're pinning to specific dev versions for now.


### PR DESCRIPTION
resolves #7688

### Problem

In versions before 0.5.0, dbt-extractor didn't parse the version parameter of ref() expressions.

### Solution

Now that dbt-extractor supports version parsing in 0.5.0, this change modifies Core to use that version, and adjusts to the new return format, which is a dict rather than a list.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
