### PR TITLE
Temporarily Disable test_run_results_are_written_on_signal Test

### DIFF
--- a/tests/functional/artifacts/test_run_results.py
+++ b/tests/functional/artifacts/test_run_results.py
@@ -2,7 +2,6 @@ from multiprocessing import Process
 from pathlib import Path
 import json
 import pytest
-import platform
 from dbt.tests.util import run_dbt
 
 good_model_sql = """
@@ -41,7 +40,9 @@ class TestRunResultsTimingFailure:
         assert len(results.results[0].timing) > 0
 
 
-@pytest.mark.skipif(platform.system() != "Darwin", reason="Fails on linux in github actions")
+# This test is failing due to the faulty assumptions that run_results.json would
+# be written multiple times. Temporarily disabling.
+@pytest.mark.skip()
 class TestRunResultsWritesFileOnSignal:
     @pytest.fixture(scope="class")
     def models(self):


### PR DESCRIPTION
Temporarily disable the test_run_results_are_written_on_signal test while we repair it.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
