### PR TITLE
Safely remove external nodes from manifest

### DIFF
--- a/.changes/unreleased/Fixes-20230828-125858.yaml
+++ b/.changes/unreleased/Fixes-20230828-125858.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: 'Fix "Internal Error: Expected node <unique-id> not found in manifest" when
+  depends_on set on ModelNodeArgs'
+time: 2023-08-28T12:58:58.061228-04:00
+custom:
+  Author: michelleark
+  Issue: "8506"


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/8506
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
`manifest.nodes.pop(unique_id)` was called as nodes are removed, causing key errors if downstream external nodes (from child_map in remove_dependent_project_references) expect them to be present in the manifest later on. This becomes problematic when external nodes configure the `depends_on` attribute of `ModelNodeArgs`. 
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Only remove nodes from the manifest once _all_ dependent project references have been removed. 

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
