### PR TITLE
Fix test_current_timestamp_matches_utc

### DIFF
--- a/.changes/unreleased/Under the Hood-20231111-175350.yaml
+++ b/.changes/unreleased/Under the Hood-20231111-175350.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Fix test_current_timestamp_matches_utc test; allow for MacOS runner system clock
+  variance
+time: 2023-11-11T17:53:50.098843-05:00
+custom:
+  Author: mikealfare
+  Issue: "9057"

--- a/tests/adapter/dbt/tests/adapter/utils/test_current_timestamp.py
+++ b/tests/adapter/dbt/tests/adapter/utils/test_current_timestamp.py
@@ -40,7 +40,8 @@ class BaseCurrentTimestamp:
         sql_timestamp = current_timestamp
         now_utc = self.utcnow_matching_type(sql_timestamp)
         # Plenty of wiggle room if clocks aren't perfectly sync'd, etc
-        tolerance = timedelta(minutes=1)
+        # The clock on the macos image appears to be a few minutes slow in GHA, causing false negatives
+        tolerance = timedelta(minutes=5)
         assert (sql_timestamp > (now_utc - tolerance)) and (
             sql_timestamp < (now_utc + tolerance)
         ), f"SQL timestamp {sql_timestamp.isoformat()} is not close enough to Python UTC {now_utc.isoformat()}"


### PR DESCRIPTION
resolves #9057

### Problem

The MacOS runner system clock is behind and causing a test to fail. The test currently allows for a 1 minute difference, but the difference on MacOS appears to be around 2.5 minutes.

### Solution

The difference appears to always be less than 3 minutes, so allow for a 5 minute buffer.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
