### PR TITLE
added hook support for dbt source freshness

### DIFF
--- a/.changes/unreleased/Features-20231231-171205.yaml
+++ b/.changes/unreleased/Features-20231231-171205.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Added hook support for `dbt source freshness`
+time: 2023-12-31T17:12:05.587185+02:00
+custom:
+  Author: ofek1weiss
+  Issue: "5609"

--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -213,7 +213,6 @@ class RunResultOutput(BaseResult):
 
 
 def process_run_result(result: RunResult) -> RunResultOutput:
-
     compiled = isinstance(result.node, CompiledNode)
 
     return RunResultOutput(
@@ -282,7 +281,8 @@ class RunResultsArtifact(ExecutionResult, ArtifactMixin):
     @classmethod
     def upgrade_schema_version(cls, data):
         """This overrides the "upgrade_schema_version" call in VersionedSchema (via
-        ArtifactMixin) to modify the dictionary passed in from earlier versions of the run_results."""
+        ArtifactMixin) to modify the dictionary passed in from earlier versions of the run_results.
+        """
         run_results_schema_version = get_artifact_schema_version(data)
         # If less than the current version (v5), preprocess contents to match latest schema version
         if run_results_schema_version <= 5:
@@ -398,12 +398,12 @@ class FreshnessMetadata(BaseArtifactMetadata):
 @dataclass
 class FreshnessResult(ExecutionResult):
     metadata: FreshnessMetadata
-    results: Sequence[FreshnessNodeResult]
+    results: Sequence[Union[FreshnessNodeResult, BaseResult]]
 
     @classmethod
     def from_node_results(
         cls,
-        results: List[FreshnessNodeResult],
+        results: List[Union[FreshnessNodeResult, BaseResult]],
         elapsed_time: float,
         generated_at: datetime,
     ):
@@ -426,7 +426,9 @@ class FreshnessExecutionResultArtifact(
 
     @classmethod
     def from_result(cls, base: FreshnessResult):
-        processed = [process_freshness_result(r) for r in base.results]
+        processed = [
+            process_freshness_result(r) for r in base.results if isinstance(r, FreshnessNodeResult)
+        ]
         return cls(
             metadata=base.metadata,
             results=processed,

--- a/core/dbt/task/freshness.py
+++ b/core/dbt/task/freshness.py
@@ -7,7 +7,7 @@ from .base import BaseRunner
 from .printer import (
     print_run_result_error,
 )
-from .runnable import GraphRunnableTask
+from .run import RunTask
 
 from dbt.contracts.results import (
     FreshnessResult,
@@ -170,7 +170,7 @@ class FreshnessSelector(ResourceTypeSelector):
         return node.has_freshness
 
 
-class FreshnessTask(GraphRunnableTask):
+class FreshnessTask(RunTask):
     def defer_to_manifest(self, adapter, selected_uids):
         # freshness don't defer
         return

--- a/core/dbt/task/freshness.py
+++ b/core/dbt/task/freshness.py
@@ -23,6 +23,7 @@ from dbt.common.events.types import (
     LogFreshnessResult,
     Note,
 )
+from dbt.contracts.results import RunStatus
 from dbt.node_types import NodeType
 
 from dbt.adapters.capability import Capability
@@ -204,7 +205,11 @@ class FreshnessTask(RunTask):
 
     def task_end_messages(self, results):
         for result in results:
-            if result.status in (FreshnessStatus.Error, FreshnessStatus.RuntimeErr):
+            if result.status in (
+                FreshnessStatus.Error,
+                FreshnessStatus.RuntimeErr,
+                RunStatus.Error,
+            ):
                 print_run_result_error(result)
 
         fire_event(FreshnessCheckComplete())


### PR DESCRIPTION
resolves #5609

### Problem
Currently, `on-run-*` hooks are not supported in the `dbt source freshness` command, this PR makes it so it does.

### Solution
Changed the `FreshnessTask` class to inherit from `RunTask` (as all other task types that support hooks do).

Alternative solutions:
* Move the hook logic to `GraphRunnableTask` and disabling in `CompileTask` - feels a little messier (disabling parent functionality in inheriter).
* Create a `HookTask` in the middle of the inheritance tree - seems like a lot more work when every other hook-able task just inherits from `RunTask`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
