### PR TITLE
update unit test key: unit -> unit-tests

### DIFF
--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -697,7 +697,7 @@ class Project:
                 "snapshots": self.snapshots,
                 "sources": self.sources,
                 "tests": self.tests,
-                "unit_tests": self.unit_tests,
+                "unit-tests": self.unit_tests,
                 "metrics": self.metrics,
                 "semantic-models": self.semantic_models,
                 "saved-queries": self.saved_queries,

--- a/core/dbt/contracts/files.py
+++ b/core/dbt/contracts/files.py
@@ -287,6 +287,7 @@ class SchemaSourceFile(BaseSourceFile):
 
     # this is only used in tests (unit + functional)
     def get_tests(self, yaml_key, name):
+        breakpoint()
         if yaml_key in self.tests:
             if name in self.tests[yaml_key]:
                 return self.tests[yaml_key][name]

--- a/core/dbt/contracts/files.py
+++ b/core/dbt/contracts/files.py
@@ -287,7 +287,6 @@ class SchemaSourceFile(BaseSourceFile):
 
     # this is only used in tests (unit + functional)
     def get_tests(self, yaml_key, name):
-        breakpoint()
         if yaml_key in self.tests:
             if name in self.tests[yaml_key]:
                 return self.tests[yaml_key][name]

--- a/core/dbt/contracts/graph/model_config.py
+++ b/core/dbt/contracts/graph/model_config.py
@@ -748,7 +748,6 @@ RESOURCE_TYPES: Dict[NodeType, Type[BaseConfig]] = {
     NodeType.Source: SourceConfig,
     NodeType.Seed: SeedConfig,
     NodeType.Test: TestConfig,
-    NodeType.Unit: TestConfig,
     NodeType.Model: NodeConfig,
     NodeType.Snapshot: SnapshotConfig,
     NodeType.Unit: UnitTestConfig,

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -256,6 +256,7 @@ class Project(dbtClassMixin, Replaceable):
             "semantic_models": "semantic-models",
             "saved_queries": "saved-queries",
             "dbt_cloud": "dbt-cloud",
+            "unit_tests": "unit-tests",
         }
 
     @classmethod

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -98,6 +98,7 @@ class PartialParsing:
     # Compare the previously saved manifest files and the just-loaded manifest
     # files to see if anything changed
     def build_file_diff(self):
+        breakpoint()
         saved_file_ids = set(self.saved_files.keys())
         new_file_ids = set(self.new_files.keys())
         deleted_all_files = saved_file_ids.difference(new_file_ids)
@@ -582,6 +583,7 @@ class PartialParsing:
     # Schema files -----------------------
     # Changed schema files
     def change_schema_file(self, file_id):
+        breakpoint()
         saved_schema_file = self.saved_files[file_id]
         new_schema_file = deepcopy(self.new_files[file_id])
         saved_yaml_dict = saved_schema_file.dict_from_yaml
@@ -681,7 +683,8 @@ class PartialParsing:
         handle_change("metrics", self.delete_schema_metric)
         handle_change("groups", self.delete_schema_group)
         handle_change("semantic_models", self.delete_schema_semantic_model)
-        handle_change("unit", self.delete_schema_unit_test)
+        breakpoint()
+        handle_change("unit_tests", self.delete_schema_unit_test)
         handle_change("saved_queries", self.delete_schema_saved_query)
 
     def _handle_element_change(
@@ -711,7 +714,8 @@ class PartialParsing:
     # Take a "section" of the schema file yaml dictionary from saved and new schema files
     # and determine which parts have changed
     def get_diff_for(self, key, saved_yaml_dict, new_yaml_dict):
-        dict_name = "model" if key == "unit" else "name"
+        # breakpoint()
+        dict_name = "model" if key == "unit_tests" else "name"
         if key in saved_yaml_dict or key in new_yaml_dict:
             saved_elements = saved_yaml_dict[key] if key in saved_yaml_dict else []
             new_elements = new_yaml_dict[key] if key in new_yaml_dict else []
@@ -754,7 +758,7 @@ class PartialParsing:
     # flag indicates that we're processing a schema file, so if a matching
     # patch has already been scheduled, replace it.
     def merge_patch(self, schema_file, key, patch, new_patch=False):
-        elem_name = "model" if key == "unit" else "name"
+        elem_name = "model" if key == "unit_tests" else "name"
         if schema_file.pp_dict is None:
             schema_file.pp_dict = {}
         pp_dict = schema_file.pp_dict

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -98,7 +98,6 @@ class PartialParsing:
     # Compare the previously saved manifest files and the just-loaded manifest
     # files to see if anything changed
     def build_file_diff(self):
-        breakpoint()
         saved_file_ids = set(self.saved_files.keys())
         new_file_ids = set(self.new_files.keys())
         deleted_all_files = saved_file_ids.difference(new_file_ids)
@@ -583,7 +582,6 @@ class PartialParsing:
     # Schema files -----------------------
     # Changed schema files
     def change_schema_file(self, file_id):
-        breakpoint()
         saved_schema_file = self.saved_files[file_id]
         new_schema_file = deepcopy(self.new_files[file_id])
         saved_yaml_dict = saved_schema_file.dict_from_yaml
@@ -683,7 +681,6 @@ class PartialParsing:
         handle_change("metrics", self.delete_schema_metric)
         handle_change("groups", self.delete_schema_group)
         handle_change("semantic_models", self.delete_schema_semantic_model)
-        breakpoint()
         handle_change("unit_tests", self.delete_schema_unit_test)
         handle_change("saved_queries", self.delete_schema_saved_query)
 
@@ -714,7 +711,6 @@ class PartialParsing:
     # Take a "section" of the schema file yaml dictionary from saved and new schema files
     # and determine which parts have changed
     def get_diff_for(self, key, saved_yaml_dict, new_yaml_dict):
-        # breakpoint()
         dict_name = "model" if key == "unit_tests" else "name"
         if key in saved_yaml_dict or key in new_yaml_dict:
             saved_elements = saved_yaml_dict[key] if key in saved_yaml_dict else []

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -299,7 +299,6 @@ class YamlReader(metaclass=ABCMeta):
     # get the list of dicts pointed to by the key in the yaml config,
     # ensure that the dicts have string keys
     def get_key_dicts(self) -> Iterable[Dict[str, Any]]:
-        breakpoint()
         data = self.yaml.data.get(self.key, [])
         if not isinstance(data, list):
             raise ParsingError(

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -231,7 +231,7 @@ class SchemaParser(SimpleParser[YamlBlock, ModelNode]):
                 semantic_model_parser = SemanticModelParser(self, yaml_block)
                 semantic_model_parser.parse()
 
-            if "unit" in dct:
+            if "unit_tests" in dct:
                 from dbt.parser.unit_tests import UnitTestParser
 
                 unit_test_parser = UnitTestParser(self, yaml_block)
@@ -262,12 +262,13 @@ class ParseResult:
 
 
 # abstract base class (ABCMeta)
-# Four subclasses: MetricParser, ExposureParser, GroupParser, SourceParser, PatchParser
+# Many subclasses: MetricParser, ExposureParser, GroupParser, SourceParser,
+# PatchParser, SemanticModelParser, SavedQueryParser, UnitTestParser
 class YamlReader(metaclass=ABCMeta):
     def __init__(self, schema_parser: SchemaParser, yaml: YamlBlock, key: str) -> None:
         self.schema_parser = schema_parser
         # key: models, seeds, snapshots, sources, macros,
-        # analyses, exposures
+        # analyses, exposures, unit_tests
         self.key = key
         self.yaml = yaml
         self.schema_yaml_vars = SchemaYamlVars()
@@ -298,6 +299,7 @@ class YamlReader(metaclass=ABCMeta):
     # get the list of dicts pointed to by the key in the yaml config,
     # ensure that the dicts have string keys
     def get_key_dicts(self) -> Iterable[Dict[str, Any]]:
+        breakpoint()
         data = self.yaml.data.get(self.key, [])
         if not isinstance(data, list):
             raise ParsingError(

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -193,20 +193,19 @@ class UnitTestManifestLoader:
 
 class UnitTestParser(YamlReader):
     def __init__(self, schema_parser: SchemaParser, yaml: YamlBlock) -> None:
-        super().__init__(schema_parser, yaml, "unit")
+        super().__init__(schema_parser, yaml, "unit_tests")
         self.schema_parser = schema_parser
         self.yaml = yaml
 
     def parse(self) -> ParseResult:
+        breakpoint()
         for data in self.get_key_dicts():
             unit_test_suite = self._get_unit_test_suite(data)
             model_name_split = unit_test_suite.model.split()
             tested_model_node = self._find_tested_model_node(unit_test_suite)
 
             for test in unit_test_suite.tests:
-                unit_test_case_unique_id = (
-                    f"unit.{self.project.project_name}.{unit_test_suite.model}.{test.name}"
-                )
+                unit_test_case_unique_id = f"{NodeType.Unit}.{self.project.project_name}.{unit_test_suite.model}.{test.name}"
                 unit_test_fqn = [self.project.project_name] + model_name_split + [test.name]
                 unit_test_config = self._build_unit_test_config(unit_test_fqn, test.config)
 

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -198,7 +198,6 @@ class UnitTestParser(YamlReader):
         self.yaml = yaml
 
     def parse(self) -> ParseResult:
-        breakpoint()
         for data in self.get_key_dicts():
             unit_test_suite = self._get_unit_test_suite(data)
             model_name_split = unit_test_suite.model.split()

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -34,7 +34,7 @@ SELECT
 """
 
 test_my_model_yml = """
-unit-tests:
+unit_tests:
   - model: my_model
     tests:
       - name: test_my_model
@@ -180,7 +180,7 @@ class TestUnitTests:
 
 
 test_my_model_csv_yml = """
-unit-tests:
+unit_tests:
   - model: my_model
     tests:
       - name: test_my_model
@@ -355,7 +355,7 @@ where event_time > (select max(event_time) from {{ this }})
 """
 
 test_my_model_incremental_yml = """
-unit:
+unit_tests:
   - model: my_incremental_model
     tests:
       - name: incremental_false

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -34,7 +34,7 @@ SELECT
 """
 
 test_my_model_yml = """
-unit:
+unit-tests:
   - model: my_model
     tests:
       - name: test_my_model
@@ -180,7 +180,7 @@ class TestUnitTests:
 
 
 test_my_model_csv_yml = """
-unit:
+unit-tests:
   - model: my_model
     tests:
       - name: test_my_model

--- a/tests/unit/test_unit_test_parser.py
+++ b/tests/unit/test_unit_test_parser.py
@@ -11,7 +11,7 @@ from dbt.contracts.graph.unparsed import UnitTestOutputFixture
 
 
 UNIT_TEST_MODEL_NOT_FOUND_SOURCE = """
-unit-tests:
+unit_tests:
     - model: my_model_doesnt_exist
       tests:
         - name: test_my_model_doesnt_exist
@@ -24,7 +24,7 @@ unit-tests:
 
 
 UNIT_TEST_SOURCE = """
-unit-tests:
+unit_tests:
     - model: my_model
       tests:
         - name: test_my_model
@@ -37,7 +37,7 @@ unit-tests:
 
 
 UNIT_TEST_VERSIONED_MODEL_SOURCE = """
-unit-tests:
+unit_tests:
     - model: my_model_versioned.v1
       tests:
         - name: test_my_model_versioned
@@ -50,7 +50,7 @@ unit-tests:
 
 
 UNIT_TEST_CONFIG_SOURCE = """
-unit-tests:
+unit_tests:
     - model: my_model
       tests:
         - name: test_my_model
@@ -68,7 +68,7 @@ unit-tests:
 
 
 UNIT_TEST_MULTIPLE_SOURCE = """
-unit-tests:
+unit_tests:
     - model: my_model
       tests:
         - name: test_my_model
@@ -105,7 +105,7 @@ class UnitTestParserTest(SchemaParserTest):
         )
 
     def file_block_for(self, data, filename):
-        return super().file_block_for(data, filename, "unit-tests")
+        return super().file_block_for(data, filename, "unit_tests")
 
     def test_basic_model_not_found(self):
         block = self.yaml_block_for(UNIT_TEST_MODEL_NOT_FOUND_SOURCE, "test_my_model.yml")
@@ -127,7 +127,7 @@ class UnitTestParserTest(SchemaParserTest):
             package_name="snowplow",
             path=block.path.relative_path,
             original_file_path=block.path.original_file_path,
-            unique_id="unit_tests.snowplow.my_model.test_my_model",
+            unique_id="unit_test.snowplow.my_model.test_my_model",
             given=[],
             expect=UnitTestOutputFixture(rows=[{"a": 1}]),
             description="unit test description",
@@ -147,7 +147,7 @@ class UnitTestParserTest(SchemaParserTest):
         UnitTestParser(self.parser, block).parse()
 
         self.assert_has_manifest_lengths(self.parser.manifest, nodes=1, unit_tests=1)
-        unit_test = self.parser.manifest.unit_tests["unit.snowplow.my_model.test_my_model"]
+        unit_test = self.parser.manifest.unit_tests["unit_test.snowplow.my_model.test_my_model"]
         self.assertEqual(sorted(unit_test.config.tags), sorted(["schema_tag", "project_tag"]))
         self.assertEqual(unit_test.config.meta, {"meta_key": "meta_value", "meta_jinja_key": "2"})
 
@@ -168,7 +168,7 @@ class UnitTestParserTest(SchemaParserTest):
 
         self.assert_has_manifest_lengths(self.parser.manifest, nodes=2, unit_tests=1)
         unit_test = self.parser.manifest.unit_tests[
-            "unit.snowplow.my_model_versioned.v1.test_my_model_versioned"
+            "unit_test.snowplow.my_model_versioned.v1.test_my_model_versioned"
         ]
         self.assertEqual(len(unit_test.depends_on.nodes), 1)
         self.assertEqual(unit_test.depends_on.nodes[0], "model.snowplow.my_model_versioned.v1")

--- a/tests/unit/test_unit_test_parser.py
+++ b/tests/unit/test_unit_test_parser.py
@@ -11,7 +11,7 @@ from dbt.contracts.graph.unparsed import UnitTestOutputFixture
 
 
 UNIT_TEST_MODEL_NOT_FOUND_SOURCE = """
-unit:
+unit-tests:
     - model: my_model_doesnt_exist
       tests:
         - name: test_my_model_doesnt_exist
@@ -24,7 +24,7 @@ unit:
 
 
 UNIT_TEST_SOURCE = """
-unit:
+unit-tests:
     - model: my_model
       tests:
         - name: test_my_model
@@ -37,7 +37,7 @@ unit:
 
 
 UNIT_TEST_VERSIONED_MODEL_SOURCE = """
-unit:
+unit-tests:
     - model: my_model_versioned.v1
       tests:
         - name: test_my_model_versioned
@@ -50,7 +50,7 @@ unit:
 
 
 UNIT_TEST_CONFIG_SOURCE = """
-unit:
+unit-tests:
     - model: my_model
       tests:
         - name: test_my_model
@@ -68,7 +68,7 @@ unit:
 
 
 UNIT_TEST_MULTIPLE_SOURCE = """
-unit:
+unit-tests:
     - model: my_model
       tests:
         - name: test_my_model
@@ -105,7 +105,7 @@ class UnitTestParserTest(SchemaParserTest):
         )
 
     def file_block_for(self, data, filename):
-        return super().file_block_for(data, filename, "unit")
+        return super().file_block_for(data, filename, "unit-tests")
 
     def test_basic_model_not_found(self):
         block = self.yaml_block_for(UNIT_TEST_MODEL_NOT_FOUND_SOURCE, "test_my_model.yml")
@@ -127,7 +127,7 @@ class UnitTestParserTest(SchemaParserTest):
             package_name="snowplow",
             path=block.path.relative_path,
             original_file_path=block.path.original_file_path,
-            unique_id="unit.snowplow.my_model.test_my_model",
+            unique_id="unit_tests.snowplow.my_model.test_my_model",
             given=[],
             expect=UnitTestOutputFixture(rows=[{"a": 1}]),
             description="unit test description",


### PR DESCRIPTION
resolves #8698 
https://github.com/dbt-labs/dbt-core/pull/8966 resolves the other half of this ticket


### Problem

We don't want the top level yaml key for unit tests to be `unit`

### Solution

Make the top level key `unit-tests`

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
