### PR TITLE
Prototype: `test` materialization that allows `materialization` to be set in the `config()`

### DIFF
--- a/core/dbt/contracts/graph/model_config.py
+++ b/core/dbt/contracts/graph/model_config.py
@@ -583,12 +583,6 @@ class TestConfig(NodeAndTestConfig):
                     return False
         return True
 
-    @classmethod
-    def validate(cls, data):
-        super().validate(data)
-        if data.get("materialized") and data.get("materialized") != "test":
-            raise ValidationError("A test must have a materialized value of 'test'")
-
 
 @dataclass
 class EmptySnapshotConfig(NodeConfig):

--- a/core/dbt/include/global_project/macros/materializations/helpers.sql
+++ b/core/dbt/include/global_project/macros/materializations/helpers.sql
@@ -1,0 +1,13 @@
+{% macro get_materialization_macro(materialization_type) -%}
+      -- Reuse a fundamental materialization type (like table, view, or materialized_view)
+      -- TODO: support actual dispatch for materialization macros
+      -- See related tracking ticket: https://github.com/dbt-labs/dbt-core/issues/7799
+      {% set base_search_name = "materialization_" ~ materialization_type ~ "_" %}
+      {% set search_name = base_search_name ~ adapter.type() %}
+
+      {% if not search_name in context %}
+          {% set search_name = base_search_name ~ "default" %}
+      {% endif %}
+      {% set materialization_macro = context[search_name] %}
+      {% do return(materialization_macro) %}
+{%- endmacro %}

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -95,9 +95,8 @@ class TestRunner(CompileRunner):
 
     def execute_test(self, test: TestNode, manifest: Manifest) -> TestResultData:
         context = generate_runtime_model_context(test, self.config, manifest)
-
         materialization_macro = manifest.find_materialization_macro_by_name(
-            self.config.project_name, test.get_materialization(), self.adapter.type()
+            self.config.project_name, "test", self.adapter.type()
         )
 
         if materialization_macro is None:


### PR DESCRIPTION
regarding #6914

🚧 This is a prototype. It currently includes logging statements an inline comments for demo purposes.

### Problem

The failures of dbt tests can only be done ephemerally or stored in a table [stored in a table](https://docs.getdbt.com/reference/resource-configs/store_failures); there is no way to capture test results as a view or a materialized view. So users need to re-run `dbt test` (or `dbt build`) to see the results that are up-to-date. Of course those results can immediately go stale 😬

### Solution

#### Big idea

Enable test results as a view or a materialized view via the [`materialized` config](https://docs.getdbt.com/docs/build/materializations) so that they will always show the current failures without the need to run dbt.
 
Users can specify the materialization within the config block in their tests like any the following:
- `materialized="table"` (isomorphic to [`--store-failures`](https://docs.getdbt.com/reference/resource-configs/store_failures))
- `materialized="view"` **NEW**
- `materialized="materialized_view"` **NEW**

#### Implementation details
Flesh out the ideas in [this Loom](https://www.loom.com/share/725ca16f9cab450b8c4c38ebd601a7b6) by combining https://github.com/dbt-labs/dbt-core/pull/8653 with the approach used by the [`clone` materialization](https://github.com/dbt-labs/dbt-core/blob/408a78985a647c52125e344c64747b21c02651f7/core/dbt/include/global_project/macros/materializations/models/clone/clone.sql#L54-L62) (introduced in #7881).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
