### PR TITLE
Add warning_tag to UnversionedBreakingChange

### DIFF
--- a/.changes/unreleased/Under the Hood-20231011-163749.yaml
+++ b/.changes/unreleased/Under the Hood-20231011-163749.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add warning_tag to UnversionedBreakingChange
+time: 2023-10-11T16:37:49.47831+02:00
+custom:
+  Author: jtcohen6
+  Issue: "8827"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1239,11 +1239,13 @@ class UnversionedBreakingChange(WarnLevel):
     def message(self) -> str:
         reasons = "\n  - ".join(self.breaking_changes)
 
-        return (
+        msg = (
             f"Breaking change to contracted, unversioned model {self.model_name} ({self.model_file_path})"
             "\nWhile comparing to previous project state, dbt detected a breaking change to an unversioned model."
             f"\n  - {reasons}\n"
         )
+
+        return warning_tag(msg)
 
 
 class WarnStateTargetEqual(WarnLevel):


### PR DESCRIPTION
resolves #8827

### Before

```
$ dbt ls -s state:modified --state state/
14:40:43  Running with dbt=1.7.0-b2
14:40:43  Registered adapter: postgres=1.7.0-b2
14:40:43  Found 2 models, 0 sources, 0 exposures, 0 metrics, 401 macros, 0 groups, 0 semantic models
14:40:43  Breaking change to contracted, unversioned model my_model (models/my_model.sql)
While comparing to previous project state, dbt detected a breaking change to an unversioned model.
  - Columns with data_type changes:
    - a_number (integer -> another)

my_dbt_project.my_model
```


### After

```
$ dbt ls -s state:modified --state state/
14:41:38  Running with dbt=1.7.0-b2
14:41:39  Registered adapter: postgres=1.7.0-b2
14:41:39  Found 2 models, 0 sources, 0 exposures, 0 metrics, 401 macros, 0 groups, 0 semantic models
14:41:39  [WARNING]: Breaking change to contracted, unversioned model my_model (models/my_model.sql)
While comparing to previous project state, dbt detected a breaking change to an unversioned model.
  - Columns with data_type changes:
    - a_number (integer -> another)

my_dbt_project.my_model
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
