### PR TITLE
pin upper bound for sqlparse

### DIFF
--- a/.changes/unreleased/Dependencies-20230727-145726.yaml
+++ b/.changes/unreleased/Dependencies-20230727-145726.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Add upper bound to sqlparse pin of <0.5
+time: 2023-07-27T14:57:26.40416-05:00
+custom:
+  Author: emmyoop
+  PR: "8236"

--- a/core/setup.py
+++ b/core/setup.py
@@ -69,8 +69,7 @@ setup(
         "pathspec>=0.9,<0.12",
         "isodate>=0.6,<0.7",
         # ----
-        # There was a pin to below 0.4.4 for a while due to a bug in Ubuntu/sqlparse 0.4.4
-        "sqlparse>=0.2.3",
+        "sqlparse>=0.2.3,<0.5",
         # ----
         # These are major-version-0 packages also maintained by dbt-labs. Accept patches.
         "dbt-extractor~=0.5.0",


### PR DESCRIPTION
resolves #8145 
~~[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#~~


### Problem

sqlparse pin has no upper bound

### Solution

pin
add upper bound <0.5 to sqlparse

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
