### PR TITLE
[Backport 1.7.latest] Fix ensuring we produce valid jsonschema artifacts for manifest, catalog, sources, and run-results

### DIFF
--- a/.changes/unreleased/Fixes-20231127-165244.yaml
+++ b/.changes/unreleased/Fixes-20231127-165244.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Ensure we produce valid jsonschema schemas for manifest, catalog, run-results,
+  and sources
+time: 2023-11-27T16:52:44.590313-08:00
+custom:
+  Author: QMalcolm
+  Issue: "8991"

--- a/core/dbt/contracts/util.py
+++ b/core/dbt/contracts/util.py
@@ -197,7 +197,7 @@ class VersionedSchema(dbtClassMixin):
     @classmethod
     @functools.lru_cache
     def json_schema(cls) -> Dict[str, Any]:
-        json_schema_obj = build_json_schema(cls, all_refs=True)
+        json_schema_obj = build_json_schema(cls)
         json_schema = json_schema_obj.to_dict()
         json_schema["$id"] = str(cls.dbt_schema_version)
         return json_schema

--- a/core/dbt/contracts/util.py
+++ b/core/dbt/contracts/util.py
@@ -18,6 +18,7 @@ from dbt.dataclass_schema import (
     ValidationError,
 )
 from mashumaro.jsonschema import build_json_schema
+from mashumaro.jsonschema.dialects import DRAFT_2020_12
 import functools
 
 
@@ -197,7 +198,7 @@ class VersionedSchema(dbtClassMixin):
     @classmethod
     @functools.lru_cache
     def json_schema(cls) -> Dict[str, Any]:
-        json_schema_obj = build_json_schema(cls)
+        json_schema_obj = build_json_schema(cls, dialect=DRAFT_2020_12)
         json_schema = json_schema_obj.to_dict()
         json_schema["$id"] = str(cls.dbt_schema_version)
         return json_schema

--- a/core/dbt/contracts/util.py
+++ b/core/dbt/contracts/util.py
@@ -198,7 +198,7 @@ class VersionedSchema(dbtClassMixin):
     @classmethod
     @functools.lru_cache
     def json_schema(cls) -> Dict[str, Any]:
-        json_schema_obj = build_json_schema(cls, dialect=DRAFT_2020_12)
+        json_schema_obj = build_json_schema(cls, dialect=DRAFT_2020_12, with_dialect_uri=True)
         json_schema = json_schema_obj.to_dict()
         json_schema["$id"] = str(cls.dbt_schema_version)
         return json_schema

--- a/schemas/dbt/catalog/v1.json
+++ b/schemas/dbt/catalog/v1.json
@@ -1,7 +1,9 @@
 {
-  "$ref": "#/$defs/CatalogArtifact",
-  "$defs": {
-    "CatalogMetadata": {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "title": "CatalogArtifact",
+  "properties": {
+    "metadata": {
       "type": "object",
       "title": "CatalogMetadata",
       "properties": {
@@ -10,7 +12,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.7.0b1"
+          "default": "1.7.3"
         },
         "generated_at": {
           "type": "string"
@@ -37,241 +39,387 @@
       },
       "additionalProperties": false
     },
-    "TableMetadata": {
+    "nodes": {
       "type": "object",
-      "title": "TableMetadata",
-      "properties": {
-        "type": {
-          "type": "string"
-        },
-        "schema": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "comment": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "owner": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "type",
-        "schema",
-        "name"
-      ]
-    },
-    "ColumnMetadata": {
-      "type": "object",
-      "title": "ColumnMetadata",
-      "properties": {
-        "type": {
-          "type": "string"
-        },
-        "index": {
-          "type": "integer"
-        },
-        "name": {
-          "type": "string"
-        },
-        "comment": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "type",
-        "index",
-        "name"
-      ]
-    },
-    "StatsItem": {
-      "type": "object",
-      "title": "StatsItem",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "label": {
-          "type": "string"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "include": {
-          "type": "boolean"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "id",
-        "label",
-        "value",
-        "include"
-      ]
-    },
-    "CatalogTable": {
-      "type": "object",
-      "title": "CatalogTable",
-      "properties": {
-        "metadata": {
-          "$ref": "#/$defs/TableMetadata"
-        },
-        "columns": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/ColumnMetadata"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "stats": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/StatsItem"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "unique_id": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "metadata",
-        "columns",
-        "stats"
-      ]
-    },
-    "CatalogArtifact": {
-      "type": "object",
-      "title": "CatalogArtifact",
-      "properties": {
-        "metadata": {
-          "$ref": "#/$defs/CatalogMetadata"
-        },
-        "nodes": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/CatalogTable"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "sources": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/CatalogTable"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "errors": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
+      "additionalProperties": {
+        "type": "object",
+        "title": "CatalogTable",
+        "properties": {
+          "metadata": {
+            "type": "object",
+            "title": "TableMetadata",
+            "properties": {
+              "type": {
                 "type": "string"
+              },
+              "schema": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "database": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "comment": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "owner": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
               }
             },
-            {
-              "type": "null"
+            "additionalProperties": false,
+            "required": [
+              "type",
+              "schema",
+              "name"
+            ]
+          },
+          "columns": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "title": "ColumnMetadata",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "index": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "comment": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "type",
+                "index",
+                "name"
+              ]
+            },
+            "propertyNames": {
+              "type": "string"
             }
-          ],
-          "default": null
+          },
+          "stats": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "title": "StatsItem",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "value": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "include": {
+                  "type": "boolean"
+                },
+                "description": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "id",
+                "label",
+                "value",
+                "include"
+              ]
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "unique_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
         },
-        "_compile_results": {
-          "anyOf": [
-            {},
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
+        "additionalProperties": false,
+        "required": [
+          "metadata",
+          "columns",
+          "stats"
+        ]
       },
-      "additionalProperties": false,
-      "required": [
-        "metadata",
-        "nodes",
-        "sources"
-      ]
+      "propertyNames": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "title": "CatalogTable",
+        "properties": {
+          "metadata": {
+            "type": "object",
+            "title": "TableMetadata",
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "schema": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "database": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "comment": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "owner": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "type",
+              "schema",
+              "name"
+            ]
+          },
+          "columns": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "title": "ColumnMetadata",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "index": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "comment": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "type",
+                "index",
+                "name"
+              ]
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "stats": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "title": "StatsItem",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "value": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "include": {
+                  "type": "boolean"
+                },
+                "description": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "id",
+                "label",
+                "value",
+                "include"
+              ]
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "unique_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "metadata",
+          "columns",
+          "stats"
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      }
+    },
+    "errors": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "_compile_results": {
+      "anyOf": [
+        {},
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
     }
   },
+  "additionalProperties": false,
+  "required": [
+    "metadata",
+    "nodes",
+    "sources"
+  ],
   "$id": "https://schemas.getdbt.com/dbt/catalog/v1.json"
 }

--- a/schemas/dbt/manifest/v11.json
+++ b/schemas/dbt/manifest/v11.json
@@ -1,16 +1,19 @@
 {
-  "$ref": "#/$defs/WritableManifest",
-  "$defs": {
-    "ManifestMetadata": {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "title": "WritableManifest",
+  "properties": {
+    "metadata": {
       "type": "object",
       "title": "ManifestMetadata",
+      "description": "Metadata about the manifest",
       "properties": {
         "dbt_schema_version": {
           "type": "string"
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.8.0a1"
+          "default": "1.7.3"
         },
         "generated_at": {
           "type": "string"
@@ -98,6159 +101,19265 @@
       },
       "additionalProperties": false
     },
-    "FileHash": {
+    "nodes": {
       "type": "object",
-      "title": "FileHash",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "checksum": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "checksum"
-      ]
-    },
-    "Hook": {
-      "type": "object",
-      "title": "Hook",
-      "properties": {
-        "sql": {
-          "type": "string"
-        },
-        "transaction": {
-          "type": "boolean",
-          "default": true
-        },
-        "index": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "sql"
-      ]
-    },
-    "Docs": {
-      "type": "object",
-      "title": "Docs",
-      "properties": {
-        "show": {
-          "type": "boolean",
-          "default": true
-        },
-        "node_color": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false
-    },
-    "ContractConfig": {
-      "type": "object",
-      "title": "ContractConfig",
-      "properties": {
-        "enforced": {
-          "type": "boolean",
-          "default": false
-        },
-        "alias_types": {
-          "type": "boolean",
-          "default": true
-        }
-      },
-      "additionalProperties": false
-    },
-    "NodeConfig": {
-      "type": "object",
-      "title": "NodeConfig",
-      "properties": {
-        "_extra": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "enabled": {
-          "type": "boolean",
-          "default": true
-        },
-        "alias": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "schema": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "tags": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "materialized": {
-          "type": "string",
-          "default": "view"
-        },
-        "incremental_strategy": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "persist_docs": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "post-hook": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Hook"
-          }
-        },
-        "pre-hook": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Hook"
-          }
-        },
-        "quoting": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "column_types": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "full_refresh": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "unique_key": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "on_schema_change": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": "ignore"
-        },
-        "on_configuration_change": {
-          "enum": [
-            "apply",
-            "continue",
-            "fail"
-          ]
-        },
-        "grants": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "packages": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "docs": {
-          "$ref": "#/$defs/Docs"
-        },
-        "contract": {
-          "$ref": "#/$defs/ContractConfig"
-        }
-      },
-      "additionalProperties": true
-    },
-    "ColumnLevelConstraint": {
-      "type": "object",
-      "title": "ColumnLevelConstraint",
-      "properties": {
-        "type": {
-          "enum": [
-            "check",
-            "not_null",
-            "unique",
-            "primary_key",
-            "foreign_key",
-            "custom"
-          ]
-        },
-        "name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "expression": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "warn_unenforced": {
-          "type": "boolean",
-          "default": true
-        },
-        "warn_unsupported": {
-          "type": "boolean",
-          "default": true
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "type"
-      ]
-    },
-    "ColumnInfo": {
-      "type": "object",
-      "title": "ColumnInfo",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string",
-          "default": ""
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "data_type": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "constraints": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ColumnLevelConstraint"
-          }
-        },
-        "quote": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "_extra": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        }
-      },
-      "additionalProperties": true,
-      "required": [
-        "name"
-      ]
-    },
-    "RefArgs": {
-      "type": "object",
-      "title": "RefArgs",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "package": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "version": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name"
-      ]
-    },
-    "DependsOn": {
-      "type": "object",
-      "title": "DependsOn",
-      "properties": {
-        "macros": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "nodes": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "additionalProperties": false
-    },
-    "InjectedCTE": {
-      "type": "object",
-      "title": "InjectedCTE",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "sql": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "id",
-        "sql"
-      ]
-    },
-    "Contract": {
-      "type": "object",
-      "title": "Contract",
-      "properties": {
-        "enforced": {
-          "type": "boolean",
-          "default": false
-        },
-        "alias_types": {
-          "type": "boolean",
-          "default": true
-        },
-        "checksum": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false
-    },
-    "AnalysisNode": {
-      "type": "object",
-      "title": "AnalysisNode",
-      "properties": {
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "schema": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "const": "analysis"
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "fqn": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "alias": {
-          "type": "string"
-        },
-        "checksum": {
-          "$ref": "#/$defs/FileHash"
-        },
-        "config": {
-          "$ref": "#/$defs/NodeConfig"
-        },
-        "_event_status": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "description": {
-          "type": "string",
-          "default": ""
-        },
-        "columns": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "docs": {
-          "$ref": "#/$defs/Docs"
-        },
-        "patch_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "build_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "deferred": {
-          "type": "boolean",
-          "default": false
-        },
-        "unrendered_config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "created_at": {
-          "type": "number"
-        },
-        "config_call_dict": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "relation_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "raw_code": {
-          "type": "string",
-          "default": ""
-        },
-        "language": {
-          "type": "string",
-          "default": "sql"
-        },
-        "refs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RefArgs"
-          }
-        },
-        "sources": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "metrics": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "depends_on": {
-          "$ref": "#/$defs/DependsOn"
-        },
-        "compiled_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "compiled": {
-          "type": "boolean",
-          "default": false
-        },
-        "compiled_code": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "extra_ctes_injected": {
-          "type": "boolean",
-          "default": false
-        },
-        "extra_ctes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/InjectedCTE"
-          }
-        },
-        "_pre_injected_sql": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "contract": {
-          "$ref": "#/$defs/Contract"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "database",
-        "schema",
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "fqn",
-        "alias",
-        "checksum"
-      ]
-    },
-    "TestConfig": {
-      "type": "object",
-      "title": "TestConfig",
-      "properties": {
-        "_extra": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "enabled": {
-          "type": "boolean",
-          "default": true
-        },
-        "alias": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "schema": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": "dbt_test__audit"
-        },
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "tags": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "materialized": {
-          "type": "string",
-          "default": "test"
-        },
-        "severity": {
-          "type": "string",
-          "default": "ERROR",
-          "pattern": "^([Ww][Aa][Rr][Nn]|[Ee][Rr][Rr][Oo][Rr])$"
-        },
-        "store_failures": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "store_failures_as": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "where": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "limit": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "fail_calc": {
-          "type": "string",
-          "default": "count(*)"
-        },
-        "warn_if": {
-          "type": "string",
-          "default": "!= 0"
-        },
-        "error_if": {
-          "type": "string",
-          "default": "!= 0"
-        }
-      },
-      "additionalProperties": true
-    },
-    "SingularTestNode": {
-      "type": "object",
-      "title": "SingularTestNode",
-      "properties": {
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "schema": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "const": "test"
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "fqn": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "alias": {
-          "type": "string"
-        },
-        "checksum": {
-          "$ref": "#/$defs/FileHash"
-        },
-        "config": {
-          "$ref": "#/$defs/TestConfig"
-        },
-        "_event_status": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "description": {
-          "type": "string",
-          "default": ""
-        },
-        "columns": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "docs": {
-          "$ref": "#/$defs/Docs"
-        },
-        "patch_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "build_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "deferred": {
-          "type": "boolean",
-          "default": false
-        },
-        "unrendered_config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "created_at": {
-          "type": "number"
-        },
-        "config_call_dict": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "relation_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "raw_code": {
-          "type": "string",
-          "default": ""
-        },
-        "language": {
-          "type": "string",
-          "default": "sql"
-        },
-        "refs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RefArgs"
-          }
-        },
-        "sources": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "metrics": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "depends_on": {
-          "$ref": "#/$defs/DependsOn"
-        },
-        "compiled_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "compiled": {
-          "type": "boolean",
-          "default": false
-        },
-        "compiled_code": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "extra_ctes_injected": {
-          "type": "boolean",
-          "default": false
-        },
-        "extra_ctes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/InjectedCTE"
-          }
-        },
-        "_pre_injected_sql": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "contract": {
-          "$ref": "#/$defs/Contract"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "database",
-        "schema",
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "fqn",
-        "alias",
-        "checksum"
-      ]
-    },
-    "HookNode": {
-      "type": "object",
-      "title": "HookNode",
-      "properties": {
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "schema": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "const": "operation"
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "fqn": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "alias": {
-          "type": "string"
-        },
-        "checksum": {
-          "$ref": "#/$defs/FileHash"
-        },
-        "config": {
-          "$ref": "#/$defs/NodeConfig"
-        },
-        "_event_status": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "description": {
-          "type": "string",
-          "default": ""
-        },
-        "columns": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "docs": {
-          "$ref": "#/$defs/Docs"
-        },
-        "patch_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "build_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "deferred": {
-          "type": "boolean",
-          "default": false
-        },
-        "unrendered_config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "created_at": {
-          "type": "number"
-        },
-        "config_call_dict": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "relation_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "raw_code": {
-          "type": "string",
-          "default": ""
-        },
-        "language": {
-          "type": "string",
-          "default": "sql"
-        },
-        "refs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RefArgs"
-          }
-        },
-        "sources": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "metrics": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "depends_on": {
-          "$ref": "#/$defs/DependsOn"
-        },
-        "compiled_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "compiled": {
-          "type": "boolean",
-          "default": false
-        },
-        "compiled_code": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "extra_ctes_injected": {
-          "type": "boolean",
-          "default": false
-        },
-        "extra_ctes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/InjectedCTE"
-          }
-        },
-        "_pre_injected_sql": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "contract": {
-          "$ref": "#/$defs/Contract"
-        },
-        "index": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "database",
-        "schema",
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "fqn",
-        "alias",
-        "checksum"
-      ]
-    },
-    "ModelConfig": {
-      "type": "object",
-      "title": "ModelConfig",
-      "properties": {
-        "_extra": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "enabled": {
-          "type": "boolean",
-          "default": true
-        },
-        "alias": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "schema": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "tags": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "materialized": {
-          "type": "string",
-          "default": "view"
-        },
-        "incremental_strategy": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "persist_docs": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "post-hook": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Hook"
-          }
-        },
-        "pre-hook": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Hook"
-          }
-        },
-        "quoting": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "column_types": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "full_refresh": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "unique_key": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "on_schema_change": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": "ignore"
-        },
-        "on_configuration_change": {
-          "enum": [
-            "apply",
-            "continue",
-            "fail"
-          ]
-        },
-        "grants": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "packages": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "docs": {
-          "$ref": "#/$defs/Docs"
-        },
-        "contract": {
-          "$ref": "#/$defs/ContractConfig"
-        },
-        "access": {
-          "enum": [
-            "private",
-            "protected",
-            "public"
-          ],
-          "default": "protected"
-        }
-      },
-      "additionalProperties": true
-    },
-    "ModelLevelConstraint": {
-      "type": "object",
-      "title": "ModelLevelConstraint",
-      "properties": {
-        "type": {
-          "enum": [
-            "check",
-            "not_null",
-            "unique",
-            "primary_key",
-            "foreign_key",
-            "custom"
-          ]
-        },
-        "name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "expression": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "warn_unenforced": {
-          "type": "boolean",
-          "default": true
-        },
-        "warn_unsupported": {
-          "type": "boolean",
-          "default": true
-        },
-        "columns": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "type"
-      ]
-    },
-    "DeferRelation": {
-      "type": "object",
-      "title": "DeferRelation",
-      "properties": {
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "schema": {
-          "type": "string"
-        },
-        "alias": {
-          "type": "string"
-        },
-        "relation_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "database",
-        "schema",
-        "alias",
-        "relation_name"
-      ]
-    },
-    "ModelNode": {
-      "type": "object",
-      "title": "ModelNode",
-      "properties": {
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "schema": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "const": "model"
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "fqn": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "alias": {
-          "type": "string"
-        },
-        "checksum": {
-          "$ref": "#/$defs/FileHash"
-        },
-        "config": {
-          "$ref": "#/$defs/ModelConfig"
-        },
-        "_event_status": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "description": {
-          "type": "string",
-          "default": ""
-        },
-        "columns": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "docs": {
-          "$ref": "#/$defs/Docs"
-        },
-        "patch_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "build_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "deferred": {
-          "type": "boolean",
-          "default": false
-        },
-        "unrendered_config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "created_at": {
-          "type": "number"
-        },
-        "config_call_dict": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "relation_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "raw_code": {
-          "type": "string",
-          "default": ""
-        },
-        "language": {
-          "type": "string",
-          "default": "sql"
-        },
-        "refs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RefArgs"
-          }
-        },
-        "sources": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "metrics": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "depends_on": {
-          "$ref": "#/$defs/DependsOn"
-        },
-        "compiled_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "compiled": {
-          "type": "boolean",
-          "default": false
-        },
-        "compiled_code": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "extra_ctes_injected": {
-          "type": "boolean",
-          "default": false
-        },
-        "extra_ctes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/InjectedCTE"
-          }
-        },
-        "_pre_injected_sql": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "contract": {
-          "$ref": "#/$defs/Contract"
-        },
-        "access": {
-          "enum": [
-            "private",
-            "protected",
-            "public"
-          ],
-          "default": "protected"
-        },
-        "constraints": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ModelLevelConstraint"
-          }
-        },
-        "version": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "latest_version": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "deprecation_date": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "defer_relation": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/DeferRelation"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "database",
-        "schema",
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "fqn",
-        "alias",
-        "checksum"
-      ]
-    },
-    "RPCNode": {
-      "type": "object",
-      "title": "RPCNode",
-      "properties": {
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "schema": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "const": "rpc"
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "fqn": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "alias": {
-          "type": "string"
-        },
-        "checksum": {
-          "$ref": "#/$defs/FileHash"
-        },
-        "config": {
-          "$ref": "#/$defs/NodeConfig"
-        },
-        "_event_status": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "description": {
-          "type": "string",
-          "default": ""
-        },
-        "columns": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "docs": {
-          "$ref": "#/$defs/Docs"
-        },
-        "patch_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "build_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "deferred": {
-          "type": "boolean",
-          "default": false
-        },
-        "unrendered_config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "created_at": {
-          "type": "number"
-        },
-        "config_call_dict": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "relation_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "raw_code": {
-          "type": "string",
-          "default": ""
-        },
-        "language": {
-          "type": "string",
-          "default": "sql"
-        },
-        "refs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RefArgs"
-          }
-        },
-        "sources": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "metrics": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "depends_on": {
-          "$ref": "#/$defs/DependsOn"
-        },
-        "compiled_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "compiled": {
-          "type": "boolean",
-          "default": false
-        },
-        "compiled_code": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "extra_ctes_injected": {
-          "type": "boolean",
-          "default": false
-        },
-        "extra_ctes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/InjectedCTE"
-          }
-        },
-        "_pre_injected_sql": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "contract": {
-          "$ref": "#/$defs/Contract"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "database",
-        "schema",
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "fqn",
-        "alias",
-        "checksum"
-      ]
-    },
-    "SqlNode": {
-      "type": "object",
-      "title": "SqlNode",
-      "properties": {
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "schema": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "const": "sql_operation"
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "fqn": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "alias": {
-          "type": "string"
-        },
-        "checksum": {
-          "$ref": "#/$defs/FileHash"
-        },
-        "config": {
-          "$ref": "#/$defs/NodeConfig"
-        },
-        "_event_status": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "description": {
-          "type": "string",
-          "default": ""
-        },
-        "columns": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "docs": {
-          "$ref": "#/$defs/Docs"
-        },
-        "patch_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "build_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "deferred": {
-          "type": "boolean",
-          "default": false
-        },
-        "unrendered_config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "created_at": {
-          "type": "number"
-        },
-        "config_call_dict": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "relation_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "raw_code": {
-          "type": "string",
-          "default": ""
-        },
-        "language": {
-          "type": "string",
-          "default": "sql"
-        },
-        "refs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RefArgs"
-          }
-        },
-        "sources": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "metrics": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "depends_on": {
-          "$ref": "#/$defs/DependsOn"
-        },
-        "compiled_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "compiled": {
-          "type": "boolean",
-          "default": false
-        },
-        "compiled_code": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "extra_ctes_injected": {
-          "type": "boolean",
-          "default": false
-        },
-        "extra_ctes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/InjectedCTE"
-          }
-        },
-        "_pre_injected_sql": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "contract": {
-          "$ref": "#/$defs/Contract"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "database",
-        "schema",
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "fqn",
-        "alias",
-        "checksum"
-      ]
-    },
-    "TestMetadata": {
-      "type": "object",
-      "title": "TestMetadata",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "kwargs": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "namespace": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name"
-      ]
-    },
-    "GenericTestNode": {
-      "type": "object",
-      "title": "GenericTestNode",
-      "properties": {
-        "test_metadata": {
-          "$ref": "#/$defs/TestMetadata"
-        },
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "schema": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "const": "test"
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "fqn": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "alias": {
-          "type": "string"
-        },
-        "checksum": {
-          "$ref": "#/$defs/FileHash"
-        },
-        "config": {
-          "$ref": "#/$defs/TestConfig"
-        },
-        "_event_status": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "description": {
-          "type": "string",
-          "default": ""
-        },
-        "columns": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "docs": {
-          "$ref": "#/$defs/Docs"
-        },
-        "patch_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "build_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "deferred": {
-          "type": "boolean",
-          "default": false
-        },
-        "unrendered_config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "created_at": {
-          "type": "number"
-        },
-        "config_call_dict": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "relation_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "raw_code": {
-          "type": "string",
-          "default": ""
-        },
-        "language": {
-          "type": "string",
-          "default": "sql"
-        },
-        "refs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RefArgs"
-          }
-        },
-        "sources": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "metrics": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "depends_on": {
-          "$ref": "#/$defs/DependsOn"
-        },
-        "compiled_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "compiled": {
-          "type": "boolean",
-          "default": false
-        },
-        "compiled_code": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "extra_ctes_injected": {
-          "type": "boolean",
-          "default": false
-        },
-        "extra_ctes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/InjectedCTE"
-          }
-        },
-        "_pre_injected_sql": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "contract": {
-          "$ref": "#/$defs/Contract"
-        },
-        "column_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "file_key_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "attached_node": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "test_metadata",
-        "database",
-        "schema",
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "fqn",
-        "alias",
-        "checksum"
-      ]
-    },
-    "SnapshotConfig": {
-      "type": "object",
-      "title": "SnapshotConfig",
-      "properties": {
-        "_extra": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "enabled": {
-          "type": "boolean",
-          "default": true
-        },
-        "alias": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "schema": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "tags": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "materialized": {
-          "type": "string",
-          "default": "snapshot"
-        },
-        "incremental_strategy": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "persist_docs": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "post-hook": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Hook"
-          }
-        },
-        "pre-hook": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Hook"
-          }
-        },
-        "quoting": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "column_types": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "full_refresh": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "unique_key": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "on_schema_change": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": "ignore"
-        },
-        "on_configuration_change": {
-          "enum": [
-            "apply",
-            "continue",
-            "fail"
-          ]
-        },
-        "grants": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "packages": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "docs": {
-          "$ref": "#/$defs/Docs"
-        },
-        "contract": {
-          "$ref": "#/$defs/ContractConfig"
-        },
-        "strategy": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "target_schema": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "target_database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "updated_at": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "check_cols": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": true
-    },
-    "SnapshotNode": {
-      "type": "object",
-      "title": "SnapshotNode",
-      "properties": {
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "schema": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "const": "snapshot"
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "fqn": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "alias": {
-          "type": "string"
-        },
-        "checksum": {
-          "$ref": "#/$defs/FileHash"
-        },
-        "config": {
-          "$ref": "#/$defs/SnapshotConfig"
-        },
-        "_event_status": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "description": {
-          "type": "string",
-          "default": ""
-        },
-        "columns": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "docs": {
-          "$ref": "#/$defs/Docs"
-        },
-        "patch_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "build_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "deferred": {
-          "type": "boolean",
-          "default": false
-        },
-        "unrendered_config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "created_at": {
-          "type": "number"
-        },
-        "config_call_dict": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "relation_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "raw_code": {
-          "type": "string",
-          "default": ""
-        },
-        "language": {
-          "type": "string",
-          "default": "sql"
-        },
-        "refs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RefArgs"
-          }
-        },
-        "sources": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "metrics": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "depends_on": {
-          "$ref": "#/$defs/DependsOn"
-        },
-        "compiled_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "compiled": {
-          "type": "boolean",
-          "default": false
-        },
-        "compiled_code": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "extra_ctes_injected": {
-          "type": "boolean",
-          "default": false
-        },
-        "extra_ctes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/InjectedCTE"
-          }
-        },
-        "_pre_injected_sql": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "contract": {
-          "$ref": "#/$defs/Contract"
-        },
-        "defer_relation": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/DeferRelation"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "database",
-        "schema",
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "fqn",
-        "alias",
-        "checksum",
-        "config"
-      ]
-    },
-    "SeedConfig": {
-      "type": "object",
-      "title": "SeedConfig",
-      "properties": {
-        "_extra": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "enabled": {
-          "type": "boolean",
-          "default": true
-        },
-        "alias": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "schema": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "tags": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "materialized": {
-          "type": "string",
-          "default": "seed"
-        },
-        "incremental_strategy": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "persist_docs": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "post-hook": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Hook"
-          }
-        },
-        "pre-hook": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Hook"
-          }
-        },
-        "quoting": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "column_types": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "full_refresh": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "unique_key": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "on_schema_change": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": "ignore"
-        },
-        "on_configuration_change": {
-          "enum": [
-            "apply",
-            "continue",
-            "fail"
-          ]
-        },
-        "grants": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "packages": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "docs": {
-          "$ref": "#/$defs/Docs"
-        },
-        "contract": {
-          "$ref": "#/$defs/ContractConfig"
-        },
-        "delimiter": {
-          "type": "string",
-          "default": ","
-        },
-        "quote_columns": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": true
-    },
-    "MacroDependsOn": {
-      "type": "object",
-      "title": "MacroDependsOn",
-      "properties": {
-        "macros": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "additionalProperties": false
-    },
-    "SeedNode": {
-      "type": "object",
-      "title": "SeedNode",
-      "properties": {
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "schema": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "const": "seed"
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "fqn": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "alias": {
-          "type": "string"
-        },
-        "checksum": {
-          "$ref": "#/$defs/FileHash"
-        },
-        "config": {
-          "$ref": "#/$defs/SeedConfig"
-        },
-        "_event_status": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "description": {
-          "type": "string",
-          "default": ""
-        },
-        "columns": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "docs": {
-          "$ref": "#/$defs/Docs"
-        },
-        "patch_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "build_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "deferred": {
-          "type": "boolean",
-          "default": false
-        },
-        "unrendered_config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "created_at": {
-          "type": "number"
-        },
-        "config_call_dict": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "relation_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "raw_code": {
-          "type": "string",
-          "default": ""
-        },
-        "root_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "depends_on": {
-          "$ref": "#/$defs/MacroDependsOn"
-        },
-        "defer_relation": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/DeferRelation"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "database",
-        "schema",
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "fqn",
-        "alias",
-        "checksum"
-      ]
-    },
-    "Quoting": {
-      "type": "object",
-      "title": "Quoting",
-      "properties": {
-        "database": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "schema": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "identifier": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "column": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false
-    },
-    "Time": {
-      "type": "object",
-      "title": "Time",
-      "properties": {
-        "count": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "period": {
-          "anyOf": [
-            {
-              "enum": [
-                "minute",
-                "hour",
-                "day"
-              ]
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false
-    },
-    "FreshnessThreshold": {
-      "type": "object",
-      "title": "FreshnessThreshold",
-      "properties": {
-        "warn_after": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Time"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "error_after": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Time"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "filter": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false
-    },
-    "ExternalPartition": {
-      "type": "object",
-      "title": "ExternalPartition",
-      "properties": {
-        "_extra": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "name": {
-          "type": "string",
-          "default": ""
-        },
-        "description": {
-          "type": "string",
-          "default": ""
-        },
-        "data_type": {
-          "type": "string",
-          "default": ""
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        }
-      },
-      "additionalProperties": true
-    },
-    "ExternalTable": {
-      "type": "object",
-      "title": "ExternalTable",
-      "properties": {
-        "_extra": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "location": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "file_format": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "row_format": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "tbl_properties": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "partitions": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/ExternalPartition"
-              }
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": true
-    },
-    "SourceConfig": {
-      "type": "object",
-      "title": "SourceConfig",
-      "properties": {
-        "_extra": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "enabled": {
-          "type": "boolean",
-          "default": true
-        }
-      },
-      "additionalProperties": true
-    },
-    "SourceDefinition": {
-      "type": "object",
-      "title": "SourceDefinition",
-      "properties": {
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "schema": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "const": "source"
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "fqn": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "source_name": {
-          "type": "string"
-        },
-        "source_description": {
-          "type": "string"
-        },
-        "loader": {
-          "type": "string"
-        },
-        "identifier": {
-          "type": "string"
-        },
-        "_event_status": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "quoting": {
-          "$ref": "#/$defs/Quoting"
-        },
-        "loaded_at_field": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "freshness": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/FreshnessThreshold"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "external": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ExternalTable"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "description": {
-          "type": "string",
-          "default": ""
-        },
-        "columns": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/ColumnInfo"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "source_meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "config": {
-          "$ref": "#/$defs/SourceConfig"
-        },
-        "patch_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "unrendered_config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "relation_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "created_at": {
-          "type": "number"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "database",
-        "schema",
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "fqn",
-        "source_name",
-        "source_description",
-        "loader",
-        "identifier"
-      ]
-    },
-    "MacroArgument": {
-      "type": "object",
-      "title": "MacroArgument",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "type": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "description": {
-          "type": "string",
-          "default": ""
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name"
-      ]
-    },
-    "Macro": {
-      "type": "object",
-      "title": "Macro",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "const": "macro"
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "macro_sql": {
-          "type": "string"
-        },
-        "depends_on": {
-          "$ref": "#/$defs/MacroDependsOn"
-        },
-        "description": {
-          "type": "string",
-          "default": ""
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "docs": {
-          "$ref": "#/$defs/Docs"
-        },
-        "patch_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "arguments": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/MacroArgument"
-          }
-        },
-        "created_at": {
-          "type": "number"
-        },
-        "supported_languages": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "enum": [
-                  "python",
-                  "sql"
+      "description": "The nodes defined in the dbt project and its dependencies",
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "object",
+            "title": "AnalysisNode",
+            "properties": {
+              "database": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
                 ]
-              }
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "macro_sql"
-      ]
-    },
-    "Documentation": {
-      "type": "object",
-      "title": "Documentation",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "const": "doc"
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "block_contents": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "block_contents"
-      ]
-    },
-    "Owner": {
-      "type": "object",
-      "title": "Owner",
-      "properties": {
-        "_extra": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "email": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": true
-    },
-    "ExposureConfig": {
-      "type": "object",
-      "title": "ExposureConfig",
-      "properties": {
-        "_extra": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "enabled": {
-          "type": "boolean",
-          "default": true
-        }
-      },
-      "additionalProperties": true
-    },
-    "Exposure": {
-      "type": "object",
-      "title": "Exposure",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "const": "exposure"
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "fqn": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "type": {
-          "enum": [
-            "dashboard",
-            "notebook",
-            "analysis",
-            "ml",
-            "application"
-          ]
-        },
-        "owner": {
-          "$ref": "#/$defs/Owner"
-        },
-        "description": {
-          "type": "string",
-          "default": ""
-        },
-        "label": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "maturity": {
-          "anyOf": [
-            {
-              "enum": [
-                "low",
-                "medium",
-                "high"
-              ]
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "config": {
-          "$ref": "#/$defs/ExposureConfig"
-        },
-        "unrendered_config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "url": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "depends_on": {
-          "$ref": "#/$defs/DependsOn"
-        },
-        "refs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RefArgs"
-          }
-        },
-        "sources": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "metrics": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "created_at": {
-          "type": "number"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "fqn",
-        "type",
-        "owner"
-      ]
-    },
-    "WhereFilter": {
-      "type": "object",
-      "title": "WhereFilter",
-      "properties": {
-        "where_sql_template": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "where_sql_template"
-      ]
-    },
-    "WhereFilterIntersection": {
-      "type": "object",
-      "title": "WhereFilterIntersection",
-      "properties": {
-        "where_filters": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/WhereFilter"
-          }
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "where_filters"
-      ]
-    },
-    "MetricInputMeasure": {
-      "type": "object",
-      "title": "MetricInputMeasure",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "filter": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WhereFilterIntersection"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "alias": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "join_to_timespine": {
-          "type": "boolean",
-          "default": false
-        },
-        "fill_nulls_with": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name"
-      ]
-    },
-    "MetricTimeWindow": {
-      "type": "object",
-      "title": "MetricTimeWindow",
-      "properties": {
-        "count": {
-          "type": "integer"
-        },
-        "granularity": {
-          "enum": [
-            "day",
-            "week",
-            "month",
-            "quarter",
-            "year"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "count",
-        "granularity"
-      ]
-    },
-    "MetricInput": {
-      "type": "object",
-      "title": "MetricInput",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "filter": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WhereFilterIntersection"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "alias": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "offset_window": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/MetricTimeWindow"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "offset_to_grain": {
-          "anyOf": [
-            {
-              "enum": [
-                "day",
-                "week",
-                "month",
-                "quarter",
-                "year"
-              ]
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name"
-      ]
-    },
-    "MetricTypeParams": {
-      "type": "object",
-      "title": "MetricTypeParams",
-      "properties": {
-        "measure": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/MetricInputMeasure"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "input_measures": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/MetricInputMeasure"
-          }
-        },
-        "numerator": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/MetricInput"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "denominator": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/MetricInput"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "expr": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "window": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/MetricTimeWindow"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "grain_to_date": {
-          "anyOf": [
-            {
-              "enum": [
-                "day",
-                "week",
-                "month",
-                "quarter",
-                "year"
-              ]
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "metrics": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/MetricInput"
-              }
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false
-    },
-    "FileSlice": {
-      "type": "object",
-      "title": "FileSlice",
-      "properties": {
-        "filename": {
-          "type": "string"
-        },
-        "content": {
-          "type": "string"
-        },
-        "start_line_number": {
-          "type": "integer"
-        },
-        "end_line_number": {
-          "type": "integer"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "filename",
-        "content",
-        "start_line_number",
-        "end_line_number"
-      ]
-    },
-    "SourceFileMetadata": {
-      "type": "object",
-      "title": "SourceFileMetadata",
-      "properties": {
-        "repo_file_path": {
-          "type": "string"
-        },
-        "file_slice": {
-          "$ref": "#/$defs/FileSlice"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "repo_file_path",
-        "file_slice"
-      ]
-    },
-    "MetricConfig": {
-      "type": "object",
-      "title": "MetricConfig",
-      "properties": {
-        "_extra": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "enabled": {
-          "type": "boolean",
-          "default": true
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": true
-    },
-    "Metric": {
-      "type": "object",
-      "title": "Metric",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "const": "metric"
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "fqn": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "description": {
-          "type": "string"
-        },
-        "label": {
-          "type": "string"
-        },
-        "type": {
-          "enum": [
-            "simple",
-            "ratio",
-            "cumulative",
-            "derived"
-          ]
-        },
-        "type_params": {
-          "$ref": "#/$defs/MetricTypeParams"
-        },
-        "filter": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WhereFilterIntersection"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "metadata": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SourceFileMetadata"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "config": {
-          "$ref": "#/$defs/MetricConfig"
-        },
-        "unrendered_config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "sources": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "depends_on": {
-          "$ref": "#/$defs/DependsOn"
-        },
-        "refs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RefArgs"
-          }
-        },
-        "metrics": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "created_at": {
-          "type": "number"
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "fqn",
-        "description",
-        "label",
-        "type",
-        "type_params"
-      ]
-    },
-    "Group": {
-      "type": "object",
-      "title": "Group",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "const": "group"
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "owner": {
-          "$ref": "#/$defs/Owner"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "owner"
-      ]
-    },
-    "QueryParams": {
-      "type": "object",
-      "title": "QueryParams",
-      "properties": {
-        "metrics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "group_by": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "where": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WhereFilterIntersection"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "metrics",
-        "group_by",
-        "where"
-      ]
-    },
-    "ExportConfig": {
-      "type": "object",
-      "title": "ExportConfig",
-      "properties": {
-        "export_as": {
-          "enum": [
-            "table",
-            "view"
-          ]
-        },
-        "schema_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "alias": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "export_as"
-      ]
-    },
-    "Export": {
-      "type": "object",
-      "title": "Export",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "config": {
-          "$ref": "#/$defs/ExportConfig"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "config"
-      ]
-    },
-    "SavedQueryConfig": {
-      "type": "object",
-      "title": "SavedQueryConfig",
-      "properties": {
-        "_extra": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "enabled": {
-          "type": "boolean",
-          "default": true
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        }
-      },
-      "additionalProperties": true
-    },
-    "SavedQuery": {
-      "type": "object",
-      "title": "SavedQuery",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "enum": [
-            "model",
-            "analysis",
-            "test",
-            "snapshot",
-            "operation",
-            "seed",
-            "rpc",
-            "sql_operation",
-            "doc",
-            "source",
-            "macro",
-            "exposure",
-            "metric",
-            "group",
-            "saved_query",
-            "semantic_model"
-          ]
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "fqn": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "query_params": {
-          "$ref": "#/$defs/QueryParams"
-        },
-        "exports": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Export"
-          }
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "label": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "metadata": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SourceFileMetadata"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "config": {
-          "$ref": "#/$defs/SavedQueryConfig"
-        },
-        "unrendered_config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "depends_on": {
-          "$ref": "#/$defs/DependsOn"
-        },
-        "created_at": {
-          "type": "number"
-        },
-        "refs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RefArgs"
-          }
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "fqn",
-        "query_params",
-        "exports"
-      ]
-    },
-    "NodeRelation": {
-      "type": "object",
-      "title": "NodeRelation",
-      "properties": {
-        "alias": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string"
-        },
-        "database": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "relation_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "alias",
-        "schema_name"
-      ]
-    },
-    "Defaults": {
-      "type": "object",
-      "title": "Defaults",
-      "properties": {
-        "agg_time_dimension": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false
-    },
-    "Entity": {
-      "type": "object",
-      "title": "Entity",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "type": {
-          "enum": [
-            "foreign",
-            "natural",
-            "primary",
-            "unique"
-          ]
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "label": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "role": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "expr": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "type"
-      ]
-    },
-    "MeasureAggregationParameters": {
-      "type": "object",
-      "title": "MeasureAggregationParameters",
-      "properties": {
-        "percentile": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "use_discrete_percentile": {
-          "type": "boolean",
-          "default": false
-        },
-        "use_approximate_percentile": {
-          "type": "boolean",
-          "default": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "NonAdditiveDimension": {
-      "type": "object",
-      "title": "NonAdditiveDimension",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "window_choice": {
-          "enum": [
-            "sum",
-            "min",
-            "max",
-            "count_distinct",
-            "sum_boolean",
-            "average",
-            "percentile",
-            "median",
-            "count"
-          ]
-        },
-        "window_groupings": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "window_choice",
-        "window_groupings"
-      ]
-    },
-    "Measure": {
-      "type": "object",
-      "title": "Measure",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "agg": {
-          "enum": [
-            "sum",
-            "min",
-            "max",
-            "count_distinct",
-            "sum_boolean",
-            "average",
-            "percentile",
-            "median",
-            "count"
-          ]
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "label": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "create_metric": {
-          "type": "boolean",
-          "default": false
-        },
-        "expr": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "agg_params": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/MeasureAggregationParameters"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "non_additive_dimension": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NonAdditiveDimension"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "agg_time_dimension": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "agg"
-      ]
-    },
-    "DimensionValidityParams": {
-      "type": "object",
-      "title": "DimensionValidityParams",
-      "properties": {
-        "is_start": {
-          "type": "boolean",
-          "default": false
-        },
-        "is_end": {
-          "type": "boolean",
-          "default": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "DimensionTypeParams": {
-      "type": "object",
-      "title": "DimensionTypeParams",
-      "properties": {
-        "time_granularity": {
-          "enum": [
-            "day",
-            "week",
-            "month",
-            "quarter",
-            "year"
-          ]
-        },
-        "validity_params": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/DimensionValidityParams"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "time_granularity"
-      ]
-    },
-    "Dimension": {
-      "type": "object",
-      "title": "Dimension",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "type": {
-          "enum": [
-            "categorical",
-            "time"
-          ]
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "label": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "is_partition": {
-          "type": "boolean",
-          "default": false
-        },
-        "type_params": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/DimensionTypeParams"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "expr": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "metadata": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SourceFileMetadata"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "type"
-      ]
-    },
-    "SemanticModelConfig": {
-      "type": "object",
-      "title": "SemanticModelConfig",
-      "properties": {
-        "_extra": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "enabled": {
-          "type": "boolean",
-          "default": true
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "meta": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        }
-      },
-      "additionalProperties": true
-    },
-    "SemanticModel": {
-      "type": "object",
-      "title": "SemanticModel",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "resource_type": {
-          "enum": [
-            "model",
-            "analysis",
-            "test",
-            "snapshot",
-            "operation",
-            "seed",
-            "rpc",
-            "sql_operation",
-            "doc",
-            "source",
-            "macro",
-            "exposure",
-            "metric",
-            "group",
-            "saved_query",
-            "semantic_model"
-          ]
-        },
-        "package_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "original_file_path": {
-          "type": "string"
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "fqn": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "model": {
-          "type": "string"
-        },
-        "node_relation": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NodeRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "label": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "defaults": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Defaults"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "entities": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Entity"
-          }
-        },
-        "measures": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Measure"
-          }
-        },
-        "dimensions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Dimension"
-          }
-        },
-        "metadata": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SourceFileMetadata"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "depends_on": {
-          "$ref": "#/$defs/DependsOn"
-        },
-        "refs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RefArgs"
-          }
-        },
-        "created_at": {
-          "type": "number"
-        },
-        "config": {
-          "$ref": "#/$defs/SemanticModelConfig"
-        },
-        "unrendered_config": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "primary_entity": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "group": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "resource_type",
-        "package_name",
-        "path",
-        "original_file_path",
-        "unique_id",
-        "fqn",
-        "model",
-        "node_relation"
-      ]
-    },
-    "WritableManifest": {
-      "type": "object",
-      "title": "WritableManifest",
-      "properties": {
-        "metadata": {
-          "description": "Metadata about the manifest",
-          "$ref": "#/$defs/ManifestMetadata"
-        },
-        "nodes": {
-          "type": "object",
-          "description": "The nodes defined in the dbt project and its dependencies",
-          "additionalProperties": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/AnalysisNode"
               },
-              {
-                "$ref": "#/$defs/SingularTestNode"
+              "schema": {
+                "type": "string"
               },
-              {
-                "$ref": "#/$defs/HookNode"
+              "name": {
+                "type": "string"
               },
-              {
-                "$ref": "#/$defs/ModelNode"
+              "resource_type": {
+                "const": "analysis"
               },
-              {
-                "$ref": "#/$defs/RPCNode"
+              "package_name": {
+                "type": "string"
               },
-              {
-                "$ref": "#/$defs/SqlNode"
+              "path": {
+                "type": "string"
               },
-              {
-                "$ref": "#/$defs/GenericTestNode"
+              "original_file_path": {
+                "type": "string"
               },
-              {
-                "$ref": "#/$defs/SnapshotNode"
+              "unique_id": {
+                "type": "string"
               },
-              {
-                "$ref": "#/$defs/SeedNode"
-              }
-            ]
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "sources": {
-          "type": "object",
-          "description": "The sources defined in the dbt project and its dependencies",
-          "additionalProperties": {
-            "$ref": "#/$defs/SourceDefinition"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "macros": {
-          "type": "object",
-          "description": "The macros defined in the dbt project and its dependencies",
-          "additionalProperties": {
-            "$ref": "#/$defs/Macro"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "docs": {
-          "type": "object",
-          "description": "The docs defined in the dbt project and its dependencies",
-          "additionalProperties": {
-            "$ref": "#/$defs/Documentation"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "exposures": {
-          "type": "object",
-          "description": "The exposures defined in the dbt project and its dependencies",
-          "additionalProperties": {
-            "$ref": "#/$defs/Exposure"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "metrics": {
-          "type": "object",
-          "description": "The metrics defined in the dbt project and its dependencies",
-          "additionalProperties": {
-            "$ref": "#/$defs/Metric"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "groups": {
-          "type": "object",
-          "description": "The groups defined in the dbt project",
-          "additionalProperties": {
-            "$ref": "#/$defs/Group"
-          },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "selectors": {
-          "type": "object",
-          "description": "The selectors defined in selectors.yml",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "disabled": {
-          "description": "A mapping of the disabled nodes in the target",
-          "anyOf": [
-            {
-              "type": "object",
-              "additionalProperties": {
+              "fqn": {
                 "type": "array",
                 "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/$defs/AnalysisNode"
-                    },
-                    {
-                      "$ref": "#/$defs/SingularTestNode"
-                    },
-                    {
-                      "$ref": "#/$defs/HookNode"
-                    },
-                    {
-                      "$ref": "#/$defs/ModelNode"
-                    },
-                    {
-                      "$ref": "#/$defs/RPCNode"
-                    },
-                    {
-                      "$ref": "#/$defs/SqlNode"
-                    },
-                    {
-                      "$ref": "#/$defs/GenericTestNode"
-                    },
-                    {
-                      "$ref": "#/$defs/SnapshotNode"
-                    },
-                    {
-                      "$ref": "#/$defs/SeedNode"
-                    },
-                    {
-                      "$ref": "#/$defs/SourceDefinition"
-                    },
-                    {
-                      "$ref": "#/$defs/Exposure"
-                    },
-                    {
-                      "$ref": "#/$defs/Metric"
-                    },
-                    {
-                      "$ref": "#/$defs/SavedQuery"
-                    },
-                    {
-                      "$ref": "#/$defs/SemanticModel"
+                  "type": "string"
+                }
+              },
+              "alias": {
+                "type": "string"
+              },
+              "checksum": {
+                "type": "object",
+                "title": "FileHash",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "checksum": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "name",
+                  "checksum"
+                ]
+              },
+              "config": {
+                "type": "object",
+                "title": "NodeConfig",
+                "properties": {
+                  "_extra": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
                     }
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "alias": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "database": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tags": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "group": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "materialized": {
+                    "type": "string",
+                    "default": "view"
+                  },
+                  "incremental_strategy": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "persist_docs": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "post-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "pre-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "quoting": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "column_types": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "full_refresh": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "unique_key": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "on_schema_change": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": "ignore"
+                  },
+                  "on_configuration_change": {
+                    "enum": [
+                      "apply",
+                      "continue",
+                      "fail"
+                    ]
+                  },
+                  "grants": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "packages": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "docs": {
+                    "type": "object",
+                    "title": "Docs",
+                    "properties": {
+                      "show": {
+                        "type": "boolean",
+                        "default": true
+                      },
+                      "node_color": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "contract": {
+                    "type": "object",
+                    "title": "ContractConfig",
+                    "properties": {
+                      "enforced": {
+                        "type": "boolean",
+                        "default": false
+                      },
+                      "alias_types": {
+                        "type": "boolean",
+                        "default": true
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": true
+              },
+              "_event_status": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "description": {
+                "type": "string",
+                "default": ""
+              },
+              "columns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "title": "ColumnInfo",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "data_type": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "ColumnLevelConstraint",
+                        "properties": {
+                          "type": {
+                            "enum": [
+                              "check",
+                              "not_null",
+                              "unique",
+                              "primary_key",
+                              "foreign_key",
+                              "custom"
+                            ]
+                          },
+                          "name": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "expression": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "warn_unenforced": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "warn_unsupported": {
+                            "type": "boolean",
+                            "default": true
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "type"
+                        ]
+                      }
+                    },
+                    "quote": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "_extra": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": true,
+                  "required": [
+                    "name"
+                  ]
+                },
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "meta": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "docs": {
+                "type": "object",
+                "title": "Docs",
+                "properties": {
+                  "show": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "node_color": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "patch_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "build_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "deferred": {
+                "type": "boolean",
+                "default": false
+              },
+              "unrendered_config": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "created_at": {
+                "type": "number"
+              },
+              "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "relation_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "raw_code": {
+                "type": "string",
+                "default": ""
+              },
+              "language": {
+                "type": "string",
+                "default": "sql"
+              },
+              "refs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "RefArgs",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "package": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name"
                   ]
                 }
               },
-              "propertyNames": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "parent_map": {
-          "description": "A mapping from\u00a0child nodes to their dependencies",
-          "anyOf": [
-            {
-              "type": "object",
-              "additionalProperties": {
+              "sources": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
-              "propertyNames": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "child_map": {
-          "description": "A mapping from parent nodes to their dependents",
-          "anyOf": [
-            {
-              "type": "object",
-              "additionalProperties": {
+              "metrics": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
-              "propertyNames": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "group_map": {
-          "description": "A mapping from group names to their nodes",
-          "anyOf": [
-            {
-              "type": "object",
-              "additionalProperties": {
+              "depends_on": {
+                "type": "object",
+                "title": "DependsOn",
+                "properties": {
+                  "macros": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "nodes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "compiled_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "compiled": {
+                "type": "boolean",
+                "default": false
+              },
+              "compiled_code": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "extra_ctes_injected": {
+                "type": "boolean",
+                "default": false
+              },
+              "extra_ctes": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "type": "object",
+                  "title": "InjectedCTE",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "sql": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "id",
+                    "sql"
+                  ]
                 }
               },
-              "propertyNames": {
-                "type": "string"
+              "_pre_injected_sql": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "contract": {
+                "type": "object",
+                "title": "Contract",
+                "properties": {
+                  "enforced": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "alias_types": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "checksum": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
               }
             },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "saved_queries": {
-          "type": "object",
-          "description": "The saved queries defined in the dbt project",
-          "additionalProperties": {
-            "$ref": "#/$defs/SavedQuery"
+            "additionalProperties": false,
+            "required": [
+              "database",
+              "schema",
+              "name",
+              "resource_type",
+              "package_name",
+              "path",
+              "original_file_path",
+              "unique_id",
+              "fqn",
+              "alias",
+              "checksum"
+            ]
           },
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "semantic_models": {
-          "type": "object",
-          "description": "The semantic models defined in the dbt project",
-          "additionalProperties": {
-            "$ref": "#/$defs/SemanticModel"
+          {
+            "type": "object",
+            "title": "SingularTestNode",
+            "properties": {
+              "database": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "resource_type": {
+                "const": "test"
+              },
+              "package_name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "original_file_path": {
+                "type": "string"
+              },
+              "unique_id": {
+                "type": "string"
+              },
+              "fqn": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "alias": {
+                "type": "string"
+              },
+              "checksum": {
+                "type": "object",
+                "title": "FileHash",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "checksum": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "name",
+                  "checksum"
+                ]
+              },
+              "config": {
+                "type": "object",
+                "title": "TestConfig",
+                "properties": {
+                  "_extra": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "alias": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": "dbt_test__audit"
+                  },
+                  "database": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tags": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "group": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "materialized": {
+                    "type": "string",
+                    "default": "test"
+                  },
+                  "severity": {
+                    "type": "string",
+                    "default": "ERROR",
+                    "pattern": "^([Ww][Aa][Rr][Nn]|[Ee][Rr][Rr][Oo][Rr])$"
+                  },
+                  "store_failures": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "store_failures_as": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "where": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "limit": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "fail_calc": {
+                    "type": "string",
+                    "default": "count(*)"
+                  },
+                  "warn_if": {
+                    "type": "string",
+                    "default": "!= 0"
+                  },
+                  "error_if": {
+                    "type": "string",
+                    "default": "!= 0"
+                  }
+                },
+                "additionalProperties": true
+              },
+              "_event_status": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "description": {
+                "type": "string",
+                "default": ""
+              },
+              "columns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "title": "ColumnInfo",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "data_type": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "ColumnLevelConstraint",
+                        "properties": {
+                          "type": {
+                            "enum": [
+                              "check",
+                              "not_null",
+                              "unique",
+                              "primary_key",
+                              "foreign_key",
+                              "custom"
+                            ]
+                          },
+                          "name": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "expression": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "warn_unenforced": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "warn_unsupported": {
+                            "type": "boolean",
+                            "default": true
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "type"
+                        ]
+                      }
+                    },
+                    "quote": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "_extra": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": true,
+                  "required": [
+                    "name"
+                  ]
+                },
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "meta": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "docs": {
+                "type": "object",
+                "title": "Docs",
+                "properties": {
+                  "show": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "node_color": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "patch_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "build_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "deferred": {
+                "type": "boolean",
+                "default": false
+              },
+              "unrendered_config": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "created_at": {
+                "type": "number"
+              },
+              "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "relation_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "raw_code": {
+                "type": "string",
+                "default": ""
+              },
+              "language": {
+                "type": "string",
+                "default": "sql"
+              },
+              "refs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "RefArgs",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "package": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "metrics": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "depends_on": {
+                "type": "object",
+                "title": "DependsOn",
+                "properties": {
+                  "macros": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "nodes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "compiled_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "compiled": {
+                "type": "boolean",
+                "default": false
+              },
+              "compiled_code": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "extra_ctes_injected": {
+                "type": "boolean",
+                "default": false
+              },
+              "extra_ctes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "InjectedCTE",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "sql": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "id",
+                    "sql"
+                  ]
+                }
+              },
+              "_pre_injected_sql": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "contract": {
+                "type": "object",
+                "title": "Contract",
+                "properties": {
+                  "enforced": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "alias_types": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "checksum": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "database",
+              "schema",
+              "name",
+              "resource_type",
+              "package_name",
+              "path",
+              "original_file_path",
+              "unique_id",
+              "fqn",
+              "alias",
+              "checksum"
+            ]
           },
-          "propertyNames": {
-            "type": "string"
+          {
+            "type": "object",
+            "title": "HookNode",
+            "properties": {
+              "database": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "resource_type": {
+                "const": "operation"
+              },
+              "package_name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "original_file_path": {
+                "type": "string"
+              },
+              "unique_id": {
+                "type": "string"
+              },
+              "fqn": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "alias": {
+                "type": "string"
+              },
+              "checksum": {
+                "type": "object",
+                "title": "FileHash",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "checksum": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "name",
+                  "checksum"
+                ]
+              },
+              "config": {
+                "type": "object",
+                "title": "NodeConfig",
+                "properties": {
+                  "_extra": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "alias": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "database": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tags": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "group": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "materialized": {
+                    "type": "string",
+                    "default": "view"
+                  },
+                  "incremental_strategy": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "persist_docs": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "post-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "pre-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "quoting": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "column_types": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "full_refresh": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "unique_key": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "on_schema_change": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": "ignore"
+                  },
+                  "on_configuration_change": {
+                    "enum": [
+                      "apply",
+                      "continue",
+                      "fail"
+                    ]
+                  },
+                  "grants": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "packages": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "docs": {
+                    "type": "object",
+                    "title": "Docs",
+                    "properties": {
+                      "show": {
+                        "type": "boolean",
+                        "default": true
+                      },
+                      "node_color": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "contract": {
+                    "type": "object",
+                    "title": "ContractConfig",
+                    "properties": {
+                      "enforced": {
+                        "type": "boolean",
+                        "default": false
+                      },
+                      "alias_types": {
+                        "type": "boolean",
+                        "default": true
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": true
+              },
+              "_event_status": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "description": {
+                "type": "string",
+                "default": ""
+              },
+              "columns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "title": "ColumnInfo",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "data_type": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "ColumnLevelConstraint",
+                        "properties": {
+                          "type": {
+                            "enum": [
+                              "check",
+                              "not_null",
+                              "unique",
+                              "primary_key",
+                              "foreign_key",
+                              "custom"
+                            ]
+                          },
+                          "name": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "expression": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "warn_unenforced": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "warn_unsupported": {
+                            "type": "boolean",
+                            "default": true
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "type"
+                        ]
+                      }
+                    },
+                    "quote": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "_extra": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": true,
+                  "required": [
+                    "name"
+                  ]
+                },
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "meta": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "docs": {
+                "type": "object",
+                "title": "Docs",
+                "properties": {
+                  "show": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "node_color": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "patch_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "build_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "deferred": {
+                "type": "boolean",
+                "default": false
+              },
+              "unrendered_config": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "created_at": {
+                "type": "number"
+              },
+              "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "relation_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "raw_code": {
+                "type": "string",
+                "default": ""
+              },
+              "language": {
+                "type": "string",
+                "default": "sql"
+              },
+              "refs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "RefArgs",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "package": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "metrics": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "depends_on": {
+                "type": "object",
+                "title": "DependsOn",
+                "properties": {
+                  "macros": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "nodes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "compiled_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "compiled": {
+                "type": "boolean",
+                "default": false
+              },
+              "compiled_code": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "extra_ctes_injected": {
+                "type": "boolean",
+                "default": false
+              },
+              "extra_ctes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "InjectedCTE",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "sql": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "id",
+                    "sql"
+                  ]
+                }
+              },
+              "_pre_injected_sql": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "contract": {
+                "type": "object",
+                "title": "Contract",
+                "properties": {
+                  "enforced": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "alias_types": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "checksum": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "index": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "database",
+              "schema",
+              "name",
+              "resource_type",
+              "package_name",
+              "path",
+              "original_file_path",
+              "unique_id",
+              "fqn",
+              "alias",
+              "checksum"
+            ]
+          },
+          {
+            "type": "object",
+            "title": "ModelNode",
+            "properties": {
+              "database": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "resource_type": {
+                "const": "model"
+              },
+              "package_name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "original_file_path": {
+                "type": "string"
+              },
+              "unique_id": {
+                "type": "string"
+              },
+              "fqn": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "alias": {
+                "type": "string"
+              },
+              "checksum": {
+                "type": "object",
+                "title": "FileHash",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "checksum": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "name",
+                  "checksum"
+                ]
+              },
+              "config": {
+                "type": "object",
+                "title": "ModelConfig",
+                "properties": {
+                  "_extra": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "alias": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "database": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tags": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "group": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "materialized": {
+                    "type": "string",
+                    "default": "view"
+                  },
+                  "incremental_strategy": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "persist_docs": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "post-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "pre-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "quoting": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "column_types": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "full_refresh": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "unique_key": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "on_schema_change": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": "ignore"
+                  },
+                  "on_configuration_change": {
+                    "enum": [
+                      "apply",
+                      "continue",
+                      "fail"
+                    ]
+                  },
+                  "grants": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "packages": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "docs": {
+                    "type": "object",
+                    "title": "Docs",
+                    "properties": {
+                      "show": {
+                        "type": "boolean",
+                        "default": true
+                      },
+                      "node_color": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "contract": {
+                    "type": "object",
+                    "title": "ContractConfig",
+                    "properties": {
+                      "enforced": {
+                        "type": "boolean",
+                        "default": false
+                      },
+                      "alias_types": {
+                        "type": "boolean",
+                        "default": true
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "access": {
+                    "enum": [
+                      "private",
+                      "protected",
+                      "public"
+                    ],
+                    "default": "protected"
+                  }
+                },
+                "additionalProperties": true
+              },
+              "_event_status": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "description": {
+                "type": "string",
+                "default": ""
+              },
+              "columns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "title": "ColumnInfo",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "data_type": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "ColumnLevelConstraint",
+                        "properties": {
+                          "type": {
+                            "enum": [
+                              "check",
+                              "not_null",
+                              "unique",
+                              "primary_key",
+                              "foreign_key",
+                              "custom"
+                            ]
+                          },
+                          "name": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "expression": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "warn_unenforced": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "warn_unsupported": {
+                            "type": "boolean",
+                            "default": true
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "type"
+                        ]
+                      }
+                    },
+                    "quote": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "_extra": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": true,
+                  "required": [
+                    "name"
+                  ]
+                },
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "meta": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "docs": {
+                "type": "object",
+                "title": "Docs",
+                "properties": {
+                  "show": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "node_color": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "patch_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "build_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "deferred": {
+                "type": "boolean",
+                "default": false
+              },
+              "unrendered_config": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "created_at": {
+                "type": "number"
+              },
+              "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "relation_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "raw_code": {
+                "type": "string",
+                "default": ""
+              },
+              "language": {
+                "type": "string",
+                "default": "sql"
+              },
+              "refs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "RefArgs",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "package": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "metrics": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "depends_on": {
+                "type": "object",
+                "title": "DependsOn",
+                "properties": {
+                  "macros": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "nodes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "compiled_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "compiled": {
+                "type": "boolean",
+                "default": false
+              },
+              "compiled_code": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "extra_ctes_injected": {
+                "type": "boolean",
+                "default": false
+              },
+              "extra_ctes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "InjectedCTE",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "sql": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "id",
+                    "sql"
+                  ]
+                }
+              },
+              "_pre_injected_sql": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "contract": {
+                "type": "object",
+                "title": "Contract",
+                "properties": {
+                  "enforced": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "alias_types": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "checksum": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "access": {
+                "enum": [
+                  "private",
+                  "protected",
+                  "public"
+                ],
+                "default": "protected"
+              },
+              "constraints": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "ModelLevelConstraint",
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "check",
+                        "not_null",
+                        "unique",
+                        "primary_key",
+                        "foreign_key",
+                        "custom"
+                      ]
+                    },
+                    "name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "expression": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "warn_unenforced": {
+                      "type": "boolean",
+                      "default": true
+                    },
+                    "warn_unsupported": {
+                      "type": "boolean",
+                      "default": true
+                    },
+                    "columns": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "type"
+                  ]
+                }
+              },
+              "version": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "latest_version": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "deprecation_date": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "defer_relation": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "title": "DeferRelation",
+                    "properties": {
+                      "database": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "schema": {
+                        "type": "string"
+                      },
+                      "alias": {
+                        "type": "string"
+                      },
+                      "relation_name": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "database",
+                      "schema",
+                      "alias",
+                      "relation_name"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "database",
+              "schema",
+              "name",
+              "resource_type",
+              "package_name",
+              "path",
+              "original_file_path",
+              "unique_id",
+              "fqn",
+              "alias",
+              "checksum"
+            ]
+          },
+          {
+            "type": "object",
+            "title": "RPCNode",
+            "properties": {
+              "database": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "resource_type": {
+                "const": "rpc"
+              },
+              "package_name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "original_file_path": {
+                "type": "string"
+              },
+              "unique_id": {
+                "type": "string"
+              },
+              "fqn": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "alias": {
+                "type": "string"
+              },
+              "checksum": {
+                "type": "object",
+                "title": "FileHash",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "checksum": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "name",
+                  "checksum"
+                ]
+              },
+              "config": {
+                "type": "object",
+                "title": "NodeConfig",
+                "properties": {
+                  "_extra": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "alias": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "database": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tags": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "group": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "materialized": {
+                    "type": "string",
+                    "default": "view"
+                  },
+                  "incremental_strategy": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "persist_docs": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "post-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "pre-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "quoting": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "column_types": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "full_refresh": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "unique_key": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "on_schema_change": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": "ignore"
+                  },
+                  "on_configuration_change": {
+                    "enum": [
+                      "apply",
+                      "continue",
+                      "fail"
+                    ]
+                  },
+                  "grants": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "packages": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "docs": {
+                    "type": "object",
+                    "title": "Docs",
+                    "properties": {
+                      "show": {
+                        "type": "boolean",
+                        "default": true
+                      },
+                      "node_color": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "contract": {
+                    "type": "object",
+                    "title": "ContractConfig",
+                    "properties": {
+                      "enforced": {
+                        "type": "boolean",
+                        "default": false
+                      },
+                      "alias_types": {
+                        "type": "boolean",
+                        "default": true
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": true
+              },
+              "_event_status": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "description": {
+                "type": "string",
+                "default": ""
+              },
+              "columns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "title": "ColumnInfo",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "data_type": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "ColumnLevelConstraint",
+                        "properties": {
+                          "type": {
+                            "enum": [
+                              "check",
+                              "not_null",
+                              "unique",
+                              "primary_key",
+                              "foreign_key",
+                              "custom"
+                            ]
+                          },
+                          "name": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "expression": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "warn_unenforced": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "warn_unsupported": {
+                            "type": "boolean",
+                            "default": true
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "type"
+                        ]
+                      }
+                    },
+                    "quote": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "_extra": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": true,
+                  "required": [
+                    "name"
+                  ]
+                },
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "meta": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "docs": {
+                "type": "object",
+                "title": "Docs",
+                "properties": {
+                  "show": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "node_color": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "patch_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "build_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "deferred": {
+                "type": "boolean",
+                "default": false
+              },
+              "unrendered_config": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "created_at": {
+                "type": "number"
+              },
+              "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "relation_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "raw_code": {
+                "type": "string",
+                "default": ""
+              },
+              "language": {
+                "type": "string",
+                "default": "sql"
+              },
+              "refs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "RefArgs",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "package": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "metrics": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "depends_on": {
+                "type": "object",
+                "title": "DependsOn",
+                "properties": {
+                  "macros": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "nodes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "compiled_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "compiled": {
+                "type": "boolean",
+                "default": false
+              },
+              "compiled_code": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "extra_ctes_injected": {
+                "type": "boolean",
+                "default": false
+              },
+              "extra_ctes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "InjectedCTE",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "sql": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "id",
+                    "sql"
+                  ]
+                }
+              },
+              "_pre_injected_sql": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "contract": {
+                "type": "object",
+                "title": "Contract",
+                "properties": {
+                  "enforced": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "alias_types": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "checksum": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "database",
+              "schema",
+              "name",
+              "resource_type",
+              "package_name",
+              "path",
+              "original_file_path",
+              "unique_id",
+              "fqn",
+              "alias",
+              "checksum"
+            ]
+          },
+          {
+            "type": "object",
+            "title": "SqlNode",
+            "properties": {
+              "database": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "resource_type": {
+                "const": "sql_operation"
+              },
+              "package_name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "original_file_path": {
+                "type": "string"
+              },
+              "unique_id": {
+                "type": "string"
+              },
+              "fqn": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "alias": {
+                "type": "string"
+              },
+              "checksum": {
+                "type": "object",
+                "title": "FileHash",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "checksum": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "name",
+                  "checksum"
+                ]
+              },
+              "config": {
+                "type": "object",
+                "title": "NodeConfig",
+                "properties": {
+                  "_extra": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "alias": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "database": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tags": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "group": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "materialized": {
+                    "type": "string",
+                    "default": "view"
+                  },
+                  "incremental_strategy": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "persist_docs": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "post-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "pre-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "quoting": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "column_types": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "full_refresh": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "unique_key": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "on_schema_change": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": "ignore"
+                  },
+                  "on_configuration_change": {
+                    "enum": [
+                      "apply",
+                      "continue",
+                      "fail"
+                    ]
+                  },
+                  "grants": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "packages": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "docs": {
+                    "type": "object",
+                    "title": "Docs",
+                    "properties": {
+                      "show": {
+                        "type": "boolean",
+                        "default": true
+                      },
+                      "node_color": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "contract": {
+                    "type": "object",
+                    "title": "ContractConfig",
+                    "properties": {
+                      "enforced": {
+                        "type": "boolean",
+                        "default": false
+                      },
+                      "alias_types": {
+                        "type": "boolean",
+                        "default": true
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": true
+              },
+              "_event_status": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "description": {
+                "type": "string",
+                "default": ""
+              },
+              "columns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "title": "ColumnInfo",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "data_type": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "ColumnLevelConstraint",
+                        "properties": {
+                          "type": {
+                            "enum": [
+                              "check",
+                              "not_null",
+                              "unique",
+                              "primary_key",
+                              "foreign_key",
+                              "custom"
+                            ]
+                          },
+                          "name": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "expression": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "warn_unenforced": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "warn_unsupported": {
+                            "type": "boolean",
+                            "default": true
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "type"
+                        ]
+                      }
+                    },
+                    "quote": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "_extra": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": true,
+                  "required": [
+                    "name"
+                  ]
+                },
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "meta": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "docs": {
+                "type": "object",
+                "title": "Docs",
+                "properties": {
+                  "show": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "node_color": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "patch_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "build_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "deferred": {
+                "type": "boolean",
+                "default": false
+              },
+              "unrendered_config": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "created_at": {
+                "type": "number"
+              },
+              "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "relation_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "raw_code": {
+                "type": "string",
+                "default": ""
+              },
+              "language": {
+                "type": "string",
+                "default": "sql"
+              },
+              "refs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "RefArgs",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "package": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "metrics": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "depends_on": {
+                "type": "object",
+                "title": "DependsOn",
+                "properties": {
+                  "macros": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "nodes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "compiled_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "compiled": {
+                "type": "boolean",
+                "default": false
+              },
+              "compiled_code": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "extra_ctes_injected": {
+                "type": "boolean",
+                "default": false
+              },
+              "extra_ctes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "InjectedCTE",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "sql": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "id",
+                    "sql"
+                  ]
+                }
+              },
+              "_pre_injected_sql": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "contract": {
+                "type": "object",
+                "title": "Contract",
+                "properties": {
+                  "enforced": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "alias_types": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "checksum": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "database",
+              "schema",
+              "name",
+              "resource_type",
+              "package_name",
+              "path",
+              "original_file_path",
+              "unique_id",
+              "fqn",
+              "alias",
+              "checksum"
+            ]
+          },
+          {
+            "type": "object",
+            "title": "GenericTestNode",
+            "properties": {
+              "test_metadata": {
+                "type": "object",
+                "title": "TestMetadata",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "kwargs": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "namespace": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "name"
+                ]
+              },
+              "database": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "resource_type": {
+                "const": "test"
+              },
+              "package_name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "original_file_path": {
+                "type": "string"
+              },
+              "unique_id": {
+                "type": "string"
+              },
+              "fqn": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "alias": {
+                "type": "string"
+              },
+              "checksum": {
+                "type": "object",
+                "title": "FileHash",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "checksum": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "name",
+                  "checksum"
+                ]
+              },
+              "config": {
+                "type": "object",
+                "title": "TestConfig",
+                "properties": {
+                  "_extra": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "alias": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": "dbt_test__audit"
+                  },
+                  "database": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tags": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "group": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "materialized": {
+                    "type": "string",
+                    "default": "test"
+                  },
+                  "severity": {
+                    "type": "string",
+                    "default": "ERROR",
+                    "pattern": "^([Ww][Aa][Rr][Nn]|[Ee][Rr][Rr][Oo][Rr])$"
+                  },
+                  "store_failures": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "store_failures_as": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "where": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "limit": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "fail_calc": {
+                    "type": "string",
+                    "default": "count(*)"
+                  },
+                  "warn_if": {
+                    "type": "string",
+                    "default": "!= 0"
+                  },
+                  "error_if": {
+                    "type": "string",
+                    "default": "!= 0"
+                  }
+                },
+                "additionalProperties": true
+              },
+              "_event_status": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "description": {
+                "type": "string",
+                "default": ""
+              },
+              "columns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "title": "ColumnInfo",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "data_type": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "ColumnLevelConstraint",
+                        "properties": {
+                          "type": {
+                            "enum": [
+                              "check",
+                              "not_null",
+                              "unique",
+                              "primary_key",
+                              "foreign_key",
+                              "custom"
+                            ]
+                          },
+                          "name": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "expression": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "warn_unenforced": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "warn_unsupported": {
+                            "type": "boolean",
+                            "default": true
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "type"
+                        ]
+                      }
+                    },
+                    "quote": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "_extra": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": true,
+                  "required": [
+                    "name"
+                  ]
+                },
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "meta": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "docs": {
+                "type": "object",
+                "title": "Docs",
+                "properties": {
+                  "show": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "node_color": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "patch_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "build_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "deferred": {
+                "type": "boolean",
+                "default": false
+              },
+              "unrendered_config": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "created_at": {
+                "type": "number"
+              },
+              "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "relation_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "raw_code": {
+                "type": "string",
+                "default": ""
+              },
+              "language": {
+                "type": "string",
+                "default": "sql"
+              },
+              "refs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "RefArgs",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "package": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "metrics": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "depends_on": {
+                "type": "object",
+                "title": "DependsOn",
+                "properties": {
+                  "macros": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "nodes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "compiled_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "compiled": {
+                "type": "boolean",
+                "default": false
+              },
+              "compiled_code": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "extra_ctes_injected": {
+                "type": "boolean",
+                "default": false
+              },
+              "extra_ctes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "InjectedCTE",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "sql": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "id",
+                    "sql"
+                  ]
+                }
+              },
+              "_pre_injected_sql": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "contract": {
+                "type": "object",
+                "title": "Contract",
+                "properties": {
+                  "enforced": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "alias_types": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "checksum": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "column_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "file_key_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "attached_node": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "test_metadata",
+              "database",
+              "schema",
+              "name",
+              "resource_type",
+              "package_name",
+              "path",
+              "original_file_path",
+              "unique_id",
+              "fqn",
+              "alias",
+              "checksum"
+            ]
+          },
+          {
+            "type": "object",
+            "title": "SnapshotNode",
+            "properties": {
+              "database": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "resource_type": {
+                "const": "snapshot"
+              },
+              "package_name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "original_file_path": {
+                "type": "string"
+              },
+              "unique_id": {
+                "type": "string"
+              },
+              "fqn": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "alias": {
+                "type": "string"
+              },
+              "checksum": {
+                "type": "object",
+                "title": "FileHash",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "checksum": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "name",
+                  "checksum"
+                ]
+              },
+              "config": {
+                "type": "object",
+                "title": "SnapshotConfig",
+                "properties": {
+                  "_extra": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "alias": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "database": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tags": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "group": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "materialized": {
+                    "type": "string",
+                    "default": "snapshot"
+                  },
+                  "incremental_strategy": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "persist_docs": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "post-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "pre-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "quoting": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "column_types": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "full_refresh": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "unique_key": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "on_schema_change": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": "ignore"
+                  },
+                  "on_configuration_change": {
+                    "enum": [
+                      "apply",
+                      "continue",
+                      "fail"
+                    ]
+                  },
+                  "grants": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "packages": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "docs": {
+                    "type": "object",
+                    "title": "Docs",
+                    "properties": {
+                      "show": {
+                        "type": "boolean",
+                        "default": true
+                      },
+                      "node_color": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "contract": {
+                    "type": "object",
+                    "title": "ContractConfig",
+                    "properties": {
+                      "enforced": {
+                        "type": "boolean",
+                        "default": false
+                      },
+                      "alias_types": {
+                        "type": "boolean",
+                        "default": true
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "strategy": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "target_schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "target_database": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "updated_at": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "check_cols": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": true
+              },
+              "_event_status": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "description": {
+                "type": "string",
+                "default": ""
+              },
+              "columns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "title": "ColumnInfo",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "data_type": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "ColumnLevelConstraint",
+                        "properties": {
+                          "type": {
+                            "enum": [
+                              "check",
+                              "not_null",
+                              "unique",
+                              "primary_key",
+                              "foreign_key",
+                              "custom"
+                            ]
+                          },
+                          "name": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "expression": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "warn_unenforced": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "warn_unsupported": {
+                            "type": "boolean",
+                            "default": true
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "type"
+                        ]
+                      }
+                    },
+                    "quote": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "_extra": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": true,
+                  "required": [
+                    "name"
+                  ]
+                },
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "meta": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "docs": {
+                "type": "object",
+                "title": "Docs",
+                "properties": {
+                  "show": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "node_color": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "patch_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "build_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "deferred": {
+                "type": "boolean",
+                "default": false
+              },
+              "unrendered_config": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "created_at": {
+                "type": "number"
+              },
+              "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "relation_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "raw_code": {
+                "type": "string",
+                "default": ""
+              },
+              "language": {
+                "type": "string",
+                "default": "sql"
+              },
+              "refs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "RefArgs",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "package": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "metrics": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "depends_on": {
+                "type": "object",
+                "title": "DependsOn",
+                "properties": {
+                  "macros": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "nodes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "compiled_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "compiled": {
+                "type": "boolean",
+                "default": false
+              },
+              "compiled_code": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "extra_ctes_injected": {
+                "type": "boolean",
+                "default": false
+              },
+              "extra_ctes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "InjectedCTE",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "sql": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "id",
+                    "sql"
+                  ]
+                }
+              },
+              "_pre_injected_sql": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "contract": {
+                "type": "object",
+                "title": "Contract",
+                "properties": {
+                  "enforced": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "alias_types": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "checksum": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "defer_relation": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "title": "DeferRelation",
+                    "properties": {
+                      "database": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "schema": {
+                        "type": "string"
+                      },
+                      "alias": {
+                        "type": "string"
+                      },
+                      "relation_name": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "database",
+                      "schema",
+                      "alias",
+                      "relation_name"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "database",
+              "schema",
+              "name",
+              "resource_type",
+              "package_name",
+              "path",
+              "original_file_path",
+              "unique_id",
+              "fqn",
+              "alias",
+              "checksum",
+              "config"
+            ]
+          },
+          {
+            "type": "object",
+            "title": "SeedNode",
+            "properties": {
+              "database": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "resource_type": {
+                "const": "seed"
+              },
+              "package_name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "original_file_path": {
+                "type": "string"
+              },
+              "unique_id": {
+                "type": "string"
+              },
+              "fqn": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "alias": {
+                "type": "string"
+              },
+              "checksum": {
+                "type": "object",
+                "title": "FileHash",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "checksum": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "name",
+                  "checksum"
+                ]
+              },
+              "config": {
+                "type": "object",
+                "title": "SeedConfig",
+                "properties": {
+                  "_extra": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "alias": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "database": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tags": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "group": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "materialized": {
+                    "type": "string",
+                    "default": "seed"
+                  },
+                  "incremental_strategy": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "persist_docs": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "post-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "pre-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "quoting": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "column_types": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "full_refresh": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "unique_key": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "on_schema_change": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": "ignore"
+                  },
+                  "on_configuration_change": {
+                    "enum": [
+                      "apply",
+                      "continue",
+                      "fail"
+                    ]
+                  },
+                  "grants": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "packages": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "docs": {
+                    "type": "object",
+                    "title": "Docs",
+                    "properties": {
+                      "show": {
+                        "type": "boolean",
+                        "default": true
+                      },
+                      "node_color": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "contract": {
+                    "type": "object",
+                    "title": "ContractConfig",
+                    "properties": {
+                      "enforced": {
+                        "type": "boolean",
+                        "default": false
+                      },
+                      "alias_types": {
+                        "type": "boolean",
+                        "default": true
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "delimiter": {
+                    "type": "string",
+                    "default": ","
+                  },
+                  "quote_columns": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": true
+              },
+              "_event_status": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "description": {
+                "type": "string",
+                "default": ""
+              },
+              "columns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "title": "ColumnInfo",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "data_type": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "ColumnLevelConstraint",
+                        "properties": {
+                          "type": {
+                            "enum": [
+                              "check",
+                              "not_null",
+                              "unique",
+                              "primary_key",
+                              "foreign_key",
+                              "custom"
+                            ]
+                          },
+                          "name": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "expression": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "warn_unenforced": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "warn_unsupported": {
+                            "type": "boolean",
+                            "default": true
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "type"
+                        ]
+                      }
+                    },
+                    "quote": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "_extra": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": true,
+                  "required": [
+                    "name"
+                  ]
+                },
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "meta": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "docs": {
+                "type": "object",
+                "title": "Docs",
+                "properties": {
+                  "show": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "node_color": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "patch_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "build_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "deferred": {
+                "type": "boolean",
+                "default": false
+              },
+              "unrendered_config": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "created_at": {
+                "type": "number"
+              },
+              "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "relation_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "raw_code": {
+                "type": "string",
+                "default": ""
+              },
+              "root_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "depends_on": {
+                "type": "object",
+                "title": "MacroDependsOn",
+                "properties": {
+                  "macros": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "defer_relation": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "title": "DeferRelation",
+                    "properties": {
+                      "database": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "schema": {
+                        "type": "string"
+                      },
+                      "alias": {
+                        "type": "string"
+                      },
+                      "relation_name": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "database",
+                      "schema",
+                      "alias",
+                      "relation_name"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "database",
+              "schema",
+              "name",
+              "resource_type",
+              "package_name",
+              "path",
+              "original_file_path",
+              "unique_id",
+              "fqn",
+              "alias",
+              "checksum"
+            ]
           }
-        }
+        ]
       },
-      "additionalProperties": false,
-      "required": [
-        "metadata",
-        "nodes",
-        "sources",
-        "macros",
-        "docs",
-        "exposures",
-        "metrics",
-        "groups",
-        "selectors",
-        "disabled",
-        "parent_map",
-        "child_map",
-        "group_map",
-        "saved_queries",
-        "semantic_models"
+      "propertyNames": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "type": "object",
+      "description": "The sources defined in the dbt project and its dependencies",
+      "additionalProperties": {
+        "type": "object",
+        "title": "SourceDefinition",
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "resource_type": {
+            "const": "source"
+          },
+          "package_name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "original_file_path": {
+            "type": "string"
+          },
+          "unique_id": {
+            "type": "string"
+          },
+          "fqn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "source_name": {
+            "type": "string"
+          },
+          "source_description": {
+            "type": "string"
+          },
+          "loader": {
+            "type": "string"
+          },
+          "identifier": {
+            "type": "string"
+          },
+          "_event_status": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "quoting": {
+            "type": "object",
+            "title": "Quoting",
+            "properties": {
+              "database": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "identifier": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "column": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": false
+          },
+          "loaded_at_field": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "freshness": {
+            "anyOf": [
+              {
+                "type": "object",
+                "title": "FreshnessThreshold",
+                "properties": {
+                  "warn_after": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "title": "Time",
+                        "properties": {
+                          "count": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "period": {
+                            "anyOf": [
+                              {
+                                "enum": [
+                                  "minute",
+                                  "hour",
+                                  "day"
+                                ]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "error_after": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "title": "Time",
+                        "properties": {
+                          "count": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "period": {
+                            "anyOf": [
+                              {
+                                "enum": [
+                                  "minute",
+                                  "hour",
+                                  "day"
+                                ]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "filter": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "external": {
+            "anyOf": [
+              {
+                "type": "object",
+                "title": "ExternalTable",
+                "properties": {
+                  "_extra": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "location": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "file_format": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "row_format": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tbl_properties": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "partitions": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "title": "ExternalPartition",
+                          "properties": {
+                            "_extra": {
+                              "type": "object",
+                              "propertyNames": {
+                                "type": "string"
+                              }
+                            },
+                            "name": {
+                              "type": "string",
+                              "default": ""
+                            },
+                            "description": {
+                              "type": "string",
+                              "default": ""
+                            },
+                            "data_type": {
+                              "type": "string",
+                              "default": ""
+                            },
+                            "meta": {
+                              "type": "object",
+                              "propertyNames": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "additionalProperties": true
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "description": {
+            "type": "string",
+            "default": ""
+          },
+          "columns": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "title": "ColumnInfo",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string",
+                  "default": ""
+                },
+                "meta": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  }
+                },
+                "data_type": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "constraints": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "title": "ColumnLevelConstraint",
+                    "properties": {
+                      "type": {
+                        "enum": [
+                          "check",
+                          "not_null",
+                          "unique",
+                          "primary_key",
+                          "foreign_key",
+                          "custom"
+                        ]
+                      },
+                      "name": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "expression": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "warn_unenforced": {
+                        "type": "boolean",
+                        "default": true
+                      },
+                      "warn_unsupported": {
+                        "type": "boolean",
+                        "default": true
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "type"
+                    ]
+                  }
+                },
+                "quote": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "_extra": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "name"
+              ]
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "meta": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "source_meta": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "config": {
+            "type": "object",
+            "title": "SourceConfig",
+            "properties": {
+              "_extra": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "enabled": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "additionalProperties": true
+          },
+          "patch_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "unrendered_config": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "relation_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "created_at": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "database",
+          "schema",
+          "name",
+          "resource_type",
+          "package_name",
+          "path",
+          "original_file_path",
+          "unique_id",
+          "fqn",
+          "source_name",
+          "source_description",
+          "loader",
+          "identifier"
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      }
+    },
+    "macros": {
+      "type": "object",
+      "description": "The macros defined in the dbt project and its dependencies",
+      "additionalProperties": {
+        "type": "object",
+        "title": "Macro",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "resource_type": {
+            "const": "macro"
+          },
+          "package_name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "original_file_path": {
+            "type": "string"
+          },
+          "unique_id": {
+            "type": "string"
+          },
+          "macro_sql": {
+            "type": "string"
+          },
+          "depends_on": {
+            "type": "object",
+            "title": "MacroDependsOn",
+            "properties": {
+              "macros": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "description": {
+            "type": "string",
+            "default": ""
+          },
+          "meta": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "docs": {
+            "type": "object",
+            "title": "Docs",
+            "properties": {
+              "show": {
+                "type": "boolean",
+                "default": true
+              },
+              "node_color": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": false
+          },
+          "patch_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "arguments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "MacroArgument",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "description": {
+                  "type": "string",
+                  "default": ""
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name"
+              ]
+            }
+          },
+          "created_at": {
+            "type": "number"
+          },
+          "supported_languages": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "enum": [
+                    "python",
+                    "sql"
+                  ]
+                }
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "resource_type",
+          "package_name",
+          "path",
+          "original_file_path",
+          "unique_id",
+          "macro_sql"
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      }
+    },
+    "docs": {
+      "type": "object",
+      "description": "The docs defined in the dbt project and its dependencies",
+      "additionalProperties": {
+        "type": "object",
+        "title": "Documentation",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "resource_type": {
+            "const": "doc"
+          },
+          "package_name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "original_file_path": {
+            "type": "string"
+          },
+          "unique_id": {
+            "type": "string"
+          },
+          "block_contents": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "resource_type",
+          "package_name",
+          "path",
+          "original_file_path",
+          "unique_id",
+          "block_contents"
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      }
+    },
+    "exposures": {
+      "type": "object",
+      "description": "The exposures defined in the dbt project and its dependencies",
+      "additionalProperties": {
+        "type": "object",
+        "title": "Exposure",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "resource_type": {
+            "const": "exposure"
+          },
+          "package_name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "original_file_path": {
+            "type": "string"
+          },
+          "unique_id": {
+            "type": "string"
+          },
+          "fqn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "type": {
+            "enum": [
+              "dashboard",
+              "notebook",
+              "analysis",
+              "ml",
+              "application"
+            ]
+          },
+          "owner": {
+            "type": "object",
+            "title": "Owner",
+            "properties": {
+              "_extra": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "email": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": true
+          },
+          "description": {
+            "type": "string",
+            "default": ""
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "maturity": {
+            "anyOf": [
+              {
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "meta": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "config": {
+            "type": "object",
+            "title": "ExposureConfig",
+            "properties": {
+              "_extra": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "enabled": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "additionalProperties": true
+          },
+          "unrendered_config": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "depends_on": {
+            "type": "object",
+            "title": "DependsOn",
+            "properties": {
+              "macros": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "nodes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "refs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "RefArgs",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "package": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "version": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name"
+              ]
+            }
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "created_at": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "resource_type",
+          "package_name",
+          "path",
+          "original_file_path",
+          "unique_id",
+          "fqn",
+          "type",
+          "owner"
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "description": "The metrics defined in the dbt project and its dependencies",
+      "additionalProperties": {
+        "type": "object",
+        "title": "Metric",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "resource_type": {
+            "const": "metric"
+          },
+          "package_name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "original_file_path": {
+            "type": "string"
+          },
+          "unique_id": {
+            "type": "string"
+          },
+          "fqn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "simple",
+              "ratio",
+              "cumulative",
+              "derived"
+            ]
+          },
+          "type_params": {
+            "type": "object",
+            "title": "MetricTypeParams",
+            "properties": {
+              "measure": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "title": "MetricInputMeasure",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "filter": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "title": "WhereFilterIntersection",
+                            "properties": {
+                              "where_filters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "title": "WhereFilter",
+                                  "properties": {
+                                    "where_sql_template": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "where_sql_template"
+                                  ]
+                                }
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "where_filters"
+                            ]
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "alias": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "join_to_timespine": {
+                        "type": "boolean",
+                        "default": false
+                      },
+                      "fill_nulls_with": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "name"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "input_measures": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "MetricInputMeasure",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "filter": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "title": "WhereFilterIntersection",
+                          "properties": {
+                            "where_filters": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "title": "WhereFilter",
+                                "properties": {
+                                  "where_sql_template": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "where_sql_template"
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "where_filters"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "alias": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "join_to_timespine": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "fill_nulls_with": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              "numerator": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "title": "MetricInput",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "filter": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "title": "WhereFilterIntersection",
+                            "properties": {
+                              "where_filters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "title": "WhereFilter",
+                                  "properties": {
+                                    "where_sql_template": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "where_sql_template"
+                                  ]
+                                }
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "where_filters"
+                            ]
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "alias": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "offset_window": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "title": "MetricTimeWindow",
+                            "properties": {
+                              "count": {
+                                "type": "integer"
+                              },
+                              "granularity": {
+                                "enum": [
+                                  "day",
+                                  "week",
+                                  "month",
+                                  "quarter",
+                                  "year"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "count",
+                              "granularity"
+                            ]
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "offset_to_grain": {
+                        "anyOf": [
+                          {
+                            "enum": [
+                              "day",
+                              "week",
+                              "month",
+                              "quarter",
+                              "year"
+                            ]
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "name"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "denominator": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "title": "MetricInput",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "filter": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "title": "WhereFilterIntersection",
+                            "properties": {
+                              "where_filters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "title": "WhereFilter",
+                                  "properties": {
+                                    "where_sql_template": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "where_sql_template"
+                                  ]
+                                }
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "where_filters"
+                            ]
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "alias": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "offset_window": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "title": "MetricTimeWindow",
+                            "properties": {
+                              "count": {
+                                "type": "integer"
+                              },
+                              "granularity": {
+                                "enum": [
+                                  "day",
+                                  "week",
+                                  "month",
+                                  "quarter",
+                                  "year"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "count",
+                              "granularity"
+                            ]
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "offset_to_grain": {
+                        "anyOf": [
+                          {
+                            "enum": [
+                              "day",
+                              "week",
+                              "month",
+                              "quarter",
+                              "year"
+                            ]
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "name"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "expr": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "window": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "title": "MetricTimeWindow",
+                    "properties": {
+                      "count": {
+                        "type": "integer"
+                      },
+                      "granularity": {
+                        "enum": [
+                          "day",
+                          "week",
+                          "month",
+                          "quarter",
+                          "year"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "count",
+                      "granularity"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "grain_to_date": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "day",
+                      "week",
+                      "month",
+                      "quarter",
+                      "year"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "metrics": {
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "MetricInput",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "filter": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "title": "WhereFilterIntersection",
+                              "properties": {
+                                "where_filters": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "title": "WhereFilter",
+                                    "properties": {
+                                      "where_sql_template": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "required": [
+                                      "where_sql_template"
+                                    ]
+                                  }
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "where_filters"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "alias": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "offset_window": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "title": "MetricTimeWindow",
+                              "properties": {
+                                "count": {
+                                  "type": "integer"
+                                },
+                                "granularity": {
+                                  "enum": [
+                                    "day",
+                                    "week",
+                                    "month",
+                                    "quarter",
+                                    "year"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "count",
+                                "granularity"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "offset_to_grain": {
+                          "anyOf": [
+                            {
+                              "enum": [
+                                "day",
+                                "week",
+                                "month",
+                                "quarter",
+                                "year"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "name"
+                      ]
+                    }
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": false
+          },
+          "filter": {
+            "anyOf": [
+              {
+                "type": "object",
+                "title": "WhereFilterIntersection",
+                "properties": {
+                  "where_filters": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "WhereFilter",
+                      "properties": {
+                        "where_sql_template": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "where_sql_template"
+                      ]
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "where_filters"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "type": "object",
+                "title": "SourceFileMetadata",
+                "properties": {
+                  "repo_file_path": {
+                    "type": "string"
+                  },
+                  "file_slice": {
+                    "type": "object",
+                    "title": "FileSlice",
+                    "properties": {
+                      "filename": {
+                        "type": "string"
+                      },
+                      "content": {
+                        "type": "string"
+                      },
+                      "start_line_number": {
+                        "type": "integer"
+                      },
+                      "end_line_number": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "filename",
+                      "content",
+                      "start_line_number",
+                      "end_line_number"
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "repo_file_path",
+                  "file_slice"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "meta": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "config": {
+            "type": "object",
+            "title": "MetricConfig",
+            "properties": {
+              "_extra": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "enabled": {
+                "type": "boolean",
+                "default": true
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": true
+          },
+          "unrendered_config": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "depends_on": {
+            "type": "object",
+            "title": "DependsOn",
+            "properties": {
+              "macros": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "nodes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "refs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "RefArgs",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "package": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "version": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name"
+              ]
+            }
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "created_at": {
+            "type": "number"
+          },
+          "group": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "resource_type",
+          "package_name",
+          "path",
+          "original_file_path",
+          "unique_id",
+          "fqn",
+          "description",
+          "label",
+          "type",
+          "type_params"
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      }
+    },
+    "groups": {
+      "type": "object",
+      "description": "The groups defined in the dbt project",
+      "additionalProperties": {
+        "type": "object",
+        "title": "Group",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "resource_type": {
+            "const": "group"
+          },
+          "package_name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "original_file_path": {
+            "type": "string"
+          },
+          "unique_id": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "object",
+            "title": "Owner",
+            "properties": {
+              "_extra": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "email": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "resource_type",
+          "package_name",
+          "path",
+          "original_file_path",
+          "unique_id",
+          "owner"
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      }
+    },
+    "selectors": {
+      "type": "object",
+      "description": "The selectors defined in selectors.yml",
+      "propertyNames": {
+        "type": "string"
+      }
+    },
+    "disabled": {
+      "description": "A mapping of the disabled nodes in the target",
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "title": "AnalysisNode",
+                  "properties": {
+                    "database": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "schema": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "resource_type": {
+                      "const": "analysis"
+                    },
+                    "package_name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "original_file_path": {
+                      "type": "string"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    },
+                    "fqn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "alias": {
+                      "type": "string"
+                    },
+                    "checksum": {
+                      "type": "object",
+                      "title": "FileHash",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "name",
+                        "checksum"
+                      ]
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "NodeConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "alias": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "schema": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "database": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "tags": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "group": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "materialized": {
+                          "type": "string",
+                          "default": "view"
+                        },
+                        "incremental_strategy": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "persist_docs": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "post-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "pre-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "quoting": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "column_types": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "full_refresh": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "unique_key": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "on_schema_change": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": "ignore"
+                        },
+                        "on_configuration_change": {
+                          "enum": [
+                            "apply",
+                            "continue",
+                            "fail"
+                          ]
+                        },
+                        "grants": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "packages": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "docs": {
+                          "type": "object",
+                          "title": "Docs",
+                          "properties": {
+                            "show": {
+                              "type": "boolean",
+                              "default": true
+                            },
+                            "node_color": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "contract": {
+                          "type": "object",
+                          "title": "ContractConfig",
+                          "properties": {
+                            "enforced": {
+                              "type": "boolean",
+                              "default": false
+                            },
+                            "alias_types": {
+                              "type": "boolean",
+                              "default": true
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "_event_status": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "columns": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "title": "ColumnInfo",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "default": ""
+                          },
+                          "meta": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          },
+                          "data_type": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "constraints": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "title": "ColumnLevelConstraint",
+                              "properties": {
+                                "type": {
+                                  "enum": [
+                                    "check",
+                                    "not_null",
+                                    "unique",
+                                    "primary_key",
+                                    "foreign_key",
+                                    "custom"
+                                  ]
+                                },
+                                "name": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "expression": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "warn_unenforced": {
+                                  "type": "boolean",
+                                  "default": true
+                                },
+                                "warn_unsupported": {
+                                  "type": "boolean",
+                                  "default": true
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "quote": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "_extra": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": true,
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "group": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "docs": {
+                      "type": "object",
+                      "title": "Docs",
+                      "properties": {
+                        "show": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "node_color": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "patch_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "build_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "deferred": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "unrendered_config": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "created_at": {
+                      "type": "number"
+                    },
+                    "config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "relation_name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "raw_code": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "language": {
+                      "type": "string",
+                      "default": "sql"
+                    },
+                    "refs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "RefArgs",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "version": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "metrics": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "depends_on": {
+                      "type": "object",
+                      "title": "DependsOn",
+                      "properties": {
+                        "macros": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "nodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "compiled_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "compiled": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "compiled_code": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "extra_ctes_injected": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "extra_ctes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "InjectedCTE",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "sql": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "id",
+                          "sql"
+                        ]
+                      }
+                    },
+                    "_pre_injected_sql": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "contract": {
+                      "type": "object",
+                      "title": "Contract",
+                      "properties": {
+                        "enforced": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "alias_types": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "checksum": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "database",
+                    "schema",
+                    "name",
+                    "resource_type",
+                    "package_name",
+                    "path",
+                    "original_file_path",
+                    "unique_id",
+                    "fqn",
+                    "alias",
+                    "checksum"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "title": "SingularTestNode",
+                  "properties": {
+                    "database": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "schema": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "resource_type": {
+                      "const": "test"
+                    },
+                    "package_name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "original_file_path": {
+                      "type": "string"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    },
+                    "fqn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "alias": {
+                      "type": "string"
+                    },
+                    "checksum": {
+                      "type": "object",
+                      "title": "FileHash",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "name",
+                        "checksum"
+                      ]
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "TestConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "alias": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "schema": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": "dbt_test__audit"
+                        },
+                        "database": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "tags": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "group": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "materialized": {
+                          "type": "string",
+                          "default": "test"
+                        },
+                        "severity": {
+                          "type": "string",
+                          "default": "ERROR",
+                          "pattern": "^([Ww][Aa][Rr][Nn]|[Ee][Rr][Rr][Oo][Rr])$"
+                        },
+                        "store_failures": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "store_failures_as": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "where": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "limit": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "fail_calc": {
+                          "type": "string",
+                          "default": "count(*)"
+                        },
+                        "warn_if": {
+                          "type": "string",
+                          "default": "!= 0"
+                        },
+                        "error_if": {
+                          "type": "string",
+                          "default": "!= 0"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "_event_status": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "columns": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "title": "ColumnInfo",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "default": ""
+                          },
+                          "meta": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          },
+                          "data_type": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "constraints": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "title": "ColumnLevelConstraint",
+                              "properties": {
+                                "type": {
+                                  "enum": [
+                                    "check",
+                                    "not_null",
+                                    "unique",
+                                    "primary_key",
+                                    "foreign_key",
+                                    "custom"
+                                  ]
+                                },
+                                "name": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "expression": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "warn_unenforced": {
+                                  "type": "boolean",
+                                  "default": true
+                                },
+                                "warn_unsupported": {
+                                  "type": "boolean",
+                                  "default": true
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "quote": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "_extra": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": true,
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "group": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "docs": {
+                      "type": "object",
+                      "title": "Docs",
+                      "properties": {
+                        "show": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "node_color": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "patch_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "build_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "deferred": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "unrendered_config": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "created_at": {
+                      "type": "number"
+                    },
+                    "config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "relation_name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "raw_code": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "language": {
+                      "type": "string",
+                      "default": "sql"
+                    },
+                    "refs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "RefArgs",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "version": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "metrics": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "depends_on": {
+                      "type": "object",
+                      "title": "DependsOn",
+                      "properties": {
+                        "macros": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "nodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "compiled_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "compiled": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "compiled_code": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "extra_ctes_injected": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "extra_ctes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "InjectedCTE",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "sql": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "id",
+                          "sql"
+                        ]
+                      }
+                    },
+                    "_pre_injected_sql": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "contract": {
+                      "type": "object",
+                      "title": "Contract",
+                      "properties": {
+                        "enforced": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "alias_types": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "checksum": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "database",
+                    "schema",
+                    "name",
+                    "resource_type",
+                    "package_name",
+                    "path",
+                    "original_file_path",
+                    "unique_id",
+                    "fqn",
+                    "alias",
+                    "checksum"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "title": "HookNode",
+                  "properties": {
+                    "database": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "schema": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "resource_type": {
+                      "const": "operation"
+                    },
+                    "package_name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "original_file_path": {
+                      "type": "string"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    },
+                    "fqn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "alias": {
+                      "type": "string"
+                    },
+                    "checksum": {
+                      "type": "object",
+                      "title": "FileHash",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "name",
+                        "checksum"
+                      ]
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "NodeConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "alias": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "schema": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "database": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "tags": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "group": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "materialized": {
+                          "type": "string",
+                          "default": "view"
+                        },
+                        "incremental_strategy": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "persist_docs": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "post-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "pre-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "quoting": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "column_types": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "full_refresh": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "unique_key": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "on_schema_change": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": "ignore"
+                        },
+                        "on_configuration_change": {
+                          "enum": [
+                            "apply",
+                            "continue",
+                            "fail"
+                          ]
+                        },
+                        "grants": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "packages": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "docs": {
+                          "type": "object",
+                          "title": "Docs",
+                          "properties": {
+                            "show": {
+                              "type": "boolean",
+                              "default": true
+                            },
+                            "node_color": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "contract": {
+                          "type": "object",
+                          "title": "ContractConfig",
+                          "properties": {
+                            "enforced": {
+                              "type": "boolean",
+                              "default": false
+                            },
+                            "alias_types": {
+                              "type": "boolean",
+                              "default": true
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "_event_status": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "columns": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "title": "ColumnInfo",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "default": ""
+                          },
+                          "meta": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          },
+                          "data_type": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "constraints": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "title": "ColumnLevelConstraint",
+                              "properties": {
+                                "type": {
+                                  "enum": [
+                                    "check",
+                                    "not_null",
+                                    "unique",
+                                    "primary_key",
+                                    "foreign_key",
+                                    "custom"
+                                  ]
+                                },
+                                "name": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "expression": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "warn_unenforced": {
+                                  "type": "boolean",
+                                  "default": true
+                                },
+                                "warn_unsupported": {
+                                  "type": "boolean",
+                                  "default": true
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "quote": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "_extra": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": true,
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "group": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "docs": {
+                      "type": "object",
+                      "title": "Docs",
+                      "properties": {
+                        "show": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "node_color": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "patch_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "build_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "deferred": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "unrendered_config": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "created_at": {
+                      "type": "number"
+                    },
+                    "config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "relation_name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "raw_code": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "language": {
+                      "type": "string",
+                      "default": "sql"
+                    },
+                    "refs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "RefArgs",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "version": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "metrics": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "depends_on": {
+                      "type": "object",
+                      "title": "DependsOn",
+                      "properties": {
+                        "macros": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "nodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "compiled_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "compiled": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "compiled_code": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "extra_ctes_injected": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "extra_ctes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "InjectedCTE",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "sql": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "id",
+                          "sql"
+                        ]
+                      }
+                    },
+                    "_pre_injected_sql": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "contract": {
+                      "type": "object",
+                      "title": "Contract",
+                      "properties": {
+                        "enforced": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "alias_types": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "checksum": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "index": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "database",
+                    "schema",
+                    "name",
+                    "resource_type",
+                    "package_name",
+                    "path",
+                    "original_file_path",
+                    "unique_id",
+                    "fqn",
+                    "alias",
+                    "checksum"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "title": "ModelNode",
+                  "properties": {
+                    "database": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "schema": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "resource_type": {
+                      "const": "model"
+                    },
+                    "package_name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "original_file_path": {
+                      "type": "string"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    },
+                    "fqn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "alias": {
+                      "type": "string"
+                    },
+                    "checksum": {
+                      "type": "object",
+                      "title": "FileHash",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "name",
+                        "checksum"
+                      ]
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "ModelConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "alias": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "schema": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "database": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "tags": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "group": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "materialized": {
+                          "type": "string",
+                          "default": "view"
+                        },
+                        "incremental_strategy": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "persist_docs": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "post-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "pre-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "quoting": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "column_types": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "full_refresh": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "unique_key": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "on_schema_change": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": "ignore"
+                        },
+                        "on_configuration_change": {
+                          "enum": [
+                            "apply",
+                            "continue",
+                            "fail"
+                          ]
+                        },
+                        "grants": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "packages": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "docs": {
+                          "type": "object",
+                          "title": "Docs",
+                          "properties": {
+                            "show": {
+                              "type": "boolean",
+                              "default": true
+                            },
+                            "node_color": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "contract": {
+                          "type": "object",
+                          "title": "ContractConfig",
+                          "properties": {
+                            "enforced": {
+                              "type": "boolean",
+                              "default": false
+                            },
+                            "alias_types": {
+                              "type": "boolean",
+                              "default": true
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "access": {
+                          "enum": [
+                            "private",
+                            "protected",
+                            "public"
+                          ],
+                          "default": "protected"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "_event_status": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "columns": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "title": "ColumnInfo",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "default": ""
+                          },
+                          "meta": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          },
+                          "data_type": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "constraints": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "title": "ColumnLevelConstraint",
+                              "properties": {
+                                "type": {
+                                  "enum": [
+                                    "check",
+                                    "not_null",
+                                    "unique",
+                                    "primary_key",
+                                    "foreign_key",
+                                    "custom"
+                                  ]
+                                },
+                                "name": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "expression": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "warn_unenforced": {
+                                  "type": "boolean",
+                                  "default": true
+                                },
+                                "warn_unsupported": {
+                                  "type": "boolean",
+                                  "default": true
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "quote": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "_extra": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": true,
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "group": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "docs": {
+                      "type": "object",
+                      "title": "Docs",
+                      "properties": {
+                        "show": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "node_color": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "patch_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "build_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "deferred": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "unrendered_config": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "created_at": {
+                      "type": "number"
+                    },
+                    "config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "relation_name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "raw_code": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "language": {
+                      "type": "string",
+                      "default": "sql"
+                    },
+                    "refs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "RefArgs",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "version": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "metrics": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "depends_on": {
+                      "type": "object",
+                      "title": "DependsOn",
+                      "properties": {
+                        "macros": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "nodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "compiled_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "compiled": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "compiled_code": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "extra_ctes_injected": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "extra_ctes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "InjectedCTE",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "sql": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "id",
+                          "sql"
+                        ]
+                      }
+                    },
+                    "_pre_injected_sql": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "contract": {
+                      "type": "object",
+                      "title": "Contract",
+                      "properties": {
+                        "enforced": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "alias_types": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "checksum": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "access": {
+                      "enum": [
+                        "private",
+                        "protected",
+                        "public"
+                      ],
+                      "default": "protected"
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "ModelLevelConstraint",
+                        "properties": {
+                          "type": {
+                            "enum": [
+                              "check",
+                              "not_null",
+                              "unique",
+                              "primary_key",
+                              "foreign_key",
+                              "custom"
+                            ]
+                          },
+                          "name": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "expression": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "warn_unenforced": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "warn_unsupported": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "columns": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "type"
+                        ]
+                      }
+                    },
+                    "version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "latest_version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "deprecation_date": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "defer_relation": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "title": "DeferRelation",
+                          "properties": {
+                            "database": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "schema": {
+                              "type": "string"
+                            },
+                            "alias": {
+                              "type": "string"
+                            },
+                            "relation_name": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "database",
+                            "schema",
+                            "alias",
+                            "relation_name"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "database",
+                    "schema",
+                    "name",
+                    "resource_type",
+                    "package_name",
+                    "path",
+                    "original_file_path",
+                    "unique_id",
+                    "fqn",
+                    "alias",
+                    "checksum"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "title": "RPCNode",
+                  "properties": {
+                    "database": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "schema": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "resource_type": {
+                      "const": "rpc"
+                    },
+                    "package_name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "original_file_path": {
+                      "type": "string"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    },
+                    "fqn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "alias": {
+                      "type": "string"
+                    },
+                    "checksum": {
+                      "type": "object",
+                      "title": "FileHash",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "name",
+                        "checksum"
+                      ]
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "NodeConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "alias": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "schema": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "database": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "tags": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "group": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "materialized": {
+                          "type": "string",
+                          "default": "view"
+                        },
+                        "incremental_strategy": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "persist_docs": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "post-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "pre-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "quoting": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "column_types": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "full_refresh": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "unique_key": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "on_schema_change": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": "ignore"
+                        },
+                        "on_configuration_change": {
+                          "enum": [
+                            "apply",
+                            "continue",
+                            "fail"
+                          ]
+                        },
+                        "grants": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "packages": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "docs": {
+                          "type": "object",
+                          "title": "Docs",
+                          "properties": {
+                            "show": {
+                              "type": "boolean",
+                              "default": true
+                            },
+                            "node_color": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "contract": {
+                          "type": "object",
+                          "title": "ContractConfig",
+                          "properties": {
+                            "enforced": {
+                              "type": "boolean",
+                              "default": false
+                            },
+                            "alias_types": {
+                              "type": "boolean",
+                              "default": true
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "_event_status": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "columns": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "title": "ColumnInfo",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "default": ""
+                          },
+                          "meta": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          },
+                          "data_type": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "constraints": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "title": "ColumnLevelConstraint",
+                              "properties": {
+                                "type": {
+                                  "enum": [
+                                    "check",
+                                    "not_null",
+                                    "unique",
+                                    "primary_key",
+                                    "foreign_key",
+                                    "custom"
+                                  ]
+                                },
+                                "name": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "expression": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "warn_unenforced": {
+                                  "type": "boolean",
+                                  "default": true
+                                },
+                                "warn_unsupported": {
+                                  "type": "boolean",
+                                  "default": true
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "quote": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "_extra": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": true,
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "group": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "docs": {
+                      "type": "object",
+                      "title": "Docs",
+                      "properties": {
+                        "show": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "node_color": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "patch_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "build_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "deferred": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "unrendered_config": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "created_at": {
+                      "type": "number"
+                    },
+                    "config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "relation_name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "raw_code": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "language": {
+                      "type": "string",
+                      "default": "sql"
+                    },
+                    "refs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "RefArgs",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "version": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "metrics": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "depends_on": {
+                      "type": "object",
+                      "title": "DependsOn",
+                      "properties": {
+                        "macros": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "nodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "compiled_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "compiled": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "compiled_code": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "extra_ctes_injected": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "extra_ctes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "InjectedCTE",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "sql": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "id",
+                          "sql"
+                        ]
+                      }
+                    },
+                    "_pre_injected_sql": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "contract": {
+                      "type": "object",
+                      "title": "Contract",
+                      "properties": {
+                        "enforced": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "alias_types": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "checksum": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "database",
+                    "schema",
+                    "name",
+                    "resource_type",
+                    "package_name",
+                    "path",
+                    "original_file_path",
+                    "unique_id",
+                    "fqn",
+                    "alias",
+                    "checksum"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "title": "SqlNode",
+                  "properties": {
+                    "database": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "schema": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "resource_type": {
+                      "const": "sql_operation"
+                    },
+                    "package_name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "original_file_path": {
+                      "type": "string"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    },
+                    "fqn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "alias": {
+                      "type": "string"
+                    },
+                    "checksum": {
+                      "type": "object",
+                      "title": "FileHash",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "name",
+                        "checksum"
+                      ]
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "NodeConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "alias": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "schema": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "database": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "tags": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "group": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "materialized": {
+                          "type": "string",
+                          "default": "view"
+                        },
+                        "incremental_strategy": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "persist_docs": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "post-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "pre-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "quoting": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "column_types": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "full_refresh": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "unique_key": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "on_schema_change": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": "ignore"
+                        },
+                        "on_configuration_change": {
+                          "enum": [
+                            "apply",
+                            "continue",
+                            "fail"
+                          ]
+                        },
+                        "grants": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "packages": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "docs": {
+                          "type": "object",
+                          "title": "Docs",
+                          "properties": {
+                            "show": {
+                              "type": "boolean",
+                              "default": true
+                            },
+                            "node_color": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "contract": {
+                          "type": "object",
+                          "title": "ContractConfig",
+                          "properties": {
+                            "enforced": {
+                              "type": "boolean",
+                              "default": false
+                            },
+                            "alias_types": {
+                              "type": "boolean",
+                              "default": true
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "_event_status": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "columns": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "title": "ColumnInfo",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "default": ""
+                          },
+                          "meta": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          },
+                          "data_type": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "constraints": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "title": "ColumnLevelConstraint",
+                              "properties": {
+                                "type": {
+                                  "enum": [
+                                    "check",
+                                    "not_null",
+                                    "unique",
+                                    "primary_key",
+                                    "foreign_key",
+                                    "custom"
+                                  ]
+                                },
+                                "name": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "expression": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "warn_unenforced": {
+                                  "type": "boolean",
+                                  "default": true
+                                },
+                                "warn_unsupported": {
+                                  "type": "boolean",
+                                  "default": true
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "quote": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "_extra": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": true,
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "group": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "docs": {
+                      "type": "object",
+                      "title": "Docs",
+                      "properties": {
+                        "show": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "node_color": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "patch_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "build_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "deferred": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "unrendered_config": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "created_at": {
+                      "type": "number"
+                    },
+                    "config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "relation_name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "raw_code": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "language": {
+                      "type": "string",
+                      "default": "sql"
+                    },
+                    "refs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "RefArgs",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "version": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "metrics": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "depends_on": {
+                      "type": "object",
+                      "title": "DependsOn",
+                      "properties": {
+                        "macros": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "nodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "compiled_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "compiled": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "compiled_code": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "extra_ctes_injected": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "extra_ctes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "InjectedCTE",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "sql": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "id",
+                          "sql"
+                        ]
+                      }
+                    },
+                    "_pre_injected_sql": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "contract": {
+                      "type": "object",
+                      "title": "Contract",
+                      "properties": {
+                        "enforced": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "alias_types": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "checksum": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "database",
+                    "schema",
+                    "name",
+                    "resource_type",
+                    "package_name",
+                    "path",
+                    "original_file_path",
+                    "unique_id",
+                    "fqn",
+                    "alias",
+                    "checksum"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "title": "GenericTestNode",
+                  "properties": {
+                    "test_metadata": {
+                      "type": "object",
+                      "title": "TestMetadata",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "kwargs": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "namespace": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    "database": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "schema": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "resource_type": {
+                      "const": "test"
+                    },
+                    "package_name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "original_file_path": {
+                      "type": "string"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    },
+                    "fqn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "alias": {
+                      "type": "string"
+                    },
+                    "checksum": {
+                      "type": "object",
+                      "title": "FileHash",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "name",
+                        "checksum"
+                      ]
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "TestConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "alias": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "schema": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": "dbt_test__audit"
+                        },
+                        "database": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "tags": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "group": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "materialized": {
+                          "type": "string",
+                          "default": "test"
+                        },
+                        "severity": {
+                          "type": "string",
+                          "default": "ERROR",
+                          "pattern": "^([Ww][Aa][Rr][Nn]|[Ee][Rr][Rr][Oo][Rr])$"
+                        },
+                        "store_failures": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "store_failures_as": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "where": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "limit": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "fail_calc": {
+                          "type": "string",
+                          "default": "count(*)"
+                        },
+                        "warn_if": {
+                          "type": "string",
+                          "default": "!= 0"
+                        },
+                        "error_if": {
+                          "type": "string",
+                          "default": "!= 0"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "_event_status": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "columns": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "title": "ColumnInfo",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "default": ""
+                          },
+                          "meta": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          },
+                          "data_type": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "constraints": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "title": "ColumnLevelConstraint",
+                              "properties": {
+                                "type": {
+                                  "enum": [
+                                    "check",
+                                    "not_null",
+                                    "unique",
+                                    "primary_key",
+                                    "foreign_key",
+                                    "custom"
+                                  ]
+                                },
+                                "name": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "expression": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "warn_unenforced": {
+                                  "type": "boolean",
+                                  "default": true
+                                },
+                                "warn_unsupported": {
+                                  "type": "boolean",
+                                  "default": true
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "quote": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "_extra": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": true,
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "group": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "docs": {
+                      "type": "object",
+                      "title": "Docs",
+                      "properties": {
+                        "show": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "node_color": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "patch_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "build_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "deferred": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "unrendered_config": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "created_at": {
+                      "type": "number"
+                    },
+                    "config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "relation_name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "raw_code": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "language": {
+                      "type": "string",
+                      "default": "sql"
+                    },
+                    "refs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "RefArgs",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "version": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "metrics": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "depends_on": {
+                      "type": "object",
+                      "title": "DependsOn",
+                      "properties": {
+                        "macros": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "nodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "compiled_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "compiled": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "compiled_code": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "extra_ctes_injected": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "extra_ctes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "InjectedCTE",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "sql": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "id",
+                          "sql"
+                        ]
+                      }
+                    },
+                    "_pre_injected_sql": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "contract": {
+                      "type": "object",
+                      "title": "Contract",
+                      "properties": {
+                        "enforced": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "alias_types": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "checksum": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "column_name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "file_key_name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "attached_node": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "test_metadata",
+                    "database",
+                    "schema",
+                    "name",
+                    "resource_type",
+                    "package_name",
+                    "path",
+                    "original_file_path",
+                    "unique_id",
+                    "fqn",
+                    "alias",
+                    "checksum"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "title": "SnapshotNode",
+                  "properties": {
+                    "database": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "schema": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "resource_type": {
+                      "const": "snapshot"
+                    },
+                    "package_name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "original_file_path": {
+                      "type": "string"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    },
+                    "fqn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "alias": {
+                      "type": "string"
+                    },
+                    "checksum": {
+                      "type": "object",
+                      "title": "FileHash",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "name",
+                        "checksum"
+                      ]
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "SnapshotConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "alias": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "schema": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "database": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "tags": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "group": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "materialized": {
+                          "type": "string",
+                          "default": "snapshot"
+                        },
+                        "incremental_strategy": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "persist_docs": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "post-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "pre-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "quoting": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "column_types": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "full_refresh": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "unique_key": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "on_schema_change": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": "ignore"
+                        },
+                        "on_configuration_change": {
+                          "enum": [
+                            "apply",
+                            "continue",
+                            "fail"
+                          ]
+                        },
+                        "grants": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "packages": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "docs": {
+                          "type": "object",
+                          "title": "Docs",
+                          "properties": {
+                            "show": {
+                              "type": "boolean",
+                              "default": true
+                            },
+                            "node_color": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "contract": {
+                          "type": "object",
+                          "title": "ContractConfig",
+                          "properties": {
+                            "enforced": {
+                              "type": "boolean",
+                              "default": false
+                            },
+                            "alias_types": {
+                              "type": "boolean",
+                              "default": true
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "strategy": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "target_schema": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "target_database": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "updated_at": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "check_cols": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "_event_status": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "columns": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "title": "ColumnInfo",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "default": ""
+                          },
+                          "meta": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          },
+                          "data_type": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "constraints": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "title": "ColumnLevelConstraint",
+                              "properties": {
+                                "type": {
+                                  "enum": [
+                                    "check",
+                                    "not_null",
+                                    "unique",
+                                    "primary_key",
+                                    "foreign_key",
+                                    "custom"
+                                  ]
+                                },
+                                "name": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "expression": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "warn_unenforced": {
+                                  "type": "boolean",
+                                  "default": true
+                                },
+                                "warn_unsupported": {
+                                  "type": "boolean",
+                                  "default": true
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "quote": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "_extra": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": true,
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "group": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "docs": {
+                      "type": "object",
+                      "title": "Docs",
+                      "properties": {
+                        "show": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "node_color": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "patch_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "build_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "deferred": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "unrendered_config": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "created_at": {
+                      "type": "number"
+                    },
+                    "config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "relation_name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "raw_code": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "language": {
+                      "type": "string",
+                      "default": "sql"
+                    },
+                    "refs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "RefArgs",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "version": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "metrics": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "depends_on": {
+                      "type": "object",
+                      "title": "DependsOn",
+                      "properties": {
+                        "macros": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "nodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "compiled_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "compiled": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "compiled_code": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "extra_ctes_injected": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "extra_ctes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "InjectedCTE",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "sql": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "id",
+                          "sql"
+                        ]
+                      }
+                    },
+                    "_pre_injected_sql": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "contract": {
+                      "type": "object",
+                      "title": "Contract",
+                      "properties": {
+                        "enforced": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "alias_types": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "checksum": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "defer_relation": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "title": "DeferRelation",
+                          "properties": {
+                            "database": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "schema": {
+                              "type": "string"
+                            },
+                            "alias": {
+                              "type": "string"
+                            },
+                            "relation_name": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "database",
+                            "schema",
+                            "alias",
+                            "relation_name"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "database",
+                    "schema",
+                    "name",
+                    "resource_type",
+                    "package_name",
+                    "path",
+                    "original_file_path",
+                    "unique_id",
+                    "fqn",
+                    "alias",
+                    "checksum",
+                    "config"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "title": "SeedNode",
+                  "properties": {
+                    "database": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "schema": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "resource_type": {
+                      "const": "seed"
+                    },
+                    "package_name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "original_file_path": {
+                      "type": "string"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    },
+                    "fqn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "alias": {
+                      "type": "string"
+                    },
+                    "checksum": {
+                      "type": "object",
+                      "title": "FileHash",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "name",
+                        "checksum"
+                      ]
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "SeedConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "alias": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "schema": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "database": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "tags": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "group": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "materialized": {
+                          "type": "string",
+                          "default": "seed"
+                        },
+                        "incremental_strategy": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "persist_docs": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "post-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "pre-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "quoting": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "column_types": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "full_refresh": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "unique_key": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "on_schema_change": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": "ignore"
+                        },
+                        "on_configuration_change": {
+                          "enum": [
+                            "apply",
+                            "continue",
+                            "fail"
+                          ]
+                        },
+                        "grants": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "packages": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "docs": {
+                          "type": "object",
+                          "title": "Docs",
+                          "properties": {
+                            "show": {
+                              "type": "boolean",
+                              "default": true
+                            },
+                            "node_color": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "contract": {
+                          "type": "object",
+                          "title": "ContractConfig",
+                          "properties": {
+                            "enforced": {
+                              "type": "boolean",
+                              "default": false
+                            },
+                            "alias_types": {
+                              "type": "boolean",
+                              "default": true
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "delimiter": {
+                          "type": "string",
+                          "default": ","
+                        },
+                        "quote_columns": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "_event_status": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "columns": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "title": "ColumnInfo",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "default": ""
+                          },
+                          "meta": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          },
+                          "data_type": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "constraints": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "title": "ColumnLevelConstraint",
+                              "properties": {
+                                "type": {
+                                  "enum": [
+                                    "check",
+                                    "not_null",
+                                    "unique",
+                                    "primary_key",
+                                    "foreign_key",
+                                    "custom"
+                                  ]
+                                },
+                                "name": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "expression": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "warn_unenforced": {
+                                  "type": "boolean",
+                                  "default": true
+                                },
+                                "warn_unsupported": {
+                                  "type": "boolean",
+                                  "default": true
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "quote": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "_extra": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": true,
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "group": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "docs": {
+                      "type": "object",
+                      "title": "Docs",
+                      "properties": {
+                        "show": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "node_color": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "patch_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "build_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "deferred": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "unrendered_config": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "created_at": {
+                      "type": "number"
+                    },
+                    "config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "relation_name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "raw_code": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "root_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "depends_on": {
+                      "type": "object",
+                      "title": "MacroDependsOn",
+                      "properties": {
+                        "macros": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "defer_relation": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "title": "DeferRelation",
+                          "properties": {
+                            "database": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "schema": {
+                              "type": "string"
+                            },
+                            "alias": {
+                              "type": "string"
+                            },
+                            "relation_name": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "database",
+                            "schema",
+                            "alias",
+                            "relation_name"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "database",
+                    "schema",
+                    "name",
+                    "resource_type",
+                    "package_name",
+                    "path",
+                    "original_file_path",
+                    "unique_id",
+                    "fqn",
+                    "alias",
+                    "checksum"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "title": "SourceDefinition",
+                  "properties": {
+                    "database": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "schema": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "resource_type": {
+                      "const": "source"
+                    },
+                    "package_name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "original_file_path": {
+                      "type": "string"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    },
+                    "fqn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "source_name": {
+                      "type": "string"
+                    },
+                    "source_description": {
+                      "type": "string"
+                    },
+                    "loader": {
+                      "type": "string"
+                    },
+                    "identifier": {
+                      "type": "string"
+                    },
+                    "_event_status": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "quoting": {
+                      "type": "object",
+                      "title": "Quoting",
+                      "properties": {
+                        "database": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "schema": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "identifier": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "column": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "loaded_at_field": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "freshness": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "title": "FreshnessThreshold",
+                          "properties": {
+                            "warn_after": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "title": "Time",
+                                  "properties": {
+                                    "count": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "period": {
+                                      "anyOf": [
+                                        {
+                                          "enum": [
+                                            "minute",
+                                            "hour",
+                                            "day"
+                                          ]
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "error_after": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "title": "Time",
+                                  "properties": {
+                                    "count": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "period": {
+                                      "anyOf": [
+                                        {
+                                          "enum": [
+                                            "minute",
+                                            "hour",
+                                            "day"
+                                          ]
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "filter": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "external": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "title": "ExternalTable",
+                          "properties": {
+                            "_extra": {
+                              "type": "object",
+                              "propertyNames": {
+                                "type": "string"
+                              }
+                            },
+                            "location": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "file_format": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "row_format": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "tbl_properties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "partitions": {
+                              "anyOf": [
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "title": "ExternalPartition",
+                                    "properties": {
+                                      "_extra": {
+                                        "type": "object",
+                                        "propertyNames": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "name": {
+                                        "type": "string",
+                                        "default": ""
+                                      },
+                                      "description": {
+                                        "type": "string",
+                                        "default": ""
+                                      },
+                                      "data_type": {
+                                        "type": "string",
+                                        "default": ""
+                                      },
+                                      "meta": {
+                                        "type": "object",
+                                        "propertyNames": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": true
+                                  }
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "additionalProperties": true
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "columns": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "title": "ColumnInfo",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "default": ""
+                          },
+                          "meta": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          },
+                          "data_type": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "constraints": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "title": "ColumnLevelConstraint",
+                              "properties": {
+                                "type": {
+                                  "enum": [
+                                    "check",
+                                    "not_null",
+                                    "unique",
+                                    "primary_key",
+                                    "foreign_key",
+                                    "custom"
+                                  ]
+                                },
+                                "name": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "expression": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "warn_unenforced": {
+                                  "type": "boolean",
+                                  "default": true
+                                },
+                                "warn_unsupported": {
+                                  "type": "boolean",
+                                  "default": true
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "quote": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "_extra": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": true,
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "source_meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "SourceConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "patch_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "unrendered_config": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "relation_name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "created_at": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "database",
+                    "schema",
+                    "name",
+                    "resource_type",
+                    "package_name",
+                    "path",
+                    "original_file_path",
+                    "unique_id",
+                    "fqn",
+                    "source_name",
+                    "source_description",
+                    "loader",
+                    "identifier"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "title": "Exposure",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "resource_type": {
+                      "const": "exposure"
+                    },
+                    "package_name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "original_file_path": {
+                      "type": "string"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    },
+                    "fqn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard",
+                        "notebook",
+                        "analysis",
+                        "ml",
+                        "application"
+                      ]
+                    },
+                    "owner": {
+                      "type": "object",
+                      "title": "Owner",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "email": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "name": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "label": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "maturity": {
+                      "anyOf": [
+                        {
+                          "enum": [
+                            "low",
+                            "medium",
+                            "high"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "ExposureConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "unrendered_config": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "url": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "depends_on": {
+                      "type": "object",
+                      "title": "DependsOn",
+                      "properties": {
+                        "macros": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "nodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "refs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "RefArgs",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "version": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "metrics": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "created_at": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "resource_type",
+                    "package_name",
+                    "path",
+                    "original_file_path",
+                    "unique_id",
+                    "fqn",
+                    "type",
+                    "owner"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "title": "Metric",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "resource_type": {
+                      "const": "metric"
+                    },
+                    "package_name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "original_file_path": {
+                      "type": "string"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    },
+                    "fqn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "simple",
+                        "ratio",
+                        "cumulative",
+                        "derived"
+                      ]
+                    },
+                    "type_params": {
+                      "type": "object",
+                      "title": "MetricTypeParams",
+                      "properties": {
+                        "measure": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "title": "MetricInputMeasure",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "filter": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "title": "WhereFilterIntersection",
+                                      "properties": {
+                                        "where_filters": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "title": "WhereFilter",
+                                            "properties": {
+                                              "where_sql_template": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "additionalProperties": false,
+                                            "required": [
+                                              "where_sql_template"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "additionalProperties": false,
+                                      "required": [
+                                        "where_filters"
+                                      ]
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "alias": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "join_to_timespine": {
+                                  "type": "boolean",
+                                  "default": false
+                                },
+                                "fill_nulls_with": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "name"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "input_measures": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "MetricInputMeasure",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "filter": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "title": "WhereFilterIntersection",
+                                    "properties": {
+                                      "where_filters": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "title": "WhereFilter",
+                                          "properties": {
+                                            "where_sql_template": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "additionalProperties": false,
+                                          "required": [
+                                            "where_sql_template"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "required": [
+                                      "where_filters"
+                                    ]
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "alias": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "join_to_timespine": {
+                                "type": "boolean",
+                                "default": false
+                              },
+                              "fill_nulls_with": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "name"
+                            ]
+                          }
+                        },
+                        "numerator": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "title": "MetricInput",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "filter": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "title": "WhereFilterIntersection",
+                                      "properties": {
+                                        "where_filters": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "title": "WhereFilter",
+                                            "properties": {
+                                              "where_sql_template": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "additionalProperties": false,
+                                            "required": [
+                                              "where_sql_template"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "additionalProperties": false,
+                                      "required": [
+                                        "where_filters"
+                                      ]
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "alias": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "offset_window": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "title": "MetricTimeWindow",
+                                      "properties": {
+                                        "count": {
+                                          "type": "integer"
+                                        },
+                                        "granularity": {
+                                          "enum": [
+                                            "day",
+                                            "week",
+                                            "month",
+                                            "quarter",
+                                            "year"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false,
+                                      "required": [
+                                        "count",
+                                        "granularity"
+                                      ]
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "offset_to_grain": {
+                                  "anyOf": [
+                                    {
+                                      "enum": [
+                                        "day",
+                                        "week",
+                                        "month",
+                                        "quarter",
+                                        "year"
+                                      ]
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "name"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "denominator": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "title": "MetricInput",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "filter": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "title": "WhereFilterIntersection",
+                                      "properties": {
+                                        "where_filters": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "title": "WhereFilter",
+                                            "properties": {
+                                              "where_sql_template": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "additionalProperties": false,
+                                            "required": [
+                                              "where_sql_template"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "additionalProperties": false,
+                                      "required": [
+                                        "where_filters"
+                                      ]
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "alias": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "offset_window": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "title": "MetricTimeWindow",
+                                      "properties": {
+                                        "count": {
+                                          "type": "integer"
+                                        },
+                                        "granularity": {
+                                          "enum": [
+                                            "day",
+                                            "week",
+                                            "month",
+                                            "quarter",
+                                            "year"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false,
+                                      "required": [
+                                        "count",
+                                        "granularity"
+                                      ]
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "offset_to_grain": {
+                                  "anyOf": [
+                                    {
+                                      "enum": [
+                                        "day",
+                                        "week",
+                                        "month",
+                                        "quarter",
+                                        "year"
+                                      ]
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "name"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "expr": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "window": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "title": "MetricTimeWindow",
+                              "properties": {
+                                "count": {
+                                  "type": "integer"
+                                },
+                                "granularity": {
+                                  "enum": [
+                                    "day",
+                                    "week",
+                                    "month",
+                                    "quarter",
+                                    "year"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "count",
+                                "granularity"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "grain_to_date": {
+                          "anyOf": [
+                            {
+                              "enum": [
+                                "day",
+                                "week",
+                                "month",
+                                "quarter",
+                                "year"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "metrics": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "title": "MetricInput",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "filter": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "title": "WhereFilterIntersection",
+                                        "properties": {
+                                          "where_filters": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "title": "WhereFilter",
+                                              "properties": {
+                                                "where_sql_template": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "additionalProperties": false,
+                                              "required": [
+                                                "where_sql_template"
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false,
+                                        "required": [
+                                          "where_filters"
+                                        ]
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "default": null
+                                  },
+                                  "alias": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "default": null
+                                  },
+                                  "offset_window": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "title": "MetricTimeWindow",
+                                        "properties": {
+                                          "count": {
+                                            "type": "integer"
+                                          },
+                                          "granularity": {
+                                            "enum": [
+                                              "day",
+                                              "week",
+                                              "month",
+                                              "quarter",
+                                              "year"
+                                            ]
+                                          }
+                                        },
+                                        "additionalProperties": false,
+                                        "required": [
+                                          "count",
+                                          "granularity"
+                                        ]
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "default": null
+                                  },
+                                  "offset_to_grain": {
+                                    "anyOf": [
+                                      {
+                                        "enum": [
+                                          "day",
+                                          "week",
+                                          "month",
+                                          "quarter",
+                                          "year"
+                                        ]
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "default": null
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "name"
+                                ]
+                              }
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "filter": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "title": "WhereFilterIntersection",
+                          "properties": {
+                            "where_filters": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "title": "WhereFilter",
+                                "properties": {
+                                  "where_sql_template": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "where_sql_template"
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "where_filters"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "metadata": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "title": "SourceFileMetadata",
+                          "properties": {
+                            "repo_file_path": {
+                              "type": "string"
+                            },
+                            "file_slice": {
+                              "type": "object",
+                              "title": "FileSlice",
+                              "properties": {
+                                "filename": {
+                                  "type": "string"
+                                },
+                                "content": {
+                                  "type": "string"
+                                },
+                                "start_line_number": {
+                                  "type": "integer"
+                                },
+                                "end_line_number": {
+                                  "type": "integer"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "filename",
+                                "content",
+                                "start_line_number",
+                                "end_line_number"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "repo_file_path",
+                            "file_slice"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "MetricConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "group": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "unrendered_config": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "depends_on": {
+                      "type": "object",
+                      "title": "DependsOn",
+                      "properties": {
+                        "macros": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "nodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "refs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "RefArgs",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "version": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    },
+                    "metrics": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "created_at": {
+                      "type": "number"
+                    },
+                    "group": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "resource_type",
+                    "package_name",
+                    "path",
+                    "original_file_path",
+                    "unique_id",
+                    "fqn",
+                    "description",
+                    "label",
+                    "type",
+                    "type_params"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "title": "SavedQuery",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "resource_type": {
+                      "enum": [
+                        "model",
+                        "analysis",
+                        "test",
+                        "snapshot",
+                        "operation",
+                        "seed",
+                        "rpc",
+                        "sql_operation",
+                        "doc",
+                        "source",
+                        "macro",
+                        "exposure",
+                        "metric",
+                        "group",
+                        "saved_query",
+                        "semantic_model"
+                      ]
+                    },
+                    "package_name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "original_file_path": {
+                      "type": "string"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    },
+                    "fqn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "query_params": {
+                      "type": "object",
+                      "title": "QueryParams",
+                      "properties": {
+                        "metrics": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "group_by": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "where": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "title": "WhereFilterIntersection",
+                              "properties": {
+                                "where_filters": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "title": "WhereFilter",
+                                    "properties": {
+                                      "where_sql_template": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "required": [
+                                      "where_sql_template"
+                                    ]
+                                  }
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "where_filters"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "metrics",
+                        "group_by",
+                        "where"
+                      ]
+                    },
+                    "exports": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "Export",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "config": {
+                            "type": "object",
+                            "title": "ExportConfig",
+                            "properties": {
+                              "export_as": {
+                                "enum": [
+                                  "table",
+                                  "view"
+                                ]
+                              },
+                              "schema_name": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "alias": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "export_as"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name",
+                          "config"
+                        ]
+                      }
+                    },
+                    "_event_status": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "description": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "label": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "metadata": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "title": "SourceFileMetadata",
+                          "properties": {
+                            "repo_file_path": {
+                              "type": "string"
+                            },
+                            "file_slice": {
+                              "type": "object",
+                              "title": "FileSlice",
+                              "properties": {
+                                "filename": {
+                                  "type": "string"
+                                },
+                                "content": {
+                                  "type": "string"
+                                },
+                                "start_line_number": {
+                                  "type": "integer"
+                                },
+                                "end_line_number": {
+                                  "type": "integer"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "filename",
+                                "content",
+                                "start_line_number",
+                                "end_line_number"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "repo_file_path",
+                            "file_slice"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "SavedQueryConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "group": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "export_as": {
+                          "anyOf": [
+                            {
+                              "enum": [
+                                "table",
+                                "view"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "schema": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "unrendered_config": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "group": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "depends_on": {
+                      "type": "object",
+                      "title": "DependsOn",
+                      "properties": {
+                        "macros": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "nodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "created_at": {
+                      "type": "number"
+                    },
+                    "refs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "RefArgs",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "version": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "resource_type",
+                    "package_name",
+                    "path",
+                    "original_file_path",
+                    "unique_id",
+                    "fqn",
+                    "query_params",
+                    "exports"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "title": "SemanticModel",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "resource_type": {
+                      "enum": [
+                        "model",
+                        "analysis",
+                        "test",
+                        "snapshot",
+                        "operation",
+                        "seed",
+                        "rpc",
+                        "sql_operation",
+                        "doc",
+                        "source",
+                        "macro",
+                        "exposure",
+                        "metric",
+                        "group",
+                        "saved_query",
+                        "semantic_model"
+                      ]
+                    },
+                    "package_name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "original_file_path": {
+                      "type": "string"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    },
+                    "fqn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "model": {
+                      "type": "string"
+                    },
+                    "node_relation": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "title": "NodeRelation",
+                          "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
+                            "schema_name": {
+                              "type": "string"
+                            },
+                            "database": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "relation_name": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "alias",
+                            "schema_name"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "description": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "label": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "defaults": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "title": "Defaults",
+                          "properties": {
+                            "agg_time_dimension": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "entities": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "Entity",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "enum": [
+                              "foreign",
+                              "natural",
+                              "primary",
+                              "unique"
+                            ]
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "label": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "role": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "expr": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name",
+                          "type"
+                        ]
+                      }
+                    },
+                    "measures": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "Measure",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "agg": {
+                            "enum": [
+                              "sum",
+                              "min",
+                              "max",
+                              "count_distinct",
+                              "sum_boolean",
+                              "average",
+                              "percentile",
+                              "median",
+                              "count"
+                            ]
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "label": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "create_metric": {
+                            "type": "boolean",
+                            "default": false
+                          },
+                          "expr": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "agg_params": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "title": "MeasureAggregationParameters",
+                                "properties": {
+                                  "percentile": {
+                                    "anyOf": [
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "default": null
+                                  },
+                                  "use_discrete_percentile": {
+                                    "type": "boolean",
+                                    "default": false
+                                  },
+                                  "use_approximate_percentile": {
+                                    "type": "boolean",
+                                    "default": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "non_additive_dimension": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "title": "NonAdditiveDimension",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "window_choice": {
+                                    "enum": [
+                                      "sum",
+                                      "min",
+                                      "max",
+                                      "count_distinct",
+                                      "sum_boolean",
+                                      "average",
+                                      "percentile",
+                                      "median",
+                                      "count"
+                                    ]
+                                  },
+                                  "window_groupings": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "name",
+                                  "window_choice",
+                                  "window_groupings"
+                                ]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "agg_time_dimension": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name",
+                          "agg"
+                        ]
+                      }
+                    },
+                    "dimensions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "Dimension",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "enum": [
+                              "categorical",
+                              "time"
+                            ]
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "label": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "is_partition": {
+                            "type": "boolean",
+                            "default": false
+                          },
+                          "type_params": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "title": "DimensionTypeParams",
+                                "properties": {
+                                  "time_granularity": {
+                                    "enum": [
+                                      "day",
+                                      "week",
+                                      "month",
+                                      "quarter",
+                                      "year"
+                                    ]
+                                  },
+                                  "validity_params": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "title": "DimensionValidityParams",
+                                        "properties": {
+                                          "is_start": {
+                                            "type": "boolean",
+                                            "default": false
+                                          },
+                                          "is_end": {
+                                            "type": "boolean",
+                                            "default": false
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "default": null
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "time_granularity"
+                                ]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "expr": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "metadata": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "title": "SourceFileMetadata",
+                                "properties": {
+                                  "repo_file_path": {
+                                    "type": "string"
+                                  },
+                                  "file_slice": {
+                                    "type": "object",
+                                    "title": "FileSlice",
+                                    "properties": {
+                                      "filename": {
+                                        "type": "string"
+                                      },
+                                      "content": {
+                                        "type": "string"
+                                      },
+                                      "start_line_number": {
+                                        "type": "integer"
+                                      },
+                                      "end_line_number": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "required": [
+                                      "filename",
+                                      "content",
+                                      "start_line_number",
+                                      "end_line_number"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "repo_file_path",
+                                  "file_slice"
+                                ]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name",
+                          "type"
+                        ]
+                      }
+                    },
+                    "metadata": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "title": "SourceFileMetadata",
+                          "properties": {
+                            "repo_file_path": {
+                              "type": "string"
+                            },
+                            "file_slice": {
+                              "type": "object",
+                              "title": "FileSlice",
+                              "properties": {
+                                "filename": {
+                                  "type": "string"
+                                },
+                                "content": {
+                                  "type": "string"
+                                },
+                                "start_line_number": {
+                                  "type": "integer"
+                                },
+                                "end_line_number": {
+                                  "type": "integer"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "filename",
+                                "content",
+                                "start_line_number",
+                                "end_line_number"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "repo_file_path",
+                            "file_slice"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "depends_on": {
+                      "type": "object",
+                      "title": "DependsOn",
+                      "properties": {
+                        "macros": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "nodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "refs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "RefArgs",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "version": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    },
+                    "created_at": {
+                      "type": "number"
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "SemanticModelConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "group": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "unrendered_config": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "primary_entity": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "group": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "resource_type",
+                    "package_name",
+                    "path",
+                    "original_file_path",
+                    "unique_id",
+                    "fqn",
+                    "model",
+                    "node_relation"
+                  ]
+                }
+              ]
+            }
+          },
+          "propertyNames": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
       ]
+    },
+    "parent_map": {
+      "description": "A mapping from\u00a0child nodes to their dependencies",
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "propertyNames": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "child_map": {
+      "description": "A mapping from parent nodes to their dependents",
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "propertyNames": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "group_map": {
+      "description": "A mapping from group names to their nodes",
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "propertyNames": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "saved_queries": {
+      "type": "object",
+      "description": "The saved queries defined in the dbt project",
+      "additionalProperties": {
+        "type": "object",
+        "title": "SavedQuery",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "resource_type": {
+            "enum": [
+              "model",
+              "analysis",
+              "test",
+              "snapshot",
+              "operation",
+              "seed",
+              "rpc",
+              "sql_operation",
+              "doc",
+              "source",
+              "macro",
+              "exposure",
+              "metric",
+              "group",
+              "saved_query",
+              "semantic_model"
+            ]
+          },
+          "package_name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "original_file_path": {
+            "type": "string"
+          },
+          "unique_id": {
+            "type": "string"
+          },
+          "fqn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "query_params": {
+            "type": "object",
+            "title": "QueryParams",
+            "properties": {
+              "metrics": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "group_by": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "where": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "title": "WhereFilterIntersection",
+                    "properties": {
+                      "where_filters": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "title": "WhereFilter",
+                          "properties": {
+                            "where_sql_template": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "where_sql_template"
+                          ]
+                        }
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "where_filters"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "metrics",
+              "group_by",
+              "where"
+            ]
+          },
+          "exports": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "Export",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "config": {
+                  "type": "object",
+                  "title": "ExportConfig",
+                  "properties": {
+                    "export_as": {
+                      "enum": [
+                        "table",
+                        "view"
+                      ]
+                    },
+                    "schema_name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "alias": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "export_as"
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "config"
+              ]
+            }
+          },
+          "_event_status": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "type": "object",
+                "title": "SourceFileMetadata",
+                "properties": {
+                  "repo_file_path": {
+                    "type": "string"
+                  },
+                  "file_slice": {
+                    "type": "object",
+                    "title": "FileSlice",
+                    "properties": {
+                      "filename": {
+                        "type": "string"
+                      },
+                      "content": {
+                        "type": "string"
+                      },
+                      "start_line_number": {
+                        "type": "integer"
+                      },
+                      "end_line_number": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "filename",
+                      "content",
+                      "start_line_number",
+                      "end_line_number"
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "repo_file_path",
+                  "file_slice"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "config": {
+            "type": "object",
+            "title": "SavedQueryConfig",
+            "properties": {
+              "_extra": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "enabled": {
+                "type": "boolean",
+                "default": true
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "meta": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "export_as": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "table",
+                      "view"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": true
+          },
+          "unrendered_config": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "group": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "depends_on": {
+            "type": "object",
+            "title": "DependsOn",
+            "properties": {
+              "macros": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "nodes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "created_at": {
+            "type": "number"
+          },
+          "refs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "RefArgs",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "package": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "version": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name"
+              ]
+            }
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "resource_type",
+          "package_name",
+          "path",
+          "original_file_path",
+          "unique_id",
+          "fqn",
+          "query_params",
+          "exports"
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      }
+    },
+    "semantic_models": {
+      "type": "object",
+      "description": "The semantic models defined in the dbt project",
+      "additionalProperties": {
+        "type": "object",
+        "title": "SemanticModel",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "resource_type": {
+            "enum": [
+              "model",
+              "analysis",
+              "test",
+              "snapshot",
+              "operation",
+              "seed",
+              "rpc",
+              "sql_operation",
+              "doc",
+              "source",
+              "macro",
+              "exposure",
+              "metric",
+              "group",
+              "saved_query",
+              "semantic_model"
+            ]
+          },
+          "package_name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "original_file_path": {
+            "type": "string"
+          },
+          "unique_id": {
+            "type": "string"
+          },
+          "fqn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "model": {
+            "type": "string"
+          },
+          "node_relation": {
+            "anyOf": [
+              {
+                "type": "object",
+                "title": "NodeRelation",
+                "properties": {
+                  "alias": {
+                    "type": "string"
+                  },
+                  "schema_name": {
+                    "type": "string"
+                  },
+                  "database": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "relation_name": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "alias",
+                  "schema_name"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "defaults": {
+            "anyOf": [
+              {
+                "type": "object",
+                "title": "Defaults",
+                "properties": {
+                  "agg_time_dimension": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "entities": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "Entity",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "foreign",
+                    "natural",
+                    "primary",
+                    "unique"
+                  ]
+                },
+                "description": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "label": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "role": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "expr": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "type"
+              ]
+            }
+          },
+          "measures": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "Measure",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "agg": {
+                  "enum": [
+                    "sum",
+                    "min",
+                    "max",
+                    "count_distinct",
+                    "sum_boolean",
+                    "average",
+                    "percentile",
+                    "median",
+                    "count"
+                  ]
+                },
+                "description": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "label": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "create_metric": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "expr": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "agg_params": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "title": "MeasureAggregationParameters",
+                      "properties": {
+                        "percentile": {
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "use_discrete_percentile": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "use_approximate_percentile": {
+                          "type": "boolean",
+                          "default": false
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "non_additive_dimension": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "title": "NonAdditiveDimension",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "window_choice": {
+                          "enum": [
+                            "sum",
+                            "min",
+                            "max",
+                            "count_distinct",
+                            "sum_boolean",
+                            "average",
+                            "percentile",
+                            "median",
+                            "count"
+                          ]
+                        },
+                        "window_groupings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "name",
+                        "window_choice",
+                        "window_groupings"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "agg_time_dimension": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "agg"
+              ]
+            }
+          },
+          "dimensions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "Dimension",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "categorical",
+                    "time"
+                  ]
+                },
+                "description": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "label": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "is_partition": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "type_params": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "title": "DimensionTypeParams",
+                      "properties": {
+                        "time_granularity": {
+                          "enum": [
+                            "day",
+                            "week",
+                            "month",
+                            "quarter",
+                            "year"
+                          ]
+                        },
+                        "validity_params": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "title": "DimensionValidityParams",
+                              "properties": {
+                                "is_start": {
+                                  "type": "boolean",
+                                  "default": false
+                                },
+                                "is_end": {
+                                  "type": "boolean",
+                                  "default": false
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "time_granularity"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "expr": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "metadata": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "title": "SourceFileMetadata",
+                      "properties": {
+                        "repo_file_path": {
+                          "type": "string"
+                        },
+                        "file_slice": {
+                          "type": "object",
+                          "title": "FileSlice",
+                          "properties": {
+                            "filename": {
+                              "type": "string"
+                            },
+                            "content": {
+                              "type": "string"
+                            },
+                            "start_line_number": {
+                              "type": "integer"
+                            },
+                            "end_line_number": {
+                              "type": "integer"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "filename",
+                            "content",
+                            "start_line_number",
+                            "end_line_number"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "repo_file_path",
+                        "file_slice"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "type"
+              ]
+            }
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "type": "object",
+                "title": "SourceFileMetadata",
+                "properties": {
+                  "repo_file_path": {
+                    "type": "string"
+                  },
+                  "file_slice": {
+                    "type": "object",
+                    "title": "FileSlice",
+                    "properties": {
+                      "filename": {
+                        "type": "string"
+                      },
+                      "content": {
+                        "type": "string"
+                      },
+                      "start_line_number": {
+                        "type": "integer"
+                      },
+                      "end_line_number": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "filename",
+                      "content",
+                      "start_line_number",
+                      "end_line_number"
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "repo_file_path",
+                  "file_slice"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "depends_on": {
+            "type": "object",
+            "title": "DependsOn",
+            "properties": {
+              "macros": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "nodes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "refs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "RefArgs",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "package": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "version": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name"
+              ]
+            }
+          },
+          "created_at": {
+            "type": "number"
+          },
+          "config": {
+            "type": "object",
+            "title": "SemanticModelConfig",
+            "properties": {
+              "_extra": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "enabled": {
+                "type": "boolean",
+                "default": true
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "meta": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": true
+          },
+          "unrendered_config": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "primary_entity": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "group": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "resource_type",
+          "package_name",
+          "path",
+          "original_file_path",
+          "unique_id",
+          "fqn",
+          "model",
+          "node_relation"
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      }
     }
   },
+  "additionalProperties": false,
+  "required": [
+    "metadata",
+    "nodes",
+    "sources",
+    "macros",
+    "docs",
+    "exposures",
+    "metrics",
+    "groups",
+    "selectors",
+    "disabled",
+    "parent_map",
+    "child_map",
+    "group_map",
+    "saved_queries",
+    "semantic_models"
+  ],
   "$id": "https://schemas.getdbt.com/dbt/manifest/v11.json"
 }

--- a/schemas/dbt/run-results/v5.json
+++ b/schemas/dbt/run-results/v5.json
@@ -1,7 +1,9 @@
 {
-  "$ref": "#/$defs/RunResultsArtifact",
-  "$defs": {
-    "BaseArtifactMetadata": {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "title": "RunResultsArtifact",
+  "properties": {
+    "metadata": {
       "type": "object",
       "title": "BaseArtifactMetadata",
       "properties": {
@@ -10,7 +12,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.7.0b1"
+          "default": "1.7.3"
         },
         "generated_at": {
           "type": "string"
@@ -40,190 +42,175 @@
         "dbt_schema_version"
       ]
     },
-    "TimingInfo": {
-      "type": "object",
-      "title": "TimingInfo",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "started_at": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "completed_at": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name"
-      ]
-    },
-    "RunResultOutput": {
-      "type": "object",
-      "title": "RunResultOutput",
-      "properties": {
-        "status": {
-          "anyOf": [
-            {
-              "enum": [
-                "success",
-                "error",
-                "skipped"
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "RunResultOutput",
+        "properties": {
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "success",
+                  "error",
+                  "skipped"
+                ]
+              },
+              {
+                "enum": [
+                  "pass",
+                  "error",
+                  "fail",
+                  "warn",
+                  "skipped"
+                ]
+              },
+              {
+                "enum": [
+                  "pass",
+                  "warn",
+                  "error",
+                  "runtime error"
+                ]
+              }
+            ]
+          },
+          "timing": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "TimingInfo",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "started_at": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "completed_at": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name"
               ]
-            },
-            {
-              "enum": [
-                "pass",
-                "error",
-                "fail",
-                "warn",
-                "skipped"
-              ]
-            },
-            {
-              "enum": [
-                "pass",
-                "warn",
-                "error",
-                "runtime error"
-              ]
             }
-          ]
-        },
-        "timing": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/TimingInfo"
-          }
-        },
-        "thread_id": {
-          "type": "string"
-        },
-        "execution_time": {
-          "type": "number"
-        },
-        "adapter_response": {
-          "type": "object",
-          "propertyNames": {
+          },
+          "thread_id": {
             "type": "string"
-          }
-        },
-        "message": {
-          "anyOf": [
-            {
+          },
+          "execution_time": {
+            "type": "number"
+          },
+          "adapter_response": {
+            "type": "object",
+            "propertyNames": {
               "type": "string"
-            },
-            {
-              "type": "null"
             }
-          ]
-        },
-        "failures": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "unique_id": {
-          "type": "string"
-        },
-        "compiled": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "compiled_code": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "relation_name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "status",
-        "timing",
-        "thread_id",
-        "execution_time",
-        "adapter_response",
-        "message",
-        "failures",
-        "unique_id",
-        "compiled",
-        "compiled_code",
-        "relation_name"
-      ]
-    },
-    "RunResultsArtifact": {
-      "type": "object",
-      "title": "RunResultsArtifact",
-      "properties": {
-        "metadata": {
-          "$ref": "#/$defs/BaseArtifactMetadata"
-        },
-        "results": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RunResultOutput"
-          }
-        },
-        "elapsed_time": {
-          "type": "number"
-        },
-        "args": {
-          "type": "object",
-          "propertyNames": {
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "failures": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "unique_id": {
             "type": "string"
+          },
+          "compiled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "compiled_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "relation_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "metadata",
-        "results",
-        "elapsed_time"
-      ]
+        },
+        "additionalProperties": false,
+        "required": [
+          "status",
+          "timing",
+          "thread_id",
+          "execution_time",
+          "adapter_response",
+          "message",
+          "failures",
+          "unique_id",
+          "compiled",
+          "compiled_code",
+          "relation_name"
+        ]
+      }
+    },
+    "elapsed_time": {
+      "type": "number"
+    },
+    "args": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      }
     }
   },
+  "additionalProperties": false,
+  "required": [
+    "metadata",
+    "results",
+    "elapsed_time"
+  ],
   "$id": "https://schemas.getdbt.com/dbt/run-results/v5.json"
 }

--- a/schemas/dbt/sources/v3.json
+++ b/schemas/dbt/sources/v3.json
@@ -1,7 +1,9 @@
 {
-  "$ref": "#/$defs/FreshnessExecutionResultArtifact",
-  "$defs": {
-    "FreshnessMetadata": {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "title": "FreshnessExecutionResultArtifact",
+  "properties": {
+    "metadata": {
       "type": "object",
       "title": "FreshnessMetadata",
       "properties": {
@@ -10,7 +12,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.7.0b1"
+          "default": "1.7.3"
         },
         "generated_at": {
           "type": "string"
@@ -37,238 +39,242 @@
       },
       "additionalProperties": false
     },
-    "SourceFreshnessRuntimeError": {
-      "type": "object",
-      "title": "SourceFreshnessRuntimeError",
-      "properties": {
-        "unique_id": {
-          "type": "string"
-        },
-        "error": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "status": {
-          "enum": [
-            "runtime error"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "unique_id",
-        "error",
-        "status"
-      ]
-    },
-    "Time": {
-      "type": "object",
-      "title": "Time",
-      "properties": {
-        "count": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "period": {
-          "anyOf": [
-            {
-              "enum": [
-                "minute",
-                "hour",
-                "day"
-              ]
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false
-    },
-    "FreshnessThreshold": {
-      "type": "object",
-      "title": "FreshnessThreshold",
-      "properties": {
-        "warn_after": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Time"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "error_after": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Time"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "filter": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false
-    },
-    "TimingInfo": {
-      "type": "object",
-      "title": "TimingInfo",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "started_at": {
-          "anyOf": [
-            {
-              "type": "string",
-              "format": "date-time"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "completed_at": {
-          "anyOf": [
-            {
-              "type": "string",
-              "format": "date-time"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name"
-      ]
-    },
-    "SourceFreshnessOutput": {
-      "type": "object",
-      "title": "SourceFreshnessOutput",
-      "properties": {
-        "unique_id": {
-          "type": "string"
-        },
-        "max_loaded_at": {
-          "type": "string"
-        },
-        "snapshotted_at": {
-          "type": "string"
-        },
-        "max_loaded_at_time_ago_in_s": {
-          "type": "number"
-        },
-        "status": {
-          "enum": [
-            "pass",
-            "warn",
-            "error",
-            "runtime error"
-          ]
-        },
-        "criteria": {
-          "$ref": "#/$defs/FreshnessThreshold"
-        },
-        "adapter_response": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          }
-        },
-        "timing": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/TimingInfo"
-          }
-        },
-        "thread_id": {
-          "type": "string"
-        },
-        "execution_time": {
-          "type": "number"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "unique_id",
-        "max_loaded_at",
-        "snapshotted_at",
-        "max_loaded_at_time_ago_in_s",
-        "status",
-        "criteria",
-        "adapter_response",
-        "timing",
-        "thread_id",
-        "execution_time"
-      ]
-    },
-    "FreshnessExecutionResultArtifact": {
-      "type": "object",
-      "title": "FreshnessExecutionResultArtifact",
-      "properties": {
-        "metadata": {
-          "$ref": "#/$defs/FreshnessMetadata"
-        },
-        "results": {
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/SourceFreshnessRuntimeError"
+    "results": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "title": "SourceFreshnessRuntimeError",
+            "properties": {
+              "unique_id": {
+                "type": "string"
               },
-              {
-                "$ref": "#/$defs/SourceFreshnessOutput"
+              "error": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "status": {
+                "enum": [
+                  "runtime error"
+                ]
               }
+            },
+            "additionalProperties": false,
+            "required": [
+              "unique_id",
+              "error",
+              "status"
+            ]
+          },
+          {
+            "type": "object",
+            "title": "SourceFreshnessOutput",
+            "properties": {
+              "unique_id": {
+                "type": "string"
+              },
+              "max_loaded_at": {
+                "type": "string"
+              },
+              "snapshotted_at": {
+                "type": "string"
+              },
+              "max_loaded_at_time_ago_in_s": {
+                "type": "number"
+              },
+              "status": {
+                "enum": [
+                  "pass",
+                  "warn",
+                  "error",
+                  "runtime error"
+                ]
+              },
+              "criteria": {
+                "type": "object",
+                "title": "FreshnessThreshold",
+                "properties": {
+                  "warn_after": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "title": "Time",
+                        "properties": {
+                          "count": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "period": {
+                            "anyOf": [
+                              {
+                                "enum": [
+                                  "minute",
+                                  "hour",
+                                  "day"
+                                ]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "error_after": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "title": "Time",
+                        "properties": {
+                          "count": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "period": {
+                            "anyOf": [
+                              {
+                                "enum": [
+                                  "minute",
+                                  "hour",
+                                  "day"
+                                ]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "filter": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "adapter_response": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "timing": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "TimingInfo",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "started_at": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "completed_at": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              "thread_id": {
+                "type": "string"
+              },
+              "execution_time": {
+                "type": "number"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "unique_id",
+              "max_loaded_at",
+              "snapshotted_at",
+              "max_loaded_at_time_ago_in_s",
+              "status",
+              "criteria",
+              "adapter_response",
+              "timing",
+              "thread_id",
+              "execution_time"
             ]
           }
-        },
-        "elapsed_time": {
-          "type": "number"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "metadata",
-        "results",
-        "elapsed_time"
-      ]
+        ]
+      }
+    },
+    "elapsed_time": {
+      "type": "number"
     }
   },
+  "additionalProperties": false,
+  "required": [
+    "metadata",
+    "results",
+    "elapsed_time"
+  ],
   "$id": "https://schemas.getdbt.com/dbt/sources/v3.json"
 }


### PR DESCRIPTION
resolves #8991

This is a manual backport of #9155 to `1.7.latest`.

This is a manual backport because some commits needed to be excluded as they have no relevance to 1.7.latest. Additionally some new commits needed to be added specifically for `1.7.latest`

### Included commits from #9155 via `cherry-pick`
* f17f9823a5123ad2627516c4b9d8a72facd03004
* c9d44a1fc9861fecbd8bee9dc194106f6f239a51
* 2f8203feda9572ea20ab2fc7a61face5895c22b4
* e9acf4166d1d52c2f2c06f3a7da9e42757162de2

### Excluded commits
* 94361bcf481e929e30f54e1b62252275a7feba07
* b80e4d42452f1c7152d86f15252438da418730b7
* 21ecdb95e634b1449c76252a0120f6bf8ff74101
* 747995f62d82155105eb7645975c19a7e17b850f
* b82d069e896fe82ab4cb25207979157db5999ee9
* 99336388cf0501e9bb6203d1920fee43efa95ee3

### Newly added commits
* 0d5fc3a0ad738c0d1e1ab40f00bb238c372d939f