### PR TITLE
pin types-requests in dev-requirements

### DIFF
--- a/.changes/unreleased/Under the Hood-20231006-093107.yaml
+++ b/.changes/unreleased/Under the Hood-20231006-093107.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Pin types-requests<2.31.0 in `dev-requirements.txt`
+time: 2023-10-06T09:31:07.591896-05:00
+custom:
+  Author: emmyoop
+  Issue: "8789"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -31,7 +31,7 @@ types-mock
 types-protobuf
 types-python-dateutil
 types-pytz
-types-requests
+types-requests<2.31.0 # types-requests 2.31.0.8 requires urllib3>=2, but we pin urllib3 ~= 1.0 because of openssl requirement for requests
 types-setuptools
 wheel
 mocker


### PR DESCRIPTION
resolves #8789 

### Problem

When installing dev dependencies you get the following error:
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behavior is the source of the following dependency conflicts.
types-requests 2.31.0.8 requires urllib3>=2, but you have urllib3 1.26.17 which is incompatible.
```

We have urllib3 pinned to version 1 because requests depends on openssl (https://github.com/dbt-labs/dbt-core/issues/7573)

### Solution

Pin `types-requests` in `dev-requirements.txt` to get it working for now.

Look into if/when we can unpin `urllib3`. https://github.com/dbt-labs/dbt-core/issues/8790

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
