### PR TITLE
[CT-2840] Improved semantic layer protocol satisfaction tests

### DIFF
--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dbt.contracts.graph.nodes import (
     Metric,
     MetricInput,
@@ -11,8 +13,10 @@ from dbt.contracts.graph.semantic_models import (
     Dimension,
     DimensionTypeParams,
     Entity,
+    FileSlice,
     Measure,
     NonAdditiveDimension,
+    SourceFileMetadata,
 )
 from dbt.node_types import NodeType
 from dbt_semantic_interfaces.protocols import (
@@ -25,6 +29,10 @@ from dbt_semantic_interfaces.protocols import (
     MetricTypeParams as DSIMetricTypeParams,
     SemanticModel as DSISemanticModel,
     WhereFilter as DSIWhereFilter,
+)
+from dbt_semantic_interfaces.protocols.metadata import (
+    FileSlice as DSIFileSlice,
+    Metadata as DSIMetadata,
 )
 from dbt_semantic_interfaces.protocols.measure import (
     NonAdditiveDimensionParameters as DSINonAdditiveDimensionParameters,
@@ -87,6 +95,39 @@ class RuntimeCheckableWhereFilter(DSIWhereFilter, Protocol):
 @runtime_checkable
 class RuntimeCheckableNonAdditiveDimension(DSINonAdditiveDimensionParameters, Protocol):
     pass
+
+
+@runtime_checkable
+class RuntimeCheckableFileSlice(DSIFileSlice, Protocol):
+    pass
+
+
+@runtime_checkable
+class RuntimeCheckableSourceFileMetadata(DSIMetadata, Protocol):
+    pass
+
+
+@pytest.fixture(scope="session")
+def file_slice() -> FileSlice:
+    return FileSlice(
+        filename="test_filename", content="test content", start_line_number=0, end_line_number=1
+    )
+
+
+@pytest.fixture(scope="session")
+def source_file_metadata(file_slice) -> SourceFileMetadata:
+    return SourceFileMetadata(
+        repo_file_path="test/file/path.yml",
+        file_slice=file_slice,
+    )
+
+
+def test_file_slice_obj_satisfies_protocol(file_slice):
+    assert isinstance(file_slice, RuntimeCheckableFileSlice)
+
+
+def test_metadata_obj_satisfies_protocol(source_file_metadata):
+    assert isinstance(source_file_metadata, RuntimeCheckableSourceFileMetadata)
 
 
 def test_semantic_model_node_satisfies_protocol_optionals_unspecified():

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -247,7 +247,15 @@ def test_dimension_satisfies_protocol_optionals_specified(
     assert isinstance(dimension, RuntimeCheckableDimension)
 
 
-def test_entity_satisfies_protocol():
+def test_entity_satisfies_protocol_optionals_unspecified():
+    entity = Entity(
+        name="test_entity",
+        type=EntityType.PRIMARY,
+    )
+    assert isinstance(entity, RuntimeCheckableEntity)
+
+
+def test_entity_satisfies_protocol_optionals_specified():
     entity = Entity(
         name="test_entity",
         description="a test entity",

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -174,6 +174,13 @@ def non_additive_dimension() -> NonAdditiveDimension:
     )
 
 
+@pytest.fixture(scope="session")
+def where_filter() -> WhereFilter:
+    return WhereFilter(
+        where_sql_template="{{ Dimension('enity_name__dimension_name') }} AND {{ TimeDimension('entity_name__time_dimension_name', 'month') }} AND {{ Entity('entity_name') }}"
+    )
+
+
 def test_file_slice_obj_satisfies_protocol(file_slice):
     assert isinstance(file_slice, RuntimeCheckableFileSlice)
 
@@ -323,7 +330,7 @@ def test_measure_satisfies_protocol_optionals_specified(
     assert isinstance(measure, RuntimeCheckableMeasure)
 
 
-def test_metric_node_satisfies_protocol():
+def test_metric_node_satisfies_protocol_optionals_unspecified():
     metric = Metric(
         name="a_metric",
         resource_type=NodeType.Metric,
@@ -344,10 +351,31 @@ def test_metric_node_satisfies_protocol():
     assert isinstance(metric, RuntimeCheckableMetric)
 
 
-def test_where_filter_satisfies_protocol():
-    where_filter = WhereFilter(
-        where_sql_template="{{ Dimension('enity_name__dimension_name') }} AND {{ TimeDimension('entity_name__time_dimension_name', 'month') }} AND {{ Entity('entity_name') }}"
+def test_metric_node_satisfies_protocol_optionals_specified(source_file_metadata, where_filter):
+    metric = Metric(
+        name="a_metric",
+        resource_type=NodeType.Metric,
+        package_name="package_name",
+        path="path.to.semantic_model",
+        original_file_path="path/to/file",
+        unique_id="not_like_the_other_semantic_models",
+        fqn=["fully", "qualified", "name"],
+        description="a test metric",
+        label="A test metric",
+        type=MetricType.SIMPLE,
+        type_params=MetricTypeParams(
+            measure=MetricInputMeasure(
+                name="a_test_measure", filter=WhereFilter(where_sql_template="a_dimension is true")
+            )
+        ),
+        filter=where_filter,
+        metadata=source_file_metadata,
+        group="test_group",
     )
+    assert isinstance(metric, RuntimeCheckableMetric)
+
+
+def test_where_filter_satisfies_protocol(where_filter):
     assert isinstance(where_filter, RuntimeCheckableWhereFilter)
 
 

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -12,6 +12,7 @@ from dbt.contracts.graph.nodes import (
 from dbt.contracts.graph.semantic_models import (
     Dimension,
     DimensionTypeParams,
+    Defaults,
     Entity,
     FileSlice,
     Measure,
@@ -28,6 +29,7 @@ from dbt_semantic_interfaces.protocols import (
     MetricInputMeasure as DSIMetricInputMeasure,
     MetricTypeParams as DSIMetricTypeParams,
     SemanticModel as DSISemanticModel,
+    SemanticModelDefaults as DSISemanticModelDefaults,
     WhereFilter as DSIWhereFilter,
 )
 from dbt_semantic_interfaces.protocols.metadata import (
@@ -107,6 +109,11 @@ class RuntimeCheckableSourceFileMetadata(DSIMetadata, Protocol):
     pass
 
 
+@runtime_checkable
+class RuntimeCheckableSemanticModelDefaults(DSISemanticModelDefaults, Protocol):
+    pass
+
+
 @pytest.fixture(scope="session")
 def file_slice() -> FileSlice:
     return FileSlice(
@@ -122,12 +129,22 @@ def source_file_metadata(file_slice) -> SourceFileMetadata:
     )
 
 
+@pytest.fixture(scope="session")
+def semantic_model_defaults() -> Defaults:
+    return Defaults(agg_time_dimension="test_time_dimension")
+
+
 def test_file_slice_obj_satisfies_protocol(file_slice):
     assert isinstance(file_slice, RuntimeCheckableFileSlice)
 
 
 def test_metadata_obj_satisfies_protocol(source_file_metadata):
     assert isinstance(source_file_metadata, RuntimeCheckableSourceFileMetadata)
+
+
+def test_defaults_obj_satisfies_protocol(semantic_model_defaults):
+    assert isinstance(semantic_model_defaults, RuntimeCheckableSemanticModelDefaults)
+    assert isinstance(Defaults(), RuntimeCheckableSemanticModelDefaults)
 
 
 def test_semantic_model_node_satisfies_protocol_optionals_unspecified():

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -12,6 +12,7 @@ from dbt.contracts.graph.nodes import (
 from dbt.contracts.graph.semantic_models import (
     Dimension,
     DimensionTypeParams,
+    DimensionValidityParams,
     Defaults,
     Entity,
     FileSlice,
@@ -108,6 +109,13 @@ class RuntimeCheckableSemanticModelDefaults(
     pass
 
 
+@runtime_checkable
+class RuntimeCheckableDimensionValidityParams(
+    DimensionProtocols.DimensionValidityParams, Protocol
+):
+    pass
+
+
 @pytest.fixture(scope="session")
 def file_slice() -> FileSlice:
     return FileSlice(
@@ -128,6 +136,11 @@ def semantic_model_defaults() -> Defaults:
     return Defaults(agg_time_dimension="test_time_dimension")
 
 
+@pytest.fixture(scope="session")
+def dimension_validity_params() -> DimensionValidityParams:
+    return DimensionValidityParams()
+
+
 def test_file_slice_obj_satisfies_protocol(file_slice):
     assert isinstance(file_slice, RuntimeCheckableFileSlice)
 
@@ -139,6 +152,10 @@ def test_metadata_obj_satisfies_protocol(source_file_metadata):
 def test_defaults_obj_satisfies_protocol(semantic_model_defaults):
     assert isinstance(semantic_model_defaults, RuntimeCheckableSemanticModelDefaults)
     assert isinstance(Defaults(), RuntimeCheckableSemanticModelDefaults)
+
+
+def test_dimension_validity_params_satisfies_protocl(dimension_validity_params):
+    assert isinstance(dimension_validity_params, RuntimeCheckableDimensionValidityParams)
 
 
 def test_semantic_model_node_satisfies_protocol_optionals_unspecified():

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -89,10 +89,9 @@ class RuntimeCheckableNonAdditiveDimension(DSINonAdditiveDimensionParameters, Pr
     pass
 
 
-def test_semantic_model_node_satisfies_protocol():
+def test_semantic_model_node_satisfies_protocol_optionals_unspecified():
     test_semantic_model = SemanticModel(
         name="test_semantic_model",
-        description="a test semantic_model",
         resource_type=NodeType.SemanticModel,
         package_name="package_name",
         path="path.to.semantic_model",
@@ -100,13 +99,13 @@ def test_semantic_model_node_satisfies_protocol():
         unique_id="not_like_the_other_semantic_models",
         fqn=["fully", "qualified", "name"],
         model="ref('a_model')",
+        # Technically NodeRelation is optional on our SemanticModel implementation
+        # however, it's functionally always loaded, it's just delayed.
+        # This will type/state mismatch will likely bite us at some point
         node_relation=NodeRelation(
             alias="test_alias",
             schema_name="test_schema_name",
         ),
-        entities=[],
-        measures=[],
-        dimensions=[],
     )
     assert isinstance(test_semantic_model, RuntimeCheckableSemanticModel)
 

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -192,14 +192,24 @@ def test_semantic_model_node_satisfies_protocol_optionals_specified(
     assert isinstance(test_semantic_model, RuntimeCheckableSemanticModel)
 
 
-def test_dimension_satisfies_protocol():
+def test_dimension_satisfies_protocol_optionals_unspecified():
     dimension = Dimension(
         name="test_dimension",
-        description="a test dimension",
         type=DimensionType.TIME,
+    )
+    assert isinstance(dimension, RuntimeCheckableDimension)
+
+
+def test_dimension_satisfies_protocol_optionals_specified(source_file_metadata):
+    dimension = Dimension(
+        name="test_dimension",
+        type=DimensionType.TIME,
+        description="test_description",
         type_params=DimensionTypeParams(
             time_granularity=TimeGranularity.DAY,
         ),
+        expr="1",
+        metadata=source_file_metadata,
     )
     assert isinstance(dimension, RuntimeCheckableDimension)
 

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -21,23 +21,13 @@ from dbt.contracts.graph.semantic_models import (
 )
 from dbt.node_types import NodeType
 from dbt_semantic_interfaces.protocols import (
-    Dimension as DSIDimension,
-    Entity as DSIEntitiy,
-    Measure as DSIMeasure,
-    Metric as DSIMetric,
-    MetricInput as DSIMetricInput,
-    MetricInputMeasure as DSIMetricInputMeasure,
-    MetricTypeParams as DSIMetricTypeParams,
-    SemanticModel as DSISemanticModel,
-    SemanticModelDefaults as DSISemanticModelDefaults,
-    WhereFilter as DSIWhereFilter,
-)
-from dbt_semantic_interfaces.protocols.metadata import (
-    FileSlice as DSIFileSlice,
-    Metadata as DSIMetadata,
-)
-from dbt_semantic_interfaces.protocols.measure import (
-    NonAdditiveDimensionParameters as DSINonAdditiveDimensionParameters,
+    dimension as DimensionProtocols,
+    entity as EntityProtocols,
+    measure as MeasureProtocols,
+    metadata as MetadataProtocols,
+    metric as MetricProtocols,
+    semantic_model as SemanticModelProtocols,
+    WhereFilter as WhereFilterProtocol,
 )
 from dbt_semantic_interfaces.type_enums import (
     AggregationType,
@@ -50,67 +40,71 @@ from typing import Protocol, runtime_checkable
 
 
 @runtime_checkable
-class RuntimeCheckableSemanticModel(DSISemanticModel, Protocol):
+class RuntimeCheckableSemanticModel(SemanticModelProtocols.SemanticModel, Protocol):
     pass
 
 
 @runtime_checkable
-class RuntimeCheckableDimension(DSIDimension, Protocol):
+class RuntimeCheckableDimension(DimensionProtocols.Dimension, Protocol):
     pass
 
 
 @runtime_checkable
-class RuntimeCheckableEntity(DSIEntitiy, Protocol):
+class RuntimeCheckableEntity(EntityProtocols.Entity, Protocol):
     pass
 
 
 @runtime_checkable
-class RuntimeCheckableMeasure(DSIMeasure, Protocol):
+class RuntimeCheckableMeasure(MeasureProtocols.Measure, Protocol):
     pass
 
 
 @runtime_checkable
-class RuntimeCheckableMetric(DSIMetric, Protocol):
+class RuntimeCheckableMetric(MetricProtocols.Metric, Protocol):
     pass
 
 
 @runtime_checkable
-class RuntimeCheckableMetricInput(DSIMetricInput, Protocol):
+class RuntimeCheckableMetricInput(MetricProtocols.MetricInput, Protocol):
     pass
 
 
 @runtime_checkable
-class RuntimeCheckableMetricInputMeasure(DSIMetricInputMeasure, Protocol):
+class RuntimeCheckableMetricInputMeasure(MetricProtocols.MetricInputMeasure, Protocol):
     pass
 
 
 @runtime_checkable
-class RuntimeCheckableMetricTypeParams(DSIMetricTypeParams, Protocol):
+class RuntimeCheckableMetricTypeParams(MetricProtocols.MetricTypeParams, Protocol):
     pass
 
 
 @runtime_checkable
-class RuntimeCheckableWhereFilter(DSIWhereFilter, Protocol):
+class RuntimeCheckableWhereFilter(WhereFilterProtocol, Protocol):
     pass
 
 
 @runtime_checkable
-class RuntimeCheckableNonAdditiveDimension(DSINonAdditiveDimensionParameters, Protocol):
+class RuntimeCheckableNonAdditiveDimension(
+    MeasureProtocols.NonAdditiveDimensionParameters, Protocol
+):
     pass
 
 
 @runtime_checkable
-class RuntimeCheckableFileSlice(DSIFileSlice, Protocol):
+class RuntimeCheckableFileSlice(MetadataProtocols.FileSlice, Protocol):
     pass
 
 
 @runtime_checkable
-class RuntimeCheckableSourceFileMetadata(DSIMetadata, Protocol):
+class RuntimeCheckableSourceFileMetadata(MetadataProtocols.Metadata, Protocol):
     pass
 
 
 @runtime_checkable
-class RuntimeCheckableSemanticModelDefaults(DSISemanticModelDefaults, Protocol):
+class RuntimeCheckableSemanticModelDefaults(
+    SemanticModelProtocols.SemanticModelDefaults, Protocol
+):
     pass
 
 

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -168,6 +168,30 @@ def test_semantic_model_node_satisfies_protocol_optionals_unspecified():
     assert isinstance(test_semantic_model, RuntimeCheckableSemanticModel)
 
 
+def test_semantic_model_node_satisfies_protocol_optionals_specified(
+    semantic_model_defaults, source_file_metadata
+):
+    test_semantic_model = SemanticModel(
+        name="test_semantic_model",
+        resource_type=NodeType.SemanticModel,
+        package_name="package_name",
+        path="path.to.semantic_model",
+        original_file_path="path/to/file",
+        unique_id="not_like_the_other_semantic_models",
+        fqn=["fully", "qualified", "name"],
+        model="ref('a_model')",
+        node_relation=NodeRelation(
+            alias="test_alias",
+            schema_name="test_schema_name",
+        ),
+        description="test_description",
+        defaults=semantic_model_defaults,
+        metadata=source_file_metadata,
+        primary_entity="test_primary_entity",
+    )
+    assert isinstance(test_semantic_model, RuntimeCheckableSemanticModel)
+
+
 def test_dimension_satisfies_protocol():
     dimension = Dimension(
         name="test_dimension",


### PR DESCRIPTION
resolves #8136 

### Problem

We weren't fully testing optional fields of semantic layer objects

### Solution

We now run a much more verbose test suite on semantic layer protocol satisfaction for our semantic layer object implementations.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
