### PR TITLE
Add test asserting GraphRunnableTasks attempt to cancel connections on SystemExit

### DIFF
--- a/tests/unit/test_graph_runnable_task.py
+++ b/tests/unit/test_graph_runnable_task.py
@@ -63,3 +63,13 @@ def test_graph_runnable_task_cancels_connection_on_keyboard_interrupt():
 
     # If `did_cancel` is True, that means `_cancel_connections` was called
     assert task.did_cancel is True
+
+
+def test_graph_runnable_task_doesnt_cancel_connection_on_generic_exception():
+    task = MockRunnableTask(exception_class=Exception)
+
+    with pytest.raises(Exception):
+        task.execute_nodes()
+
+    # If `did_cancel` is True, that means `_cancel_connections` was called
+    assert task.did_cancel is False

--- a/tests/unit/test_graph_runnable_task.py
+++ b/tests/unit/test_graph_runnable_task.py
@@ -1,0 +1,52 @@
+import pytest
+
+from dataclasses import dataclass
+from dbt.task.runnable import GraphRunnableTask
+from typing import AbstractSet, Any, Dict, Optional
+
+
+@dataclass
+class MockArgs:
+    """Simple mock args for us in a runnable task"""
+
+    state: Optional[Dict[str, Any]] = None
+    defer_state: Optional[Dict[str, Any]] = None
+    write_json: bool = False
+
+
+@dataclass
+class MockConfig:
+    """Simple mock config for use in a RunnableTask"""
+
+    threads: int = 1
+    target_name: str = "mock_config_target_name"
+
+
+class CustomRunnableTask(GraphRunnableTask):
+    did_cancel: bool = False
+
+    def run_queue(self, pool):
+        """Override `run_queue` to raise a system exit"""
+        raise SystemExit()
+
+    def _cancel_connections(self, pool):
+        """Override `_cancel_connections` to track whether it was called"""
+        self.did_cancel = True
+
+    def get_node_selector(self):
+        """This is an `abstract_method` on `GraphRunnableTask`, thus we must implement it"""
+        return None
+
+    def defer_to_manifest(self, adapter, selected_uids: AbstractSet[str]):
+        """This is an `abstract_method` on `GraphRunnableTask`, thus we must implement it"""
+        return None
+
+
+def test_graph_runnable_task_cancels_connection_on_system_exit():
+    task = CustomRunnableTask(args=MockArgs(), config=MockConfig(), manifest=None)
+
+    with pytest.raises(SystemExit):
+        task.execute_nodes()
+
+    # If `did_cancel` is True, that means `_cancel_connections` was called
+    assert task.did_cancel is True


### PR DESCRIPTION
resolves #9088 

### Problem

In #8994 we added functionality for cancelling connections on caught `SystemExit` exceptions, but did not add a test for checking this functionality. 

### Solution
To test this without running a full integration test, we created a custom implementation of the `GrapheRunnableTask` abstract class which guarantees a `SystemExit` will be raised on execution. I'm sure a mocking library could have helped, but this seemed slim enough to not need something more powerful.

*Note*: There is not changelog entry because this only adds a test

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
