### PR TITLE
Fix ambiguous reference error for duplicate model names across packages with tests

### DIFF
--- a/.changes/unreleased/Fixes-20230824-161024.yaml
+++ b/.changes/unreleased/Fixes-20230824-161024.yaml
@@ -1,7 +1,7 @@
 kind: Fixes
-body: fix ambiguous reference error for tests when model name is duplicated across
+body: fix ambiguous reference error for tests and versions when model name is duplicated across
   packages
 time: 2023-08-24T16:10:24.437362-04:00
 custom:
   Author: michelleark
-  Issue: "8327"
+  Issue: "8327 8493"

--- a/.changes/unreleased/Fixes-20230824-161024.yaml
+++ b/.changes/unreleased/Fixes-20230824-161024.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: fix ambiguous reference error for tests when model name is duplicated across
+  packages
+time: 2023-08-24T16:10:24.437362-04:00
+custom:
+  Author: michelleark
+  Issue: "8327"

--- a/core/dbt/parser/schema_generic_tests.py
+++ b/core/dbt/parser/schema_generic_tests.py
@@ -233,7 +233,7 @@ class SchemaGenericTestParser(SimpleParser):
         attached_node = None  # type: Optional[Union[ManifestNode, GraphMemberNode]]
         if not isinstance(target, UnpatchedSourceDefinition):
             attached_node_unique_id = self.manifest.ref_lookup.get_unique_id(
-                target.name, None, version
+                target.name, target.package_name, version
             )
             if attached_node_unique_id:
                 attached_node = self.manifest.nodes[attached_node_unique_id]

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -693,7 +693,7 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
                 )
                 # ref lookup without version - version is not set yet
                 versioned_model_unique_id = self.manifest.ref_lookup.get_unique_id(
-                    versioned_model_name, None, None
+                    versioned_model_name, target.package_name, None
                 )
 
                 versioned_model_node = None
@@ -702,7 +702,7 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
                 # If this is the latest version, it's allowed to define itself in a model file name that doesn't have a suffix
                 if versioned_model_unique_id is None and unparsed_version.v == latest_version:
                     versioned_model_unique_id = self.manifest.ref_lookup.get_unique_id(
-                        block.name, None, None
+                        block.name, target.package_name, None
                     )
 
                 if versioned_model_unique_id is None:

--- a/tests/functional/duplicates/test_duplicate_model.py
+++ b/tests/functional/duplicates/test_duplicate_model.py
@@ -54,6 +54,15 @@ models:
           - unique
 """
 
+local_dep_versions_schema_yml = """
+models:
+  - name: table_model
+    config:
+      alias: table_model_local_dep
+    versions:
+      - v: 1
+"""
+
 
 class TestDuplicateModelEnabled:
     @pytest.fixture(scope="class")
@@ -185,6 +194,38 @@ class TestDuplicateModelNameWithTestAcrossPackages:
         test_node_id = "test.local_dep.unique_table_model_id.1da9e464d9"
         assert test_node_id in manifest.nodes
         assert manifest.nodes[test_node_id].attached_node == local_dep_model_node_id
+
+
+class TestDuplicateModelNameWithVersionAcrossPackages:
+    @pytest.fixture(scope="class", autouse=True)
+    def setUp(self, project_root):
+        local_dependency_files = {
+            "dbt_project.yml": dbt_project_yml,
+            "models": {
+                "table_model.sql": enabled_model_sql,
+                "schema.yml": local_dep_versions_schema_yml,
+            },
+        }
+        write_project_files(project_root, "local_dependency", local_dependency_files)
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"table_model.sql": enabled_model_sql}
+
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {"packages": [{"local": "local_dependency"}]}
+
+    def test_duplicate_model_name_with_test_across_packages(self, project):
+        run_dbt(["deps"])
+        manifest = run_dbt(["parse"])
+        assert len(manifest.nodes) == 2
+
+        # model nodes with duplicate names exist
+        local_dep_model_node_id = "model.local_dep.table_model.v1"
+        root_model_node_id = "model.test.table_model"
+        assert local_dep_model_node_id in manifest.nodes
+        assert root_model_node_id in manifest.nodes
 
 
 class TestModelTestOverlap:

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -612,7 +612,7 @@ class SchemaParserVersionedModels(SchemaParserTest):
     def setUp(self):
         super().setUp()
         my_model_v1_node = MockNode(
-            package="root",
+            package="snowplow",
             name="arbitrary_file_name",
             config=mock.MagicMock(enabled=True),
             refs=[],
@@ -621,7 +621,7 @@ class SchemaParserVersionedModels(SchemaParserTest):
             file_id="snowplow://models/arbitrary_file_name.sql",
         )
         my_model_v2_node = MockNode(
-            package="root",
+            package="snowplow",
             name="my_model_v2",
             config=mock.MagicMock(enabled=True),
             refs=[],


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/8327
resolves https://github.com/dbt-labs/dbt-core/issues/8493
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  N/A

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
When generic test nodes are constructed, an 'attached_node' attribute is set by looking up the attached node in the manifest via `manifest.ref_lookup.get_unique_id`. Currently, this call passes `None` as the value for `package_name` -- resulting in ambiguous reference errors if the model exists with a duplicate name across packages. 

This is unexpected behaviour since the restriction to have unique model names across packages was lifted in https://github.com/dbt-labs/dbt-core/pull/7374.

Similarly, looking up the unique id from ref_lookup for versioned node parsing also passes in `None` for package_name, resulting in an ambiguous ref name error described in #8493.

### Solution

Pass the target package_name to ref lookup for attached_node, as generic test nodes should only ever be attached to nodes defined in the same package

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
