### PR TITLE
Support quoted parameter list for MultiOption cli options

### DIFF
--- a/.changes/unreleased/Features-20230918-150855.yaml
+++ b/.changes/unreleased/Features-20230918-150855.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Support quoted parameter list for MultiOption CLI options..
+body: Support quoted parameter list for MultiOption CLI options.
 time: 2023-09-18T15:08:55.625412-05:00
 custom:
   Author: emmyoop

--- a/.changes/unreleased/Features-20230918-150855.yaml
+++ b/.changes/unreleased/Features-20230918-150855.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support quoted parameter list for MultiOption CLI options..
+time: 2023-09-18T15:08:55.625412-05:00
+custom:
+  Author: emmyoop
+  Issue: "8598"

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -57,7 +57,7 @@ def args_to_context(args: List[str]) -> Context:
     from dbt.cli.main import cli
 
     cli_ctx = cli.make_context(cli.name, args)
-    # Split args if they're a comma seperated string.
+    # Split args if they're a comma separated string.
     if len(args) == 1 and "," in args[0]:
         args = args[0].split(",")
     sub_command_name, sub_command, args = cli.resolve_command(cli_ctx, args)
@@ -339,6 +339,10 @@ def command_params(command: CliCommand, args_dict: Dict[str, Any]) -> CommandPar
                 res.insert(0, x)
 
         spinal_cased = k.replace("_", "-")
+
+        # MultiOption flags come back as lists, but we want to pass them as space separated strings
+        if isinstance(v, list):
+            v = " ".join(v)
 
         if k == "macro" and command == CliCommand.RUN_OPERATION:
             add_fn(v)

--- a/core/dbt/cli/options.py
+++ b/core/dbt/cli/options.py
@@ -14,8 +14,9 @@ class MultiOption(click.Option):
         nargs = kwargs.pop("nargs", -1)
         assert nargs == -1, "nargs, if set, must be -1 not {}".format(nargs)
         super(MultiOption, self).__init__(*args, **kwargs)
-        self._previous_parser_process = None
-        self._eat_all_parser = None
+        # this makes mypy happy, setting these to None causes mypy failures
+        self._previous_parser_process = lambda *args, **kwargs: None
+        self._eat_all_parser = lambda *args, **kwargs: None
 
         # validate that multiple=True
         multiple = kwargs.pop("multiple", None)
@@ -55,9 +56,9 @@ class MultiOption(click.Option):
         for name in self.opts:
             our_parser = parser._long_opt.get(name) or parser._short_opt.get(name)
             if our_parser:
-                self._eat_all_parser = our_parser
-                self._previous_parser_process = our_parser.process
                 # mypy doesnt like assingment to a method see https://github.com/python/mypy/issues/708
+                self._eat_all_parser = our_parser  # type: ignore
+                self._previous_parser_process = our_parser.process  # type: ignore
                 our_parser.process = parser_process  # type: ignore
                 break
         return retval

--- a/core/dbt/cli/options.py
+++ b/core/dbt/cli/options.py
@@ -56,7 +56,7 @@ class MultiOption(click.Option):
         for name in self.opts:
             our_parser = parser._long_opt.get(name) or parser._short_opt.get(name)
             if our_parser:
-                self._eat_all_parser = our_parser
+                self._eat_all_parser = our_parser  # type: ignore[assignment]
                 self._previous_parser_process = our_parser.process
                 # mypy doesnt like assingment to a method see https://github.com/python/mypy/issues/708
                 our_parser.process = parser_process  # type: ignore[method-assign]

--- a/core/dbt/cli/options.py
+++ b/core/dbt/cli/options.py
@@ -15,8 +15,8 @@ class MultiOption(click.Option):
         assert nargs == -1, "nargs, if set, must be -1 not {}".format(nargs)
         super(MultiOption, self).__init__(*args, **kwargs)
         # this makes mypy happy, setting these to None causes mypy failures
-        self._previous_parser_process = None
-        self._eat_all_parser = None
+        self._previous_parser_process = lambda *args, **kwargs: None
+        self._eat_all_parser = lambda *args, **kwargs: None
 
         # validate that multiple=True
         multiple = kwargs.pop("multiple", None)
@@ -56,9 +56,9 @@ class MultiOption(click.Option):
         for name in self.opts:
             our_parser = parser._long_opt.get(name) or parser._short_opt.get(name)
             if our_parser:
-                # mypy doesnt like assingment to a method see https://github.com/python/mypy/issues/708
                 self._eat_all_parser = our_parser
                 self._previous_parser_process = our_parser.process
+                # mypy doesnt like assingment to a method see https://github.com/python/mypy/issues/708
                 our_parser.process = parser_process  # type: ignore[method-assign]
                 break
         return retval

--- a/core/dbt/cli/options.py
+++ b/core/dbt/cli/options.py
@@ -33,7 +33,7 @@ class MultiOption(click.Option):
         def parser_process(value, state):
             # method to hook to the parser.process
             done = False
-            value = [value]
+            value = str.split(value, " ")
             if self.save_other_options:
                 # grab everything up to the next option
                 while state.rargs and not done:

--- a/core/dbt/cli/options.py
+++ b/core/dbt/cli/options.py
@@ -15,8 +15,8 @@ class MultiOption(click.Option):
         assert nargs == -1, "nargs, if set, must be -1 not {}".format(nargs)
         super(MultiOption, self).__init__(*args, **kwargs)
         # this makes mypy happy, setting these to None causes mypy failures
-        self._previous_parser_process = lambda *args, **kwargs: None
-        self._eat_all_parser = lambda *args, **kwargs: None
+        self._previous_parser_process = None
+        self._eat_all_parser = None
 
         # validate that multiple=True
         multiple = kwargs.pop("multiple", None)
@@ -39,7 +39,7 @@ class MultiOption(click.Option):
             if self.save_other_options:
                 # grab everything up to the next option
                 while state.rargs and not done:
-                    for prefix in self._eat_all_parser.prefixes:
+                    for prefix in self._eat_all_parser.prefixes:  # type: ignore[attr-defined]
                         if state.rargs[0].startswith(prefix):
                             done = True
                     if not done:
@@ -57,9 +57,9 @@ class MultiOption(click.Option):
             our_parser = parser._long_opt.get(name) or parser._short_opt.get(name)
             if our_parser:
                 # mypy doesnt like assingment to a method see https://github.com/python/mypy/issues/708
-                self._eat_all_parser = our_parser  # type: ignore
-                self._previous_parser_process = our_parser.process  # type: ignore
-                our_parser.process = parser_process  # type: ignore
+                self._eat_all_parser = our_parser
+                self._previous_parser_process = our_parser.process
+                our_parser.process = parser_process  # type: ignore[method-assign]
                 break
         return retval
 

--- a/tests/functional/cli/test_multioption.py
+++ b/tests/functional/cli/test_multioption.py
@@ -24,14 +24,17 @@ class TestResourceType:
     def test_resource_type_single(self, project):
         result = run_dbt(["-q", "ls", "--resource-types", "model"])
         assert len(result) == 1
+        assert result == ["test.model_one"]
 
-    def test_resource_type_quoted(self):
+    def test_resource_type_quoted(self, project):
         result = run_dbt(["-q", "ls", "--resource-types", "model source"])
         assert len(result) == 2
+        assert result == ["test.model_one", "source:test.my_source.my_table"]
 
-    def test_resource_type_args(self):
+    def test_resource_type_args(self, project):
         result = run_dbt(["-q", "ls", "--resource-type", "model", "--resource-type", "source"])
         assert len(result) == 2
+        assert result == ["test.model_one", "source:test.my_source.my_table"]
 
 
 class TestOutputKeys:
@@ -44,13 +47,13 @@ class TestOutputKeys:
         assert len(result) == 1
         assert result == ['{"name": "model_one"}']
 
-    def test_output_key_quoted(self):
+    def test_output_key_quoted(self, project):
         result = run_dbt(["-q", "ls", "--output", "json", "--output-keys", "name resource_type"])
 
         assert len(result) == 1
         assert result == ['{"name": "model_one", "resource_type": "model"}']
 
-    def test_output_key_args(self):
+    def test_output_key_args(self, project):
         result = run_dbt(
             [
                 "-q",
@@ -85,7 +88,7 @@ class TestSelectExclude:
         assert len(result) == 2
         assert "test.model_one" not in result
 
-    def test_select_exclude_quoted(self):
+    def test_select_exclude_quoted(self, project):
         result = run_dbt(["-q", "ls", "--select", "model_one model_two"])
         assert len(result) == 2
         assert "test.model_three" not in result
@@ -93,7 +96,7 @@ class TestSelectExclude:
         assert len(result) == 1
         assert result == ["test.model_three"]
 
-    def test_select_exclude_args(self):
+    def test_select_exclude_args(self, project):
         result = run_dbt(["-q", "ls", "--select", "model_one", "--select", "model_two"])
         assert len(result) == 2
         assert "test.model_three" not in result

--- a/tests/functional/cli/test_multioption.py
+++ b/tests/functional/cli/test_multioption.py
@@ -1,0 +1,102 @@
+import pytest
+from dbt.tests.util import run_dbt
+
+
+model_one_sql = """
+select 1 as fun
+"""
+
+source_sql = """
+sources:
+  - name: my_source
+    description: "My source"
+    schema: test_schema
+    tables:
+      - name: my_table
+"""
+
+
+class TestResourceType:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"schema.yml": source_sql, "model_one.sql": model_one_sql}
+
+    def test_resource_type_single(self, project):
+        result = run_dbt(["-q", "ls", "--resource-types", "model"])
+        assert len(result) == 1
+
+    def test_resource_type_quoted(self):
+        result = run_dbt(["-q", "ls", "--resource-types", "model source"])
+        assert len(result) == 2
+
+    def test_resource_type_args(self):
+        result = run_dbt(["-q", "ls", "--resource-type", "model", "--resource-type", "source"])
+        assert len(result) == 2
+
+
+class TestOutputKeys:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_one.sql": model_one_sql}
+
+    def test_output_key_single(self, project):
+        result = run_dbt(["-q", "ls", "--output", "json", "--output-keys", "name"])
+        assert len(result) == 1
+        assert result == ['{"name": "model_one"}']
+
+    def test_output_key_quoted(self):
+        result = run_dbt(["-q", "ls", "--output", "json", "--output-keys", "name resource_type"])
+
+        assert len(result) == 1
+        assert result == ['{"name": "model_one", "resource_type": "model"}']
+
+    def test_output_key_args(self):
+        result = run_dbt(
+            [
+                "-q",
+                "ls",
+                "--output",
+                "json",
+                "--output-keys",
+                "name",
+                "--output-keys",
+                "resource_type",
+            ]
+        )
+
+        assert len(result) == 1
+        assert result == ['{"name": "model_one", "resource_type": "model"}']
+
+
+class TestSelectExclude:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_one.sql": model_one_sql,
+            "model_two.sql": model_one_sql,
+            "model_three.sql": model_one_sql,
+        }
+
+    def test_select_exclude_single(self, project):
+        result = run_dbt(["-q", "ls", "--select", "model_one"])
+        assert len(result) == 1
+        assert result == ["test.model_one"]
+        result = run_dbt(["-q", "ls", "--exclude", "model_one"])
+        assert len(result) == 2
+        assert "test.model_one" not in result
+
+    def test_select_exclude_quoted(self):
+        result = run_dbt(["-q", "ls", "--select", "model_one model_two"])
+        assert len(result) == 2
+        assert "test.model_three" not in result
+        result = run_dbt(["-q", "ls", "--exclude", "model_one model_two"])
+        assert len(result) == 1
+        assert result == ["test.model_three"]
+
+    def test_select_exclude_args(self):
+        result = run_dbt(["-q", "ls", "--select", "model_one", "--select", "model_two"])
+        assert len(result) == 2
+        assert "test.model_three" not in result
+        result = run_dbt(["-q", "ls", "--exclude", "model_one", "--exclude", "model_two"])
+        assert len(result) == 1
+        assert result == ["test.model_three"]

--- a/tests/functional/cli/test_multioption.py
+++ b/tests/functional/cli/test_multioption.py
@@ -29,12 +29,14 @@ class TestResourceType:
     def test_resource_type_quoted(self, project):
         result = run_dbt(["-q", "ls", "--resource-types", "model source"])
         assert len(result) == 2
-        assert result == ["test.model_one", "source:test.my_source.my_table"]
+        expected_result = {"test.model_one", "source:test.my_source.my_table"}
+        assert set(result) == expected_result
 
     def test_resource_type_args(self, project):
         result = run_dbt(["-q", "ls", "--resource-type", "model", "--resource-type", "source"])
         assert len(result) == 2
-        assert result == ["test.model_one", "source:test.my_source.my_table"]
+        expected_result = {"test.model_one", "source:test.my_source.my_table"}
+        assert set(result) == expected_result
 
 
 class TestOutputKeys:

--- a/tests/functional/retry/fixtures.py
+++ b/tests/functional/retry/fixtures.py
@@ -45,3 +45,16 @@ macros__alter_timezone_sql = """
 {% do log("Timezone set to: " + timezone, info=True) %}
 {% endmacro %}
 """
+
+simple_model = """
+select null as id
+"""
+
+simple_schema = """
+models:
+  - name: some_model
+    columns:
+      - name: id
+        tests:
+          - not_null
+"""

--- a/tests/unit/test_cli_flags.py
+++ b/tests/unit/test_cli_flags.py
@@ -370,7 +370,7 @@ class TestFlags:
         }
         result = self._create_flags_from_dict(Command.RUN, args_dict)
         assert "model_one" in result.select[0]
-        assert "model_two" in result.select[0]
+        assert "model_two" in result.select[1]
 
     def test_from_dict__build(self):
         args_dict = {

--- a/tests/unit/test_cli_flags.py
+++ b/tests/unit/test_cli_flags.py
@@ -366,7 +366,7 @@ class TestFlags:
     def test_from_dict__run(self):
         args_dict = {
             "print": False,
-            "select": ["model_one", "model_two"],
+            "select": "model_one, model_two",
         }
         result = self._create_flags_from_dict(Command.RUN, args_dict)
         assert "model_one" in result.select[0]
@@ -382,7 +382,7 @@ class TestFlags:
         assert "some/path" in str(result.state)
 
     def test_from_dict__seed(self):
-        args_dict = {"use_colors": False, "exclude": ["model_three"]}
+        args_dict = {"use_colors": False, "exclude": "model_three"}
         result = self._create_flags_from_dict(Command.SEED, args_dict)
         assert result.use_colors is False
         assert "model_three" in result.exclude[0]

--- a/tests/unit/test_cli_flags.py
+++ b/tests/unit/test_cli_flags.py
@@ -366,7 +366,7 @@ class TestFlags:
     def test_from_dict__run(self):
         args_dict = {
             "print": False,
-            "select": "model_one, model_two",
+            "select": ["model_one, model_two"],
         }
         result = self._create_flags_from_dict(Command.RUN, args_dict)
         assert "model_one" in result.select[0]
@@ -382,7 +382,7 @@ class TestFlags:
         assert "some/path" in str(result.state)
 
     def test_from_dict__seed(self):
-        args_dict = {"use_colors": False, "exclude": "model_three"}
+        args_dict = {"use_colors": False, "exclude": ["model_three"]}
         result = self._create_flags_from_dict(Command.SEED, args_dict)
         assert result.use_colors is False
         assert "model_three" in result.exclude[0]

--- a/tests/unit/test_cli_flags.py
+++ b/tests/unit/test_cli_flags.py
@@ -366,7 +366,7 @@ class TestFlags:
     def test_from_dict__run(self):
         args_dict = {
             "print": False,
-            "select": ["model_one, model_two"],
+            "select": ["model_one", "model_two"],
         }
         result = self._create_flags_from_dict(Command.RUN, args_dict)
         assert "model_one" in result.select[0]


### PR DESCRIPTION
resolves #8598 
resolves #8575 

### Problem

1. When the list of parameters sent into are quoted, it cannot be processed and produces an error:

```
dbt -q ls --resource-type "model semantic_model"
Usage: dbt ls [OPTIONS]
Try 'dbt ls -h' for help.

Error: Invalid value for '--resource-types' / '--resource-type': 'model semantic_model' is not one of 'metric', 'semantic_model', 'source', 'analysis', 'model', 'test', 'exposure', 'snapshot', 'seed', 'default', 'all'.
```

2. `resource-type` does not work on `retry`.

```
dbt build -s some_model --resource-type all
dbt retry
```
The above fails with 
```
click.exceptions.BadParameter: "['all']" is not one of 'metric', 'source', 'analysis', 'model', 'test', 'exposure', 'snapshot', 'seed', 'default', 'all'.
````

### Solution

1. Support quoted parameter lists while continuing to support unquoted lists, separated args and single parameters.
2. Stop treating the parameters in `retry` as a quoted list

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
