### PR TITLE
roll back agate pin

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -49,7 +49,7 @@ setup(
         # ----
         # dbt-core uses these packages deeply, throughout the codebase, and there have been breaking changes in past patch releases (even though these are major-version-one).
         # Pin to the patch or minor version, and bump in each new minor version of dbt-core.
-        "agate~=1.7.1",
+        "agate~=1.7.0",
         "Jinja2~=3.1.2",
         "mashumaro[msgpack]~=3.9",
         # ----


### PR DESCRIPTION
resolves #9107 

### Problem

The pin for agate got bumped to `~=1.7.1` during the `1.7.1` release.

### Solution

Repin to `agate~=1.7.0`

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
