### PR TITLE
still run register adapter when manifest is provided.

### DIFF
--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -1,7 +1,7 @@
 import dbt.tracking
 from dbt_common.invocation import reset_invocation_id
 from dbt.version import installed as installed_version
-from dbt.adapters.factory import adapter_management
+from dbt.adapters.factory import adapter_management, register_adapter
 from dbt.flags import set_flags, get_flag_dict
 from dbt.cli.exceptions import (
     ExceptionExit,
@@ -31,6 +31,7 @@ from dbt.profiler import profiler
 from dbt.tracking import active_user, initialize_from_flags, track_run
 from dbt_common.utils import cast_dict_to_dict_of_strings
 from dbt.plugins import set_up_plugin_manager
+from dbt.mp_context import get_mp_context
 
 from click import Context
 from functools import update_wrapper
@@ -277,6 +278,8 @@ def manifest(*args0, write=True, write_perf_info=False):
                 ctx.obj["manifest"] = parse_manifest(
                     runtime_config, write_perf_info, write, ctx.obj["flags"].write_json
                 )
+            else:
+                register_adapter(runtime_config, get_mp_context())
             return func(*args, **kwargs)
 
         return update_wrapper(wrapper, func)

--- a/tests/functional/dbt_runner/test_dbt_runner.py
+++ b/tests/functional/dbt_runner/test_dbt_runner.py
@@ -5,12 +5,19 @@ import pytest
 from dbt.cli.exceptions import DbtUsageException
 from dbt.cli.main import dbtRunner
 from dbt.exceptions import DbtProjectError
+from dbt.adapters.factory import reset_adapters, FACTORY
 
 
 class TestDbtRunner:
     @pytest.fixture
     def dbt(self) -> dbtRunner:
         return dbtRunner()
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "models.sql": "select 1 as id",
+        }
 
     def test_group_invalid_option(self, dbt: dbtRunner) -> None:
         res = dbt.invoke(["--invalid-option"])
@@ -70,3 +77,14 @@ class TestDbtRunner:
     def test_invoke_kwargs_and_flags(self, project, dbt):
         res = dbt.invoke(["--log-format=text", "run"], log_format="json")
         assert res.result.args["log_format"] == "json"
+
+    def test_pass_in_manifest(self, project, dbt):
+        result = dbt.invoke(["parse"])
+        manifest = result.result
+
+        reset_adapters()
+        assert len(FACTORY.adapters) == 0
+        result = dbtRunner(manifest=manifest).invoke(["run"])
+        # Check that the adapters are registered again.
+        assert result.success
+        assert len(FACTORY.adapters) == 1


### PR DESCRIPTION
@peterallenwebb I tried but couldn't write a test that would fail without this change.