### PR TITLE
Fix #8398: Add typing to __init__ in base.py

### DIFF
--- a/.changes/unreleased/Under the Hood-20230906-164901.yaml
+++ b/.changes/unreleased/Under the Hood-20230906-164901.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add typing to __init__ in base.py
+time: 2023-09-06T16:49:01.150713+01:00
+custom:
+  Author: aranke
+  Issue: "8398"

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -193,7 +193,7 @@ class ExecutionContext:
 
 
 class BaseRunner(metaclass=ABCMeta):
-    def __init__(self, config, adapter, node, node_index, num_nodes):
+    def __init__(self, config, adapter, node, node_index, num_nodes) -> None:
         self.config = config
         self.adapter = adapter
         self.node = node


### PR DESCRIPTION
resolves #8398 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

`__init__` in `base.py` was untyped.

### Solution

Add a return type of `None` to `__init__` in `base.py`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
