### PR TITLE
[Backport] Make relation filtering None-tolerant for maximal flexibility

### DIFF
--- a/.changes/unreleased/Fixes-20231101-155824.yaml
+++ b/.changes/unreleased/Fixes-20231101-155824.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Make relation filtering None-tolerant for maximal flexibility across adapters.
+time: 2023-11-01T15:58:24.552054-04:00
+custom:
+  Author: peterallenwebb
+  Issue: "8974"

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -1179,9 +1179,12 @@ class BaseAdapter(metaclass=AdapterMeta):
             }
 
             def in_map(row: agate.Row):
-                d = _expect_row_value("table_database", row).casefold()
-                s = _expect_row_value("table_schema", row).casefold()
-                i = _expect_row_value("table_name", row).casefold()
+                d = _expect_row_value("table_database", row)
+                s = _expect_row_value("table_schema", row)
+                i = _expect_row_value("table_name", row)
+                d = d.casefold() if d is not None else None
+                s = s.casefold() if s is not None else None
+                i = i.casefold() if i is not None else None
                 return (d, s, i) in relation_map
 
             catalogs = catalogs.where(in_map)


### PR DESCRIPTION
resolves #8975 

### Problem

We need the fix to #8975 in 1.7.0 final.

### Solution
Backport to 1.7.latest before tomorrow's release.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
