### PR TITLE
ADAP-835: Optimize manual refresh on auto-refreshed materialized views

### DIFF
--- a/.changes/unreleased/Features-20231012-122917.yaml
+++ b/.changes/unreleased/Features-20231012-122917.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Optimize refreshing materialized views when autorefreshed
+time: 2023-10-12T12:29:17.705373-04:00
+custom:
+  Author: mikealfare
+  Issue: "6911"

--- a/core/dbt/tests/util.py
+++ b/core/dbt/tests/util.py
@@ -634,7 +634,9 @@ def set_model_file(project, relation: BaseRelation, model_sql: str):
     write_file(model_sql, project.project_root, "models", f"{relation.name}.sql")
 
 
-def utility_method_not_implemented_exception(class_name: str, method_name: str):
-    return NotImplementedError(
-        f"To use this test, please implement `{class_name}`.`{method_name}`."
-    )
+class UtilityMethodNotImplementedError(NotImplementedError):
+    def __int__(self, class_name: str, method_name: str, additional_message: Optional[str] = None):
+        message = f"To use this test, please implement `{class_name}`.`{method_name}`."
+        if additional_message:
+            message += f" {additional_message}"
+        super().__init__(message)

--- a/core/dbt/tests/util.py
+++ b/core/dbt/tests/util.py
@@ -297,6 +297,7 @@ class TestProcessingException(Exception):
 
 # Testing utilities that use adapter code
 
+
 # Uses:
 #    adapter.config.credentials
 #    adapter.quote
@@ -631,3 +632,9 @@ def get_model_file(project, relation: BaseRelation) -> str:
 
 def set_model_file(project, relation: BaseRelation, model_sql: str):
     write_file(model_sql, project.project_root, "models", f"{relation.name}.sql")
+
+
+def utility_method_not_implemented_exception(class_name: str, method_name: str):
+    return NotImplementedError(
+        f"To use this test, please implement `{class_name}`.`{method_name}`."
+    )

--- a/tests/adapter/dbt/tests/adapter/materialized_view/auto_refresh.py
+++ b/tests/adapter/dbt/tests/adapter/materialized_view/auto_refresh.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+from typing import Tuple
+
+import pytest
+
+from dbt.tests.util import UtilityMethodNotImplementedError, run_dbt
+
+
+class MaterializedViewAutoRefreshNoChanges:
+    """
+    When dbt runs on a materialized view that has no configuration changes, it can default
+    to manually refresh the materialized view. In order to optimize cost and performance,
+    there is no need to run a manual refresh if one is already scheduled due to
+    auto refresh being turned on. Therefore, we should ensure that a manual refresh
+    is only issued if the materialized view does not refresh automatically, and dbt
+    otherwise does nothing.
+
+    To implement:
+    - override `seeds` and provide a seed for your materialized views
+    - override `models` and provide a materialized view auto refresh turned off called "auto_refresh_off.sql"
+    - override `last_refreshed` with logic that inspects the platform for the last refresh timestamp
+
+    If your platform supports auto refresh:
+    - in `models`, provide another materialized view with auto refresh turned on called "auto_refresh_on.sql"
+
+    If your platform does not support auto refresh:
+    - override `test_manual_refresh_does_not_occur_when_auto_refresh_is_on` and mark it with `@pytest.mark.skip`
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": ""}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"auto_refresh_on.sql": "", "auto_refresh_off.sql": ""}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        yield
+
+    def last_refreshed(self, project, materialized_view: str) -> datetime:
+        raise UtilityMethodNotImplementedError(
+            "MaterializedViewAutoRefreshNoChanges", "last_refreshed"
+        )
+
+    def run_dbt_with_no_changes_and_capture_refresh_times(
+        self, project, materialized_view: str
+    ) -> Tuple[datetime, datetime]:
+        last_refresh = self.last_refreshed(project, materialized_view)
+        run_dbt(["run", "--models", materialized_view])
+        next_refresh = self.last_refreshed(project, materialized_view)
+        return last_refresh, next_refresh
+
+    def test_manual_refresh_occurs_when_auto_refresh_is_off(self, project):
+        last_refresh, next_refresh = self.run_dbt_with_no_changes_and_capture_refresh_times(
+            project, "auto_refresh_off"
+        )
+        assert next_refresh > last_refresh
+
+    def test_manual_refresh_does_not_occur_when_auto_refresh_is_on(self, project):
+        last_refresh, next_refresh = self.run_dbt_with_no_changes_and_capture_refresh_times(
+            project, "auto_refresh_on"
+        )
+        assert next_refresh == last_refresh

--- a/tests/adapter/dbt/tests/adapter/materialized_view/changes.py
+++ b/tests/adapter/dbt/tests/adapter/materialized_view/changes.py
@@ -152,6 +152,16 @@ class MaterializedViewChanges:
         assert_message_in_logs(f"Applying ALTER to: {my_materialized_view}", logs, False)
         assert_message_in_logs(f"Applying REPLACE to: {my_materialized_view}", logs)
 
+    def test_no_alter_and_no_replace_occurs_with_no_changes(self, project, my_materialized_view):
+        # no changes were made to the model
+        _, logs = run_dbt_and_capture(
+            ["--debug", "run", "--models", my_materialized_view.identifier]
+        )
+        # no changes were submitted to the database
+        assert self.query_relation_type(project, my_materialized_view) == "materialized_view"
+        assert_message_in_logs(f"Applying ALTER to: {my_materialized_view}", logs, False)
+        assert_message_in_logs(f"Applying REPLACE to: {my_materialized_view}", logs, False)
+
 
 class MaterializedViewChangesApplyMixin:
     @pytest.fixture(scope="class")

--- a/tests/adapter/dbt/tests/adapter/materialized_view/changes.py
+++ b/tests/adapter/dbt/tests/adapter/materialized_view/changes.py
@@ -6,12 +6,12 @@ from dbt.adapters.base.relation import BaseRelation
 from dbt.contracts.graph.model_config import OnConfigurationChangeOption
 from dbt.contracts.relation import RelationType
 from dbt.tests.util import (
+    UtilityMethodNotImplementedError,
     assert_message_in_logs,
     get_model_file,
     run_dbt,
     run_dbt_and_capture,
     set_model_file,
-    utility_method_not_implemented_exception,
 )
 
 from dbt.tests.adapter.materialized_view.files import (
@@ -46,9 +46,7 @@ class MaterializedViewChanges:
         """
         Check the starting state; this should align with `files.MY_MATERIALIZED_VIEW`.
         """
-        raise utility_method_not_implemented_exception(
-            "MaterializedViewsChanges", "check_start_state"
-        )
+        raise UtilityMethodNotImplementedError("MaterializedViewsChanges", "check_start_state")
 
     @staticmethod
     def change_config_via_alter(project, materialized_view):
@@ -65,7 +63,7 @@ class MaterializedViewChanges:
         """
         Verify that the changes in `change_config_via_alter` were applied.
         """
-        raise utility_method_not_implemented_exception(
+        raise UtilityMethodNotImplementedError(
             "MaterializedViewsChanges", "change_config_via_alter"
         )
 
@@ -85,15 +83,13 @@ class MaterializedViewChanges:
         Verify that the changes in `change_config_via_replace` were applied.
         This is independent of `check_state_alter_change_is_applied`.
         """
-        raise utility_method_not_implemented_exception(
+        raise UtilityMethodNotImplementedError(
             "MaterializedViewsChanges", "change_config_via_replace"
         )
 
     @staticmethod
     def query_relation_type(project, relation: BaseRelation) -> Optional[str]:
-        raise utility_method_not_implemented_exception(
-            "MaterializedViewsChanges", "query_relation_type"
-        )
+        raise UtilityMethodNotImplementedError("MaterializedViewsChanges", "query_relation_type")
 
     """
     Configure these if needed

--- a/tests/adapter/dbt/tests/adapter/materialized_view/changes.py
+++ b/tests/adapter/dbt/tests/adapter/materialized_view/changes.py
@@ -11,6 +11,7 @@ from dbt.tests.util import (
     run_dbt,
     run_dbt_and_capture,
     set_model_file,
+    utility_method_not_implemented_exception,
 )
 
 from dbt.tests.adapter.materialized_view.files import (
@@ -45,9 +46,8 @@ class MaterializedViewChanges:
         """
         Check the starting state; this should align with `files.MY_MATERIALIZED_VIEW`.
         """
-        raise NotImplementedError(
-            "To use this test, please implement `check_start_state`,"
-            " inherited from `MaterializedViewsChanges`."
+        raise utility_method_not_implemented_exception(
+            "MaterializedViewsChanges", "check_start_state"
         )
 
     @staticmethod
@@ -65,10 +65,8 @@ class MaterializedViewChanges:
         """
         Verify that the changes in `change_config_via_alter` were applied.
         """
-        raise NotImplementedError(
-            "To use this test, please implement `change_config_via_alter` and"
-            " `check_state_alter_change_is_applied`,"
-            " inherited from `MaterializedViewsChanges`."
+        raise utility_method_not_implemented_exception(
+            "MaterializedViewsChanges", "change_config_via_alter"
         )
 
     @staticmethod
@@ -87,16 +85,14 @@ class MaterializedViewChanges:
         Verify that the changes in `change_config_via_replace` were applied.
         This is independent of `check_state_alter_change_is_applied`.
         """
-        raise NotImplementedError(
-            "To use this test, please implement `change_config_via_replace` and"
-            " `check_state_replace_change_is_applied`,"
-            " inherited from `MaterializedViewsChanges`."
+        raise utility_method_not_implemented_exception(
+            "MaterializedViewsChanges", "change_config_via_replace"
         )
 
     @staticmethod
     def query_relation_type(project, relation: BaseRelation) -> Optional[str]:
-        raise NotImplementedError(
-            "To use this test, please implement `query_relation_type`, inherited from `MaterializedViewsChanges`."
+        raise utility_method_not_implemented_exception(
+            "MaterializedViewsChanges", "query_relation_type"
         )
 
     """

--- a/tests/functional/materializations/materialized_view_tests/files.py
+++ b/tests/functional/materializations/materialized_view_tests/files.py
@@ -1,0 +1,24 @@
+SEED__MY_SEED = """
+id,value
+1,100
+2,200
+3,300
+""".strip()
+
+
+MODEL__MY_MATERIALIZED_VIEW = """
+{{ config(
+    materialized="materialized_view"
+) }}
+select *, now() as last_refreshed from {{ ref('my_seed') }}
+"""
+
+
+MACRO__LAST_REFRESH = """
+{% macro postgres__test__last_refresh(schema, identifier) %}
+    {% set _sql %}
+        select max(last_refreshed) as last_refresh from {{ schema }}.{{ identifier }}
+    {% endset %}
+    {% do return(run_query(_sql)) %}
+{% endmacro %}
+"""

--- a/tests/functional/materializations/materialized_view_tests/test_auto_refresh.py
+++ b/tests/functional/materializations/materialized_view_tests/test_auto_refresh.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+
+import pytest
+
+from tests.adapter.dbt.tests.adapter.materialized_view.auto_refresh import (
+    MaterializedViewAutoRefreshNoChanges,
+)
+
+from tests.functional.materializations.materialized_view_tests import files
+
+
+class TestMaterializedViewAutoRefreshNoChanges(MaterializedViewAutoRefreshNoChanges):
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": files.SEED__MY_SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"auto_refresh_off.sql": files.MODEL__MY_MATERIALIZED_VIEW}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def macros(self):
+        yield {"postgres__test__last_refresh.sql": files.MACRO__LAST_REFRESH}
+
+    def last_refreshed(self, project, materialized_view: str) -> datetime:
+        with project.adapter.connection_named("__test"):
+            kwargs = {"schema": project.test_schema, "identifier": materialized_view}
+            last_refresh_results = project.adapter.execute_macro(
+                "postgres__test__last_refresh", kwargs=kwargs
+            )
+        last_refresh = last_refresh_results[0].get("last_refresh")
+        return last_refresh
+
+    @pytest.mark.skip("Postgres does not support auto refresh.")
+    def test_manual_refresh_does_not_occur_when_auto_refresh_is_on(self, project):
+        pass


### PR DESCRIPTION
resolves #6911

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

`dbt run` will issue a manual refresh of a materialized view if there are no changes detected during a run. This happens regardless of whether the materialized view is setup to be automatically refreshed. If the materialized view is already scheduled to be refreshed, there is no need to insert an additional refresh. This will add cost and potentially introduce unexpected data as the refresh schedule will not match what's set with the extra refresh.

### Solution

dbt will inspect the materialized view to determine if it is set to automatically refresh. If it is, and there are no changes, then `dbt run` will do nothing. If it is not set to automatically refresh, then `dbt run` will issue a refresh command.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
