### PR TITLE
Add tests for specifcally checking the population of `SemanticModel.depends_on`

### DIFF
--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -1,0 +1,52 @@
+metricflow_time_spine_sql = """
+SELECT to_date('02/20/2023, 'mm/dd/yyyy') as date_day
+"""
+
+models_people_sql = """
+select 1 as id, 'Drew' as first_name, 'Banin' as last_name, 'yellow' as favorite_color, true as loves_dbt, 5 as tenure, current_timestamp as created_at
+union all
+select 2 as id, 'Jeremy' as first_name, 'Cohen' as last_name, 'indigo' as favorite_color, true as loves_dbt, 4 as tenure, current_timestamp as created_at
+union all
+select 3 as id, 'Callum' as first_name, 'McCann' as last_name, 'emerald' as favorite_color, true as loves_dbt, 0 as tenure, current_timestamp as created_at
+"""
+
+models_people_metrics_yml = """
+version: 2
+
+metrics:
+  - name: number_of_people
+    label: "Number of people"
+    description: Total count of people
+    type: simple
+    type_params:
+      measure: people
+    meta:
+        my_meta: 'testing'
+"""
+
+semantic_model_people_yml = """
+version: 2
+
+semantic_models:
+  - name: semantic_people
+    model: ref('people')
+    dimensions:
+      - name: favorite_color
+        type: categorical
+      - name: created_at
+        type: TIME
+        type_params:
+          time_granularity: day
+    measures:
+      - name: years_tenure
+        agg: SUM
+        expr: tenure
+      - name: people
+        agg: count
+        expr: id
+    entities:
+      - name: id
+        type: primary
+    defaults:
+      agg_time_dimension: created_at
+"""

--- a/tests/functional/semantic_models/test_semantic_models.py
+++ b/tests/functional/semantic_models/test_semantic_models.py
@@ -1,0 +1,52 @@
+import pytest
+
+from dbt.contracts.graph.manifest import Manifest
+from dbt.exceptions import CompilationError
+from dbt.tests.util import run_dbt
+
+
+from tests.functional.semantic_models.fixtures import (
+    models_people_sql,
+    metricflow_time_spine_sql,
+    semantic_model_people_yml,
+    models_people_metrics_yml,
+)
+
+
+class TestSemanticModelDependsOn:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people.sql": models_people_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "semantic_models.yml": semantic_model_people_yml,
+            "people_metrics.yml": models_people_metrics_yml,
+        }
+
+    def test_depends_on(self, project):
+        manifest = run_dbt(["parse"])
+        assert isinstance(manifest, Manifest)
+
+        expected_depends_on_for_people_semantic_model = ["model.test.people"]
+
+        number_of_people_metric = manifest.semantic_models["semantic_model.test.semantic_people"]
+        assert (
+            number_of_people_metric.depends_on.nodes
+            == expected_depends_on_for_people_semantic_model
+        )
+
+
+class TestSemanticModelUnknownModel:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "not_people.sql": models_people_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "semantic_models.yml": semantic_model_people_yml,
+            "people_metrics.yml": models_people_metrics_yml,
+        }
+
+    def test_unknown_model_raises_issue(self, project):
+        with pytest.raises(CompilationError) as excinfo:
+            run_dbt(["parse"])
+        assert "depends on a node named 'people' which was not found" in str(excinfo.value)


### PR DESCRIPTION
resolves #8142 

### Problem

We weren't testing the `depends_on` value of `SemanticModel`s

### Solution

Begin testing the `depends_on` value of `SemanticModel`s

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
