### PR TITLE
rebuild manifest missed fields

### DIFF
--- a/.changes/unreleased/Features-20230914-074429.yaml
+++ b/.changes/unreleased/Features-20230914-074429.yaml
@@ -4,4 +4,4 @@ body: Add support for optional label in semantic_models, measures, dimensions an
 time: 2023-09-14T07:44:29.828199-05:00
 custom:
   Author: emmyoop
-  Issue: "8595"
+  Issue: 8595 8755

--- a/.changes/unreleased/Features-20230922-150754.yaml
+++ b/.changes/unreleased/Features-20230922-150754.yaml
@@ -2,5 +2,5 @@ kind: Features
 body: Support `fill_nulls_with` and `join_to_timespine` for metric nodes
 time: 2023-09-22T15:07:54.981752-07:00
 custom:
-  Author: QMalcolm
-  Issue: "8593"
+  Author: QMalcolm emmyoop
+  Issue: 8593 8755

--- a/schemas/dbt/manifest/v11.json
+++ b/schemas/dbt/manifest/v11.json
@@ -4610,6 +4610,21 @@
             }
           ],
           "default": null
+        },
+        "join_to_timespine": {
+          "type": "boolean",
+          "default": false
+        },
+        "fill_nulls_with": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "additionalProperties": false,
@@ -5137,6 +5152,17 @@
           ],
           "default": null
         },
+        "label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "role": {
           "anyOf": [
             {
@@ -5247,6 +5273,17 @@
           ]
         },
         "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
           "anyOf": [
             {
               "type": "string"
@@ -5371,6 +5408,17 @@
           ]
         },
         "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
           "anyOf": [
             {
               "type": "string"
@@ -5511,6 +5559,17 @@
           ]
         },
         "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
           "anyOf": [
             {
               "type": "string"


### PR DESCRIPTION
missing from PRs #8700 & #8646

### Problem

Fields were added but the manifest was not regenerated.

### Solution

Regenerate v11 of the manifest to add missing fields

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
