### PR TITLE
Fix test_numeric_values of the show test

### DIFF
--- a/.changes/unreleased/Under the Hood-20230913-141651.yaml
+++ b/.changes/unreleased/Under the Hood-20230913-141651.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Fix test_numeric_values to look for more specific strings
+time: 2023-09-13T14:16:51.453247-04:00
+custom:
+  Author: gshank
+  Issue: "8470"

--- a/tests/functional/show/test_show.py
+++ b/tests/functional/show/test_show.py
@@ -83,12 +83,12 @@ class TestShowNumeric(ShowBase):
             ["show", "--select", "sample_number_model", "--output", "json"]
         )
         assert "Previewing node 'sample_number_model'" not in log_output
-        assert "1.0" not in log_output
-        assert "1" in log_output
-        assert "3.0" in log_output
-        assert "4.3" in log_output
-        assert "5" in log_output
-        assert "5.0" not in log_output
+        assert '"float_to_int_field": 1.0' not in log_output
+        assert '"float_to_int_field": 1' in log_output
+        assert '"float_field": 3.0' in log_output
+        assert '"float_with_dec_field": 4.3' in log_output
+        assert '"int_field": 5' in log_output
+        assert '"int_field": 5.0' not in log_output
 
 
 class TestShowNumericNulls(ShowBase):
@@ -98,12 +98,12 @@ class TestShowNumericNulls(ShowBase):
             ["show", "--select", "sample_number_model_with_nulls", "--output", "json"]
         )
         assert "Previewing node 'sample_number_model_with_nulls'" not in log_output
-        assert "1.0" not in log_output
-        assert "1" in log_output
-        assert "3.0" in log_output
-        assert "4.3" in log_output
-        assert "5" in log_output
-        assert "5.0" not in log_output
+        assert '"float_to_int_field": 1.0' not in log_output
+        assert '"float_to_int_field": 1' in log_output
+        assert '"float_field": 3.0' in log_output
+        assert '"float_with_dec_field": 4.3' in log_output
+        assert '"int_field": 5' in log_output
+        assert '"int_field": 5.0' not in log_output
 
 
 class TestShowInline(ShowBase):

--- a/tests/functional/show/test_show.py
+++ b/tests/functional/show/test_show.py
@@ -82,6 +82,8 @@ class TestShowNumeric(ShowBase):
         (_, log_output) = run_dbt_and_capture(
             ["show", "--select", "sample_number_model", "--output", "json"]
         )
+        # json log output needs the escapes removed for string matching
+        log_output = log_output.replace("\\", "")
         assert "Previewing node 'sample_number_model'" not in log_output
         assert '"float_to_int_field": 1.0' not in log_output
         assert '"float_to_int_field": 1' in log_output
@@ -97,6 +99,8 @@ class TestShowNumericNulls(ShowBase):
         (_, log_output) = run_dbt_and_capture(
             ["show", "--select", "sample_number_model_with_nulls", "--output", "json"]
         )
+        # json log output needs the escapes removed for string matching
+        log_output = log_output.replace("\\", "")
         assert "Previewing node 'sample_number_model_with_nulls'" not in log_output
         assert '"float_to_int_field": 1.0' not in log_output
         assert '"float_to_int_field": 1' in log_output


### PR DESCRIPTION
resolves #8470

### Problem

The "test_numeric_values" test was checking for strings that were in or not in the logs. This is problematic, because as soon as something else accidentally had a 1.0 or 5.0 (such 1.06 seconds or something) the test would fail.

### Solution


Check for more specific strings in show output, such as '"float_to_int_field": 1'.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
