### PR TITLE
Render `sql_header` for `dbt show`

### DIFF
--- a/.changes/unreleased/Fixes-20230817-164722.yaml
+++ b/.changes/unreleased/Fixes-20230817-164722.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Render sql_header before prepending for 'dbt show'
+time: 2023-08-17T16:47:22.030206+02:00
+custom:
+  Author: jtcohen6
+  Issue: "8417"

--- a/tests/functional/show/fixtures.py
+++ b/tests/functional/show/fixtures.py
@@ -37,7 +37,7 @@ from {{ ref('sample_model') }}
 
 models__sql_header = """
 {% call set_sql_header(config) %}
-set session time zone 'Asia/Kolkata';
+set session time zone '{{ var("timezone", "Europe/Paris") }}';
 {%- endcall %}
 select current_setting('timezone') as timezone
 """

--- a/tests/functional/show/fixtures.py
+++ b/tests/functional/show/fixtures.py
@@ -35,9 +35,16 @@ select
 from {{ ref('sample_model') }}
 """
 
-models__sql_header = """
+models__sql_header_no_rendering = """
 {% call set_sql_header(config) %}
-set session time zone '{{ var("timezone", "Europe/Paris") }}';
+set session time zone 'Asia/Kolkata';
+{%- endcall %}
+select current_setting('timezone') as timezone
+"""
+
+models__sql_header_yes_rendering = """
+{% call set_sql_header(config) %}
+set session time zone '{{ var("timezone", "Asia/Kolkata") }}';
 {%- endcall %}
 select current_setting('timezone') as timezone
 """

--- a/tests/functional/show/test_show.py
+++ b/tests/functional/show/test_show.py
@@ -11,7 +11,8 @@ from tests.functional.show.fixtures import (
     models__second_model,
     models__ephemeral_model,
     schema_yml,
-    models__sql_header,
+    models__sql_header_no_rendering,
+    models__sql_header_yes_rendering,
     private_model_yml,
 )
 
@@ -25,7 +26,8 @@ class ShowBase:
             "sample_number_model_with_nulls.sql": models__sample_number_model_with_nulls,
             "second_model.sql": models__second_model,
             "ephemeral_model.sql": models__ephemeral_model,
-            "sql_header.sql": models__sql_header,
+            "sql_header_no_rendering.sql": models__sql_header_no_rendering,
+            "sql_header_yes_rendering.sql": models__sql_header_yes_rendering,
         }
 
     @pytest.fixture(scope="class")
@@ -164,14 +166,15 @@ class TestShowSeed(ShowBase):
         (_, log_output) = run_dbt_and_capture(["show", "--select", "sample_seed"])
         assert "Previewing node 'sample_seed'" in log_output
 
-
-class TestShowSqlHeader(ShowBase):
-    def test_sql_header(self, project):
-        run_dbt(["build", "--vars", "timezone: Asia/Kolkata"])
-        (_, log_output) = run_dbt_and_capture(
-            ["show", "--select", "sql_header", "--vars", "timezone: Asia/Kolkata"]
-        )
+    def test_sql_header_no_rendering(self, project):
+        (_, log_output) = run_dbt_and_capture(["show", "--select", "sql_header_no_rendering"])
         assert "Asia/Kolkata" in log_output
+
+    def test_sql_header_yes_rendering(self, project):
+        (_, log_output) = run_dbt_and_capture(
+            ["show", "--select", "sql_header_yes_rendering", "--vars", "timezone: Europe/Paris"]
+        )
+        assert "Europe/Paris" in log_output
 
 
 class TestShowModelVersions:

--- a/tests/functional/show/test_show.py
+++ b/tests/functional/show/test_show.py
@@ -167,8 +167,10 @@ class TestShowSeed(ShowBase):
 
 class TestShowSqlHeader(ShowBase):
     def test_sql_header(self, project):
-        run_dbt(["build"])
-        (_, log_output) = run_dbt_and_capture(["show", "--select", "sql_header"])
+        run_dbt(["build", "--vars", "timezone: Asia/Kolkata"])
+        (_, log_output) = run_dbt_and_capture(
+            ["show", "--select", "sql_header", "--vars", "timezone: Asia/Kolkata"]
+        )
         assert "Asia/Kolkata" in log_output
 
 


### PR DESCRIPTION
resolves #8417

### Problem

`sql_header` is not rendered for `dbt show`. It is while running dbt models, as `{{ sql_header }}` is included within the materialization logic.

### Solution

Always render `sql_header`, if configured, before prepending to the model's `compiled_code`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
