### PR TITLE
Decouple warn error options from core and adapters

### DIFF
--- a/.changes/unreleased/Under the Hood-20240104-165248.yaml
+++ b/.changes/unreleased/Under the Hood-20240104-165248.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Accept valid_error_names in WarnErrorOptions constructor, remove global usage
+  of event modules
+time: 2024-01-04T16:52:48.173716-05:00
+custom:
+  Author: michelleark
+  Issue: "9337"

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -19,6 +19,7 @@ from dbt.common.exceptions import DbtInternalError
 from dbt.common.clients import jinja
 from dbt.deprecations import renamed_env_var
 from dbt.common.helper_types import WarnErrorOptions
+from dbt.events import ALL_EVENT_NAMES
 
 if os.name != "nt":
     # https://bugs.python.org/issue41567
@@ -50,7 +51,9 @@ def convert_config(config_name, config_value):
     ret = config_value
     if config_name.lower() == "warn_error_options" and type(config_value) == dict:
         ret = WarnErrorOptions(
-            include=config_value.get("include", []), exclude=config_value.get("exclude", [])
+            include=config_value.get("include", []),
+            exclude=config_value.get("exclude", []),
+            valid_error_names=ALL_EVENT_NAMES,
         )
     return ret
 

--- a/core/dbt/cli/option_types.py
+++ b/core/dbt/cli/option_types.py
@@ -1,6 +1,7 @@
 from click import ParamType, Choice
 
 from dbt.config.utils import parse_cli_yaml_string
+from dbt.events import ALL_EVENT_NAMES
 from dbt.exceptions import ValidationError, OptionNotYamlDictError
 from dbt.common.exceptions import DbtValidationError
 
@@ -53,7 +54,9 @@ class WarnErrorOptionsType(YAML):
         include_exclude = super().convert(value, param, ctx)
 
         return WarnErrorOptions(
-            include=include_exclude.get("include", []), exclude=include_exclude.get("exclude", [])
+            include=include_exclude.get("include", []),
+            exclude=include_exclude.get("exclude", []),
+            valid_error_names=ALL_EVENT_NAMES,
         )
 
 

--- a/core/dbt/common/helper_types.py
+++ b/core/dbt/common/helper_types.py
@@ -5,17 +5,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Tuple, AbstractSet, Union
-from typing import Callable, cast, Generic, Optional, TypeVar, List, NewType, Any, Dict
+from typing import Callable, cast, Generic, Optional, TypeVar, List, NewType, Set
 
 from dbt.common.dataclass_schema import (
     dbtClassMixin,
     ValidationError,
     StrEnum,
 )
-import dbt.adapters.events.types as adapter_dbt_event_types
-import dbt.common.events.types as dbt_event_types
-import dbt.events.types as core_dbt_event_types
-
 
 Port = NewType("Port", int)
 
@@ -68,18 +64,18 @@ class IncludeExclude(dbtClassMixin):
 
 
 class WarnErrorOptions(IncludeExclude):
-    def _validate_items(self, items: List[str]):
-        all_event_types: Dict[str, Any] = {
-            **dbt_event_types.__dict__,
-            **core_dbt_event_types.__dict__,
-            **adapter_dbt_event_types.__dict__,
-        }
-        valid_exception_names = set(
-            [name for name, cls in all_event_types.items() if isinstance(cls, type)]
-        )
+    def __init__(
+        self,
+        include: Union[str, List[str]],
+        exclude: Optional[List[str]] = None,
+        valid_error_names: Optional[Set[str]] = None,
+    ):
+        self._valid_error_names: Set[str] = valid_error_names or set()
+        super().__init__(include=include, exclude=(exclude or []))
 
+    def _validate_items(self, items: List[str]):
         for item in items:
-            if item not in valid_exception_names:
+            if item not in self._valid_error_names:
                 raise ValidationError(f"{item} is not a valid dbt error name.")
 
 

--- a/core/dbt/events/__init__.py
+++ b/core/dbt/events/__init__.py
@@ -1,0 +1,15 @@
+from typing import Dict, Any, Set
+
+import dbt.adapters.events.types as adapter_dbt_event_types
+import dbt.common.events.types as dbt_event_types
+import dbt.events.types as core_dbt_event_types
+
+ALL_EVENT_TYPES: Dict[str, Any] = {
+    **dbt_event_types.__dict__,
+    **core_dbt_event_types.__dict__,
+    **adapter_dbt_event_types.__dict__,
+}
+
+ALL_EVENT_NAMES: Set[str] = set(
+    [name for name, cls in ALL_EVENT_TYPES.items() if isinstance(cls, type)]
+)

--- a/tests/unit/test_helper_types.py
+++ b/tests/unit/test_helper_types.py
@@ -31,24 +31,29 @@ class TestIncludeExclude:
 class TestWarnErrorOptions:
     def test_init_invalid_error(self):
         with pytest.raises(ValidationError):
+            WarnErrorOptions(include=["InvalidError"], valid_error_names=set(["ValidError"]))
+
+        with pytest.raises(ValidationError):
+            WarnErrorOptions(
+                include="*", exclude=["InvalidError"], valid_error_names=set(["ValidError"])
+            )
+
+    def test_init_invalid_error_default_valid_error_names(self):
+        with pytest.raises(ValidationError):
             WarnErrorOptions(include=["InvalidError"])
 
         with pytest.raises(ValidationError):
             WarnErrorOptions(include="*", exclude=["InvalidError"])
 
-    @pytest.mark.parametrize(
-        "valid_error_name",
-        [
-            "NoNodesForSelectionCriteria",  # core event
-            "AdapterDeprecationWarning",  # adapter event
-            "RetryExternalCall",  # common event
-        ],
-    )
-    def test_init_valid_error(self, valid_error_name):
-        warn_error_options = WarnErrorOptions(include=[valid_error_name])
-        assert warn_error_options.include == [valid_error_name]
+    def test_init_valid_error(self):
+        warn_error_options = WarnErrorOptions(
+            include=["ValidError"], valid_error_names=set(["ValidError"])
+        )
+        assert warn_error_options.include == ["ValidError"]
         assert warn_error_options.exclude == []
 
-        warn_error_options = WarnErrorOptions(include="*", exclude=[valid_error_name])
+        warn_error_options = WarnErrorOptions(
+            include="*", exclude=["ValidError"], valid_error_names=set(["ValidError"])
+        )
         assert warn_error_options.include == "*"
-        assert warn_error_options.exclude == [valid_error_name]
+        assert warn_error_options.exclude == ["ValidError"]


### PR DESCRIPTION
resolves #9337 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

WarnErrorOptions is now defined in dbt/common, which is being moved to a separate upstream package/repo (dbt-common) shortly. It is defined in dbt/common because it is used both by dbt-common and dbt-core. Unfortunately, it depends on both dbt-core and dbt-adapter to import the event type module to validate items in its collection. This would represent a circular dependency once moved to a separate repo as dbt-common should be upstream to both dbt-adapter and dbt-core.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
* update WarnErrorOptions constructor to accept `valid_error_names` on instantiation, for use in validation
* provide `valid_error_names` during `WarnErrorOptions` construction in dbt-core with `ALL_EVENT_NAMES` (combines adapter+common+core events)
* moved test_helper_types unit tests to tests/common since `helper_types` is defined in common and only has dbt-common dependencies!

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
