### PR TITLE
Partial parsing issue when adding groups and updating models at the same time

### DIFF
--- a/.changes/unreleased/Fixes-20231010-202148.yaml
+++ b/.changes/unreleased/Fixes-20231010-202148.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Partial parsing fix for adding groups and updating models at the same time
+time: 2023-10-10T20:21:48.154666-04:00
+custom:
+  Author: gshank
+  Issue: "8697"

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -338,7 +338,10 @@ class PartialParsing:
             file_id = node.patch_path
             # it might be changed...  then what?
             if file_id not in self.file_diff["deleted"] and file_id in self.saved_files:
-                # schema_files should already be updated
+                # Schema files should already be updated if this comes from a node,
+                # but this code is also called when updating groups and exposures.
+                # This might save the old schema file element, so when the schema file
+                # is processed, it should overwrite it by passing True to "merge_patch"
                 schema_file = self.saved_files[file_id]
                 dict_key = parse_file_type_to_key[source_file.parse_file_type]
                 # look for a matching list dictionary
@@ -615,13 +618,13 @@ class PartialParsing:
             if key_diff["changed"]:
                 for elem in key_diff["changed"]:
                     self.delete_schema_mssa_links(schema_file, dict_key, elem)
-                    self.merge_patch(schema_file, dict_key, elem)
+                    self.merge_patch(schema_file, dict_key, elem, True)
             if key_diff["deleted"]:
                 for elem in key_diff["deleted"]:
                     self.delete_schema_mssa_links(schema_file, dict_key, elem)
             if key_diff["added"]:
                 for elem in key_diff["added"]:
-                    self.merge_patch(schema_file, dict_key, elem)
+                    self.merge_patch(schema_file, dict_key, elem, True)
             # Handle schema file updates due to env_var changes
             if dict_key in env_var_changes and dict_key in new_yaml_dict:
                 for name in env_var_changes[dict_key]:
@@ -630,7 +633,7 @@ class PartialParsing:
                     elem = self.get_schema_element(new_yaml_dict[dict_key], name)
                     if elem:
                         self.delete_schema_mssa_links(schema_file, dict_key, elem)
-                        self.merge_patch(schema_file, dict_key, elem)
+                        self.merge_patch(schema_file, dict_key, elem, True)
 
         # sources
         dict_key = "sources"
@@ -640,7 +643,7 @@ class PartialParsing:
                 if "overrides" in source:  # This is a source patch; need to re-parse orig source
                     self.remove_source_override_target(source)
                 self.delete_schema_source(schema_file, source)
-                self.merge_patch(schema_file, dict_key, source)
+                self.merge_patch(schema_file, dict_key, source, True)
         if source_diff["deleted"]:
             for source in source_diff["deleted"]:
                 if "overrides" in source:  # This is a source patch; need to re-parse orig source
@@ -650,7 +653,7 @@ class PartialParsing:
             for source in source_diff["added"]:
                 if "overrides" in source:  # This is a source patch; need to re-parse orig source
                     self.remove_source_override_target(source)
-                self.merge_patch(schema_file, dict_key, source)
+                self.merge_patch(schema_file, dict_key, source, True)
         # Handle schema file updates due to env_var changes
         if dict_key in env_var_changes and dict_key in new_yaml_dict:
             for name in env_var_changes[dict_key]:
@@ -661,7 +664,7 @@ class PartialParsing:
                     if "overrides" in source:
                         self.remove_source_override_target(source)
                     self.delete_schema_source(schema_file, source)
-                    self.merge_patch(schema_file, dict_key, source)
+                    self.merge_patch(schema_file, dict_key, source, True)
 
         def handle_change(key: str, delete: Callable):
             self._handle_element_change(
@@ -681,13 +684,13 @@ class PartialParsing:
         if element_diff["changed"]:
             for element in element_diff["changed"]:
                 delete(schema_file, element)
-                self.merge_patch(schema_file, dict_key, element)
+                self.merge_patch(schema_file, dict_key, element, True)
         if element_diff["deleted"]:
             for element in element_diff["deleted"]:
                 delete(schema_file, element)
         if element_diff["added"]:
             for element in element_diff["added"]:
-                self.merge_patch(schema_file, dict_key, element)
+                self.merge_patch(schema_file, dict_key, element, True)
         # Handle schema file updates due to env_var changes
         if dict_key in env_var_changes and dict_key in new_yaml_dict:
             for name in env_var_changes[dict_key]:
@@ -696,7 +699,7 @@ class PartialParsing:
                 elem = self.get_schema_element(new_yaml_dict[dict_key], name)
                 if elem:
                     delete(schema_file, elem)
-                    self.merge_patch(schema_file, dict_key, elem)
+                    self.merge_patch(schema_file, dict_key, elem, True)
 
     # Take a "section" of the schema file yaml dictionary from saved and new schema files
     # and determine which parts have changed
@@ -739,8 +742,10 @@ class PartialParsing:
         }
         return diff
 
-    # Merge a patch file into the pp_dict in a schema file
-    def merge_patch(self, schema_file, key, patch):
+    # Merge a patch file into the pp_dict in a schema file. The "new_patch"
+    # flag indicates that we're processing a schema file, so if a matching
+    # patch has already been scheduled, replace it.
+    def merge_patch(self, schema_file, key, patch, new_patch=False):
         if schema_file.pp_dict is None:
             schema_file.pp_dict = {}
         pp_dict = schema_file.pp_dict
@@ -748,12 +753,17 @@ class PartialParsing:
             pp_dict[key] = [patch]
         else:
             # check that this patch hasn't already been saved
-            found = False
+            found_elem = None
             for elem in pp_dict[key]:
                 if elem["name"] == patch["name"]:
-                    found = True
-            if not found:
+                    found_elem = elem
+            if not found_elem:
                 pp_dict[key].append(patch)
+            elif found_elem and new_patch:
+                # remove patch and replace with new one
+                pp_dict.remove(found_elem)
+                pp_dict[key].append(patch)
+
         schema_file.delete_from_env_vars(key, patch["name"])
         self.add_to_pp_files(schema_file)
 

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -761,7 +761,7 @@ class PartialParsing:
                 pp_dict[key].append(patch)
             elif found_elem and new_patch:
                 # remove patch and replace with new one
-                pp_dict.remove(found_elem)
+                pp_dict[key].remove(found_elem)
                 pp_dict[key].append(patch)
 
         schema_file.delete_from_env_vars(key, patch["name"])

--- a/tests/functional/partial_parsing/test_partial_parsing.py
+++ b/tests/functional/partial_parsing/test_partial_parsing.py
@@ -54,22 +54,15 @@ from tests.functional.partial_parsing.fixtures import (
     gsm_override_sql,
     gsm_override2_sql,
     orders_sql,
-    orders_downstream_sql,
     snapshot_sql,
     snapshot2_sql,
     generic_schema_yml,
     generic_test_sql,
     generic_test_schema_yml,
     generic_test_edited_sql,
-    groups_schema_yml_one_group,
-    groups_schema_yml_two_groups,
-    groups_schema_yml_two_groups_edited,
-    groups_schema_yml_one_group_model_in_group2,
-    groups_schema_yml_two_groups_private_orders_valid_access,
-    groups_schema_yml_two_groups_private_orders_invalid_access,
 )
 
-from dbt.exceptions import CompilationError, ParsingError
+from dbt.exceptions import CompilationError
 from dbt.contracts.files import ParseFileType
 from dbt.contracts.results import TestStatus
 from dbt.plugins.manifest import PluginNodes, ModelNodeArgs
@@ -651,93 +644,6 @@ class TestTests:
             "test.test.is_odd_orders_id.82834fdc5b",
         ]
         assert expected_nodes == list(manifest.nodes.keys())
-
-
-class TestGroups:
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "orders.sql": orders_sql,
-            "orders_downstream.sql": orders_downstream_sql,
-            "schema.yml": groups_schema_yml_one_group,
-        }
-
-    def test_pp_groups(self, project):
-
-        # initial run
-        results = run_dbt()
-        assert len(results) == 2
-        manifest = get_manifest(project.project_root)
-        expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
-        expected_groups = ["group.test.test_group"]
-        assert expected_nodes == sorted(list(manifest.nodes.keys()))
-        assert expected_groups == sorted(list(manifest.groups.keys()))
-
-        # add group to schema
-        write_file(groups_schema_yml_two_groups, project.project_root, "models", "schema.yml")
-        results = run_dbt(["--partial-parse", "run"])
-        assert len(results) == 2
-        manifest = get_manifest(project.project_root)
-        expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
-        expected_groups = ["group.test.test_group", "group.test.test_group2"]
-        assert expected_nodes == sorted(list(manifest.nodes.keys()))
-        assert expected_groups == sorted(list(manifest.groups.keys()))
-
-        # edit group in schema
-        write_file(
-            groups_schema_yml_two_groups_edited, project.project_root, "models", "schema.yml"
-        )
-        results = run_dbt(["--partial-parse", "run"])
-        assert len(results) == 2
-        manifest = get_manifest(project.project_root)
-        expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
-        expected_groups = ["group.test.test_group", "group.test.test_group2_edited"]
-        assert expected_nodes == sorted(list(manifest.nodes.keys()))
-        assert expected_groups == sorted(list(manifest.groups.keys()))
-
-        # delete group in schema
-        write_file(groups_schema_yml_one_group, project.project_root, "models", "schema.yml")
-        results = run_dbt(["--partial-parse", "run"])
-        assert len(results) == 2
-        manifest = get_manifest(project.project_root)
-        expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
-        expected_groups = ["group.test.test_group"]
-        assert expected_nodes == sorted(list(manifest.nodes.keys()))
-        assert expected_groups == sorted(list(manifest.groups.keys()))
-
-        # add back second group
-        write_file(groups_schema_yml_two_groups, project.project_root, "models", "schema.yml")
-        results = run_dbt(["--partial-parse", "run"])
-        assert len(results) == 2
-
-        # remove second group with model still configured to second group
-        write_file(
-            groups_schema_yml_one_group_model_in_group2,
-            project.project_root,
-            "models",
-            "schema.yml",
-        )
-        with pytest.raises(ParsingError):
-            results = run_dbt(["--partial-parse", "run"])
-
-        # add back second group, make orders private with valid ref
-        write_file(
-            groups_schema_yml_two_groups_private_orders_valid_access,
-            project.project_root,
-            "models",
-            "schema.yml",
-        )
-        results = run_dbt(["--partial-parse", "run"])
-        assert len(results) == 2
-
-        write_file(
-            groups_schema_yml_two_groups_private_orders_invalid_access,
-            project.project_root,
-            "models",
-            "schema.yml",
-        )
-        with pytest.raises(ParsingError):
-            results = run_dbt(["--partial-parse", "run"])
 
 
 class TestExternalModels:

--- a/tests/functional/partial_parsing/test_pp_groups.py
+++ b/tests/functional/partial_parsing/test_pp_groups.py
@@ -1,0 +1,102 @@
+import pytest
+from dbt.tests.util import run_dbt, get_manifest, write_file
+
+from dbt.exceptions import ParsingError
+
+from tests.functional.partial_parsing.fixtures import (
+    orders_sql,
+    orders_downstream_sql,
+    groups_schema_yml_one_group,
+    groups_schema_yml_two_groups,
+    groups_schema_yml_two_groups_edited,
+    groups_schema_yml_one_group_model_in_group2,
+    groups_schema_yml_two_groups_private_orders_valid_access,
+    groups_schema_yml_two_groups_private_orders_invalid_access,
+)
+
+
+class TestGroups:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "orders.sql": orders_sql,
+            "orders_downstream.sql": orders_downstream_sql,
+            "schema.yml": groups_schema_yml_one_group,
+        }
+
+    def test_pp_groups(self, project):
+
+        # initial run
+        results = run_dbt()
+        assert len(results) == 2
+        manifest = get_manifest(project.project_root)
+        expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
+        expected_groups = ["group.test.test_group"]
+        assert expected_nodes == sorted(list(manifest.nodes.keys()))
+        assert expected_groups == sorted(list(manifest.groups.keys()))
+
+        # add group to schema
+        write_file(groups_schema_yml_two_groups, project.project_root, "models", "schema.yml")
+        results = run_dbt(["--partial-parse", "run"])
+        assert len(results) == 2
+        manifest = get_manifest(project.project_root)
+        expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
+        expected_groups = ["group.test.test_group", "group.test.test_group2"]
+        assert expected_nodes == sorted(list(manifest.nodes.keys()))
+        assert expected_groups == sorted(list(manifest.groups.keys()))
+
+        # edit group in schema
+        write_file(
+            groups_schema_yml_two_groups_edited, project.project_root, "models", "schema.yml"
+        )
+        results = run_dbt(["--partial-parse", "run"])
+        assert len(results) == 2
+        manifest = get_manifest(project.project_root)
+        expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
+        expected_groups = ["group.test.test_group", "group.test.test_group2_edited"]
+        assert expected_nodes == sorted(list(manifest.nodes.keys()))
+        assert expected_groups == sorted(list(manifest.groups.keys()))
+
+        # delete group in schema
+        write_file(groups_schema_yml_one_group, project.project_root, "models", "schema.yml")
+        results = run_dbt(["--partial-parse", "run"])
+        assert len(results) == 2
+        manifest = get_manifest(project.project_root)
+        expected_nodes = ["model.test.orders", "model.test.orders_downstream"]
+        expected_groups = ["group.test.test_group"]
+        assert expected_nodes == sorted(list(manifest.nodes.keys()))
+        assert expected_groups == sorted(list(manifest.groups.keys()))
+
+        # add back second group
+        write_file(groups_schema_yml_two_groups, project.project_root, "models", "schema.yml")
+        results = run_dbt(["--partial-parse", "run"])
+        assert len(results) == 2
+
+        # remove second group with model still configured to second group
+        write_file(
+            groups_schema_yml_one_group_model_in_group2,
+            project.project_root,
+            "models",
+            "schema.yml",
+        )
+        with pytest.raises(ParsingError):
+            results = run_dbt(["--partial-parse", "run"])
+
+        # add back second group, make orders private with valid ref
+        write_file(
+            groups_schema_yml_two_groups_private_orders_valid_access,
+            project.project_root,
+            "models",
+            "schema.yml",
+        )
+        results = run_dbt(["--partial-parse", "run"])
+        assert len(results) == 2
+
+        write_file(
+            groups_schema_yml_two_groups_private_orders_invalid_access,
+            project.project_root,
+            "models",
+            "schema.yml",
+        )
+        with pytest.raises(ParsingError):
+            results = run_dbt(["--partial-parse", "run"])

--- a/tests/functional/partial_parsing/test_pp_groups.py
+++ b/tests/functional/partial_parsing/test_pp_groups.py
@@ -146,5 +146,12 @@ class TestAddingModelsToNewGroups:
 
     def test_adding_models_to_new_groups(self, project):
         run_dbt(["compile"])
+        # This tests that the correct patch is added to my_model_c. The bug
+        # was that it was using the old patch, so model_c didn't have the
+        # correct group and access.
         write_file(models_and_groups_yml, project.project_root, "models", "models.yml")
         run_dbt(["compile"])
+        manifest = get_manifest(project.project_root)
+        model_c_node = manifest.nodes["model.test.my_model_c"]
+        assert model_c_node.group == "sales_analytics"
+        assert model_c_node.access == "private"


### PR DESCRIPTION
resolves #8697

### Problem

When processing changed models the partial parsing code was removing referencing nodes and updating pp_dict with the original model yaml dictionary, but the dictionary had changed so the patch information was lost when doing "merge_patch".

### Solution

The code was called in the order handle_schema_file_changes => delete_schema_mssa_links => schedule_referencing_nodes_for_parsing => schedule_nodes_for_parsing => remove_mssat_file => remove_node_in_saved => merge_patch.

The merge_patch call was saving the original patch from the saved schema file, so when the changed schema file patch was encountered it was skipped in merge_patch. An additional parameter was added to "merge_patch" so that if the merge_patch call comes from a schema file change, it will update the patch to replace the old saved patch.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
