### PR TITLE
fixed comment util.py

### DIFF
--- a/.changes/unreleased/Docs-20230727-170900.yaml
+++ b/.changes/unreleased/Docs-20230727-170900.yaml
@@ -1,0 +1,6 @@
+kind: Docs
+body: fixed comment util.py
+time: 2023-07-27T17:09:00.089237+09:00
+custom:
+  Author: d-kaneshiro
+  Issue: None

--- a/core/dbt/tests/util.py
+++ b/core/dbt/tests/util.py
@@ -68,7 +68,7 @@ from dbt.adapters.base.relation import BaseRelation
 # The first parameter is a list of dbt command line arguments, such as
 #   run_dbt(["run", "--vars", "seed_name: base"])
 # If the command is expected to fail, pass in "expect_pass=False"):
-#   run_dbt("test"], expect_pass=False)
+#   run_dbt(["test"], expect_pass=False)
 def run_dbt(
     args: Optional[List[str]] = None,
     expect_pass: bool = True,


### PR DESCRIPTION
resolves #  None

Issue is not created because it corresponds to the following cases.

> Exception to this rule: If you’re just opening a PR for a cosmetic fix, such as a typo in documentation, an issue isn’t needed.

https://docs.getdbt.com/community/resources/oss-expectations

### Problem

There is a possibility of executing the wrong command when using the dbt command in pytest.

### Solution

Fixed the comment to run correctly.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
