### PR TITLE
Decouple core exceptions from common

### DIFF
--- a/.changes/unreleased/Under the Hood-20240104-133249.yaml
+++ b/.changes/unreleased/Under the Hood-20240104-133249.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: move exceptions used only in dbt/common to dbt/common/exceptions
+time: 2024-01-04T13:32:49.076149-05:00
+custom:
+  Author: michelleark
+  Issue: "9332"

--- a/core/dbt/common/clients/_jinja_blocks.py
+++ b/core/dbt/common/clients/_jinja_blocks.py
@@ -1,7 +1,7 @@
 import re
 from collections import namedtuple
 
-from dbt.exceptions import (
+from dbt.common.exceptions import (
     BlockDefinitionNotAtTopError,
     DbtInternalError,
     MissingCloseTagError,

--- a/core/dbt/common/clients/system.py
+++ b/core/dbt/common/clients/system.py
@@ -421,7 +421,7 @@ def _interpret_oserror(exc: OSError, cwd: str, cmd: List[str]) -> NoReturn:
         _handle_posix_error(exc, cwd, cmd)
 
     # this should not be reachable, raise _something_ at least!
-    raise dbt.exceptions.DbtInternalError(
+    raise dbt.common.exceptions.DbtInternalError(
         "Unhandled exception in _interpret_oserror: {}".format(exc)
     )
 

--- a/core/dbt/common/clients/system.py
+++ b/core/dbt/common/clients/system.py
@@ -154,7 +154,7 @@ def make_symlink(source: str, link_path: str) -> None:
     """
     if not supports_symlinks():
         # TODO: why not import these at top?
-        raise dbt.exceptions.SymbolicLinkError()
+        raise dbt.common.exceptions.SymbolicLinkError()
 
     os.symlink(source, link_path)
 
@@ -345,7 +345,7 @@ def _handle_posix_cwd_error(exc: OSError, cwd: str, cmd: List[str]) -> NoReturn:
         message = "Not a directory"
     else:
         message = "Unknown OSError: {} - cwd".format(str(exc))
-    raise dbt.exceptions.WorkingDirectoryError(cwd, cmd, message)
+    raise dbt.common.exceptions.WorkingDirectoryError(cwd, cmd, message)
 
 
 def _handle_posix_cmd_error(exc: OSError, cwd: str, cmd: List[str]) -> NoReturn:
@@ -355,7 +355,7 @@ def _handle_posix_cmd_error(exc: OSError, cwd: str, cmd: List[str]) -> NoReturn:
         message = "User does not have permissions for this command"
     else:
         message = "Unknown OSError: {} - cmd".format(str(exc))
-    raise dbt.exceptions.ExecutableError(cwd, cmd, message)
+    raise dbt.common.exceptions.ExecutableError(cwd, cmd, message)
 
 
 def _handle_posix_error(exc: OSError, cwd: str, cmd: List[str]) -> NoReturn:
@@ -392,16 +392,16 @@ def _handle_windows_error(exc: OSError, cwd: str, cmd: List[str]) -> NoReturn:
             "Could not find command, ensure it is in the user's PATH "
             "and that the user has permissions to run it"
         )
-        cls = dbt.exceptions.ExecutableError
+        cls = dbt.common.exceptions.ExecutableError
     elif exc.errno == errno.ENOEXEC:
         message = "Command was not executable, ensure it is valid"
-        cls = dbt.exceptions.ExecutableError
+        cls = dbt.common.exceptions.ExecutableError
     elif exc.errno == errno.ENOTDIR:
         message = (
             "Unable to cd: path does not exist, user does not have"
             " permissions, or not a directory"
         )
-        cls = dbt.exceptions.WorkingDirectoryError
+        cls = dbt.common.exceptions.WorkingDirectoryError
     else:
         message = 'Unknown error: {} (errno={}: "{}")'.format(
             str(exc), exc.errno, errno.errorcode.get(exc.errno, "<Unknown!>")
@@ -455,7 +455,7 @@ def run_cmd(cwd: str, cmd: List[str], env: Optional[Dict[str, Any]] = None) -> T
 
     if proc.returncode != 0:
         fire_event(SystemReportReturnCode(returncode=proc.returncode))
-        raise dbt.exceptions.CommandResultError(cwd, cmd, proc.returncode, out, err)
+        raise dbt.common.exceptions.CommandResultError(cwd, cmd, proc.returncode, out, err)
 
     return out, err
 

--- a/core/dbt/common/contracts/config/base.py
+++ b/core/dbt/common/contracts/config/base.py
@@ -6,7 +6,7 @@ from typing import Callable, Dict, Any, List, TypeVar
 from dbt.common.contracts.config.metadata import Metadata
 from dbt.common.exceptions import CompilationError, DbtInternalError
 from dbt.common.contracts.config.properties import AdditionalPropertiesAllowed
-from dbt.contracts.util import Replaceable
+from dbt.common.contracts.util import Replaceable
 
 T = TypeVar("T", bound="BaseConfig")
 

--- a/core/dbt/common/exceptions/__init__.py
+++ b/core/dbt/common/exceptions/__init__.py
@@ -3,3 +3,5 @@ from dbt.common.exceptions.events import *  # noqa
 from dbt.common.exceptions.macros import *  # noqa
 from dbt.common.exceptions.contracts import *  # noqa
 from dbt.common.exceptions.connection import *  # noqa
+from dbt.common.exceptions.system import *  # noqa
+from dbt.common.exceptions.jinja import *  # noqa

--- a/core/dbt/common/exceptions/__init__.py
+++ b/core/dbt/common/exceptions/__init__.py
@@ -2,3 +2,4 @@ from dbt.common.exceptions.base import *  # noqa
 from dbt.common.exceptions.events import *  # noqa
 from dbt.common.exceptions.macros import *  # noqa
 from dbt.common.exceptions.contracts import *  # noqa
+from dbt.common.exceptions.connection import *  # noqa

--- a/core/dbt/common/exceptions/connection.py
+++ b/core/dbt/common/exceptions/connection.py
@@ -1,0 +1,7 @@
+class ConnectionError(Exception):
+    """
+    There was a problem with the connection that returned a bad response,
+    timed out, or resulted in a file that is corrupt.
+    """
+
+    pass

--- a/core/dbt/common/exceptions/jinja.py
+++ b/core/dbt/common/exceptions/jinja.py
@@ -1,0 +1,85 @@
+from dbt.common.exceptions import CompilationError
+
+
+class BlockDefinitionNotAtTopError(CompilationError):
+    def __init__(self, tag_parser, tag_start) -> None:
+        self.tag_parser = tag_parser
+        self.tag_start = tag_start
+        super().__init__(msg=self.get_message())
+
+    def get_message(self) -> str:
+        position = self.tag_parser.linepos(self.tag_start)
+        msg = (
+            f"Got a block definition inside control flow at {position}. "
+            "All dbt block definitions must be at the top level"
+        )
+        return msg
+
+
+class MissingCloseTagError(CompilationError):
+    def __init__(self, block_type_name: str, linecount: int) -> None:
+        self.block_type_name = block_type_name
+        self.linecount = linecount
+        super().__init__(msg=self.get_message())
+
+    def get_message(self) -> str:
+        msg = f"Reached EOF without finding a close tag for {self.block_type_name} (searched from line {self.linecount})"
+        return msg
+
+
+class MissingControlFlowStartTagError(CompilationError):
+    def __init__(self, tag, expected_tag: str, tag_parser) -> None:
+        self.tag = tag
+        self.expected_tag = expected_tag
+        self.tag_parser = tag_parser
+        super().__init__(msg=self.get_message())
+
+    def get_message(self) -> str:
+        linepos = self.tag_parser.linepos(self.tag.start)
+        msg = (
+            f"Got an unexpected control flow end tag, got {self.tag.block_type_name} but "
+            f"expected {self.expected_tag} next (@ {linepos})"
+        )
+        return msg
+
+
+class NestedTagsError(CompilationError):
+    def __init__(self, outer, inner) -> None:
+        self.outer = outer
+        self.inner = inner
+        super().__init__(msg=self.get_message())
+
+    def get_message(self) -> str:
+        msg = (
+            f"Got nested tags: {self.outer.block_type_name} (started at {self.outer.start}) did "
+            f"not have a matching {{{{% end{self.outer.block_type_name} %}}}} before a "
+            f"subsequent {self.inner.block_type_name} was found (started at {self.inner.start})"
+        )
+        return msg
+
+
+class UnexpectedControlFlowEndTagError(CompilationError):
+    def __init__(self, tag, expected_tag: str, tag_parser) -> None:
+        self.tag = tag
+        self.expected_tag = expected_tag
+        self.tag_parser = tag_parser
+        super().__init__(msg=self.get_message())
+
+    def get_message(self) -> str:
+        linepos = self.tag_parser.linepos(self.tag.start)
+        msg = (
+            f"Got an unexpected control flow end tag, got {self.tag.block_type_name} but "
+            f"never saw a preceeding {self.expected_tag} (@ {linepos})"
+        )
+        return msg
+
+
+class UnexpectedMacroEOFError(CompilationError):
+    def __init__(self, expected_name: str, actual_name: str) -> None:
+        self.expected_name = expected_name
+        self.actual_name = actual_name
+        super().__init__(msg=self.get_message())
+
+    def get_message(self) -> str:
+        msg = f'unexpected EOF, expected {self.expected_name}, got "{self.actual_name}"'
+        return msg

--- a/core/dbt/common/exceptions/system.py
+++ b/core/dbt/common/exceptions/system.py
@@ -1,0 +1,50 @@
+from typing import List, Union, Any
+
+from dbt.common.exceptions import CompilationError, CommandError, scrub_secrets, env_secrets
+
+
+class SymbolicLinkError(CompilationError):
+    def __init__(self) -> None:
+        super().__init__(msg=self.get_message())
+
+    def get_message(self) -> str:
+        msg = (
+            "dbt encountered an error when attempting to create a symbolic link. "
+            "If this error persists, please create an issue at: \n\n"
+            "https://github.com/dbt-labs/dbt-core"
+        )
+
+        return msg
+
+
+class ExecutableError(CommandError):
+    def __init__(self, cwd: str, cmd: List[str], msg: str) -> None:
+        super().__init__(cwd, cmd, msg)
+
+
+class WorkingDirectoryError(CommandError):
+    def __init__(self, cwd: str, cmd: List[str], msg: str) -> None:
+        super().__init__(cwd, cmd, msg)
+
+    def __str__(self):
+        return f'{self.msg}: "{self.cwd}"'
+
+
+class CommandResultError(CommandError):
+    def __init__(
+        self,
+        cwd: str,
+        cmd: List[str],
+        returncode: Union[int, Any],
+        stdout: bytes,
+        stderr: bytes,
+        msg: str = "Got a non-zero returncode",
+    ) -> None:
+        super().__init__(cwd, cmd, msg)
+        self.returncode = returncode
+        self.stdout = scrub_secrets(stdout.decode("utf-8"), env_secrets())
+        self.stderr = scrub_secrets(stderr.decode("utf-8"), env_secrets())
+        self.args = (cwd, self.cmd, returncode, self.stdout, self.stderr, msg)
+
+    def __str__(self):
+        return f"{self.msg} running: {self.cmd}"

--- a/core/dbt/common/utils/connection.py
+++ b/core/dbt/common/utils/connection.py
@@ -1,7 +1,7 @@
 import time
 
 from dbt.common.events.types import RecordRetryException, RetryExternalCall
-from dbt.exceptions import ConnectionError
+from dbt.common.exceptions import ConnectionError
 from tarfile import ReadError
 
 import requests

--- a/core/dbt/common/utils/dict.py
+++ b/core/dbt/common/utils/dict.py
@@ -118,7 +118,7 @@ def deep_map_render(func: Callable[[Any, Tuple[Union[str, int], ...]], Any], val
     iterable over the __getitem__ keys needed to get to it.
 
     :raises: If there are cycles in the value, raises a
-        dbt.exceptions.RecursionException
+        dbt.common.exceptions.RecursionError
     """
     try:
         return _deep_map_render(func, value, ())

--- a/core/dbt/deps/git.py
+++ b/core/dbt/deps/git.py
@@ -10,7 +10,8 @@ from dbt.contracts.project import (
     GitPackage,
 )
 from dbt.deps.base import PinnedPackage, UnpinnedPackage, get_downloads_path
-from dbt.exceptions import ExecutableError, MultipleVersionGitDepsError
+from dbt.common.exceptions import ExecutableError
+from dbt.exceptions import MultipleVersionGitDepsError
 from dbt.common.events.functions import fire_event, warn_or_error, scrub_secrets, env_secrets
 from dbt.events.types import EnsureGitInstalled, DepsUnpinned, DepsScrubbedPackageName
 from dbt.utils import md5

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -12,7 +12,7 @@ from dbt.common.exceptions import (
     env_secrets,
     scrub_secrets,
     DbtValidationError,
-    CommandError,
+    CommandResultError,
 )
 from dbt.node_types import NodeType, AccessType
 
@@ -136,39 +136,6 @@ class DbtProfileError(DbtConfigError):
     pass
 
 
-class ExecutableError(CommandError):
-    def __init__(self, cwd: str, cmd: List[str], msg: str) -> None:
-        super().__init__(cwd, cmd, msg)
-
-
-class WorkingDirectoryError(CommandError):
-    def __init__(self, cwd: str, cmd: List[str], msg: str) -> None:
-        super().__init__(cwd, cmd, msg)
-
-    def __str__(self):
-        return f'{self.msg}: "{self.cwd}"'
-
-
-class CommandResultError(CommandError):
-    def __init__(
-        self,
-        cwd: str,
-        cmd: List[str],
-        returncode: Union[int, Any],
-        stdout: bytes,
-        stderr: bytes,
-        msg: str = "Got a non-zero returncode",
-    ) -> None:
-        super().__init__(cwd, cmd, msg)
-        self.returncode = returncode
-        self.stdout = scrub_secrets(stdout.decode("utf-8"), env_secrets())
-        self.stderr = scrub_secrets(stderr.decode("utf-8"), env_secrets())
-        self.args = (cwd, self.cmd, returncode, self.stdout, self.stderr, msg)
-
-    def __str__(self):
-        return f"{self.msg} running: {self.cmd}"
-
-
 class InvalidSelectorError(DbtRuntimeError):
     def __init__(self, name: str) -> None:
         self.name = name
@@ -208,49 +175,6 @@ class MaterializtionMacroNotUsedError(CompilationError):
         super().__init__(msg=self.msg)
 
 
-class MissingControlFlowStartTagError(CompilationError):
-    def __init__(self, tag, expected_tag: str, tag_parser) -> None:
-        self.tag = tag
-        self.expected_tag = expected_tag
-        self.tag_parser = tag_parser
-        super().__init__(msg=self.get_message())
-
-    def get_message(self) -> str:
-        linepos = self.tag_parser.linepos(self.tag.start)
-        msg = (
-            f"Got an unexpected control flow end tag, got {self.tag.block_type_name} but "
-            f"expected {self.expected_tag} next (@ {linepos})"
-        )
-        return msg
-
-
-class UnexpectedControlFlowEndTagError(CompilationError):
-    def __init__(self, tag, expected_tag: str, tag_parser) -> None:
-        self.tag = tag
-        self.expected_tag = expected_tag
-        self.tag_parser = tag_parser
-        super().__init__(msg=self.get_message())
-
-    def get_message(self) -> str:
-        linepos = self.tag_parser.linepos(self.tag.start)
-        msg = (
-            f"Got an unexpected control flow end tag, got {self.tag.block_type_name} but "
-            f"never saw a preceeding {self.expected_tag} (@ {linepos})"
-        )
-        return msg
-
-
-class UnexpectedMacroEOFError(CompilationError):
-    def __init__(self, expected_name: str, actual_name: str) -> None:
-        self.expected_name = expected_name
-        self.actual_name = actual_name
-        super().__init__(msg=self.get_message())
-
-    def get_message(self) -> str:
-        msg = f'unexpected EOF, expected {self.expected_name}, got "{self.actual_name}"'
-        return msg
-
-
 class MacroNamespaceNotStringError(CompilationError):
     def __init__(self, kwarg_type: Any) -> None:
         self.kwarg_type = kwarg_type
@@ -261,47 +185,6 @@ class MacroNamespaceNotStringError(CompilationError):
             "The macro_namespace parameter to adapter.dispatch "
             f"is a {self.kwarg_type}, not a string"
         )
-        return msg
-
-
-class NestedTagsError(CompilationError):
-    def __init__(self, outer, inner) -> None:
-        self.outer = outer
-        self.inner = inner
-        super().__init__(msg=self.get_message())
-
-    def get_message(self) -> str:
-        msg = (
-            f"Got nested tags: {self.outer.block_type_name} (started at {self.outer.start}) did "
-            f"not have a matching {{{{% end{self.outer.block_type_name} %}}}} before a "
-            f"subsequent {self.inner.block_type_name} was found (started at {self.inner.start})"
-        )
-        return msg
-
-
-class BlockDefinitionNotAtTopError(CompilationError):
-    def __init__(self, tag_parser, tag_start) -> None:
-        self.tag_parser = tag_parser
-        self.tag_start = tag_start
-        super().__init__(msg=self.get_message())
-
-    def get_message(self) -> str:
-        position = self.tag_parser.linepos(self.tag_start)
-        msg = (
-            f"Got a block definition inside control flow at {position}. "
-            "All dbt block definitions must be at the top level"
-        )
-        return msg
-
-
-class MissingCloseTagError(CompilationError):
-    def __init__(self, block_type_name: str, linecount: int) -> None:
-        self.block_type_name = block_type_name
-        self.linecount = linecount
-        super().__init__(msg=self.get_message())
-
-    def get_message(self) -> str:
-        msg = f"Reached EOF without finding a close tag for {self.block_type_name} (searched from line {self.linecount})"
         return msg
 
 
@@ -370,20 +253,6 @@ class OperationError(CompilationError):
     def get_message(self) -> str:
         msg = (
             f"dbt encountered an error when attempting to create a {self.operation_name}. "
-            "If this error persists, please create an issue at: \n\n"
-            "https://github.com/dbt-labs/dbt-core"
-        )
-
-        return msg
-
-
-class SymbolicLinkError(CompilationError):
-    def __init__(self) -> None:
-        super().__init__(msg=self.get_message())
-
-    def get_message(self) -> str:
-        msg = (
-            "dbt encountered an error when attempting to create a symbolic link. "
             "If this error persists, please create an issue at: \n\n"
             "https://github.com/dbt-labs/dbt-core"
         )

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -179,15 +179,6 @@ class DuplicateYamlKeyError(CompilationError):
     pass
 
 
-class ConnectionError(Exception):
-    """
-    There was a problem with the connection that returned a bad response,
-    timed out, or resulted in a file that is corrupt.
-    """
-
-    pass
-
-
 # compilation level exceptions
 class GraphDependencyNotFoundError(CompilationError):
     def __init__(self, node, dependency: str) -> None:

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -399,7 +399,7 @@ class DebugTask(BaseTask):
     def test_git(self) -> SubtaskStatus:
         try:
             dbt.common.clients.system.run_cmd(os.getcwd(), ["git", "--help"])
-        except dbt.exceptions.ExecutableError as exc:
+        except dbt.common.exceptions.ExecutableError as exc:
             return SubtaskStatus(
                 log_msg=red("ERROR"),
                 run_status=RunStatus.Error,

--- a/tests/unit/common/test_system_client.py
+++ b/tests/unit/common/test_system_client.py
@@ -7,7 +7,7 @@ import pathspec
 from pathlib import Path
 from tempfile import mkdtemp, NamedTemporaryFile
 
-from dbt.exceptions import ExecutableError, WorkingDirectoryError
+from dbt.common.exceptions import ExecutableError, WorkingDirectoryError
 import dbt.common.clients.system
 
 

--- a/tests/unit/test_connection_retries.py
+++ b/tests/unit/test_connection_retries.py
@@ -1,7 +1,7 @@
 import functools
 import pytest
 from requests.exceptions import RequestException
-from dbt.exceptions import ConnectionError
+from dbt.common.exceptions import ConnectionError
 from dbt.common.utils.connection import connection_exception_retry
 
 

--- a/tests/unit/test_core_dbt_utils.py
+++ b/tests/unit/test_core_dbt_utils.py
@@ -2,7 +2,7 @@ import requests
 import tarfile
 import unittest
 
-from dbt.exceptions import ConnectionError
+from dbt.common.exceptions import ConnectionError
 from dbt.common.utils.connection import connection_exception_retry
 
 

--- a/tests/unit/test_registry_get_request_exception.py
+++ b/tests/unit/test_registry_get_request_exception.py
@@ -1,6 +1,6 @@
 import unittest
 
-from dbt.exceptions import ConnectionError
+from dbt.common.exceptions import ConnectionError
 from dbt.clients.registry import _get_with_retries
 
 


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/9332

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

dbt/common importing exceptions defined in core, which will result in cyclic dependencies once dbt-common is ported into a new repo as an upstream to dbt-core. 

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
* fix a couple import paths of exceptions already defined in the right place, but imported from core (dbt.exceptions -> dbt.common.exceptions)
* add exceptions.system for usage in common system client
* add exceptions.jinja for usage in common jinja blocks utilities (not used elsewhere in core)
* add exceptions.connection for usage in common connection methods (not used elsewhere in core)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions

Some additional sanity checking: 

(the following does not address dbt.adapter usage on dbt/common, that will be addressed in another PR)
```sh
❯ python3 scripts/migrate-adapters.py core/dbt/common

migration progress: 100.0% of dbt imports are valid (from adapters or common)
remaining core imports: 0
```

not regressing in adapter cyclical imports: 
```sh
❯ python3 scripts/migrate-adapters.py core/dbt/adapters

migration progress: 100.0% of dbt imports are valid (from adapters or common)
remaining core imports: 0
```