### PR TITLE
Allow use of sources as unit testing inputs

### DIFF
--- a/.changes/unreleased/Features-20231111-191150.yaml
+++ b/.changes/unreleased/Features-20231111-191150.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support source inputs in unit tests
+time: 2023-11-11T19:11:50.870494-05:00
+custom:
+  Author: gshank
+  Issue: "8507"

--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -2,7 +2,13 @@ from collections.abc import Hashable
 from dataclasses import dataclass, field
 from typing import Optional, TypeVar, Any, Type, Dict, Iterator, Tuple, Set, Union, FrozenSet
 
-from dbt.contracts.graph.nodes import SourceDefinition, ManifestNode, ResultNode, ParsedNode
+from dbt.contracts.graph.nodes import (
+    SourceDefinition,
+    ManifestNode,
+    ResultNode,
+    ParsedNode,
+    UnitTestSourceDefinition,
+)
 from dbt.contracts.relation import (
     RelationType,
     ComponentName,
@@ -201,7 +207,9 @@ class BaseRelation(FakeAPIObject, Hashable):
         )
 
     @classmethod
-    def create_from_source(cls: Type[Self], source: SourceDefinition, **kwargs: Any) -> Self:
+    def create_from_source(
+        cls: Type[Self], source: Union[SourceDefinition, UnitTestSourceDefinition], **kwargs: Any
+    ) -> Self:
         source_quoting = source.quoting.to_dict(omit_none=True)
         source_quoting.pop("column", None)
         quote_policy = deep_merge(
@@ -263,8 +271,10 @@ class BaseRelation(FakeAPIObject, Hashable):
         node: ResultNode,
         **kwargs: Any,
     ) -> Self:
-        if node.resource_type == NodeType.Source:
-            if not isinstance(node, SourceDefinition):
+        if node.resource_type == NodeType.Source or isinstance(node, UnitTestSourceDefinition):
+            if not (
+                isinstance(node, SourceDefinition) or isinstance(node, UnitTestSourceDefinition)
+            ):
                 raise DbtInternalError(
                     "type mismatch, expected SourceDefinition but got {}".format(type(node))
                 )

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -622,16 +622,11 @@ class RuntimeUnitTestSourceResolver(RuntimeSourceResolver):
                 disabled=(isinstance(target_source, Disabled)),
             )
         # For unit tests, this isn't a "real" source, it's a ModelNode taking
-        # the place of a source. We want to get the relation of the fake model
-        # node, not the original source relation.
-        return self.create_relation(target_source)
-
-    def create_relation(self, target_source: ManifestNode) -> RelationProxy:
-        if target_source.is_ephemeral_model:
-            self.model.set_cte(target_source.unique_id, None)
-            return self.Relation.create_ephemeral_from_node(self.config, target_source)
-        else:
-            return self.Relation.create_from(self.config, target_source)
+        # the place of a source. We don't really need to return the relation here,
+        # we just need to set_cte, but skipping it confuses typing. We *do* need
+        # the relation in the "this" property.
+        self.model.set_cte(target_source.unique_id, None)
+        return self.Relation.create_ephemeral_from_node(self.config, target_source)
 
 
 # metric` implementations

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -606,7 +606,7 @@ class RuntimeSourceResolver(BaseSourceResolver):
         return self.Relation.create_from_source(target_source)
 
 
-class RuntimeUnitTestSourceResolver(RuntimeSourceResolver):
+class RuntimeUnitTestSourceResolver(BaseSourceResolver):
     def resolve(self, source_name: str, table_name: str):
         target_source = self.manifest.resolve_source(
             source_name,

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1063,8 +1063,18 @@ class GenericTestNode(TestShouldStoreFailures, CompiledNode, HasTestMetadata):
 
 
 @dataclass
+class UnitTestSourceDefinition(ModelNode):
+    source_name: str = "undefined"
+    quoting: Quoting = field(default_factory=Quoting)
+
+    @property
+    def search_name(self):
+        return f"{self.source_name}.{self.name}"
+
+
+@dataclass
 class UnitTestNode(CompiledNode):
-    resource_type: NodeType = field(metadata={"restrict": [NodeType.Unit]})
+    resource_type: Literal[NodeType.Unit]
     tested_node_unique_id: Optional[str] = None
     this_input_node_unique_id: Optional[str] = None
     overrides: Optional[UnitTestOverrides] = None

--- a/core/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
+++ b/core/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
@@ -3,15 +3,15 @@
 {% set default_row = {} %}
 
 {%- if not column_name_to_data_types -%}
-{%- set columns_in_relation = adapter.get_columns_in_relation(this) -%}
-{%- set column_name_to_data_types = {} -%}
-{%- for column in columns_in_relation -%}
-{%- do column_name_to_data_types.update({column.name: column.dtype}) -%}
-{%- endfor -%}
+{%-   set columns_in_relation = adapter.get_columns_in_relation(this) -%}
+{%-   set column_name_to_data_types = {} -%}
+{%-   for column in columns_in_relation -%}
+{%-     do column_name_to_data_types.update({column.name: column.dtype}) -%}
+{%-   endfor -%}
 {%- endif -%}
 
 {%- if not column_name_to_data_types -%}
-    {{ exceptions.raise_compiler_error("columns not available for" ~ model.name) }}
+    {{ exceptions.raise_compiler_error("columns not available for " ~ model.name) }}
 {%- endif -%}
 
 {%- for column_name, column_type in column_name_to_data_types.items() -%}
@@ -19,16 +19,15 @@
 {%- endfor -%}
 
 {%- for row in rows -%}
-{%- do format_row(row, column_name_to_data_types) -%}
-
-{%- set default_row_copy = default_row.copy() -%}
-{%- do default_row_copy.update(row) -%}
+{%-   do format_row(row, column_name_to_data_types) -%}
+{%-   set default_row_copy = default_row.copy() -%}
+{%-   do default_row_copy.update(row) -%}
 select
-{%- for column_name, column_value in default_row_copy.items() %} {{ column_value }} AS {{ column_name }}{% if not loop.last -%}, {%- endif %}
-{%- endfor %}
-{%- if not loop.last %}
+{%-   for column_name, column_value in default_row_copy.items() %} {{ column_value }} AS {{ column_name }}{% if not loop.last -%}, {%- endif %}
+{%-   endfor %}
+{%-   if not loop.last %}
 union all
-{% endif %}
+{%    endif %}
 {%- endfor -%}
 
 {%- if (rows | length) == 0 -%}

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -201,22 +201,22 @@ class UnitTestManifestLoader:
                 raise InvalidUnitTestGivenInput(input=input)
 
             if statically_parsed["refs"]:
-                for ref in statically_parsed["refs"]:
-                    name = ref.get("name")
-                    package = ref.get("package")
-                    version = ref.get("version")
-                    # TODO: disabled lookup, versioned lookup, public models
-                    original_input_node = self.manifest.ref_lookup.find(
-                        name, package, version, self.manifest
-                    )
+                ref = list(statically_parsed["refs"])[0]
+                name = ref.get("name")
+                package = ref.get("package")
+                version = ref.get("version")
+                # TODO: disabled lookup, versioned lookup, public models
+                original_input_node = self.manifest.ref_lookup.find(
+                    name, package, version, self.manifest
+                )
             elif statically_parsed["sources"]:
-                for source in statically_parsed["sources"]:
-                    input_source_name, input_name = source
-                    original_input_node = self.manifest.source_lookup.find(
-                        f"{input_source_name}.{input_name}",
-                        self.root_project.project_name,
-                        self.manifest,
-                    )
+                source = list(statically_parsed["sources"])[0]
+                input_source_name, input_name = source
+                original_input_node = self.manifest.source_lookup.find(
+                    f"{input_source_name}.{input_name}",
+                    self.root_project.project_name,
+                    self.manifest,
+                )
             else:
                 raise InvalidUnitTestGivenInput(input=input)
 

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -114,13 +114,11 @@ class UnitTestManifestLoader:
             # extract the original_input_node from the ref in the "input" key of the given list
             original_input_node = self._get_original_input_node(given.input, tested_node)
 
-            input_name = f"{unit_test_node.name}__{original_input_node.name}"
             project_root = self.root_project.project_root
             common_fields = {
                 "resource_type": NodeType.Model,
                 "package_name": package_name,
                 "original_file_path": original_input_node.original_file_path,
-                "unique_id": f"model.{package_name}.{input_name}",
                 "config": ModelConfig(materialized="ephemeral"),
                 "database": original_input_node.database,
                 "alias": original_input_node.identifier,
@@ -133,8 +131,10 @@ class UnitTestManifestLoader:
             }
 
             if original_input_node.resource_type == NodeType.Model:
+                input_name = f"{unit_test_node.name}__{original_input_node.name}"
                 input_node = ModelNode(
                     **common_fields,
+                    unique_id=f"model.{package_name}.{input_name}",
                     name=input_name,
                     path=original_input_node.path,
                 )
@@ -142,8 +142,10 @@ class UnitTestManifestLoader:
                 # We are reusing the database/schema/identifier from the original source,
                 # but that shouldn't matter since this acts as an ephemeral model which just
                 # wraps a CTE around the unit test node.
+                input_name = f"{unit_test_node.name}__{original_input_node.search_name}__{original_input_node.name}"
                 input_node = UnitTestSourceDefinition(
                     **common_fields,
+                    unique_id=f"model.{package_name}.{input_name}",
                     name=original_input_node.name,  # must be the same name for source lookup to work
                     path=input_name + ".sql",  # for writing out compiled_code
                     source_name=original_input_node.source_name,  # needed for source lookup
@@ -202,7 +204,7 @@ class UnitTestManifestLoader:
                 input_source_name, input_name = source
                 original_input_node = self.manifest.source_lookup.find(
                     f"{input_source_name}.{input_name}",
-                    self.root_project.project_name,
+                    None,
                     self.manifest,
                 )
             else:

--- a/tests/functional/unit_testing/test_ut_sources.py
+++ b/tests/functional/unit_testing/test_ut_sources.py
@@ -1,0 +1,69 @@
+import pytest
+from dbt.tests.util import run_dbt
+
+raw_customers_csv = """id,first_name,last_name,email
+1,Michael,Perez,mperez0@chronoengine.com
+2,Shawn,Mccoy,smccoy1@reddit.com
+3,Kathleen,Payne,kpayne2@cargocollective.com
+4,Jimmy,Cooper,jcooper3@cargocollective.com
+5,Katherine,Rice,krice4@typepad.com
+6,Sarah,Ryan,sryan5@gnu.org
+7,Martin,Mcdonald,mmcdonald6@opera.com
+8,Frank,Robinson,frobinson7@wunderground.com
+9,Jennifer,Franklin,jfranklin8@mail.ru
+10,Henry,Welch,hwelch9@list-manage.com
+"""
+
+schema_sources_yml = """
+sources:
+  - name: seed_sources
+    schema: "{{ target.schema }}"
+    tables:
+      - name: raw_customers
+        columns:
+          - name: id
+            tests:
+              - not_null:
+                  severity: "{{ 'error' if target.name == 'prod' else 'warn' }}"
+              - unique
+          - name: first_name
+          - name: last_name
+          - name: email
+unit_tests:
+  - name: test_customers
+    model: customers
+    given:
+      - input: source('seed_sources', 'raw_customers')
+        rows:
+          - {id: 1, first_name: Emily}
+    expect:
+      rows:
+        - {id: 1, first_name: Emily}
+"""
+
+customers_sql = """
+select * from {{ source('seed_sources', 'raw_customers') }}
+"""
+
+
+class TestUnitTestSourceInput:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "raw_customers.csv": raw_customers_csv,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "customers.sql": customers_sql,
+            "sources.yml": schema_sources_yml,
+        }
+
+    def test_source_input(self, project):
+        results = run_dbt(["seed"])
+        results = run_dbt(["run"])
+        len(results) == 1
+
+        results = run_dbt(["unit-test"])
+        assert len(results) == 1


### PR DESCRIPTION
resolves #8507


### Problem

We want to support the use of sources as inputs in unit test cases.

### Solution

Created a UnitTestSourceDefinition object, which acts as a source for purposes of resolving "source" calls, but acts as a model for purpose of executing the test case.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
