### PR TITLE
[1.6.latest] regenerate v10 manifest

### DIFF
--- a/.changes/unreleased/Fixes-20231004-075904.yaml
+++ b/.changes/unreleased/Fixes-20231004-075904.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Regenerate the v10 manifest jsonschema
+time: 2023-10-04T07:59:04.593928-05:00
+custom:
+  Author: emmyoop
+  Issue: "8763"

--- a/schemas/dbt/manifest/v10.json
+++ b/schemas/dbt/manifest/v10.json
@@ -227,12 +227,12 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.6.0"
+          "default": "1.6.5"
         },
         "generated_at": {
           "type": "string",
           "format": "date-time",
-          "default": "2023-08-07T20:10:03.381822Z"
+          "default": "2023-10-04T12:51:08.278576Z"
         },
         "invocation_id": {
           "oneOf": [
@@ -243,7 +243,7 @@
               "type": "null"
             }
           ],
-          "default": "03dee192-ff77-43cc-bc3f-5eeaf6d36344"
+          "default": "91c3fe8c-af16-45af-addf-bad2baaac57b"
         },
         "env": {
           "type": "object",
@@ -474,7 +474,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1691439003.386713
+          "default": 1696423868.282719
         },
         "config_call_dict": {
           "type": "object",
@@ -1187,7 +1187,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1691439003.389955
+          "default": 1696423868.286342
         },
         "config_call_dict": {
           "type": "object",
@@ -1575,7 +1575,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1691439003.3916101
+          "default": 1696423868.2879858
         },
         "config_call_dict": {
           "type": "object",
@@ -1851,7 +1851,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1691439003.393298
+          "default": 1696423868.2906518
         },
         "config_call_dict": {
           "type": "object",
@@ -1954,8 +1954,8 @@
         "access": {
           "type": "string",
           "enum": [
-            "protected",
             "private",
+            "protected",
             "public"
           ],
           "default": "protected"
@@ -2273,7 +2273,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1691439003.39583
+          "default": 1696423868.293976
         },
         "config_call_dict": {
           "type": "object",
@@ -2539,7 +2539,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1691439003.3974268
+          "default": 1696423868.29565
         },
         "config_call_dict": {
           "type": "object",
@@ -2797,7 +2797,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1691439003.399393
+          "default": 1696423868.2974122
         },
         "config_call_dict": {
           "type": "object",
@@ -3092,7 +3092,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1691439003.4026701
+          "default": 1696423868.3007638
         },
         "config_call_dict": {
           "type": "object",
@@ -3599,7 +3599,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1691439003.4056058
+          "default": 1696423868.3035781
         },
         "config_call_dict": {
           "type": "object",
@@ -4020,7 +4020,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1691439003.408927
+          "default": 1696423868.3070972
         }
       },
       "additionalProperties": false,
@@ -4120,6 +4120,138 @@
       "additionalProperties": false,
       "description": "FreshnessThreshold(warn_after: Union[dbt.contracts.graph.unparsed.Time, NoneType] = <factory>, error_after: Union[dbt.contracts.graph.unparsed.Time, NoneType] = <factory>, filter: Union[str, NoneType] = None)"
     },
+    "FreshnessMetadata": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "dbt_schema_version": {
+          "type": "string",
+          "default": "https://schemas.getdbt.com/dbt/sources/v3.json"
+        },
+        "dbt_version": {
+          "type": "string",
+          "default": "1.6.5"
+        },
+        "generated_at": {
+          "type": "string",
+          "format": "date-time",
+          "default": "2023-10-04T12:51:08.273991Z"
+        },
+        "invocation_id": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "91c3fe8c-af16-45af-addf-bad2baaac57b"
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false,
+      "description": "FreshnessMetadata(dbt_schema_version: str = <factory>, dbt_version: str = '1.6.5', generated_at: datetime.datetime = <factory>, invocation_id: Union[str, NoneType] = <factory>, env: Dict[str, str] = <factory>)"
+    },
+    "SourceFreshnessRuntimeError": {
+      "type": "object",
+      "required": [
+        "unique_id",
+        "status"
+      ],
+      "properties": {
+        "unique_id": {
+          "type": "string"
+        },
+        "error": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "runtime error"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "description": "SourceFreshnessRuntimeError(unique_id: str, error: Union[str, int, NoneType], status: dbt.contracts.results.FreshnessErrorEnum)"
+    },
+    "SourceFreshnessOutput": {
+      "type": "object",
+      "required": [
+        "unique_id",
+        "max_loaded_at",
+        "snapshotted_at",
+        "max_loaded_at_time_ago_in_s",
+        "status",
+        "criteria",
+        "adapter_response",
+        "timing",
+        "thread_id",
+        "execution_time"
+      ],
+      "properties": {
+        "unique_id": {
+          "type": "string"
+        },
+        "max_loaded_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "snapshotted_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "max_loaded_at_time_ago_in_s": {
+          "type": "number"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "pass",
+            "warn",
+            "error",
+            "runtime error"
+          ]
+        },
+        "criteria": {
+          "$ref": "#/definitions/FreshnessThreshold"
+        },
+        "adapter_response": {
+          "type": "object"
+        },
+        "timing": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TimingInfo"
+          }
+        },
+        "thread_id": {
+          "type": "string"
+        },
+        "execution_time": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "description": "SourceFreshnessOutput(unique_id: str, max_loaded_at: datetime.datetime, snapshotted_at: datetime.datetime, max_loaded_at_time_ago_in_s: float, status: dbt.contracts.results.FreshnessStatus, criteria: dbt.contracts.graph.unparsed.FreshnessThreshold, adapter_response: Dict[str, Any], timing: List[dbt.contracts.results.TimingInfo], thread_id: str, execution_time: float)"
+    },
     "Time": {
       "type": "object",
       "required": [],
@@ -4152,6 +4284,41 @@
       },
       "additionalProperties": false,
       "description": "Time(count: Union[int, NoneType] = None, period: Union[dbt.contracts.graph.unparsed.TimePeriod, NoneType] = None)"
+    },
+    "TimingInfo": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "started_at": {
+          "oneOf": [
+            {
+              "type": "string",
+              "format": "date-time"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "completed_at": {
+          "oneOf": [
+            {
+              "type": "string",
+              "format": "date-time"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "description": "TimingInfo(name: str, started_at: Union[datetime.datetime, NoneType] = None, completed_at: Union[datetime.datetime, NoneType] = None)"
     },
     "ExternalTable": {
       "type": "object",
@@ -4332,7 +4499,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1691439003.409885
+          "default": 1696423868.3079429
         },
         "supported_languages": {
           "oneOf": [
@@ -4572,7 +4739,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1691439003.411563
+          "default": 1696423868.309657
         }
       },
       "additionalProperties": false,
@@ -4757,7 +4924,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1691439003.41419
+          "default": 1696423868.3126311
         },
         "group": {
           "oneOf": [
@@ -5179,6 +5346,16 @@
             }
           ]
         },
+        "label": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "defaults": {
           "oneOf": [
             {
@@ -5236,7 +5413,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1691439003.4182558
+          "default": 1696423868.316482
         },
         "config": {
           "$ref": "#/definitions/SemanticModelConfig",
@@ -5256,7 +5433,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "SemanticModel(name: str, resource_type: dbt.node_types.NodeType, package_name: str, path: str, original_file_path: str, unique_id: str, fqn: List[str], model: str, node_relation: Union[dbt.contracts.graph.nodes.NodeRelation, NoneType], description: Union[str, NoneType] = None, defaults: Union[dbt.contracts.graph.semantic_models.Defaults, NoneType] = None, entities: Sequence[dbt.contracts.graph.semantic_models.Entity] = <factory>, measures: Sequence[dbt.contracts.graph.semantic_models.Measure] = <factory>, dimensions: Sequence[dbt.contracts.graph.semantic_models.Dimension] = <factory>, metadata: Union[dbt.contracts.graph.semantic_models.SourceFileMetadata, NoneType] = None, depends_on: dbt.contracts.graph.nodes.DependsOn = <factory>, refs: List[dbt.contracts.graph.nodes.RefArgs] = <factory>, created_at: float = <factory>, config: dbt.contracts.graph.model_config.SemanticModelConfig = <factory>, primary_entity: Union[str, NoneType] = None)"
+      "description": "SemanticModel(name: str, resource_type: dbt.node_types.NodeType, package_name: str, path: str, original_file_path: str, unique_id: str, fqn: List[str], model: str, node_relation: Union[dbt.contracts.graph.nodes.NodeRelation, NoneType], description: Union[str, NoneType] = None, label: Union[str, NoneType] = None, defaults: Union[dbt.contracts.graph.semantic_models.Defaults, NoneType] = None, entities: Sequence[dbt.contracts.graph.semantic_models.Entity] = <factory>, measures: Sequence[dbt.contracts.graph.semantic_models.Measure] = <factory>, dimensions: Sequence[dbt.contracts.graph.semantic_models.Dimension] = <factory>, metadata: Union[dbt.contracts.graph.semantic_models.SourceFileMetadata, NoneType] = None, depends_on: dbt.contracts.graph.nodes.DependsOn = <factory>, refs: List[dbt.contracts.graph.nodes.RefArgs] = <factory>, created_at: float = <factory>, config: dbt.contracts.graph.model_config.SemanticModelConfig = <factory>, primary_entity: Union[str, NoneType] = None)"
     },
     "NodeRelation": {
       "type": "object",
@@ -5342,6 +5519,16 @@
             }
           ]
         },
+        "label": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "role": {
           "oneOf": [
             {
@@ -5364,7 +5551,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Entity(name: str, type: dbt_semantic_interfaces.type_enums.entity_type.EntityType, description: Union[str, NoneType] = None, role: Union[str, NoneType] = None, expr: Union[str, NoneType] = None)"
+      "description": "Entity(name: str, type: dbt_semantic_interfaces.type_enums.entity_type.EntityType, description: Union[str, NoneType] = None, label: Union[str, NoneType] = None, role: Union[str, NoneType] = None, expr: Union[str, NoneType] = None)"
     },
     "Measure": {
       "type": "object",
@@ -5391,6 +5578,16 @@
           ]
         },
         "description": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label": {
           "oneOf": [
             {
               "type": "string"
@@ -5446,7 +5643,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Measure(name: str, agg: dbt_semantic_interfaces.type_enums.aggregation_type.AggregationType, description: Union[str, NoneType] = None, create_metric: bool = False, expr: Union[str, NoneType] = None, agg_params: Union[dbt.contracts.graph.semantic_models.MeasureAggregationParameters, NoneType] = None, non_additive_dimension: Union[dbt.contracts.graph.semantic_models.NonAdditiveDimension, NoneType] = None, agg_time_dimension: Union[str, NoneType] = None)"
+      "description": "Measure(name: str, agg: dbt_semantic_interfaces.type_enums.aggregation_type.AggregationType, description: Union[str, NoneType] = None, label: Union[str, NoneType] = None, create_metric: bool = False, expr: Union[str, NoneType] = None, agg_params: Union[dbt.contracts.graph.semantic_models.MeasureAggregationParameters, NoneType] = None, non_additive_dimension: Union[dbt.contracts.graph.semantic_models.NonAdditiveDimension, NoneType] = None, agg_time_dimension: Union[str, NoneType] = None)"
     },
     "MeasureAggregationParameters": {
       "type": "object",
@@ -5536,6 +5733,16 @@
             }
           ]
         },
+        "label": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "is_partition": {
           "type": "boolean",
           "default": false
@@ -5572,7 +5779,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Dimension(name: str, type: dbt_semantic_interfaces.type_enums.dimension_type.DimensionType, description: Union[str, NoneType] = None, is_partition: bool = False, type_params: Union[dbt.contracts.graph.semantic_models.DimensionTypeParams, NoneType] = None, expr: Union[str, NoneType] = None, metadata: Union[dbt.contracts.graph.semantic_models.SourceFileMetadata, NoneType] = None)"
+      "description": "Dimension(name: str, type: dbt_semantic_interfaces.type_enums.dimension_type.DimensionType, description: Union[str, NoneType] = None, label: Union[str, NoneType] = None, is_partition: bool = False, type_params: Union[dbt.contracts.graph.semantic_models.DimensionTypeParams, NoneType] = None, expr: Union[str, NoneType] = None, metadata: Union[dbt.contracts.graph.semantic_models.SourceFileMetadata, NoneType] = None)"
     },
     "DimensionTypeParams": {
       "type": "object",


### PR DESCRIPTION
resolves #8763 

### Problem
Support for labels in semantic models was backported to 1.6 but the manifest was not regenerated to support it so the v10 manifest schema cannot be used to validate manifests.

### Solution

Update the v10 manifest json schema.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
