### PR TITLE
remove adapter.get_compiler

### DIFF
--- a/.changes/unreleased/Breaking Changes-20231127-114757.yaml
+++ b/.changes/unreleased/Breaking Changes-20231127-114757.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Remove adapter.get_compiler interface
+time: 2023-11-27T11:47:57.443202-05:00
+custom:
+  Author: michelleark
+  Issue: "9148"

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -1370,11 +1370,6 @@ class BaseAdapter(metaclass=AdapterMeta):
         """
         pass
 
-    def get_compiler(self):
-        from dbt.compilation import Compiler
-
-        return Compiler(self.config)
-
     # Methods used in adapter tests
     def update_column_sql(
         self,

--- a/core/dbt/adapters/protocol.py
+++ b/core/dbt/adapters/protocol.py
@@ -8,20 +8,16 @@ from typing import (
     Generic,
     TypeVar,
     Tuple,
-    Dict,
-    Any,
 )
 from typing_extensions import Protocol
 
 import agate
 
 from dbt.adapters.contracts.connection import Connection, AdapterRequiredConfig, AdapterResponse
-from dbt.contracts.graph.nodes import ResultNode, ManifestNode
+from dbt.contracts.graph.nodes import ResultNode
 from dbt.contracts.graph.model_config import BaseConfig
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.relation import Policy, HasQuoting
-
-from dbt.graph import Graph
 
 
 @dataclass
@@ -50,24 +46,10 @@ class RelationProtocol(Protocol):
         ...
 
 
-class CompilerProtocol(Protocol):
-    def compile(self, manifest: Manifest, write=True) -> Graph:
-        ...
-
-    def compile_node(
-        self,
-        node: ManifestNode,
-        manifest: Manifest,
-        extra_context: Optional[Dict[str, Any]] = None,
-    ) -> ManifestNode:
-        ...
-
-
 AdapterConfig_T = TypeVar("AdapterConfig_T", bound=AdapterConfig)
 ConnectionManager_T = TypeVar("ConnectionManager_T", bound=ConnectionManagerProtocol)
 Relation_T = TypeVar("Relation_T", bound=RelationProtocol)
 Column_T = TypeVar("Column_T", bound=ColumnProtocol)
-Compiler_T = TypeVar("Compiler_T", bound=CompilerProtocol)
 
 
 # TODO CT-211
@@ -78,7 +60,6 @@ class AdapterProtocol(  # type: ignore[misc]
         ConnectionManager_T,
         Relation_T,
         Column_T,
-        Compiler_T,
     ],
 ):
     # N.B. Technically these are ClassVars, but mypy doesn't support putting type vars in a
@@ -152,7 +133,4 @@ class AdapterProtocol(  # type: ignore[misc]
     def execute(
         self, sql: str, auto_begin: bool = False, fetch: bool = False
     ) -> Tuple[AdapterResponse, agate.Table]:
-        ...
-
-    def get_compiler(self) -> Compiler_T:
         ...

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -1,4 +1,3 @@
-import argparse
 import json
 
 import networkx as nx  # type: ignore
@@ -34,7 +33,6 @@ from dbt.common.events.contextvars import get_node_info
 from dbt.node_types import NodeType, ModelLanguage
 from dbt.common.events.format import pluralize
 import dbt.tracking
-import dbt.task.list as list_task
 import sqlparse
 
 graph_file_name = "graph.gpickle"
@@ -485,11 +483,8 @@ class Compiler:
         if write:
             self.write_graph_file(linker, manifest)
 
-        # Do not print these for ListTask's
-        if not (
-            self.config.args.__class__ == argparse.Namespace
-            and self.config.args.cls == list_task.ListTask
-        ):
+        # Do not print these for list command
+        if self.config.args.which != "list":
             stats = _generate_stats(manifest)
             print_compile_stats(stats)
 

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -5,7 +5,6 @@ from .snapshot import SnapshotRunner as snapshot_model_runner
 from .seed import SeedRunner as seed_runner
 from .test import TestRunner as test_runner
 
-from dbt.adapters.factory import get_adapter
 from dbt.contracts.results import NodeStatus
 from dbt.common.exceptions import DbtInternalError
 from dbt.graph import ResourceTypeSelector
@@ -129,6 +128,4 @@ class BuildTask(RunTask):
     def compile_manifest(self):
         if self.manifest is None:
             raise DbtInternalError("compile_manifest called before manifest was loaded")
-        adapter = get_adapter(self.config)
-        compiler = adapter.get_compiler()
-        self.graph = compiler.compile(self.manifest, add_test_edges=True)
+        self.graph = self.compiler.compile(self.manifest, add_test_edges=True)

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -40,8 +40,7 @@ class CompileRunner(BaseRunner):
         )
 
     def compile(self, manifest):
-        compiler = self.adapter.get_compiler()
-        return compiler.compile_node(self.node, manifest, {})
+        return self.compiler.compile_node(self.node, manifest, {})
 
 
 class CompileTask(GraphRunnableTask):

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -315,8 +315,10 @@ class RunTask(CompileTask):
         return False
 
     def get_hook_sql(self, adapter, hook, idx, num_hooks, extra_context) -> str:
-        compiler = adapter.get_compiler()
-        compiled = compiler.compile_node(hook, self.manifest, extra_context)
+        if self.manifest is None:
+            raise DbtInternalError("compile_node called before manifest was loaded")
+
+        compiled = self.compiler.compile_node(hook, self.manifest, extra_context)
         statement = compiled.compiled_code
         hook_index = hook.index or num_hooks
         hook_obj = get_hook(statement, index=hook_index)

--- a/core/dbt/task/sql.py
+++ b/core/dbt/task/sql.py
@@ -37,8 +37,7 @@ class GenericSqlRunner(CompileRunner, Generic[SQLResult]):
         pass
 
     def compile(self, manifest):
-        compiler = self.adapter.get_compiler()
-        return compiler.compile_node(self.node, manifest, {}, write=False)
+        return self.compiler.compile_node(self.node, manifest, {}, write=False)
 
     @abstractmethod
     def execute(self, compiled_node, manifest) -> SQLResult:


### PR DESCRIPTION
resolves #9148

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

* BaseAdapter.get_compiler has a circular dependency on `dbt.compilation.Compiler`
* the compiler protocol is overly broad - it requires passing a full manifest which is also a circular dependency. if we want to support this type of override in the future, it should be more granular and narrowly scoped to set of adapter-specific interfaces. 
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

* remove CompilerProtocol and BaseAdapter.get_compiler method + usages. 

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
  - confirmed no override of get_compiler method in sqlserver adapter: https://github.com/dbt-msft/dbt-sqlserver/blob/master/dbt/adapters/sqlserver/sql_server_adapter.py
  - bigquery: https://github.com/dbt-labs/dbt-bigquery/blob/main/dbt/adapters/bigquery/impl.py
  - snowflake:  https://github.com/dbt-labs/dbt-snowflake/blob/main/dbt/adapters/snowflake/impl.py
  - spark: https://github.com/dbt-labs/dbt-spark/blob/main/dbt/adapters/spark/impl.py
  - redshift: https://github.com/dbt-labs/dbt-redshift/blob/main/dbt/adapters/redshift/impl.py
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
