### PR TITLE
duplicate exposure test

### DIFF
--- a/tests/functional/exposures/fixtures.py
+++ b/tests/functional/exposures/fixtures.py
@@ -159,3 +159,14 @@ exposures:
     owner:
       email: something@example.com
 """
+
+duplicate_exposure_yml = """
+  - name: simple_exposure
+    type: dashboard
+    config:
+      enabled: True
+    depends_on:
+      - ref('model')
+    owner:
+      email: something@example.com
+"""


### PR DESCRIPTION
resolves #

### Problem

Duplicate exposures (and other nodes) are not detected by partial parsing, only by a full parse.

### Solution

None yet, this is just a test.  But I think the issue is with [this bit of code](https://github.com/dbt-labs/dbt-core/blob/bb21403c9e906097c4913edcf7a013d404e93d80/core/dbt/parser/partial.py#L722-L725)

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
