### PR TITLE
Fix using project-dir with list command and path selector

### DIFF
--- a/.changes/unreleased/Fixes-20230814-145702.yaml
+++ b/.changes/unreleased/Fixes-20230814-145702.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix using list command with path selector and project-dir
+time: 2023-08-14T14:57:02.02816-04:00
+custom:
+  Author: gshank
+  Issue: "8385"

--- a/tests/functional/graph_selection/test_graph_selection.py
+++ b/tests/functional/graph_selection/test_graph_selection.py
@@ -142,6 +142,24 @@ class TestGraphSelection(SelectionFixtures):
         check_result_nodes_by_name(results, ["subdir"])
         assert_correct_schemas(project)
 
+        # Check that list command works
+        os.chdir(
+            project.profiles_dir
+        )  # Change to random directory to test that Path selector works with project-dir
+        results = run_dbt(
+            [
+                "-q",
+                "ls",
+                "-s",
+                "path:models/test/subdir.sql",
+                "--project-dir",
+                str(project.project_root),
+            ]
+            #           ["list", "--project-dir", str(project.project_root), "--select", "models/test/subdir*"]
+        )
+        print(f"--- results: {results}")
+        assert len(results) == 1
+
     def test_locally_qualified_name_model_with_dots(self, project):
         results = run_dbt(["run", "--select", "alternative.users"], expect_pass=False)
         check_result_nodes_by_name(results, ["alternative.users"])
@@ -268,3 +286,22 @@ class TestGraphSelection(SelectionFixtures):
                 "users",
             ],
         )
+
+
+class TestListPathGraphSelection(SelectionFixtures):
+    def test_list_select_with_project_dir(self, project):
+        # Check that list command works
+        os.chdir(
+            project.profiles_dir
+        )  # Change to random directory to test that Path selector works with project-dir
+        results = run_dbt(
+            [
+                "-q",
+                "ls",
+                "-s",
+                "path:models/test/subdir.sql",
+                "--project-dir",
+                str(project.project_root),
+            ]
+        )
+        assert results == ["test.test.subdir"]


### PR DESCRIPTION
resolves #8385

### Problem

We changed the way we access the contextvar for project_root in #7949, but also needed to add the contextvar to the run method of the list command.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
