### PR TITLE
Lower bound of `8.0.2` for `click`

### DIFF
--- a/.changes/unreleased/Fixes-20230920-165635.yaml
+++ b/.changes/unreleased/Fixes-20230920-165635.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Lower bound of `8.0.2` for `click`
+time: 2023-09-20T16:56:35.484024-06:00
+custom:
+  Author: dylan-murray dbeatty10
+  Issue: "8683"

--- a/core/setup.py
+++ b/core/setup.py
@@ -59,7 +59,7 @@ setup(
         # ----
         # dbt-core uses these packages in standard ways. Pin to the major version, and check compatibility
         # with major versions in each new minor version of dbt-core.
-        "click<9",
+        "click>=8.0.2,<9",
         "networkx>=2.3,<4",
         # ----
         # These packages are major-version-0. Keep upper bounds on upcoming minor versions (which could have breaking changes)


### PR DESCRIPTION
resolves #8683

### Problem

When installing `dbt-core` into an environment where an older version of click is installed, `dbt-core` will throw a vague error `Error: Invalid value for '--warn-error-options': Cannot load YAML from type <class 'dbt.helper_types.WarnErrorOptions'>`. It seems `dbt-core` is pinning `click<9` which allows it to use older versions of click that it seems no longer compatible with.

### Solution

Establish a lower bound that was determined via trial and error. `~=8.0.0` works (with the exclusion of 8.0.0 and 8.0.1), so:
- `>=8.0.2`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] Tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)
