### PR TITLE
Align with order of unit test output when `actual` differs from `expected`

### DIFF
--- a/.changes/unreleased/Features-20240118-135651.yaml
+++ b/.changes/unreleased/Features-20240118-135651.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Align with order of unit test output when `actual` differs from `expected`
+time: 2024-01-18T13:56:51.131001-07:00
+custom:
+  Author: dbeatty10
+  Issue: "9370"

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -232,7 +232,7 @@ class TestRunner(CompileRunner):
         if daff_diff.hasDifference():
             should_error = True
             rendered = self._render_daff_diff(daff_diff)
-            rendered = f"\n\n{red('expected')} differs from {green('actual')}:\n\n{rendered}\n"
+            rendered = f"\n\n{green('actual')} differs from {red('expected')}:\n\n{rendered}\n"
 
             diff = UnitTestDiff(
                 actual=json_rows_from_table(actual),


### PR DESCRIPTION
resolves #9370

### Problem

Two things:
1. Note how the current output of a failing unit test says "expected" first, but _shows_ it second:

    ```
    expected differs from actual:
    ```
    
    <img width="235" alt="image" src="https://github.com/dbt-labs/dbt-core/assets/44704949/654b08fe-cfa8-4451-a52b-326751f9e681">

2. Since it's the _actual_ result that's being tested against the _expected_ result, we want to communicate that the result differs from the standard (rather than the other way around).

### Solution

It makes more sense and is more readable with this order:

```
actual differs from expected:
```

<img width="235" alt="image" src="https://github.com/dbt-labs/dbt-core/assets/44704949/e39f13fb-3929-4f39-970a-aa1a5be4f812">

And it's a very easy code change 😎 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [x] Tests are not required/relevant for this PR
- [x] This PR has already received feedback and approval from Product or DX
- [x] This PR does not include any new and modified functions, so no [type annotations](https://docs.python.org/3/library/typing.html) are needed.
