### PR TITLE
[spike] [Snowflake] Support complex types unit testing

### DIFF
--- a/core/dbt/include/global_project/macros/materializations/tests/helpers.sql
+++ b/core/dbt/include/global_project/macros/materializations/tests/helpers.sql
@@ -22,7 +22,7 @@
 -- Build actual result given inputs
 with dbt_internal_unit_test_actual AS (
   select
-    {% for expected_column_name in expected_column_names %}{{expected_column_name}}{% if not loop.last -%},{% endif %}{%- endfor -%}, {{ dbt.string_literal("actual") }} as actual_or_expected
+    {% for expected_column_name in expected_column_names %}{{expected_column_name}}{% if not loop.last -%},{% endif %}{%- endfor -%}, {{ dbt.string_literal("actual") }} as {{ adapter.quote("actual_or_expected") }}
   from (
     {{ main_sql }}
   ) _dbt_internal_unit_test_actual
@@ -30,7 +30,7 @@ with dbt_internal_unit_test_actual AS (
 -- Build expected result
 dbt_internal_unit_test_expected AS (
   select
-    {% for expected_column_name in expected_column_names %}{{expected_column_name}}{% if not loop.last -%}, {% endif %}{%- endfor -%}, {{ dbt.string_literal("expected") }} as actual_or_expected
+    {% for expected_column_name in expected_column_names %}{{expected_column_name}}{% if not loop.last -%}, {% endif %}{%- endfor -%}, {{ dbt.string_literal("expected") }} as {{ adapter.quote("actual_or_expected") }}
   from (
     {{ expected_fixture_sql }}
   ) _dbt_internal_unit_test_expected

--- a/core/dbt/include/global_project/macros/materializations/tests/unit.sql
+++ b/core/dbt/include/global_project/macros/materializations/tests/unit.sql
@@ -10,7 +10,7 @@
   {% set columns_in_relation = adapter.get_column_schema_from_query(get_empty_subquery_sql(sql)) %}
   {%- set column_name_to_data_types = {} -%}
   {%- for column in columns_in_relation -%}
-  {%- do column_name_to_data_types.update({column.name: column.data_type}) -%}
+  {%- do column_name_to_data_types.update({column.name|lower: column.data_type}) -%}
   {%- endfor -%}
 
   {% set unit_test_sql = get_unit_test_sql(sql, get_expected_sql(expected_rows, column_name_to_data_types), tested_expected_column_names) %}

--- a/core/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
+++ b/core/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
@@ -9,7 +9,8 @@
 
 {%-   set column_name_to_data_types = {} -%}
 {%-   for column in columns_in_relation -%}
-{%-     do column_name_to_data_types.update({column.name: column.data_type}) -%}
+{#-- This needs to be a case-insensitive comparison --#}
+{%-     do column_name_to_data_types.update({column.name|lower: column.data_type}) -%}
 {%-   endfor -%}
 {%- endif -%}
 
@@ -67,7 +68,7 @@ union all
 {%- for column_name, column_value in row.items() -%}
 {% set row_update = {column_name: column_value} %}
 {%- if column_value is string -%}
-{%- set row_update = {column_name: safe_cast(dbt.string_literal(column_value), column_name_to_data_types[column_name]) } -%}
+{%- set row_update = {column_name: safe_cast(dbt.string_literal(dbt.escape_single_quotes(column_value)), column_name_to_data_types[column_name]) } -%}
 {%- elif column_value is none -%}
 {%- set row_update = {column_name: safe_cast('null', column_name_to_data_types[column_name]) } -%}
 {%- else -%}


### PR DESCRIPTION
To get unit tests working on Snowflake at all, we need case-insensitive comparisons in a few places.

To get "complex data types" working on Snowflake in particular, I needed to:
- escape single quotes in strings
- ~hack~ extend [`snowflake__safe_cast`](https://github.com/dbt-labs/dbt-snowflake/blob/main/dbt/include/snowflake/macros/utils/safe_cast.sql) to also do JSON-parsing for me, as a treat:
```sql
{% macro snowflake__safe_cast(field, type) %}
  {#-- Hack for now --#}
  {% if type|lower in ['array', 'variant'] %}
    cast(parse_json({{field}}) as {{type}})
  {% else %}
    try_cast({{field}} as {{type}})
  {% endif %}
{% endmacro %}
```

Then, this "just works":
```sql
-- models/my_upstream_model.sql
select
  ['a','b','c'] as tested_column

-- models/my_model.sql
select
    tested_column
from {{ ref('my_upstream_model')}}
```
```yaml
unit_tests:
  - name: test_array
    model: my_model
    given:
      - input: ref('my_upstream_model')
        rows:
          - tested_column: "['a','b','c']"
    expect:
      rows:
        - tested_column: "['a','b','c']"
  - name: test_object
    model: my_model
    given:
      - input: ref('my_upstream_model')
        rows:
          - tested_column: "{'a': 'b', 'c': 123}"
    expect:
      rows:
        - tested_column: "{'a': 'b', 'c': 123}"
  - name: test_combined
    model: my_model
    given:
      - input: ref('my_upstream_model')
        rows:
          - tested_column: "[{'a': 'b', 'c': [1,2,3]}]"
    expect:
      rows:
        - tested_column: "[{'a': 'b', 'c': [1,2,3]}]"
```