### PR TITLE
generalize BaseConfig.update_from + call adapter factory methods in core

### DIFF
--- a/.changes/unreleased/Under the Hood-20240104-135849.yaml
+++ b/.changes/unreleased/Under the Hood-20240104-135849.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove usage of dbt.adapters.factory in dbt/common
+time: 2024-01-04T13:58:49.221966-05:00
+custom:
+  Author: michelleark
+  Issue: "9334"

--- a/core/dbt/common/contracts/config/base.py
+++ b/core/dbt/common/contracts/config/base.py
@@ -1,7 +1,10 @@
+# necessary for annotating constructors
+from __future__ import annotations
+
 from dataclasses import dataclass, Field
 
 from itertools import chain
-from typing import Callable, Dict, Any, List, TypeVar
+from typing import Callable, Dict, Any, List, TypeVar, Type
 
 from dbt.common.contracts.config.metadata import Metadata
 from dbt.common.exceptions import CompilationError, DbtInternalError
@@ -140,21 +143,18 @@ class BaseConfig(AdditionalPropertiesAllowed, Replaceable):
             )
         return result
 
-    def update_from(self: T, data: Dict[str, Any], adapter_type: str, validate: bool = True) -> T:
+    def update_from(
+        self: T, data: Dict[str, Any], config_cls: Type[BaseConfig], validate: bool = True
+    ) -> T:
         """Given a dict of keys, update the current config from them, validate
         it, and return a new config with the updated values
         """
-        # sadly, this is a circular import
-        from dbt.adapters.factory import get_config_class_by_name
-
         dct = self.to_dict(omit_none=False)
-
-        adapter_config_cls = get_config_class_by_name(adapter_type)
 
         self_merged = self._merge_dicts(dct, data)
         dct.update(self_merged)
 
-        adapter_merged = adapter_config_cls._merge_dicts(dct, data)
+        adapter_merged = config_cls._merge_dicts(dct, data)
         dct.update(adapter_merged)
 
         # any remaining fields must be "clobber"


### PR DESCRIPTION
resolves #9334

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
* BaseConfig.update_from in dbt/common was using a method imported from dbt.adapter to convert an adapter type -> its config class. This would represent a circular dependency once dbt/common is moved out of dbt-core and into an upstream package

### Solution
* call the dbt.adpater method in dbt.core (which can depend on dbt.adapter) and pass the resulting config class to the `update_from` call

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
