### PR TITLE
Fix dbt deps failing on tarballs

### DIFF
--- a/.changes/unreleased/Fixes-20231113-114956.yaml
+++ b/.changes/unreleased/Fixes-20231113-114956.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix formating of tarball inforamtion in packages-lock.yml
+time: 2023-11-13T11:49:56.437007-08:00
+custom:
+  Author: ChenyuLInx QMalcolm
+  Issue: "9062"

--- a/.changes/unreleased/Fixes-20231113-114956.yaml
+++ b/.changes/unreleased/Fixes-20231113-114956.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: Fix formating of tarball inforamtion in packages-lock.yml
+body: Fix formatting of tarball information in packages-lock.yml
 time: 2023-11-13T11:49:56.437007-08:00
 custom:
   Author: ChenyuLInx QMalcolm

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -96,6 +96,8 @@ class PackageConfig(dbtClassMixin, Replaceable):
     def validate(cls, data):
         for package in data.get("packages", data):
             if isinstance(package, dict) and package.get("package"):
+                if "tarball" in package:
+                    continue
                 if not package["version"]:
                     raise ValidationError(
                         f"{package['package']} is missing the version. When installing from the Hub "

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -96,8 +96,6 @@ class PackageConfig(dbtClassMixin, Replaceable):
     def validate(cls, data):
         for package in data.get("packages", data):
             if isinstance(package, dict) and package.get("package"):
-                if "tarball" in package:
-                    continue
                 if not package["version"]:
                     raise ValidationError(
                         f"{package['package']} is missing the version. When installing from the Hub "

--- a/core/dbt/deps/tarball.py
+++ b/core/dbt/deps/tarball.py
@@ -31,8 +31,7 @@ class TarballPinnedPackage(TarballPackageMixin, PinnedPackage):
     def to_dict(self) -> Dict[str, str]:
         return {
             "tarball": self.tarball,
-            "version": self.version,
-            "package": self.package,
+            "name": self.package,
         }
 
     def get_version(self):

--- a/tests/functional/dependencies/test_simple_dependency.py
+++ b/tests/functional/dependencies/test_simple_dependency.py
@@ -4,9 +4,11 @@ import tempfile
 
 from pathlib import Path
 
+from dbt.exceptions import DbtProjectError
 from dbt.tests.util import (
     check_relations_equal,
     run_dbt,
+    write_config_file,
 )
 
 
@@ -392,5 +394,32 @@ class TestSimpleDependcyTarball(object):
             ]
         }
 
-    def test_deps_tarball(self, project):
+    def test_deps_simple_tarball_doesnt_error_out(self, project):
         run_dbt(["deps"])
+        assert len(os.listdir("dbt_packages")) == 1
+
+
+class TestBadTarballDependency(object):
+    @pytest.fixture(scope="class", autouse=True)
+    def setUp(self, project):
+        project.run_sql_file(project.test_data_dir / Path("seed.sql"))
+
+    def test_malformed_tarball_package_causes_exception(self, project):
+        # We have to specify the bad formatted package here because if we do it
+        # in a `packages` fixture, the test will blow up in the setup phase, meaning
+        # we can't appropriately catch it with a `pytest.raises`
+        bad_tarball_package_spec = {
+            "packages": [
+                {
+                    "tarball": "https://codeload.github.com/dbt-labs/dbt-utils/tar.gz/0.9.6",
+                    "version": "dbt_utils",
+                }
+            ]
+        }
+        write_config_file(bad_tarball_package_spec, "packages.yml")
+
+        with pytest.raises(
+            DbtProjectError, match=r"The packages.yml file in this project is malformed"
+        ) as e:
+            run_dbt(["deps"])
+            assert e is not None

--- a/tests/functional/dependencies/test_simple_dependency.py
+++ b/tests/functional/dependencies/test_simple_dependency.py
@@ -374,3 +374,23 @@ class TestSimpleDependencyBadProfile(object):
         del os.environ["PROFILE_TEST_HOST"]
         run_dbt(["deps"])
         run_dbt(["clean"])
+
+
+class TestSimpleDependcyTarball(object):
+    @pytest.fixture(scope="class", autouse=True)
+    def setUp(self, project):
+        project.run_sql_file(project.test_data_dir / Path("seed.sql"))
+
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {
+                    "tarball": "https://codeload.github.com/dbt-labs/dbt-utils/tar.gz/0.9.6",
+                    "name": "dbt_utils",
+                }
+            ]
+        }
+
+    def test_deps_tarball(self, project):
+        run_dbt(["deps"])

--- a/tests/functional/dependencies/test_simple_dependency.py
+++ b/tests/functional/dependencies/test_simple_dependency.py
@@ -379,10 +379,6 @@ class TestSimpleDependencyBadProfile(object):
 
 
 class TestSimpleDependcyTarball(object):
-    @pytest.fixture(scope="class", autouse=True)
-    def setUp(self, project):
-        project.run_sql_file(project.test_data_dir / Path("seed.sql"))
-
     @pytest.fixture(scope="class")
     def packages(self):
         return {
@@ -400,10 +396,6 @@ class TestSimpleDependcyTarball(object):
 
 
 class TestBadTarballDependency(object):
-    @pytest.fixture(scope="class", autouse=True)
-    def setUp(self, project):
-        project.run_sql_file(project.test_data_dir / Path("seed.sql"))
-
     def test_malformed_tarball_package_causes_exception(self, project):
         # We have to specify the bad formatted package here because if we do it
         # in a `packages` fixture, the test will blow up in the setup phase, meaning


### PR DESCRIPTION
resolves #9062

### Problem

In 1.7.x it's default behavior for a `packages-lock.yml` to be produced when running `dbt deps`. However, our `to_dict` function on tarball packages tries to produces fields which don't actually exist (and are thus populated with `None`), and drop some of the required fields 😬 Thus when we try to parse the `packages-lock.yml` the process blows up 😅 Specifically it raises a `DbtProjectError` saying the `packages.yml` is malformed. However the error is really that we mangled the `packages-lock.yml`, and thus the yaml can't be used to produce the python object representation of the tarball package.

### Solution

We corrected the `to_dict` function for tarball packages.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
