### PR TITLE
Initialize sqlparse lexer and tweak order of setting compilation fields

### DIFF
--- a/.changes/unreleased/Fixes-20230726-104448.yaml
+++ b/.changes/unreleased/Fixes-20230726-104448.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Improve handling of CTE injection with ephemeral models
+time: 2023-07-26T10:44:48.888451-04:00
+custom:
+  Author: gshank
+  Issue: "8213"

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -4,7 +4,6 @@ import json
 import networkx as nx  # type: ignore
 import os
 import pickle
-import sqlparse
 
 from collections import defaultdict
 from typing import List, Dict, Any, Tuple, Optional
@@ -36,6 +35,7 @@ from dbt.node_types import NodeType, ModelLanguage
 from dbt.events.format import pluralize
 import dbt.tracking
 import dbt.task.list as list_task
+import sqlparse
 
 graph_file_name = "graph.gpickle"
 
@@ -378,16 +378,16 @@ class Compiler:
 
             _add_prepended_cte(prepended_ctes, InjectedCTE(id=cte.id, sql=sql))
 
-        injected_sql = inject_ctes_into_sql(
-            model.compiled_code,
-            prepended_ctes,
-        )
         # Check again before updating for multi-threading
         if not model.extra_ctes_injected:
+            injected_sql = inject_ctes_into_sql(
+                model.compiled_code,
+                prepended_ctes,
+            )
+            model.extra_ctes_injected = True
             model._pre_injected_sql = model.compiled_code
             model.compiled_code = injected_sql
             model.extra_ctes = prepended_ctes
-            model.extra_ctes_injected = True
 
         # if model.extra_ctes is not set to prepended ctes, something went wrong
         return model, model.extra_ctes
@@ -562,6 +562,12 @@ def inject_ctes_into_sql(sql: str, ctes: List[InjectedCTE]) -> str:
     """
     if len(ctes) == 0:
         return sql
+
+    # Make sure Lexer for sqlparse 0.4.4 is initialized
+    from sqlparse.lexer import Lexer  # type: ignore
+
+    if hasattr(Lexer, "get_default_instance"):
+        Lexer.get_default_instance()
 
     parsed_stmts = sqlparse.parse(sql)
     parsed = parsed_stmts[0]

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -523,6 +523,12 @@ class Compiler:
         the node's raw_code into compiled_code, and then calls the
         recursive method to "prepend" the ctes.
         """
+        # Make sure Lexer for sqlparse 0.4.4 is initialized
+        from sqlparse.lexer import Lexer  # type: ignore
+
+        if hasattr(Lexer, "get_default_instance"):
+            Lexer.get_default_instance()
+
         node = self._compile_code(node, manifest, extra_context)
 
         node, _ = self._recursively_prepend_ctes(node, manifest, extra_context)
@@ -562,12 +568,6 @@ def inject_ctes_into_sql(sql: str, ctes: List[InjectedCTE]) -> str:
     """
     if len(ctes) == 0:
         return sql
-
-    # Make sure Lexer for sqlparse 0.4.4 is initialized
-    from sqlparse.lexer import Lexer  # type: ignore
-
-    if hasattr(Lexer, "get_default_instance"):
-        Lexer.get_default_instance()
 
     parsed_stmts = sqlparse.parse(sql)
     parsed = parsed_stmts[0]


### PR DESCRIPTION
resolves #8213

### Problem

Sqlparse 0.4.4 causes intermittent compilation errors with ephemeral models.

### Solution

This pr ensures that the sqlparse Lexer is initialized, since that's one of the things that changed with 0.4.4. It also slightly changes the order in which compiled fields are set.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
