### PR TITLE
Restore warning on unpinned git packages

### DIFF
--- a/core/dbt/deps/git.py
+++ b/core/dbt/deps/git.py
@@ -101,11 +101,14 @@ class GitPinnedPackage(GitPackageMixin, PinnedPackage):
         self, project: Project, renderer: PackageRenderer
     ) -> ProjectPackageMetadata:
         path = self._checkout()
-        # overwrite 'revision' with actual commit SHA
+
+        # raise warning (or error) if this package is not pinned
+        if (self.revision == "HEAD" or self.revision in ("main", "master")) and self.warn_unpinned:
+            warn_or_error(DepsUnpinned(revision=self.revision, git=self.git))
+
+        # now overwrite 'revision' with actual commit SHA
         self.revision = git.get_current_sha(path)
 
-        if (self.revision == "HEAD" or self.revision in ("main", "master")) and self.warn_unpinned:
-            warn_or_error(DepsUnpinned(git=self.git))
         partial = PartialProject.from_project_root(path)
         return partial.render_package_metadata(renderer)
 


### PR DESCRIPTION
_follow-up to #9147_

In the fix for #9050, I'd accidentally removed the warning that we raise on "unpinned" `git` packages. Restore that warning by raising it first, then overwriting the `revision` with a pinned commit SHA.

I found this while 🎩'ing the backport PR (#9156), so I've also incorporated this commit there.

🎩 
**Before** (`main`)
```yml
# packages.yml
packages:
  - git: https://github.com/dbt-labs/dbt-utils.git
```
```
$ dbt deps --upgrade
10:04:11  Running with dbt=1.8.0-a1
10:04:14  Updating lock file in file path: /Users/jerco/dev/scratch/testy/package-lock.yml
10:04:14  Installing https://github.com/dbt-labs/dbt-utils.git
```

**After** (this branch)
```yml
# packages.yml
packages:
  - git: https://github.com/dbt-labs/dbt-utils.git
```
Run the first time to generate/upgrade the lock file, and the git package is unpinned:
```
$ dbt deps --upgrade
10:02:52  Running with dbt=1.8.0-a1
10:02:54  WARNING: The git package "https://github.com/dbt-labs/dbt-utils.git"
	is not pinned, using HEAD (default branch).
	This can introduce breaking changes into your project without warning!

See https://docs.getdbt.com/docs/package-management#section-specifying-package-versions
10:02:55  WARNING: The git package "https://github.com/dbt-labs/dbt-utils.git"
	is not pinned, using HEAD (default branch).
	This can introduce breaking changes into your project without warning!

See https://docs.getdbt.com/docs/package-management#section-specifying-package-versions
10:02:55  Updating lock file in file path: /Users/jerco/dev/scratch/testy/package-lock.yml
10:02:55  Installing https://github.com/dbt-labs/dbt-utils.git
10:02:57  Installed from revision 23ddc9e1526416b6a8ceeb9a317ca75ba0e92acf
```
Run it again, now it's "locked":
```
$ dbt deps
10:03:05  Running with dbt=1.8.0-a1
10:03:07  Updating lock file in file path: /Users/jerco/dev/scratch/testy/package-lock.yml
10:03:07  Installing https://github.com/dbt-labs/dbt-utils.git
10:03:10  Installed from revision 23ddc9e1526416b6a8ceeb9a317ca75ba0e92acf
```
```yml
# packages.yml
packages:
  - git: https://github.com/dbt-labs/dbt-utils.git
    warn-unpinned: False
```
Run again with upgrade, this time disabling the warning:
```
$ dbt deps --upgrade
10:03:14  Running with dbt=1.8.0-a1
10:03:16  Updating lock file in file path: /Users/jerco/dev/scratch/testy/package-lock.yml
10:03:16  Installing https://github.com/dbt-labs/dbt-utils.git
10:03:19  Installed from revision 23ddc9e1526416b6a8ceeb9a317ca75ba0e92acf
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
