### PR TITLE
Fix uncaught exception for group updates

### DIFF
--- a/.changes/unreleased/Fixes-20231010-125948.yaml
+++ b/.changes/unreleased/Fixes-20231010-125948.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Group updates on unmodified nodes are handled gracefully for state:modified
+time: 2023-10-10T12:59:48.390113-05:00
+custom:
+  Author: emmyoop
+  Issue: "8371"

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -945,7 +945,12 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         group_map = {group.name: [] for group in self.groups.values()}
         for node in groupable_nodes:
             if node.group is not None:
-                # TODO: should we log something here?  We don't want to count group changes
+                # group updates are not included with state:modified and
+                # by ignoring the groups that aren't in the group map we
+                # can avoid hitting errors for groups that are not getting
+                # updated.  This is a hack but any groups that are not
+                # valid will be caught in
+                # parser.manifest.ManifestLoader.check_valid_group_config_node
                 if node.group in group_map:
                     group_map[node.group].append(node.unique_id)
         self.group_map = group_map

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -944,8 +944,11 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         )
         group_map = {group.name: [] for group in self.groups.values()}
         for node in groupable_nodes:
+            # breakpoint()
             if node.group is not None:
-                group_map[node.group].append(node.unique_id)
+                # TODO: should we log something here?  We don't want to count group changes
+                if node.group in group_map:
+                    group_map[node.group].append(node.unique_id)
         self.group_map = group_map
 
     def writable_manifest(self) -> "WritableManifest":

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -944,7 +944,6 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         )
         group_map = {group.name: [] for group in self.groups.values()}
         for node in groupable_nodes:
-            # breakpoint()
             if node.group is not None:
                 # TODO: should we log something here?  We don't want to count group changes
                 if node.group in group_map:

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1225,7 +1225,6 @@ class ManifestLoader:
             self.check_valid_group_config_node(semantic_model, group_names)
 
         for node in manifest.nodes.values():
-            # breakpoint()
             self.check_valid_group_config_node(node, group_names)
 
     def check_valid_group_config_node(

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1225,6 +1225,7 @@ class ManifestLoader:
             self.check_valid_group_config_node(semantic_model, group_names)
 
         for node in manifest.nodes.values():
+            # breakpoint()
             self.check_valid_group_config_node(node, group_names)
 
     def check_valid_group_config_node(

--- a/tests/functional/defer_state/fixtures.py
+++ b/tests/functional/defer_state/fixtures.py
@@ -359,3 +359,66 @@ snapshot_sql = """
 
 {% endsnapshot %}
 """
+
+model_1_sql = """
+select * from {{ ref('seed') }}
+"""
+
+modified_model_1_sql = """
+select * from  {{ ref('seed') }}
+order by 1
+"""
+
+model_2_sql = """
+select id from  {{ ref('model_1') }}
+"""
+
+modified_model_2_sql = """
+select * from  {{ ref('model_1') }}
+order by 1
+"""
+
+
+group_schema_yml = """
+groups:
+  - name: finance
+    owner:
+      email: finance@jaffleshop.com
+
+models:
+  - name: model_1
+    config:
+      group: finance
+  - name: model_2
+    config:
+      group: finance
+"""
+
+
+group_modified_schema_yml = """
+groups:
+  - name: accounting
+    owner:
+      email: finance@jaffleshop.com
+models:
+  - name: model_1
+    config:
+      group: accounting
+  - name: model_2
+    config:
+      group: accounting
+"""
+
+group_modified_fail_schema_yml = """
+groups:
+  - name: finance
+    owner:
+      email: finance@jaffleshop.com
+models:
+  - name: model_1
+    config:
+      group: accounting
+  - name: model_2
+    config:
+      group: finance
+"""

--- a/tests/functional/defer_state/test_group_updates.py
+++ b/tests/functional/defer_state/test_group_updates.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from dbt.tests.util import run_dbt, write_file, rm_file, copy_file
+from dbt.tests.util import run_dbt, write_file, copy_file
 
 from tests.functional.defer_state.fixtures import (
     seed_csv,
@@ -93,16 +93,12 @@ class TestModifiedGroups:
         write_file(modified_model_1_sql, "models", "model_1.sql")
         write_file(modified_schema_yml, "models", "schema.yml")
 
-        # only thing in results should be model_1
+        # this test is flaky if you don't clean first before the build
         run_dbt(["clean"])
+        # only thing in results should be model_1
         results = run_dbt(["build", "-s", "state:modified", "--defer", "--state", "./state"])
 
         assert len(results) == 1
         model_1_result = results[0].node
         assert model_1_result.unique_id == "model.test.model_1"
         assert model_1_result.group == "accounting"  # new group name!
-
-        # cleanup
-        rm_file("state/manifest.json")
-
-        # TODO: fix so that the error is just ignored.  we don't care about the unmodifed models with group name changes

--- a/tests/functional/defer_state/test_group_updates.py
+++ b/tests/functional/defer_state/test_group_updates.py
@@ -37,6 +37,8 @@ models:
     config:
       group: finance
   - name: model_2
+    config:
+      group: finance
 """
 
 
@@ -50,6 +52,8 @@ models:
     config:
       group: accounting
   - name: model_2
+    config:
+      group: accounting
 """
 
 
@@ -82,7 +86,7 @@ class TestModifiedGroups:
         assert model_1_result.group == "finance"
         model_2_result = results[2].node
         assert model_2_result.unique_id == "model.test.model_2"
-        assert model_2_result.group is None
+        assert model_2_result.group == "finance"
 
         os.makedirs("state")
         shutil.copyfile("target/manifest.json", "state/manifest.json")
@@ -98,3 +102,5 @@ class TestModifiedGroups:
         model_1_result = results[0].node
         assert model_1_result.unique_id == "model.test.model_1"
         assert model_1_result.group == "accounting"  # new group name!
+
+        # TODO: fix so that the error is just ignored.  we don't care about the unmodifed models with group name changes

--- a/tests/functional/defer_state/test_group_updates.py
+++ b/tests/functional/defer_state/test_group_updates.py
@@ -1,0 +1,85 @@
+import os
+import shutil
+
+import pytest
+
+from dbt.tests.util import (
+    run_dbt,
+    write_file,
+)
+
+from tests.functional.defer_state.fixtures import (
+    seed_csv,
+)
+
+model_1_sql = """
+select * from {{ ref('seed') }}
+"""
+
+modified_model_1_sql = """
+select * from  {{ ref('seed') }}
+order by 1
+"""
+
+model_2_sql = """
+select id from  {{ ref('model_1') }}
+"""
+
+
+schema_yml = """
+groups:
+  - name: finance
+    owner:
+      email: finance@jaffleshop.com
+
+models:
+  - name: model_1
+    config:
+      group: finance
+  - name: model_2
+"""
+
+
+modified_schema_yml = """
+groups:
+  - name: accounting
+    owner:
+      email: finance@jaffleshop.com
+models:
+  - name: model_1
+    config:
+      group: accounting
+  - name: model_2
+"""
+
+
+class TestModifiedGroups:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_1.sql": model_1_sql,
+            "model_2.sql": model_2_sql,
+            "schema.yml": schema_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "seed.csv": seed_csv,
+        }
+
+    def test_changed_groups(self, project):
+        # save initial state
+        run_dbt(["seed"])
+        run_dbt(["compile"])
+
+        os.makedirs("state")
+        shutil.copyfile("target/manifest.json", "state/manifest.json")
+
+        # update group name everywhere, modify model so it gets picked up
+        write_file(modified_model_1_sql, "models", "model_1.sql")
+        write_file(modified_schema_yml, "models", "schema.yml")
+
+        results = run_dbt(["build", "-s", "state:modified", "--defer", "--state", "./state"])
+        breakpoint()
+        assert len(results) == 1

--- a/tests/functional/defer_state/test_group_updates.py
+++ b/tests/functional/defer_state/test_group_updates.py
@@ -8,65 +8,14 @@ from dbt.exceptions import ParsingError
 
 from tests.functional.defer_state.fixtures import (
     seed_csv,
+    model_1_sql,
+    modified_model_1_sql,
+    model_2_sql,
+    modified_model_2_sql,
+    group_schema_yml,
+    group_modified_schema_yml,
+    group_modified_fail_schema_yml,
 )
-
-model_1_sql = """
-select * from {{ ref('seed') }}
-"""
-
-modified_model_1_sql = """
-select * from  {{ ref('seed') }}
-order by 1
-"""
-
-model_2_sql = """
-select id from  {{ ref('model_1') }}
-"""
-
-
-schema_yml = """
-groups:
-  - name: finance
-    owner:
-      email: finance@jaffleshop.com
-
-models:
-  - name: model_1
-    config:
-      group: finance
-  - name: model_2
-    config:
-      group: finance
-"""
-
-
-modified_schema_yml = """
-groups:
-  - name: accounting
-    owner:
-      email: finance@jaffleshop.com
-models:
-  - name: model_1
-    config:
-      group: accounting
-  - name: model_2
-    config:
-      group: accounting
-"""
-
-modified_fail_schema_yml = """
-groups:
-  - name: finance
-    owner:
-      email: finance@jaffleshop.com
-models:
-  - name: model_1
-    config:
-      group: accounting
-  - name: model_2
-    config:
-      group: finance
-"""
 
 
 class GroupSetup:
@@ -75,7 +24,7 @@ class GroupSetup:
         return {
             "model_1.sql": model_1_sql,
             "model_2.sql": model_2_sql,
-            "schema.yml": schema_yml,
+            "schema.yml": group_schema_yml,
         }
 
     @pytest.fixture(scope="class")
@@ -101,7 +50,7 @@ class GroupSetup:
         assert model_2_result.group == "finance"
 
 
-class TestModifiedGroups(GroupSetup):
+class TestFullyModifiedGroups(GroupSetup):
     def test_changed_groups(self, project):
         self.group_setup()
 
@@ -112,7 +61,35 @@ class TestModifiedGroups(GroupSetup):
 
         # update group name, modify model so it gets picked up
         write_file(modified_model_1_sql, "models", "model_1.sql")
-        write_file(modified_schema_yml, "models", "schema.yml")
+        write_file(modified_model_2_sql, "models", "model_2.sql")
+        write_file(group_modified_schema_yml, "models", "schema.yml")
+
+        # this test is flaky if you don't clean first before the build
+        run_dbt(["clean"])
+        # only thing in results should be model_1
+        results = run_dbt(["build", "-s", "state:modified", "--defer", "--state", "./state"])
+
+        assert len(results) == 2
+        model_1_result = results[0].node
+        assert model_1_result.unique_id == "model.test.model_1"
+        assert model_1_result.group == "accounting"  # new group name!
+        model_2_result = results[1].node
+        assert model_2_result.unique_id == "model.test.model_2"
+        assert model_2_result.group == "accounting"  # new group name!
+
+
+class TestPartiallyModifiedGroups(GroupSetup):
+    def test_changed_groups(self, project):
+        self.group_setup()
+
+        # copy manifest.json to "state" directory
+        os.makedirs("state")
+        target_path = os.path.join(project.project_root, "target")
+        copy_file(target_path, "manifest.json", project.project_root, ["state", "manifest.json"])
+
+        # update group name, modify model so it gets picked up
+        write_file(modified_model_1_sql, "models", "model_1.sql")
+        write_file(group_modified_schema_yml, "models", "schema.yml")
 
         # this test is flaky if you don't clean first before the build
         run_dbt(["clean"])
@@ -136,7 +113,7 @@ class TestBadGroups(GroupSetup):
 
         # update group with invalid name, modify model so it gets picked up
         write_file(modified_model_1_sql, "models", "model_1.sql")
-        write_file(modified_fail_schema_yml, "models", "schema.yml")
+        write_file(group_modified_fail_schema_yml, "models", "schema.yml")
 
         # this test is flaky if you don't clean first before the build
         run_dbt(["clean"])

--- a/tests/functional/defer_state/test_group_updates.py
+++ b/tests/functional/defer_state/test_group_updates.py
@@ -94,6 +94,7 @@ class TestModifiedGroups:
         write_file(modified_schema_yml, "models", "schema.yml")
 
         # only thing in results should be model_1
+        run_dbt(["clean"])
         results = run_dbt(["build", "-s", "state:modified", "--defer", "--state", "./state"])
 
         assert len(results) == 1


### PR DESCRIPTION
resolves #8371 


### Problem

Uncaught exception when a group is updated when a model is also modified.

### Solution

Prevent the exception

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
