### PR TITLE
[BACKPORT] Split integration tests into parallel groups / jobs (#6346)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,11 @@ defaults:
   run:
     shell: bash
 
+# top-level adjustments can be made here
+env:
+  # number of parallel processes to spawn for python integration testing
+  PYTHON_INTEGRATION_TEST_WORKERS: ${{ vars.PYTHON_INTEGRATION_TEST_WORKERS }}
+
 jobs:
   code-quality:
     name: code-quality
@@ -107,23 +112,55 @@ jobs:
           name: unit_results_${{ matrix.python-version }}-${{ steps.date.outputs.date }}.csv
           path: unit_results.csv
 
+  integration-metadata:
+    name: integration test metadata generation
+    runs-on: ubuntu-latest
+    outputs:
+      split-groups: ${{ steps.generate-split-groups.outputs.split-groups }}
+      include: ${{ steps.generate-include.outputs.include }}
+
+    steps:
+      - name: generate split-groups
+        id: generate-split-groups
+        run: |
+          MATRIX_JSON="["
+          for B in $(seq 1 ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }}); do
+              MATRIX_JSON+=$(sed 's/^/"/;s/$/"/' <<< "${B}")
+          done
+          MATRIX_JSON="${MATRIX_JSON//\"\"/\", \"}"
+          MATRIX_JSON+="]"
+          echo "split-groups=${MATRIX_JSON}"
+          echo "split-groups=${MATRIX_JSON}" >> $GITHUB_OUTPUT
+
+      - name: generate include
+        id: generate-include
+        run: |
+          INCLUDE=('"python-version":"3.8","os":"windows-latest"' '"python-version":"3.8","os":"macos-latest"' )
+          INCLUDE_GROUPS="["
+          for include in ${INCLUDE[@]}; do
+              for group in $(seq 1 ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }}); do
+                  INCLUDE_GROUPS+=$(sed 's/$/, /' <<< "{\"split-group\":\"${group}\",${include}}")
+              done
+          done
+          INCLUDE_GROUPS=$(echo $INCLUDE_GROUPS | sed 's/,*$//g')
+          INCLUDE_GROUPS+="]"
+          echo "include=${INCLUDE_GROUPS}"
+          echo "include=${INCLUDE_GROUPS}" >> $GITHUB_OUTPUT
+
   integration:
-    name: integration test / python ${{ matrix.python-version }} / ${{ matrix.os }}
+    name: (${{ matrix.split-group }}) integration test / python ${{ matrix.python-version }} / ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
-
+    timeout-minutes: 30
+    needs:
+      - integration-metadata
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-20.04]
-        include:
-          - python-version: 3.8
-            os: windows-latest
-          - python-version: 3.8
-            os: macos-latest
-
+        split-group: ${{ fromJson(needs.integration-metadata.outputs.split-groups) }}
+        include: ${{ fromJson(needs.integration-metadata.outputs.include) }}
     env:
       TOXENV: integration
       PYTEST_ADDOPTS: "-v --color=yes -n4 --csv integration_results.csv"
@@ -167,6 +204,8 @@ jobs:
 
       - name: Run tests
         run: tox -- --ddtrace
+        env:
+          PYTEST_ADDOPTS: ${{ format('--splits {0} --group {1}', env.PYTHON_INTEGRATION_TEST_WORKERS, matrix.split-group) }}
 
       - name: Get current date
         if: always()
@@ -186,6 +225,15 @@ jobs:
         with:
           name: integration_results_${{ matrix.python-version }}_${{ matrix.os }}_${{ steps.date.outputs.date }}.csv
           path: integration_results.csv
+
+  integration-report:
+    name: integration test suite
+    runs-on: ubuntu-latest
+    needs: integration
+    steps:
+      - name: "[Notification] Integration test suite passes"
+        run: |
+          echo "::notice title="Integration test suite passes""
 
   build:
     name: build packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,7 +227,8 @@ jobs:
           path: integration_results.csv
 
   integration-report:
-    name: integration test suite
+    if: ${{ always() }}
+    name: Integration Test Suite
     runs-on: ubuntu-latest
     needs: integration
     steps:

--- a/.github/workflows/structured-logging-schema-check.yml
+++ b/.github/workflows/structured-logging-schema-check.yml
@@ -18,11 +18,41 @@ on:
 
 permissions: read-all
 
+# top-level adjustments can be made here
+env:
+  # number of parallel processes to spawn for python testing
+  PYTHON_INTEGRATION_TEST_WORKERS: ${{ vars.PYTHON_INTEGRATION_TEST_WORKERS }}
+
 jobs:
+  integration-metadata:
+    name: integration test metadata generation
+    runs-on: ubuntu-latest
+    outputs:
+      split-groups: ${{ steps.generate-split-groups.outputs.split-groups }}
+
+    steps:
+      - name: generate split-groups
+        id: generate-split-groups
+        run: |
+          MATRIX_JSON="["
+          for B in $(seq 1 ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }}); do
+              MATRIX_JSON+=$(sed 's/^/"/;s/$/"/' <<< "${B}")
+          done
+          MATRIX_JSON="${MATRIX_JSON//\"\"/\", \"}"
+          MATRIX_JSON+="]"
+          echo "split-groups=${MATRIX_JSON}" >> $GITHUB_OUTPUT
+
   # run the performance measurements on the current or default branch
   test-schema:
     name: Test Log Schema
     runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    needs:
+      - integration-metadata
+    strategy:
+      fail-fast: false
+      matrix:
+        split-group: ${{ fromJson(needs.integration-metadata.outputs.split-groups) }}
     env:
       # turns warnings into errors
       RUSTFLAGS: "-D warnings"
@@ -65,3 +95,14 @@ jobs:
       # we actually care if these pass, because the normal test run doesn't usually include many json log outputs
       - name: Run integration tests
         run: tox -e integration -- -nauto
+        env:
+          PYTEST_ADDOPTS: ${{ format('--splits {0} --group {1}', env.PYTHON_INTEGRATION_TEST_WORKERS, matrix.split-group) }}
+
+  test-schema-report:
+    name: Log Schema Test Suite
+    runs-on: ubuntu-latest
+    needs: test-schema
+    steps:
+      - name: "[Notification] Log test suite passes"
+        run: |
+          echo "::notice title="Log test suite passes""

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,6 +16,7 @@ pytest-csv
 pytest-dotenv
 pytest-logbook
 pytest-mock
+pytest-split
 pytest-xdist
 sphinx
 tox>=3.13


### PR DESCRIPTION
# Conflicts:
#	.github/workflows/main.yml

resolves #8612 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  

### Problem

Windows tests are timing out

### Solution

Split up tests

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
