### PR TITLE
Update comment regarding setting input_measures in metric parsing

### DIFF
--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -308,9 +308,7 @@ class MetricParser(YamlReader):
             window=self._get_time_window(type_params.window),
             grain_to_date=grain_to_date,
             metrics=self._get_metric_inputs(type_params.metrics),
-            # TODO This is a compiled list of measure/numerator/denominator as
-            # well as the `input_measures` of included metrics. We're planning
-            # on doing this as part of CT-2707
+            # input measures are calculated via metric processing post parsing
             # input_measures=?,
         )
 


### PR DESCRIPTION
resolves #NONE

### Problem

In https://github.com/dbt-labs/dbt-core/pull/7984 we began setting a metrics `type_params.input_measures` during metric processing post parsing. However in that PR we didn't clean up the comment in the parser about setting `input_measures`. The comment is thus out of date and confusing.

### Solution

Update the comment

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
