### PR TITLE
[CT-748] feat: resolve packages with same git repo and unique subdirectory

### DIFF
--- a/.changes/unreleased/Features-20230916-120547.yaml
+++ b/.changes/unreleased/Features-20230916-120547.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: resolve packages with same git repo and unique subdirectory
+time: 2023-09-16T12:05:47.353417149-04:00
+custom:
+  Author: philippeboyd
+  Issue: "5374"

--- a/tests/unit/test_deps.py
+++ b/tests/unit/test_deps.py
@@ -120,17 +120,29 @@ class TestGitPackage(unittest.TestCase):
         b_contract = GitPackage.from_dict(
             {"git": "http://example.com", "revision": "0.0.1", "warn-unpinned": False},
         )
+        d_contract = GitPackage.from_dict(
+            {"git": "http://example.com", "revision": "0.0.1", "subdirectory": "foo-bar"},
+        )
         a = GitUnpinnedPackage.from_contract(a_contract)
         b = GitUnpinnedPackage.from_contract(b_contract)
+        c = a.incorporate(b)
+        d = GitUnpinnedPackage.from_contract(d_contract)
+
         self.assertTrue(a.warn_unpinned)
         self.assertFalse(b.warn_unpinned)
-        c = a.incorporate(b)
+        self.assertTrue(d.warn_unpinned)
 
         c_pinned = c.resolved()
         self.assertEqual(c_pinned.name, "http://example.com")
         self.assertEqual(c_pinned.get_version(), "0.0.1")
         self.assertEqual(c_pinned.source_type(), "git")
         self.assertFalse(c_pinned.warn_unpinned)
+
+        d_pinned = d.resolved()
+        self.assertEqual(d_pinned.name, "http://example.com/foo-bar")
+        self.assertEqual(d_pinned.get_version(), "0.0.1")
+        self.assertEqual(d_pinned.source_type(), "git")
+        self.assertEqual(d_pinned.subdirectory, "foo-bar")
 
     def test_resolve_fail(self):
         a_contract = GitPackage.from_dict(


### PR DESCRIPTION
resolves #5374

### Problem

It is currently impossible to refer multiple git packages that are contained within the same mono repo such as:

```yaml
  - git: "git@github.com:acme/git-repo.git"
    subdirectory: "dbt-source-pkg-1"
    revision: "dbt-source-pkg-1-v0.1.12"
  - git: "git@github.com:acme/git-repo.git" # This will not work...
    subdirectory: "dbt-source-pkg-2" # This will not work...
    revision: "dbt-source-pkg-2-v0.1.2" # This will not work...
```

### Solution

Use the `git` and `subdirectory` values as the unique combination of values when managing dependencies. This will enable dbt to clone multiple git repositories but with different subdirectories; treating them as differents packages.

```yaml
packages:
  - package: "calogica/dbt_date"
    version: [ ">=0.5.4", "<0.8.0" ]
  - package: "dbt-labs/dbt_utils"
    version: [ ">=1.0.0", "<2.0.0" ]
  - git: "git@github.com:acme/git-repo.git"
    subdirectory: "dbt-source-pkg-1"
    revision: "dbt-source-pkg-1-v0.1.12"
  - git: "git@github.com:acme/git-repo.git"
    subdirectory: "dbt-source-pkg-2"
    revision: "dbt-source-pkg-2-v0.1.2"
```

The following will import correctly
```bash
❯ dbt deps
14:49:31  Running with dbt=1.5.1
14:49:41  Installing calogica/dbt_date
14:49:41  Installed from version 0.7.2
14:49:41  Up to date!
14:49:41  Installing dbt-labs/dbt_utils
14:49:42  Installed from version 1.1.1
14:49:42  Up to date!
14:49:42  Installing git@github.com:acme/git-repo.git/dbt-source-pkg-1
14:49:43  Installed from revision dbt-source-pkg-1-v0.1.12
14:49:43  and subdirectory dbt-source-pkg-1
14:49:43  Installing git@github.com:acme/git-repo.git/dbt-source-pkg-2
14:49:44  Installed from revision dbt-source-pkg-2-v0.1.2
14:49:44  and subdirectory dbt-source-pkg-2
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
