### PR TITLE
Fix issues around new get_catalog_by_relations macro

### DIFF
--- a/.changes/unreleased/Fixes-20231024-155400.yaml
+++ b/.changes/unreleased/Fixes-20231024-155400.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Rework get_catalog implementation to retain previous adapter interface semantics
+time: 2023-10-24T15:54:00.628086-04:00
+custom:
+  Author: peterallenwebb
+  Issue: "8846"

--- a/tests/functional/docs/test_generate.py
+++ b/tests/functional/docs/test_generate.py
@@ -28,3 +28,8 @@ class TestGenerate:
         catalog = run_dbt(["docs", "generate", "--select", "my_model"])
         assert len(catalog.nodes) == 1
         assert "model.test.my_model" in catalog.nodes
+
+    def test_select_limits_no_match(self, project):
+        run_dbt(["run"])
+        catalog = run_dbt(["docs", "generate", "--select", "my_missing_model"])
+        assert len(catalog.nodes) == 0


### PR DESCRIPTION
resolves #8846

### Problem

An optional parameter was added to BaseAdapter.get_catalog() in 1.7.0rc1, which was unfortunately overridden by databricks, and may also be overridden in other adapter implementations.

### Solution

This changeset reverts the function to its original signature, and adds a new function called BaseAdapter.get_filtered_catalog(). It also reworks the `docs generate` code which had relied previously relied on the new parameter. 

Significantly, the filtering is now performed against a set of BaseRelation objects passed to the adapter, instead of a set of nodes. This reduces the number of concepts that leak into the adapter, which should not need to "know" about the dag or nodes.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
