### PR TITLE
remove guild as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,23 +13,6 @@
 # the core team as a whole will be assigned
 *       @dbt-labs/core-team
 
-### OSS Tooling Guild
-
-/.github/                       @dbt-labs/guild-oss-tooling
-.bumpversion.cfg                @dbt-labs/guild-oss-tooling
-
-.changie.yaml                   @dbt-labs/guild-oss-tooling
-
-pre-commit-config.yaml          @dbt-labs/guild-oss-tooling
-pytest.ini                      @dbt-labs/guild-oss-tooling
-tox.ini                         @dbt-labs/guild-oss-tooling
-
-pyproject.toml                  @dbt-labs/guild-oss-tooling
-requirements.txt                @dbt-labs/guild-oss-tooling
-dev_requirements.txt            @dbt-labs/guild-oss-tooling
-/core/setup.py                  @dbt-labs/guild-oss-tooling
-/core/MANIFEST.in               @dbt-labs/guild-oss-tooling
-
 ### ADAPTERS
 
 # Adapter interface ("base" + "sql" adapter defaults, cache)
@@ -40,7 +23,7 @@ dev_requirements.txt            @dbt-labs/guild-oss-tooling
 
 # Postgres plugin
 /plugins/                       @dbt-labs/core-adapters
-/plugins/postgres/setup.py      @dbt-labs/core-adapters @dbt-labs/guild-oss-tooling
+/plugins/postgres/setup.py      @dbt-labs/core-adapters
 
 # Functional tests for adapter plugins
 /tests/adapter                  @dbt-labs/core-adapters


### PR DESCRIPTION
### Problem

CODEOWNERS contains the guild as a code owner but it's no longer relevant

### Solution

Remove the oss guild from the file

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
