### PR TITLE
Support longer unit test names + improve error handling in unit test construction

### DIFF
--- a/.changes/unreleased/Fixes-20240115-165310.yaml
+++ b/.changes/unreleased/Fixes-20240115-165310.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Support reasonably long unit test names
+time: 2024-01-15T16:53:10.42761-05:00
+custom:
+  Author: michelleark
+  Issue: "9015"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -577,7 +577,6 @@ class RuntimeUnitTestRefResolver(RuntimeRefResolver):
         target_package: Optional[str] = None,
         target_version: Optional[NodeVersion] = None,
     ) -> RelationProxy:
-        target_name = f"{self.model.name}__{target_name}"
         return super().resolve(target_name, target_package, target_version)
 
 

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -64,7 +64,7 @@ class UnitTestManifestLoader:
         # already been done, we don't have to care about fields that are necessary
         # for selection.
         # Note: no depends_on, that's added later using input nodes
-        name = f"{test_case.model}__{test_case.name}"
+        name = test_case.name
         unit_test_node = UnitTestNode(
             name=name,
             resource_type=NodeType.Unit,
@@ -134,7 +134,7 @@ class UnitTestManifestLoader:
                 NodeType.Seed,
                 NodeType.Snapshot,
             ):
-                input_name = f"{unit_test_node.name}__{original_input_node.name}"
+                input_name = original_input_node.name
                 input_node = ModelNode(
                     **common_fields,
                     unique_id=f"model.{test_case.package_name}.{input_name}",
@@ -145,7 +145,7 @@ class UnitTestManifestLoader:
                 # We are reusing the database/schema/identifier from the original source,
                 # but that shouldn't matter since this acts as an ephemeral model which just
                 # wraps a CTE around the unit test node.
-                input_name = f"{unit_test_node.name}__{original_input_node.search_name}__{original_input_node.name}"
+                input_name = original_input_node.name
                 input_node = UnitTestSourceDefinition(
                     **common_fields,
                     unique_id=f"model.{test_case.package_name}.{input_name}",

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -27,11 +27,9 @@ from dbt.events.types import (
     LogTestResult,
     LogStartLine,
 )
-from dbt.exceptions import (
-    DbtInternalError,
-    BooleanError,
-)
-from ..adapters.exceptions import MissingMaterializationError
+from dbt.exceptions import DbtInternalError, BooleanError
+from dbt.common.exceptions import DbtBaseException, DbtRuntimeError
+from dbt.adapters.exceptions import MissingMaterializationError
 from dbt.graph import (
     ResourceTypeSelector,
 )
@@ -213,7 +211,13 @@ class TestRunner(CompileRunner):
         # generate materialization macro
         macro_func = MacroGenerator(materialization_macro, context)
         # execute materialization macro
-        macro_func()
+        try:
+            macro_func()
+        except DbtBaseException as e:
+            raise DbtRuntimeError(
+                f"During unit test execution of {self.describe_node_name()}, dbt could not build the 'actual' result for comparison against 'expected' given the unit test definition:\n {e}"
+            )
+
         # load results from context
         # could eventually be returned directly by materialization
         result = context["load_result"]("main")

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -83,15 +83,21 @@ class UnitTestResultData(dbtClassMixin):
 class TestRunner(CompileRunner):
     _ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
+    def describe_node_name(self):
+        if self.node.resource_type == NodeType.Unit:
+            return f"{self.node.model}::{self.node.name}"
+        else:
+            return self.node.name
+
     def describe_node(self):
-        return f"{self.node.resource_type} {self.node.name}"
+        return f"{self.node.resource_type} {self.describe_node_name()}"
 
     def print_result_line(self, result):
         model = result.node
 
         fire_event(
             LogTestResult(
-                name=model.name,
+                name=self.describe_node_name(),
                 status=str(result.status),
                 index=self.node_index,
                 num_models=self.num_nodes,

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -28,7 +28,7 @@ from dbt.events.types import (
     LogStartLine,
 )
 from dbt.exceptions import DbtInternalError, BooleanError
-from dbt.common.exceptions import DbtBaseException, DbtRuntimeError
+from dbt_common.exceptions import DbtBaseException, DbtRuntimeError
 from dbt.adapters.exceptions import MissingMaterializationError
 from dbt.graph import (
     ResourceTypeSelector,

--- a/tests/adapter/dbt/tests/adapter/unit_testing/test_unit_testing.py
+++ b/tests/adapter/dbt/tests/adapter/unit_testing/test_unit_testing.py
@@ -1,0 +1,69 @@
+import pytest
+
+from dbt.adapters.postgres.relation_configs import MAX_CHARACTERS_IN_IDENTIFIER
+from dbt.tests.util import run_dbt, write_file
+
+my_model_a_sql = """
+SELECT
+1 as a,
+1 as id,
+2 as not_testing,
+'a' as string_a,
+DATE '2020-01-02' as date_a
+"""
+
+test_model_a_long_test_name_yml = """
+unit_tests:
+  - name: {test_name}
+    model: my_model_a
+    given: []
+    expect:
+      rows:
+        - {{a: 1, id: 1, not_testing: 2, string_a: "a", date_a: "2020-01-02"}}
+"""
+
+
+class BaseUnitTestLongTestName:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_a.sql": my_model_a_sql,
+            "test_model_a.yml": test_model_a_long_test_name_yml,
+        }
+
+    @pytest.fixture
+    def max_unit_test_name_length(self) -> int:
+        return -1
+
+    def test_long_unit_test_name(self, project, max_unit_test_name_length):
+        # max test name == passing unit test
+        write_file(
+            test_model_a_long_test_name_yml.format(test_name="a" * max_unit_test_name_length),
+            "models",
+            "test_model_a.yml",
+        )
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        results = run_dbt(["test"], expect_pass=True)
+        assert len(results) == 1
+
+        # max test name == failing command
+        write_file(
+            test_model_a_long_test_name_yml.format(
+                test_name="a" * (max_unit_test_name_length + 1)
+            ),
+            "models",
+            "test_model_a.yml",
+        )
+
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        run_dbt(["test"], expect_pass=False)
+
+
+class TestPostgresUnitTestLongTestNames(BaseUnitTestLongTestName):
+    @pytest.fixture
+    def max_unit_test_name_length(self) -> int:
+        return MAX_CHARACTERS_IN_IDENTIFIER

--- a/tests/functional/unit_testing/fixtures.py
+++ b/tests/functional/unit_testing/fixtures.py
@@ -598,3 +598,37 @@ unit_tests:
       format: csv
       fixture: test_my_model_basic_fixture
 """
+
+test_model_a_b_yml = """
+unit_tests:
+  - name: my_test_name
+    model: my_model_a
+    given: []
+    expect:
+      rows:
+        - {a: 1, id: 1, not_testing: 2, string_a: "a", date_a: "2020-01-02"}
+
+  - name: my_test_name
+    model: my_model_b
+    given: []
+    expect:
+      rows:
+        - {b: 2, id: 1, c: 2, string_b: "b"}
+"""
+
+test_model_a_with_duplicate_test_name_yml = """
+unit_tests:
+  - name: my_test_name
+    model: my_model_a
+    given: []
+    expect:
+      rows:
+        - {a: 1, id: 1, not_testing: 2, string_a: "a", date_a: "2020-01-02"}
+
+  - name: my_test_name
+    model: my_model_a
+    given: []
+    expect:
+      rows:
+        - {a: 1, id: 1, not_testing: 2, string_a: "a", date_a: "2020-01-02"}
+"""

--- a/tests/functional/unit_testing/fixtures.py
+++ b/tests/functional/unit_testing/fixtures.py
@@ -632,3 +632,14 @@ unit_tests:
       rows:
         - {a: 1, id: 1, not_testing: 2, string_a: "a", date_a: "2020-01-02"}
 """
+
+
+test_model_a_with_bad_test_name_yml = """
+unit_tests:
+  - name: !!my_test_name
+    model: my_model_a
+    given: []
+    expect:
+      rows:
+        - {a: 1, id: 1, not_testing: 2, string_a: "a", date_a: "2020-01-02"}
+"""

--- a/tests/functional/unit_testing/fixtures.py
+++ b/tests/functional/unit_testing/fixtures.py
@@ -633,13 +633,19 @@ unit_tests:
         - {a: 1, id: 1, not_testing: 2, string_a: "a", date_a: "2020-01-02"}
 """
 
-
-test_model_a_with_bad_test_name_yml = """
+test_my_model_yml_invalid = """
 unit_tests:
-  - name: !!my_test_name
-    model: my_model_a
-    given: []
+  - name: test_my_model
+    model: my_model
+    given:
+      - input: ref('my_model_a')
+        rows:
+          - {id: 1, a: "a"}
+      - input: ref('my_model_b')
+        rows:
+          - {id: 1, b: 2}
+          - {id: 2, b: 2}
     expect:
       rows:
-        - {a: 1, id: 1, not_testing: 2, string_a: "a", date_a: "2020-01-02"}
+        - {c: 3}
 """

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -7,6 +7,7 @@ from dbt.tests.util import (
 from dbt.contracts.results import NodeStatus
 from dbt.exceptions import DuplicateResourceNameError, ParsingError
 from fixtures import (
+    my_model_sql,
     my_model_vars_sql,
     my_model_a_sql,
     my_model_b_sql,
@@ -15,6 +16,7 @@ from fixtures import (
     my_incremental_model_sql,
     event_sql,
     test_my_model_incremental_yml,
+    test_my_model_yml_invalid,
 )
 
 
@@ -237,3 +239,20 @@ class TestUnitTestNonexistentSeed:
             ParsingError, match="Unable to find seed 'test.my_second_favorite_seed' for unit tests"
         ):
             run_dbt(["test", "--select", "my_new_model"], expect_pass=False)
+
+
+class TestUnitTestInvalidInputConfiguration:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "my_model_a.sql": my_model_a_sql,
+            "my_model_b.sql": my_model_b_sql,
+            "test_my_model.yml": test_my_model_yml_invalid,
+        }
+
+    def test_invalid_input_configuration(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 3
+
+        run_dbt(["test"], expect_pass=False)

--- a/tests/functional/unit_testing/test_ut_names.py
+++ b/tests/functional/unit_testing/test_ut_names.py
@@ -1,0 +1,97 @@
+import pytest
+
+from dbt.tests.util import run_dbt, run_dbt_and_capture
+from dbt.exceptions import DuplicateResourceNameError
+
+from fixtures import (
+    my_model_a_sql,
+    my_model_b_sql,
+    test_model_a_b_yml,
+    test_model_a_with_duplicate_test_name_yml,
+)
+
+
+class TestUnitTestDuplicateTestNamesAcrossModels:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_a.sql": my_model_a_sql,
+            "my_model_b.sql": my_model_b_sql,
+            "test_model_a_b.yml": test_model_a_b_yml,
+        }
+
+    def test_duplicate_test_names_across_models(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 2
+
+        # Select duplicate tests
+        results, log_output = run_dbt_and_capture(["test"], expect_pass=True)
+        assert len(results) == 2
+        assert ["my_model_a", "my_model_b"] == sorted([result.node.model for result in results])
+        assert "my_model_a::my_test_name" in log_output
+        assert "my_model_b::my_test_name" in log_output
+
+        # Test select duplicates by by test name
+        results = run_dbt(["test", "--select", "test_name:my_test_name"])
+        assert len(results) == 2
+        assert ["my_model_a", "my_model_b"] == sorted([result.node.model for result in results])
+        assert "my_model_a::my_test_name" in log_output
+        assert "my_model_b::my_test_name" in log_output
+
+        results = run_dbt(["test", "--select", "my_model_a,test_name:my_test_name"])
+        assert len(results) == 1
+        assert results[0].node.model == "my_model_a"
+
+        results = run_dbt(["test", "--select", "my_model_b,test_name:my_test_name"])
+        assert len(results) == 1
+        assert results[0].node.model == "my_model_b"
+
+        # Test select by model name
+        results = run_dbt(["test", "--select", "my_model_a"])
+        assert len(results) == 1
+        assert results[0].node.model == "my_model_a"
+
+        results = run_dbt(["test", "--select", "my_model_b"])
+        assert len(results) == 1
+        assert results[0].node.model == "my_model_b"
+
+
+class TestUnitTestDuplicateTestNamesWithinModel:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_a.sql": my_model_a_sql,
+            "test_model_a.yml": test_model_a_with_duplicate_test_name_yml,
+        }
+
+    def test_duplicate_test_names_within_model(self, project):
+        with pytest.raises(DuplicateResourceNameError):
+            run_dbt(["run"])
+
+
+test_model_a_long_test_name_yml = """
+unit_tests:
+  - name: my_very_reasonable_but_kind_of_long_test_name_for_model_a
+    model: my_model_a
+    given: []
+    expect:
+      rows:
+        - {a: 1, id: 1, not_testing: 2, string_a: "a", date_a: "2020-01-02"}
+"""
+
+
+class TestUnitTestLongTestNames:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_a.sql": my_model_a_sql,
+            "test_model_a.yml": test_model_a_long_test_name_yml,
+        }
+
+    def test_long_unit_test_name(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        results = run_dbt(["test"], expect_pass=True)
+        assert len(results) == 1
+        assert len(results[0].node.name) >= 50

--- a/tests/functional/unit_testing/test_ut_names.py
+++ b/tests/functional/unit_testing/test_ut_names.py
@@ -67,31 +67,3 @@ class TestUnitTestDuplicateTestNamesWithinModel:
     def test_duplicate_test_names_within_model(self, project):
         with pytest.raises(DuplicateResourceNameError):
             run_dbt(["run"])
-
-
-test_model_a_long_test_name_yml = """
-unit_tests:
-  - name: my_very_reasonable_but_kind_of_long_test_name_for_model_a
-    model: my_model_a
-    given: []
-    expect:
-      rows:
-        - {a: 1, id: 1, not_testing: 2, string_a: "a", date_a: "2020-01-02"}
-"""
-
-
-class TestUnitTestLongTestNames:
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "my_model_a.sql": my_model_a_sql,
-            "test_model_a.yml": test_model_a_long_test_name_yml,
-        }
-
-    def test_long_unit_test_name(self, project):
-        results = run_dbt(["run"])
-        assert len(results) == 1
-
-        results = run_dbt(["test"], expect_pass=True)
-        assert len(results) == 1
-        assert len(results[0].node.name) >= 50

--- a/tests/functional/unit_testing/test_ut_names.py
+++ b/tests/functional/unit_testing/test_ut_names.py
@@ -1,14 +1,13 @@
 import pytest
 
 from dbt.tests.util import run_dbt, run_dbt_and_capture
-from dbt.exceptions import DuplicateResourceNameError, DbtRuntimeError
+from dbt.exceptions import DuplicateResourceNameError
 
 from fixtures import (
     my_model_a_sql,
     my_model_b_sql,
     test_model_a_b_yml,
     test_model_a_with_duplicate_test_name_yml,
-    test_model_a_with_bad_test_name_yml,
 )
 
 
@@ -68,16 +67,3 @@ class TestUnitTestDuplicateTestNamesWithinModel:
     def test_duplicate_test_names_within_model(self, project):
         with pytest.raises(DuplicateResourceNameError):
             run_dbt(["run"])
-
-
-class TestUnitTestBadTestName:
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "my_model_a.sql": my_model_a_sql,
-            "test_model_a.yml": test_model_a_with_bad_test_name_yml,
-        }
-
-    def test_duplicate_test_names_bad_name(self, project):
-        with pytest.raises(DbtRuntimeError):
-            run_dbt(["test"])

--- a/tests/functional/unit_testing/test_ut_names.py
+++ b/tests/functional/unit_testing/test_ut_names.py
@@ -1,13 +1,14 @@
 import pytest
 
 from dbt.tests.util import run_dbt, run_dbt_and_capture
-from dbt.exceptions import DuplicateResourceNameError
+from dbt.exceptions import DuplicateResourceNameError, DbtRuntimeError
 
 from fixtures import (
     my_model_a_sql,
     my_model_b_sql,
     test_model_a_b_yml,
     test_model_a_with_duplicate_test_name_yml,
+    test_model_a_with_bad_test_name_yml,
 )
 
 
@@ -67,3 +68,16 @@ class TestUnitTestDuplicateTestNamesWithinModel:
     def test_duplicate_test_names_within_model(self, project):
         with pytest.raises(DuplicateResourceNameError):
             run_dbt(["run"])
+
+
+class TestUnitTestBadTestName:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_a.sql": my_model_a_sql,
+            "test_model_a.yml": test_model_a_with_bad_test_name_yml,
+        }
+
+    def test_duplicate_test_names_bad_name(self, project):
+        with pytest.raises(DbtRuntimeError):
+            run_dbt(["test"])


### PR DESCRIPTION
resolves #9015

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

On Postgres, even modestly long test names (~20 characters) were hitting the "Relation name '{}' is longer than 63 characters" during construction of the 'actual' unit test result.

This is because we were creating model names and unique_ids in the unit test manifest out of the concatenation of the original model name, test name, and model being tested name to prevent key collision in the unit test manifest.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Now that we are creating a unit test manifest per unit test definition, there is no risk of key collisions if we just use the model name! This PR propagates those changes through and adds tests to ensure expected behaviour when: 
* there are duplicate test names within a model (error)
* there are duplicate test names across models (pass, selection tested as well)
* a generally "invalid" test configuration (e.g. wrong data type in given input)
* right-size (pass) or long (fail, with handled exception) on postgres

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
