### PR TITLE
Er/retry numbers

### DIFF
--- a/.changes/unreleased/Fixes-20230803-093502.yaml
+++ b/.changes/unreleased/Fixes-20230803-093502.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add explicit support for integers for the show command
+time: 2023-08-03T09:35:02.163968-05:00
+custom:
+  Author: dave-connors-3
+  Issue: "8153"

--- a/core/dbt/clients/agate_helper.py
+++ b/core/dbt/clients/agate_helper.py
@@ -12,6 +12,17 @@ from dbt.exceptions import DbtRuntimeError
 BOM = BOM_UTF8.decode("utf-8")  # '\ufeff'
 
 
+class Integer(agate.data_types.DataType):
+    def cast(self, d):
+        if type(d) == int:
+            return d
+        else:
+            raise agate.exceptions.CastError('Can not parse value "%s" as Integer.' % d)
+
+    def jsonify(self, d):
+        return d
+
+
 class Number(agate.data_types.Number):
     # undo the change in https://github.com/wireservice/agate/pull/733
     # i.e. do not cast True and False to numeric 1 and 0
@@ -47,6 +58,7 @@ def build_type_tester(
 ) -> agate.TypeTester:
 
     types = [
+        Integer(null_values=("null", "")),
         Number(null_values=("null", "")),
         agate.data_types.Date(null_values=("null", ""), date_format="%Y-%m-%d"),
         agate.data_types.DateTime(null_values=("null", ""), datetime_format="%Y-%m-%d %H:%M:%S"),

--- a/core/dbt/clients/agate_helper.py
+++ b/core/dbt/clients/agate_helper.py
@@ -177,6 +177,13 @@ class ColumnTypeBuilder(Dict[str, NullableAgateType]):
         elif isinstance(value, _NullMarker):
             # use the existing value
             return
+        # when one table column is Number while another is Integer, let the column become Number on merge
+        elif isinstance(value, Integer) and isinstance(existing_type, agate.data_types.Number):
+            # use the existing value
+            return
+        elif isinstance(existing_type, Integer) and isinstance(value, agate.data_types.Number):
+            # overwrite
+            super().__setitem__(key, value)
         elif not isinstance(value, type(existing_type)):
             # actual type mismatch!
             raise DbtRuntimeError(

--- a/tests/functional/show/fixtures.py
+++ b/tests/functional/show/fixtures.py
@@ -2,6 +2,14 @@ models__sample_model = """
 select * from {{ ref('sample_seed') }}
 """
 
+models__sample_number_model = """
+select
+  cast(1.0 as int) as float_to_int_field,
+  3.0 as float_field,
+  4.3 as float_with_dec_field,
+  5 as int_field
+"""
+
 models__second_model = """
 select
     sample_num as col_one,

--- a/tests/functional/show/test_show.py
+++ b/tests/functional/show/test_show.py
@@ -6,6 +6,7 @@ from tests.functional.show.fixtures import (
     models__second_ephemeral_model,
     seeds__sample_seed,
     models__sample_model,
+    models__sample_number_model,
     models__second_model,
     models__ephemeral_model,
     schema_yml,
@@ -14,11 +15,12 @@ from tests.functional.show.fixtures import (
 )
 
 
-class BaseTestShow:
+class TestShow:
     @pytest.fixture(scope="class")
     def models(self):
         return {
             "sample_model.sql": models__sample_model,
+            "sample_number_model.sql": models__sample_number_model,
             "second_model.sql": models__second_model,
             "ephemeral_model.sql": models__ephemeral_model,
             "sql_header.sql": models__sql_header,
@@ -28,8 +30,6 @@ class BaseTestShow:
     def seeds(self):
         return {"sample_seed.csv": seeds__sample_seed}
 
-
-class TestNone(BaseTestShow):
     def test_none(self, project):
         with pytest.raises(
             DbtRuntimeError, match="Either --select or --inline must be passed to show"
@@ -37,8 +37,6 @@ class TestNone(BaseTestShow):
             run_dbt(["seed"])
             run_dbt(["show"])
 
-
-class TestSelectModelText(BaseTestShow):
     def test_select_model_text(self, project):
         run_dbt(["build"])
         (results, log_output) = run_dbt_and_capture(["show", "--select", "second_model"])
@@ -48,8 +46,6 @@ class TestSelectModelText(BaseTestShow):
         assert "col_two" in log_output
         assert "answer" in log_output
 
-
-class TestSelectMultModelText(BaseTestShow):
     def test_select_multiple_model_text(self, project):
         run_dbt(["build"])
         (results, log_output) = run_dbt_and_capture(
@@ -59,8 +55,6 @@ class TestSelectMultModelText(BaseTestShow):
         assert "sample_num" in log_output
         assert "sample_bool" in log_output
 
-
-class TestSelectSingleMultModelJson(BaseTestShow):
     def test_select_single_model_json(self, project):
         run_dbt(["build"])
         (results, log_output) = run_dbt_and_capture(
@@ -70,8 +64,19 @@ class TestSelectSingleMultModelJson(BaseTestShow):
         assert "sample_num" in log_output
         assert "sample_bool" in log_output
 
+    def test_numeric_values(self, project):
+        run_dbt(["build"])
+        (results, log_output) = run_dbt_and_capture(
+            ["show", "--select", "sample_number_model", "--output", "json"]
+        )
+        assert "Previewing node 'sample_number_model'" not in log_output
+        assert "1.0" not in log_output
+        assert "1" in log_output
+        assert "3.0" in log_output
+        assert "4.3" in log_output
+        assert "5" in log_output
+        assert "5.0" not in log_output
 
-class TestInlinePass(BaseTestShow):
     def test_inline_pass(self, project):
         run_dbt(["build"])
         (results, log_output) = run_dbt_and_capture(
@@ -81,8 +86,6 @@ class TestInlinePass(BaseTestShow):
         assert "sample_num" in log_output
         assert "sample_bool" in log_output
 
-
-class TestShowExceptions(BaseTestShow):
     def test_inline_fail(self, project):
         with pytest.raises(DbtException, match="Error parsing inline query"):
             run_dbt(["show", "--inline", "select * from {{ ref('third_model') }}"])
@@ -91,8 +94,6 @@ class TestShowExceptions(BaseTestShow):
         with pytest.raises(DbtRuntimeError, match="Database Error"):
             run_dbt(["show", "--inline", "slect asdlkjfsld;j"])
 
-
-class TestEphemeralModels(BaseTestShow):
     def test_ephemeral_model(self, project):
         run_dbt(["build"])
         (results, log_output) = run_dbt_and_capture(["show", "--select", "ephemeral_model"])
@@ -105,8 +106,6 @@ class TestEphemeralModels(BaseTestShow):
         )
         assert "col_hundo" in log_output
 
-
-class TestLimit(BaseTestShow):
     @pytest.mark.parametrize(
         "args,expected",
         [
@@ -121,14 +120,10 @@ class TestLimit(BaseTestShow):
         results, log_output = run_dbt_and_capture(dbt_args)
         assert len(results.results[0].agate_table) == expected
 
-
-class TestSeed(BaseTestShow):
     def test_seed(self, project):
         (results, log_output) = run_dbt_and_capture(["show", "--select", "sample_seed"])
         assert "Previewing node 'sample_seed'" in log_output
 
-
-class TestSqlHeader(BaseTestShow):
     def test_sql_header(self, project):
         run_dbt(["build"])
         (results, log_output) = run_dbt_and_capture(["show", "--select", "sql_header"])

--- a/tests/unit/test_agate_helper.py
+++ b/tests/unit/test_agate_helper.py
@@ -121,37 +121,37 @@ class TestAgateHelper(unittest.TestCase):
             self.assertEqual(tbl[0][0], expected)
 
     def test_merge_allnull(self):
-        t1 = agate.Table([(1, "a", None), (2, "b", None)], ("a", "b", "c"))
-        t2 = agate.Table([(3, "c", None), (4, "d", None)], ("a", "b", "c"))
+        t1 = agate_helper.table_from_rows([(1, "a", None), (2, "b", None)], ("a", "b", "c"))
+        t2 = agate_helper.table_from_rows([(3, "c", None), (4, "d", None)], ("a", "b", "c"))
         result = agate_helper.merge_tables([t1, t2])
         self.assertEqual(result.column_names, ("a", "b", "c"))
-        assert isinstance(result.column_types[0], agate.data_types.Number)
+        assert isinstance(result.column_types[0], agate_helper.Integer)
         assert isinstance(result.column_types[1], agate.data_types.Text)
         assert isinstance(result.column_types[2], agate.data_types.Number)
         self.assertEqual(len(result), 4)
 
     def test_merge_mixed(self):
-        t1 = agate.Table([(1, "a", None), (2, "b", None)], ("a", "b", "c"))
-        t2 = agate.Table([(3, "c", "dog"), (4, "d", "cat")], ("a", "b", "c"))
-        t3 = agate.Table([(3, "c", None), (4, "d", None)], ("a", "b", "c"))
+        t1 = agate_helper.table_from_rows([(1, "a", None), (2, "b", None)], ("a", "b", "c"))
+        t2 = agate_helper.table_from_rows([(3, "c", "dog"), (4, "d", "cat")], ("a", "b", "c"))
+        t3 = agate_helper.table_from_rows([(3, "c", None), (4, "d", None)], ("a", "b", "c"))
 
         result = agate_helper.merge_tables([t1, t2])
         self.assertEqual(result.column_names, ("a", "b", "c"))
-        assert isinstance(result.column_types[0], agate.data_types.Number)
+        assert isinstance(result.column_types[0], agate_helper.Integer)
         assert isinstance(result.column_types[1], agate.data_types.Text)
         assert isinstance(result.column_types[2], agate.data_types.Text)
         self.assertEqual(len(result), 4)
 
         result = agate_helper.merge_tables([t2, t3])
         self.assertEqual(result.column_names, ("a", "b", "c"))
-        assert isinstance(result.column_types[0], agate.data_types.Number)
+        assert isinstance(result.column_types[0], agate_helper.Integer)
         assert isinstance(result.column_types[1], agate.data_types.Text)
         assert isinstance(result.column_types[2], agate.data_types.Text)
         self.assertEqual(len(result), 4)
 
         result = agate_helper.merge_tables([t1, t2, t3])
         self.assertEqual(result.column_names, ("a", "b", "c"))
-        assert isinstance(result.column_types[0], agate.data_types.Number)
+        assert isinstance(result.column_types[0], agate_helper.Integer)
         assert isinstance(result.column_types[1], agate.data_types.Text)
         assert isinstance(result.column_types[2], agate.data_types.Text)
         self.assertEqual(len(result), 6)
@@ -191,7 +191,7 @@ class TestAgateHelper(unittest.TestCase):
         self.assertEqual(len(tbl), len(result_set))
 
         assert isinstance(tbl.column_types[0], agate.data_types.Boolean)
-        assert isinstance(tbl.column_types[1], agate.data_types.Number)
+        assert isinstance(tbl.column_types[1], agate_helper.Integer)
 
         expected = [
             [True, Decimal(1)],

--- a/tests/unit/test_agate_helper.py
+++ b/tests/unit/test_agate_helper.py
@@ -131,29 +131,46 @@ class TestAgateHelper(unittest.TestCase):
         self.assertEqual(len(result), 4)
 
     def test_merge_mixed(self):
-        t1 = agate_helper.table_from_rows([(1, "a", None), (2, "b", None)], ("a", "b", "c"))
-        t2 = agate_helper.table_from_rows([(3, "c", "dog"), (4, "d", "cat")], ("a", "b", "c"))
-        t3 = agate_helper.table_from_rows([(3, "c", None), (4, "d", None)], ("a", "b", "c"))
+        t1 = agate_helper.table_from_rows(
+            [(1, "a", None, None), (2, "b", None, None)], ("a", "b", "c", "d")
+        )
+        t2 = agate_helper.table_from_rows(
+            [(3, "c", "dog", 1), (4, "d", "cat", 5)], ("a", "b", "c", "d")
+        )
+        t3 = agate_helper.table_from_rows(
+            [(3, "c", None, 1.5), (4, "d", None, 3.5)], ("a", "b", "c", "d")
+        )
 
         result = agate_helper.merge_tables([t1, t2])
-        self.assertEqual(result.column_names, ("a", "b", "c"))
+        self.assertEqual(result.column_names, ("a", "b", "c", "d"))
         assert isinstance(result.column_types[0], agate_helper.Integer)
         assert isinstance(result.column_types[1], agate.data_types.Text)
         assert isinstance(result.column_types[2], agate.data_types.Text)
+        assert isinstance(result.column_types[3], agate_helper.Integer)
+        self.assertEqual(len(result), 4)
+
+        result = agate_helper.merge_tables([t1, t3])
+        self.assertEqual(result.column_names, ("a", "b", "c", "d"))
+        assert isinstance(result.column_types[0], agate_helper.Integer)
+        assert isinstance(result.column_types[1], agate.data_types.Text)
+        assert isinstance(result.column_types[2], agate.data_types.Number)
+        assert isinstance(result.column_types[3], agate.data_types.Number)
         self.assertEqual(len(result), 4)
 
         result = agate_helper.merge_tables([t2, t3])
-        self.assertEqual(result.column_names, ("a", "b", "c"))
+        self.assertEqual(result.column_names, ("a", "b", "c", "d"))
         assert isinstance(result.column_types[0], agate_helper.Integer)
         assert isinstance(result.column_types[1], agate.data_types.Text)
         assert isinstance(result.column_types[2], agate.data_types.Text)
+        assert isinstance(result.column_types[3], agate.data_types.Number)
         self.assertEqual(len(result), 4)
 
         result = agate_helper.merge_tables([t1, t2, t3])
-        self.assertEqual(result.column_names, ("a", "b", "c"))
+        self.assertEqual(result.column_names, ("a", "b", "c", "d"))
         assert isinstance(result.column_types[0], agate_helper.Integer)
         assert isinstance(result.column_types[1], agate.data_types.Text)
         assert isinstance(result.column_types[2], agate.data_types.Text)
+        assert isinstance(result.column_types[3], agate.data_types.Number)
         self.assertEqual(len(result), 6)
 
     def test_nocast_string_types(self):


### PR DESCRIPTION
resolves #8153 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  

### Problem
Agate tables, which power dbt show, and therefore the dbt cloud IDE, show integer values as decimals, leading to user confusion when columns seem to have decimals when they don't! this overrides that behavior in the dbt-core customization of the agate Number class

### Solution
Ensure that the Number.cast() and Number.jsonify() methods properly handle integer values.
Also ensure it handles table merges appropriately.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
