### PR TITLE
make UnparsedVersion.__lt__ order-agnostic

### DIFF
--- a/.changes/unreleased/Fixes-20230906-142213.yaml
+++ b/.changes/unreleased/Fixes-20230906-142213.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: make version comparison insensitive to order
+time: 2023-09-06T14:22:13.114549-04:00
+custom:
+  Author: michelleark
+  Issue: "8571"

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -150,14 +150,9 @@ class UnparsedVersion(dbtClassMixin):
 
     def __lt__(self, other):
         try:
-            v = type(other.v)(self.v)
-            return v < other.v
+            return float(self.v) < float(other.v)
         except ValueError:
-            try:
-                other_v = type(self.v)(other.v)
-                return self.v < other_v
-            except ValueError:
-                return str(self.v) < str(other.v)
+            return str(self.v) < str(other.v)
 
     @property
     def include_exclude(self) -> dbt.helper_types.IncludeExclude:

--- a/tests/unit/test_contracts_graph_unparsed.py
+++ b/tests/unit/test_contracts_graph_unparsed.py
@@ -1,5 +1,6 @@
-import pickle
 from datetime import timedelta
+import pickle
+import pytest
 
 from dbt.contracts.graph.unparsed import (
     UnparsedNode,
@@ -928,3 +929,25 @@ class TestUnparsedVersion(ContractTestCase):
         version = self.get_ok_dict()
         del version["v"]
         self.assert_fails_validation(version)
+
+
+@pytest.mark.parametrize(
+    "left,right,expected_lt",
+    [
+        # same types
+        (2, 12, True),
+        (12, 2, False),
+        ("a", "b", True),
+        ("b", "a", False),
+        # mismatched types - numeric
+        (2, 12.0, True),
+        (12.0, 2, False),
+        (2, "12", True),
+        ("12", 2, False),
+        # mismatched types
+        (1, "test", True),
+        ("test", 1, False),
+    ],
+)
+def test_unparsed_version_lt(left, right, expected_lt):
+    assert (UnparsedVersion(left) < UnparsedVersion(right)) == expected_lt

--- a/tests/unit/test_graph_selector_methods.py
+++ b/tests/unit/test_graph_selector_methods.py
@@ -639,6 +639,21 @@ def versioned_model_v3(seed):
 
 
 @pytest.fixture
+def versioned_model_v12_string(seed):
+    return make_model(
+        "pkg",
+        "versioned_model",
+        'select * from {{ ref("seed") }}',
+        config_kwargs={"materialized": "table"},
+        refs=[seed],
+        sources=[],
+        path="subdirectory/versioned_model_v12.sql",
+        version="12",
+        latest_version=2,
+    )
+
+
+@pytest.fixture
 def versioned_model_v4_nested_dir(seed):
     return make_model(
         "pkg",
@@ -732,6 +747,7 @@ def manifest(
     versioned_model_v2,
     versioned_model_v3,
     versioned_model_v4_nested_dir,
+    versioned_model_v12_string,
     ext_source_2,
     ext_source_other,
     ext_source_other_2,
@@ -760,6 +776,7 @@ def manifest(
         versioned_model_v2,
         versioned_model_v3,
         versioned_model_v4_nested_dir,
+        versioned_model_v12_string,
         ext_model,
         table_id_unique,
         table_id_not_null,
@@ -823,6 +840,7 @@ def test_select_fqn(manifest):
         "versioned_model.v2",
         "versioned_model.v3",
         "versioned_model.v4",
+        "versioned_model.v12",
         "table_model",
         "table_model_py",
         "table_model_csv",
@@ -840,6 +858,7 @@ def test_select_fqn(manifest):
         "versioned_model.v2",
         "versioned_model.v3",
         "versioned_model.v4",
+        "versioned_model.v12",
     }
     assert search_manifest_using_method(manifest, method, "versioned_model.v1") == {
         "versioned_model.v1"
@@ -1051,6 +1070,7 @@ def test_select_package(manifest):
         "versioned_model.v2",
         "versioned_model.v3",
         "versioned_model.v4",
+        "versioned_model.v12",
         "table_model",
         "table_model_py",
         "table_model_csv",
@@ -1103,6 +1123,7 @@ def test_select_config_materialized(manifest):
         "versioned_model.v2",
         "versioned_model.v3",
         "versioned_model.v4",
+        "versioned_model.v12",
         "mynamespace.union_model",
     }
 
@@ -1189,6 +1210,7 @@ def test_select_version(manifest):
     assert search_manifest_using_method(manifest, method, "prerelease") == {
         "versioned_model.v3",
         "versioned_model.v4",
+        "versioned_model.v12",
     }
     assert search_manifest_using_method(manifest, method, "none") == {
         "table_model_py",


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/8571
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

The current implementation of [UnparsedVersion.__lt](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/contracts/graph/unparsed.py#L151-L160)__ is sensitive to the order of arguments, leading to surprising behaviour such as:
```
>>> from dbt.contracts.graph.unparsed import UnparsedVersion
>>> UnparsedVersion(12) < UnparsedVersion("2")
True
>>> UnparsedVersion(12) > UnparsedVersion("2")
True
```

The root cause is that UnparsedVersion.__lt__ first attempts to cast `self.v` to `other`'s type in order to do the comparison, and if that fails then attempts to cast `other.v` to `self` type. This means that casting may work in some directions but not others and result in different comparison methods (e.g. numeric vs alphabetic) depending on which input is `self` and which is `other`. 

### Solution

`UnparsedVersion.v` is either `float` or `str`. Simplify the lt implementation to just try to cast both inputs to floats and do a numeric comparison, falling back to `str` if this is not posssible -- making the method insensitive to order but more tightly coupled to the type of `UnparsedVersion.v` 

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX