### PR TITLE
Selectors in docs generate limits catalog generation

### DIFF
--- a/.changes/unreleased/Features-20231004-170155.yaml
+++ b/.changes/unreleased/Features-20231004-170155.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Selectors with docs generate limits catalog generation
+time: 2023-10-04T17:01:55.845479-04:00
+custom:
+  Author: gshank
+  Issue: "6014"

--- a/core/dbt/task/generate.py
+++ b/core/dbt/task/generate.py
@@ -220,6 +220,10 @@ class GenerateTask(CompileTask):
             DOCS_INDEX_FILE_PATH, os.path.join(self.config.project_target_path, "index.html")
         )
 
+        # Get the list of nodes that have been selected
+        assert self.job_queue is not None
+        selected_nodes: Set = self.job_queue.get_selected_nodes()
+
         for asset_path in self.config.asset_paths:
             to_asset_path = os.path.join(self.config.project_target_path, asset_path)
 
@@ -239,6 +243,7 @@ class GenerateTask(CompileTask):
             adapter = get_adapter(self.config)
             with adapter.connection_named("generate_catalog"):
                 fire_event(BuildingCatalog())
+                # This generates the catalog as an agate.Table
                 catalog_table, exceptions = adapter.get_catalog(self.manifest)
 
         catalog_data: List[PrimitiveDict] = [

--- a/core/dbt/task/generate.py
+++ b/core/dbt/task/generate.py
@@ -221,8 +221,9 @@ class GenerateTask(CompileTask):
         )
 
         # Get the list of nodes that have been selected
-        assert self.job_queue is not None
-        selected_nodes: Set = self.job_queue.get_selected_nodes()
+        selected_nodes = None
+        if self.job_queue is not None:
+            selected_nodes = self.job_queue.get_selected_nodes()
 
         for asset_path in self.config.asset_paths:
             to_asset_path = os.path.join(self.config.project_target_path, asset_path)

--- a/core/dbt/task/generate.py
+++ b/core/dbt/task/generate.py
@@ -244,7 +244,7 @@ class GenerateTask(CompileTask):
             with adapter.connection_named("generate_catalog"):
                 fire_event(BuildingCatalog())
                 # This generates the catalog as an agate.Table
-                catalog_table, exceptions = adapter.get_catalog(self.manifest)
+                catalog_table, exceptions = adapter.get_catalog(self.manifest, selected_nodes)
 
         catalog_data: List[PrimitiveDict] = [
             dict(zip(catalog_table.column_names, map(dbt.utils._coerce_decimal, row)))

--- a/tests/functional/defer_state/test_defer_state.py
+++ b/tests/functional/defer_state/test_defer_state.py
@@ -178,8 +178,7 @@ class TestRunDeferState(BaseDeferState):
                 "otherschema",
             ]
         )
-        assert other_schema not in catalog.nodes["seed.test.seed"].metadata.schema
-        assert unique_schema in catalog.nodes["seed.test.seed"].metadata.schema
+        assert "seed.test.seed" not in catalog.nodes
 
         # with state it should work though
         results = run_dbt(


### PR DESCRIPTION
resolves #6014

### Problem

Catalog generation is expensive, so we want to limit catalog queries to only the selected nodes.

### Solution

Retrieve the selected node unique_ids and pass them to the methods used to get the catalog information. 

### Docs

In the past using a selector on docs generate would only affect which nodes were compiled. With this change, selectors will limit the information in the catalog.json.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
