### PR TITLE
update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,12 @@
-resolves #  
-[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#  
+resolves #
 
 <!---
   Include the number of the issue addressed by this PR above if applicable.
   PRs for code changes without an associated issue *will not be merged*.
   See CONTRIBUTING.md for more information.
 
-  Include the number of the docs issue that was opened for this PR. If
-  this change has no user-facing implications, "N/A" suffices instead. New
-  docs tickets can be created by clicking the link above or by going to
-  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
+  Add the `user docs` label to this PR if it will need docs changes.  An 
+  issue will get opened in docs.getdbt.com upon successful merge of this PR.
 -->
 
 ### Problem


### PR DESCRIPTION
resolves #  


### Problem

The PR template had extra spaces after the `resolves #  ` that had to be manually every time a PR got opened.
The PR template required a docs url but we now have automation to generate the docs issues via a label.  

### Solution

Fix formatting
Update comment and remove docs url

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
