### PR TITLE
Modify run results test to wait on timer instead of file write

### DIFF
--- a/tests/functional/artifacts/test_run_results.py
+++ b/tests/functional/artifacts/test_run_results.py
@@ -61,7 +61,7 @@ class TestRunResultsWritesFileOnSignal:
 
         # Wait long enough for first model to complete, then SIGINT the process.
         # It would be better to monitor the dbt log until the first model completes.
-        time.sleep(10)
+        time.sleep(30)
         os.kill(external_process_dbt.pid, signal.SIGINT)
 
         # Wait until the process is dead, then check the file that there is only one result.


### PR DESCRIPTION
### Problem

This test previously waited on a file write which was not guaranteed to happen.

### Solution

We now wait on a timer, which is not ideal, but should suffice for now.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
