### PR TITLE
Register Postgres UUID and CIDR datatypes when creating a connection

### DIFF
--- a/.changes/unreleased/Features-20230810-153314.yaml
+++ b/.changes/unreleased/Features-20230810-153314.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add Postgres adapter configuration to register extra data types
+time: 2023-08-10T15:33:14.254894544-03:00
+custom:
+  Author: gmontanola
+  Issue: '8353'

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -34,7 +34,6 @@ class PostgresCredentials(Credentials):
     sslrootcert: Optional[str] = None
     application_name: Optional[str] = "dbt"
     retries: int = 1
-    register_extra_data_types: bool = False
 
     _ALIASES = {"dbname": "database", "pass": "password"}
 
@@ -63,7 +62,6 @@ class PostgresCredentials(Credentials):
             "sslrootcert",
             "application_name",
             "retries",
-            "register_extra_data_types",
         )
 
 
@@ -133,9 +131,6 @@ class PostgresConnectionManager(SQLConnectionManager):
         if credentials.application_name:
             kwargs["application_name"] = credentials.application_name
 
-        if credentials.register_extra_data_types:
-            kwargs["register_extra_data_types"] = credentials.register_extra_data_types
-
         def connect():
             handle = psycopg2.connect(
                 dbname=credentials.database,
@@ -147,9 +142,9 @@ class PostgresConnectionManager(SQLConnectionManager):
                 **kwargs,
             )
 
-            if credentials.register_extra_data_types:
-                register_uuid(conn_or_curs=handle)
-                register_ipaddress(conn_or_curs=handle)
+            # Register extra data types to avoid dbt contract errors
+            register_uuid(conn_or_curs=handle)
+            register_ipaddress(conn_or_curs=handle)
 
             if credentials.role:
                 handle.cursor().execute("set role {}".format(credentials.role))

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -143,8 +143,8 @@ class PostgresConnectionManager(SQLConnectionManager):
             )
 
             # Register extra data types to avoid dbt contract errors
-            register_uuid(conn_or_curs=handle)
-            register_ipaddress(conn_or_curs=handle)
+            register_uuid()
+            register_ipaddress()
 
             if credentials.role:
                 handle.cursor().execute("set role {}".format(credentials.role))

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -33,6 +33,7 @@ class PostgresCredentials(Credentials):
     sslrootcert: Optional[str] = None
     application_name: Optional[str] = "dbt"
     retries: int = 1
+    register_extra_data_types: bool = False
 
     _ALIASES = {"dbname": "database", "pass": "password"}
 
@@ -61,6 +62,7 @@ class PostgresCredentials(Credentials):
             "sslrootcert",
             "application_name",
             "retries",
+            "register_extra_data_types",
         )
 
 
@@ -129,6 +131,9 @@ class PostgresConnectionManager(SQLConnectionManager):
 
         if credentials.application_name:
             kwargs["application_name"] = credentials.application_name
+
+        if credentials.register_extra_data_types:
+            kwargs["register_extra_data_types"] = credentials.register_extra_data_types
 
         def connect():
             handle = psycopg2.connect(

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 
 import psycopg2
 from psycopg2.extensions import string_types
+from psycopg2.extras import register_uuid, register_ipaddress
 
 import dbt.exceptions
 from dbt.adapters.base import Credentials
@@ -145,6 +146,11 @@ class PostgresConnectionManager(SQLConnectionManager):
                 connect_timeout=credentials.connect_timeout,
                 **kwargs,
             )
+
+            if credentials.register_extra_data_types:
+                register_uuid(conn_or_curs=handle)
+                register_ipaddress(conn_or_curs=handle)
+
             if credentials.role:
                 handle.cursor().execute("set role {}".format(credentials.role))
             return handle


### PR DESCRIPTION
resolves dbt-labs/dbt-postgres#54
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

Contracts checks for data types and when it finds stuff like UUID it fails because it's not registered by default.

### Solution

Registering some extra data types - UUID and IP ADDR

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
