### PR TITLE
Support dbt-cloud config dict in dbt_project.yml

### DIFF
--- a/.changes/unreleased/Features-20230830-212828.yaml
+++ b/.changes/unreleased/Features-20230830-212828.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Accept a `dbt-cloud` config in dbt_project.yml
+time: 2023-08-30T21:28:28.976746-05:00
+custom:
+  Author: emmyoop
+  Issue: "8438"

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -429,6 +429,7 @@ class PartialProject(RenderComponents):
         semantic_models: Dict[str, Any]
         exposures: Dict[str, Any]
         vars_value: VarProvider
+        dbt_cloud: Dict[str, Any]
 
         dispatch = cfg.dispatch
         models = cfg.models
@@ -461,6 +462,8 @@ class PartialProject(RenderComponents):
             manifest_selectors = SelectorDict.parse_from_selectors_list(
                 rendered.selectors_dict["selectors"]
             )
+        dbt_cloud = cfg.dbt_cloud
+
         project = Project(
             project_name=name,
             version=version,
@@ -501,6 +504,7 @@ class PartialProject(RenderComponents):
             unrendered=unrendered,
             project_env_vars=project_env_vars,
             restrict_access=cfg.restrict_access,
+            dbt_cloud=dbt_cloud,
         )
         # sanity check - this means an internal issue
         project.validate()
@@ -613,6 +617,7 @@ class Project:
     unrendered: RenderComponents
     project_env_vars: Dict[str, Any]
     restrict_access: bool
+    dbt_cloud: Dict[str, Any]
 
     @property
     def all_source_paths(self) -> List[str]:
@@ -683,6 +688,7 @@ class Project:
                 "require-dbt-version": [v.to_version_string() for v in self.dbt_version],
                 "config-version": self.config_version,
                 "restrict-access": self.restrict_access,
+                "dbt-cloud": self.dbt_cloud,
             }
         )
         if self.query_comment:

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -183,6 +183,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
             args=args,
             cli_vars=cli_vars,
             dependencies=dependencies,
+            dbt_cloud=project.dbt_cloud,
         )
 
     # Called by 'load_projects' in this class

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -225,6 +225,7 @@ class Project(dbtClassMixin, Replaceable):
     packages: List[PackageSpec] = field(default_factory=list)
     query_comment: Optional[Union[QueryComment, NoValue, str]] = field(default_factory=NoValue)
     restrict_access: bool = False
+    dbt_cloud: Dict[str, Any] = field(default_factory=dict)
 
     class Config(dbtMashConfig):
         # These tell mashumaro to use aliases for jsonschema and for "from_dict"
@@ -251,6 +252,7 @@ class Project(dbtClassMixin, Replaceable):
             "query_comment": "query-comment",
             "restrict_access": "restrict-access",
             "semantic_models": "semantic-models",
+            "dbt_cloud": "dbt-cloud",
         }
 
     @classmethod

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -225,7 +225,7 @@ class Project(dbtClassMixin, Replaceable):
     packages: List[PackageSpec] = field(default_factory=list)
     query_comment: Optional[Union[QueryComment, NoValue, str]] = field(default_factory=NoValue)
     restrict_access: bool = False
-    dbt_cloud: Dict[str, Any] = field(default_factory=dict)
+    dbt_cloud: Optional[Dict[str, Any]] = None
 
     class Config(dbtMashConfig):
         # These tell mashumaro to use aliases for jsonschema and for "from_dict"
@@ -270,6 +270,10 @@ class Project(dbtClassMixin, Replaceable):
                     or not isinstance(entry["search_order"], list)
                 ):
                     raise ValidationError(f"Invalid project dispatch config: {entry}")
+        if "dbt_cloud" in data and not isinstance(data["dbt_cloud"], dict):
+            raise ValidationError(
+                f"Invalid dbt_cloud config. Expected a 'dict' but got '{type(data['dbt_cloud'])}'"
+            )
 
 
 @dataclass

--- a/tests/functional/basic/test_project.py
+++ b/tests/functional/basic/test_project.py
@@ -1,5 +1,8 @@
+import os
 import pytest
-from dbt.tests.util import run_dbt, update_config_file
+import yaml
+from pathlib import Path
+from dbt.tests.util import run_dbt, update_config_file, write_config_file
 from dbt.exceptions import ProjectContractError
 
 
@@ -62,3 +65,61 @@ class TestProjectYamlVersionInvalid:
         assert "at path ['version']: 'invalid' is not valid under any of the given schemas" in str(
             excinfo.value
         )
+
+
+class TestProjectDbtCloudConfig:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"simple_model.sql": simple_model_sql, "simple_model.yml": simple_model_yml}
+
+    # @pytest.fixture(scope="class")
+    # def project_config_update(self):
+    #     return {
+    #         "dbt-cloud": {
+    #             "account_id": "123",
+    #             "application": "test",
+    #             "environment": "test",
+    #             "api_key": "test",
+    #         }
+    #     }
+
+    def test_dbt_cloud(self, project):
+        run_dbt(["parse"], expect_pass=True)
+        conf = yaml.safe_load(
+            Path(os.path.join(project.project_root, "dbt_project.yml")).read_text()
+        )
+        assert conf == {"name": "test", "profile": "test"}
+
+        config = {
+            "name": "test",
+            "profile": "test",
+            "dbt-cloud": {
+                "account_id": "123",
+                "application": "test",
+                "environment": "test",
+                "api_key": "test",
+            },
+        }
+        write_config_file(config, project.project_root, "dbt_project.yml")
+        run_dbt(["parse"], expect_pass=True)
+        conf = yaml.safe_load(
+            Path(os.path.join(project.project_root, "dbt_project.yml")).read_text()
+        )
+        assert conf == config
+
+
+class TestProjectDbtCloudConfigString:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"simple_model.sql": simple_model_sql, "simple_model.yml": simple_model_yml}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"dbt-cloud": "Some string"}
+
+    def test_dbt_cloud(self, project):
+        expected_err = (
+            "at path ['dbt-cloud']: 'Some string' is not valid under any of the given schemas"
+        )
+        with pytest.raises(ProjectContractError, match=expected_err):
+            run_dbt()

--- a/tests/functional/basic/test_project.py
+++ b/tests/functional/basic/test_project.py
@@ -72,17 +72,6 @@ class TestProjectDbtCloudConfig:
     def models(self):
         return {"simple_model.sql": simple_model_sql, "simple_model.yml": simple_model_yml}
 
-    # @pytest.fixture(scope="class")
-    # def project_config_update(self):
-    #     return {
-    #         "dbt-cloud": {
-    #             "account_id": "123",
-    #             "application": "test",
-    #             "environment": "test",
-    #             "api_key": "test",
-    #         }
-    #     }
-
     def test_dbt_cloud(self, project):
         run_dbt(["parse"], expect_pass=True)
         conf = yaml.safe_load(
@@ -113,13 +102,13 @@ class TestProjectDbtCloudConfigString:
     def models(self):
         return {"simple_model.sql": simple_model_sql, "simple_model.yml": simple_model_yml}
 
-    @pytest.fixture(scope="class")
-    def project_config_update(self):
-        return {"dbt-cloud": "Some string"}
-
-    def test_dbt_cloud(self, project):
+    def test_dbt_cloud_invalid(self, project):
+        run_dbt()
+        config = {"name": "test", "profile": "test", "dbt-cloud": "Some string"}
+        update_config_file(config, "dbt_project.yml")
         expected_err = (
             "at path ['dbt-cloud']: 'Some string' is not valid under any of the given schemas"
         )
-        with pytest.raises(ProjectContractError, match=expected_err):
+        with pytest.raises(ProjectContractError) as excinfo:
             run_dbt()
+        assert expected_err in str(excinfo.value)


### PR DESCRIPTION
resolves #8438 
[doc] TBD

### Problem

Need ability to add arbitrary configs to dbt_project.yml.
### Solution

Add `dbt-cloud` config to `dbt_project.yml`.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
