### PR TITLE
Add contributor to 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@
 -  ([#5033](https://github.com/dbt-labs/dbt-core/issues/5033), [#5032](https://github.com/dbt-labs/dbt-core/pull/5032))
 
 ### Contributors
+- [@triedandtested-dev](https://github.com/triedandtested-dev) ([#4618](https://github.com/dbt-labs/dbt-core/pull/4618))
 - [@NiallRees](https://github.com/NiallRees) ([#4447](https://github.com/dbt-labs/dbt-core/pull/4447))
 - [@agoblet](https://github.com/agoblet) ([#5000](https://github.com/dbt-labs/dbt-core/pull/5000))
 - [@alswang18](https://github.com/alswang18) ([#4644](https://github.com/dbt-labs/dbt-core/pull/4644))


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/pull/4618/files#r799340999

### Problem

We accidentally missed a contributor when we replaced https://github.com/dbt-labs/dbt-core/pull/4159 with  https://github.com/dbt-labs/dbt-core/pull/4618

### Solution

Just grabbed the code suggestion from https://github.com/dbt-labs/dbt-core/pull/4618/files#r799340999 and opened a pull request 😎

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] ~I have run this code in development and it appears to resolve the stated issue~ If the Markdown is malformed then we can just open a new PR
- [x] Tests are not required/relevant for this PR
- [x] This PR has no interface changes
- [ ] ~This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions~
