### PR TITLE
Dbeatty/8877 unknown data type code

### DIFF
--- a/.changes/unreleased/Fixes-20231024-110151.yaml
+++ b/.changes/unreleased/Fixes-20231024-110151.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Handle unknown `type_code` for model contracts
+time: 2023-10-24T11:01:51.980781-06:00
+custom:
+  Author: dbeatty10
+  Issue: "8877" "8353"

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -204,4 +204,7 @@ class PostgresConnectionManager(SQLConnectionManager):
 
     @classmethod
     def data_type_code_to_name(cls, type_code: int) -> str:
-        return string_types[type_code].name
+        if type_code in string_types:
+            return string_types[type_code].name
+        else:
+            return f"unknown type_code {type_code}"


### PR DESCRIPTION
resolves #8353
resolves #8877

### Problem

Postgres has built-in data types like `money`, `uuid`, etc that aren't recognized by default. In addition, Postgres has the ability to create user-defined data types. In both cases, the `psycopg2` Python driver won't know how to do a reverse lookup from the `type_code` into a human-readable data type string (like `money` or `uuid`).

Other database platforms may have similar situations.

### Solution

The proposed solution is to check if a lookup is available. If not, then provide a stand-in of the form `unknown data_type 4678`. This stand-in only applies if a data contract is broken. If the data contract is valid, then this text label isn't necessary. 

### TODO
- [ ] Put screenshots of error messages above
- [ ] Add applicable test cases

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [ ] 👈 This PR includes tests
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)
- [x] This PR does **not** include [type annotations](https://docs.python.org/3/library/typing.html) because there are no new or modified functions
