### PR TITLE
Support null coalescing properties for metric nodes

### DIFF
--- a/.changes/unreleased/Features-20230922-150754.yaml
+++ b/.changes/unreleased/Features-20230922-150754.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support `fill_nulls_with` and `join_to_timespine` for metric nodes
+time: 2023-09-22T15:07:54.981752-07:00
+custom:
+  Author: QMalcolm
+  Issue: "8593"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1411,6 +1411,8 @@ class MetricInputMeasure(dbtClassMixin):
     name: str
     filter: Optional[WhereFilter] = None
     alias: Optional[str] = None
+    join_to_timespine: bool = False
+    fill_nulls_with: Optional[int] = None
 
     def measure_reference(self) -> MeasureReference:
         return MeasureReference(element_name=self.name)

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -584,6 +584,8 @@ class UnparsedMetricInputMeasure(dbtClassMixin):
     name: str
     filter: Optional[str] = None
     alias: Optional[str] = None
+    join_to_timespine: bool = False
+    fill_nulls_with: Optional[int] = None
 
 
 @dataclass

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -178,6 +178,8 @@ class MetricParser(YamlReader):
                 name=unparsed_input_measure.name,
                 filter=filter,
                 alias=unparsed_input_measure.alias,
+                join_to_timespine=unparsed_input_measure.join_to_timespine,
+                fill_nulls_with=unparsed_input_measure.fill_nulls_with,
             )
 
     def _get_optional_input_measure(

--- a/tests/functional/metrics/fixtures.py
+++ b/tests/functional/metrics/fixtures.py
@@ -116,6 +116,8 @@ metrics:
       measure:
         name: years_tenure
         filter: "{{ Dimension('id__loves_dbt') }} is true"
+        join_to_timespine: true
+        fill_nulls_with: 0
 
   - name: collective_window
     label: "Collective window"

--- a/tests/unit/test_contracts_graph_unparsed.py
+++ b/tests/unit/test_contracts_graph_unparsed.py
@@ -858,6 +858,7 @@ class TestUnparsedMetric(ContractTestCase):
                 "measure": {
                     "name": "customers",
                     "filter": "is_new = true",
+                    "join_to_timespine": False,
                 },
             },
             "config": {},

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -216,7 +216,11 @@ def simple_metric_input_measure() -> MetricInputMeasure:
 @pytest.fixture(scope="session")
 def complex_metric_input_measure(where_filter) -> MetricInputMeasure:
     return MetricInputMeasure(
-        name="test_complex_metric_input_measure", filter=where_filter, alias="complex_alias"
+        name="test_complex_metric_input_measure",
+        filter=where_filter,
+        alias="complex_alias",
+        join_to_timespine=True,
+        fill_nulls_with=0,
     )
 
 


### PR DESCRIPTION
resolves #8593 

### Problem

MetricFlow is adding support for null value coalescing (https://github.com/dbt-labs/metricflow/issues/759). In order to use that, dbt-core needs to support the related properties

### Solution

Add the properties `join_to_timespine` and `fill_nulls_with` (as defined in the related MF and DSI issues: https://github.com/dbt-labs/metricflow/issues/759, https://github.com/dbt-labs/dbt-semantic-interfaces/issues/142) to the metric node definition.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
