### PR TITLE
Contract enforcement on temporary tables

### DIFF
--- a/.changes/unreleased/Fixes-20231024-145504.yaml
+++ b/.changes/unreleased/Fixes-20231024-145504.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add back contract enforcement for incremental tables
+time: 2023-10-24T14:55:04.051683-05:00
+custom:
+  Author: emmyoop
+  Issue: "8857"

--- a/.changes/unreleased/Fixes-20231024-145504.yaml
+++ b/.changes/unreleased/Fixes-20231024-145504.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: Add back contract enforcement for incremental tables
+body: Add back contract enforcement for temporary tables on postgres
 time: 2023-10-24T14:55:04.051683-05:00
 custom:
   Author: emmyoop

--- a/plugins/postgres/dbt/include/postgres/macros/adapters.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/adapters.sql
@@ -10,9 +10,13 @@
     unlogged
   {%- endif %} table {{ relation }}
   {% set contract_config = config.get('contract') %}
-  {% if contract_config.enforced and (not temporary) %}
+  {% if contract_config.enforced %}
     {{ get_assert_columns_equivalent(sql) }}
-    {{ get_table_columns_and_constraints() }} ;
+    {%- if temporary -%}
+      {{ temporary_table_columns_and_constraints() }} ;
+    {% else -%}
+      {{ get_table_columns_and_constraints() }} ;
+    {% endif -%}
     insert into {{ relation }} (
       {{ adapter.dispatch('get_column_names', 'dbt')() }}
     )
@@ -24,6 +28,25 @@
     {{ sql }}
   );
 {%- endmacro %}
+
+-- when it's a tmp table we need to skip foreign key contraints
+{% macro temporary_table_columns_and_constraints() %}
+  {# loop through user_provided_columns to create DDL with data types and constraints #}
+    {%- set raw_column_constraints = adapter.render_raw_columns_constraints(raw_columns=model['columns']) -%}
+    {%- set raw_model_constraints = adapter.render_raw_model_constraints(raw_constraints=model['constraints']) -%}
+    (
+    {% for c in raw_column_constraints -%}
+      {%- if c != 'foreign_key' -%}
+        {{ c }}{{ "," if not loop.last or raw_model_constraints }}
+      {%- endif -%}
+    {% endfor %}
+    {% for c in raw_model_constraints -%}
+      {% if c != 'foreign_key' -%}
+        {{ c }}{{ "," if not loop.last }}
+      {% endif -%}
+    {% endfor -%}
+    )
+{% endmacro %}
 
 {% macro postgres__get_create_index_sql(relation, index_dict) -%}
   {%- set index_config = adapter.parse_index(index_dict) -%}

--- a/tests/functional/contracts/test_contract_enforcement.py
+++ b/tests/functional/contracts/test_contract_enforcement.py
@@ -1,6 +1,5 @@
 import pytest
 from dbt.tests.util import run_dbt, write_file
-from dbt.exceptions import CompilationError
 
 
 my_model_sql = """
@@ -37,9 +36,9 @@ class TestIncrementalModelContractEnforcement:
         assert len(results) == 1
         # now update the column type in the model to break the contract
         write_file(my_model_int_sql, project.project_root, "models", "my_model.sql")
-        breakpoint()
 
-        with pytest.raises(
-            CompilationError, match="This model has an enforced contract that failed."
-        ):
-            run_dbt()
+        expected_msg = "This model has an enforced contract that failed."
+        results = run_dbt(expect_pass=False)
+        assert len(results) == 1
+        msg = results[0].message
+        assert expected_msg in msg

--- a/tests/functional/contracts/test_contract_enforcement.py
+++ b/tests/functional/contracts/test_contract_enforcement.py
@@ -1,0 +1,45 @@
+import pytest
+from dbt.tests.util import run_dbt, write_file
+from dbt.exceptions import CompilationError
+
+
+my_model_sql = """
+select 'some string' as string_column
+"""
+
+my_model_int_sql = """
+select 123 as int_column
+"""
+
+model_schema_yml = """
+models:
+  - name: my_model
+    config:
+      materialized: incremental
+      on_schema_change: append_new_columns
+      contract: {enforced: true}
+    columns:
+      - name: string_column
+        data_type: text
+"""
+
+
+class TestIncrementalModelContractEnforcement:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "schema.yml": model_schema_yml,
+        }
+
+    def test_contracted_incremental(self, project):
+        results = run_dbt()
+        assert len(results) == 1
+        # now update the column type in the model to break the contract
+        write_file(my_model_int_sql, project.project_root, "models", "my_model.sql")
+        breakpoint()
+
+        with pytest.raises(
+            CompilationError, match="This model has an enforced contract that failed."
+        ):
+            run_dbt()


### PR DESCRIPTION
resolves #8896

### Problem

Contract enforcement checks not happening during an incremental run.

### Solution

Add contract checks back for temporary tables but keep skipping constraints.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
