### PR TITLE
Add an optional name field for the Postgres adapter indexes configurations

### DIFF
--- a/.changes/unreleased/Features-20231104-213414.yaml
+++ b/.changes/unreleased/Features-20231104-213414.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Ability to add a meaningful name in the Postgresql Indexes
+time: 2023-11-04T21:34:14.9393+01:00
+custom:
+  Author: nazliander
+  Issue: "8580"

--- a/tests/functional/postgres/fixtures.py
+++ b/tests/functional/postgres/fixtures.py
@@ -4,7 +4,7 @@ models__incremental_sql = """
     materialized = "incremental",
     indexes=[
       {'columns': ['column_a'], 'type': 'hash'},
-      {'columns': ['column_a', 'column_b'], 'unique': True},
+      {'columns': ['column_a', 'column_b'], 'unique': True, 'name': 'column_a_and_column_b_index'},
     ]
   )
 }}
@@ -29,12 +29,13 @@ models__table_sql = """
       {'columns': ['column_b']},
       {'columns': ['column_a', 'column_b']},
       {'columns': ['column_b', 'column_a'], 'type': 'btree', 'unique': True},
-      {'columns': ['column_a'], 'type': 'hash'}
+      {'columns': ['column_a'], 'type': 'hash'},
+      {'columns': ['column_c'], 'name': 'column_c_index'},
     ]
   )
 }}
 
-select 1 as column_a, 2 as column_b
+select 1 as column_a, 2 as column_b, 3 as column_c
 
 """
 

--- a/tests/functional/postgres/test_postgres_indexes.py
+++ b/tests/functional/postgres/test_postgres_indexes.py
@@ -1,20 +1,19 @@
-import pytest
 import re
-from dbt.tests.util import (
-    run_dbt,
-    run_dbt_and_capture,
-)
+
+import pytest
+from dbt.tests.util import run_dbt, run_dbt_and_capture
+from freezegun import freeze_time
+
 from tests.functional.postgres.fixtures import (
     models__incremental_sql,
     models__table_sql,
-    models_invalid__missing_columns_sql,
     models_invalid__invalid_columns_type_sql,
     models_invalid__invalid_type_sql,
     models_invalid__invalid_unique_config_sql,
+    models_invalid__missing_columns_sql,
     seeds__seed_csv,
     snapshots__colors_sql,
 )
-
 
 INDEX_DEFINITION_PATTERN = re.compile(r"using\s+(\w+)\s+\((.+)\)\Z")
 
@@ -51,6 +50,7 @@ class TestPostgresIndex:
             },
         }
 
+    @freeze_time("2023-11-04 12:00:00")
     def test_table(self, project, unique_schema):
         results = run_dbt(["run", "--models", "table"])
         assert len(results) == 1
@@ -62,9 +62,16 @@ class TestPostgresIndex:
             {"columns": "column_a, column_b", "unique": False, "type": "btree"},
             {"columns": "column_b, column_a", "unique": True, "type": "btree"},
             {"columns": "column_a", "unique": False, "type": "hash"},
+            {
+                "name": "column_c_index_1699099200000",
+                "columns": "column_c",
+                "unique": False,
+                "type": "btree",
+            },
         ]
-        assert len(indexes) == len(expected)
+        assert indexes == expected
 
+    @freeze_time("2023-11-04 12:00:00")
     def test_incremental(self, project, unique_schema):
         for additional_argument in [[], [], ["--full-refresh"]]:
             results = run_dbt(["run", "--models", "incremental"] + additional_argument)
@@ -73,9 +80,14 @@ class TestPostgresIndex:
             indexes = self.get_indexes("incremental", project, unique_schema)
             expected = [
                 {"columns": "column_a", "unique": False, "type": "hash"},
-                {"columns": "column_a, column_b", "unique": True, "type": "btree"},
+                {
+                    "name": "column_a_and_column_b_index_1699099200000",
+                    "columns": "column_a, column_b",
+                    "unique": True,
+                    "type": "btree",
+                },
             ]
-            assert len(indexes) == len(expected)
+            assert indexes == expected
 
     def test_seed(self, project, unique_schema):
         for additional_argument in [[], [], ["--full-refresh"]]:
@@ -104,17 +116,18 @@ class TestPostgresIndex:
     def get_indexes(self, table_name, project, unique_schema):
         sql = f"""
             SELECT
-              pg_get_indexdef(idx.indexrelid) as index_definition
-            FROM pg_index idx
-            JOIN pg_class tab ON tab.oid = idx.indrelid
-            WHERE
-              tab.relname = '{table_name}'
-              AND tab.relnamespace = (
-                SELECT oid FROM pg_namespace WHERE nspname = '{unique_schema}'
-              );
+              indexname AS index_name, indexdef as index_definition
+            FROM pg_indexes
+            WHERE tablename = '{table_name}'
+              AND schemaname = '{unique_schema}'
         """
         results = project.run_sql(sql, fetch="all")
-        return [self.parse_index_definition(row[0]) for row in results]
+        return [
+            dict(name=row[0], **self.parse_index_definition(row[1]))
+            if row[0].startswith("column")
+            else self.parse_index_definition(row[1])
+            for row in results
+        ]
 
     def parse_index_definition(self, index_definition):
         index_definition = index_definition.lower()


### PR DESCRIPTION
resolves dbt-labs/dbt-postgres#52

### Problem

Currently Postgres Adapter does not accept a `name` field in the model indexes configurations. This might be unnecessary for some of the users. But for readability and maintenance, a meaningful index name can be helpful. As I understood from the previous threads this is mainly due to the need of unique names of indices within a transaction. I did not test or understood fully what is breaking. However, I wanted to follow the following threads and keep the original idea of uniqueness. So developed a solution bearing this in mind.

- https://github.com/dbt-labs/dbt-core/issues/1945#issuecomment-576714925
- https://github.com/dbt-labs/dbt-core/issues/804 

### Solution

Adding an optional `name` field in the Postgres Index Config. If the `name` is not provided the index name will be an MD5 hash of the index config contents as it was previously. If the `name` is provided then the Unix Time of the index creation will be concatenated to the name provided. This way we will have the benefit of both uniqueness and the semantics.

I also edited the relevant tests. This is my first time contribution attempt. Please let me know if there is something over or under developed. Happy to help.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
