### PR TITLE
Cache plugin modules

### DIFF
--- a/.changes/unreleased/Under the Hood-20231107-191546.yaml
+++ b/.changes/unreleased/Under the Hood-20231107-191546.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Cache dbt plugin modules to improve integration test performance
+time: 2023-11-07T19:15:46.170151-05:00
+custom:
+  Author: peterallenwebb
+  Issue: "9029"

--- a/core/dbt/plugins/manager.py
+++ b/core/dbt/plugins/manager.py
@@ -65,7 +65,7 @@ class dbtPlugin:
         raise NotImplementedError(f"get_manifest_artifacts hook not implemented for {self.name}")
 
 
-@functools.cache
+@functools.lru_cache(maxsize=None)
 def _get_dbt_modules() -> Mapping[str, ModuleType]:
     # This is an expensive function, especially in the context of testing, when
     # it is called repeatedly, so we break it out and cache the result globally.

--- a/core/dbt/plugins/manager.py
+++ b/core/dbt/plugins/manager.py
@@ -1,6 +1,8 @@
+import functools
 import importlib
 import pkgutil
-from typing import Dict, List, Callable
+from types import ModuleType
+from typing import Dict, List, Callable, Mapping
 
 from dbt.contracts.graph.manifest import Manifest
 from dbt.exceptions import DbtRuntimeError
@@ -63,6 +65,17 @@ class dbtPlugin:
         raise NotImplementedError(f"get_manifest_artifacts hook not implemented for {self.name}")
 
 
+@functools.cache
+def _get_dbt_modules() -> Mapping[str, ModuleType]:
+    # This is an expensive function, especially in the context of testing, when
+    # it is called repeatedly, so we break it out and cache the result globally.
+    return {
+        name: importlib.import_module(name)
+        for _, name, _ in pkgutil.iter_modules()
+        if name.startswith(PluginManager.PLUGIN_MODULE_PREFIX)
+    }
+
+
 class PluginManager:
     PLUGIN_MODULE_PREFIX = "dbt_"
     PLUGIN_ATTR_NAME = "plugins"
@@ -91,11 +104,7 @@ class PluginManager:
 
     @classmethod
     def from_modules(cls, project_name: str) -> "PluginManager":
-        discovered_dbt_modules = {
-            name: importlib.import_module(name)
-            for _, name, _ in pkgutil.iter_modules()
-            if name.startswith(cls.PLUGIN_MODULE_PREFIX)
-        }
+        discovered_dbt_modules = _get_dbt_modules()
 
         plugins = []
         for name, module in discovered_dbt_modules.items():


### PR DESCRIPTION
resolves #9029

Local results:
- Before: make integration  1377.96s user 124.94s system 834% cpu 3:00.16 total
- After: make integration  1057.26s user 61.76s system 719% cpu 2:35.55 total


### Problem

Scanning all available python modules is slow.

### Solution

For the purposes of detecting dbt plugins, only do this once per process invocation and cache the result.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
