### PR TITLE
Add return value to AdapterContainer.__init__ and AdapterMeta.__new__

### DIFF
--- a/.changes/unreleased/Under the Hood-20230830-140231.yaml
+++ b/.changes/unreleased/Under the Hood-20230830-140231.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Mypy errors - adapters/factory.py
+time: 2023-08-30T14:02:31.519929-04:00
+custom:
+  Author: gshank
+  Issue: "8387"

--- a/core/dbt/adapters/base/meta.py
+++ b/core/dbt/adapters/base/meta.py
@@ -93,7 +93,7 @@ class AdapterMeta(abc.ABCMeta):
     _available_: FrozenSet[str]
     _parse_replacements_: Dict[str, Callable]
 
-    def __new__(mcls, name, bases, namespace, **kwargs):
+    def __new__(mcls, name, bases, namespace, **kwargs) -> "AdapterMeta":
         # mypy does not like the `**kwargs`. But `ABCMeta` itself takes
         # `**kwargs` in its argspec here (and passes them to `type.__new__`.
         # I'm not sure there is any benefit to it after poking around a bit,

--- a/core/dbt/adapters/factory.py
+++ b/core/dbt/adapters/factory.py
@@ -19,7 +19,7 @@ Adapter = AdapterProtocol
 
 
 class AdapterContainer:
-    def __init__(self):
+    def __init__(self) -> None:
         self.lock = threading.Lock()
         self.adapters: Dict[str, Adapter] = {}
         self.plugins: Dict[str, AdapterPlugin] = {}


### PR DESCRIPTION
resolves #8397

### Problem

Mypy warnings because of lack of return value for functions.

### Solution

Adds return values.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
