### PR TITLE
Loosen type on replaceable_relation and renameable_relation and provide guidance in docstrings

### DIFF
--- a/.changes/unreleased/Features-20230913-182707.yaml
+++ b/.changes/unreleased/Features-20230913-182707.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Loosen typing requirement on renameable/replaceable relations to Iterable to
+  allow adapters more flexibility in registering relation types, include docstrings
+  as suggestions
+time: 2023-09-13T18:27:07.974612-04:00
+custom:
+  Author: mikealfare
+  Issue: "8647"

--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -1,6 +1,6 @@
 from collections.abc import Hashable
 from dataclasses import dataclass, field
-from typing import Optional, TypeVar, Any, Type, Dict, Iterator, Tuple, Set, Iterable
+from typing import Optional, TypeVar, Any, Type, Dict, Iterator, Tuple, Set, Union, FrozenSet
 
 from dbt.contracts.graph.nodes import SourceDefinition, ManifestNode, ResultNode, ParsedNode
 from dbt.contracts.relation import (
@@ -23,6 +23,7 @@ import dbt.exceptions
 
 
 Self = TypeVar("Self", bound="BaseRelation")
+SerializableIterable = Union[Tuple, FrozenSet]
 
 
 @dataclass(frozen=True, eq=False, repr=False)
@@ -40,13 +41,13 @@ class BaseRelation(FakeAPIObject, Hashable):
     # adding a relation type here also requires defining the associated rename macro
     # e.g. adding RelationType.View in dbt-postgres requires that you define:
     # include/postgres/macros/relations/view/rename.sql::postgres__get_rename_view_sql()
-    renameable_relations: Iterable[str] = ()
+    renameable_relations: SerializableIterable = ()
 
     # register relation types that are atomically replaceable, e.g. they have "create or replace" syntax
     # adding a relation type here also requires defining the associated replace macro
     # e.g. adding RelationType.View in dbt-postgres requires that you define:
     # include/postgres/macros/relations/view/replace.sql::postgres__get_replace_view_sql()
-    replaceable_relations: Iterable[str] = ()
+    replaceable_relations: SerializableIterable = ()
 
     def _is_exactish_match(self, field: ComponentName, value: str) -> bool:
         if self.dbt_created and self.quote_policy.get_part(field) is False:

--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -300,11 +300,11 @@ class BaseRelation(FakeAPIObject, Hashable):
 
     @property
     def can_be_renamed(self) -> bool:
-        return self.type in self.renameable_relations if self.type else False
+        return self.type in self.renameable_relations
 
     @property
     def can_be_replaced(self) -> bool:
-        return self.type in self.replaceable_relations if self.type else False
+        return self.type in self.replaceable_relations
 
     def __repr__(self) -> str:
         return "<{} {}>".format(self.__class__.__name__, self.render())


### PR DESCRIPTION
### Problem

The typing on `renameable_relations` and `replaceable_relations` is overly prescriptive. The only requirement is that the relations in this class variable are contained in an object that defines `__contains__` and that said object is immutable (frozen dataclass). `Tuple` and `FrozenSet` are both valid examples, and an adapter maintainer may prefer one or the other, or some third option.

### Solution

Update the type to `Iterable[str]` and make updates in the methods to account for `None`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
