### PR TITLE
Fix mypy warnings for ManifestLoader.load()

### DIFF
--- a/.changes/unreleased/Under the Hood-20230817-134548.yaml
+++ b/.changes/unreleased/Under the Hood-20230817-134548.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Fix mypy warnings for ManifestLoader.load()
+time: 2023-08-17T13:45:48.937252-04:00
+custom:
+  Author: gshank
+  Issue: "8401"

--- a/core/dbt/parser/read_files.py
+++ b/core/dbt/parser/read_files.py
@@ -16,9 +16,10 @@ from dbt.dataclass_schema import dbtClassMixin
 from dbt.parser.schemas import yaml_from_file, schema_file_keys
 from dbt.exceptions import ParsingError
 from dbt.parser.search import filesystem_search
-from typing import Optional, Dict, List, Mapping
+from typing import Optional, Dict, List, Mapping, MutableMapping
 from dbt.events.types import InputFileDiffError
 from dbt.events.functions import fire_event
+from typing import Protocol
 
 
 @dataclass
@@ -173,12 +174,21 @@ def generate_dbt_ignore_spec(project_root):
     return ignore_spec
 
 
+# Protocol for the ReadFiles... classes
+class ReadFiles(Protocol):
+    files: MutableMapping[str, AnySourceFile]
+    project_parser_files: Dict
+
+    def read_files(self):
+        pass
+
+
 @dataclass
 class ReadFilesFromFileSystem:
     all_projects: Mapping[str, Project]
-    files: Dict[str, AnySourceFile] = field(default_factory=dict)
+    files: MutableMapping[str, AnySourceFile] = field(default_factory=dict)
     # saved_files is only used to compare schema files
-    saved_files: Dict[str, AnySourceFile] = field(default_factory=dict)
+    saved_files: MutableMapping[str, AnySourceFile] = field(default_factory=dict)
     # project_parser_files = {
     #   "my_project": {
     #     "ModelParser": ["my_project://models/my_model.sql"]
@@ -212,10 +222,10 @@ class ReadFilesFromDiff:
     root_project_name: str
     all_projects: Mapping[str, Project]
     file_diff: FileDiff
-    files: Dict[str, AnySourceFile] = field(default_factory=dict)
+    files: MutableMapping[str, AnySourceFile] = field(default_factory=dict)
     # saved_files is used to construct a fresh copy of files, without
     # additional information from parsing
-    saved_files: Dict[str, AnySourceFile] = field(default_factory=dict)
+    saved_files: MutableMapping[str, AnySourceFile] = field(default_factory=dict)
     project_parser_files: Dict = field(default_factory=dict)
     project_file_types: Dict = field(default_factory=dict)
     local_package_dirs: Optional[List[str]] = None


### PR DESCRIPTION
resolves #8401

### Problem

Mypy warnings because ManifestLoader.load() did not have a return type annotation

### Solution

Add a type annotation and fix the cascading mypy errors.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
