### PR TITLE
Add quotes to usernames when revoking and granting table permissions

### DIFF
--- a/.changes/unreleased/Fixes-20231010-193527.yaml
+++ b/.changes/unreleased/Fixes-20231010-193527.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add quotes to usernames when revoking and granting table permissions
+time: 2023-10-10T19:35:27.223761+01:00
+custom:
+  Author: barton996
+  Issue: 6444 8751

--- a/core/dbt/include/global_project/macros/adapters/apply_grants.sql
+++ b/core/dbt/include/global_project/macros/adapters/apply_grants.sql
@@ -70,7 +70,11 @@
 {% endmacro %}
 
 {%- macro default__get_grant_sql(relation, privilege, grantees) -%}
-    grant {{ privilege }} on {{ relation }} to {{ grantees | join(', ') }}
+    grant {{ privilege }} on {{ relation }} to
+    {% for grantee in grantees %}
+    {{ adapter.quote(grantee) }}
+    {% if not loop.last %},{% endif %}
+    {% endfor %}
 {%- endmacro -%}
 
 
@@ -79,7 +83,11 @@
 {% endmacro %}
 
 {%- macro default__get_revoke_sql(relation, privilege, grantees) -%}
-    revoke {{ privilege }} on {{ relation }} from {{ grantees | join(', ') }}
+    revoke {{ privilege }} on {{ relation }} from
+    {% for grantee in grantees %}
+    {{ adapter.quote(grantee) }}
+    {% if not loop.last %},{% endif %}
+    {% endfor %}
 {%- endmacro -%}
 
 


### PR DESCRIPTION
resolves dbt-labs/dbt-adapters#156
resolves dbt-labs/dbt-postgres#55


<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem
For models with grants, where the corresponding table is not new (model has been run before), dbt revokes all grants on this table by looping through all users with table permissions.

The macro currently does not surround the user names that it reads from the table permissions with quotes, meaning that revoke statements on users with usernames like first.last will fail.

This is problematic when granting to a user GROUP, as you cannot control what is returned by the table permissions query using your grant yaml config e.g. grants: select: ["GROUP developers"].
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
apply_grants.sql jinja template is updated so that usernames are surrounded with adapter.quote() character when granting and revoking.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
