### PR TITLE
Fix cased comparison in catalog-retrieval function

### DIFF
--- a/.changes/unreleased/Fixes-20231030-093734.yaml
+++ b/.changes/unreleased/Fixes-20231030-093734.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix cased comparison in catalog-retrieval function.
+time: 2023-10-30T09:37:34.258612-04:00
+custom:
+  Author: peterallenwebb
+  Issue: "8939"

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -1179,9 +1179,9 @@ class BaseAdapter(metaclass=AdapterMeta):
             }
 
             def in_map(row: agate.Row):
-                d = _expect_row_value("table_database", row)
-                s = _expect_row_value("table_schema", row)
-                i = _expect_row_value("table_name", row)
+                d = _expect_row_value("table_database", row).casefold()
+                s = _expect_row_value("table_schema", row).casefold()
+                i = _expect_row_value("table_name", row).casefold()
                 return (d, s, i) in relation_map
 
             catalogs = catalogs.where(in_map)


### PR DESCRIPTION
resolves #8939

### Problem


### Solution

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
