### PR TITLE
[Backport 1.5.latest] Initialize sqlparse lexer and tweak order of setting compilation fields

### DIFF
--- a/.changes/unreleased/Fixes-20230726-104448.yaml
+++ b/.changes/unreleased/Fixes-20230726-104448.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Improve handling of CTE injection with ephemeral models
+time: 2023-07-26T10:44:48.888451-04:00
+custom:
+  Author: gshank
+  Issue: "8213"


### PR DESCRIPTION
Backport https://github.com/dbt-labs/dbt-core/commit/fdeccfaf248e6421017f7cfe911b549b93f86a32 from https://github.com/dbt-labs/dbt-core/pull/8215.