### PR TITLE
Catalog/bug/9013

### DIFF
--- a/tests/adapter/dbt/tests/adapter/catalog/files.py
+++ b/tests/adapter/dbt/tests/adapter/catalog/files.py
@@ -1,0 +1,16 @@
+MODELS__VIEW = """
+select 1 as id
+"""
+
+
+MACROS__GET_CATALOG = """
+{% macro default__get_catalog(information_schema, schemas) -%}
+
+  {% set typename = adapter.type() %}
+  {% set msg -%}
+    get_catalog not implemented for {{ typename }}
+  {%- endset %}
+
+  {{ exceptions.raise_compiler_error(msg) }}
+{% endmacro %}
+"""

--- a/tests/adapter/dbt/tests/adapter/catalog/test_include_policy.py
+++ b/tests/adapter/dbt/tests/adapter/catalog/test_include_policy.py
@@ -1,0 +1,28 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+from tests.adapter.dbt.tests.adapter.catalog import files
+
+
+class CatalogRecognizesIncludePolicy:
+    """
+    This test addresses: https://github.com/dbt-labs/dbt-core/issues/9013
+
+    To implement this, overwrite `macros` with the version of `get_catalog` that is
+    specific to your adapter. Remember to remove database, schema, or both to test the flexibility.
+    """
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_view.sql": files.MODELS__VIEW}
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"default__get_catalog.sql": files.MACROS__GET_CATALOG}
+
+    def test_include_policy_recognized_during_docs_generate(self, project):
+        """
+        Running successfully is passing
+        """
+        run_dbt(["run"])
+        run_dbt(["docs", "generate"])

--- a/tests/functional/catalog_tests/files.py
+++ b/tests/functional/catalog_tests/files.py
@@ -31,3 +31,64 @@ MY_MATERIALIZED_VIEW = """
 select *
 from {{ ref('my_seed') }}
 """
+
+
+# this is the same as `postgres__get_catalog_relations`, but with `table_database` removed
+MACROS__GET_CATALOG_RELATIONS = """
+{% macro postgres__get_catalog_relations(information_schema, relations) -%}
+  {%- call statement('catalog', fetch_result=True) -%}
+
+    {#
+      If the user has multiple databases set and the first one is wrong, this will fail.
+      But we won't fail in the case where there are multiple quoting-difference-only dbs, which is better.
+    #}
+    {% set database = information_schema.database %}
+    {{ adapter.verify_database(database) }}
+
+    select
+        sch.nspname as table_schema,
+        tbl.relname as table_name,
+        case tbl.relkind
+            when 'v' then 'VIEW'
+            when 'm' then 'MATERIALIZED VIEW'
+            else 'BASE TABLE'
+        end as table_type,
+        tbl_desc.description as table_comment,
+        col.attname as column_name,
+        col.attnum as column_index,
+        pg_catalog.format_type(col.atttypid, col.atttypmod) as column_type,
+        col_desc.description as column_comment,
+        pg_get_userbyid(tbl.relowner) as table_owner
+
+    from pg_catalog.pg_namespace sch
+    join pg_catalog.pg_class tbl on tbl.relnamespace = sch.oid
+    join pg_catalog.pg_attribute col on col.attrelid = tbl.oid
+    left outer join pg_catalog.pg_description tbl_desc on (tbl_desc.objoid = tbl.oid and tbl_desc.objsubid = 0)
+    left outer join pg_catalog.pg_description col_desc on (col_desc.objoid = tbl.oid and col_desc.objsubid = col.attnum)
+    where (
+      {%- for relation in relations -%}
+        {%- if relation.identifier -%}
+          (upper(sch.nspname) = upper('{{ relation.schema }}') and
+           upper(tbl.relname) = upper('{{ relation.identifier }}'))
+        {%- else-%}
+          upper(sch.nspname) = upper('{{ relation.schema }}')
+        {%- endif -%}
+        {%- if not loop.last %} or {% endif -%}
+      {%- endfor -%}
+    )
+      and not pg_is_other_temp_schema(sch.oid) -- not a temporary schema belonging to another session
+      and tbl.relpersistence in ('p', 'u') -- [p]ermanent table or [u]nlogged table. Exclude [t]emporary tables
+      and tbl.relkind in ('r', 'v', 'f', 'p', 'm') -- o[r]dinary table, [v]iew, [f]oreign table, [p]artitioned table, [m]aterialized view. Other values are [i]ndex, [S]equence, [c]omposite type, [t]OAST table
+      and col.attnum > 0 -- negative numbers are used for system columns such as oid
+      and not col.attisdropped -- column as not been dropped
+
+    order by
+        sch.nspname,
+        tbl.relname,
+        col.attnum
+
+  {%- endcall -%}
+
+  {{ return(load_result('catalog').table) }}
+{%- endmacro %}
+"""

--- a/tests/functional/catalog_tests/test_include_policy.py
+++ b/tests/functional/catalog_tests/test_include_policy.py
@@ -1,0 +1,12 @@
+import pytest
+
+from tests.adapter.dbt.tests.adapter.catalog.test_include_policy import (
+    CatalogRecognizesIncludePolicy,
+)
+from tests.functional.catalog_tests import files
+
+
+class TestCatalogRecognizesIncludePolicy(CatalogRecognizesIncludePolicy):
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"postgres__get_catalog_relations.sql": files.MACROS__GET_CATALOG_RELATIONS}


### PR DESCRIPTION
resolves #9013

### Problem

We allow adapters to use only a database or only a schema based on how the platform works. However, we require a catalog query to include both a database and a schema. This happens specifically when filtering the catalog to only included schemas, not when attributing attribution to a schema.

### Solution

Update catalog workflows to allow for a missing `table_database` or `table_schema` field.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
