### PR TITLE
Support hierarchical config setting for SavedQueryExport configs

### DIFF
--- a/.changes/unreleased/Features-20231110-154255.yaml
+++ b/.changes/unreleased/Features-20231110-154255.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support setting export configs hierarchically via saved query and project configs
+time: 2023-11-10T15:42:55.042317-08:00
+custom:
+  Author: QMalcolm
+  Issue: "8956"

--- a/core/dbt/contracts/graph/model_config.py
+++ b/core/dbt/contracts/graph/model_config.py
@@ -15,6 +15,7 @@ from dbt.contracts.util import Replaceable, list_str
 from dbt.exceptions import DbtInternalError, CompilationError
 from dbt import hooks
 from dbt.node_types import NodeType, AccessType
+from dbt_semantic_interfaces.type_enums.export_destination_type import ExportDestinationType
 from mashumaro.jsonschema.annotations import Pattern
 
 
@@ -407,6 +408,8 @@ class SavedQueryConfig(BaseConfig):
         default_factory=dict,
         metadata=MergeBehavior.Update.meta(),
     )
+    export_as: Optional[ExportDestinationType] = None
+    schema: Optional[str] = None
 
 
 @dataclass

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -19,7 +19,6 @@ import dbt.helper_types  # noqa:F401
 from dbt.exceptions import CompilationError, ParsingError, DbtInternalError
 
 from dbt.dataclass_schema import dbtClassMixin, StrEnum, ExtensibleDbtClassMixin, ValidationError
-from dbt_semantic_interfaces.type_enums.export_destination_type import ExportDestinationType
 
 from dataclasses import dataclass, field
 from datetime import timedelta
@@ -730,20 +729,11 @@ class UnparsedQueryParams(dbtClassMixin):
 
 
 @dataclass
-class UnparsedExportConfig(dbtClassMixin):
-    """Nested configuration attributes for exports."""
-
-    export_as: ExportDestinationType
-    schema: Optional[str] = None
-    alias: Optional[str] = None
-
-
-@dataclass
 class UnparsedExport(dbtClassMixin):
     """Configuration for writing query results to a table."""
 
     name: str
-    config: UnparsedExportConfig
+    config: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from dbt.parser.schemas import YamlReader, SchemaParser, ParseResult
 from dbt.parser.common import YamlBlock
 from dbt.node_types import NodeType
@@ -6,7 +7,6 @@ from dbt.contracts.graph.unparsed import (
     UnparsedDimensionTypeParams,
     UnparsedEntity,
     UnparsedExport,
-    UnparsedExportConfig,
     UnparsedExposure,
     UnparsedGroup,
     UnparsedMeasure,
@@ -57,7 +57,7 @@ from dbt_semantic_interfaces.type_enums import (
     MetricType,
     TimeGranularity,
 )
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 
 def parse_where_filter(
@@ -669,12 +669,11 @@ class SavedQueryParser(YamlReader):
 
         return config
 
-    def _get_export_config(self, unparsed: UnparsedExportConfig) -> ExportConfig:
-        return ExportConfig(
-            export_as=unparsed.export_as,
-            schema_name=unparsed.schema,
-            alias=unparsed.alias,
-        )
+    def _get_export_config(self, unparsed: Dict[str, Any]) -> ExportConfig:
+        parsed = deepcopy(unparsed)
+        if parsed.get("schema") is not parsed.get("schema_name") is None:
+            parsed["schema_name"] = parsed["schema"]
+        return ExportConfig.from_dict(parsed)
 
     def _get_export(self, unparsed: UnparsedExport) -> Export:
         return Export(name=unparsed.name, config=self._get_export_config(unparsed.config))

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -670,11 +670,11 @@ class SavedQueryParser(YamlReader):
         return config
 
     def _get_export_config(
-        self, unparsed: Dict[str, Any], saved_query_config: SavedQueryConfig
+        self, unparsed_export_config: Dict[str, Any], saved_query_config: SavedQueryConfig
     ) -> ExportConfig:
         # Combine the two dictionaries using dictionary unpacking
         # the second dictionary is the one whose keys take priority
-        combined = {**saved_query_config.__dict__, **unparsed}
+        combined = {**saved_query_config.__dict__, **unparsed_export_config}
         # `schema` is the user facing attribute, but for DSI protocol purposes we track it as `schema_name`
         if combined.get("schema") is not None and combined.get("schema_name") is None:
             combined["schema_name"] = combined["schema"]

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from dbt.parser.schemas import YamlReader, SchemaParser, ParseResult
 from dbt.parser.common import YamlBlock
 from dbt.node_types import NodeType
@@ -19,6 +18,7 @@ from dbt.contracts.graph.unparsed import (
     UnparsedSavedQuery,
     UnparsedSemanticModel,
 )
+from dbt.contracts.graph.model_config import SavedQueryConfig
 from dbt.contracts.graph.nodes import (
     Exposure,
     Group,
@@ -669,14 +669,24 @@ class SavedQueryParser(YamlReader):
 
         return config
 
-    def _get_export_config(self, unparsed: Dict[str, Any]) -> ExportConfig:
-        parsed = deepcopy(unparsed)
-        if parsed.get("schema") is not parsed.get("schema_name") is None:
-            parsed["schema_name"] = parsed["schema"]
-        return ExportConfig.from_dict(parsed)
+    def _get_export_config(
+        self, unparsed: Dict[str, Any], saved_query_config: SavedQueryConfig
+    ) -> ExportConfig:
+        # Combine the two dictionaries using dictionary unpacking
+        # the second dictionary is the one whose keys take priority
+        combined = {**saved_query_config.__dict__, **unparsed}
+        # `schema` is the user facing attribute, but for DSI protocol purposes we track it as `schema_name`
+        if combined.get("schema") is not combined.get("schema_name") is None:
+            combined["schema_name"] = combined["schema"]
 
-    def _get_export(self, unparsed: UnparsedExport) -> Export:
-        return Export(name=unparsed.name, config=self._get_export_config(unparsed.config))
+        return ExportConfig.from_dict(combined)
+
+    def _get_export(
+        self, unparsed: UnparsedExport, saved_query_config: SavedQueryConfig
+    ) -> Export:
+        return Export(
+            name=unparsed.name, config=self._get_export_config(unparsed.config, saved_query_config)
+        )
 
     def _get_query_params(self, unparsed: UnparsedQueryParams) -> QueryParams:
         return QueryParams(
@@ -720,7 +730,7 @@ class SavedQueryParser(YamlReader):
             resource_type=NodeType.SavedQuery,
             unique_id=unique_id,
             query_params=self._get_query_params(unparsed.query_params),
-            exports=[self._get_export(export) for export in unparsed.exports],
+            exports=[self._get_export(export, config) for export in unparsed.exports],
             config=config,
             unrendered_config=unrendered_config,
             group=config.group,

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -676,7 +676,7 @@ class SavedQueryParser(YamlReader):
         # the second dictionary is the one whose keys take priority
         combined = {**saved_query_config.__dict__, **unparsed}
         # `schema` is the user facing attribute, but for DSI protocol purposes we track it as `schema_name`
-        if combined.get("schema") is not combined.get("schema_name") is None:
+        if combined.get("schema") is not None and combined.get("schema_name") is None:
             combined["schema_name"] = combined["schema"]
 
         return ExportConfig.from_dict(combined)

--- a/tests/functional/saved_queries/fixtures.py
+++ b/tests/functional/saved_queries/fixtures.py
@@ -24,3 +24,25 @@ saved_queries:
             export_as: table
             schema: my_export_schema_name
 """
+
+saved_query_with_extra_config_attributes_yml = """
+version: 2
+
+saved_queries:
+  - name: test_saved_query
+    description: "{{ doc('saved_query_description') }}"
+    label: Test Saved Query
+    query_params:
+        metrics:
+            - simple_metric
+        group_by:
+            - "Dimension('user__ds')"
+        where:
+            - "{{ Dimension('user__ds', 'DAY') }} <= now()"
+            - "{{ Dimension('user__ds', 'DAY') }} >= '2023-01-01'"
+    exports:
+        - name: my_export
+          config:
+            my_random_config: 'I have this for some reason'
+            export_as: table
+"""

--- a/tests/functional/saved_queries/fixtures.py
+++ b/tests/functional/saved_queries/fixtures.py
@@ -46,3 +46,48 @@ saved_queries:
             my_random_config: 'I have this for some reason'
             export_as: table
 """
+
+saved_query_with_export_configs_defined_at_saved_query_level_yml = """
+version: 2
+
+saved_queries:
+  - name: test_saved_query
+    description: "{{ doc('saved_query_description') }}"
+    label: Test Saved Query
+    config:
+      export_as: table
+      schema: my_default_export_schema
+    query_params:
+        metrics:
+            - simple_metric
+        group_by:
+            - "Dimension('user__ds')"
+        where:
+            - "{{ Dimension('user__ds', 'DAY') }} <= now()"
+            - "{{ Dimension('user__ds', 'DAY') }} >= '2023-01-01'"
+    exports:
+        - name: my_export
+          config:
+            export_as: view
+            schema: my_custom_export_schema
+        - name: my_export2
+"""
+
+saved_query_without_export_configs_defined_yml = """
+version: 2
+
+saved_queries:
+  - name: test_saved_query
+    description: "{{ doc('saved_query_description') }}"
+    label: Test Saved Query
+    query_params:
+        metrics:
+            - simple_metric
+        group_by:
+            - "Dimension('user__ds')"
+        where:
+            - "{{ Dimension('user__ds', 'DAY') }} <= now()"
+            - "{{ Dimension('user__ds', 'DAY') }} >= '2023-01-01'"
+    exports:
+        - name: my_export
+"""

--- a/tests/functional/saved_queries/test_configs.py
+++ b/tests/functional/saved_queries/test_configs.py
@@ -1,0 +1,55 @@
+import pytest
+
+from dbt.contracts.graph.manifest import Manifest
+from dbt.tests.util import update_config_file
+from tests.functional.assertions.test_runner import dbtTestRunner
+from tests.functional.configs.fixtures import BaseConfigProject
+from tests.functional.saved_queries.fixtures import saved_queries_yml, saved_query_description
+from tests.functional.semantic_models.fixtures import (
+    fct_revenue_sql,
+    metricflow_time_spine_sql,
+    schema_yml,
+)
+
+
+class TestSavedQueryConfigs(BaseConfigProject):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "saved-queries": {
+                "test": {
+                    "test_saved_query": {
+                        "+enabled": True,
+                    }
+                },
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "saved_queries.yml": saved_queries_yml,
+            "schema.yml": schema_yml,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "docs.md": saved_query_description,
+        }
+
+    def test_basic_saved_query_config(
+        self,
+        project,
+    ):
+        runner = dbtTestRunner()
+
+        # parse with default fixture project config
+        result = runner.invoke(["parse"])
+        assert result.success
+        assert isinstance(result.result, Manifest)
+        assert len(result.result.saved_queries) == 1
+
+        # disable the saved_query via project config and rerun
+        config_patch = {"saved-queries": {"test": {"test_saved_query": {"+enabled": False}}}}
+        update_config_file(config_patch, project.project_root, "dbt_project.yml")
+        result = runner.invoke(["parse"])
+        assert result.success
+        assert len(result.result.saved_queries) == 0

--- a/tests/functional/saved_queries/test_configs.py
+++ b/tests/functional/saved_queries/test_configs.py
@@ -9,6 +9,8 @@ from tests.functional.saved_queries.fixtures import (
     saved_queries_yml,
     saved_query_description,
     saved_query_with_extra_config_attributes_yml,
+    saved_query_with_export_configs_defined_at_saved_query_level_yml,
+    saved_query_without_export_configs_defined_yml,
 )
 from tests.functional.semantic_models.fixtures import (
     fct_revenue_sql,
@@ -87,3 +89,98 @@ class TestExportConfigsWithAdditionalProperties(BaseConfigProject):
         saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
         assert len(saved_query.exports) == 1
         assert saved_query.exports[0].config.__dict__.get("my_random_config") is None
+
+
+class TestInheritingExportConfigFromSavedQueryConfig(BaseConfigProject):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "saved_queries.yml": saved_query_with_export_configs_defined_at_saved_query_level_yml,
+            "schema.yml": schema_yml,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "docs.md": saved_query_description,
+        }
+
+    def test_export_config_inherits_from_saved_query(self, project):
+        runner = dbtTestRunner()
+
+        # parse with default fixture project config
+        result = runner.invoke(["parse"])
+        assert result.success
+        assert isinstance(result.result, Manifest)
+        assert len(result.result.saved_queries) == 1
+        saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
+        assert len(saved_query.exports) == 2
+
+        # assert Export `my_export` has its configs defined from itself because they should take priority
+        export1 = next(
+            (export for export in saved_query.exports if export.name == "my_export"), None
+        )
+        assert export1 is not None
+        assert export1.config.export_as == ExportDestinationType.VIEW
+        assert export1.config.export_as != saved_query.config.export_as
+        assert export1.config.schema_name == "my_custom_export_schema"
+        assert export1.config.schema_name != saved_query.config.schema
+
+        # assert Export `my_export` has its configs defined from the saved_query because they should take priority
+        export2 = next(
+            (export for export in saved_query.exports if export.name == "my_export2"), None
+        )
+        assert export2 is not None
+        assert export2.config.export_as == ExportDestinationType.TABLE
+        assert export2.config.export_as == saved_query.config.export_as
+        assert export2.config.schema_name == "my_default_export_schema"
+        assert export2.config.schema_name == saved_query.config.schema
+
+
+class TestInheritingExportConfigsFromProject(BaseConfigProject):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "saved-queries": {
+                "test": {
+                    "test_saved_query": {
+                        "+export_as": ExportDestinationType.VIEW.value,
+                    }
+                },
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "saved_queries.yml": saved_query_without_export_configs_defined_yml,
+            "schema.yml": schema_yml,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "docs.md": saved_query_description,
+        }
+
+    def test_export_config_inherits_from_project(
+        self,
+        project,
+    ):
+        runner = dbtTestRunner()
+
+        # parse with default fixture project config
+        result = runner.invoke(["parse"])
+        assert result.success
+        assert isinstance(result.result, Manifest)
+        assert len(result.result.saved_queries) == 1
+        saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
+        assert saved_query.config.export_as == ExportDestinationType.VIEW
+
+        # change export's `export_as` to `TABLE` via project config
+        config_patch = {
+            "saved-queries": {
+                "test": {"test_saved_query": {"+export_as": ExportDestinationType.TABLE.value}}
+            }
+        }
+        update_config_file(config_patch, project.project_root, "dbt_project.yml")
+        result = runner.invoke(["parse"])
+        assert result.success
+        assert isinstance(result.result, Manifest)
+        assert len(result.result.saved_queries) == 1
+        saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
+        assert saved_query.config.export_as == ExportDestinationType.TABLE

--- a/tests/functional/saved_queries/test_configs.py
+++ b/tests/functional/saved_queries/test_configs.py
@@ -2,6 +2,7 @@ import pytest
 
 from dbt.contracts.graph.manifest import Manifest
 from dbt.tests.util import update_config_file
+from dbt_semantic_interfaces.type_enums.export_destination_type import ExportDestinationType
 from tests.functional.assertions.test_runner import dbtTestRunner
 from tests.functional.configs.fixtures import BaseConfigProject
 from tests.functional.saved_queries.fixtures import (
@@ -24,6 +25,8 @@ class TestSavedQueryConfigs(BaseConfigProject):
                 "test": {
                     "test_saved_query": {
                         "+enabled": True,
+                        "+export_as": ExportDestinationType.VIEW.value,
+                        "+schema": "my_default_export_schema",
                     }
                 },
             },
@@ -50,6 +53,9 @@ class TestSavedQueryConfigs(BaseConfigProject):
         assert result.success
         assert isinstance(result.result, Manifest)
         assert len(result.result.saved_queries) == 1
+        saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
+        assert saved_query.config.export_as == ExportDestinationType.VIEW
+        assert saved_query.config.schema == "my_default_export_schema"
 
         # disable the saved_query via project config and rerun
         config_patch = {"saved-queries": {"test": {"test_saved_query": {"+enabled": False}}}}

--- a/tests/functional/saved_queries/test_configs.py
+++ b/tests/functional/saved_queries/test_configs.py
@@ -4,7 +4,11 @@ from dbt.contracts.graph.manifest import Manifest
 from dbt.tests.util import update_config_file
 from tests.functional.assertions.test_runner import dbtTestRunner
 from tests.functional.configs.fixtures import BaseConfigProject
-from tests.functional.saved_queries.fixtures import saved_queries_yml, saved_query_description
+from tests.functional.saved_queries.fixtures import (
+    saved_queries_yml,
+    saved_query_description,
+    saved_query_with_extra_config_attributes_yml,
+)
 from tests.functional.semantic_models.fixtures import (
     fct_revenue_sql,
     metricflow_time_spine_sql,
@@ -28,7 +32,7 @@ class TestSavedQueryConfigs(BaseConfigProject):
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "saved_queries.yml": saved_queries_yml,
+            "saved_queries.yml": saved_query_with_extra_config_attributes_yml,
             "schema.yml": schema_yml,
             "fct_revenue.sql": fct_revenue_sql,
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
@@ -53,3 +57,27 @@ class TestSavedQueryConfigs(BaseConfigProject):
         result = runner.invoke(["parse"])
         assert result.success
         assert len(result.result.saved_queries) == 0
+
+
+class TestExportConfigsWithAdditionalProperties(BaseConfigProject):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "saved_queries.yml": saved_queries_yml,
+            "schema.yml": schema_yml,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "docs.md": saved_query_description,
+        }
+
+    def test_extra_config_properties_dont_break_parsing(self, project):
+        runner = dbtTestRunner()
+
+        # parse with default fixture project config
+        result = runner.invoke(["parse"])
+        assert result.success
+        assert isinstance(result.result, Manifest)
+        assert len(result.result.saved_queries) == 1
+        saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
+        assert len(saved_query.exports) == 1
+        assert saved_query.exports[0].config.__dict__.get("my_random_config") is None


### PR DESCRIPTION
resolves #8956 

### Problem
In https://github.com/dbt-labs/dbt-core/pull/8950 we added Exports to SavedQueries. Exports have configs and we want these configs to be setable from a project's dbt_project.yml, i.e. hierarchical. Originally this work was to be part of https://github.com/dbt-labs/dbt-core/issues/8892 in https://github.com/dbt-labs/dbt-core/pull/8950, however due to deadlines and some pesky edge cases, we separated out this work.

### Solution

In #8956 we outlined some paths forward, and we ended up taking none of them. We did not make `ExportConfig` a typical `BaseConfig` like all other configs, and we didn't use the `calculate_node_config` nor create any abstraction of it. Instead we decided to continue treating `ExportConfig` like a non-config object. An `ExportConfig` is mapped from an `Export.config` dictionary. We've taken the extra step to merge in any relevant `SavedQueryConfig` attributes with a preference for attributes defined directly on the `ExportConfig`. Additionally because the `SavedQueryConfig` is produced from the `calculate_node_config` process, we also get relevant configs in the dbt_project.yml.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
