### PR TITLE
Add return values to functions to fix mypy warnings

### DIFF
--- a/.changes/unreleased/Under the Hood-20230815-170307.yaml
+++ b/.changes/unreleased/Under the Hood-20230815-170307.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add return values to a number of functions for mypy
+time: 2023-08-15T17:03:07.895252-04:00
+custom:
+  Author: gshank
+  Issue: "8389"

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -25,9 +25,9 @@ class _QueryComment(local):
         - a source_name indicating what set the current thread's query comment
     """
 
-    def __init__(self, initial):
+    def __init__(self, initial) -> None:
         self.query_comment: Optional[str] = initial
-        self.append = False
+        self.append: bool = False
 
     def add(self, sql: str) -> str:
         if not self.query_comment:

--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -191,7 +191,7 @@ NativeSandboxEnvironment.template_class = NativeSandboxTemplate  # type: ignore
 
 
 class TemplateCache:
-    def __init__(self):
+    def __init__(self) -> None:
         self.file_cache: Dict[str, jinja2.Template] = {}
 
     def get_node_template(self, node) -> jinja2.Template:

--- a/core/dbt/context/macro_resolver.py
+++ b/core/dbt/context/macro_resolver.py
@@ -40,7 +40,7 @@ class MacroResolver:
         self._build_internal_packages_namespace()
         self._build_macros_by_name()
 
-    def _build_internal_packages_namespace(self):
+    def _build_internal_packages_namespace(self) -> None:
         # Iterate in reverse-order and overwrite: the packages that are first
         # in the list are the ones we want to "win".
         self.internal_packages_namespace: MacroNamespace = {}
@@ -56,7 +56,7 @@ class MacroResolver:
     # root package namespace
     # non-internal packages (that aren't local or root)
     # dbt internal packages
-    def _build_macros_by_name(self):
+    def _build_macros_by_name(self) -> None:
         macros_by_name = {}
 
         # all internal packages (already in the right order)
@@ -78,7 +78,7 @@ class MacroResolver:
         self,
         package_namespaces: Dict[str, MacroNamespace],
         macro: Macro,
-    ):
+    ) -> None:
         if macro.package_name in package_namespaces:
             namespace = package_namespaces[macro.package_name]
         else:
@@ -89,7 +89,7 @@ class MacroResolver:
             raise DuplicateMacroNameError(macro, macro, macro.package_name)
         package_namespaces[macro.package_name][macro.name] = macro
 
-    def add_macro(self, macro: Macro):
+    def add_macro(self, macro: Macro) -> None:
         macro_name: str = macro.name
 
         # internal macros (from plugins) will be processed separately from
@@ -103,11 +103,11 @@ class MacroResolver:
             if macro.package_name == self.root_project_name:
                 self.root_package_macros[macro_name] = macro
 
-    def add_macros(self):
+    def add_macros(self) -> None:
         for macro in self.macros.values():
             self.add_macro(macro)
 
-    def get_macro(self, local_package, macro_name):
+    def get_macro(self, local_package, macro_name) -> Optional[Macro]:
         local_package_macros = {}
         # If the macro is explicitly prefixed with an internal namespace
         # (e.g. 'dbt.some_macro'), look there first
@@ -125,7 +125,7 @@ class MacroResolver:
             return self.macros_by_name[macro_name]
         return None
 
-    def get_macro_id(self, local_package, macro_name):
+    def get_macro_id(self, local_package, macro_name) -> Optional[str]:
         macro = self.get_macro(local_package, macro_name)
         if macro is None:
             return None

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -220,7 +220,7 @@ class UnparsedModelUpdate(UnparsedNodeUpdate):
     versions: Sequence[UnparsedVersion] = field(default_factory=list)
     deprecation_date: Optional[datetime.datetime] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.latest_version:
             version_values = [version.v for version in self.versions]
             if self.latest_version not in version_values:
@@ -228,7 +228,7 @@ class UnparsedModelUpdate(UnparsedNodeUpdate):
                     f"latest_version: {self.latest_version} is not one of model '{self.name}' versions: {version_values} "
                 )
 
-        seen_versions: set[str] = set()
+        seen_versions = set()
         for version in self.versions:
             if str(version.v) in seen_versions:
                 raise ParsingError(

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -103,7 +103,7 @@ SelectorTarget = Union[SourceDefinition, ManifestNode, Exposure, Metric]
 class SelectorMethod(metaclass=abc.ABCMeta):
     def __init__(
         self, manifest: Manifest, previous_state: Optional[PreviousState], arguments: List[str]
-    ):
+    ) -> None:
         self.manifest: Manifest = manifest
         self.previous_state = previous_state
         self.arguments: List[str] = arguments
@@ -467,7 +467,7 @@ class TestTypeSelectorMethod(SelectorMethod):
 
 
 class StateSelectorMethod(SelectorMethod):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.modified_macros: Optional[List[str]] = None
 

--- a/core/dbt/parser/common.py
+++ b/core/dbt/parser/common.py
@@ -177,10 +177,10 @@ class GenericTestBlock(TestBlock[Testable], Generic[Testable]):
 class ParserRef:
     """A helper object to hold parse-time references."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.column_info: Dict[str, ColumnInfo] = {}
 
-    def _add(self, column: HasColumnProps):
+    def _add(self, column: HasColumnProps) -> None:
         tags: List[str] = []
         tags.extend(getattr(column, "tags", ()))
         quote: Optional[bool]

--- a/core/dbt/semver.py
+++ b/core/dbt/semver.py
@@ -107,7 +107,7 @@ class VersionSpecifier(VersionSpecification):
     def __str__(self):
         return self.to_version_string()
 
-    def to_range(self):
+    def to_range(self) -> "VersionRange":
         range_start: VersionSpecifier = UnboundedVersionSpecifier()
         range_end: VersionSpecifier = UnboundedVersionSpecifier()
 

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -74,7 +74,7 @@ class DebugRunStatus(Flag):
 
 
 class DebugTask(BaseTask):
-    def __init__(self, args, config):
+    def __init__(self, args, config) -> None:
         super().__init__(args, config)
         self.profiles_dir = args.PROFILES_DIR
         self.profile_path = os.path.join(self.profiles_dir, "profiles.yml")

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -301,18 +301,18 @@ class ModelRunner(CompileRunner):
 
 
 class RunTask(CompileTask):
-    def __init__(self, args, config, manifest):
+    def __init__(self, args, config, manifest) -> None:
         super().__init__(args, config, manifest)
-        self.ran_hooks = []
+        self.ran_hooks: List[HookNode] = []
         self._total_executed = 0
 
     def index_offset(self, value: int) -> int:
         return self._total_executed + value
 
-    def raise_on_first_error(self):
+    def raise_on_first_error(self) -> bool:
         return False
 
-    def get_hook_sql(self, adapter, hook, idx, num_hooks, extra_context):
+    def get_hook_sql(self, adapter, hook, idx, num_hooks, extra_context) -> str:
         compiler = adapter.get_compiler()
         compiled = compiler.compile_node(hook, self.manifest, extra_context)
         statement = compiled.compiled_code
@@ -337,7 +337,7 @@ class RunTask(CompileTask):
         hooks.sort(key=self._hook_keyfunc)
         return hooks
 
-    def run_hooks(self, adapter, hook_type: RunHookType, extra_context):
+    def run_hooks(self, adapter, hook_type: RunHookType, extra_context) -> None:
         ordered_hooks = self.get_hooks_by_type(hook_type)
 
         # on-run-* hooks should run outside of a transaction. This happens
@@ -423,7 +423,7 @@ class RunTask(CompileTask):
                 )
             )
 
-    def print_results_line(self, results, execution_time):
+    def print_results_line(self, results, execution_time) -> None:
         nodes = [r.node for r in results if hasattr(r, "node")] + self.ran_hooks
         stat_line = get_counts(nodes)
 
@@ -440,7 +440,7 @@ class RunTask(CompileTask):
             )
         )
 
-    def before_run(self, adapter, selected_uids: AbstractSet[str]):
+    def before_run(self, adapter, selected_uids: AbstractSet[str]) -> None:
         with adapter.connection_named("master"):
             required_schemas = self.get_model_schemas(adapter, selected_uids)
             self.create_schemas(adapter, required_schemas)
@@ -448,7 +448,7 @@ class RunTask(CompileTask):
             self.defer_to_manifest(adapter, selected_uids)
             self.safe_run_hooks(adapter, RunHookType.Start, {})
 
-    def after_run(self, adapter, results):
+    def after_run(self, adapter, results) -> None:
         # in on-run-end hooks, provide the value 'database_schemas', which is a
         # list of unique (database, schema) pairs that successfully executed
         # models were in. For backwards compatibility, include the old
@@ -484,6 +484,6 @@ class RunTask(CompileTask):
     def get_runner_type(self, _):
         return ModelRunner
 
-    def task_end_messages(self, results):
+    def task_end_messages(self, results) -> None:
         if results:
             print_run_end_messages(results)

--- a/core/dbt/tests/util.py
+++ b/core/dbt/tests/util.py
@@ -149,7 +149,7 @@ def get_logging_events(log_output, event_name):
 # Used in test cases to get the manifest from the partial parsing file
 # Note: this uses an internal version of the manifest, and in the future
 # parts of it will not be supported for external use.
-def get_manifest(project_root):
+def get_manifest(project_root) -> Optional[Manifest]:
     path = os.path.join(project_root, "target", "partial_parse.msgpack")
     if os.path.exists(path):
         with open(path, "rb") as fp:


### PR DESCRIPTION
resolves #8389

### Problem

Mypy warnings cluttering up mypy errors

### Solution

Add return values to functions in:
* core/dbt/adapters/base/query_headers.py
* core/dbt/clients/jinja.py
* core/dbt/context/macro_resolver.py
* core/dbt/contracts/graph/unparsed.py
* core/dbt/graph/selector_methods.py
* core/dbt/parser/common.py
* core/dbt/semver.py
* core/dbt/task/run.py
* core/dbt/tests/util.py


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
