### PR TITLE
Add drop_schema_named macro

### DIFF
--- a/.changes/unreleased/Features-20231017-143620.yaml
+++ b/.changes/unreleased/Features-20231017-143620.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add drop_schema_named macro
+time: 2023-10-17T14:36:20.612289-07:00
+custom:
+  Author: colin-rogers-dbt
+  Issue: "8025"

--- a/core/dbt/include/global_project/macros/relations/schema.sql
+++ b/core/dbt/include/global_project/macros/relations/schema.sql
@@ -1,0 +1,4 @@
+{% macro drop_schema_named(schema_name) %}
+  {% set schema_relation = api.Relation.create(schema=schema_name) %}
+  {{ adapter.drop_schema(schema_relation) }}
+{% endmacro %}

--- a/core/dbt/include/global_project/macros/relations/schema.sql
+++ b/core/dbt/include/global_project/macros/relations/schema.sql
@@ -1,4 +1,8 @@
 {% macro drop_schema_named(schema_name) %}
+    {{ return(adapter.dispatch('drop_schema_named', 'dbt') (schema_name)) }}
+{% endmacro %}
+
+{% macro default__drop_schema_named(schema_name) %}
   {% set schema_relation = api.Relation.create(schema=schema_name) %}
   {{ adapter.drop_schema(schema_relation) }}
 {% endmacro %}

--- a/tests/adapter/dbt/tests/adapter/relations/test_dropping_schema_named.py
+++ b/tests/adapter/dbt/tests/adapter/relations/test_dropping_schema_named.py
@@ -1,0 +1,35 @@
+import pytest
+
+from dbt.tests.util import run_dbt, get_connection
+
+
+class BaseDropSchemaNamed:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_a.sql": "select 1 as id",
+        }
+
+    def test_dropped_schema_named_drops_expected_schema(self, project):
+
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        run_dbt(
+            [
+                "run-operation",
+                "drop_schema_named",
+                "--args",
+                f"{{schema_name: {project.test_schema} }}",
+            ]
+        )
+
+        adapter = project.adapter
+        with get_connection(adapter):
+            schemas = adapter.list_schemas(project.database)
+
+        assert project.test_schema not in schemas
+
+
+class TestDropSchemaNamed(BaseDropSchemaNamed):
+    pass


### PR DESCRIPTION
resolves #8025

Tested on a couple adapters, there's some variance in `api.Relation.create` but I think the default will work for most adapters

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
