### PR TITLE
Ensure unit test models can depend on external nodes

### DIFF
--- a/.changes/unreleased/Features-20240119-101335.yaml
+++ b/.changes/unreleased/Features-20240119-101335.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Added support for external nodes in unit test nodes
+time: 2024-01-19T10:13:35.589099-06:00
+custom:
+  Author: QMalcolm MichelleArk
+  Issue: "8944"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -67,7 +67,6 @@ from dbt.exceptions import (
     MacroResultAlreadyLoadedError,
     MetricArgsError,
     OperationsCannotRefEphemeralNodesError,
-    PackageNotInDepsError,
     ParsingError,
     RefBadContextError,
     RefArgsError,
@@ -675,10 +674,8 @@ class ModelConfiguredVar(Var):
         package_name = self._node.package_name
 
         if package_name != self._config.project_name:
-            if package_name not in dependencies:
-                # I don't think this is actually reachable
-                raise PackageNotInDepsError(package_name, node=self._node)
-            yield dependencies[package_name]
+            if package_name in dependencies:
+                yield dependencies[package_name]
         yield self._config
 
     def _generate_merged(self) -> Mapping[str, Any]:

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -139,7 +139,7 @@ class UnitTestManifestLoader:
                     package_name=original_input_node.package_name,
                     unique_id=f"model.{original_input_node.package_name}.{input_name}",
                     name=input_name,
-                    path=original_input_node.path,
+                    path=original_input_node.path or f"{input_name}.sql",
                 )
             elif original_input_node.resource_type == NodeType.Source:
                 # We are reusing the database/schema/identifier from the original source,

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -118,7 +118,6 @@ class UnitTestManifestLoader:
 
             common_fields = {
                 "resource_type": NodeType.Model,
-                "package_name": test_case.package_name,
                 "original_file_path": original_input_node.original_file_path,
                 "config": ModelConfig(materialized="ephemeral"),
                 "database": original_input_node.database,
@@ -137,7 +136,8 @@ class UnitTestManifestLoader:
                 input_name = original_input_node.name
                 input_node = ModelNode(
                     **common_fields,
-                    unique_id=f"model.{test_case.package_name}.{input_name}",
+                    package_name=original_input_node.package_name,
+                    unique_id=f"model.{original_input_node.package_name}.{input_name}",
                     name=input_name,
                     path=original_input_node.path,
                 )
@@ -148,7 +148,8 @@ class UnitTestManifestLoader:
                 input_name = original_input_node.name
                 input_node = UnitTestSourceDefinition(
                     **common_fields,
-                    unique_id=f"model.{test_case.package_name}.{input_name}",
+                    package_name=original_input_node.package_name,
+                    unique_id=f"model.{original_input_node.package_name}.{input_name}",
                     name=original_input_node.name,  # must be the same name for source lookup to work
                     path=input_name + ".sql",  # for writing out compiled_code
                     source_name=original_input_node.source_name,  # needed for source lookup

--- a/tests/functional/unit_testing/fixtures.py
+++ b/tests/functional/unit_testing/fixtures.py
@@ -656,7 +656,7 @@ UNION ALL
 SELECT 'gmail.com' AS tld
 """
 
-test_my_model_external_nodes_sql = """
+valid_emails_sql = """
 WITH
 accounts AS (
   SELECT user_id, email, email_top_level_domain

--- a/tests/functional/unit_testing/fixtures.py
+++ b/tests/functional/unit_testing/fixtures.py
@@ -1,3 +1,5 @@
+import pytest
+
 my_model_vars_sql = """
 SELECT
 a+b as c,
@@ -679,3 +681,42 @@ SELECT
   CASE WHEN joined.tld IS NULL THEN FALSE ELSE TRUE END AS is_valid_email_address
 from joined
 """
+
+external_package__accounts_seed_csv = """user_id,email,email_top_level_domain
+1,"example@example.com","example.com"
+"""
+
+external_package__external_model_sql = """
+SELECT user_id, email, email_top_level_domain FROM {{ ref('accounts_seed') }}
+"""
+
+
+external_package_project_yml = """
+name: external_package
+version: '1.0'
+config-version: 2
+
+model-paths: ["models"]    # paths to models
+analysis-paths: ["analyses"] # path with analysis files which are compiled, but not run
+target-path: "target"      # path for compiled code
+clean-targets: ["target"]  # directories removed by the clean task
+test-paths: ["tests"]       # where to store test results
+seed-paths: ["seeds"]       # load CSVs from this directory with `dbt seed`
+macro-paths: ["macros"]    # where to find macros
+
+profile: user
+
+models:
+    external_package:
+"""
+
+
+@pytest.fixture(scope="class")
+def external_package():
+    return {
+        "dbt_project.yml": external_package_project_yml,
+        "seeds": {"accounts_seed.csv": external_package__accounts_seed_csv},
+        "models": {
+            "external_model.sql": external_package__external_model_sql,
+        },
+    }

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -19,7 +19,7 @@ from fixtures import (
     event_sql,
     test_my_model_incremental_yml,
     test_my_model_yml_invalid,
-    test_my_model_external_nodes_sql,
+    valid_emails_sql,
     top_level_domains_sql,
 )
 
@@ -262,10 +262,10 @@ class TestUnitTestInvalidInputConfiguration:
         run_dbt(["test"], expect_pass=False)
 
 
-test_unit_test_with_external_nodes_yml = """
+unit_test_ext_node_yml = """
 unit_tests:
-  - name: test_unit_test_with_external_nodes
-    model: test_my_model_external_nodes
+  - name: unit_test_ext_node
+    model: valid_emails
     given:
       - input: ref('external_package', 'external_model')
         rows:
@@ -300,12 +300,12 @@ class TestUnitTestExternalNode:
     def models(self):
         return {
             "top_level_domains.sql": top_level_domains_sql,
-            "test_my_model_external_nodes.sql": test_my_model_external_nodes_sql,
-            "test_unit_test_with_external_nodes.yml": test_unit_test_with_external_nodes_yml,
+            "valid_emails.sql": valid_emails_sql,
+            "unit_test_ext_node.yml": unit_test_ext_node_yml,
         }
 
     @mock.patch("dbt.plugins.get_plugin_manager")
-    def test_unit_test_external_nodes(
+    def test_unit_test_ext_nodes(
         self,
         get_plugin_manager,
         project,
@@ -316,5 +316,5 @@ class TestUnitTestExternalNode:
         external_nodes.add_model(external_model_node)
         get_plugin_manager.return_value.get_nodes.return_value = external_nodes
 
-        results = run_dbt(["test", "--select", "test_my_model_external_nodes"], expect_pass=True)
+        results = run_dbt(["test", "--select", "valid_emails"], expect_pass=True)
         assert len(results) == 1

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest import mock
 from dbt.tests.util import (
     run_dbt,
     write_file,
@@ -6,6 +7,7 @@ from dbt.tests.util import (
 )
 from dbt.contracts.results import NodeStatus
 from dbt.exceptions import DuplicateResourceNameError, ParsingError
+from dbt.plugins.manifest import PluginNodes, ModelNodeArgs
 from fixtures import (
     my_model_sql,
     my_model_vars_sql,
@@ -17,6 +19,8 @@ from fixtures import (
     event_sql,
     test_my_model_incremental_yml,
     test_my_model_yml_invalid,
+    test_my_model_external_nodes_sql,
+    top_level_domains_sql,
 )
 
 
@@ -256,3 +260,61 @@ class TestUnitTestInvalidInputConfiguration:
         assert len(results) == 3
 
         run_dbt(["test"], expect_pass=False)
+
+
+test_unit_test_with_external_nodes_yml = """
+unit_tests:
+  - name: test_unit_test_with_external_nodes
+    model: test_my_model_external_nodes
+    given:
+      - input: ref('external_package', 'external_model')
+        rows:
+          - {user_id: 1, email: cool@example.com,     email_top_level_domain: example.com}
+          - {user_id: 2, email: cool@unknown.com,     email_top_level_domain: unknown.com}
+          - {user_id: 3, email: badgmail.com,         email_top_level_domain: gmail.com}
+          - {user_id: 4, email: missingdot@gmailcom,  email_top_level_domain: gmail.com}
+      - input: ref('top_level_domains')
+        rows:
+          - {tld: example.com}
+          - {tld: gmail.com}
+    expect:
+      rows:
+        - {user_id: 1, is_valid_email_address: true}
+        - {user_id: 2, is_valid_email_address: false}
+        - {user_id: 3, is_valid_email_address: true}
+        - {user_id: 4, is_valid_email_address: true}
+"""
+
+
+class TestUnitTestExternalNode:
+    @pytest.fixture(scope="class")
+    def external_model_node(self):
+        return ModelNodeArgs(
+            name="external_model",
+            package_name="external_package",
+            identifier="test_identifier",
+            schema="test_schema",
+        )
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "top_level_domains.sql": top_level_domains_sql,
+            "test_my_model_external_nodes.sql": test_my_model_external_nodes_sql,
+            "test_unit_test_with_external_nodes.yml": test_unit_test_with_external_nodes_yml,
+        }
+
+    @mock.patch("dbt.plugins.get_plugin_manager")
+    def test_unit_test_external_nodes(
+        self,
+        get_plugin_manager,
+        project,
+        external_model_node,
+    ):
+        # initial plugin - one external model
+        external_nodes = PluginNodes()
+        external_nodes.add_model(external_model_node)
+        get_plugin_manager.return_value.get_nodes.return_value = external_nodes
+
+        results = run_dbt(["test", "--select", "test_my_model_external_nodes"], expect_pass=True)
+        assert len(results) == 1

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -326,5 +326,7 @@ class TestUnitTestExternalNode:
 
         # `seed` need so a table exists for `external_model` to point to
         run_dbt(["seed"], expect_pass=True)
+        # `run` needed to ensure `top_level_domains` exists in database for column getting step
+        run_dbt(["run"], expect_pass=True)
         results = run_dbt(["test", "--select", "valid_emails"], expect_pass=True)
         assert len(results) == 1

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -1,5 +1,4 @@
 import pytest
-from unittest import mock
 from dbt.tests.util import (
     run_dbt,
     write_file,
@@ -7,8 +6,8 @@ from dbt.tests.util import (
 )
 from dbt.contracts.results import NodeStatus
 from dbt.exceptions import DuplicateResourceNameError, ParsingError
-from dbt.plugins.manifest import PluginNodes, ModelNodeArgs
-from fixtures import (
+from dbt.tests.fixtures.project import write_project_files
+from fixtures import (  # noqa: F401
     my_model_sql,
     my_model_vars_sql,
     my_model_a_sql,
@@ -21,6 +20,7 @@ from fixtures import (
     test_my_model_yml_invalid,
     valid_emails_sql,
     top_level_domains_sql,
+    external_package,
 )
 
 
@@ -285,24 +285,15 @@ unit_tests:
         - {user_id: 4, is_valid_email_address: true}
 """
 
-external_node_seed_csv = """user_id,email,email_top_level_domain
-1,"example@example.com","example.com"
-"""
-
 
 class TestUnitTestExternalNode:
-    @pytest.fixture(scope="class")
-    def external_model_node(self, unique_schema):
-        return ModelNodeArgs(
-            name="external_model",
-            package_name="external_package",
-            identifier="external_node_seed",
-            schema=unique_schema,
-        )
+    @pytest.fixture(scope="class", autouse=True)
+    def setUp(self, project_root, external_package):  # noqa: F811
+        write_project_files(project_root, "external_package", external_package)
 
     @pytest.fixture(scope="class")
-    def seeds(self):
-        return {"external_node_seed.csv": external_node_seed_csv}
+    def packages(self):
+        return {"packages": [{"local": "external_package"}]}
 
     @pytest.fixture(scope="class")
     def models(self):
@@ -312,18 +303,12 @@ class TestUnitTestExternalNode:
             "unit_test_ext_node.yml": unit_test_ext_node_yml,
         }
 
-    @mock.patch("dbt.plugins.get_plugin_manager")
     def test_unit_test_ext_nodes(
         self,
-        get_plugin_manager,
         project,
-        external_model_node,
     ):
-        # initial plugin - one external model
-        external_nodes = PluginNodes()
-        external_nodes.add_model(external_model_node)
-        get_plugin_manager.return_value.get_nodes.return_value = external_nodes
-
+        # `deps` to install the external package
+        run_dbt(["deps"], expect_pass=True)
         # `seed` need so a table exists for `external_model` to point to
         run_dbt(["seed"], expect_pass=True)
         # `run` needed to ensure `top_level_domains` exists in database for column getting step


### PR DESCRIPTION
resolves #8944

### Problem
We weren't sure if external nodes were already supported in unit test nodes. This PR added tests that identified that unit test nodes didn't have full support for external nodes, and then made the necessary changes to support them.

### Solution
* Update all models in a unit test node's `shadow manifest` have a `path` for file writing
* Update unit test parsing to ensure models keep their original package name
* Altered the `packages_for_node` to gracefully allow for unknown dependencies

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
