### PR TITLE
remove top level meta attribute from SemanticModels

### DIFF
--- a/.changes/unreleased/Features-20230929-170945.yaml
+++ b/.changes/unreleased/Features-20230929-170945.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Add meta attribute to SemanticModels
+body: Add meta attribute to SemanticModels config
 time: 2023-09-29T17:09:45.0354-05:00
 custom:
   Author: emmyoop

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1583,7 +1583,6 @@ class SemanticModel(GraphNode):
     refs: List[RefArgs] = field(default_factory=list)
     created_at: float = field(default_factory=lambda: time.time())
     config: SemanticModelConfig = field(default_factory=SemanticModelConfig)
-    meta: Dict[str, Any] = field(default_factory=dict)
     unrendered_config: Dict[str, Any] = field(default_factory=dict)
     primary_entity: Optional[str] = None
     group: Optional[str] = None

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -712,7 +712,6 @@ class UnparsedSemanticModel(dbtClassMixin):
     name: str
     model: str  # looks like "ref(...)"
     config: Dict[str, Any] = field(default_factory=dict)
-    meta: Dict[str, Any] = field(default_factory=dict)
     description: Optional[str] = None
     label: Optional[str] = None
     defaults: Optional[Defaults] = None

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -596,13 +596,7 @@ class SemanticModelParser(YamlReader):
             config=config,
             unrendered_config=unrendered_config,
             group=config.group,
-            meta=unparsed.meta,
         )
-
-        # If we have meta in the config, copy to node level, for backwards
-        # compatibility with earlier node-only config.
-        if "meta" in config and config["meta"]:
-            parsed.meta = config["meta"]
 
         ctx = generate_parse_semantic_models(
             parsed,

--- a/schemas/dbt/manifest/v11.json
+++ b/schemas/dbt/manifest/v11.json
@@ -5641,12 +5641,6 @@
         "config": {
           "$ref": "#/$defs/SemanticModelConfig"
         },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
         "unrendered_config": {
           "type": "object",
           "propertyNames": {

--- a/tests/functional/semantic_models/test_semantic_model_configs.py
+++ b/tests/functional/semantic_models/test_semantic_model_configs.py
@@ -225,5 +225,4 @@ class TestMetaConfig:
         assert sm_id in manifest.semantic_models
         sm_node = manifest.semantic_models[sm_id]
         meta_expected = {"my_meta": "testing", "my_other_meta": "testing more"}
-        assert sm_node.meta == meta_expected
         assert sm_node.config.meta == meta_expected


### PR DESCRIPTION
related to #8511

### Problem

`meta` is a top level attribute in #8754 but doesn't need to be

### Solution

Modify to only allow meta under the config key.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
