### PR TITLE
Remove manifest from catalog and connection method signatures

### DIFF
--- a/.changes/unreleased/Under the Hood-20231205-235830.yaml
+++ b/.changes/unreleased/Under the Hood-20231205-235830.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: remove manifest from adapter.set_relations_cache signature
+time: 2023-12-05T23:58:30.920144+09:00
+custom:
+  Author: michelleark
+  Issue: "9217"

--- a/.changes/unreleased/Under the Hood-20231206-000343.yaml
+++ b/.changes/unreleased/Under the Hood-20231206-000343.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: ' remove manifest from adapter catalog method signatures'
+time: 2023-12-06T00:03:43.824252+09:00
+custom:
+  Author: michelleark
+  Issue: "9218"

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -18,6 +18,7 @@ from typing import (
     Type,
     TypedDict,
     Union,
+    FrozenSet,
 )
 from multiprocessing.context import SpawnContext
 
@@ -110,7 +111,7 @@ def _expect_row_value(key: str, row: agate.Row):
 
 
 def _catalog_filter_schemas(
-    used_schemas: frozenset[tuple[str, str]]
+    used_schemas: FrozenSet[tuple[str, str]]
 ) -> Callable[[agate.Row], bool]:
     """Return a function that takes a row and decides if the row should be
     included in the catalog output.
@@ -1114,7 +1115,7 @@ class BaseAdapter(metaclass=AdapterMeta):
 
     @classmethod
     def _catalog_filter_table(
-        cls, table: agate.Table, used_schemas: frozenset[tuple[str, str]]
+        cls, table: agate.Table, used_schemas: FrozenSet[tuple[str, str]]
     ) -> agate.Table:
         """Filter the table as appropriate for catalog entries. Subclasses can
         override this to change filtering rules on a per-adapter basis.
@@ -1131,7 +1132,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         self,
         information_schema: InformationSchema,
         schemas: Set[str],
-        used_schemas: frozenset[tuple[str, str]],
+        used_schemas: FrozenSet[tuple[str, str]],
     ) -> agate.Table:
         kwargs = {"information_schema": information_schema, "schemas": schemas}
         table = self.execute_macro(
@@ -1146,7 +1147,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         self,
         information_schema: InformationSchema,
         relations: List[BaseRelation],
-        used_schemas: frozenset[tuple[str, str]],
+        used_schemas: FrozenSet[tuple[str, str]],
     ) -> agate.Table:
 
         kwargs = {
@@ -1164,7 +1165,7 @@ class BaseAdapter(metaclass=AdapterMeta):
     def get_filtered_catalog(
         self,
         relation_configs: Iterable[RelationConfig],
-        used_schemas: frozenset,
+        used_schemas: FrozenSet[tuple[str, str]],
         relations: Optional[Set[BaseRelation]] = None,
     ):
         catalogs: agate.Table
@@ -1209,7 +1210,7 @@ class BaseAdapter(metaclass=AdapterMeta):
     def get_catalog(
         self,
         relation_configs: Iterable[RelationConfig],
-        used_schemas: frozenset[tuple[str, str]],
+        used_schemas: FrozenSet[tuple[str, str]],
     ) -> Tuple[agate.Table, List[Exception]]:
         with executor(self.config) as tpe:
             futures: List[Future[agate.Table]] = []
@@ -1227,7 +1228,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         return catalogs, exceptions
 
     def get_catalog_by_relations(
-        self, used_schemas: frozenset[tuple[str, str]], relations: Set[BaseRelation]
+        self, used_schemas: FrozenSet[tuple[str, str]], relations: Set[BaseRelation]
     ) -> Tuple[agate.Table, List[Exception]]:
         with executor(self.config) as tpe:
             futures: List[Future[agate.Table]] = []

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -420,15 +420,13 @@ class BaseAdapter(metaclass=AdapterMeta):
         else:
             return True
 
-    def _get_cache_schemas(self, manifest: Manifest) -> Set[BaseRelation]:
+    def _get_cache_schemas(self, relation_configs: Iterable[RelationConfig]) -> Set[BaseRelation]:
         """Get the set of schema relations that the cache logic needs to
-        populate. This means only executable nodes are included.
+        populate.
         """
-        # the cache only cares about executable nodes
         return {
-            self.Relation.create_from(self.config, node).without_identifier()  # type: ignore[arg-type]
-            for node in manifest.nodes.values()
-            if (node.is_relational and not node.is_ephemeral_model and not node.is_external_node)
+            self.Relation.create_from(quoting=self.config, config=relation_config)
+            for relation_config in relation_configs
         }
 
     def _get_catalog_schemas(self, relation_configs: Iterable[RelationConfig]) -> SchemaSearchMap:
@@ -472,13 +470,15 @@ class BaseAdapter(metaclass=AdapterMeta):
         return relations
 
     def _relations_cache_for_schemas(
-        self, manifest: Manifest, cache_schemas: Optional[Set[BaseRelation]] = None
+        self,
+        relation_configs: Iterable[RelationConfig],
+        cache_schemas: Optional[Set[BaseRelation]] = None,
     ) -> None:
         """Populate the relations cache for the given schemas. Returns an
         iterable of the schemas populated, as strings.
         """
         if not cache_schemas:
-            cache_schemas = self._get_cache_schemas(manifest)
+            cache_schemas = self._get_cache_schemas(relation_configs)
         with executor(self.config) as tpe:
             futures: List[Future[List[BaseRelation]]] = []
             for cache_schema in cache_schemas:
@@ -507,7 +507,7 @@ class BaseAdapter(metaclass=AdapterMeta):
 
     def set_relations_cache(
         self,
-        manifest: Manifest,
+        relation_configs: Iterable[RelationConfig],
         clear: bool = False,
         required_schemas: Optional[Set[BaseRelation]] = None,
     ) -> None:
@@ -517,7 +517,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         with self.cache.lock:
             if clear:
                 self.cache.clear()
-            self._relations_cache_for_schemas(manifest, required_schemas)
+            self._relations_cache_for_schemas(relation_configs, required_schemas)
 
     @available
     def cache_added(self, relation: Optional[BaseRelation]) -> str:

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -466,7 +466,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         self, relation_configs: Iterable[RelationConfig]
     ) -> List[BaseRelation]:
         relations = [
-            self.Relation.create_from(quoting=self.config, config=relation_config)
+            self.Relation.create_from(quoting=self.config, relation_config=relation_config)
             for relation_config in relation_configs
         ]
         return relations

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 from datetime import datetime
 from enum import Enum
 import time
-from itertools import chain
 from typing import (
     Any,
     Callable,
@@ -75,6 +74,7 @@ from dbt.adapters.events.types import (
 )
 from dbt.common.utils import filter_null_values, executor, cast_to_str, AttrDict
 
+from dbt.adapters.contracts.relation import RelationConfig
 from dbt.adapters.base.connections import Connection, AdapterResponse, BaseConnectionManager
 from dbt.adapters.base.meta import AdapterMeta, available
 from dbt.adapters.base.relation import (
@@ -109,11 +109,13 @@ def _expect_row_value(key: str, row: agate.Row):
     return row[key]
 
 
-def _catalog_filter_schemas(manifest: Manifest) -> Callable[[agate.Row], bool]:
+def _catalog_filter_schemas(
+    used_schemas: frozenset[tuple[str, str]]
+) -> Callable[[agate.Row], bool]:
     """Return a function that takes a row and decides if the row should be
     included in the catalog output.
     """
-    schemas = frozenset((d.lower(), s.lower()) for d, s in manifest.get_used_schemas())
+    schemas = frozenset((d.lower(), s.lower()) for d, s in used_schemas)
 
     def test(row: agate.Row) -> bool:
         table_database = _expect_row_value("table_database", row)
@@ -428,7 +430,7 @@ class BaseAdapter(metaclass=AdapterMeta):
             if (node.is_relational and not node.is_ephemeral_model and not node.is_external_node)
         }
 
-    def _get_catalog_schemas(self, manifest: Manifest) -> SchemaSearchMap:
+    def _get_catalog_schemas(self, relation_configs: Iterable[RelationConfig]) -> SchemaSearchMap:
         """Get a mapping of each node's "information_schema" relations to a
         set of all schemas expected in that information_schema.
 
@@ -438,7 +440,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         lowercase strings.
         """
         info_schema_name_map = SchemaSearchMap()
-        relations = self._get_catalog_relations(manifest)
+        relations = self._get_catalog_relations(relation_configs)
         for relation in relations:
             info_schema_name_map.add(relation)
         # result is a map whose keys are information_schema Relations without
@@ -459,18 +461,13 @@ class BaseAdapter(metaclass=AdapterMeta):
 
         return relations_by_info_schema
 
-    def _get_catalog_relations(self, manifest: Manifest) -> List[BaseRelation]:
-
-        nodes = chain(
-            [
-                node
-                for node in manifest.nodes.values()
-                if (node.is_relational and not node.is_ephemeral_model)
-            ],
-            manifest.sources.values(),
-        )
-
-        relations = [self.Relation.create_from(self.config, n) for n in nodes]  # type: ignore[arg-type]
+    def _get_catalog_relations(
+        self, relation_configs: Iterable[RelationConfig]
+    ) -> List[BaseRelation]:
+        relations = [
+            self.Relation.create_from(quoting=self.config, config=relation_config)
+            for relation_config in relation_configs
+        ]
         return relations
 
     def _relations_cache_for_schemas(
@@ -1116,7 +1113,9 @@ class BaseAdapter(metaclass=AdapterMeta):
         return result
 
     @classmethod
-    def _catalog_filter_table(cls, table: agate.Table, manifest: Manifest) -> agate.Table:
+    def _catalog_filter_table(
+        cls, table: agate.Table, used_schemas: frozenset[tuple[str, str]]
+    ) -> agate.Table:
         """Filter the table as appropriate for catalog entries. Subclasses can
         override this to change filtering rules on a per-adapter basis.
         """
@@ -1126,31 +1125,28 @@ class BaseAdapter(metaclass=AdapterMeta):
             table.column_names,
             text_only_columns=["table_database", "table_schema", "table_name"],
         )
-        return table.where(_catalog_filter_schemas(manifest))
+        return table.where(_catalog_filter_schemas(used_schemas))
 
     def _get_one_catalog(
         self,
         information_schema: InformationSchema,
         schemas: Set[str],
-        manifest: Manifest,
+        used_schemas: frozenset[tuple[str, str]],
     ) -> agate.Table:
         kwargs = {"information_schema": information_schema, "schemas": schemas}
         table = self.execute_macro(
             GET_CATALOG_MACRO_NAME,
             kwargs=kwargs,
-            # pass in the full manifest so we get any local project
-            # overrides
-            manifest=manifest,
         )
 
-        results = self._catalog_filter_table(table, manifest)  # type: ignore[arg-type]
+        results = self._catalog_filter_table(table, used_schemas)  # type: ignore[arg-type]
         return results
 
     def _get_one_catalog_by_relations(
         self,
         information_schema: InformationSchema,
         relations: List[BaseRelation],
-        manifest: Manifest,
+        used_schemas: frozenset[tuple[str, str]],
     ) -> agate.Table:
 
         kwargs = {
@@ -1160,16 +1156,16 @@ class BaseAdapter(metaclass=AdapterMeta):
         table = self.execute_macro(
             GET_CATALOG_RELATIONS_MACRO_NAME,
             kwargs=kwargs,
-            # pass in the full manifest, so we get any local project
-            # overrides
-            manifest=manifest,
         )
 
-        results = self._catalog_filter_table(table, manifest)  # type: ignore[arg-type]
+        results = self._catalog_filter_table(table, used_schemas)  # type: ignore[arg-type]
         return results
 
     def get_filtered_catalog(
-        self, manifest: Manifest, relations: Optional[Set[BaseRelation]] = None
+        self,
+        relation_configs: Iterable[RelationConfig],
+        used_schemas: frozenset,
+        relations: Optional[Set[BaseRelation]] = None,
     ):
         catalogs: agate.Table
         if (
@@ -1178,11 +1174,11 @@ class BaseAdapter(metaclass=AdapterMeta):
             or not self.supports(Capability.SchemaMetadataByRelations)
         ):
             # Do it the traditional way. We get the full catalog.
-            catalogs, exceptions = self.get_catalog(manifest)
+            catalogs, exceptions = self.get_catalog(relation_configs, used_schemas)
         else:
             # Do it the new way. We try to save time by selecting information
             # only for the exact set of relations we are interested in.
-            catalogs, exceptions = self.get_catalog_by_relations(manifest, relations)
+            catalogs, exceptions = self.get_catalog_by_relations(used_schemas, relations)
 
         if relations and catalogs:
             relation_map = {
@@ -1210,16 +1206,20 @@ class BaseAdapter(metaclass=AdapterMeta):
     def row_matches_relation(self, row: agate.Row, relations: Set[BaseRelation]):
         pass
 
-    def get_catalog(self, manifest: Manifest) -> Tuple[agate.Table, List[Exception]]:
+    def get_catalog(
+        self,
+        relation_configs: Iterable[RelationConfig],
+        used_schemas: frozenset[tuple[str, str]],
+    ) -> Tuple[agate.Table, List[Exception]]:
         with executor(self.config) as tpe:
             futures: List[Future[agate.Table]] = []
-            schema_map: SchemaSearchMap = self._get_catalog_schemas(manifest)
+            schema_map: SchemaSearchMap = self._get_catalog_schemas(relation_configs)
             for info, schemas in schema_map.items():
                 if len(schemas) == 0:
                     continue
                 name = ".".join([str(info.database), "information_schema"])
                 fut = tpe.submit_connected(
-                    self, name, self._get_one_catalog, info, schemas, manifest
+                    self, name, self._get_one_catalog, info, schemas, used_schemas
                 )
                 futures.append(fut)
 
@@ -1227,7 +1227,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         return catalogs, exceptions
 
     def get_catalog_by_relations(
-        self, manifest: Manifest, relations: Set[BaseRelation]
+        self, used_schemas: frozenset[tuple[str, str]], relations: Set[BaseRelation]
     ) -> Tuple[agate.Table, List[Exception]]:
         with executor(self.config) as tpe:
             futures: List[Future[agate.Table]] = []
@@ -1241,7 +1241,7 @@ class BaseAdapter(metaclass=AdapterMeta):
                     self._get_one_catalog_by_relations,
                     info_schema,
                     relations,
-                    manifest,
+                    used_schemas,
                 )
                 futures.append(fut)
 

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -425,7 +425,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         populate.
         """
         return {
-            self.Relation.create_from(quoting=self.config, config=relation_config)
+            self.Relation.create_from(quoting=self.config, relation_config=relation_config)
             for relation_config in relation_configs
         }
 

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -111,7 +111,7 @@ def _expect_row_value(key: str, row: agate.Row):
 
 
 def _catalog_filter_schemas(
-    used_schemas: FrozenSet[tuple[str, str]]
+    used_schemas: FrozenSet[Tuple[str, str]]
 ) -> Callable[[agate.Row], bool]:
     """Return a function that takes a row and decides if the row should be
     included in the catalog output.
@@ -1115,7 +1115,7 @@ class BaseAdapter(metaclass=AdapterMeta):
 
     @classmethod
     def _catalog_filter_table(
-        cls, table: agate.Table, used_schemas: FrozenSet[tuple[str, str]]
+        cls, table: agate.Table, used_schemas: FrozenSet[Tuple[str, str]]
     ) -> agate.Table:
         """Filter the table as appropriate for catalog entries. Subclasses can
         override this to change filtering rules on a per-adapter basis.
@@ -1132,7 +1132,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         self,
         information_schema: InformationSchema,
         schemas: Set[str],
-        used_schemas: FrozenSet[tuple[str, str]],
+        used_schemas: FrozenSet[Tuple[str, str]],
     ) -> agate.Table:
         kwargs = {"information_schema": information_schema, "schemas": schemas}
         table = self.execute_macro(
@@ -1147,7 +1147,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         self,
         information_schema: InformationSchema,
         relations: List[BaseRelation],
-        used_schemas: FrozenSet[tuple[str, str]],
+        used_schemas: FrozenSet[Tuple[str, str]],
     ) -> agate.Table:
 
         kwargs = {
@@ -1165,7 +1165,7 @@ class BaseAdapter(metaclass=AdapterMeta):
     def get_filtered_catalog(
         self,
         relation_configs: Iterable[RelationConfig],
-        used_schemas: FrozenSet[tuple[str, str]],
+        used_schemas: FrozenSet[Tuple[str, str]],
         relations: Optional[Set[BaseRelation]] = None,
     ):
         catalogs: agate.Table
@@ -1210,7 +1210,7 @@ class BaseAdapter(metaclass=AdapterMeta):
     def get_catalog(
         self,
         relation_configs: Iterable[RelationConfig],
-        used_schemas: FrozenSet[tuple[str, str]],
+        used_schemas: FrozenSet[Tuple[str, str]],
     ) -> Tuple[agate.Table, List[Exception]]:
         with executor(self.config) as tpe:
             futures: List[Future[agate.Table]] = []
@@ -1228,7 +1228,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         return catalogs, exceptions
 
     def get_catalog_by_relations(
-        self, used_schemas: FrozenSet[tuple[str, str]], relations: Set[BaseRelation]
+        self, used_schemas: FrozenSet[Tuple[str, str]], relations: Set[BaseRelation]
     ) -> Tuple[agate.Table, List[Exception]]:
         with executor(self.config) as tpe:
             futures: List[Future[agate.Table]] = []

--- a/tests/unit/test_postgres_adapter.py
+++ b/tests/unit/test_postgres_adapter.py
@@ -352,15 +352,15 @@ class TestPostgresAdapter(unittest.TestCase):
 
         mock_get_relations.return_value = relations
 
-        mock_manifest = mock.MagicMock()
-        mock_manifest.get_used_schemas.return_value = {("dbt", "foo"), ("dbt", "quux")}
+        relation_configs = []
+        used_schemas = {("dbt", "foo"), ("dbt", "quux")}
 
         if filtered:
             catalog, exceptions = self.adapter.get_filtered_catalog(
-                mock_manifest, set([relations[0], relations[3]])
+                relation_configs, used_schemas, set([relations[0], relations[3]])
             )
         else:
-            catalog, exceptions = self.adapter.get_catalog(mock_manifest)
+            catalog, exceptions = self.adapter.get_catalog(relation_configs, used_schemas)
 
         tupled_catalog = set(map(tuple, catalog))
         if filtered:
@@ -560,8 +560,7 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
 
 class TestPostgresFilterCatalog(unittest.TestCase):
     def test__catalog_filter_table(self):
-        manifest = mock.MagicMock()
-        manifest.get_used_schemas.return_value = [["a", "B"], ["a", "1234"]]
+        used_schemas = [["a", "B"], ["a", "1234"]]
         column_names = ["table_name", "table_database", "table_schema", "something"]
         rows = [
             ["foo", "a", "b", "1234"],  # include
@@ -571,7 +570,7 @@ class TestPostgresFilterCatalog(unittest.TestCase):
         ]
         table = agate.Table(rows, column_names, agate_helper.DEFAULT_TYPE_TESTER)
 
-        result = PostgresAdapter._catalog_filter_table(table, manifest)
+        result = PostgresAdapter._catalog_filter_table(table, used_schemas)
         assert len(result) == 3
         for row in result.rows:
             assert isinstance(row["table_schema"], str)


### PR DESCRIPTION
resolves #9218 
resolves #9217

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

1. Setting the relations cache requires an entire manifest currently, even though just a sliver of functionality is necessary for the task.
2. An entire manifest object is passed from core to adapters for catalog methods, when all that is needed is an iterable of ResultConfig protocols to create relations from, and a set of used schemas.
### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Using up prior PRs to close these out on a clean PR: https://github.com/dbt-labs/dbt-core/pull/9212, https://github.com/dbt-labs/dbt-core/pull/9213

1. Pre-compute the manifest nodes to populate the cache for - passing in an iterable of RelationConfigs to the adapter instead of the entire manifest.
2. Refactor the generate task to pre-compute the list of catalogable relation configs + used schemas and pass those + plumb them through adapter methods instead of passing an overly broad manifest object through core -> adapters.




### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
