### PR TITLE
[CT-2526]  Add ability to automatically create metrics from semantic model measures

### DIFF
--- a/.changes/unreleased/Features-20230803-151824.yaml
+++ b/.changes/unreleased/Features-20230803-151824.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: 'Allow specification of `create_metric: true` on measures'
+time: 2023-08-03T15:18:24.351003-07:00
+custom:
+  Author: QMalcolm
+  Issue: "8125"

--- a/core/dbt/contracts/files.py
+++ b/core/dbt/contracts/files.py
@@ -225,6 +225,8 @@ class SchemaSourceFile(BaseSourceFile):
     sources: List[str] = field(default_factory=list)
     exposures: List[str] = field(default_factory=list)
     metrics: List[str] = field(default_factory=list)
+    # metrics generated from semantic_model measures
+    generated_metrics: List[str] = field(default_factory=list)
     groups: List[str] = field(default_factory=list)
     # node patches contain models, seeds, snapshots, analyses
     ndp: List[str] = field(default_factory=list)

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1331,10 +1331,13 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         self.exposures[exposure.unique_id] = exposure
         source_file.exposures.append(exposure.unique_id)
 
-    def add_metric(self, source_file: SchemaSourceFile, metric: Metric):
+    def add_metric(self, source_file: SchemaSourceFile, metric: Metric, generated: bool = False):
         _check_duplicates(metric, self.metrics)
         self.metrics[metric.unique_id] = metric
-        source_file.metrics.append(metric.unique_id)
+        if not generated:
+            source_file.metrics.append(metric.unique_id)
+        else:
+            source_file.generated_metrics.append(metric.unique_id)
 
     def add_group(self, source_file: SchemaSourceFile, group: Group):
         _check_duplicates(group, self.groups)

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -701,6 +701,7 @@ class UnparsedMeasure(dbtClassMixin):
     agg_params: Optional[MeasureAggregationParameters] = None
     non_additive_dimension: Optional[UnparsedNonAdditiveDimension] = None
     agg_time_dimension: Optional[str] = None
+    create_metric: bool = False
 
 
 @dataclass

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -895,11 +895,11 @@ class PartialParsing:
             elif unique_id in self.saved_manifest.disabled:
                 self.delete_disabled(unique_id, schema_file.file_id)
 
-        metrics = schema_file.metrics.copy()
+        metrics = schema_file.generated_metrics.copy()
         for unique_id in metrics:
             if unique_id in self.saved_manifest.metrics:
                 self.saved_manifest.metrics.pop(unique_id)
-                schema_file.metrics.remove(unique_id)
+                schema_file.generated_metrics.remove(unique_id)
             elif unique_id in self.saved_manifest.disabled:
                 self.delete_disabled(unique_id, schema_file.file_id)
 

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -895,6 +895,14 @@ class PartialParsing:
             elif unique_id in self.saved_manifest.disabled:
                 self.delete_disabled(unique_id, schema_file.file_id)
 
+        metrics = schema_file.metrics.copy()
+        for unique_id in metrics:
+            if unique_id in self.saved_manifest.metrics:
+                self.saved_manifest.metrics.pop(unique_id)
+                schema_file.metrics.remove(unique_id)
+            elif unique_id in self.saved_manifest.disabled:
+                self.delete_disabled(unique_id, schema_file.file_id)
+
     def get_schema_element(self, elem_list, elem_name):
         for element in elem_list:
             if "name" in element and element["name"] == elem_name:

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -303,7 +303,7 @@ class MetricParser(YamlReader):
             # input_measures=?,
         )
 
-    def parse_metric(self, unparsed: UnparsedMetric):
+    def parse_metric(self, unparsed: UnparsedMetric, generated: bool = False):
         package_name = self.project.project_name
         unique_id = f"{NodeType.Metric}.{package_name}.{unparsed.name}"
         path = self.yaml.path.relative_path
@@ -358,7 +358,7 @@ class MetricParser(YamlReader):
 
         # if the metric is disabled we do not want it included in the manifest, only in the disabled dict
         if parsed.config.enabled:
-            self.manifest.add_metric(self.yaml.file, parsed)
+            self.manifest.add_metric(self.yaml.file, parsed, generated)
         else:
             self.manifest.add_disabled(self.yaml.file, parsed)
 
@@ -520,7 +520,7 @@ class SemanticModelParser(YamlReader):
         )
 
         parser = MetricParser(self.schema_parser, yaml=self.yaml)
-        parser.parse_metric(unparsed=unparsed_metric)
+        parser.parse_metric(unparsed=unparsed_metric, generated=True)
 
     def parse_semantic_model(self, unparsed: UnparsedSemanticModel):
         package_name = self.project.project_name

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -27,6 +27,7 @@ semantic_models:
         expr: revenue
         agg: sum
         agg_time_dimension: ds
+        create_metric: true
       - name: sum_of_things
         expr: 2
         agg: sum
@@ -63,14 +64,6 @@ semantic_models:
         expr: user_id
       - name: id
         type: primary
-
-metrics:
-  - name: records_with_revenue
-    label: "Number of records with revenue"
-    description: Total number of records with revenue
-    type: simple
-    type_params:
-      measure: has_revenue
 """
 
 schema_without_semantic_model_yml = """models:
@@ -126,6 +119,10 @@ class TestSemanticModelParsing:
             == f'"dbt"."{project.test_schema}"."fct_revenue"'
         )
         assert len(semantic_model.measures) == 5
+        # manifest should have one metric (that was created from a measure)
+        assert len(manifest.metrics) == 1
+        metric = manifest.metrics["metric.test.txn_revenue"]
+        assert metric.name == "txn_revenue"
 
     def test_semantic_model_error(self, project):
         # Next, modify the default schema.yml to remove the semantic model.

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -218,6 +218,9 @@ class TestSemanticModelPartialParsing:
         # Verify the metric originally created by `create_metric: true` was removed
         assert result.result.metrics.get(generated_metric) is None
 
+        # Verify that partial parsing didn't clobber the normal metric
+        assert result.result.metrics.get("metric.test.simple_metric") is not None
+
         # --- Now bring it back ---
         create_metric_schema_yml = schema_yml.replace(
             "create_metric: false", "create_metric: true"


### PR DESCRIPTION
resolves #7504 

### Problem

Many metrics are just simple metrics defined directly off measures. This work could be easily automated by adding a property to measures that indicates a simple metric should be created

### Solution

The first step is to simply create a metric when `create_metric: true` is specified. If a `create_metric` value isn't specified in the raw measure, then `create_metric` will default to `False`. There are also a number of implications with partial parsing.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
