### PR TITLE
Fix run_results.json Performance Regression

### DIFF
--- a/.changes/unreleased/Fixes-20230815-104444.yaml
+++ b/.changes/unreleased/Fixes-20230815-104444.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remedy performance regression by only writing run_results.json once.
+time: 2023-08-15T10:44:44.836991-04:00
+custom:
+  Author: peterallenwebb
+  Issue: "8360"

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -313,15 +313,6 @@ class GraphRunnableTask(ConfiguredTask):
                 cause = None
             self._mark_dependent_errors(node.unique_id, result, cause)
 
-        interim_run_result = self.get_result(
-            results=self.node_results,
-            elapsed_time=time.time() - self.started_at,
-            generated_at=datetime.utcnow(),
-        )
-
-        if self.args.write_json and hasattr(interim_run_result, "write"):
-            interim_run_result.write(self.result_path())
-
     def _cancel_connections(self, pool):
         """Given a pool, cancel all adapter connections and wait until all
         runners gentle terminates.
@@ -380,6 +371,16 @@ class GraphRunnableTask(ConfiguredTask):
         except KeyboardInterrupt:
             self._cancel_connections(pool)
             print_run_end_messages(self.node_results, keyboard_interrupt=True)
+
+            run_result = self.get_result(
+                results=self.node_results,
+                elapsed_time=time.time() - self.started_at,
+                generated_at=datetime.utcnow(),
+            )
+
+            if self.args.write_json and hasattr(run_result, "write"):
+                run_result.write(self.result_path())
+
             raise
 
         pool.close()
@@ -443,7 +444,7 @@ class GraphRunnableTask(ConfiguredTask):
         Run dbt for the query, based on the graph.
         """
         # We set up a context manager here with "task_contextvars" because we
-        # we need the project_root in runtime_initialize.
+        # need the project_root in runtime_initialize.
         with task_contextvars(project_root=self.config.project_root):
             self._runtime_initialize()
 
@@ -584,7 +585,7 @@ class GraphRunnableTask(ConfiguredTask):
                     create_futures.append(fut)
 
             for create_future in as_completed(create_futures):
-                # trigger/re-raise any excceptions while creating schemas
+                # trigger/re-raise any exceptions while creating schemas
                 create_future.result()
 
     def get_result(self, results, elapsed_time, generated_at):

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -369,9 +369,6 @@ class GraphRunnableTask(ConfiguredTask):
             # ensure information about all nodes is propagated to run results when failing fast
             return self.node_results
         except KeyboardInterrupt:
-            self._cancel_connections(pool)
-            print_run_end_messages(self.node_results, keyboard_interrupt=True)
-
             run_result = self.get_result(
                 results=self.node_results,
                 elapsed_time=time.time() - self.started_at,
@@ -380,6 +377,9 @@ class GraphRunnableTask(ConfiguredTask):
 
             if self.args.write_json and hasattr(run_result, "write"):
                 run_result.write(self.result_path())
+
+            self._cancel_connections(pool)
+            print_run_end_messages(self.node_results, keyboard_interrupt=True)
 
             raise
 


### PR DESCRIPTION
resolves #8360 

### Problem

In an attempt to ensure run_results.json was always written, dbt 1.6 was modified to write it out after every node completed. This proved too time consuming in practice.

### Solution

We no longer write run_results.json after every node completion, instead writing it once at the end of an invocation, taking care to do so even if a KeyboardInterrupt or FailFastError occurs.

### Testing Notes

I verified that the run_results.json file is written even when a dbt compile operation is interrupted by a Ctrl-C keyboard break in the terminal. I further verified that it is written on a RunResultError by artificially raising such an error. If people have suggestions around automated test changes, I'm open to them and I think it would be preferable to add some before merging.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
