### PR TITLE
Add git info to context

### DIFF
--- a/.changes/unreleased/Features-20230925-182237.yaml
+++ b/.changes/unreleased/Features-20230925-182237.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add git_branch and git_sha to the Jinja context
+time: 2023-09-25T18:22:37.142445+02:00
+custom:
+  Author: b-per
+  Issue: "8690"

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -208,12 +208,18 @@ class BaseContext(metaclass=ContextMeta):
 
     @contextproperty()
     def git_branch(self) -> str:
-        """The `git_branch` variable returns the current branch if the
+        """The `git_branch` variable returns the current branch name if the
         code is version controlled by git.
         Otherwise it returns an empty string.
         """
+
+        if hasattr(get_flags(), "PROJECT_DIR"):
+            project_dir = get_flags().PROJECT_DIR
+        else:
+            project_dir = "."
+
         try:
-            branch_name = Repository(".").head.shorthand
+            branch_name = Repository(project_dir).head.shorthand
         except GitError:
             branch_name = ""
 
@@ -225,8 +231,14 @@ class BaseContext(metaclass=ContextMeta):
         if the dbt code is version controlled in git.
         Otherwise it returns an empty string.
         """
+
+        if hasattr(get_flags(), "PROJECT_DIR"):
+            project_dir = get_flags().PROJECT_DIR
+        else:
+            project_dir = "."
+
         try:
-            repo = Repository(".")
+            repo = Repository(project_dir)
             sha = repo.head.target.hex
         except GitError:
             sha = ""

--- a/core/setup.py
+++ b/core/setup.py
@@ -83,6 +83,7 @@ setup(
         "pytz>=2015.7",
         "pyyaml>=6.0",
         "typing-extensions>=3.7.4",
+        "pygit2 >= 1.0.0",
         # ----
         # Match snowflake-connector-python, to ensure compatibility in dbt-snowflake
         "cffi>=1.9,<2.0.0",

--- a/tests/functional/context_values/test_git.py
+++ b/tests/functional/context_values/test_git.py
@@ -1,0 +1,37 @@
+import os
+import subprocess
+import pytest
+
+from dbt.tests.util import run_dbt_and_capture
+
+# we use a macro to print the value and check the logs when testing
+on_run_start_macro_assert_git_branch = """
+{% macro assert_git_branch_name() %}
+    {{ log("git branch name: " ~ git_branch, 1) }}
+{% endmacro %}
+"""
+
+
+class TestContextGitValues:
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "assert_git_branch_name.sql": on_run_start_macro_assert_git_branch,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "on-run-start": "{{ assert_git_branch_name() }}",
+        }
+
+    def test_git_values(self, project):
+        os.chdir(project.project_root)
+        # Initialize a new git repository
+        subprocess.run(["git", "init"], check=True)
+        subprocess.run(["git", "checkout", "-b" "new_branch_for_testing"], check=True)
+        subprocess.run(["git", "add", "*"], check=True)
+        subprocess.run(["git", "commit", "-m", "commit to git"], check=True)
+
+        _, run_logs = run_dbt_and_capture(["run"])
+        assert "git branch name: new_branch_for_testing" in run_logs

--- a/tests/functional/context_values/test_git.py
+++ b/tests/functional/context_values/test_git.py
@@ -29,6 +29,8 @@ class TestContextGitValues:
         os.chdir(project.project_root)
         # Initialize a new git repository
         subprocess.run(["git", "init"], check=True)
+        subprocess.run(["git", "config", "user.email", "no-mail@dbtlabs.com"], check=True)
+        subprocess.run(["git", "config", "user.name", "dbt Labs"], check=True)
         subprocess.run(["git", "checkout", "-b" "new_branch_for_testing"], check=True)
         subprocess.run(["git", "add", "*"], check=True)
         subprocess.run(["git", "commit", "-m", "commit to git"], check=True)

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -188,6 +188,8 @@ REQUIRED_BASE_KEYS = frozenset(
         "print",
         "diff_of_two_dicts",
         "local_md5",
+        "git_branch",
+        "git_sha",
     }
 )
 


### PR DESCRIPTION
resolves #8690 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
Today, it is not possible to know which branch and/or which commit dbt's current code is based on. This PR adds the variables `git_branch` and `git_sha` to the Jinja context

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Add objects to the context

### Still To be Done (and keen to get Core Team inputs on the 2 first ones)

- [x] Handle the case where `--project-dir` is set and not the current dir
- [x] Add tests
- [ ] Handle partial parsing gracefully, forcing a full parse if any of the [`special_override_macros`](https://github.com/dbt-labs/dbt-core/blob/81447496418e6ae71670b9aea73c7d3b54fff436/core/dbt/parser/partial.py#L53-L60) refers to git_branch` or `git_sha`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
