### PR TITLE
fix duplication of docs issues

### DIFF
--- a/.github/workflows/docs-issue.yml
+++ b/.github/workflows/docs-issue.yml
@@ -27,7 +27,13 @@ permissions:
 
 jobs:
   open_issues:
-    if: contains( github.event.pull_request.labels.*.name, 'user docs') && github.event.pull_request.merged == true
+    # we only want to run this when the PR has been merged or the label in the labeled event is `user docs`.  Otherwise it runs the
+    # risk of duplicaton of issues being created due to merge and label both triggering this workflow to run and neither having
+    # generating the comment before the other runs.  This lives here instead of the shared workflow because this is where we
+    # decide if it should run or not.
+    if: |
+      (contains( github.event.pull_request.labels.*.name, 'user docs') && github.event.pull_request.merged == true) ||
+      (github.event.label.name == 'user docs' && github.event.action == 'labeled' )
     uses: dbt-labs/actions/.github/workflows/open-issue-in-repo.yml@main
     with:
         issue_repository: "dbt-labs/docs.getdbt.com"

--- a/.github/workflows/docs-issue.yml
+++ b/.github/workflows/docs-issue.yml
@@ -32,8 +32,9 @@ jobs:
     # generating the comment before the other runs.  This lives here instead of the shared workflow because this is where we
     # decide if it should run or not.
     if: |
-      (contains( github.event.pull_request.labels.*.name, 'user docs') && github.event.pull_request.merged == true) ||
-      (github.event.label.name == 'user docs' && github.event.action == 'labeled' )
+      (github.event.pull_request.merged == true) &&
+      ((github.event.action == 'closed' && contains( github.event.pull_request.labels.*.name, 'user docs')) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'user docs'))
     uses: dbt-labs/actions/.github/workflows/open-issue-in-repo.yml@main
     with:
         issue_repository: "dbt-labs/docs.getdbt.com"


### PR DESCRIPTION
resolves #8746 

### Problem

Workflow has double generated issues in the other repo

### Solution

Ensure the label added in the labeled event is `user docs` and only run if that's true or the PR is in a merged state with the correct label.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
