### PR TITLE
add patch all flag for dd

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,7 +202,7 @@ jobs:
           tox --version
 
       - name: Run tests
-        run: tox -- --ddtrace
+        run: tox -- --ddtrace --ddtrace-patch-all
         env:
           PYTEST_ADDOPTS: ${{ format('--splits {0} --group {1}', env.PYTHON_INTEGRATION_TEST_WORKERS, matrix.split-group) }}
 


### PR DESCRIPTION
resolves #

### Problem

Can only see how long the entire job takes to run in DD.

### Solution

Get for info on the flamegraph: https://docs.datadoghq.com/continuous_integration/tests/setup/python/?tab=onpremisesciproviderdatadogagent

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
