### PR TITLE
[IDE] also treat SystemExit exception as an interrupt.

### DIFF
--- a/.changes/unreleased/Under the Hood-20231106-080422.yaml
+++ b/.changes/unreleased/Under the Hood-20231106-080422.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Treat SystemExit as an interrupt if raised during node execution.
+time: 2023-11-06T08:04:22.022179-05:00
+custom:
+  Author: benmosher
+  Issue: n/a

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -371,7 +371,7 @@ class GraphRunnableTask(ConfiguredTask):
             print_run_result_error(failure.result)
             # ensure information about all nodes is propagated to run results when failing fast
             return self.node_results
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, SystemExit):
             run_result = self.get_result(
                 results=self.node_results,
                 elapsed_time=time.time() - self.started_at,


### PR DESCRIPTION
IDE worker process is sent SIGTERM in multiple scenarios, including user abort of a command. IDE task runner (Celery) has a signal handler that raises `SystemExit` when SIGTERM is received. 

Because `SystemExit` is raised instead of `KeyboardInterrupt`, cancelation is not being sent to the data warehouse.

Likely resolves JIRA:TRIAGE-667 -- I will attempt to validate this but wanted to open the PR and get feedback in parallel.

**Update**: testing in a custom IDE build when backported to 1.6-latest* does resolve the JIRA:TRIAGE-667 issue with nodes appearing to run forever, when tested in a Postgres-backed project. I have not yet fully validated with Snowflake specifically.

**Note:** would like to back port this to 1.6 as well.

*I was unable to test on latest because of errors raised about duplicate macros.

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

When IDE commands are canceled, the data warehouse is not being sent cancelation commands.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Any system exit caused by raising `SystemExit` will now send cancelation commands.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
    - I did not find existing tests for the cancelation on `KeyboardInterrupt`
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
