### PR TITLE
Fix missing quote in fixtures.py

### DIFF
--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -1,5 +1,5 @@
 metricflow_time_spine_sql = """
-SELECT to_date('02/20/2023, 'mm/dd/yyyy') as date_day
+SELECT to_date('02/20/2023', 'mm/dd/yyyy') as date_day
 """
 
 models_people_sql = """


### PR DESCRIPTION
resolves # none
~~[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#~~

### Problem

Syntax error on fixture that wasn't caught as an error because parse doesn't catch it, only run.

### Solution

Add missing quote.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
