### PR TITLE
ADAP-974: Fix issue where materialized views were not showing up in catalog queries

### DIFF
--- a/.changes/unreleased/Fixes-20231031-005345.yaml
+++ b/.changes/unreleased/Fixes-20231031-005345.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Catalog queries now assign the correct type to materialized views
+time: 2023-10-31T00:53:45.486203-04:00
+custom:
+  Author: mikealfare
+  Issue: "8864"

--- a/plugins/postgres/dbt/include/postgres/macros/catalog.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/catalog.sql
@@ -15,6 +15,7 @@
         tbl.relname as table_name,
         case tbl.relkind
             when 'v' then 'VIEW'
+            when 'm' then 'MATERIALIZED VIEW'
             else 'BASE TABLE'
         end as table_type,
         tbl_desc.description as table_comment,
@@ -42,7 +43,7 @@
     )
       and not pg_is_other_temp_schema(sch.oid) -- not a temporary schema belonging to another session
       and tbl.relpersistence in ('p', 'u') -- [p]ermanent table or [u]nlogged table. Exclude [t]emporary tables
-      and tbl.relkind in ('r', 'v', 'f', 'p') -- o[r]dinary table, [v]iew, [f]oreign table, [p]artitioned table. Other values are [i]ndex, [S]equence, [c]omposite type, [t]OAST table, [m]aterialized view
+      and tbl.relkind in ('r', 'v', 'f', 'p', 'm') -- o[r]dinary table, [v]iew, [f]oreign table, [p]artitioned table, [m]aterialized view. Other values are [i]ndex, [S]equence, [c]omposite type, [t]OAST table
       and col.attnum > 0 -- negative numbers are used for system columns such as oid
       and not col.attisdropped -- column as not been dropped
 

--- a/tests/functional/catalog_tests/files.py
+++ b/tests/functional/catalog_tests/files.py
@@ -1,0 +1,33 @@
+MY_SEED = """
+id,value,record_valid_date
+1,100,2023-01-01 00:00:00
+2,200,2023-01-02 00:00:00
+3,300,2023-01-02 00:00:00
+""".strip()
+
+
+MY_TABLE = """
+{{ config(
+    materialized='table',
+) }}
+select *
+from {{ ref('my_seed') }}
+"""
+
+
+MY_VIEW = """
+{{ config(
+    materialized='view',
+) }}
+select *
+from {{ ref('my_seed') }}
+"""
+
+
+MY_MATERIALIZED_VIEW = """
+{{ config(
+    materialized='materialized_view',
+) }}
+select *
+from {{ ref('my_seed') }}
+"""

--- a/tests/functional/catalog_tests/test_relation_types.py
+++ b/tests/functional/catalog_tests/test_relation_types.py
@@ -1,0 +1,44 @@
+from dbt.contracts.results import CatalogArtifact
+from dbt.tests.util import run_dbt
+import pytest
+
+from tests.functional.catalog_tests import files
+
+
+class TestCatalogRelationTypes:
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": files.MY_SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "my_table.sql": files.MY_TABLE,
+            "my_view.sql": files.MY_VIEW,
+            "my_materialized_view.sql": files.MY_MATERIALIZED_VIEW,
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def docs(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        yield run_dbt(["docs", "generate"])
+
+    @pytest.mark.parametrize(
+        "node_name,relation_type",
+        [
+            ("seed.test.my_seed", "BASE TABLE"),
+            ("model.test.my_table", "BASE TABLE"),
+            ("model.test.my_view", "VIEW"),
+            ("model.test.my_materialized_view", "MATERIALIZED VIEW"),
+        ],
+    )
+    def test_relation_types_populate_correctly(
+        self, docs: CatalogArtifact, node_name: str, relation_type: str
+    ):
+        """
+        This test addresses: https://github.com/dbt-labs/dbt-core/issues/8864
+        """
+        assert node_name in docs.nodes
+        node = docs.nodes[node_name]
+        assert node.metadata.type == relation_type


### PR DESCRIPTION
resolves #8864

### Problem

Materialized views do not show up in catalog queries.

### Solution

- write a test demonstrating the issue
- update the catalog queries to reflect materialized views

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
