### PR TITLE
Update typing-extensions version to >=4.4

### DIFF
--- a/.changes/unreleased/Dependencies-20231106-130051.yaml
+++ b/.changes/unreleased/Dependencies-20231106-130051.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Update typing-extensions version to >=4.4
+time: 2023-11-06T13:00:51.062386-08:00
+custom:
+  Author: tlento
+  PR: "9012"

--- a/core/setup.py
+++ b/core/setup.py
@@ -73,7 +73,6 @@ setup(
         # These are major-version-0 packages also maintained by dbt-labs. Accept patches.
         "dbt-extractor~=0.5.0",
         "minimal-snowplow-tracker~=0.0.2",
-        # DSI is under active development, so we're pinning to specific dev versions for now.
         "dbt-semantic-interfaces~=0.4.0",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
@@ -82,7 +81,7 @@ setup(
         "protobuf>=4.0.0",
         "pytz>=2015.7",
         "pyyaml>=6.0",
-        "typing-extensions>=3.7.4",
+        "typing-extensions>=4.4",
         # ----
         # Match snowflake-connector-python, to ensure compatibility in dbt-snowflake
         "cffi>=1.9,<2.0.0",


### PR DESCRIPTION
resolves #7828

### Problem

With the addition of dbt-semantic-interfaces as a package dependency
for dbt-core we added an implicit requirement that the local install
of typing-extensions be for a version >= 4.4. This means, effective
with dbt-core 1.6, our version minimum for typing-extensions has been
updated to 4.4.

This caused issues in certain install environments due to virtual envs with
pre-installs of out of date packages. While that has been addressed with
a patch update of dbt-semantic-interfaces, we should still have the correct
dependencies listed in dbt-core as well.

### Solution

The solution is to just update the verison.

This change reflects the reality imposed on us by our dependency hierarchy.
Happily, mashumaro previously boosted its base version dependency to 4.1
some time ago, and effective with major version 4 the typing-extensions
package maintainers have committed to strictly following SemVer, so this
should be a low risk minimum version change.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
