### PR TITLE
pin dbt-common

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -71,7 +71,7 @@ setup(
         "dbt-extractor~=0.5.0",
         "minimal-snowplow-tracker~=0.0.2",
         "dbt-semantic-interfaces~=0.5.0a2",
-        "dbt-common~=0.0.1",
+        "dbt-common~=0.1.0",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
         "packaging>20.9",

--- a/core/setup.py
+++ b/core/setup.py
@@ -71,7 +71,7 @@ setup(
         "dbt-extractor~=0.5.0",
         "minimal-snowplow-tracker~=0.0.2",
         "dbt-semantic-interfaces~=0.5.0a2",
-        "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git#egg=dbt",
+        "dbt-common~=0.0.1",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
         "packaging>20.9",


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-common/issues/8

### Problem

PyPI doesn't allow pinning to github releases so we need to pin `dbt-common` to a PyPI release.

### Solution

Pin `dbt-common`

Note: Blocked on releasing `dbt-common` to pypi prod right now

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
