### PR TITLE
remove usage of dbt.config.PartialProject from dbt/adapters

### DIFF
--- a/.changes/unreleased/Features-20231026-123913.yaml
+++ b/.changes/unreleased/Features-20231026-123913.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: remove usage of dbt.config.PartialProject from dbt/adapters
+time: 2023-10-26T12:39:13.904116-07:00
+custom:
+  Author: MichelleArk
+  Issue: "8928"

--- a/core/dbt/adapters/base/plugin.py
+++ b/core/dbt/adapters/base/plugin.py
@@ -1,18 +1,8 @@
 from typing import List, Optional, Type
+from pathlib import Path
 
 from dbt.adapters.base import Credentials
-from dbt.exceptions import CompilationError
 from dbt.adapters.protocol import AdapterProtocol
-
-
-def project_name_from_path(include_path: str) -> str:
-    # avoid an import cycle
-    from dbt.config.project import PartialProject
-
-    partial = PartialProject.from_project_root(include_path)
-    if partial.project_name is None:
-        raise CompilationError(f"Invalid project at {include_path}: name not set!")
-    return partial.project_name
 
 
 class AdapterPlugin:
@@ -29,12 +19,13 @@ class AdapterPlugin:
         credentials: Type[Credentials],
         include_path: str,
         dependencies: Optional[List[str]] = None,
+        project_name: Optional[str] = None,
     ) -> None:
 
         self.adapter: Type[AdapterProtocol] = adapter
         self.credentials: Type[Credentials] = credentials
         self.include_path: str = include_path
-        self.project_name: str = project_name_from_path(include_path)
+        self.project_name: str = project_name or f"dbt_{Path(include_path).name}"
         self.dependencies: List[str]
         if dependencies is None:
             self.dependencies = []

--- a/tests/unit/test_adapter_factory.py
+++ b/tests/unit/test_adapter_factory.py
@@ -10,33 +10,32 @@ from dbt.include.global_project import (
 
 class TestGetPackageNames(unittest.TestCase):
     def setUp(self):
-        with mock.patch("dbt.adapters.base.plugin.project_name_from_path") as get_name:
-            get_name.return_value = "root"
-            self.root_plugin = AdapterPlugin(
-                adapter=mock.MagicMock(),
-                credentials=mock.MagicMock(),
-                include_path="/path/to/root/plugin",
-                dependencies=["childa", "childb"],
-            )
-            get_name.return_value = "pkg_childa"
-            self.childa = AdapterPlugin(
-                adapter=mock.MagicMock(),
-                credentials=mock.MagicMock(),
-                include_path="/path/to/childa",
-            )
-            get_name.return_value = "pkg_childb"
-            self.childb = AdapterPlugin(
-                adapter=mock.MagicMock(),
-                credentials=mock.MagicMock(),
-                include_path="/path/to/childb",
-                dependencies=["childc"],
-            )
-            get_name.return_value = "pkg_childc"
-            self.childc = AdapterPlugin(
-                adapter=mock.MagicMock(),
-                credentials=mock.MagicMock(),
-                include_path="/path/to/childc",
-            )
+        self.root_plugin = AdapterPlugin(
+            adapter=mock.MagicMock(),
+            credentials=mock.MagicMock(),
+            include_path="/path/to/root/plugin",
+            dependencies=["childa", "childb"],
+            project_name="root",
+        )
+        self.childa = AdapterPlugin(
+            adapter=mock.MagicMock(),
+            credentials=mock.MagicMock(),
+            include_path="/path/to/childa",
+            project_name="pkg_childa",
+        )
+        self.childb = AdapterPlugin(
+            adapter=mock.MagicMock(),
+            credentials=mock.MagicMock(),
+            include_path="/path/to/childb",
+            dependencies=["childc"],
+            project_name="pkg_childb",
+        )
+        self.childc = AdapterPlugin(
+            adapter=mock.MagicMock(),
+            credentials=mock.MagicMock(),
+            include_path="/path/to/childc",
+            project_name="pkg_childc",
+        )
 
         self._mock_modules = {
             "root": self.root_plugin,

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -1246,25 +1246,24 @@ FindMaterializationSpec = namedtuple("FindMaterializationSpec", "macros,adapter_
 
 def _materialization_parameter_sets():
     # inject the plugins used for materialization parameter tests
-    with mock.patch("dbt.adapters.base.plugin.project_name_from_path") as get_name:
-        get_name.return_value = "foo"
-        FooPlugin = AdapterPlugin(
-            adapter=mock.MagicMock(),
-            credentials=mock.MagicMock(),
-            include_path="/path/to/root/plugin",
-        )
-        FooPlugin.adapter.type.return_value = "foo"
-        inject_plugin(FooPlugin)
+    FooPlugin = AdapterPlugin(
+        adapter=mock.MagicMock(),
+        credentials=mock.MagicMock(),
+        include_path="/path/to/root/plugin",
+        project_name="foo",
+    )
+    FooPlugin.adapter.type.return_value = "foo"
+    inject_plugin(FooPlugin)
 
-        get_name.return_value = "bar"
-        BarPlugin = AdapterPlugin(
-            adapter=mock.MagicMock(),
-            credentials=mock.MagicMock(),
-            include_path="/path/to/root/plugin",
-            dependencies=["foo"],
-        )
-        BarPlugin.adapter.type.return_value = "bar"
-        inject_plugin(BarPlugin)
+    BarPlugin = AdapterPlugin(
+        adapter=mock.MagicMock(),
+        credentials=mock.MagicMock(),
+        include_path="/path/to/root/plugin",
+        dependencies=["foo"],
+        project_name="bar",
+    )
+    BarPlugin.adapter.type.return_value = "bar"
+    inject_plugin(BarPlugin)
 
     sets = [
         FindMaterializationSpec(macros=[], adapter_type="foo", expected=None),


### PR DESCRIPTION
resolves #8928 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

dbt/adapters makes use of dbt.config.PartialProject to read the dbt_project.yml that adapters provide, just to grab the project_name. This causes a circular dependency.
### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Instead, add project_name as an optional argument to the AdapterPlugin constructor, and infer a project_name based on the include path if not provided. This should not be a breaking change.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
