### PR TITLE
Remove `documentable` as it isn't used anywhere

### DIFF
--- a/.changes/unreleased/Under the Hood-20231106-105730.yaml
+++ b/.changes/unreleased/Under the Hood-20231106-105730.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Removing unused 'documentable'
+time: 2023-11-06T10:57:30.694056-08:00
+custom:
+  Author: QMalcolm
+  Issue: "8871"

--- a/core/dbt/node_types.py
+++ b/core/dbt/node_types.py
@@ -64,19 +64,6 @@ class NodeType(StrEnum):
             cls.Model,
         ]
 
-    @classmethod
-    def documentable(cls) -> List["NodeType"]:
-        return [
-            cls.Model,
-            cls.Seed,
-            cls.Snapshot,
-            cls.Source,
-            cls.Macro,
-            cls.Analysis,
-            cls.Exposure,
-            cls.Metric,
-        ]
-
     def pluralize(self) -> str:
         if self is self.Analysis:
             return "analyses"


### PR DESCRIPTION
resolves #8871

### Problem

`NodeType.documentable` isn't being used anywhere, so lets drop the dead code.

### Solution

Deleting the `documentable` definition on `NodeType`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
