### PR TITLE
Remove ResultNode usage from connections

### DIFF
--- a/.changes/unreleased/Under the Hood-20231205-165812.yaml
+++ b/.changes/unreleased/Under the Hood-20231205-165812.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove usage of dbt.contracts.graph.nodes.ResultNode in dbt/adapters
+time: 2023-12-05T16:58:12.932172+09:00
+custom:
+  Author: michelleark
+  Issue: "9214"

--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -146,7 +146,7 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
 
     def set_connection_name(self, name: Optional[str] = None) -> Connection:
         """Called by 'acquire_connection' in BaseAdapter, which is called by
-        'connection_named', called by 'connection_for(node)'.
+        'connection_named'.
         Creates a connection for this thread if one doesn't already
         exist, and will rename an existing connection."""
 

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -63,7 +63,6 @@ from dbt.common.clients.agate_helper import (
 )
 from dbt.common.clients.jinja import CallableMacroGenerator
 from dbt.contracts.graph.manifest import Manifest, MacroManifest
-from dbt.contracts.graph.nodes import ResultNode
 from dbt.common.events.functions import fire_event, warn_or_error
 from dbt.adapters.events.types import (
     CacheMiss,
@@ -285,10 +284,10 @@ class BaseAdapter(metaclass=AdapterMeta):
         return conn.name
 
     @contextmanager
-    def connection_named(self, name: str, node: Optional[ResultNode] = None) -> Iterator[None]:
+    def connection_named(self, name: str, query_header_context: Any = None) -> Iterator[None]:
         try:
             if self.connections.query_header is not None:
-                self.connections.query_header.set(name, node)
+                self.connections.query_header.set(name, query_header_context)
             self.acquire_connection(name)
             yield
         finally:

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -296,11 +296,6 @@ class BaseAdapter(metaclass=AdapterMeta):
             if self.connections.query_header is not None:
                 self.connections.query_header.reset()
 
-    @contextmanager
-    def connection_for(self, node: ResultNode) -> Iterator[None]:
-        with self.connection_named(node.unique_id, node):
-            yield
-
     @available.parse(lambda *a, **k: ("", empty_table()))
     def execute(
         self, sql: str, auto_begin: bool = False, fetch: bool = False, limit: Optional[int] = None

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -5,17 +5,16 @@ from dbt.adapters.clients.jinja import QueryStringGenerator
 
 from dbt.context.manifest import generate_query_header_context
 from dbt.adapters.contracts.connection import AdapterRequiredConfig, QueryComment
-from dbt.contracts.graph.nodes import ResultNode
 from dbt.contracts.graph.manifest import Manifest
 from dbt.common.exceptions import DbtRuntimeError
 
 
-class NodeWrapper:
-    def __init__(self, node) -> None:
-        self._inner_node = node
+class QueryHeaderContextWrapper:
+    def __init__(self, context) -> None:
+        self._inner_context = context
 
     def __getattr__(self, name):
-        return getattr(self._inner_node, name, "")
+        return getattr(self._inner_context, name, "")
 
 
 class _QueryComment(local):
@@ -53,7 +52,7 @@ class _QueryComment(local):
         self.append = append
 
 
-QueryStringFunc = Callable[[str, Optional[NodeWrapper]], str]
+QueryStringFunc = Callable[[str, Optional[QueryHeaderContextWrapper]], str]
 
 
 class MacroQueryStringSetter:
@@ -90,10 +89,10 @@ class MacroQueryStringSetter:
     def reset(self):
         self.set("master", None)
 
-    def set(self, name: str, node: Optional[ResultNode]):
-        wrapped: Optional[NodeWrapper] = None
-        if node is not None:
-            wrapped = NodeWrapper(node)
+    def set(self, name: str, query_header_context: Any):
+        wrapped: Optional[QueryHeaderContextWrapper] = None
+        if query_header_context is not None:
+            wrapped = QueryHeaderContextWrapper(query_header_context)
         comment_str = self.generator(name, wrapped)
 
         append = False

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -298,7 +298,9 @@ class BaseRunner(metaclass=ABCMeta):
 
     def compile_and_execute(self, manifest, ctx):
         result = None
-        with self.adapter.connection_for(self.node) if get_flags().INTROSPECT else nullcontext():
+        with self.adapter.connection_named(
+            self.node.unique_id, self.node
+        ) if get_flags().INTROSPECT else nullcontext():
             ctx.node.update_event_status(node_status=RunningStatus.Compiling)
             fire_event(
                 NodeCompiling(

--- a/core/dbt/task/freshness.py
+++ b/core/dbt/task/freshness.py
@@ -101,7 +101,7 @@ class FreshnessRunner(BaseRunner):
     def execute(self, compiled_node, manifest):
         relation = self.adapter.Relation.create_from_source(compiled_node)
         # given a Source, calculate its freshness.
-        with self.adapter.connection_for(compiled_node):
+        with self.adapter.connection_named(compiled_node.unique_id, compiled_node):
             self.adapter.clear_transaction()
             adapter_response: Optional[AdapterResponse] = None
             freshness = None


### PR DESCRIPTION
resolves #9214 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

Usage of dbt.contracts.graph.nodes.ResultNode in dbt/adapters
### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Context:
- ResultNode was used as a type annotation on inputs to the connection_named method. 
- This method already wrapped a node in NodeWrapper for safe access - creating a safe layer of abstraction between core's ResultNode and the object necessar

Solution: 
- Pass Any to connection_named instead, renaming `node` to `query_header_context` (since that's what the node is actually used for)
- rename NodeWrapper to QueryContextWrapper - wrapping the `Any` object with a safe accessor method
- remove ResultNode imports

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
