### PR TITLE
CT-3144 Fix test edges type filter on Graph (#8696)

### DIFF
--- a/.changes/unreleased/Fixes-20230922-223313.yaml
+++ b/.changes/unreleased/Fixes-20230922-223313.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fixes test type edges filter
+time: 2023-09-22T22:33:13.200662+02:00
+custom:
+  Author: renanleme
+  Issue: "8692"


### PR DESCRIPTION
resolves #8692

Backports #8696 to 1.6.latest to repair a performance regression.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
