### PR TITLE
add env vars to tox.ini

### DIFF
--- a/tests/functional/basic/test_basic.py
+++ b/tests/functional/basic/test_basic.py
@@ -17,4 +17,4 @@ def test_basic(project):
     results = run_dbt(["run"])
     assert len(results) == 1
     manifest = get_manifest(project.project_root)
-    assert "model.test.my_model" in manifest.nodes
+    assert "you won't find me" in manifest.nodes

--- a/tests/functional/basic/test_basic.py
+++ b/tests/functional/basic/test_basic.py
@@ -17,4 +17,4 @@ def test_basic(project):
     results = run_dbt(["run"])
     assert len(results) == 1
     manifest = get_manifest(project.project_root)
-    assert "you won't find me" in manifest.nodes
+    assert "model.test.my_model" in manifest.nodes

--- a/tox.ini
+++ b/tox.ini
@@ -23,8 +23,11 @@ passenv =
   DBT_*
   POSTGRES_TEST_*
   PYTEST_ADDOPTS
-  DD_SERVICE
+  DD_CIVISIBILITY_AGENTLESS_ENABLED
+  DD_API_KEY
+  DD_SITE
   DD_ENV
+  DD_SERVICE
 commands =
   {envpython} -m pytest --cov=core --cov-append --cov-report=xml {posargs} tests/functional -k "not tests/functional/graph_selection"
   {envpython} -m pytest --cov=core --cov-append --cov-report=xml {posargs} tests/functional/graph_selection


### PR DESCRIPTION
resolves #8366
~~[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#~~


### Problem

Test visibility not getting populated into Datadog

### Solution

Add the env vars to tox.ini so they get passed through

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
