### PR TITLE
[Fix] raise execution errors for runnable tasks

### DIFF
--- a/.changes/unreleased/Fixes-20230728-115620.yaml
+++ b/.changes/unreleased/Fixes-20230728-115620.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Ensure runtime errors are raised for graph runnable tasks (compile, show, run,
+  etc)
+time: 2023-07-28T11:56:20.863718-04:00
+custom:
+  Author: michelleark
+  Issue: "8166"

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -375,15 +375,17 @@ class GraphRunnableTask(ConfiguredTask):
                     )
 
             print_run_result_error(failure.result)
-            raise
+            # ensure information about all nodes is propagated to run results when failing fast
+            return self.node_results
         except KeyboardInterrupt:
             self._cancel_connections(pool)
             print_run_end_messages(self.node_results, keyboard_interrupt=True)
             raise
-        finally:
-            pool.close()
-            pool.join()
-            return self.node_results
+
+        pool.close()
+        pool.join()
+
+        return self.node_results
 
     def _mark_dependent_errors(self, node_id, result, cause):
         if self.graph is None:

--- a/tests/functional/compile/test_compile.py
+++ b/tests/functional/compile/test_compile.py
@@ -164,6 +164,10 @@ class TestCompile:
         with pytest.raises(DbtException, match="Error parsing inline query"):
             run_dbt(["compile", "--inline", "select * from {{ ref('third_model') }}"])
 
+    def test_inline_fail_database_error(self, project):
+        with pytest.raises(DbtRuntimeError, match="Database Error"):
+            run_dbt(["show", "--inline", "slect asdlkjfsld;j"])
+
     def test_multiline_jinja(self, project):
         (results, log_output) = run_dbt_and_capture(["compile", "--inline", model_multiline_jinja])
         assert len(results) == 1

--- a/tests/functional/dependencies/test_local_dependency.py
+++ b/tests/functional/dependencies/test_local_dependency.py
@@ -13,7 +13,6 @@ from contextlib import contextmanager
 import dbt.semver
 import dbt.config
 import dbt.exceptions
-from dbt.contracts.results import RunStatus
 
 from dbt.tests.util import check_relations_equal, run_dbt, run_dbt_and_capture
 
@@ -208,9 +207,8 @@ class TestMissingDependency(object):
 
     def test_missing_dependency(self, project):
         # dbt should raise a runtime exception
-        res = run_dbt(["compile"], expect_pass=False)
-        assert len(res) == 1
-        assert res[0].status == RunStatus.Error
+        with pytest.raises(dbt.exceptions.DbtRuntimeError):
+            run_dbt(["compile"])
 
 
 class TestSimpleDependencyWithSchema(BaseDependencyTest):

--- a/tests/functional/show/test_show.py
+++ b/tests/functional/show/test_show.py
@@ -72,9 +72,12 @@ class TestShow:
         assert "sample_bool" in log_output
 
     def test_inline_fail(self, project):
-        run_dbt(["build"])
         with pytest.raises(DbtException, match="Error parsing inline query"):
             run_dbt(["show", "--inline", "select * from {{ ref('third_model') }}"])
+
+    def test_inline_fail_database_error(self, project):
+        with pytest.raises(DbtRuntimeError, match="Database Error"):
+            run_dbt(["show", "--inline", "slect asdlkjfsld;j"])
 
     def test_ephemeral_model(self, project):
         run_dbt(["build"])


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/8166
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  N/A

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
Root cause is this `return` statement within a `finally` clause: https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/task/runnable.py#L386

From: https://docs.python.org/3/tutorial/errors.html#defining-clean-up-actions
> If the finally clause executes a [break](https://docs.python.org/3/reference/simple_stmts.html#break), [continue](https://docs.python.org/3/reference/simple_stmts.html#continue) or [return](https://docs.python.org/3/reference/simple_stmts.html#return) statement, exceptions are not re-raised.


The initial motivation for this change was to ensure that the current node as well as any other nodes involved in the command had their run result metadata returned for writing to run_results.json. https://github.com/dbt-labs/dbt-core/pull/8066/files#r1260138324

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

- move the return statement out of the finally block, this is typically discouraged for reasons such as this issue. 
- return node_results on fail-fast to ensure the [initial fail-fast issue](https://github.com/dbt-labs/dbt-core/issues/7785) remains resolved (test coverage is here as well under tests/functional/fail_fast)
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX


🎩 
```sh
❯ dbt show --inline 'slect asdlkjfsld;j'
16:28:51  Running with dbt=1.7.0-a1
16:28:51  target not specified in profile 'postgres', using 'default'
16:28:51  Registered adapter: postgres=1.7.0-a1
16:28:51  Found 10 models, 3 seeds, 20 tests, 0 sources, 0 exposures, 0 metrics, 353 macros, 0 groups, 0 semantic models
16:28:51  
16:28:52  Concurrency: 1 threads (target='default')
16:28:52  
16:28:52  Encountered an error:
Runtime Error
  Database Error in sql_operation inline_query (from remote system.sql)
    syntax error at or near "slect"
    LINE 2: slect asdlkjfsld;j
```
