### PR TITLE
Remove `--dry-run` flag from `dbt deps`

### DIFF
--- a/.changes/unreleased/Breaking Changes-20231129-091921.yaml
+++ b/.changes/unreleased/Breaking Changes-20231129-091921.yaml
@@ -1,0 +1,7 @@
+kind: Breaking Changes
+body: Rm --dry-run flag from 'dbt deps --add-package', in favor of just 'dbt deps
+  --lock'
+time: 2023-11-29T09:19:21.071212+01:00
+custom:
+  Author: jtcohen6
+  Issue: "9100"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -457,7 +457,6 @@ def debug(ctx, **kwargs):
 @p.target
 @p.vars
 @p.source
-@p.dry_run
 @p.lock
 @p.upgrade
 @p.add_package
@@ -482,12 +481,6 @@ def deps(ctx, **kwargs):
             raise BadOptionUsage(
                 message=f"Version is required in --add-package when a package when source is {flags.SOURCE}",
                 option_name="--add-package",
-            )
-    else:
-        if flags.DRY_RUN:
-            raise BadOptionUsage(
-                message="Invalid flag `--dry-run` when not using `--add-package`.",
-                option_name="--dry-run",
             )
     task = DepsTask(flags, ctx.obj["project"])
     results = task.run()

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -83,13 +83,6 @@ deprecated_defer = click.option(
     hidden=True,
 )
 
-dry_run = click.option(
-    "--dry-run",
-    envvar=None,
-    help="Option to run `dbt deps --add-package` without updating package-lock.yml file.",
-    is_flag=True,
-)
-
 empty = click.option(
     "--empty/--no-empty",
     envvar="DBT_EMPTY",

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -220,8 +220,9 @@ class DepsTask(BaseTask):
             if previous_hash != current_hash:
                 self.lock()
 
-        # Early return when dry run or lock only.
-        if self.args.dry_run or self.args.lock:
+        # Early return when 'dbt deps --lock'
+        # Just resolve packages and write lock file, don't actually install packages
+        if self.args.lock:
             return
 
         if system.path_exists(self.project.packages_install_path):

--- a/tests/functional/dependencies/test_dependency_options.py
+++ b/tests/functional/dependencies/test_dependency_options.py
@@ -75,7 +75,7 @@ sha1_hash: 71304bca2138cf8004070b3573a1e17183c0c1a8
         )
         assert len(os.listdir("dbt_packages")) == 3
 
-    def test_deps_add_dry_run(self, clean_start):
+    def test_deps_add_without_install(self, clean_start):
         os.rename("packages.yml", "dependencies.yml")
         run_dbt(
             [

--- a/tests/functional/dependencies/test_dependency_options.py
+++ b/tests/functional/dependencies/test_dependency_options.py
@@ -82,7 +82,6 @@ sha1_hash: 71304bca2138cf8004070b3573a1e17183c0c1a8
                 "deps",
                 "--add-package",
                 "dbt-labs/audit_helper@0.9.0",
-                "--dry-run",
             ]
         )
         assert not os.path.exists("dbt_packages")

--- a/tests/functional/dependencies/test_dependency_options.py
+++ b/tests/functional/dependencies/test_dependency_options.py
@@ -82,6 +82,7 @@ sha1_hash: 71304bca2138cf8004070b3573a1e17183c0c1a8
                 "deps",
                 "--add-package",
                 "dbt-labs/audit_helper@0.9.0",
+                "--lock",
             ]
         )
         assert not os.path.exists("dbt_packages")


### PR DESCRIPTION
resolves #9100

### Problem

In theory, `dbt deps --add-package --dry-run` only updates `packages.yml` with the package entry being added, without actually resolving packages, writing `package-lock.yml`, or installing packages.

It took me a while to understand this workflow:
```bash
# add a package to *just* packages.yml / dependencies.yml
$ dbt deps --add-package dbt-labs/dbt_utils@1.0.0 --dry-run
# now do 'package resolution' and update lock file
$ dbt deps --lock
# now actually install packages, using lock file
$ dbt deps
```
~It doesn't seem to work in practice.~ Now that I've understood the workflow, I understand why we added this flag — but I don't think it's essential that we support it. I'd rather remove the flag entirely than have it hanging out as extra weight. It's already possible to achieve what is (IMO) the important part of this workflow with `dbt deps --lock --add-package ...`.

### Solution

Remove the `dbt deps --dry-run` flag.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
