### PR TITLE
[Backport 1.6.latest] Support null coalescing properties for metric nodes (#8700)

### DIFF
--- a/.changes/unreleased/Features-20230922-150754.yaml
+++ b/.changes/unreleased/Features-20230922-150754.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support `fill_nulls_with` and `join_to_timespine` for metric nodes
+time: 2023-09-22T15:07:54.981752-07:00
+custom:
+  Author: QMalcolm
+  Issue: "8593"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1342,6 +1342,8 @@ class MetricInputMeasure(dbtClassMixin):
     name: str
     filter: Optional[WhereFilter] = None
     alias: Optional[str] = None
+    join_to_timespine: bool = False
+    fill_nulls_with: Optional[int] = None
 
     def measure_reference(self) -> MeasureReference:
         return MeasureReference(element_name=self.name)

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -597,6 +597,8 @@ class UnparsedMetricInputMeasure(dbtClassMixin):
     name: str
     filter: Optional[str] = None
     alias: Optional[str] = None
+    join_to_timespine: bool = False
+    fill_nulls_with: Optional[int] = None
 
 
 @dataclass

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -178,6 +178,8 @@ class MetricParser(YamlReader):
                 name=unparsed_input_measure.name,
                 filter=filter,
                 alias=unparsed_input_measure.alias,
+                join_to_timespine=unparsed_input_measure.join_to_timespine,
+                fill_nulls_with=unparsed_input_measure.fill_nulls_with,
             )
 
     def _get_optional_input_measure(

--- a/schemas/dbt/manifest/v10.json
+++ b/schemas/dbt/manifest/v10.json
@@ -232,7 +232,7 @@
         "generated_at": {
           "type": "string",
           "format": "date-time",
-          "default": "2023-10-04T12:51:08.278576Z"
+          "default": "2023-10-05T00:33:14.410024Z"
         },
         "invocation_id": {
           "oneOf": [
@@ -243,7 +243,7 @@
               "type": "null"
             }
           ],
-          "default": "91c3fe8c-af16-45af-addf-bad2baaac57b"
+          "default": "603e2fae-9c7d-4d17-8530-7d28c9875263"
         },
         "env": {
           "type": "object",
@@ -474,7 +474,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1696423868.282719
+          "default": 1696465994.411958
         },
         "config_call_dict": {
           "type": "object",
@@ -1187,7 +1187,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1696423868.286342
+          "default": 1696465994.413604
         },
         "config_call_dict": {
           "type": "object",
@@ -1575,7 +1575,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1696423868.2879858
+          "default": 1696465994.414359
         },
         "config_call_dict": {
           "type": "object",
@@ -1851,7 +1851,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1696423868.2906518
+          "default": 1696465994.4150689
         },
         "config_call_dict": {
           "type": "object",
@@ -2273,7 +2273,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1696423868.293976
+          "default": 1696465994.416128
         },
         "config_call_dict": {
           "type": "object",
@@ -2539,7 +2539,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1696423868.29565
+          "default": 1696465994.41679
         },
         "config_call_dict": {
           "type": "object",
@@ -2797,7 +2797,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1696423868.2974122
+          "default": 1696465994.4175282
         },
         "config_call_dict": {
           "type": "object",
@@ -3092,7 +3092,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1696423868.3007638
+          "default": 1696465994.418854
         },
         "config_call_dict": {
           "type": "object",
@@ -3599,7 +3599,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1696423868.3035781
+          "default": 1696465994.420199
         },
         "config_call_dict": {
           "type": "object",
@@ -4020,7 +4020,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1696423868.3070972
+          "default": 1696465994.421661
         }
       },
       "additionalProperties": false,
@@ -4120,138 +4120,6 @@
       "additionalProperties": false,
       "description": "FreshnessThreshold(warn_after: Union[dbt.contracts.graph.unparsed.Time, NoneType] = <factory>, error_after: Union[dbt.contracts.graph.unparsed.Time, NoneType] = <factory>, filter: Union[str, NoneType] = None)"
     },
-    "FreshnessMetadata": {
-      "type": "object",
-      "required": [],
-      "properties": {
-        "dbt_schema_version": {
-          "type": "string",
-          "default": "https://schemas.getdbt.com/dbt/sources/v3.json"
-        },
-        "dbt_version": {
-          "type": "string",
-          "default": "1.6.5"
-        },
-        "generated_at": {
-          "type": "string",
-          "format": "date-time",
-          "default": "2023-10-04T12:51:08.273991Z"
-        },
-        "invocation_id": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": "91c3fe8c-af16-45af-addf-bad2baaac57b"
-        },
-        "env": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "default": {}
-        }
-      },
-      "additionalProperties": false,
-      "description": "FreshnessMetadata(dbt_schema_version: str = <factory>, dbt_version: str = '1.6.5', generated_at: datetime.datetime = <factory>, invocation_id: Union[str, NoneType] = <factory>, env: Dict[str, str] = <factory>)"
-    },
-    "SourceFreshnessRuntimeError": {
-      "type": "object",
-      "required": [
-        "unique_id",
-        "status"
-      ],
-      "properties": {
-        "unique_id": {
-          "type": "string"
-        },
-        "error": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "status": {
-          "type": "string",
-          "enum": [
-            "runtime error"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "description": "SourceFreshnessRuntimeError(unique_id: str, error: Union[str, int, NoneType], status: dbt.contracts.results.FreshnessErrorEnum)"
-    },
-    "SourceFreshnessOutput": {
-      "type": "object",
-      "required": [
-        "unique_id",
-        "max_loaded_at",
-        "snapshotted_at",
-        "max_loaded_at_time_ago_in_s",
-        "status",
-        "criteria",
-        "adapter_response",
-        "timing",
-        "thread_id",
-        "execution_time"
-      ],
-      "properties": {
-        "unique_id": {
-          "type": "string"
-        },
-        "max_loaded_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "snapshotted_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "max_loaded_at_time_ago_in_s": {
-          "type": "number"
-        },
-        "status": {
-          "type": "string",
-          "enum": [
-            "pass",
-            "warn",
-            "error",
-            "runtime error"
-          ]
-        },
-        "criteria": {
-          "$ref": "#/definitions/FreshnessThreshold"
-        },
-        "adapter_response": {
-          "type": "object"
-        },
-        "timing": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/TimingInfo"
-          }
-        },
-        "thread_id": {
-          "type": "string"
-        },
-        "execution_time": {
-          "type": "number"
-        }
-      },
-      "additionalProperties": false,
-      "description": "SourceFreshnessOutput(unique_id: str, max_loaded_at: datetime.datetime, snapshotted_at: datetime.datetime, max_loaded_at_time_ago_in_s: float, status: dbt.contracts.results.FreshnessStatus, criteria: dbt.contracts.graph.unparsed.FreshnessThreshold, adapter_response: Dict[str, Any], timing: List[dbt.contracts.results.TimingInfo], thread_id: str, execution_time: float)"
-    },
     "Time": {
       "type": "object",
       "required": [],
@@ -4284,41 +4152,6 @@
       },
       "additionalProperties": false,
       "description": "Time(count: Union[int, NoneType] = None, period: Union[dbt.contracts.graph.unparsed.TimePeriod, NoneType] = None)"
-    },
-    "TimingInfo": {
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "started_at": {
-          "oneOf": [
-            {
-              "type": "string",
-              "format": "date-time"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "completed_at": {
-          "oneOf": [
-            {
-              "type": "string",
-              "format": "date-time"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "description": "TimingInfo(name: str, started_at: Union[datetime.datetime, NoneType] = None, completed_at: Union[datetime.datetime, NoneType] = None)"
     },
     "ExternalTable": {
       "type": "object",
@@ -4499,7 +4332,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1696423868.3079429
+          "default": 1696465994.421958
         },
         "supported_languages": {
           "oneOf": [
@@ -4739,7 +4572,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1696423868.309657
+          "default": 1696465994.422623
         }
       },
       "additionalProperties": false,
@@ -4924,7 +4757,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1696423868.3126311
+          "default": 1696465994.4238322
         },
         "group": {
           "oneOf": [
@@ -5063,10 +4896,24 @@
               "type": "null"
             }
           ]
+        },
+        "join_to_timespine": {
+          "type": "boolean",
+          "default": false
+        },
+        "fill_nulls_with": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,
-      "description": "MetricInputMeasure(name: str, filter: Union[dbt.contracts.graph.nodes.WhereFilter, NoneType] = None, alias: Union[str, NoneType] = None)"
+      "description": "MetricInputMeasure(name: str, filter: Union[dbt.contracts.graph.nodes.WhereFilter, NoneType] = None, alias: Union[str, NoneType] = None, join_to_timespine: bool = False, fill_nulls_with: Union[int, NoneType] = None)"
     },
     "WhereFilter": {
       "type": "object",
@@ -5413,7 +5260,7 @@
         },
         "created_at": {
           "type": "number",
-          "default": 1696423868.316482
+          "default": 1696465994.425479
         },
         "config": {
           "$ref": "#/definitions/SemanticModelConfig",

--- a/tests/functional/metrics/fixtures.py
+++ b/tests/functional/metrics/fixtures.py
@@ -116,6 +116,8 @@ metrics:
       measure:
         name: years_tenure
         filter: "{{ Dimension('id__loves_dbt') }} is true"
+        join_to_timespine: true
+        fill_nulls_with: 0
 
   - name: collective_window
     label: "Collective window"

--- a/tests/unit/test_contracts_graph_unparsed.py
+++ b/tests/unit/test_contracts_graph_unparsed.py
@@ -870,6 +870,7 @@ class TestUnparsedMetric(ContractTestCase):
                 "measure": {
                     "name": "customers",
                     "filter": "is_new = true",
+                    "join_to_timespine": False,
                 },
             },
             "config": {},

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -216,7 +216,11 @@ def simple_metric_input_measure() -> MetricInputMeasure:
 @pytest.fixture(scope="session")
 def complex_metric_input_measure(where_filter) -> MetricInputMeasure:
     return MetricInputMeasure(
-        name="test_complex_metric_input_measure", filter=where_filter, alias="complex_alias"
+        name="test_complex_metric_input_measure",
+        filter=where_filter,
+        alias="complex_alias",
+        join_to_timespine=True,
+        fill_nulls_with=0,
     )
 
 


### PR DESCRIPTION
resolves #8593

THIS IS A BACKPORT OF #8700 

### Problem

MetricFlow is adding support for null value coalescing (https://github.com/dbt-labs/metricflow/issues/759). In order to use that, dbt-core needs to support the related properties

### Solution

Add the properties join_to_timespine and fill_nulls_with (as defined in the related MF and DSI issues: https://github.com/dbt-labs/metricflow/issues/759, https://github.com/dbt-labs/dbt-semantic-interfaces/issues/142) to the metric node definition.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
