### PR TITLE
revert python version for docker images

### DIFF
--- a/.changes/unreleased/Fixes-20230817-130915.yaml
+++ b/.changes/unreleased/Fixes-20230817-130915.yaml
@@ -1,6 +1,5 @@
-kind: Fixes
-body: revert prs 7196 and 6424 to have docker python version be 3.10.7 as dbt-spark
-  does not support 3.11py and is missing images in 1.6 and 1.5
+kind: Under the Hood
+body: Use python version 3.10.7 in Docker image.
 time: 2023-08-17T13:09:15.936349-05:00
 custom:
   Author: McKnight-42

--- a/.changes/unreleased/Fixes-20230817-130915.yaml
+++ b/.changes/unreleased/Fixes-20230817-130915.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: revert prs 7196 and 6424 to have docker python version be 3.10.7 as dbt-spark
+  does not support 3.11py and is missing images in 1.6 and 1.5
+time: 2023-08-17T13:09:15.936349-05:00
+custom:
+  Author: McKnight-42
+  Issue: "8444"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG build_for=linux/amd64
 ##
 # base image (abstract)
 ##
-FROM --platform=$build_for python:3.11.2-slim-bullseye as base
+FROM --platform=$build_for python:3.10.7-slim-bullseye as base
 
 # N.B. The refs updated automagically every release via bumpversion
 # N.B. dbt-postgres is currently found in the core codebase so a value of dbt-core@<some_version> is correct

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,8 @@ ARG build_for=linux/amd64
 ##
 # base image (abstract)
 ##
+# Please do not upgrade beyond python3.10.7 currently as dbt-spark does not support
+# 3.11py and images do not get made properly
 FROM --platform=$build_for python:3.10.7-slim-bullseye as base
 
 # N.B. The refs updated automagically every release via bumpversion


### PR DESCRIPTION
resolves #8444 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

the python version being used to build images in main to 1.5.latest (3.11.12/11) is not supported by dbt-spark and does not appear to be building .latest images

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
- [ ]backprt to 1.5 and 1.6
revert back to python 3.10.7 similar to 1.4.latest for now.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
