### PR TITLE
[Backport 1.6.latest]  Fix parsing of `window_groupings` (#8454)

### DIFF
--- a/.changes/unreleased/Fixes-20230818-095348.yaml
+++ b/.changes/unreleased/Fixes-20230818-095348.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Ensure parsing does not break when `window_groupings` is not specified for `non_additive_dimension`
+time: 2023-08-18T09:53:48.154848-07:00
+custom:
+  Author: QMalcolm
+  Issue: "8453"

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -689,7 +689,7 @@ class UnparsedEntity(dbtClassMixin):
 class UnparsedNonAdditiveDimension(dbtClassMixin):
     name: str
     window_choice: str  # AggregationType enum
-    window_groupings: List[str]
+    window_groupings: List[str] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -49,6 +49,12 @@ semantic_models:
         agg_time_dimension: ds
         agg_params:
           percentile: 0.99
+      - name: test_non_additive
+        expr: txn_revenue
+        agg: sum
+        non_additive_dimension:
+          name: ds
+          window_choice: max
 
     dimensions:
       - name: ds
@@ -125,7 +131,7 @@ class TestSemanticModelParsing:
             semantic_model.node_relation.relation_name
             == f'"dbt"."{project.test_schema}"."fct_revenue"'
         )
-        assert len(semantic_model.measures) == 5
+        assert len(semantic_model.measures) == 6
 
     def test_semantic_model_error(self, project):
         # Next, modify the default schema.yml to remove the semantic model.


### PR DESCRIPTION
backport 49397b4 from #8454
