### PR TITLE
Make extract_toplevel_blocks() Faster

### DIFF
--- a/.changes/unreleased/Under the Hood-20231109-131545.yaml
+++ b/.changes/unreleased/Under the Hood-20231109-131545.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Make extract_toplevel_blocks() Faster
+time: 2023-11-09T13:15:45.338059-05:00
+custom:
+  Author: peterallenwebb qmalcolm
+  Issue: "9037"

--- a/core/dbt/clients/_jinja_blocks.py
+++ b/core/dbt/clients/_jinja_blocks.py
@@ -143,7 +143,8 @@ class TagIterator:
         positioned_match = self._past_matches.get(pattern)
 
         if positioned_match is None or positioned_match.start_pos > self.pos:
-            # We did not have a cached search, just do one from scratch.
+            # We did not have a cached search, or we did, but it was done at a location
+            # further along in the string. Do a new search and cache it.
             match = pattern.search(self.data, self.pos)
             self._past_matches[pattern] = PositionedMatch(self.pos, match)
         else:
@@ -153,11 +154,12 @@ class TagIterator:
                 # ...but there is no match in the rest of the 'data'.
                 match = None
             elif positioned_match.match.start() >= self.pos:
-                # ...and there is a match we can reuse, because we have not yet reached
-                # the location of the match.
+                # ...and there is a match we can reuse, because we have not yet passed
+                # the start position of the match. It's still the next match.
                 match = positioned_match.match
             else:
-                # ...but we have passed the match, and need to re-search from the position.
+                # ...but we have passed the start of the cached match, and need to do a
+                # new search from our current position and cache it.
                 match = pattern.search(self.data, self.pos)
                 self._past_matches[pattern] = PositionedMatch(self.pos, match)
 


### PR DESCRIPTION
resolves #9037 

### Problem

The extract_toplevel_blocks() function was a severe bottleneck for some large-ish (>100Kb) files.

### Solution

By caching string search results instead of re-search many times, we were able to accelerate performance by >500x on a file of size ~500Kb, from 15s to .039s.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
