### PR TITLE
Fix `tag:` selection for projects with semantic models

### DIFF
--- a/.changes/unreleased/Fixes-20230929-175342.yaml
+++ b/.changes/unreleased/Fixes-20230929-175342.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix tag selection for projects with semantic models
+time: 2023-09-29T17:53:42.960596+02:00
+custom:
+  Author: jtcohen6
+  Issue: "8749"

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -234,7 +234,9 @@ class TagSelectorMethod(SelectorMethod):
     def search(self, included_nodes: Set[UniqueId], selector: str) -> Iterator[UniqueId]:
         """yields nodes from included that have the specified tag"""
         for node, real_node in self.all_nodes(included_nodes):
-            if any(fnmatch(tag, selector) for tag in real_node.tags):
+            if hasattr(real_node, "tags") and any(
+                fnmatch(tag, selector) for tag in real_node.tags
+            ):
                 yield node
 
 

--- a/tests/unit/test_graph_selector_methods.py
+++ b/tests/unit/test_graph_selector_methods.py
@@ -1295,6 +1295,21 @@ def test_select_semantic_model(manifest):
     assert search_manifest_using_method(manifest, method, "*omer") == {"customer"}
 
 
+def test_select_semantic_model_by_tag(manifest):
+    semantic_model = make_semantic_model(
+        "pkg",
+        "customer",
+        model="customers",
+        path="_semantic_models.yml",
+    )
+    manifest.semantic_models[semantic_model.unique_id] = semantic_model
+    methods = MethodManager(manifest, None)
+    method = methods.get_method("tag", [])
+    assert isinstance(method, TagSelectorMethod)
+    assert method.arguments == []
+    search_manifest_using_method(manifest, method, "any_tag")
+
+
 @pytest.fixture
 def previous_state(manifest):
     writable = copy.deepcopy(manifest).writable_manifest()


### PR DESCRIPTION
resolves #8749

### Problem

In projects with semantic models, `tag:` selection started failing with the release of v1.6.4

### Solution

Add more defensive code around `tag:` selection. Previously, this method assumed that all graph-selectable resources have a `tags` attribute, but semantic models do not (yet).

Rather than backporting an addition of `tags` to semantic models, we would rather backport more defensive code.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
