### PR TITLE
CT-3144 Fix test edges type filter on Graph

### DIFF
--- a/.changes/unreleased/Fixes-20230922-223313.yaml
+++ b/.changes/unreleased/Fixes-20230922-223313.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fixes test type edges filter
+time: 2023-09-22T22:33:13.200662+02:00
+custom:
+  Author: renanleme
+  Issue: "8692"

--- a/core/dbt/graph/graph.py
+++ b/core/dbt/graph/graph.py
@@ -45,7 +45,7 @@ class Graph:
     def exclude_edge_type(self, edge_type_to_exclude):
         return nx.subgraph_view(
             self.graph,
-            filter_edge=partial(self.filter_edges_by_type, edge_type=edge_type_to_exclude)
+            filter_edge=partial(self.filter_edges_by_type, edge_type=edge_type_to_exclude),
         )
 
     def filter_edges_by_type(self, node_1, node_2, edge_type):

--- a/core/dbt/graph/graph.py
+++ b/core/dbt/graph/graph.py
@@ -1,6 +1,7 @@
 from typing import Set, Iterable, Iterator, Optional, NewType
 from itertools import product
 import networkx as nx  # type: ignore
+from functools import partial
 
 from dbt.exceptions import DbtInternalError
 
@@ -42,15 +43,13 @@ class Graph:
         return {child for _, child in nx.bfs_edges(filtered_graph, node, depth_limit=max_depth)}
 
     def exclude_edge_type(self, edge_type_to_exclude):
-        return nx.restricted_view(
+        return nx.subgraph_view(
             self.graph,
-            nodes=[],
-            edges=(
-                (a, b)
-                for a, b in self.graph.edges
-                if self.graph[a][b].get("edge_type") == edge_type_to_exclude
-            ),
+            filter_edge=partial(self.filter_edges_by_type, edge_type=edge_type_to_exclude)
         )
+
+    def filter_edges_by_type(self, node_1, node_2, edge_type):
+        return self.graph[node_1][node_2].get("edge_type", edge_type)
 
     def select_childrens_parents(self, selected: Set[UniqueId]) -> Set[UniqueId]:
         ancestors_for = self.select_children(selected) | selected
@@ -133,4 +132,5 @@ class Graph:
         return Graph(self.graph.subgraph(nodes))
 
     def get_dependent_nodes(self, node: UniqueId):
+        return nx.descendants(self.graph, node)
         return nx.descendants(self.graph, node)

--- a/core/dbt/graph/graph.py
+++ b/core/dbt/graph/graph.py
@@ -133,4 +133,3 @@ class Graph:
 
     def get_dependent_nodes(self, node: UniqueId):
         return nx.descendants(self.graph, node)
-        return nx.descendants(self.graph, node)

--- a/core/dbt/graph/graph.py
+++ b/core/dbt/graph/graph.py
@@ -49,7 +49,7 @@ class Graph:
         )
 
     def filter_edges_by_type(self, first_node, second_node, edge_type):
-        return self.graph[first_node][second_node].get("edge_type", edge_type)
+        return self.graph.get_edge_data(first_node, second_node).get("edge_type") != edge_type
 
     def select_childrens_parents(self, selected: Set[UniqueId]) -> Set[UniqueId]:
         ancestors_for = self.select_children(selected) | selected

--- a/core/dbt/graph/graph.py
+++ b/core/dbt/graph/graph.py
@@ -48,8 +48,8 @@ class Graph:
             filter_edge=partial(self.filter_edges_by_type, edge_type=edge_type_to_exclude),
         )
 
-    def filter_edges_by_type(self, node_1, node_2, edge_type):
-        return self.graph[node_1][node_2].get("edge_type", edge_type)
+    def filter_edges_by_type(self, first_node, second_node, edge_type):
+        return self.graph[first_node][second_node].get("edge_type", edge_type)
 
     def select_childrens_parents(self, selected: Set[UniqueId]) -> Set[UniqueId]:
         ancestors_for = self.select_children(selected) | selected


### PR DESCRIPTION
resolves #8692

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
After upgrading to 1.6.2 from 1.5.1 our build is taking way longer to start the first model
From around 7 to 8 minutes to complete to more than 1 hour without starting.
### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Changed the `networkx` function used to filter test type edges

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
