### PR TITLE
Ensure support for external nodes in unit tests

### DIFF
--- a/tests/functional/unit_testing/fixtures.py
+++ b/tests/functional/unit_testing/fixtures.py
@@ -598,3 +598,33 @@ unit_tests:
       format: csv
       fixture: test_my_model_basic_fixture
 """
+
+top_level_domains_sql = """
+SELECT 'example.com' AS tld
+UNION ALL
+SELECT 'gmail.com' AS tld
+"""
+
+test_my_model_external_nodes_sql = """
+WITH
+accounts AS (
+  SELECT user_id, email, email_top_level_domain
+  FROM {{ ref('external_package', 'external_model')}}
+),
+top_level_domains AS (
+  SELECT tld FROM {{ ref('top_level_domains')}}
+),
+joined AS (
+  SELECT
+    accounts.user_id as user_id,
+    top_level_domains.tld as tld
+  FROM accounts
+  LEFT OUTER JOIN top_level_domains
+    ON   accounts.email_top_level_domain = top_level_domains.tld
+)
+
+SELECT
+  joined.user_id as user_id,
+  CASE WHEN joined.tld IS NULL THEN 'FALSE' ELSE 'TRUE' END AS is_valid_email_address
+from joined
+"""

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest import mock
 from dbt.tests.util import (
     run_dbt,
     write_file,
@@ -6,6 +7,7 @@ from dbt.tests.util import (
 )
 from dbt.contracts.results import NodeStatus
 from dbt.exceptions import DuplicateResourceNameError, ParsingError
+from dbt.plugins.manifest import PluginNodes, ModelNodeArgs
 from fixtures import (
     my_model_vars_sql,
     my_model_a_sql,
@@ -15,6 +17,8 @@ from fixtures import (
     my_incremental_model_sql,
     event_sql,
     test_my_model_incremental_yml,
+    test_my_model_external_nodes_sql,
+    top_level_domains_sql,
 )
 
 
@@ -237,3 +241,61 @@ class TestUnitTestNonexistentSeed:
             ParsingError, match="Unable to find seed 'test.my_second_favorite_seed' for unit tests"
         ):
             run_dbt(["test", "--select", "my_new_model"], expect_pass=False)
+
+
+test_unit_test_with_external_nodes_yml = """
+unit_tests:
+  - name: test_unit_test_with_external_nodes
+    model: test_my_model_external_nodes
+    given:
+      - input: ref('external_package', 'external_model')
+        rows:
+          - {user_id: 1, email: cool@example.com,     email_top_level_domain: example.com}
+          - {user_id: 2, email: cool@unknown.com,     email_top_level_domain: unknown.com}
+          - {user_id: 3, email: badgmail.com,         email_top_level_domain: gmail.com}
+          - {user_id: 4, email: missingdot@gmailcom,  email_top_level_domain: gmail.com}
+      - input: ref('top_level_domains')
+        rows:
+          - {tld: example.com}
+          - {tld: gmail.com}
+    expect:
+      rows:
+        - {user_id: 1, is_valid_email_address: true}
+        - {user_id: 2, is_valid_email_address: false}
+        - {user_id: 3, is_valid_email_address: false}
+        - {user_id: 4, is_valid_email_address: false}
+"""
+
+
+class TestUnitTestExternalNode:
+    @pytest.fixture(scope="class")
+    def external_model_node(self):
+        return ModelNodeArgs(
+            name="external_model",
+            package_name="external_package",
+            identifier="test_identifier",
+            schema="test_schema",
+        )
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "top_level_domains.sql": top_level_domains_sql,
+            "test_my_model_external_nodes.sql": test_my_model_external_nodes_sql,
+            "test_unit_test_with_external_nodes.yml": test_unit_test_with_external_nodes_yml,
+        }
+
+    @mock.patch("dbt.plugins.get_plugin_manager")
+    def test_unit_test_external_nodes(
+        self,
+        get_plugin_manager,
+        project,
+        external_model_node,
+    ):
+        # initial plugin - one external model
+        external_nodes = PluginNodes()
+        external_nodes.add_model(external_model_node)
+        get_plugin_manager.return_value.get_nodes.return_value = external_nodes
+
+        results = run_dbt(["test", "--select", "test_my_model_external_nodes"], expect_pass=True)
+        assert len(results) == 1


### PR DESCRIPTION
resolves #8944 

## Problem

We weren't sure if external nodes in unit tests would just work, and it turns out that they do!

### Note: this wasn't originally working
Before the winter break this didn't just work. I started on this work early in December, and at that time it was failing to find the external node at ref resolution time. This was because under the hood the identifier for refs in unit tests are under a different name to spoof the node to be ref'd. At the time there was a disconnect between the ref in the unit test, and the unit test in the model. 

## Solution

Added a test which includes an external node

### Note
There is no changelog for this PR because nothing in core itself was changed, just an added test.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
