### PR TITLE
Add doc string context to Identifier validion regex rule

### DIFF
--- a/core/dbt/contracts/util.py
+++ b/core/dbt/contracts/util.py
@@ -258,6 +258,13 @@ class ArtifactMixin(VersionedSchema, Writable, Readable):
 
 
 class Identifier(ValidatedStringMixin):
+    """Our definition of a valid Identifier is the same as what's valid for an unquoted database table name.
+
+    That is:
+    1. It can contain a-z, A-Z, 0-9, and _
+    1. It cannot start with a number
+    """
+
     ValidationRegex = r"^[^\d\W]\w*$"
 
     @classmethod


### PR DESCRIPTION
### Problem

The regex pattern for Identifier string validation had no context on WHY the restriction of identifiers was
what it was.

### Solution

Add a docstring documenting the reason for the regex.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
