### PR TITLE
Unskip and rename test_expression_metric

### DIFF
--- a/.changes/unreleased/Fixes-20230906-120212.yaml
+++ b/.changes/unreleased/Fixes-20230906-120212.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Update metric helper functions to work with new semantic layer metrics
+time: 2023-09-06T12:02:12.156534-07:00
+custom:
+  Author: QMalcolm
+  Issue: "8134"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -618,7 +618,7 @@ class RuntimeMetricResolver(BaseMetricResolver):
                 target_package=target_package,
             )
 
-        return ResolvedMetricReference(target_metric, self.manifest, self.Relation)
+        return ResolvedMetricReference(target_metric, self.manifest)
 
 
 # `var` implementations.

--- a/core/dbt/contracts/graph/metrics.py
+++ b/core/dbt/contracts/graph/metrics.py
@@ -66,12 +66,11 @@ class ResolvedMetricReference(MetricReference):
         """
         if metric_node.type in DERIVED_METRICS:
             yield {metric_node.name: metric_depth_count}
-            metric_depth_count = metric_depth_count + 1
 
-        for parent_unique_id in metric_node.depends_on.nodes:
-            metric = manifest.metrics.get(parent_unique_id)
-            if metric is not None and metric.type in DERIVED_METRICS:
-                yield from cls.reverse_dag_parsing(metric, manifest, metric_depth_count)
+            for parent_unique_id in metric_node.depends_on.nodes:
+                metric = manifest.metrics.get(parent_unique_id)
+                if metric is not None:
+                    yield from cls.reverse_dag_parsing(metric, manifest, metric_depth_count + 1)
 
     def full_metric_dependency(self):
         """Returns a unique list of all upstream metric names."""

--- a/core/dbt/contracts/graph/metrics.py
+++ b/core/dbt/contracts/graph/metrics.py
@@ -31,6 +31,7 @@ class ResolvedMetricReference(MetricReference):
 
     @classmethod
     def parent_metrics(cls, metric_node, manifest):
+        """For a given metric, yeilds all upstream metrics."""
         yield metric_node
 
         for parent_unique_id in metric_node.depends_on.nodes:
@@ -40,6 +41,7 @@ class ResolvedMetricReference(MetricReference):
 
     @classmethod
     def parent_metrics_names(cls, metric_node, manifest):
+        """For a given metric, yeilds all upstream metric names"""
         yield metric_node.name
 
         for parent_unique_id in metric_node.depends_on.nodes:
@@ -49,6 +51,10 @@ class ResolvedMetricReference(MetricReference):
 
     @classmethod
     def reverse_dag_parsing(cls, metric_node, manifest, metric_depth_count):
+        """For the given metric, yeilds dictionaries having {<metric_name>: <depth_from_initial_metric} of upstream derived metrics.
+
+        This function is intended as a helper function for other metric helper functions.
+        """
         if metric_node.calculation_method == "derived":
             yield {metric_node.name: metric_depth_count}
             metric_depth_count = metric_depth_count + 1
@@ -63,10 +69,12 @@ class ResolvedMetricReference(MetricReference):
                 yield from cls.reverse_dag_parsing(node, manifest, metric_depth_count)
 
     def full_metric_dependency(self):
+        """Returns a unique list of all upstream metric names."""
         to_return = list(set(self.parent_metrics_names(self.node, self.manifest)))
         return to_return
 
     def base_metric_dependency(self):
+        """Returns a list of names for all upstream non-derived metrics."""
         in_scope_metrics = list(self.parent_metrics(self.node, self.manifest))
 
         to_return = []
@@ -77,6 +85,7 @@ class ResolvedMetricReference(MetricReference):
         return to_return
 
     def derived_metric_dependency(self):
+        """Returns a list of names for all upstream derived metrics."""
         in_scope_metrics = list(self.parent_metrics(self.node, self.manifest))
 
         to_return = []
@@ -87,6 +96,7 @@ class ResolvedMetricReference(MetricReference):
         return to_return
 
     def derived_metric_dependency_depth(self):
+        """Returns a list of {<metric_name>: <depth_from_initial_metric>} for all upstream metrics."""
         metric_depth_count = 1
         to_return = list(self.reverse_dag_parsing(self.node, self.manifest, metric_depth_count))
 

--- a/core/dbt/contracts/graph/metrics.py
+++ b/core/dbt/contracts/graph/metrics.py
@@ -41,9 +41,9 @@ class ResolvedMetricReference(MetricReference):
         yield metric_node
 
         for parent_unique_id in metric_node.depends_on.nodes:
-            metric = manifest.metrics.get(parent_unique_id)
-            if metric is not None:
-                yield from cls.parent_metrics(metric, manifest)
+            node = manifest.expect(parent_unique_id)
+            if isinstance(node, Metric):
+                yield from cls.parent_metrics(node, manifest)
 
     @classmethod
     def parent_metrics_names(cls, metric_node: Metric, manifest: Manifest) -> Iterator[str]:
@@ -63,9 +63,9 @@ class ResolvedMetricReference(MetricReference):
             yield {metric_node.name: metric_depth_count}
 
             for parent_unique_id in metric_node.depends_on.nodes:
-                metric = manifest.metrics.get(parent_unique_id)
-                if metric is not None:
-                    yield from cls.reverse_dag_parsing(metric, manifest, metric_depth_count + 1)
+                node = manifest.expect(parent_unique_id)
+                if isinstance(node, Metric):
+                    yield from cls.reverse_dag_parsing(node, manifest, metric_depth_count + 1)
 
     def full_metric_dependency(self):
         """Returns a unique list of all upstream metric names."""

--- a/core/dbt/contracts/graph/metrics.py
+++ b/core/dbt/contracts/graph/metrics.py
@@ -24,11 +24,10 @@ class ResolvedMetricReference(MetricReference):
     for working with metrics (ie. __str__ and templating functions)
     """
 
-    def __init__(self, node: Metric, manifest: Manifest, Relation=None):
+    def __init__(self, node: Metric, manifest: Manifest):
         super().__init__(node.name, node.package_name)
         self.node = node
         self.manifest = manifest
-        self.Relation = Relation
 
     def __getattr__(self, key):
         return getattr(self.node, key)

--- a/core/dbt/contracts/graph/metrics.py
+++ b/core/dbt/contracts/graph/metrics.py
@@ -2,7 +2,7 @@ from dbt.node_types import NodeType
 from dbt.contracts.graph.manifest import Manifest, Metric
 from dbt_semantic_interfaces.type_enums import MetricType
 
-from typing import Dict, Iterator
+from typing import Dict, Iterator, List
 
 
 DERIVED_METRICS = [MetricType.DERIVED, MetricType.RATIO]
@@ -79,24 +79,24 @@ class ResolvedMetricReference(MetricReference):
         to_return = list(set(self.parent_metrics_names(self.node, self.manifest)))
         return to_return
 
-    def base_metric_dependency(self):
+    def base_metric_dependency(self) -> List[str]:
         """Returns a list of names for all upstream non-derived metrics."""
         in_scope_metrics = list(self.parent_metrics(self.node, self.manifest))
 
         to_return = []
         for metric in in_scope_metrics:
-            if metric.calculation_method != "derived" and metric.name not in to_return:
+            if metric.type not in DERIVED_METRICS and metric.name not in to_return:
                 to_return.append(metric.name)
 
         return to_return
 
-    def derived_metric_dependency(self):
+    def derived_metric_dependency(self) -> List[str]:
         """Returns a list of names for all upstream derived metrics."""
         in_scope_metrics = list(self.parent_metrics(self.node, self.manifest))
 
         to_return = []
         for metric in in_scope_metrics:
-            if metric.calculation_method == "derived" and metric.name not in to_return:
+            if metric.type in DERIVED_METRICS and metric.name not in to_return:
                 to_return.append(metric.name)
 
         return to_return

--- a/core/dbt/contracts/graph/metrics.py
+++ b/core/dbt/contracts/graph/metrics.py
@@ -38,7 +38,7 @@ class ResolvedMetricReference(MetricReference):
         return f"{self.node.name}"
 
     @classmethod
-    def parent_metrics(cls, metric_node, manifest):
+    def parent_metrics(cls, metric_node: Metric, manifest: Manifest) -> Iterator[Metric]:
         """For a given metric, yeilds all upstream metrics."""
         yield metric_node
 
@@ -48,7 +48,7 @@ class ResolvedMetricReference(MetricReference):
                 yield from cls.parent_metrics(node, manifest)
 
     @classmethod
-    def parent_metrics_names(cls, metric_node, manifest):
+    def parent_metrics_names(cls, metric_node: Metric, manifest: Manifest) -> Iterator[str]:
         """For a given metric, yeilds all upstream metric names"""
         yield metric_node.name
 

--- a/core/dbt/contracts/graph/metrics.py
+++ b/core/dbt/contracts/graph/metrics.py
@@ -97,7 +97,7 @@ class ResolvedMetricReference(MetricReference):
 
         return list(derived_metrics)
 
-    def derived_metric_dependency_depth(self):
+    def derived_metric_dependency_depth(self) -> List[Dict[str, int]]:
         """Returns a list of {<metric_name>: <depth_from_initial_metric>} for all upstream metrics."""
         metric_depth_count = 1
         to_return = list(self.reverse_dag_parsing(self.node, self.manifest, metric_depth_count))

--- a/core/dbt/contracts/graph/metrics.py
+++ b/core/dbt/contracts/graph/metrics.py
@@ -25,7 +25,7 @@ class ResolvedMetricReference(MetricReference):
     for working with metrics (ie. __str__ and templating functions)
     """
 
-    def __init__(self, node, manifest, Relation):
+    def __init__(self, node: Metric, manifest: Manifest, Relation=None):
         super().__init__(node.name, node.package_name)
         self.node = node
         self.manifest = manifest

--- a/core/dbt/contracts/graph/metrics.py
+++ b/core/dbt/contracts/graph/metrics.py
@@ -80,26 +80,22 @@ class ResolvedMetricReference(MetricReference):
         return to_return
 
     def base_metric_dependency(self) -> List[str]:
-        """Returns a list of names for all upstream non-derived metrics."""
+        """Returns a unique list of names for all upstream non-derived metrics."""
         in_scope_metrics = list(self.parent_metrics(self.node, self.manifest))
+        base_metrics = {
+            metric.name for metric in in_scope_metrics if metric.type not in DERIVED_METRICS
+        }
 
-        to_return = []
-        for metric in in_scope_metrics:
-            if metric.type not in DERIVED_METRICS and metric.name not in to_return:
-                to_return.append(metric.name)
-
-        return to_return
+        return list(base_metrics)
 
     def derived_metric_dependency(self) -> List[str]:
-        """Returns a list of names for all upstream derived metrics."""
+        """Returns a unique list of names for all upstream derived metrics."""
         in_scope_metrics = list(self.parent_metrics(self.node, self.manifest))
+        derived_metrics = {
+            metric.name for metric in in_scope_metrics if metric.type in DERIVED_METRICS
+        }
 
-        to_return = []
-        for metric in in_scope_metrics:
-            if metric.type in DERIVED_METRICS and metric.name not in to_return:
-                to_return.append(metric.name)
-
-        return to_return
+        return list(derived_metrics)
 
     def derived_metric_dependency_depth(self):
         """Returns a list of {<metric_name>: <depth_from_initial_metric>} for all upstream metrics."""

--- a/core/dbt/contracts/graph/metrics.py
+++ b/core/dbt/contracts/graph/metrics.py
@@ -49,12 +49,8 @@ class ResolvedMetricReference(MetricReference):
     @classmethod
     def parent_metrics_names(cls, metric_node: Metric, manifest: Manifest) -> Iterator[str]:
         """For a given metric, yeilds all upstream metric names"""
-        yield metric_node.name
-
-        for parent_unique_id in metric_node.depends_on.nodes:
-            metric = manifest.metrics.get(parent_unique_id)
-            if metric is not None:
-                yield from cls.parent_metrics_names(metric, manifest)
+        for metric in cls.parent_metrics(metric_node, manifest):
+            yield metric.name
 
     @classmethod
     def reverse_dag_parsing(

--- a/core/dbt/contracts/graph/metrics.py
+++ b/core/dbt/contracts/graph/metrics.py
@@ -1,7 +1,7 @@
 from dbt.contracts.graph.manifest import Manifest, Metric
 from dbt_semantic_interfaces.type_enums import MetricType
 
-from typing import Dict, Iterator, List
+from typing import Any, Dict, Iterator, List
 
 
 DERIVED_METRICS = [MetricType.DERIVED, MetricType.RATIO]
@@ -24,15 +24,15 @@ class ResolvedMetricReference(MetricReference):
     for working with metrics (ie. __str__ and templating functions)
     """
 
-    def __init__(self, node: Metric, manifest: Manifest):
+    def __init__(self, node: Metric, manifest: Manifest) -> None:
         super().__init__(node.name, node.package_name)
         self.node = node
         self.manifest = manifest
 
-    def __getattr__(self, key):
+    def __getattr__(self, key) -> Any:
         return getattr(self.node, key)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.node.name}"
 
     @classmethod

--- a/core/dbt/contracts/graph/metrics.py
+++ b/core/dbt/contracts/graph/metrics.py
@@ -1,4 +1,3 @@
-from dbt.node_types import NodeType
 from dbt.contracts.graph.manifest import Manifest, Metric
 from dbt_semantic_interfaces.type_enums import MetricType
 
@@ -43,9 +42,9 @@ class ResolvedMetricReference(MetricReference):
         yield metric_node
 
         for parent_unique_id in metric_node.depends_on.nodes:
-            node = manifest.metrics.get(parent_unique_id)
-            if node and node.resource_type == NodeType.Metric:
-                yield from cls.parent_metrics(node, manifest)
+            metric = manifest.metrics.get(parent_unique_id)
+            if metric is not None:
+                yield from cls.parent_metrics(metric, manifest)
 
     @classmethod
     def parent_metrics_names(cls, metric_node: Metric, manifest: Manifest) -> Iterator[str]:
@@ -53,9 +52,9 @@ class ResolvedMetricReference(MetricReference):
         yield metric_node.name
 
         for parent_unique_id in metric_node.depends_on.nodes:
-            node = manifest.metrics.get(parent_unique_id)
-            if node and node.resource_type == NodeType.Metric:
-                yield from cls.parent_metrics_names(node, manifest)
+            metric = manifest.metrics.get(parent_unique_id)
+            if metric is not None:
+                yield from cls.parent_metrics_names(metric, manifest)
 
     @classmethod
     def reverse_dag_parsing(
@@ -70,9 +69,9 @@ class ResolvedMetricReference(MetricReference):
             metric_depth_count = metric_depth_count + 1
 
         for parent_unique_id in metric_node.depends_on.nodes:
-            node = manifest.metrics.get(parent_unique_id)
-            if node and node.resource_type == NodeType.Metric and node.type in DERIVED_METRICS:
-                yield from cls.reverse_dag_parsing(node, manifest, metric_depth_count)
+            metric = manifest.metrics.get(parent_unique_id)
+            if metric is not None and metric.type in DERIVED_METRICS:
+                yield from cls.reverse_dag_parsing(metric, manifest, metric_depth_count)
 
     def full_metric_dependency(self):
         """Returns a unique list of all upstream metric names."""

--- a/tests/functional/metrics/test_metric_helper_functions.py
+++ b/tests/functional/metrics/test_metric_helper_functions.py
@@ -3,7 +3,12 @@ import pytest
 from dbt.tests.util import run_dbt, get_manifest
 from dbt.contracts.graph.metrics import ResolvedMetricReference
 
-from tests.functional.metrics.fixtures import models_people_sql, basic_metrics_yml
+from tests.functional.metrics.fixtures import (
+    models_people_sql,
+    basic_metrics_yml,
+    semantic_model_people_yml,
+    metricflow_time_spine_sql,
+)
 
 
 class TestMetricHelperFunctions:
@@ -11,22 +16,22 @@ class TestMetricHelperFunctions:
     def models(self):
         return {
             "metrics.yml": basic_metrics_yml,
+            "semantic_people.yml": semantic_model_people_yml,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
             "people.sql": models_people_sql,
         }
 
-    @pytest.mark.skip(
-        "TODO reactivate after we begin property hydrating metric `depends_on` and `refs`"
-    )
-    def test_expression_metric(
+    def test_derived_metric(
         self,
         project,
     ):
 
         # initial parse
-        run_dbt(["compile"])
+        run_dbt(["parse"])
 
         # make sure all the metrics are in the manifest
         manifest = get_manifest(project.project_root)
+        assert manifest is not None
         parsed_metric = manifest.metrics["metric.test.average_tenure_plus_one"]
         testing_metric = ResolvedMetricReference(parsed_metric, manifest, None)
 

--- a/tests/functional/metrics/test_metric_helper_functions.py
+++ b/tests/functional/metrics/test_metric_helper_functions.py
@@ -1,6 +1,7 @@
 import pytest
 
-from dbt.tests.util import run_dbt, get_manifest
+from dbt.tests.util import run_dbt
+from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.metrics import ResolvedMetricReference
 
 from tests.functional.metrics.fixtures import (
@@ -27,11 +28,9 @@ class TestMetricHelperFunctions:
     ):
 
         # initial parse
-        run_dbt(["parse"])
+        manifest = run_dbt(["parse"])
+        assert isinstance(manifest, Manifest)
 
-        # make sure all the metrics are in the manifest
-        manifest = get_manifest(project.project_root)
-        assert manifest is not None
         parsed_metric = manifest.metrics["metric.test.average_tenure_plus_one"]
         testing_metric = ResolvedMetricReference(parsed_metric, manifest, None)
 

--- a/tests/functional/metrics/test_metric_helper_functions.py
+++ b/tests/functional/metrics/test_metric_helper_functions.py
@@ -32,7 +32,7 @@ class TestMetricHelperFunctions:
         assert isinstance(manifest, Manifest)
 
         parsed_metric = manifest.metrics["metric.test.average_tenure_plus_one"]
-        testing_metric = ResolvedMetricReference(parsed_metric, manifest, None)
+        testing_metric = ResolvedMetricReference(parsed_metric, manifest)
 
         full_metric_dependency = set(testing_metric.full_metric_dependency())
         expected_full_metric_dependency = set(


### PR DESCRIPTION
resolves #8134 

### Problem

Previously we were skipping `TestMetricHelperFunctions.test_expression_metric` leaving all the helper metric helper functions untested. Additionally because this test was being skipped, we didn't realize all the helper functions were broken 😬 

### Solution

Correct, simplify, and add typing to the metric helper functions. Unskip `TestMetricHelperFunctions.test_expression_metric` and rename it to `TestMetricHelperFunctions.test_derived_metric`.

### Note
I'm not a huge fan of the `parent_metrics` functions and dependency tree functions returning the originating metric. That seems unnecessary. It'd also simplify the code to not return the originating function. However, as I don't know who depends on these functions, I didn't want to alter their behavior unexpectedly.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
