### PR TITLE
support doc blocks on versioned models

### DIFF
--- a/.changes/unreleased/Fixes-20231004-144148.yaml
+++ b/.changes/unreleased/Fixes-20231004-144148.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Support docs blocks on versioned model column descriptions
+time: 2023-10-04T14:41:48.843486-05:00
+custom:
+  Author: emmyoop
+  Issue: "8540"

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1117,10 +1117,12 @@ class ManifestLoader:
                 database=refd_node.database,
             )
 
-    # nodes: node and column descriptions
+    # nodes: node and column descriptions, version columns descriptions
     # sources: source and table descriptions, column descriptions
     # macros: macro argument descriptions
     # exposures: exposure descriptions
+    # metrics: metric descriptions
+    # semantic_models: semantic model descriptions
     def process_docs(self, config: RuntimeConfig):
         for node in self.manifest.nodes.values():
             if node.created_at < self.started_at:

--- a/core/dbt/parser/schema_renderer.py
+++ b/core/dbt/parser/schema_renderer.py
@@ -34,10 +34,16 @@ class SchemaYamlRenderer(BaseRenderer):
         Return True if it's tests or description - those aren't rendered now
         because they're rendered later in parse_generic_tests or process_docs.
         """
+        # top level descriptions and tests
         if len(keypath) >= 1 and keypath[0] in ("tests", "description"):
             return True
 
+        # columns descriptions and tests
         if len(keypath) == 2 and keypath[1] in ("tests", "description"):
+            return True
+
+        # versions
+        if len(keypath) == 5 and keypath[4] == "description":
             return True
 
         if (

--- a/tests/functional/docs/test_model_version_docs_blocks.py
+++ b/tests/functional/docs/test_model_version_docs_blocks.py
@@ -1,0 +1,74 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+model_1 = """
+select 1 as id, 'joe' as first_name
+"""
+
+model_versioned = """
+select 1 as id, 'joe' as first_name
+"""
+
+docs_md = """
+{% docs model_description %}
+unversioned model
+{% enddocs %}
+
+{% docs column_id_doc %}
+column id for some thing
+{% enddocs %}
+
+{% docs versioned_model_description %}
+versioned model
+{% enddocs %}
+
+"""
+
+schema_yml = """
+models:
+  - name: model_1
+    description: '{{ doc("model_description") }}'
+    columns:
+        - name: id
+          description: '{{ doc("column_id_doc") }}'
+
+  - name: model_versioned
+    description: '{{ doc("versioned_model_description") }}'
+    latest_version: 1
+    versions:
+      - v: 1
+        config:
+          alias: my_alias
+        columns:
+          - name: id
+            description: '{{ doc("column_id_doc") }}'
+          - name: first_name
+            description: 'plain text'
+      - v: 2
+        columns:
+          - name: other_id
+"""
+
+
+class TestVersionedModelDocsBlock:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_1.sql": model_1,
+            "model_versioned.sql": model_versioned,
+            "schema.yml": schema_yml,
+            "docs.md": docs_md,
+        }
+
+    def test_versioned_doc_ref(self, project):
+        manifest = run_dbt(["parse"])
+        model_1 = manifest.nodes["model.test.model_1"]
+        model_v1 = manifest.nodes["model.test.model_versioned.v1"]
+
+        assert model_1.description == "unversioned model"
+        assert model_v1.description == "versioned model"
+
+        assert model_1.columns["id"].description == "column id for some thing"
+        assert model_v1.columns["id"].description == "column id for some thing"
+        assert model_v1.columns["first_name"].description == "plain text"


### PR DESCRIPTION
resolves #8540 


### Problem

Column descriptions on versioned models error out when using doc blocks

### Solution

Support doc blocks for versioned columns

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
