### PR TITLE
Use MANIFEST.in to identify package data, allows recursive include

### DIFF
--- a/.changes/unreleased/Fixes-20231107-094130.yaml
+++ b/.changes/unreleased/Fixes-20231107-094130.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Use MANIFEST.in to recursively include all jinja templates; fixes issue where
+  some templates were not included in the distribution
+time: 2023-11-07T09:41:30.121733-05:00
+custom:
+  Author: mikealfare
+  Issue: "9016"

--- a/plugins/postgres/MANIFEST.in
+++ b/plugins/postgres/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include dbt/include *.sql *.yml

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -60,14 +60,7 @@ setup(
     author_email="info@dbtlabs.com",
     url="https://github.com/dbt-labs/dbt-core",
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
-    package_data={
-        "dbt": [
-            "include/postgres/dbt_project.yml",
-            "include/postgres/sample_profiles.yml",
-            "include/postgres/macros/*.sql",
-            "include/postgres/macros/**/*.sql",
-        ]
-    },
+    include_package_data=True,
     install_requires=[
         "dbt-core=={}".format(package_version),
         "{}~=2.8".format(DBT_PSYCOPG2_NAME),


### PR DESCRIPTION
resolves #9016

### Problem

We were using `package_data` in `setup.py` to identify package data, which does not allow for fully recursive file paths. We made updates in 1.7 that moved some jinja templates a layer lower in the file hierarchy. These templates were not caught when building the distribution.

### Solution

Replace `package_data` in `setup.py` with `MANIFEST.in` and `include_package_data=True` in `setup.py`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
