### PR TITLE
Cleanup spacing in array_construct macro

### DIFF
--- a/.changes/unreleased/Fixes-20231208-154129.yaml
+++ b/.changes/unreleased/Fixes-20231208-154129.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Clean up whitespace in array_construct macro
+time: 2023-12-08T15:41:29.095036354+01:00
+custom:
+  Author: barskern
+  Issue: "9257"

--- a/core/dbt/include/global_project/macros/utils/array_construct.sql
+++ b/core/dbt/include/global_project/macros/utils/array_construct.sql
@@ -4,9 +4,9 @@
 
 {# all inputs must be the same data type to match postgres functionality #}
 {% macro default__array_construct(inputs, data_type) -%}
-    {% if inputs|length > 0 %}
-    array[ {{ inputs|join(' , ') }} ]
-    {% else %}
-    array[]::{{data_type}}[]
-    {% endif %}
+    {%- if inputs|length > 0 -%}
+        array[{{ inputs|join(',') }}]
+    {%- else -%}
+        array[]::{{data_type}}[]
+    {%- endif -%}
 {%- endmacro %}


### PR DESCRIPTION
### Problem

Before this PR the generate SQL when using the `dbt.array_construct` macros is "messy". There is unneeded whitespace which add characters in addition to unneeded newlines. 

**Before**:
```sql
        and (dsc.scanner_key = any(
    array[ 1 , 2 , 3 , 4 ]
    ))
```

### Solution

This PR simply cleans up the whitespace in this macro to enable cleaner looking output.

**After**:
```sql
        and (dsc.scanner_key = any(array[1,2,3,4]))
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
