### PR TITLE
[DO NOT MERGE] Possible fix for `dbt parse` failure when an unkown macro is in columns.tests

### DIFF
--- a/tests/functional/compile/fixtures.py
+++ b/tests/functional/compile/fixtures.py
@@ -56,3 +56,19 @@ models:
         tests:
           - unique
 """
+
+schema_with_unknown_macro_yml = """
+version: 2
+
+models:
+  - name: second_model
+    description: "The second model"
+    columns:
+      - name: fun
+        tests:
+          - not_null
+      - name: schema
+        tests:
+          - unique
+          - im_the_unknown_macro
+"""


### PR DESCRIPTION
Only for documentation purposes:

## Problem
`dbt parse` does not fail when there's an unknown macro in a schema file:

```yml
models:
  - name: second_model
    description: "The second model"
    columns:
      - name: fun
        tests:
          - not_null
          - unknow_macro  # this is either invalid or a typo
```

## Expected behaviour
`dbt parse` fails when there's an unknown macro in a schema file

## Current behaviour
`dbt parse` succeeds and there's a `None` in the `node.depends_on.macros` list

`dbt compile` fails when it runs (or build) the SQL queries as it fails to resolve the `None` macro from the `node.depends_on.macros` list.

## Possible solution
When the `SchemaGenericTestParser` finds a `None` macro, raises the `UndefinedMacroError`. This was only tested against the 2 tests and with the limited knowledge I have of dbt.

## Rejected solutions
Raise in `MacroResolver#get_macro` or `MacroResolver#get_macro_id`. The reason it not in this class is because there are a lot of `None` macros that do not seem to impact dbt.

## Stacktrace for the manifest loading

1. [requires.py::L271 calls ManifestLoader#get_full_manifest](https://github.com/dbt-labs/dbt-core/blob/0ab954e1af9bb2be01fa4ebad2df7626249a1fab/core/dbt/cli/requires.py#L271)
2. [manifest.py::L318 calls ManifestLoader#load](https://github.com/dbt-labs/dbt-core/blob/0ab954e1af9bb2be01fa4ebad2df7626249a1fab/core/dbt/parser/manifest.py#L318)
3. [manifest.py::L495 calls ManifestLoader#parse_project](https://github.com/dbt-labs/dbt-core/blob/0ab954e1af9bb2be01fa4ebad2df7626249a1fab/core/dbt/parser/manifest.py#L495)
4.  [manifest.py::L671 calls SchemaParser#parse_file](https://github.com/dbt-labs/dbt-core/blob/0ab954e1af9bb2be01fa4ebad2df7626249a1fab/core/dbt/parser/manifest.py#L671)
5. [schemas.py::L171 calls GenericTestParser#parse_versioned_tests](https://github.com/dbt-labs/dbt-core/blob/0ab954e1af9bb2be01fa4ebad2df7626249a1fab/core/dbt/parser/schemas.py#L171)
6. [schema_generic_tests.py::L395 calls GenericTestParser#parse_tests](https://github.com/dbt-labs/dbt-core/blob/0ab954e1af9bb2be01fa4ebad2df7626249a1fab/core/dbt/parser/schema_generic_tests.py#L395)
7. [schema_generic_tests.py::L391 calls GenericTestParser#parse_test](https://github.com/dbt-labs/dbt-core/blob/0ab954e1af9bb2be01fa4ebad2df7626249a1fab/core/dbt/parser/schema_generic_tests.py#L391)
8. [schema_generic_tests.py::L384 calls GenericTestParser#parse_node](https://github.com/dbt-labs/dbt-core/blob/0ab954e1af9bb2be01fa4ebad2df7626249a1fab/core/dbt/parser/schema_generic_tests.py#L384)
9. [schema_generic_tests.py::L322 calls GenericTestParser#parse_generic_test](https://github.com/dbt-labs/dbt-core/blob/0ab954e1af9bb2be01fa4ebad2df7626249a1fab/core/dbt/parser/schema_generic_tests.py#L322)
10. [schema_generic_tests.py::L225 calls GenericTestParser#render_test_update](https://github.com/dbt-labs/dbt-core/blob/0ab954e1af9bb2be01fa4ebad2df7626249a1fab/core/dbt/parser/schema_generic_tests.py#L225)
11. [schema_generic_tests.py::L271 calls MacroResolver#get_macro_id](https://github.com/dbt-labs/dbt-core/blob/0ab954e1af9bb2be01fa4ebad2df7626249a1fab/core/dbt/parser/schema_generic_tests.py#L271). This is what yields the critical `None` value
12. [macro_resolver::L129 calls MacroResolver#get_macro](https://github.com/dbt-labs/dbt-core/blob/0ab954e1af9bb2be01fa4ebad2df7626249a1fab/core/dbt/context/macro_resolver.py#L129) which returns `None`.