### PR TITLE
Add quoting for sync all columns

### DIFF
--- a/.changes/unreleased/Fixes-20231026-003750.yaml
+++ b/.changes/unreleased/Fixes-20231026-003750.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix bug where incremental column changes did not quote columns.
+time: 2023-10-26T00:37:50.705609-04:00
+custom:
+  Author: DTchebotarev
+  Issue: "4423"

--- a/core/dbt/include/global_project/macros/adapters/columns.sql
+++ b/core/dbt/include/global_project/macros/adapters/columns.sql
@@ -123,11 +123,11 @@
      alter {{ relation.type }} {{ relation }}
 
             {% for column in add_columns %}
-               add column {{ column.name }} {{ column.data_type }}{{ ',' if not loop.last }}
+               add column {{ adapter.quote(column.name) }} {{ column.data_type }}{{ ',' if not loop.last }}
             {% endfor %}{{ ',' if add_columns and remove_columns }}
 
             {% for column in remove_columns %}
-                drop column {{ column.name }}{{ ',' if not loop.last }}
+                drop column {{ adapter.quote(column.name) }}{{ ',' if not loop.last }}
             {% endfor %}
 
   {%- endset -%}

--- a/tests/adapter/dbt/tests/adapter/incremental/test_incremental_on_schema_change.py
+++ b/tests/adapter/dbt/tests/adapter/incremental/test_incremental_on_schema_change.py
@@ -12,11 +12,14 @@ from dbt.tests.adapter.incremental.fixtures import (
     _MODELS__INCREMENTAL_IGNORE_TARGET,
     _MODELS__INCREMENTAL_FAIL,
     _MODELS__INCREMENTAL_SYNC_ALL_COLUMNS,
+    _MODELS__INCREMENTAL_SYNC_ALL_QUOTED_COLUMNS,
     _MODELS__INCREMENTAL_APPEND_NEW_COLUMNS_REMOVE_ONE,
     _MODELS__A,
+    _MODELS__B,
     _MODELS__INCREMENTAL_APPEND_NEW_COLUMNS_TARGET,
     _MODELS__INCREMENTAL_APPEND_NEW_COLUMNS,
     _MODELS__INCREMENTAL_SYNC_ALL_COLUMNS_TARGET,
+    _MODELS__INCREMENTAL_SYNC_ALL_QUOTED_COLUMNS_TARGET,
     _MODELS__INCREMENTAL_APPEND_NEW_COLUMNS_REMOVE_ONE_TARGET,
 )
 
@@ -31,11 +34,14 @@ class BaseIncrementalOnSchemaChangeSetup:
             "incremental_ignore_target.sql": _MODELS__INCREMENTAL_IGNORE_TARGET,
             "incremental_fail.sql": _MODELS__INCREMENTAL_FAIL,
             "incremental_sync_all_columns.sql": _MODELS__INCREMENTAL_SYNC_ALL_COLUMNS,
+            "incremental_sync_all_quoted_columns.sql": _MODELS__INCREMENTAL_SYNC_ALL_QUOTED_COLUMNS,
             "incremental_append_new_columns_remove_one.sql": _MODELS__INCREMENTAL_APPEND_NEW_COLUMNS_REMOVE_ONE,
             "model_a.sql": _MODELS__A,
+            "model_b.sql": _MODELS__B,
             "incremental_append_new_columns_target.sql": _MODELS__INCREMENTAL_APPEND_NEW_COLUMNS_TARGET,
             "incremental_append_new_columns.sql": _MODELS__INCREMENTAL_APPEND_NEW_COLUMNS,
             "incremental_sync_all_columns_target.sql": _MODELS__INCREMENTAL_SYNC_ALL_COLUMNS_TARGET,
+            "incremental_sync_all_quoted_columns_target.sql": _MODELS__INCREMENTAL_SYNC_ALL_QUOTED_COLUMNS_TARGET,
             "incremental_append_new_columns_remove_one_target.sql": _MODELS__INCREMENTAL_APPEND_NEW_COLUMNS_REMOVE_ONE_TARGET,
         }
 
@@ -71,6 +77,12 @@ class BaseIncrementalOnSchemaChangeSetup:
         compare_target = "incremental_sync_all_columns_target"
         self.run_twice_and_assert(select, compare_source, compare_target, project)
 
+    def run_incremental_sync_all_quoted_columns(self, project):
+        select = "model_b incremental_sync_all_quoted_columns incremental_sync_all_quoted_columns_target"
+        compare_source = "incremental_sync_all_quoted_columns"
+        compare_target = "incremental_sync_all_quoted_columns_target"
+        self.run_twice_and_assert(select, compare_source, compare_target, project)
+
     def run_incremental_sync_remove_only(self, project):
         select = "model_a incremental_sync_remove_only incremental_sync_remove_only_target"
         compare_source = "incremental_sync_remove_only"
@@ -90,8 +102,9 @@ class BaseIncrementalOnSchemaChange(BaseIncrementalOnSchemaChangeSetup):
         self.run_incremental_append_new_columns_remove_one(project)
 
     def test_run_incremental_sync_all_columns(self, project):
-        self.run_incremental_sync_all_columns(project)
-        self.run_incremental_sync_remove_only(project)
+        # self.run_incremental_sync_all_columns(project)
+        self.run_incremental_sync_all_quoted_columns(project)
+        # self.run_incremental_sync_remove_only(project)
 
     def test_run_incremental_fail_on_schema_change(self, project):
         select = "model_a incremental_fail"

--- a/tests/adapter/dbt/tests/adapter/incremental/test_incremental_on_schema_change.py
+++ b/tests/adapter/dbt/tests/adapter/incremental/test_incremental_on_schema_change.py
@@ -102,9 +102,9 @@ class BaseIncrementalOnSchemaChange(BaseIncrementalOnSchemaChangeSetup):
         self.run_incremental_append_new_columns_remove_one(project)
 
     def test_run_incremental_sync_all_columns(self, project):
-        # self.run_incremental_sync_all_columns(project)
+        self.run_incremental_sync_all_columns(project)
         self.run_incremental_sync_all_quoted_columns(project)
-        # self.run_incremental_sync_remove_only(project)
+        self.run_incremental_sync_remove_only(project)
 
     def test_run_incremental_fail_on_schema_change(self, project):
         select = "model_a incremental_fail"


### PR DESCRIPTION
Resolves dbt-labs/dbt-adapters#160
Resolves https://github.com/dbt-labs/dbt-adapters/issues/63

Partial fix for dbt-labs/dbt-adapters#160, sounds like it will need follow up PRs in specific adapter repos (e.g. snowflake adatper)

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

When the `sync_all_columns` incremental option is used, the columns that are added and dropped are not quoted. This means that DBT will throw an error if the columns to be added or dropped have spaces or other unconventional names which require quotes.

### Solution

Add `adapter.quote()` around column names.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
