### PR TITLE
Semantic model configs - enable/disable + groups

### DIFF
--- a/.changes/unreleased/Features-20230828-092100.yaml
+++ b/.changes/unreleased/Features-20230828-092100.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support configuration of semantic models with the addition of enable/disable and group enablement.
+time: 2023-08-28T09:21:00.551633-05:00
+custom:
+  Author: emmyoop
+  Issue: "7968"

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -426,6 +426,7 @@ class PartialProject(RenderComponents):
         sources: Dict[str, Any]
         tests: Dict[str, Any]
         metrics: Dict[str, Any]
+        semantic_models: Dict[str, Any]
         exposures: Dict[str, Any]
         vars_value: VarProvider
 
@@ -436,6 +437,7 @@ class PartialProject(RenderComponents):
         sources = cfg.sources
         tests = cfg.tests
         metrics = cfg.metrics
+        semantic_models = cfg.semantic_models
         exposures = cfg.exposures
         if cfg.vars is None:
             vars_dict: Dict[str, Any] = {}
@@ -492,6 +494,7 @@ class PartialProject(RenderComponents):
             sources=sources,
             tests=tests,
             metrics=metrics,
+            semantic_models=semantic_models,
             exposures=exposures,
             vars=vars_value,
             config_version=cfg.config_version,
@@ -598,6 +601,7 @@ class Project:
     sources: Dict[str, Any]
     tests: Dict[str, Any]
     metrics: Dict[str, Any]
+    semantic_models: Dict[str, Any]
     exposures: Dict[str, Any]
     vars: VarProvider
     dbt_version: List[VersionSpecifier]
@@ -673,6 +677,7 @@ class Project:
                 "sources": self.sources,
                 "tests": self.tests,
                 "metrics": self.metrics,
+                "semantic-models": self.semantic_models,
                 "exposures": self.exposures,
                 "vars": self.vars.to_dict(),
                 "require-dbt-version": [v.to_version_string() for v in self.dbt_version],

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -167,6 +167,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
             sources=project.sources,
             tests=project.tests,
             metrics=project.metrics,
+            semantic_models=project.semantic_models,
             exposures=project.exposures,
             vars=project.vars,
             config_version=project.config_version,
@@ -322,6 +323,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
             "sources": self._get_config_paths(self.sources),
             "tests": self._get_config_paths(self.tests),
             "metrics": self._get_config_paths(self.metrics),
+            "semantic_models": self._get_config_paths(self.semantic_models),
             "exposures": self._get_config_paths(self.exposures),
         }
 

--- a/core/dbt/context/context_config.py
+++ b/core/dbt/context/context_config.py
@@ -45,6 +45,8 @@ class UnrenderedConfig(ConfigSource):
             model_configs = unrendered.get("tests")
         elif resource_type == NodeType.Metric:
             model_configs = unrendered.get("metrics")
+        elif resource_type == NodeType.SemanticModel:
+            model_configs = unrendered.get("semantic_models")
         elif resource_type == NodeType.Exposure:
             model_configs = unrendered.get("exposures")
         else:
@@ -70,6 +72,8 @@ class RenderedConfig(ConfigSource):
             model_configs = self.project.tests
         elif resource_type == NodeType.Metric:
             model_configs = self.project.metrics
+        elif resource_type == NodeType.SemanticModel:
+            model_configs = self.project.semantic_models
         elif resource_type == NodeType.Exposure:
             model_configs = self.project.exposures
         else:

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1359,6 +1359,8 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
                 source_file.add_test(node.unique_id, test_from)
             if isinstance(node, Metric):
                 source_file.metrics.append(node.unique_id)
+            if isinstance(node, SemanticModel):
+                source_file.semantic_models.append(node.unique_id)
             if isinstance(node, Exposure):
                 source_file.exposures.append(node.unique_id)
         else:

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -927,6 +927,7 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         groupable_nodes = list(
             chain(
                 self.nodes.values(),
+                self.semantic_models.values(),
                 self.metrics.values(),
             )
         )
@@ -1056,8 +1057,7 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
 
         return resolved_refs
 
-    # Called by dbt.parser.manifest._process_refs_for_exposure, _process_refs_for_metric,
-    # and dbt.parser.manifest._process_refs_for_node
+    # Called by dbt.parser.manifest._process_refs & ManifestLoader.check_for_model_deprecations
     def resolve_ref(
         self,
         source_node: GraphMemberNode,

--- a/core/dbt/contracts/graph/model_config.py
+++ b/core/dbt/contracts/graph/model_config.py
@@ -378,12 +378,19 @@ class BaseConfig(AdditionalPropertiesAllowed, Replaceable):
 @dataclass
 class SemanticModelConfig(BaseConfig):
     enabled: bool = True
+    group: Optional[str] = field(
+        default=None,
+        metadata=CompareBehavior.Exclude.meta(),
+    )
 
 
 @dataclass
 class MetricConfig(BaseConfig):
     enabled: bool = True
-    group: Optional[str] = None
+    group: Optional[str] = field(
+        default=None,
+        metadata=CompareBehavior.Exclude.meta(),
+    )
 
 
 @dataclass

--- a/core/dbt/contracts/graph/model_config.py
+++ b/core/dbt/contracts/graph/model_config.py
@@ -642,6 +642,7 @@ class SnapshotConfig(EmptySnapshotConfig):
 
 RESOURCE_TYPES: Dict[NodeType, Type[BaseConfig]] = {
     NodeType.Metric: MetricConfig,
+    NodeType.SemanticModel: SemanticModelConfig,
     NodeType.Exposure: ExposureConfig,
     NodeType.Source: SourceConfig,
     NodeType.Seed: SeedConfig,

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1579,6 +1579,7 @@ class SemanticModel(GraphNode):
     created_at: float = field(default_factory=lambda: time.time())
     config: SemanticModelConfig = field(default_factory=SemanticModelConfig)
     primary_entity: Optional[str] = None
+    group: Optional[str] = None
 
     @property
     def entity_references(self) -> List[LinkableElementReference]:

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1639,12 +1639,6 @@ class SemanticModel(GraphNode):
     def depends_on_macros(self):
         return self.depends_on.macros
 
-    # def same_config(self, old: "SemanticModel") -> bool:
-    #     return self.config.same_contents(
-    #         self.unrendered_config,
-    #         old.unrendered_config,
-    #     )
-
     def checked_agg_time_dimension_for_measure(
         self, measure_reference: MeasureReference
     ) -> TimeDimensionReference:

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1578,6 +1578,7 @@ class SemanticModel(GraphNode):
     refs: List[RefArgs] = field(default_factory=list)
     created_at: float = field(default_factory=lambda: time.time())
     config: SemanticModelConfig = field(default_factory=SemanticModelConfig)
+    unrendered_config: Dict[str, Any] = field(default_factory=dict)
     primary_entity: Optional[str] = None
     group: Optional[str] = None
 
@@ -1637,6 +1638,12 @@ class SemanticModel(GraphNode):
     @property
     def depends_on_macros(self):
         return self.depends_on.macros
+
+    # def same_config(self, old: "SemanticModel") -> bool:
+    #     return self.config.same_contents(
+    #         self.unrendered_config,
+    #         old.unrendered_config,
+    #     )
 
     def checked_agg_time_dimension_for_measure(
         self, measure_reference: MeasureReference

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -711,6 +711,7 @@ class UnparsedDimension(dbtClassMixin):
 class UnparsedSemanticModel(dbtClassMixin):
     name: str
     model: str  # looks like "ref(...)"
+    config: Dict[str, Any] = field(default_factory=dict)
     description: Optional[str] = None
     defaults: Optional[Defaults] = None
     entities: List[UnparsedEntity] = field(default_factory=list)

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -214,6 +214,7 @@ class Project(dbtClassMixin, Replaceable):
     sources: Dict[str, Any] = field(default_factory=dict)
     tests: Dict[str, Any] = field(default_factory=dict)
     metrics: Dict[str, Any] = field(default_factory=dict)
+    semantic_models: Dict[str, Any] = field(default_factory=dict)
     exposures: Dict[str, Any] = field(default_factory=dict)
     vars: Optional[Dict[str, Any]] = field(
         default=None,

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -250,6 +250,7 @@ class Project(dbtClassMixin, Replaceable):
             "require_dbt_version": "require-dbt-version",
             "query_comment": "query-comment",
             "restrict_access": "restrict-access",
+            "semantic_models": "semantic-models",
         }
 
     @classmethod

--- a/core/dbt/graph/selector.py
+++ b/core/dbt/graph/selector.py
@@ -169,7 +169,8 @@ class NodeSelector(MethodManager):
             metric = self.manifest.metrics[unique_id]
             return metric.config.enabled
         elif unique_id in self.manifest.semantic_models:
-            return True
+            semantic_model = self.manifest.semantic_models[unique_id]
+            return semantic_model.config.enabled
         node = self.manifest.nodes[unique_id]
 
         if self.include_empty_nodes:

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1501,7 +1501,7 @@ def _process_metric_node(
             )
         if target_semantic_model.config.enabled is False:
             raise dbt.exceptions.ParsingError(
-                f"A semantic model having a measure `{metric.type_params.measure.name}` is disabled but was referenced.",
+                f"The measure `{metric.type_params.measure.name}` is referenced on disabled semantic model `{target_semantic_model.name}`.",
                 node=metric,
             )
 

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -95,6 +95,7 @@ from dbt.contracts.graph.nodes import (
     Exposure,
     Metric,
     SeedNode,
+    SemanticModel,
     ManifestNode,
     ResultNode,
     ModelNode,
@@ -1220,11 +1221,16 @@ class ManifestLoader:
         for metric in manifest.metrics.values():
             self.check_valid_group_config_node(metric, group_names)
 
+        for semantic_model in manifest.semantic_models.values():
+            self.check_valid_group_config_node(semantic_model, group_names)
+
         for node in manifest.nodes.values():
             self.check_valid_group_config_node(node, group_names)
 
     def check_valid_group_config_node(
-        self, groupable_node: Union[Metric, ManifestNode], valid_group_names: Set[str]
+        self,
+        groupable_node: Union[Metric, SemanticModel, ManifestNode],
+        valid_group_names: Set[str],
     ):
         groupable_node_group = groupable_node.group
         if groupable_node_group and groupable_node_group not in valid_group_names:
@@ -1491,6 +1497,11 @@ def _process_metric_node(
         if target_semantic_model is None:
             raise dbt.exceptions.ParsingError(
                 f"A semantic model having a measure `{metric.type_params.measure.name}` does not exist but was referenced.",
+                node=metric,
+            )
+        if target_semantic_model.config.enabled is False:
+            raise dbt.exceptions.ParsingError(
+                f"A semantic model having a measure `{metric.type_params.measure.name}` is disabled but was referenced.",
                 node=metric,
             )
 

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -36,7 +36,7 @@ from dbt.contracts.graph.semantic_models import (
 from dbt.exceptions import DbtInternalError, YamlParseDictError, JSONValidationError
 from dbt.context.providers import generate_parse_exposure, generate_parse_semantic_models
 
-from dbt.contracts.graph.model_config import MetricConfig, ExposureConfig, SemanticModelConfig
+from dbt.contracts.graph.model_config import MetricConfig, ExposureConfig
 from dbt.context.context_config import (
     BaseContextConfigGenerator,
     ContextConfigGenerator,
@@ -569,11 +569,6 @@ class SemanticModelParser(YamlReader):
             package_name=package_name,
             rendered=False,
         )
-
-        if not isinstance(config, SemanticModelConfig):
-            raise DbtInternalError(
-                f"Calculated a {type(config)} for a semantic model, but expected a SemanticModelConfig"
-            )
 
         parsed = SemanticModel(
             description=unparsed.description,

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -533,13 +533,13 @@ class SemanticModelParser(YamlReader):
 
         # configs with precendence set
         precedence_configs = dict()
-        # first apply metric configs
+        # first apply semantic model configs
         precedence_configs.update(target.config)
 
         config = generator.calculate_node_config(
             config_call_dict={},
             fqn=fqn,
-            resource_type=NodeType.Metric,
+            resource_type=NodeType.SemanticModel,
             project_name=package_name,
             base=False,
             patch_config_dict=precedence_configs,
@@ -600,7 +600,7 @@ class SemanticModelParser(YamlReader):
 
         if parsed.model is not None:
             model_ref = "{{ " + parsed.model + " }}"
-            # This sets the "refs" in the SemanticModel from the MetricRefResolver in context/providers.py
+            # This sets the "refs" in the SemanticModel from the SemanticModelRefResolver in context/providers.py
             get_rendered(model_ref, ctx, parsed)
 
         # No ability to disable a semantic model at this time

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -603,8 +603,12 @@ class SemanticModelParser(YamlReader):
             # This sets the "refs" in the SemanticModel from the SemanticModelRefResolver in context/providers.py
             get_rendered(model_ref, ctx, parsed)
 
-        # No ability to disable a semantic model at this time
-        self.manifest.add_semantic_model(self.yaml.file, parsed)
+        # if the semantic model is disabled we do not want it included in the manifest,
+        # only in the disabled dict
+        if parsed.config.enabled:
+            self.manifest.add_semantic_model(self.yaml.file, parsed)
+        else:
+            self.manifest.add_disabled(self.yaml.file, parsed)
 
         # Create a metric for each measure with `create_metric = True`
         for measure in unparsed.measures:

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -36,7 +36,7 @@ from dbt.contracts.graph.semantic_models import (
 from dbt.exceptions import DbtInternalError, YamlParseDictError, JSONValidationError
 from dbt.context.providers import generate_parse_exposure, generate_parse_semantic_models
 
-from dbt.contracts.graph.model_config import MetricConfig, ExposureConfig
+from dbt.contracts.graph.model_config import MetricConfig, ExposureConfig, SemanticModelConfig
 from dbt.context.context_config import (
     BaseContextConfigGenerator,
     ContextConfigGenerator,
@@ -569,6 +569,11 @@ class SemanticModelParser(YamlReader):
             package_name=package_name,
             rendered=False,
         )
+
+        if not isinstance(config, SemanticModelConfig):
+            raise DbtInternalError(
+                f"Calculated a {type(config)} for a semantic model, but expected a SemanticModelConfig"
+            )
 
         parsed = SemanticModel(
             description=unparsed.description,

--- a/schemas/dbt/manifest/v11.json
+++ b/schemas/dbt/manifest/v11.json
@@ -1,5 +1,5 @@
 {
-  "$ref": "#/$defs/WritableManifest",
+  "$ref": "#/defs/WritableManifest",
   "$defs": {
     "ManifestMetadata": {
       "type": "object",
@@ -35,7 +35,6 @@
           }
         },
         "project_name": {
-          "description": "Name of the root project",
           "anyOf": [
             {
               "type": "string"
@@ -47,7 +46,6 @@
           "default": null
         },
         "project_id": {
-          "description": "A unique identifier for the project, hashed from the project name",
           "anyOf": [
             {
               "type": "string"
@@ -59,7 +57,6 @@
           "default": null
         },
         "user_id": {
-          "description": "A unique identifier for the user",
           "anyOf": [
             {
               "type": "string",
@@ -72,7 +69,6 @@
           "default": null
         },
         "send_anonymous_usage_stats": {
-          "description": "Whether dbt is configured to send anonymous usage statistics",
           "anyOf": [
             {
               "type": "boolean"
@@ -84,7 +80,6 @@
           "default": null
         },
         "adapter_type": {
-          "description": "The type name of the adapter",
           "anyOf": [
             {
               "type": "string"
@@ -96,7 +91,13 @@
           "default": null
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "dbt_schema_version",
+        "generated_at",
+        "invocation_id",
+        "env"
+      ]
     },
     "FileHash": {
       "type": "object",
@@ -277,13 +278,13 @@
         "post-hook": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/Hook"
+            "$ref": "#/defs/Hook"
           }
         },
         "pre-hook": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/Hook"
+            "$ref": "#/defs/Hook"
           }
         },
         "quoting": {
@@ -357,13 +358,28 @@
           }
         },
         "docs": {
-          "$ref": "#/$defs/Docs"
+          "$ref": "#/defs/Docs"
         },
         "contract": {
-          "$ref": "#/$defs/ContractConfig"
+          "$ref": "#/defs/ContractConfig"
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false,
+      "required": [
+        "_extra",
+        "tags",
+        "meta",
+        "persist_docs",
+        "post-hook",
+        "pre-hook",
+        "quoting",
+        "column_types",
+        "on_configuration_change",
+        "grants",
+        "packages",
+        "docs",
+        "contract"
+      ]
     },
     "ColumnLevelConstraint": {
       "type": "object",
@@ -446,7 +462,7 @@
         "constraints": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ColumnLevelConstraint"
+            "$ref": "#/defs/ColumnLevelConstraint"
           }
         },
         "quote": {
@@ -473,9 +489,13 @@
           }
         }
       },
-      "additionalProperties": true,
+      "additionalProperties": false,
       "required": [
-        "name"
+        "name",
+        "meta",
+        "constraints",
+        "tags",
+        "_extra"
       ]
     },
     "RefArgs": {
@@ -533,7 +553,11 @@
           }
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "macros",
+        "nodes"
+      ]
     },
     "InjectedCTE": {
       "type": "object",
@@ -619,10 +643,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/$defs/FileHash"
+          "$ref": "#/defs/FileHash"
         },
         "config": {
-          "$ref": "#/$defs/NodeConfig"
+          "$ref": "#/defs/NodeConfig"
         },
         "_event_status": {
           "type": "object",
@@ -643,7 +667,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
+            "$ref": "#/defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -667,7 +691,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/$defs/Docs"
+          "$ref": "#/defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -732,7 +756,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/RefArgs"
+            "$ref": "#/defs/RefArgs"
           }
         },
         "sources": {
@@ -754,7 +778,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/$defs/DependsOn"
+          "$ref": "#/defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -789,7 +813,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/InjectedCTE"
+            "$ref": "#/defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -804,7 +828,7 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/$defs/Contract"
+          "$ref": "#/defs/Contract"
         }
       },
       "additionalProperties": false,
@@ -819,7 +843,22 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum"
+        "checksum",
+        "config",
+        "_event_status",
+        "tags",
+        "columns",
+        "meta",
+        "docs",
+        "unrendered_config",
+        "created_at",
+        "config_call_dict",
+        "refs",
+        "sources",
+        "metrics",
+        "depends_on",
+        "extra_ctes",
+        "contract"
       ]
     },
     "TestConfig": {
@@ -954,7 +993,12 @@
           "default": "!= 0"
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false,
+      "required": [
+        "_extra",
+        "tags",
+        "meta"
+      ]
     },
     "SingularTestNode": {
       "type": "object",
@@ -1001,10 +1045,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/$defs/FileHash"
+          "$ref": "#/defs/FileHash"
         },
         "config": {
-          "$ref": "#/$defs/TestConfig"
+          "$ref": "#/defs/TestConfig"
         },
         "_event_status": {
           "type": "object",
@@ -1025,7 +1069,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
+            "$ref": "#/defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -1049,7 +1093,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/$defs/Docs"
+          "$ref": "#/defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -1114,7 +1158,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/RefArgs"
+            "$ref": "#/defs/RefArgs"
           }
         },
         "sources": {
@@ -1136,7 +1180,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/$defs/DependsOn"
+          "$ref": "#/defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -1171,7 +1215,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/InjectedCTE"
+            "$ref": "#/defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -1186,7 +1230,7 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/$defs/Contract"
+          "$ref": "#/defs/Contract"
         }
       },
       "additionalProperties": false,
@@ -1201,7 +1245,22 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum"
+        "checksum",
+        "config",
+        "_event_status",
+        "tags",
+        "columns",
+        "meta",
+        "docs",
+        "unrendered_config",
+        "created_at",
+        "config_call_dict",
+        "refs",
+        "sources",
+        "metrics",
+        "depends_on",
+        "extra_ctes",
+        "contract"
       ]
     },
     "HookNode": {
@@ -1249,10 +1308,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/$defs/FileHash"
+          "$ref": "#/defs/FileHash"
         },
         "config": {
-          "$ref": "#/$defs/NodeConfig"
+          "$ref": "#/defs/NodeConfig"
         },
         "_event_status": {
           "type": "object",
@@ -1273,7 +1332,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
+            "$ref": "#/defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -1297,7 +1356,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/$defs/Docs"
+          "$ref": "#/defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -1362,7 +1421,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/RefArgs"
+            "$ref": "#/defs/RefArgs"
           }
         },
         "sources": {
@@ -1384,7 +1443,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/$defs/DependsOn"
+          "$ref": "#/defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -1419,7 +1478,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/InjectedCTE"
+            "$ref": "#/defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -1434,7 +1493,7 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/$defs/Contract"
+          "$ref": "#/defs/Contract"
         },
         "index": {
           "anyOf": [
@@ -1460,7 +1519,22 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum"
+        "checksum",
+        "config",
+        "_event_status",
+        "tags",
+        "columns",
+        "meta",
+        "docs",
+        "unrendered_config",
+        "created_at",
+        "config_call_dict",
+        "refs",
+        "sources",
+        "metrics",
+        "depends_on",
+        "extra_ctes",
+        "contract"
       ]
     },
     "ModelLevelConstraint": {
@@ -1516,7 +1590,8 @@
       },
       "additionalProperties": false,
       "required": [
-        "type"
+        "type",
+        "columns"
       ]
     },
     "DeferRelation": {
@@ -1603,10 +1678,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/$defs/FileHash"
+          "$ref": "#/defs/FileHash"
         },
         "config": {
-          "$ref": "#/$defs/NodeConfig"
+          "$ref": "#/defs/NodeConfig"
         },
         "_event_status": {
           "type": "object",
@@ -1627,7 +1702,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
+            "$ref": "#/defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -1651,7 +1726,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/$defs/Docs"
+          "$ref": "#/defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -1716,7 +1791,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/RefArgs"
+            "$ref": "#/defs/RefArgs"
           }
         },
         "sources": {
@@ -1738,7 +1813,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/$defs/DependsOn"
+          "$ref": "#/defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -1773,7 +1848,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/InjectedCTE"
+            "$ref": "#/defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -1788,7 +1863,7 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/$defs/Contract"
+          "$ref": "#/defs/Contract"
         },
         "access": {
           "enum": [
@@ -1801,7 +1876,7 @@
         "constraints": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ModelLevelConstraint"
+            "$ref": "#/defs/ModelLevelConstraint"
           }
         },
         "version": {
@@ -1847,7 +1922,7 @@
         "defer_relation": {
           "anyOf": [
             {
-              "$ref": "#/$defs/DeferRelation"
+              "$ref": "#/defs/DeferRelation"
             },
             {
               "type": "null"
@@ -1868,7 +1943,23 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum"
+        "checksum",
+        "config",
+        "_event_status",
+        "tags",
+        "columns",
+        "meta",
+        "docs",
+        "unrendered_config",
+        "created_at",
+        "config_call_dict",
+        "refs",
+        "sources",
+        "metrics",
+        "depends_on",
+        "extra_ctes",
+        "contract",
+        "constraints"
       ]
     },
     "RPCNode": {
@@ -1916,10 +2007,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/$defs/FileHash"
+          "$ref": "#/defs/FileHash"
         },
         "config": {
-          "$ref": "#/$defs/NodeConfig"
+          "$ref": "#/defs/NodeConfig"
         },
         "_event_status": {
           "type": "object",
@@ -1940,7 +2031,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
+            "$ref": "#/defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -1964,7 +2055,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/$defs/Docs"
+          "$ref": "#/defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -2029,7 +2120,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/RefArgs"
+            "$ref": "#/defs/RefArgs"
           }
         },
         "sources": {
@@ -2051,7 +2142,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/$defs/DependsOn"
+          "$ref": "#/defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -2086,7 +2177,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/InjectedCTE"
+            "$ref": "#/defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -2101,7 +2192,7 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/$defs/Contract"
+          "$ref": "#/defs/Contract"
         }
       },
       "additionalProperties": false,
@@ -2116,7 +2207,22 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum"
+        "checksum",
+        "config",
+        "_event_status",
+        "tags",
+        "columns",
+        "meta",
+        "docs",
+        "unrendered_config",
+        "created_at",
+        "config_call_dict",
+        "refs",
+        "sources",
+        "metrics",
+        "depends_on",
+        "extra_ctes",
+        "contract"
       ]
     },
     "SqlNode": {
@@ -2164,10 +2270,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/$defs/FileHash"
+          "$ref": "#/defs/FileHash"
         },
         "config": {
-          "$ref": "#/$defs/NodeConfig"
+          "$ref": "#/defs/NodeConfig"
         },
         "_event_status": {
           "type": "object",
@@ -2188,7 +2294,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
+            "$ref": "#/defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -2212,7 +2318,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/$defs/Docs"
+          "$ref": "#/defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -2277,7 +2383,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/RefArgs"
+            "$ref": "#/defs/RefArgs"
           }
         },
         "sources": {
@@ -2299,7 +2405,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/$defs/DependsOn"
+          "$ref": "#/defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -2334,7 +2440,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/InjectedCTE"
+            "$ref": "#/defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -2349,7 +2455,7 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/$defs/Contract"
+          "$ref": "#/defs/Contract"
         }
       },
       "additionalProperties": false,
@@ -2364,7 +2470,22 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum"
+        "checksum",
+        "config",
+        "_event_status",
+        "tags",
+        "columns",
+        "meta",
+        "docs",
+        "unrendered_config",
+        "created_at",
+        "config_call_dict",
+        "refs",
+        "sources",
+        "metrics",
+        "depends_on",
+        "extra_ctes",
+        "contract"
       ]
     },
     "TestMetadata": {
@@ -2394,7 +2515,8 @@
       },
       "additionalProperties": false,
       "required": [
-        "name"
+        "name",
+        "kwargs"
       ]
     },
     "GenericTestNode": {
@@ -2402,7 +2524,7 @@
       "title": "GenericTestNode",
       "properties": {
         "test_metadata": {
-          "$ref": "#/$defs/TestMetadata"
+          "$ref": "#/defs/TestMetadata"
         },
         "database": {
           "anyOf": [
@@ -2445,10 +2567,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/$defs/FileHash"
+          "$ref": "#/defs/FileHash"
         },
         "config": {
-          "$ref": "#/$defs/TestConfig"
+          "$ref": "#/defs/TestConfig"
         },
         "_event_status": {
           "type": "object",
@@ -2469,7 +2591,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
+            "$ref": "#/defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -2493,7 +2615,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/$defs/Docs"
+          "$ref": "#/defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -2558,7 +2680,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/RefArgs"
+            "$ref": "#/defs/RefArgs"
           }
         },
         "sources": {
@@ -2580,7 +2702,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/$defs/DependsOn"
+          "$ref": "#/defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -2615,7 +2737,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/InjectedCTE"
+            "$ref": "#/defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -2630,7 +2752,7 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/$defs/Contract"
+          "$ref": "#/defs/Contract"
         },
         "column_name": {
           "anyOf": [
@@ -2679,7 +2801,22 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum"
+        "checksum",
+        "config",
+        "_event_status",
+        "tags",
+        "columns",
+        "meta",
+        "docs",
+        "unrendered_config",
+        "created_at",
+        "config_call_dict",
+        "refs",
+        "sources",
+        "metrics",
+        "depends_on",
+        "extra_ctes",
+        "contract"
       ]
     },
     "SnapshotConfig": {
@@ -2783,13 +2920,13 @@
         "post-hook": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/Hook"
+            "$ref": "#/defs/Hook"
           }
         },
         "pre-hook": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/Hook"
+            "$ref": "#/defs/Hook"
           }
         },
         "quoting": {
@@ -2857,10 +2994,10 @@
           }
         },
         "docs": {
-          "$ref": "#/$defs/Docs"
+          "$ref": "#/defs/Docs"
         },
         "contract": {
-          "$ref": "#/$defs/ContractConfig"
+          "$ref": "#/defs/ContractConfig"
         },
         "strategy": {
           "anyOf": [
@@ -2924,7 +3061,22 @@
           "default": null
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false,
+      "required": [
+        "_extra",
+        "tags",
+        "meta",
+        "persist_docs",
+        "post-hook",
+        "pre-hook",
+        "quoting",
+        "column_types",
+        "on_configuration_change",
+        "grants",
+        "packages",
+        "docs",
+        "contract"
+      ]
     },
     "SnapshotNode": {
       "type": "object",
@@ -2971,10 +3123,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/$defs/FileHash"
+          "$ref": "#/defs/FileHash"
         },
         "config": {
-          "$ref": "#/$defs/SnapshotConfig"
+          "$ref": "#/defs/SnapshotConfig"
         },
         "_event_status": {
           "type": "object",
@@ -2995,7 +3147,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
+            "$ref": "#/defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -3019,7 +3171,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/$defs/Docs"
+          "$ref": "#/defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -3084,7 +3236,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/RefArgs"
+            "$ref": "#/defs/RefArgs"
           }
         },
         "sources": {
@@ -3106,7 +3258,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/$defs/DependsOn"
+          "$ref": "#/defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -3141,7 +3293,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/InjectedCTE"
+            "$ref": "#/defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -3156,12 +3308,12 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/$defs/Contract"
+          "$ref": "#/defs/Contract"
         },
         "defer_relation": {
           "anyOf": [
             {
-              "$ref": "#/$defs/DeferRelation"
+              "$ref": "#/defs/DeferRelation"
             },
             {
               "type": "null"
@@ -3183,7 +3335,21 @@
         "fqn",
         "alias",
         "checksum",
-        "config"
+        "config",
+        "_event_status",
+        "tags",
+        "columns",
+        "meta",
+        "docs",
+        "unrendered_config",
+        "created_at",
+        "config_call_dict",
+        "refs",
+        "sources",
+        "metrics",
+        "depends_on",
+        "extra_ctes",
+        "contract"
       ]
     },
     "SeedConfig": {
@@ -3287,13 +3453,13 @@
         "post-hook": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/Hook"
+            "$ref": "#/defs/Hook"
           }
         },
         "pre-hook": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/Hook"
+            "$ref": "#/defs/Hook"
           }
         },
         "quoting": {
@@ -3367,10 +3533,10 @@
           }
         },
         "docs": {
-          "$ref": "#/$defs/Docs"
+          "$ref": "#/defs/Docs"
         },
         "contract": {
-          "$ref": "#/$defs/ContractConfig"
+          "$ref": "#/defs/ContractConfig"
         },
         "delimiter": {
           "type": "string",
@@ -3388,7 +3554,22 @@
           "default": null
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false,
+      "required": [
+        "_extra",
+        "tags",
+        "meta",
+        "persist_docs",
+        "post-hook",
+        "pre-hook",
+        "quoting",
+        "column_types",
+        "on_configuration_change",
+        "grants",
+        "packages",
+        "docs",
+        "contract"
+      ]
     },
     "MacroDependsOn": {
       "type": "object",
@@ -3401,7 +3582,10 @@
           }
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "macros"
+      ]
     },
     "SeedNode": {
       "type": "object",
@@ -3448,10 +3632,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/$defs/FileHash"
+          "$ref": "#/defs/FileHash"
         },
         "config": {
-          "$ref": "#/$defs/SeedConfig"
+          "$ref": "#/defs/SeedConfig"
         },
         "_event_status": {
           "type": "object",
@@ -3472,7 +3656,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
+            "$ref": "#/defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -3496,7 +3680,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/$defs/Docs"
+          "$ref": "#/defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -3566,12 +3750,12 @@
           "default": null
         },
         "depends_on": {
-          "$ref": "#/$defs/MacroDependsOn"
+          "$ref": "#/defs/MacroDependsOn"
         },
         "defer_relation": {
           "anyOf": [
             {
-              "$ref": "#/$defs/DeferRelation"
+              "$ref": "#/defs/DeferRelation"
             },
             {
               "type": "null"
@@ -3592,7 +3776,17 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum"
+        "checksum",
+        "config",
+        "_event_status",
+        "tags",
+        "columns",
+        "meta",
+        "docs",
+        "unrendered_config",
+        "created_at",
+        "config_call_dict",
+        "depends_on"
       ]
     },
     "Quoting": {
@@ -3686,7 +3880,7 @@
         "warn_after": {
           "anyOf": [
             {
-              "$ref": "#/$defs/Time"
+              "$ref": "#/defs/Time"
             },
             {
               "type": "null"
@@ -3696,7 +3890,7 @@
         "error_after": {
           "anyOf": [
             {
-              "$ref": "#/$defs/Time"
+              "$ref": "#/defs/Time"
             },
             {
               "type": "null"
@@ -3715,7 +3909,11 @@
           "default": null
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "warn_after",
+        "error_after"
+      ]
     },
     "ExternalPartition": {
       "type": "object",
@@ -3746,7 +3944,11 @@
           }
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false,
+      "required": [
+        "_extra",
+        "meta"
+      ]
     },
     "ExternalTable": {
       "type": "object",
@@ -3813,7 +4015,7 @@
             {
               "type": "array",
               "items": {
-                "$ref": "#/$defs/ExternalPartition"
+                "$ref": "#/defs/ExternalPartition"
               }
             },
             {
@@ -3823,7 +4025,10 @@
           "default": null
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false,
+      "required": [
+        "_extra"
+      ]
     },
     "SourceConfig": {
       "type": "object",
@@ -3840,7 +4045,10 @@
           "default": true
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false,
+      "required": [
+        "_extra"
+      ]
     },
     "SourceDefinition": {
       "type": "object",
@@ -3902,7 +4110,7 @@
           }
         },
         "quoting": {
-          "$ref": "#/$defs/Quoting"
+          "$ref": "#/defs/Quoting"
         },
         "loaded_at_field": {
           "anyOf": [
@@ -3918,7 +4126,7 @@
         "freshness": {
           "anyOf": [
             {
-              "$ref": "#/$defs/FreshnessThreshold"
+              "$ref": "#/defs/FreshnessThreshold"
             },
             {
               "type": "null"
@@ -3929,7 +4137,7 @@
         "external": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ExternalTable"
+              "$ref": "#/defs/ExternalTable"
             },
             {
               "type": "null"
@@ -3944,7 +4152,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
+            "$ref": "#/defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -3969,7 +4177,7 @@
           }
         },
         "config": {
-          "$ref": "#/$defs/SourceConfig"
+          "$ref": "#/defs/SourceConfig"
         },
         "patch_path": {
           "anyOf": [
@@ -4017,7 +4225,16 @@
         "source_name",
         "source_description",
         "loader",
-        "identifier"
+        "identifier",
+        "_event_status",
+        "quoting",
+        "columns",
+        "meta",
+        "source_meta",
+        "tags",
+        "config",
+        "unrendered_config",
+        "created_at"
       ]
     },
     "MacroArgument": {
@@ -4074,7 +4291,7 @@
           "type": "string"
         },
         "depends_on": {
-          "$ref": "#/$defs/MacroDependsOn"
+          "$ref": "#/defs/MacroDependsOn"
         },
         "description": {
           "type": "string",
@@ -4087,7 +4304,7 @@
           }
         },
         "docs": {
-          "$ref": "#/$defs/Docs"
+          "$ref": "#/defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -4103,7 +4320,7 @@
         "arguments": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/MacroArgument"
+            "$ref": "#/defs/MacroArgument"
           }
         },
         "created_at": {
@@ -4135,7 +4352,12 @@
         "path",
         "original_file_path",
         "unique_id",
-        "macro_sql"
+        "macro_sql",
+        "depends_on",
+        "meta",
+        "docs",
+        "arguments",
+        "created_at"
       ]
     },
     "Documentation": {
@@ -4208,7 +4430,10 @@
           "default": null
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false,
+      "required": [
+        "_extra"
+      ]
     },
     "ExposureConfig": {
       "type": "object",
@@ -4225,7 +4450,10 @@
           "default": true
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false,
+      "required": [
+        "_extra"
+      ]
     },
     "Exposure": {
       "type": "object",
@@ -4265,7 +4493,7 @@
           ]
         },
         "owner": {
-          "$ref": "#/$defs/Owner"
+          "$ref": "#/defs/Owner"
         },
         "description": {
           "type": "string",
@@ -4310,7 +4538,7 @@
           }
         },
         "config": {
-          "$ref": "#/$defs/ExposureConfig"
+          "$ref": "#/defs/ExposureConfig"
         },
         "unrendered_config": {
           "type": "object",
@@ -4330,12 +4558,12 @@
           "default": null
         },
         "depends_on": {
-          "$ref": "#/$defs/DependsOn"
+          "$ref": "#/defs/DependsOn"
         },
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/RefArgs"
+            "$ref": "#/defs/RefArgs"
           }
         },
         "sources": {
@@ -4370,7 +4598,16 @@
         "unique_id",
         "fqn",
         "type",
-        "owner"
+        "owner",
+        "meta",
+        "tags",
+        "config",
+        "unrendered_config",
+        "depends_on",
+        "refs",
+        "sources",
+        "metrics",
+        "created_at"
       ]
     },
     "WhereFilter": {
@@ -4396,7 +4633,7 @@
         "filter": {
           "anyOf": [
             {
-              "$ref": "#/$defs/WhereFilter"
+              "$ref": "#/defs/WhereFilter"
             },
             {
               "type": "null"
@@ -4454,7 +4691,7 @@
         "filter": {
           "anyOf": [
             {
-              "$ref": "#/$defs/WhereFilter"
+              "$ref": "#/defs/WhereFilter"
             },
             {
               "type": "null"
@@ -4476,7 +4713,7 @@
         "offset_window": {
           "anyOf": [
             {
-              "$ref": "#/$defs/MetricTimeWindow"
+              "$ref": "#/defs/MetricTimeWindow"
             },
             {
               "type": "null"
@@ -4514,7 +4751,7 @@
         "measure": {
           "anyOf": [
             {
-              "$ref": "#/$defs/MetricInputMeasure"
+              "$ref": "#/defs/MetricInputMeasure"
             },
             {
               "type": "null"
@@ -4525,13 +4762,13 @@
         "input_measures": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/MetricInputMeasure"
+            "$ref": "#/defs/MetricInputMeasure"
           }
         },
         "numerator": {
           "anyOf": [
             {
-              "$ref": "#/$defs/MetricInput"
+              "$ref": "#/defs/MetricInput"
             },
             {
               "type": "null"
@@ -4542,7 +4779,7 @@
         "denominator": {
           "anyOf": [
             {
-              "$ref": "#/$defs/MetricInput"
+              "$ref": "#/defs/MetricInput"
             },
             {
               "type": "null"
@@ -4564,7 +4801,7 @@
         "window": {
           "anyOf": [
             {
-              "$ref": "#/$defs/MetricTimeWindow"
+              "$ref": "#/defs/MetricTimeWindow"
             },
             {
               "type": "null"
@@ -4594,7 +4831,7 @@
             {
               "type": "array",
               "items": {
-                "$ref": "#/$defs/MetricInput"
+                "$ref": "#/defs/MetricInput"
               }
             },
             {
@@ -4604,7 +4841,10 @@
           "default": null
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "input_measures"
+      ]
     },
     "FileSlice": {
       "type": "object",
@@ -4639,7 +4879,7 @@
           "type": "string"
         },
         "file_slice": {
-          "$ref": "#/$defs/FileSlice"
+          "$ref": "#/defs/FileSlice"
         }
       },
       "additionalProperties": false,
@@ -4674,7 +4914,10 @@
           "default": null
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false,
+      "required": [
+        "_extra"
+      ]
     },
     "Metric": {
       "type": "object",
@@ -4719,12 +4962,12 @@
           ]
         },
         "type_params": {
-          "$ref": "#/$defs/MetricTypeParams"
+          "$ref": "#/defs/MetricTypeParams"
         },
         "filter": {
           "anyOf": [
             {
-              "$ref": "#/$defs/WhereFilter"
+              "$ref": "#/defs/WhereFilter"
             },
             {
               "type": "null"
@@ -4735,7 +4978,7 @@
         "metadata": {
           "anyOf": [
             {
-              "$ref": "#/$defs/SourceFileMetadata"
+              "$ref": "#/defs/SourceFileMetadata"
             },
             {
               "type": "null"
@@ -4756,7 +4999,7 @@
           }
         },
         "config": {
-          "$ref": "#/$defs/MetricConfig"
+          "$ref": "#/defs/MetricConfig"
         },
         "unrendered_config": {
           "type": "object",
@@ -4774,12 +5017,12 @@
           }
         },
         "depends_on": {
-          "$ref": "#/$defs/DependsOn"
+          "$ref": "#/defs/DependsOn"
         },
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/RefArgs"
+            "$ref": "#/defs/RefArgs"
           }
         },
         "metrics": {
@@ -4818,7 +5061,16 @@
         "description",
         "label",
         "type",
-        "type_params"
+        "type_params",
+        "meta",
+        "tags",
+        "config",
+        "unrendered_config",
+        "sources",
+        "depends_on",
+        "refs",
+        "metrics",
+        "created_at"
       ]
     },
     "Group": {
@@ -4844,7 +5096,7 @@
           "type": "string"
         },
         "owner": {
-          "$ref": "#/$defs/Owner"
+          "$ref": "#/defs/Owner"
         }
       },
       "additionalProperties": false,
@@ -5079,7 +5331,7 @@
         "agg_params": {
           "anyOf": [
             {
-              "$ref": "#/$defs/MeasureAggregationParameters"
+              "$ref": "#/defs/MeasureAggregationParameters"
             },
             {
               "type": "null"
@@ -5090,7 +5342,7 @@
         "non_additive_dimension": {
           "anyOf": [
             {
-              "$ref": "#/$defs/NonAdditiveDimension"
+              "$ref": "#/defs/NonAdditiveDimension"
             },
             {
               "type": "null"
@@ -5147,7 +5399,7 @@
         "validity_params": {
           "anyOf": [
             {
-              "$ref": "#/$defs/DimensionValidityParams"
+              "$ref": "#/defs/DimensionValidityParams"
             },
             {
               "type": "null"
@@ -5192,7 +5444,7 @@
         "type_params": {
           "anyOf": [
             {
-              "$ref": "#/$defs/DimensionTypeParams"
+              "$ref": "#/defs/DimensionTypeParams"
             },
             {
               "type": "null"
@@ -5214,7 +5466,7 @@
         "metadata": {
           "anyOf": [
             {
-              "$ref": "#/$defs/SourceFileMetadata"
+              "$ref": "#/defs/SourceFileMetadata"
             },
             {
               "type": "null"
@@ -5242,9 +5494,23 @@
         "enabled": {
           "type": "boolean",
           "default": true
+        },
+        "group": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false,
+      "required": [
+        "_extra"
+      ]
     },
     "SemanticModel": {
       "type": "object",
@@ -5296,7 +5562,7 @@
         "node_relation": {
           "anyOf": [
             {
-              "$ref": "#/$defs/NodeRelation"
+              "$ref": "#/defs/NodeRelation"
             },
             {
               "type": "null"
@@ -5317,7 +5583,7 @@
         "defaults": {
           "anyOf": [
             {
-              "$ref": "#/$defs/Defaults"
+              "$ref": "#/defs/Defaults"
             },
             {
               "type": "null"
@@ -5328,25 +5594,25 @@
         "entities": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/Entity"
+            "$ref": "#/defs/Entity"
           }
         },
         "measures": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/Measure"
+            "$ref": "#/defs/Measure"
           }
         },
         "dimensions": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/Dimension"
+            "$ref": "#/defs/Dimension"
           }
         },
         "metadata": {
           "anyOf": [
             {
-              "$ref": "#/$defs/SourceFileMetadata"
+              "$ref": "#/defs/SourceFileMetadata"
             },
             {
               "type": "null"
@@ -5355,21 +5621,38 @@
           "default": null
         },
         "depends_on": {
-          "$ref": "#/$defs/DependsOn"
+          "$ref": "#/defs/DependsOn"
         },
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/RefArgs"
+            "$ref": "#/defs/RefArgs"
           }
         },
         "created_at": {
           "type": "number"
         },
         "config": {
-          "$ref": "#/$defs/SemanticModelConfig"
+          "$ref": "#/defs/SemanticModelConfig"
+        },
+        "unrendered_config": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          }
         },
         "primary_entity": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "group": {
           "anyOf": [
             {
               "type": "string"
@@ -5391,7 +5674,15 @@
         "unique_id",
         "fqn",
         "model",
-        "node_relation"
+        "node_relation",
+        "entities",
+        "measures",
+        "dimensions",
+        "depends_on",
+        "refs",
+        "created_at",
+        "config",
+        "unrendered_config"
       ]
     },
     "WritableManifest": {
@@ -5399,39 +5690,38 @@
       "title": "WritableManifest",
       "properties": {
         "metadata": {
-          "$ref": "#/$defs/ManifestMetadata"
+          "$ref": "#/defs/ManifestMetadata"
         },
         "nodes": {
           "type": "object",
-          "description": "The nodes defined in the dbt project and its dependencies",
           "additionalProperties": {
             "anyOf": [
               {
-                "$ref": "#/$defs/AnalysisNode"
+                "$ref": "#/defs/AnalysisNode"
               },
               {
-                "$ref": "#/$defs/SingularTestNode"
+                "$ref": "#/defs/SingularTestNode"
               },
               {
-                "$ref": "#/$defs/HookNode"
+                "$ref": "#/defs/HookNode"
               },
               {
-                "$ref": "#/$defs/ModelNode"
+                "$ref": "#/defs/ModelNode"
               },
               {
-                "$ref": "#/$defs/RPCNode"
+                "$ref": "#/defs/RPCNode"
               },
               {
-                "$ref": "#/$defs/SqlNode"
+                "$ref": "#/defs/SqlNode"
               },
               {
-                "$ref": "#/$defs/GenericTestNode"
+                "$ref": "#/defs/GenericTestNode"
               },
               {
-                "$ref": "#/$defs/SnapshotNode"
+                "$ref": "#/defs/SnapshotNode"
               },
               {
-                "$ref": "#/$defs/SeedNode"
+                "$ref": "#/defs/SeedNode"
               }
             ]
           },
@@ -5441,9 +5731,8 @@
         },
         "sources": {
           "type": "object",
-          "description": "The sources defined in the dbt project and its dependencies",
           "additionalProperties": {
-            "$ref": "#/$defs/SourceDefinition"
+            "$ref": "#/defs/SourceDefinition"
           },
           "propertyNames": {
             "type": "string"
@@ -5451,9 +5740,8 @@
         },
         "macros": {
           "type": "object",
-          "description": "The macros defined in the dbt project and its dependencies",
           "additionalProperties": {
-            "$ref": "#/$defs/Macro"
+            "$ref": "#/defs/Macro"
           },
           "propertyNames": {
             "type": "string"
@@ -5461,9 +5749,8 @@
         },
         "docs": {
           "type": "object",
-          "description": "The docs defined in the dbt project and its dependencies",
           "additionalProperties": {
-            "$ref": "#/$defs/Documentation"
+            "$ref": "#/defs/Documentation"
           },
           "propertyNames": {
             "type": "string"
@@ -5471,9 +5758,8 @@
         },
         "exposures": {
           "type": "object",
-          "description": "The exposures defined in the dbt project and its dependencies",
           "additionalProperties": {
-            "$ref": "#/$defs/Exposure"
+            "$ref": "#/defs/Exposure"
           },
           "propertyNames": {
             "type": "string"
@@ -5481,9 +5767,8 @@
         },
         "metrics": {
           "type": "object",
-          "description": "The metrics defined in the dbt project and its dependencies",
           "additionalProperties": {
-            "$ref": "#/$defs/Metric"
+            "$ref": "#/defs/Metric"
           },
           "propertyNames": {
             "type": "string"
@@ -5491,9 +5776,8 @@
         },
         "groups": {
           "type": "object",
-          "description": "The groups defined in the dbt project",
           "additionalProperties": {
-            "$ref": "#/$defs/Group"
+            "$ref": "#/defs/Group"
           },
           "propertyNames": {
             "type": "string"
@@ -5501,13 +5785,11 @@
         },
         "selectors": {
           "type": "object",
-          "description": "The selectors defined in selectors.yml",
           "propertyNames": {
             "type": "string"
           }
         },
         "disabled": {
-          "description": "A mapping of the disabled nodes in the target",
           "anyOf": [
             {
               "type": "object",
@@ -5516,43 +5798,43 @@
                 "items": {
                   "anyOf": [
                     {
-                      "$ref": "#/$defs/AnalysisNode"
+                      "$ref": "#/defs/AnalysisNode"
                     },
                     {
-                      "$ref": "#/$defs/SingularTestNode"
+                      "$ref": "#/defs/SingularTestNode"
                     },
                     {
-                      "$ref": "#/$defs/HookNode"
+                      "$ref": "#/defs/HookNode"
                     },
                     {
-                      "$ref": "#/$defs/ModelNode"
+                      "$ref": "#/defs/ModelNode"
                     },
                     {
-                      "$ref": "#/$defs/RPCNode"
+                      "$ref": "#/defs/RPCNode"
                     },
                     {
-                      "$ref": "#/$defs/SqlNode"
+                      "$ref": "#/defs/SqlNode"
                     },
                     {
-                      "$ref": "#/$defs/GenericTestNode"
+                      "$ref": "#/defs/GenericTestNode"
                     },
                     {
-                      "$ref": "#/$defs/SnapshotNode"
+                      "$ref": "#/defs/SnapshotNode"
                     },
                     {
-                      "$ref": "#/$defs/SeedNode"
+                      "$ref": "#/defs/SeedNode"
                     },
                     {
-                      "$ref": "#/$defs/SourceDefinition"
+                      "$ref": "#/defs/SourceDefinition"
                     },
                     {
-                      "$ref": "#/$defs/Exposure"
+                      "$ref": "#/defs/Exposure"
                     },
                     {
-                      "$ref": "#/$defs/Metric"
+                      "$ref": "#/defs/Metric"
                     },
                     {
-                      "$ref": "#/$defs/SemanticModel"
+                      "$ref": "#/defs/SemanticModel"
                     }
                   ]
                 }
@@ -5567,7 +5849,6 @@
           ]
         },
         "parent_map": {
-          "description": "A mapping from\u00a0child nodes to their dependencies",
           "anyOf": [
             {
               "type": "object",
@@ -5587,7 +5868,6 @@
           ]
         },
         "child_map": {
-          "description": "A mapping from parent nodes to their dependents",
           "anyOf": [
             {
               "type": "object",
@@ -5607,7 +5887,6 @@
           ]
         },
         "group_map": {
-          "description": "A mapping from group names to their nodes",
           "anyOf": [
             {
               "type": "object",
@@ -5628,9 +5907,8 @@
         },
         "semantic_models": {
           "type": "object",
-          "description": "The semantic models defined in the dbt project",
           "additionalProperties": {
-            "$ref": "#/$defs/SemanticModel"
+            "$ref": "#/defs/SemanticModel"
           },
           "propertyNames": {
             "type": "string"

--- a/schemas/dbt/manifest/v11.json
+++ b/schemas/dbt/manifest/v11.json
@@ -1,5 +1,5 @@
 {
-  "$ref": "#/defs/WritableManifest",
+  "$ref": "#/$defs/WritableManifest",
   "$defs": {
     "ManifestMetadata": {
       "type": "object",
@@ -35,6 +35,7 @@
           }
         },
         "project_name": {
+          "description": "Name of the root project",
           "anyOf": [
             {
               "type": "string"
@@ -46,6 +47,7 @@
           "default": null
         },
         "project_id": {
+          "description": "A unique identifier for the project, hashed from the project name",
           "anyOf": [
             {
               "type": "string"
@@ -57,6 +59,7 @@
           "default": null
         },
         "user_id": {
+          "description": "A unique identifier for the user",
           "anyOf": [
             {
               "type": "string",
@@ -69,6 +72,7 @@
           "default": null
         },
         "send_anonymous_usage_stats": {
+          "description": "Whether dbt is configured to send anonymous usage statistics",
           "anyOf": [
             {
               "type": "boolean"
@@ -80,6 +84,7 @@
           "default": null
         },
         "adapter_type": {
+          "description": "The type name of the adapter",
           "anyOf": [
             {
               "type": "string"
@@ -91,13 +96,7 @@
           "default": null
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "dbt_schema_version",
-        "generated_at",
-        "invocation_id",
-        "env"
-      ]
+      "additionalProperties": false
     },
     "FileHash": {
       "type": "object",
@@ -278,13 +277,13 @@
         "post-hook": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/Hook"
+            "$ref": "#/$defs/Hook"
           }
         },
         "pre-hook": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/Hook"
+            "$ref": "#/$defs/Hook"
           }
         },
         "quoting": {
@@ -358,28 +357,13 @@
           }
         },
         "docs": {
-          "$ref": "#/defs/Docs"
+          "$ref": "#/$defs/Docs"
         },
         "contract": {
-          "$ref": "#/defs/ContractConfig"
+          "$ref": "#/$defs/ContractConfig"
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "_extra",
-        "tags",
-        "meta",
-        "persist_docs",
-        "post-hook",
-        "pre-hook",
-        "quoting",
-        "column_types",
-        "on_configuration_change",
-        "grants",
-        "packages",
-        "docs",
-        "contract"
-      ]
+      "additionalProperties": true
     },
     "ColumnLevelConstraint": {
       "type": "object",
@@ -462,7 +446,7 @@
         "constraints": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/ColumnLevelConstraint"
+            "$ref": "#/$defs/ColumnLevelConstraint"
           }
         },
         "quote": {
@@ -489,13 +473,9 @@
           }
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": [
-        "name",
-        "meta",
-        "constraints",
-        "tags",
-        "_extra"
+        "name"
       ]
     },
     "RefArgs": {
@@ -553,11 +533,7 @@
           }
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "macros",
-        "nodes"
-      ]
+      "additionalProperties": false
     },
     "InjectedCTE": {
       "type": "object",
@@ -643,10 +619,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/defs/FileHash"
+          "$ref": "#/$defs/FileHash"
         },
         "config": {
-          "$ref": "#/defs/NodeConfig"
+          "$ref": "#/$defs/NodeConfig"
         },
         "_event_status": {
           "type": "object",
@@ -667,7 +643,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/defs/ColumnInfo"
+            "$ref": "#/$defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -691,7 +667,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/defs/Docs"
+          "$ref": "#/$defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -756,7 +732,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/RefArgs"
+            "$ref": "#/$defs/RefArgs"
           }
         },
         "sources": {
@@ -778,7 +754,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/defs/DependsOn"
+          "$ref": "#/$defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -813,7 +789,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/InjectedCTE"
+            "$ref": "#/$defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -828,7 +804,7 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/defs/Contract"
+          "$ref": "#/$defs/Contract"
         }
       },
       "additionalProperties": false,
@@ -843,22 +819,7 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum",
-        "config",
-        "_event_status",
-        "tags",
-        "columns",
-        "meta",
-        "docs",
-        "unrendered_config",
-        "created_at",
-        "config_call_dict",
-        "refs",
-        "sources",
-        "metrics",
-        "depends_on",
-        "extra_ctes",
-        "contract"
+        "checksum"
       ]
     },
     "TestConfig": {
@@ -993,12 +954,7 @@
           "default": "!= 0"
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "_extra",
-        "tags",
-        "meta"
-      ]
+      "additionalProperties": true
     },
     "SingularTestNode": {
       "type": "object",
@@ -1045,10 +1001,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/defs/FileHash"
+          "$ref": "#/$defs/FileHash"
         },
         "config": {
-          "$ref": "#/defs/TestConfig"
+          "$ref": "#/$defs/TestConfig"
         },
         "_event_status": {
           "type": "object",
@@ -1069,7 +1025,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/defs/ColumnInfo"
+            "$ref": "#/$defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -1093,7 +1049,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/defs/Docs"
+          "$ref": "#/$defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -1158,7 +1114,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/RefArgs"
+            "$ref": "#/$defs/RefArgs"
           }
         },
         "sources": {
@@ -1180,7 +1136,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/defs/DependsOn"
+          "$ref": "#/$defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -1215,7 +1171,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/InjectedCTE"
+            "$ref": "#/$defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -1230,7 +1186,7 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/defs/Contract"
+          "$ref": "#/$defs/Contract"
         }
       },
       "additionalProperties": false,
@@ -1245,22 +1201,7 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum",
-        "config",
-        "_event_status",
-        "tags",
-        "columns",
-        "meta",
-        "docs",
-        "unrendered_config",
-        "created_at",
-        "config_call_dict",
-        "refs",
-        "sources",
-        "metrics",
-        "depends_on",
-        "extra_ctes",
-        "contract"
+        "checksum"
       ]
     },
     "HookNode": {
@@ -1308,10 +1249,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/defs/FileHash"
+          "$ref": "#/$defs/FileHash"
         },
         "config": {
-          "$ref": "#/defs/NodeConfig"
+          "$ref": "#/$defs/NodeConfig"
         },
         "_event_status": {
           "type": "object",
@@ -1332,7 +1273,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/defs/ColumnInfo"
+            "$ref": "#/$defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -1356,7 +1297,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/defs/Docs"
+          "$ref": "#/$defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -1421,7 +1362,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/RefArgs"
+            "$ref": "#/$defs/RefArgs"
           }
         },
         "sources": {
@@ -1443,7 +1384,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/defs/DependsOn"
+          "$ref": "#/$defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -1478,7 +1419,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/InjectedCTE"
+            "$ref": "#/$defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -1493,7 +1434,7 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/defs/Contract"
+          "$ref": "#/$defs/Contract"
         },
         "index": {
           "anyOf": [
@@ -1519,22 +1460,7 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum",
-        "config",
-        "_event_status",
-        "tags",
-        "columns",
-        "meta",
-        "docs",
-        "unrendered_config",
-        "created_at",
-        "config_call_dict",
-        "refs",
-        "sources",
-        "metrics",
-        "depends_on",
-        "extra_ctes",
-        "contract"
+        "checksum"
       ]
     },
     "ModelLevelConstraint": {
@@ -1590,8 +1516,7 @@
       },
       "additionalProperties": false,
       "required": [
-        "type",
-        "columns"
+        "type"
       ]
     },
     "DeferRelation": {
@@ -1678,10 +1603,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/defs/FileHash"
+          "$ref": "#/$defs/FileHash"
         },
         "config": {
-          "$ref": "#/defs/NodeConfig"
+          "$ref": "#/$defs/NodeConfig"
         },
         "_event_status": {
           "type": "object",
@@ -1702,7 +1627,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/defs/ColumnInfo"
+            "$ref": "#/$defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -1726,7 +1651,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/defs/Docs"
+          "$ref": "#/$defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -1791,7 +1716,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/RefArgs"
+            "$ref": "#/$defs/RefArgs"
           }
         },
         "sources": {
@@ -1813,7 +1738,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/defs/DependsOn"
+          "$ref": "#/$defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -1848,7 +1773,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/InjectedCTE"
+            "$ref": "#/$defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -1863,7 +1788,7 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/defs/Contract"
+          "$ref": "#/$defs/Contract"
         },
         "access": {
           "enum": [
@@ -1876,7 +1801,7 @@
         "constraints": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/ModelLevelConstraint"
+            "$ref": "#/$defs/ModelLevelConstraint"
           }
         },
         "version": {
@@ -1910,8 +1835,7 @@
         "deprecation_date": {
           "anyOf": [
             {
-              "type": "string",
-              "format": "date-time"
+              "type": "string"
             },
             {
               "type": "null"
@@ -1922,7 +1846,7 @@
         "defer_relation": {
           "anyOf": [
             {
-              "$ref": "#/defs/DeferRelation"
+              "$ref": "#/$defs/DeferRelation"
             },
             {
               "type": "null"
@@ -1943,23 +1867,7 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum",
-        "config",
-        "_event_status",
-        "tags",
-        "columns",
-        "meta",
-        "docs",
-        "unrendered_config",
-        "created_at",
-        "config_call_dict",
-        "refs",
-        "sources",
-        "metrics",
-        "depends_on",
-        "extra_ctes",
-        "contract",
-        "constraints"
+        "checksum"
       ]
     },
     "RPCNode": {
@@ -2007,10 +1915,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/defs/FileHash"
+          "$ref": "#/$defs/FileHash"
         },
         "config": {
-          "$ref": "#/defs/NodeConfig"
+          "$ref": "#/$defs/NodeConfig"
         },
         "_event_status": {
           "type": "object",
@@ -2031,7 +1939,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/defs/ColumnInfo"
+            "$ref": "#/$defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -2055,7 +1963,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/defs/Docs"
+          "$ref": "#/$defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -2120,7 +2028,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/RefArgs"
+            "$ref": "#/$defs/RefArgs"
           }
         },
         "sources": {
@@ -2142,7 +2050,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/defs/DependsOn"
+          "$ref": "#/$defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -2177,7 +2085,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/InjectedCTE"
+            "$ref": "#/$defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -2192,7 +2100,7 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/defs/Contract"
+          "$ref": "#/$defs/Contract"
         }
       },
       "additionalProperties": false,
@@ -2207,22 +2115,7 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum",
-        "config",
-        "_event_status",
-        "tags",
-        "columns",
-        "meta",
-        "docs",
-        "unrendered_config",
-        "created_at",
-        "config_call_dict",
-        "refs",
-        "sources",
-        "metrics",
-        "depends_on",
-        "extra_ctes",
-        "contract"
+        "checksum"
       ]
     },
     "SqlNode": {
@@ -2270,10 +2163,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/defs/FileHash"
+          "$ref": "#/$defs/FileHash"
         },
         "config": {
-          "$ref": "#/defs/NodeConfig"
+          "$ref": "#/$defs/NodeConfig"
         },
         "_event_status": {
           "type": "object",
@@ -2294,7 +2187,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/defs/ColumnInfo"
+            "$ref": "#/$defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -2318,7 +2211,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/defs/Docs"
+          "$ref": "#/$defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -2383,7 +2276,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/RefArgs"
+            "$ref": "#/$defs/RefArgs"
           }
         },
         "sources": {
@@ -2405,7 +2298,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/defs/DependsOn"
+          "$ref": "#/$defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -2440,7 +2333,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/InjectedCTE"
+            "$ref": "#/$defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -2455,7 +2348,7 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/defs/Contract"
+          "$ref": "#/$defs/Contract"
         }
       },
       "additionalProperties": false,
@@ -2470,22 +2363,7 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum",
-        "config",
-        "_event_status",
-        "tags",
-        "columns",
-        "meta",
-        "docs",
-        "unrendered_config",
-        "created_at",
-        "config_call_dict",
-        "refs",
-        "sources",
-        "metrics",
-        "depends_on",
-        "extra_ctes",
-        "contract"
+        "checksum"
       ]
     },
     "TestMetadata": {
@@ -2515,8 +2393,7 @@
       },
       "additionalProperties": false,
       "required": [
-        "name",
-        "kwargs"
+        "name"
       ]
     },
     "GenericTestNode": {
@@ -2524,7 +2401,7 @@
       "title": "GenericTestNode",
       "properties": {
         "test_metadata": {
-          "$ref": "#/defs/TestMetadata"
+          "$ref": "#/$defs/TestMetadata"
         },
         "database": {
           "anyOf": [
@@ -2567,10 +2444,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/defs/FileHash"
+          "$ref": "#/$defs/FileHash"
         },
         "config": {
-          "$ref": "#/defs/TestConfig"
+          "$ref": "#/$defs/TestConfig"
         },
         "_event_status": {
           "type": "object",
@@ -2591,7 +2468,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/defs/ColumnInfo"
+            "$ref": "#/$defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -2615,7 +2492,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/defs/Docs"
+          "$ref": "#/$defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -2680,7 +2557,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/RefArgs"
+            "$ref": "#/$defs/RefArgs"
           }
         },
         "sources": {
@@ -2702,7 +2579,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/defs/DependsOn"
+          "$ref": "#/$defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -2737,7 +2614,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/InjectedCTE"
+            "$ref": "#/$defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -2752,7 +2629,7 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/defs/Contract"
+          "$ref": "#/$defs/Contract"
         },
         "column_name": {
           "anyOf": [
@@ -2801,22 +2678,7 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum",
-        "config",
-        "_event_status",
-        "tags",
-        "columns",
-        "meta",
-        "docs",
-        "unrendered_config",
-        "created_at",
-        "config_call_dict",
-        "refs",
-        "sources",
-        "metrics",
-        "depends_on",
-        "extra_ctes",
-        "contract"
+        "checksum"
       ]
     },
     "SnapshotConfig": {
@@ -2920,13 +2782,13 @@
         "post-hook": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/Hook"
+            "$ref": "#/$defs/Hook"
           }
         },
         "pre-hook": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/Hook"
+            "$ref": "#/$defs/Hook"
           }
         },
         "quoting": {
@@ -2994,10 +2856,10 @@
           }
         },
         "docs": {
-          "$ref": "#/defs/Docs"
+          "$ref": "#/$defs/Docs"
         },
         "contract": {
-          "$ref": "#/defs/ContractConfig"
+          "$ref": "#/$defs/ContractConfig"
         },
         "strategy": {
           "anyOf": [
@@ -3061,22 +2923,7 @@
           "default": null
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "_extra",
-        "tags",
-        "meta",
-        "persist_docs",
-        "post-hook",
-        "pre-hook",
-        "quoting",
-        "column_types",
-        "on_configuration_change",
-        "grants",
-        "packages",
-        "docs",
-        "contract"
-      ]
+      "additionalProperties": true
     },
     "SnapshotNode": {
       "type": "object",
@@ -3123,10 +2970,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/defs/FileHash"
+          "$ref": "#/$defs/FileHash"
         },
         "config": {
-          "$ref": "#/defs/SnapshotConfig"
+          "$ref": "#/$defs/SnapshotConfig"
         },
         "_event_status": {
           "type": "object",
@@ -3147,7 +2994,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/defs/ColumnInfo"
+            "$ref": "#/$defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -3171,7 +3018,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/defs/Docs"
+          "$ref": "#/$defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -3236,7 +3083,7 @@
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/RefArgs"
+            "$ref": "#/$defs/RefArgs"
           }
         },
         "sources": {
@@ -3258,7 +3105,7 @@
           }
         },
         "depends_on": {
-          "$ref": "#/defs/DependsOn"
+          "$ref": "#/$defs/DependsOn"
         },
         "compiled_path": {
           "anyOf": [
@@ -3293,7 +3140,7 @@
         "extra_ctes": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/InjectedCTE"
+            "$ref": "#/$defs/InjectedCTE"
           }
         },
         "_pre_injected_sql": {
@@ -3308,12 +3155,12 @@
           "default": null
         },
         "contract": {
-          "$ref": "#/defs/Contract"
+          "$ref": "#/$defs/Contract"
         },
         "defer_relation": {
           "anyOf": [
             {
-              "$ref": "#/defs/DeferRelation"
+              "$ref": "#/$defs/DeferRelation"
             },
             {
               "type": "null"
@@ -3335,21 +3182,7 @@
         "fqn",
         "alias",
         "checksum",
-        "config",
-        "_event_status",
-        "tags",
-        "columns",
-        "meta",
-        "docs",
-        "unrendered_config",
-        "created_at",
-        "config_call_dict",
-        "refs",
-        "sources",
-        "metrics",
-        "depends_on",
-        "extra_ctes",
-        "contract"
+        "config"
       ]
     },
     "SeedConfig": {
@@ -3453,13 +3286,13 @@
         "post-hook": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/Hook"
+            "$ref": "#/$defs/Hook"
           }
         },
         "pre-hook": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/Hook"
+            "$ref": "#/$defs/Hook"
           }
         },
         "quoting": {
@@ -3533,10 +3366,10 @@
           }
         },
         "docs": {
-          "$ref": "#/defs/Docs"
+          "$ref": "#/$defs/Docs"
         },
         "contract": {
-          "$ref": "#/defs/ContractConfig"
+          "$ref": "#/$defs/ContractConfig"
         },
         "delimiter": {
           "type": "string",
@@ -3554,22 +3387,7 @@
           "default": null
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "_extra",
-        "tags",
-        "meta",
-        "persist_docs",
-        "post-hook",
-        "pre-hook",
-        "quoting",
-        "column_types",
-        "on_configuration_change",
-        "grants",
-        "packages",
-        "docs",
-        "contract"
-      ]
+      "additionalProperties": true
     },
     "MacroDependsOn": {
       "type": "object",
@@ -3582,10 +3400,7 @@
           }
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "macros"
-      ]
+      "additionalProperties": false
     },
     "SeedNode": {
       "type": "object",
@@ -3632,10 +3447,10 @@
           "type": "string"
         },
         "checksum": {
-          "$ref": "#/defs/FileHash"
+          "$ref": "#/$defs/FileHash"
         },
         "config": {
-          "$ref": "#/defs/SeedConfig"
+          "$ref": "#/$defs/SeedConfig"
         },
         "_event_status": {
           "type": "object",
@@ -3656,7 +3471,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/defs/ColumnInfo"
+            "$ref": "#/$defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -3680,7 +3495,7 @@
           "default": null
         },
         "docs": {
-          "$ref": "#/defs/Docs"
+          "$ref": "#/$defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -3750,12 +3565,12 @@
           "default": null
         },
         "depends_on": {
-          "$ref": "#/defs/MacroDependsOn"
+          "$ref": "#/$defs/MacroDependsOn"
         },
         "defer_relation": {
           "anyOf": [
             {
-              "$ref": "#/defs/DeferRelation"
+              "$ref": "#/$defs/DeferRelation"
             },
             {
               "type": "null"
@@ -3776,17 +3591,7 @@
         "unique_id",
         "fqn",
         "alias",
-        "checksum",
-        "config",
-        "_event_status",
-        "tags",
-        "columns",
-        "meta",
-        "docs",
-        "unrendered_config",
-        "created_at",
-        "config_call_dict",
-        "depends_on"
+        "checksum"
       ]
     },
     "Quoting": {
@@ -3880,7 +3685,7 @@
         "warn_after": {
           "anyOf": [
             {
-              "$ref": "#/defs/Time"
+              "$ref": "#/$defs/Time"
             },
             {
               "type": "null"
@@ -3890,7 +3695,7 @@
         "error_after": {
           "anyOf": [
             {
-              "$ref": "#/defs/Time"
+              "$ref": "#/$defs/Time"
             },
             {
               "type": "null"
@@ -3909,11 +3714,7 @@
           "default": null
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "warn_after",
-        "error_after"
-      ]
+      "additionalProperties": false
     },
     "ExternalPartition": {
       "type": "object",
@@ -3944,11 +3745,7 @@
           }
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "_extra",
-        "meta"
-      ]
+      "additionalProperties": true
     },
     "ExternalTable": {
       "type": "object",
@@ -4015,7 +3812,7 @@
             {
               "type": "array",
               "items": {
-                "$ref": "#/defs/ExternalPartition"
+                "$ref": "#/$defs/ExternalPartition"
               }
             },
             {
@@ -4025,10 +3822,7 @@
           "default": null
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "_extra"
-      ]
+      "additionalProperties": true
     },
     "SourceConfig": {
       "type": "object",
@@ -4045,10 +3839,7 @@
           "default": true
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "_extra"
-      ]
+      "additionalProperties": true
     },
     "SourceDefinition": {
       "type": "object",
@@ -4110,7 +3901,7 @@
           }
         },
         "quoting": {
-          "$ref": "#/defs/Quoting"
+          "$ref": "#/$defs/Quoting"
         },
         "loaded_at_field": {
           "anyOf": [
@@ -4126,7 +3917,7 @@
         "freshness": {
           "anyOf": [
             {
-              "$ref": "#/defs/FreshnessThreshold"
+              "$ref": "#/$defs/FreshnessThreshold"
             },
             {
               "type": "null"
@@ -4137,7 +3928,7 @@
         "external": {
           "anyOf": [
             {
-              "$ref": "#/defs/ExternalTable"
+              "$ref": "#/$defs/ExternalTable"
             },
             {
               "type": "null"
@@ -4152,7 +3943,7 @@
         "columns": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/defs/ColumnInfo"
+            "$ref": "#/$defs/ColumnInfo"
           },
           "propertyNames": {
             "type": "string"
@@ -4177,7 +3968,7 @@
           }
         },
         "config": {
-          "$ref": "#/defs/SourceConfig"
+          "$ref": "#/$defs/SourceConfig"
         },
         "patch_path": {
           "anyOf": [
@@ -4225,16 +4016,7 @@
         "source_name",
         "source_description",
         "loader",
-        "identifier",
-        "_event_status",
-        "quoting",
-        "columns",
-        "meta",
-        "source_meta",
-        "tags",
-        "config",
-        "unrendered_config",
-        "created_at"
+        "identifier"
       ]
     },
     "MacroArgument": {
@@ -4291,7 +4073,7 @@
           "type": "string"
         },
         "depends_on": {
-          "$ref": "#/defs/MacroDependsOn"
+          "$ref": "#/$defs/MacroDependsOn"
         },
         "description": {
           "type": "string",
@@ -4304,7 +4086,7 @@
           }
         },
         "docs": {
-          "$ref": "#/defs/Docs"
+          "$ref": "#/$defs/Docs"
         },
         "patch_path": {
           "anyOf": [
@@ -4320,7 +4102,7 @@
         "arguments": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/MacroArgument"
+            "$ref": "#/$defs/MacroArgument"
           }
         },
         "created_at": {
@@ -4352,12 +4134,7 @@
         "path",
         "original_file_path",
         "unique_id",
-        "macro_sql",
-        "depends_on",
-        "meta",
-        "docs",
-        "arguments",
-        "created_at"
+        "macro_sql"
       ]
     },
     "Documentation": {
@@ -4430,10 +4207,7 @@
           "default": null
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "_extra"
-      ]
+      "additionalProperties": true
     },
     "ExposureConfig": {
       "type": "object",
@@ -4450,10 +4224,7 @@
           "default": true
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "_extra"
-      ]
+      "additionalProperties": true
     },
     "Exposure": {
       "type": "object",
@@ -4493,7 +4264,7 @@
           ]
         },
         "owner": {
-          "$ref": "#/defs/Owner"
+          "$ref": "#/$defs/Owner"
         },
         "description": {
           "type": "string",
@@ -4538,7 +4309,7 @@
           }
         },
         "config": {
-          "$ref": "#/defs/ExposureConfig"
+          "$ref": "#/$defs/ExposureConfig"
         },
         "unrendered_config": {
           "type": "object",
@@ -4558,12 +4329,12 @@
           "default": null
         },
         "depends_on": {
-          "$ref": "#/defs/DependsOn"
+          "$ref": "#/$defs/DependsOn"
         },
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/RefArgs"
+            "$ref": "#/$defs/RefArgs"
           }
         },
         "sources": {
@@ -4598,16 +4369,7 @@
         "unique_id",
         "fqn",
         "type",
-        "owner",
-        "meta",
-        "tags",
-        "config",
-        "unrendered_config",
-        "depends_on",
-        "refs",
-        "sources",
-        "metrics",
-        "created_at"
+        "owner"
       ]
     },
     "WhereFilter": {
@@ -4633,7 +4395,7 @@
         "filter": {
           "anyOf": [
             {
-              "$ref": "#/defs/WhereFilter"
+              "$ref": "#/$defs/WhereFilter"
             },
             {
               "type": "null"
@@ -4691,7 +4453,7 @@
         "filter": {
           "anyOf": [
             {
-              "$ref": "#/defs/WhereFilter"
+              "$ref": "#/$defs/WhereFilter"
             },
             {
               "type": "null"
@@ -4713,7 +4475,7 @@
         "offset_window": {
           "anyOf": [
             {
-              "$ref": "#/defs/MetricTimeWindow"
+              "$ref": "#/$defs/MetricTimeWindow"
             },
             {
               "type": "null"
@@ -4751,7 +4513,7 @@
         "measure": {
           "anyOf": [
             {
-              "$ref": "#/defs/MetricInputMeasure"
+              "$ref": "#/$defs/MetricInputMeasure"
             },
             {
               "type": "null"
@@ -4762,13 +4524,13 @@
         "input_measures": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/MetricInputMeasure"
+            "$ref": "#/$defs/MetricInputMeasure"
           }
         },
         "numerator": {
           "anyOf": [
             {
-              "$ref": "#/defs/MetricInput"
+              "$ref": "#/$defs/MetricInput"
             },
             {
               "type": "null"
@@ -4779,7 +4541,7 @@
         "denominator": {
           "anyOf": [
             {
-              "$ref": "#/defs/MetricInput"
+              "$ref": "#/$defs/MetricInput"
             },
             {
               "type": "null"
@@ -4801,7 +4563,7 @@
         "window": {
           "anyOf": [
             {
-              "$ref": "#/defs/MetricTimeWindow"
+              "$ref": "#/$defs/MetricTimeWindow"
             },
             {
               "type": "null"
@@ -4831,7 +4593,7 @@
             {
               "type": "array",
               "items": {
-                "$ref": "#/defs/MetricInput"
+                "$ref": "#/$defs/MetricInput"
               }
             },
             {
@@ -4841,10 +4603,7 @@
           "default": null
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "input_measures"
-      ]
+      "additionalProperties": false
     },
     "FileSlice": {
       "type": "object",
@@ -4879,7 +4638,7 @@
           "type": "string"
         },
         "file_slice": {
-          "$ref": "#/defs/FileSlice"
+          "$ref": "#/$defs/FileSlice"
         }
       },
       "additionalProperties": false,
@@ -4914,10 +4673,7 @@
           "default": null
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "_extra"
-      ]
+      "additionalProperties": true
     },
     "Metric": {
       "type": "object",
@@ -4962,12 +4718,12 @@
           ]
         },
         "type_params": {
-          "$ref": "#/defs/MetricTypeParams"
+          "$ref": "#/$defs/MetricTypeParams"
         },
         "filter": {
           "anyOf": [
             {
-              "$ref": "#/defs/WhereFilter"
+              "$ref": "#/$defs/WhereFilter"
             },
             {
               "type": "null"
@@ -4978,7 +4734,7 @@
         "metadata": {
           "anyOf": [
             {
-              "$ref": "#/defs/SourceFileMetadata"
+              "$ref": "#/$defs/SourceFileMetadata"
             },
             {
               "type": "null"
@@ -4999,7 +4755,7 @@
           }
         },
         "config": {
-          "$ref": "#/defs/MetricConfig"
+          "$ref": "#/$defs/MetricConfig"
         },
         "unrendered_config": {
           "type": "object",
@@ -5017,12 +4773,12 @@
           }
         },
         "depends_on": {
-          "$ref": "#/defs/DependsOn"
+          "$ref": "#/$defs/DependsOn"
         },
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/RefArgs"
+            "$ref": "#/$defs/RefArgs"
           }
         },
         "metrics": {
@@ -5061,16 +4817,7 @@
         "description",
         "label",
         "type",
-        "type_params",
-        "meta",
-        "tags",
-        "config",
-        "unrendered_config",
-        "sources",
-        "depends_on",
-        "refs",
-        "metrics",
-        "created_at"
+        "type_params"
       ]
     },
     "Group": {
@@ -5096,7 +4843,7 @@
           "type": "string"
         },
         "owner": {
-          "$ref": "#/defs/Owner"
+          "$ref": "#/$defs/Owner"
         }
       },
       "additionalProperties": false,
@@ -5331,7 +5078,7 @@
         "agg_params": {
           "anyOf": [
             {
-              "$ref": "#/defs/MeasureAggregationParameters"
+              "$ref": "#/$defs/MeasureAggregationParameters"
             },
             {
               "type": "null"
@@ -5342,7 +5089,7 @@
         "non_additive_dimension": {
           "anyOf": [
             {
-              "$ref": "#/defs/NonAdditiveDimension"
+              "$ref": "#/$defs/NonAdditiveDimension"
             },
             {
               "type": "null"
@@ -5399,7 +5146,7 @@
         "validity_params": {
           "anyOf": [
             {
-              "$ref": "#/defs/DimensionValidityParams"
+              "$ref": "#/$defs/DimensionValidityParams"
             },
             {
               "type": "null"
@@ -5444,7 +5191,7 @@
         "type_params": {
           "anyOf": [
             {
-              "$ref": "#/defs/DimensionTypeParams"
+              "$ref": "#/$defs/DimensionTypeParams"
             },
             {
               "type": "null"
@@ -5466,7 +5213,7 @@
         "metadata": {
           "anyOf": [
             {
-              "$ref": "#/defs/SourceFileMetadata"
+              "$ref": "#/$defs/SourceFileMetadata"
             },
             {
               "type": "null"
@@ -5507,10 +5254,7 @@
           "default": null
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "_extra"
-      ]
+      "additionalProperties": true
     },
     "SemanticModel": {
       "type": "object",
@@ -5562,7 +5306,7 @@
         "node_relation": {
           "anyOf": [
             {
-              "$ref": "#/defs/NodeRelation"
+              "$ref": "#/$defs/NodeRelation"
             },
             {
               "type": "null"
@@ -5583,7 +5327,7 @@
         "defaults": {
           "anyOf": [
             {
-              "$ref": "#/defs/Defaults"
+              "$ref": "#/$defs/Defaults"
             },
             {
               "type": "null"
@@ -5594,25 +5338,25 @@
         "entities": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/Entity"
+            "$ref": "#/$defs/Entity"
           }
         },
         "measures": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/Measure"
+            "$ref": "#/$defs/Measure"
           }
         },
         "dimensions": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/Dimension"
+            "$ref": "#/$defs/Dimension"
           }
         },
         "metadata": {
           "anyOf": [
             {
-              "$ref": "#/defs/SourceFileMetadata"
+              "$ref": "#/$defs/SourceFileMetadata"
             },
             {
               "type": "null"
@@ -5621,19 +5365,19 @@
           "default": null
         },
         "depends_on": {
-          "$ref": "#/defs/DependsOn"
+          "$ref": "#/$defs/DependsOn"
         },
         "refs": {
           "type": "array",
           "items": {
-            "$ref": "#/defs/RefArgs"
+            "$ref": "#/$defs/RefArgs"
           }
         },
         "created_at": {
           "type": "number"
         },
         "config": {
-          "$ref": "#/defs/SemanticModelConfig"
+          "$ref": "#/$defs/SemanticModelConfig"
         },
         "unrendered_config": {
           "type": "object",
@@ -5674,15 +5418,7 @@
         "unique_id",
         "fqn",
         "model",
-        "node_relation",
-        "entities",
-        "measures",
-        "dimensions",
-        "depends_on",
-        "refs",
-        "created_at",
-        "config",
-        "unrendered_config"
+        "node_relation"
       ]
     },
     "WritableManifest": {
@@ -5690,38 +5426,40 @@
       "title": "WritableManifest",
       "properties": {
         "metadata": {
-          "$ref": "#/defs/ManifestMetadata"
+          "description": "Metadata about the manifest",
+          "$ref": "#/$defs/ManifestMetadata"
         },
         "nodes": {
           "type": "object",
+          "description": "The nodes defined in the dbt project and its dependencies",
           "additionalProperties": {
             "anyOf": [
               {
-                "$ref": "#/defs/AnalysisNode"
+                "$ref": "#/$defs/AnalysisNode"
               },
               {
-                "$ref": "#/defs/SingularTestNode"
+                "$ref": "#/$defs/SingularTestNode"
               },
               {
-                "$ref": "#/defs/HookNode"
+                "$ref": "#/$defs/HookNode"
               },
               {
-                "$ref": "#/defs/ModelNode"
+                "$ref": "#/$defs/ModelNode"
               },
               {
-                "$ref": "#/defs/RPCNode"
+                "$ref": "#/$defs/RPCNode"
               },
               {
-                "$ref": "#/defs/SqlNode"
+                "$ref": "#/$defs/SqlNode"
               },
               {
-                "$ref": "#/defs/GenericTestNode"
+                "$ref": "#/$defs/GenericTestNode"
               },
               {
-                "$ref": "#/defs/SnapshotNode"
+                "$ref": "#/$defs/SnapshotNode"
               },
               {
-                "$ref": "#/defs/SeedNode"
+                "$ref": "#/$defs/SeedNode"
               }
             ]
           },
@@ -5731,8 +5469,9 @@
         },
         "sources": {
           "type": "object",
+          "description": "The sources defined in the dbt project and its dependencies",
           "additionalProperties": {
-            "$ref": "#/defs/SourceDefinition"
+            "$ref": "#/$defs/SourceDefinition"
           },
           "propertyNames": {
             "type": "string"
@@ -5740,8 +5479,9 @@
         },
         "macros": {
           "type": "object",
+          "description": "The macros defined in the dbt project and its dependencies",
           "additionalProperties": {
-            "$ref": "#/defs/Macro"
+            "$ref": "#/$defs/Macro"
           },
           "propertyNames": {
             "type": "string"
@@ -5749,8 +5489,9 @@
         },
         "docs": {
           "type": "object",
+          "description": "The docs defined in the dbt project and its dependencies",
           "additionalProperties": {
-            "$ref": "#/defs/Documentation"
+            "$ref": "#/$defs/Documentation"
           },
           "propertyNames": {
             "type": "string"
@@ -5758,8 +5499,9 @@
         },
         "exposures": {
           "type": "object",
+          "description": "The exposures defined in the dbt project and its dependencies",
           "additionalProperties": {
-            "$ref": "#/defs/Exposure"
+            "$ref": "#/$defs/Exposure"
           },
           "propertyNames": {
             "type": "string"
@@ -5767,8 +5509,9 @@
         },
         "metrics": {
           "type": "object",
+          "description": "The metrics defined in the dbt project and its dependencies",
           "additionalProperties": {
-            "$ref": "#/defs/Metric"
+            "$ref": "#/$defs/Metric"
           },
           "propertyNames": {
             "type": "string"
@@ -5776,8 +5519,9 @@
         },
         "groups": {
           "type": "object",
+          "description": "The groups defined in the dbt project",
           "additionalProperties": {
-            "$ref": "#/defs/Group"
+            "$ref": "#/$defs/Group"
           },
           "propertyNames": {
             "type": "string"
@@ -5785,11 +5529,13 @@
         },
         "selectors": {
           "type": "object",
+          "description": "The selectors defined in selectors.yml",
           "propertyNames": {
             "type": "string"
           }
         },
         "disabled": {
+          "description": "A mapping of the disabled nodes in the target",
           "anyOf": [
             {
               "type": "object",
@@ -5798,43 +5544,43 @@
                 "items": {
                   "anyOf": [
                     {
-                      "$ref": "#/defs/AnalysisNode"
+                      "$ref": "#/$defs/AnalysisNode"
                     },
                     {
-                      "$ref": "#/defs/SingularTestNode"
+                      "$ref": "#/$defs/SingularTestNode"
                     },
                     {
-                      "$ref": "#/defs/HookNode"
+                      "$ref": "#/$defs/HookNode"
                     },
                     {
-                      "$ref": "#/defs/ModelNode"
+                      "$ref": "#/$defs/ModelNode"
                     },
                     {
-                      "$ref": "#/defs/RPCNode"
+                      "$ref": "#/$defs/RPCNode"
                     },
                     {
-                      "$ref": "#/defs/SqlNode"
+                      "$ref": "#/$defs/SqlNode"
                     },
                     {
-                      "$ref": "#/defs/GenericTestNode"
+                      "$ref": "#/$defs/GenericTestNode"
                     },
                     {
-                      "$ref": "#/defs/SnapshotNode"
+                      "$ref": "#/$defs/SnapshotNode"
                     },
                     {
-                      "$ref": "#/defs/SeedNode"
+                      "$ref": "#/$defs/SeedNode"
                     },
                     {
-                      "$ref": "#/defs/SourceDefinition"
+                      "$ref": "#/$defs/SourceDefinition"
                     },
                     {
-                      "$ref": "#/defs/Exposure"
+                      "$ref": "#/$defs/Exposure"
                     },
                     {
-                      "$ref": "#/defs/Metric"
+                      "$ref": "#/$defs/Metric"
                     },
                     {
-                      "$ref": "#/defs/SemanticModel"
+                      "$ref": "#/$defs/SemanticModel"
                     }
                   ]
                 }
@@ -5849,6 +5595,7 @@
           ]
         },
         "parent_map": {
+          "description": "A mapping from\u00a0child nodes to their dependencies",
           "anyOf": [
             {
               "type": "object",
@@ -5868,6 +5615,7 @@
           ]
         },
         "child_map": {
+          "description": "A mapping from parent nodes to their dependents",
           "anyOf": [
             {
               "type": "object",
@@ -5887,6 +5635,7 @@
           ]
         },
         "group_map": {
+          "description": "A mapping from group names to their nodes",
           "anyOf": [
             {
               "type": "object",
@@ -5907,8 +5656,9 @@
         },
         "semantic_models": {
           "type": "object",
+          "description": "The semantic models defined in the dbt project",
           "additionalProperties": {
-            "$ref": "#/defs/SemanticModel"
+            "$ref": "#/$defs/SemanticModel"
           },
           "propertyNames": {
             "type": "string"

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -1,4 +1,4 @@
-metricflow_time_spine_sql = """
+simple_metricflow_time_spine_sql = """
 SELECT to_date('02/20/2023', 'mm/dd/yyyy') as date_day
 """
 
@@ -15,6 +15,22 @@ version: 2
 
 metrics:
   - name: number_of_people
+    label: "Number of people"
+    description: Total count of people
+    type: simple
+    type_params:
+      measure: people
+    meta:
+        my_meta: 'testing'
+"""
+
+disabled_models_people_metrics_yml = """
+version: 2
+
+metrics:
+  - name: number_of_people
+    config:
+      enabled: false
     label: "Number of people"
     description: Total count of people
     type: simple
@@ -49,4 +65,160 @@ semantic_models:
         type: primary
     defaults:
       agg_time_dimension: created_at
+"""
+
+enabled_semantic_model_people_yml = """
+version: 2
+
+semantic_models:
+  - name: semantic_people
+    model: ref('people')
+    config:
+      enabled: true
+    dimensions:
+      - name: favorite_color
+        type: categorical
+      - name: created_at
+        type: TIME
+        type_params:
+          time_granularity: day
+    measures:
+      - name: years_tenure
+        agg: SUM
+        expr: tenure
+      - name: people
+        agg: count
+        expr: id
+    entities:
+      - name: id
+        type: primary
+    defaults:
+      agg_time_dimension: created_at
+"""
+
+disabled_semantic_model_people_yml = """
+version: 2
+
+semantic_models:
+  - name: semantic_people
+    model: ref('people')
+    config:
+      enabled: false
+    dimensions:
+      - name: favorite_color
+        type: categorical
+      - name: created_at
+        type: TIME
+        type_params:
+          time_granularity: day
+    measures:
+      - name: years_tenure
+        agg: SUM
+        expr: tenure
+      - name: people
+        agg: count
+        expr: id
+    entities:
+      - name: id
+        type: primary
+    defaults:
+      agg_time_dimension: created_at
+"""
+
+schema_yml = """models:
+  - name: fct_revenue
+    description: This is the model fct_revenue. It should be able to use doc blocks
+
+semantic_models:
+  - name: revenue
+    description: This is the revenue semantic model. It should be able to use doc blocks
+    model: ref('fct_revenue')
+
+    defaults:
+      agg_time_dimension: ds
+
+    measures:
+      - name: txn_revenue
+        expr: revenue
+        agg: sum
+        agg_time_dimension: ds
+        create_metric: true
+      - name: sum_of_things
+        expr: 2
+        agg: sum
+        agg_time_dimension: ds
+      - name: has_revenue
+        expr: true
+        agg: sum_boolean
+        agg_time_dimension: ds
+      - name: discrete_order_value_p99
+        expr: order_total
+        agg: percentile
+        agg_time_dimension: ds
+        agg_params:
+          percentile: 0.99
+          use_discrete_percentile: True
+          use_approximate_percentile: False
+      - name: test_agg_params_optional_are_empty
+        expr: order_total
+        agg: percentile
+        agg_time_dimension: ds
+        agg_params:
+          percentile: 0.99
+      - name: test_non_additive
+        expr: txn_revenue
+        agg: sum
+        non_additive_dimension:
+          name: ds
+          window_choice: max
+
+    dimensions:
+      - name: ds
+        type: time
+        expr: created_at
+        type_params:
+          time_granularity: day
+
+    entities:
+      - name: user
+        type: foreign
+        expr: user_id
+      - name: id
+        type: primary
+
+metrics:
+  - name: simple_metric
+    label: Simple Metric
+    type: simple
+    type_params:
+      measure: sum_of_things
+"""
+
+schema_without_semantic_model_yml = """models:
+  - name: fct_revenue
+    description: This is the model fct_revenue. It should be able to use doc blocks
+"""
+
+fct_revenue_sql = """select
+  1 as id,
+  10 as user_id,
+  1000 as revenue,
+  current_timestamp as created_at"""
+
+metricflow_time_spine_sql = """
+with days as (
+    {{dbt_utils.date_spine('day'
+    , "to_date('01/01/2000','mm/dd/yyyy')"
+    , "to_date('01/01/2027','mm/dd/yyyy')"
+    )
+    }}
+),
+
+final as (
+    select cast(date_day as date) as date_day
+    from days
+)
+
+select *
+from final
 """

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -10,6 +10,15 @@ union all
 select 3 as id, 'Callum' as first_name, 'McCann' as last_name, 'emerald' as favorite_color, true as loves_dbt, 0 as tenure, current_timestamp as created_at
 """
 
+groups_yml = """
+version: 2
+
+groups:
+  - name: some_group
+    owner:
+      email: me@gmail.com
+"""
+
 models_people_metrics_yml = """
 version: 2
 
@@ -31,6 +40,7 @@ metrics:
   - name: number_of_people
     config:
       enabled: false
+      group: some_group
     label: "Number of people"
     description: Total count of people
     type: simple
@@ -45,6 +55,8 @@ version: 2
 
 semantic_models:
   - name: semantic_people
+    config:
+      group: some_group
     model: ref('people')
     dimensions:
       - name: favorite_color
@@ -75,6 +87,7 @@ semantic_models:
     model: ref('people')
     config:
       enabled: true
+      group: some_group
     dimensions:
       - name: favorite_color
         type: categorical

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -17,6 +17,9 @@ groups:
   - name: some_group
     owner:
       email: me@gmail.com
+  - name: some_other_group
+    owner:
+      email: me@gmail.com
 """
 
 models_people_metrics_yml = """
@@ -55,8 +58,6 @@ version: 2
 
 semantic_models:
   - name: semantic_people
-    config:
-      group: some_group
     model: ref('people')
     dimensions:
       - name: favorite_color

--- a/tests/functional/semantic_models/test_semantic_model_configs.py
+++ b/tests/functional/semantic_models/test_semantic_model_configs.py
@@ -1,0 +1,120 @@
+import pytest
+from dbt.exceptions import ParsingError
+from dbt.contracts.graph.model_config import SemanticModelConfig
+
+from dbt.tests.util import run_dbt, update_config_file, get_manifest
+
+from tests.functional.semantic_models.fixtures import (
+    models_people_sql,
+    metricflow_time_spine_sql,
+    semantic_model_people_yml,
+    disabled_models_people_metrics_yml,
+    models_people_metrics_yml,
+    disabled_semantic_model_people_yml,
+    enabled_semantic_model_people_yml,
+)
+
+
+# Test disabled config at semantic_models level in yaml file
+class TestConfigYamlLevel:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people.sql": models_people_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "semantic_models.yml": disabled_semantic_model_people_yml,
+            "people_metrics.yml": disabled_models_people_metrics_yml,
+        }
+
+    def test_yaml_level(self, project):
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        assert "semantic_model.test.semantic_people" not in manifest.semantic_models
+        assert "semantic_model.test.semantic_people" in manifest.disabled
+
+
+# Test disabled config at semantic_models level with a still enabled metric
+class TestDisabledConfigYamlLevelEnabledMetric:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people.sql": models_people_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "semantic_models.yml": disabled_semantic_model_people_yml,
+            "people_metrics.yml": models_people_metrics_yml,
+        }
+
+    def test_yaml_level(self, project):
+        with pytest.raises(
+            ParsingError,
+            match="A semantic model having a measure `people` is disabled but was referenced",
+        ):
+            run_dbt(["parse"])
+
+
+# Test disabling config in dbt_project.yml
+class TestConfigProjectLevel:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people.sql": models_people_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "semantic_models.yml": semantic_model_people_yml,
+            "people_metrics.yml": models_people_metrics_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "semantic-models": {
+                "semantic_people": {
+                    "enabled": True,
+                },
+            }
+        }
+
+    def test_project_level(self, project):
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        assert "semantic_model.test.semantic_people" in manifest.semantic_models
+
+        new_enabled_config = {
+            "semantic-models": {
+                "test": {
+                    "semantic_people": {
+                        "enabled": False,
+                    },
+                }
+            }
+        }
+        update_config_file(new_enabled_config, project.project_root, "dbt_project.yml")
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+
+        assert "semantic_model.test.semantic_people" not in manifest.semantic_models
+
+
+# Test inheritence - set configs at project and semantic_model level - expect semantic_model level to win
+class TestConfigsInheritence:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people.sql": models_people_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "semantic_models.yml": enabled_semantic_model_people_yml,
+            "people_metrics.yml": models_people_metrics_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"semantic_models": {"enabled": False}}
+
+    def test_project_plus_yaml_level(self, project):
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        assert "semantic_model.test.semantic_people" in manifest.semantic_models
+        config_test_table = manifest.semantic_models.get(
+            "semantic_model.test.semantic_people"
+        ).config
+
+        assert isinstance(config_test_table, SemanticModelConfig)

--- a/tests/functional/semantic_models/test_semantic_model_configs.py
+++ b/tests/functional/semantic_models/test_semantic_model_configs.py
@@ -53,7 +53,7 @@ class TestDisabledConfigYamlLevelEnabledMetric:
     def test_yaml_level(self, project):
         with pytest.raises(
             ParsingError,
-            match="A semantic model having a measure `people` is disabled but was referenced",
+            match="The measure `people` is referenced on disabled semantic model `semantic_people`.",
         ):
             run_dbt(["parse"])
 
@@ -97,7 +97,7 @@ class TestMismatchesConfigProjectLevel:
         update_config_file(new_enabled_config, project.project_root, "dbt_project.yml")
         with pytest.raises(
             ParsingError,
-            match="A semantic model having a measure `people` is disabled but was referenced",
+            match="The measure `people` is referenced on disabled semantic model `semantic_people`.",
         ):
             run_dbt(["parse"])
 

--- a/tests/functional/semantic_models/test_semantic_model_configs.py
+++ b/tests/functional/semantic_models/test_semantic_model_configs.py
@@ -157,7 +157,7 @@ class TestConfigsInheritence:
 
     @pytest.fixture(scope="class")
     def project_config_update(self):
-        return {"semantic_models": {"enabled": False}}
+        return {"semantic-models": {"enabled": False}}
 
     def test_project_plus_yaml_level(self, project):
         run_dbt(["parse"])

--- a/tests/functional/semantic_models/test_semantic_model_configs.py
+++ b/tests/functional/semantic_models/test_semantic_model_configs.py
@@ -85,9 +85,7 @@ class TestMismatchesConfigProjectLevel:
         manifest = get_manifest(project.project_root)
         assert "semantic_model.test.semantic_people" in manifest.semantic_models
         assert "group.test.some_group" in manifest.groups
-        assert (
-            manifest.semantic_models["semantic_model.test.semantic_people"].group == "some_group"
-        )
+        assert manifest.semantic_models["semantic_model.test.semantic_people"].group is None
 
         new_enabled_config = {
             "semantic-models": {
@@ -136,8 +134,26 @@ class TestConfigProjectLevel:
         manifest = get_manifest(project.project_root)
         assert "semantic_model.test.semantic_people" in manifest.semantic_models
         assert "group.test.some_group" in manifest.groups
+        assert "group.test.some_other_group" in manifest.groups
+        assert manifest.semantic_models["semantic_model.test.semantic_people"].group is None
+
+        new_group_config = {
+            "semantic-models": {
+                "test": {
+                    "group": "some_other_group",
+                }
+            },
+        }
+        update_config_file(new_group_config, project.project_root, "dbt_project.yml")
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+
+        assert "semantic_model.test.semantic_people" in manifest.semantic_models
+        assert "group.test.some_other_group" in manifest.groups
+        assert "group.test.some_group" in manifest.groups
         assert (
-            manifest.semantic_models["semantic_model.test.semantic_people"].group == "some_group"
+            manifest.semantic_models["semantic_model.test.semantic_people"].group
+            == "some_other_group"
         )
 
         new_enabled_config = {

--- a/tests/functional/semantic_models/test_semantic_model_configs.py
+++ b/tests/functional/semantic_models/test_semantic_model_configs.py
@@ -52,7 +52,48 @@ class TestDisabledConfigYamlLevelEnabledMetric:
             run_dbt(["parse"])
 
 
-# Test disabling config in dbt_project.yml
+# Test disabling semantic model config but not metric config in dbt_project.yml
+class TestMismatchesConfigProjectLevel:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people.sql": models_people_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "semantic_models.yml": semantic_model_people_yml,
+            "people_metrics.yml": models_people_metrics_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "semantic-models": {
+                "test": {
+                    "enabled": True,
+                }
+            }
+        }
+
+    def test_project_level(self, project):
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        assert "semantic_model.test.semantic_people" in manifest.semantic_models
+
+        new_enabled_config = {
+            "semantic-models": {
+                "test": {
+                    "enabled": False,
+                }
+            }
+        }
+        update_config_file(new_enabled_config, project.project_root, "dbt_project.yml")
+        with pytest.raises(
+            ParsingError,
+            match="A semantic model having a measure `people` is disabled but was referenced",
+        ):
+            run_dbt(["parse"])
+
+
+# Test disabling semantic model and metric configs in dbt_project.yml
 class TestConfigProjectLevel:
     @pytest.fixture(scope="class")
     def models(self):
@@ -67,10 +108,15 @@ class TestConfigProjectLevel:
     def project_config_update(self):
         return {
             "semantic-models": {
-                "semantic_people": {
+                "test": {
                     "enabled": True,
-                },
-            }
+                }
+            },
+            "metrics": {
+                "test": {
+                    "enabled": True,
+                }
+            },
         }
 
     def test_project_level(self, project):
@@ -81,17 +127,21 @@ class TestConfigProjectLevel:
         new_enabled_config = {
             "semantic-models": {
                 "test": {
-                    "semantic_people": {
-                        "enabled": False,
-                    },
+                    "enabled": False,
                 }
-            }
+            },
+            "metrics": {
+                "test": {
+                    "enabled": False,
+                }
+            },
         }
         update_config_file(new_enabled_config, project.project_root, "dbt_project.yml")
         run_dbt(["parse"])
         manifest = get_manifest(project.project_root)
 
         assert "semantic_model.test.semantic_people" not in manifest.semantic_models
+        assert "semantic_model.test.semantic_people" in manifest.disabled
 
 
 # Test inheritence - set configs at project and semantic_model level - expect semantic_model level to win

--- a/tests/functional/semantic_models/test_semantic_model_configs.py
+++ b/tests/functional/semantic_models/test_semantic_model_configs.py
@@ -12,6 +12,7 @@ from tests.functional.semantic_models.fixtures import (
     models_people_metrics_yml,
     disabled_semantic_model_people_yml,
     enabled_semantic_model_people_yml,
+    groups_yml,
 )
 
 
@@ -24,6 +25,7 @@ class TestConfigYamlLevel:
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
             "semantic_models.yml": disabled_semantic_model_people_yml,
             "people_metrics.yml": disabled_models_people_metrics_yml,
+            "groups.yml": groups_yml,
         }
 
     def test_yaml_level(self, project):
@@ -31,6 +33,9 @@ class TestConfigYamlLevel:
         manifest = get_manifest(project.project_root)
         assert "semantic_model.test.semantic_people" not in manifest.semantic_models
         assert "semantic_model.test.semantic_people" in manifest.disabled
+
+        assert "group.test.some_group" in manifest.groups
+        assert "semantic_model.test.semantic_people" not in manifest.groups
 
 
 # Test disabled config at semantic_models level with a still enabled metric
@@ -42,6 +47,7 @@ class TestDisabledConfigYamlLevelEnabledMetric:
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
             "semantic_models.yml": disabled_semantic_model_people_yml,
             "people_metrics.yml": models_people_metrics_yml,
+            "groups.yml": groups_yml,
         }
 
     def test_yaml_level(self, project):
@@ -61,6 +67,7 @@ class TestMismatchesConfigProjectLevel:
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
             "semantic_models.yml": semantic_model_people_yml,
             "people_metrics.yml": models_people_metrics_yml,
+            "groups.yml": groups_yml,
         }
 
     @pytest.fixture(scope="class")
@@ -77,6 +84,10 @@ class TestMismatchesConfigProjectLevel:
         run_dbt(["parse"])
         manifest = get_manifest(project.project_root)
         assert "semantic_model.test.semantic_people" in manifest.semantic_models
+        assert "group.test.some_group" in manifest.groups
+        assert (
+            manifest.semantic_models["semantic_model.test.semantic_people"].group == "some_group"
+        )
 
         new_enabled_config = {
             "semantic-models": {
@@ -102,6 +113,7 @@ class TestConfigProjectLevel:
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
             "semantic_models.yml": semantic_model_people_yml,
             "people_metrics.yml": models_people_metrics_yml,
+            "groups.yml": groups_yml,
         }
 
     @pytest.fixture(scope="class")
@@ -123,6 +135,10 @@ class TestConfigProjectLevel:
         run_dbt(["parse"])
         manifest = get_manifest(project.project_root)
         assert "semantic_model.test.semantic_people" in manifest.semantic_models
+        assert "group.test.some_group" in manifest.groups
+        assert (
+            manifest.semantic_models["semantic_model.test.semantic_people"].group == "some_group"
+        )
 
         new_enabled_config = {
             "semantic-models": {
@@ -143,6 +159,9 @@ class TestConfigProjectLevel:
         assert "semantic_model.test.semantic_people" not in manifest.semantic_models
         assert "semantic_model.test.semantic_people" in manifest.disabled
 
+        assert "group.test.some_group" in manifest.groups
+        assert "semantic_model.test.semantic_people" not in manifest.groups
+
 
 # Test inheritence - set configs at project and semantic_model level - expect semantic_model level to win
 class TestConfigsInheritence:
@@ -153,6 +172,7 @@ class TestConfigsInheritence:
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
             "semantic_models.yml": enabled_semantic_model_people_yml,
             "people_metrics.yml": models_people_metrics_yml,
+            "groups.yml": groups_yml,
         }
 
     @pytest.fixture(scope="class")

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -7,6 +7,7 @@ from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from dbt.contracts.graph.manifest import Manifest
 from dbt.events.base_types import BaseEvent
 from dbt.tests.util import write_file
+from tests.functional.assertions.test_runner import dbtTestRunner
 
 from tests.functional.semantic_models.fixtures import (
     schema_without_semantic_model_yml,

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -8,7 +8,7 @@ from dbt.contracts.graph.manifest import Manifest
 from dbt.events.base_types import BaseEvent
 from dbt.tests.util import write_file
 
-from .fixtures import (
+from tests.functional.semantic_models.fixtures import (
     schema_without_semantic_model_yml,
     fct_revenue_sql,
     metricflow_time_spine_sql,

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -7,105 +7,13 @@ from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from dbt.contracts.graph.manifest import Manifest
 from dbt.events.base_types import BaseEvent
 from dbt.tests.util import write_file
-from tests.functional.assertions.test_runner import dbtTestRunner
 
-schema_yml = """models:
-  - name: fct_revenue
-    description: This is the model fct_revenue. It should be able to use doc blocks
-
-semantic_models:
-  - name: revenue
-    description: This is the revenue semantic model. It should be able to use doc blocks
-    model: ref('fct_revenue')
-
-    defaults:
-      agg_time_dimension: ds
-
-    measures:
-      - name: txn_revenue
-        expr: revenue
-        agg: sum
-        agg_time_dimension: ds
-        create_metric: true
-      - name: sum_of_things
-        expr: 2
-        agg: sum
-        agg_time_dimension: ds
-      - name: has_revenue
-        expr: true
-        agg: sum_boolean
-        agg_time_dimension: ds
-      - name: discrete_order_value_p99
-        expr: order_total
-        agg: percentile
-        agg_time_dimension: ds
-        agg_params:
-          percentile: 0.99
-          use_discrete_percentile: True
-          use_approximate_percentile: False
-      - name: test_agg_params_optional_are_empty
-        expr: order_total
-        agg: percentile
-        agg_time_dimension: ds
-        agg_params:
-          percentile: 0.99
-      - name: test_non_additive
-        expr: txn_revenue
-        agg: sum
-        non_additive_dimension:
-          name: ds
-          window_choice: max
-
-    dimensions:
-      - name: ds
-        type: time
-        expr: created_at
-        type_params:
-          time_granularity: day
-
-    entities:
-      - name: user
-        type: foreign
-        expr: user_id
-      - name: id
-        type: primary
-
-metrics:
-  - name: simple_metric
-    label: Simple Metric
-    type: simple
-    type_params:
-      measure: sum_of_things
-"""
-
-schema_without_semantic_model_yml = """models:
-  - name: fct_revenue
-    description: This is the model fct_revenue. It should be able to use doc blocks
-"""
-
-fct_revenue_sql = """select
-  1 as id,
-  10 as user_id,
-  1000 as revenue,
-  current_timestamp as created_at"""
-
-metricflow_time_spine_sql = """
-with days as (
-    {{dbt_utils.date_spine('day'
-    , "to_date('01/01/2000','mm/dd/yyyy')"
-    , "to_date('01/01/2027','mm/dd/yyyy')"
-    )
-    }}
-),
-
-final as (
-    select cast(date_day as date) as date_day
-    from days
+from .fixtures import (
+    schema_without_semantic_model_yml,
+    fct_revenue_sql,
+    metricflow_time_spine_sql,
+    schema_yml,
 )
-
-select *
-from final
-"""
 
 
 class TestSemanticModelParsing:

--- a/tests/functional/semantic_models/test_semantic_models.py
+++ b/tests/functional/semantic_models/test_semantic_models.py
@@ -7,7 +7,7 @@ from dbt.tests.util import run_dbt
 
 from tests.functional.semantic_models.fixtures import (
     models_people_sql,
-    metricflow_time_spine_sql,
+    simple_metricflow_time_spine_sql,
     semantic_model_people_yml,
     models_people_metrics_yml,
 )
@@ -18,7 +18,7 @@ class TestSemanticModelDependsOn:
     def models(self):
         return {
             "people.sql": models_people_sql,
-            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "metricflow_time_spine.sql": simple_metricflow_time_spine_sql,
             "semantic_models.yml": semantic_model_people_yml,
             "people_metrics.yml": models_people_metrics_yml,
         }
@@ -41,7 +41,7 @@ class TestSemanticModelUnknownModel:
     def models(self):
         return {
             "not_people.sql": models_people_sql,
-            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "metricflow_time_spine.sql": simple_metricflow_time_spine_sql,
             "semantic_models.yml": semantic_model_people_yml,
             "people_metrics.yml": models_people_metrics_yml,
         }


### PR DESCRIPTION
resolves #7968 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  

### Problem

Semantic models cannot be enabled/disabled and also cannot belong to groups.

### Solution

Enable configs to allow semantic models to be disabled and be in groups.
When a semantic model is disabled but the defined metric for the measure is not, it throws a ParsingError.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
