### PR TITLE
compile --suppress-ephemeral-ctes flag

### DIFF
--- a/.changes/unreleased/Features-20230823-140407.yaml
+++ b/.changes/unreleased/Features-20230823-140407.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add --suppress-ephemeral-ctes flag for `compile` command, for usage by linting.
+time: 2023-08-23T14:04:07.617476-04:00
+custom:
+  Author: benmosher
+  Issue: "8480"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -330,6 +330,7 @@ def docs_serve(ctx, **kwargs):
 @p.state
 @p.defer_state
 @p.deprecated_state
+@p.compile_suppress_ephemeral_ctes
 @p.target
 @p.target_path
 @p.threads

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -40,6 +40,14 @@ compile_docs = click.option(
     default=True,
 )
 
+compile_suppress_ephemeral_ctes = click.option(
+    "--suppress-ephemeral-ctes/--no-suppress-ephemeral-ctes",
+    envvar="DBT_SUPPRESS_EPHEMERAL_CTES",
+    help="Internal flag for whether to supress injecting referenced ephemeral models' CTEs during `compile`.",
+    hidden=True,
+    default=False,
+)
+
 config_dir = click.option(
     "--config-dir",
     envvar=None,

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -320,6 +320,10 @@ class Compiler:
         if model.compiled_code is None:
             raise DbtRuntimeError("Cannot inject ctes into an uncompiled node", model)
 
+        flags = get_flags()
+        if getattr(flags, "SUPPRESS_EPHEMERAL_CTES", False):
+            return (model, [])
+
         # extra_ctes_injected flag says that we've already recursively injected the ctes
         if model.extra_ctes_injected:
             return (model, model.extra_ctes)

--- a/tests/functional/materializations/test_ephemeral_compilation.py
+++ b/tests/functional/materializations/test_ephemeral_compilation.py
@@ -1,3 +1,5 @@
+from dbt.contracts.graph.nodes import ModelNode
+from dbt.contracts.results import RunExecutionResult, RunResult
 import pytest
 from dbt.tests.util import run_dbt
 
@@ -53,6 +55,16 @@ models:
 """
 
 
+SUPPRESSED_CTE_EXPECTED_OUTPUT = """-- fct_eph_first.sql
+
+
+with int_eph_first as(
+    select * from __dbt__cte__int_eph_first
+)
+
+select * from int_eph_first"""
+
+
 class TestEphemeralCompilation:
     @pytest.fixture(scope="class")
     def models(self):
@@ -67,5 +79,13 @@ class TestEphemeralCompilation:
         results = run_dbt(["run"])
         assert len(results) == 0
 
-        results = run_dbt(["test"])
-        len(results) == 4
+    def test__suppress_injected_ctes(self, project):
+        compile_output = run_dbt(
+            ["compile", "--suppress-ephemeral-ctes", "--select", "fct_eph_first"]
+        )
+        assert isinstance(compile_output, RunExecutionResult)
+        node_result = compile_output.results[0]
+        assert isinstance(node_result, RunResult)
+        node = node_result.node
+        assert isinstance(node, ModelNode)
+        assert node.compiled_code == SUPPRESSED_CTE_EXPECTED_OUTPUT


### PR DESCRIPTION
...for inline compilation of models during linting only.

resolves #8480  
<!-- [docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  -->

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

Injection of ephemeral model CTEs breaks SQLFluff linting in Cloud.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Optionally suppressing the injection of CTEs (intentionally added to the `compile` command only!) enables SQLFluff linting of models with direct ephemeral model references.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
