### PR TITLE
[CT-3013]  Fix parsing of `window_groupings`

### DIFF
--- a/.changes/unreleased/Fixes-20230818-095348.yaml
+++ b/.changes/unreleased/Fixes-20230818-095348.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Ensure parsing does not break when `window_groupings` is not specified for `non_additive_dimension`
+time: 2023-08-18T09:53:48.154848-07:00
+custom:
+  Author: QMalcolm
+  Issue: "8453"

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -689,7 +689,7 @@ class UnparsedEntity(dbtClassMixin):
 class UnparsedNonAdditiveDimension(dbtClassMixin):
     name: str
     window_choice: str  # AggregationType enum
-    window_groupings: List[str]
+    window_groupings: List[str] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -50,6 +50,12 @@ semantic_models:
         agg_time_dimension: ds
         agg_params:
           percentile: 0.99
+      - name: test_non_additive
+        expr: txn_revenue
+        agg: sum
+        non_additive_dimension:
+          name: ds
+          window_choice: max
 
     dimensions:
       - name: ds
@@ -125,7 +131,7 @@ class TestSemanticModelParsing:
             semantic_model.node_relation.relation_name
             == f'"dbt"."{project.test_schema}"."fct_revenue"'
         )
-        assert len(semantic_model.measures) == 5
+        assert len(semantic_model.measures) == 6
         # manifest should have one metric (that was created from a measure)
         assert len(manifest.metrics) == 2
         metric = manifest.metrics["metric.test.txn_revenue"]


### PR DESCRIPTION
resolves #8453 

### Problem

`window_groupings` is supposed to be optional in user yaml specifications. However when not specified, parsing breaks. See #8453 for further details.

### Solution

Default `window_groupings` to empty list when not specified

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
