### PR TITLE
Fix package-lock file's bad indentation

### DIFF
--- a/.changes/unreleased/Fixes-20240106-003649.yaml
+++ b/.changes/unreleased/Fixes-20240106-003649.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: fix lock-file bad indentation
+time: 2024-01-06T00:36:49.547533+09:00
+custom:
+  Author: jx2lee
+  Issue: "9319"

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -201,7 +201,7 @@ class DepsTask(BaseTask):
         )
 
         with open(lock_filepath, "w") as lock_obj:
-            yaml.safe_dump(packages_installed, lock_obj)
+            yaml.dump(packages_installed, lock_obj, Dumper=dbtPackageDumper)
 
         fire_event(DepsLockUpdating(lock_filepath=lock_filepath))
 

--- a/tests/functional/dependencies/test_dependency_options.py
+++ b/tests/functional/dependencies/test_dependency_options.py
@@ -35,10 +35,10 @@ class TestDepsOptions(object):
         assert (
             contents
             == """packages:
-- package: fivetran/fivetran_utils
-  version: 0.4.7
-- package: dbt-labs/dbt_utils
-  version: 1.1.1
+  - package: fivetran/fivetran_utils
+    version: 0.4.7
+  - package: dbt-labs/dbt_utils
+    version: 1.1.1
 sha1_hash: 71304bca2138cf8004070b3573a1e17183c0c1a8
 """
         )
@@ -52,10 +52,10 @@ sha1_hash: 71304bca2138cf8004070b3573a1e17183c0c1a8
         assert (
             contents
             == """packages:
-- package: fivetran/fivetran_utils
-  version: 0.4.7
-- package: dbt-labs/dbt_utils
-  version: 1.1.1
+  - package: fivetran/fivetran_utils
+    version: 0.4.7
+  - package: dbt-labs/dbt_utils
+    version: 1.1.1
 sha1_hash: 71304bca2138cf8004070b3573a1e17183c0c1a8
 """
         )

--- a/tests/functional/dependencies/test_simple_dependency.py
+++ b/tests/functional/dependencies/test_simple_dependency.py
@@ -241,12 +241,12 @@ class TestSimpleDependencyWithSubdirs(object):
         run_dbt(["deps"])
         assert os.path.exists("package-lock.yml")
         expected = """packages:
-- git: https://github.com/dbt-labs/dbt-multipe-packages.git
-  revision: 53782f3ede8fdf307ee1d8e418aa65733a4b72fa
-  subdirectory: dbt-utils-main
-- git: https://github.com/dbt-labs/dbt-multipe-packages.git
-  revision: 53782f3ede8fdf307ee1d8e418aa65733a4b72fa
-  subdirectory: dbt-date-main
+  - git: https://github.com/dbt-labs/dbt-multipe-packages.git
+    revision: 53782f3ede8fdf307ee1d8e418aa65733a4b72fa
+    subdirectory: dbt-utils-main
+  - git: https://github.com/dbt-labs/dbt-multipe-packages.git
+    revision: 53782f3ede8fdf307ee1d8e418aa65733a4b72fa
+    subdirectory: dbt-date-main
 sha1_hash: b9c8042f29446c55a33f9f211737f445a640c7a1
 """
         with open("package-lock.yml") as fp:


### PR DESCRIPTION
resolves #9319 

### Problem

when `dbt deps` created package-lock file, `yaml.safe_load` didn't include indents.

```yaml
packages:
- package: dbt-labs/dbt_utils
  version: 1.0.0
- package: calogica/dbt_date
  version: 0.8.1
sha1_hash: f2bef868041b4f03296151f8be2969fc320a781a
```

### Solution

solve bad indentation using `yaml.load` (set Dumper `dbtPackageDumper`)
```yaml
packages:
  - package: dbt-labs/dbt_utils
    version: 1.0.0
  - package: calogica/dbt_date
    version: 0.8.1
sha1_hash: f2bef868041b4f03296151f8be2969fc320a781a
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
