### PR TITLE
Rename tests -> data_tests for model-level + versions

### DIFF
--- a/.changes/unreleased/Fixes-20240119-215214.yaml
+++ b/.changes/unreleased/Fixes-20240119-215214.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix back-compat parsing for model-level 'tests', source table-level 'tests',
+  and 'tests' defined on model versions
+time: 2024-01-19T21:52:14.090462+01:00
+custom:
+  Author: jtcohen6
+  Issue: "9411"

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -106,7 +106,9 @@ TestDef = Union[Dict[str, Any], str]
 @dataclass
 class HasColumnAndTestProps(HasColumnProps):
     data_tests: List[TestDef] = field(default_factory=list)
-    tests: List[TestDef] = field(default_factory=list)
+    tests: List[TestDef] = field(
+        default_factory=list
+    )  # back compat for previous name of 'data_tests'
 
 
 @dataclass
@@ -154,6 +156,7 @@ class UnparsedVersion(dbtClassMixin):
     constraints: List[Dict[str, Any]] = field(default_factory=list)
     docs: Docs = field(default_factory=Docs)
     data_tests: Optional[List[TestDef]] = None
+    tests: Optional[List[TestDef]] = None  # back compat for previous name of 'data_tests'
     columns: Sequence[Union[dbt_common.helper_types.IncludeExclude, UnparsedColumn]] = field(
         default_factory=list
     )

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -412,6 +412,7 @@ class SourceTablePatch(dbtClassMixin):
     external: Optional[ExternalTable] = None
     tags: Optional[List[str]] = None
     data_tests: Optional[List[TestDef]] = None
+    tests: Optional[List[TestDef]] = None  # back compat for previous name of 'data_tests'
     columns: Optional[Sequence[UnparsedColumn]] = None
 
     def to_patch_dict(self) -> Dict[str, Any]:

--- a/tests/functional/deprecations/fixtures.py
+++ b/tests/functional/deprecations/fixtures.py
@@ -10,6 +10,13 @@ models_trivial__model_sql = """
 select 1 as id
 """
 
+macros__custom_test_sql = """
+{% test custom(model) %}
+  select * from {{ model }}
+  limit 0
+{% endtest %}
+"""
+
 
 bad_name_yaml = """
 version: 2
@@ -44,13 +51,26 @@ models:
          - unique
 """
 
-old_tests_yaml = """
+old_tests_yml = """
 models:
   - name: model
+    tests:
+      - custom
     columns:
-     - name: id
-       tests:
-         - not_null
+      - name: id
+        tests:
+          - not_null
+
+  - name: versioned_model
+    tests:
+      - custom
+    versions:
+      - v: 1
+        tests:
+        columns:
+          - name: id
+            tests:
+              - not_null
 """
 
 sources_old_tests_yaml = """
@@ -59,6 +79,8 @@ sources:
     schema: "{{ var('schema_override', target.schema) }}"
     tables:
       - name: "seed"
+        tests:
+          - custom
         columns:
           - name: id
             tests:

--- a/tests/functional/deprecations/test_config_deprecations.py
+++ b/tests/functional/deprecations/test_config_deprecations.py
@@ -6,8 +6,9 @@ from dbt.tests.util import run_dbt, update_config_file
 from dbt.tests.fixtures.project import write_project_files
 
 from tests.functional.deprecations.fixtures import (
+    macros__custom_test_sql,
     models_trivial__model_sql,
-    old_tests_yaml,
+    old_tests_yml,
     local_dependency__dbt_project_yml,
     local_dependency__schema_yml,
     local_dependency__seed_csv,
@@ -28,14 +29,14 @@ class TestTestsConfigDeprecation:
     def project_config_update(self, unique_schema):
         return {"tests": {"enabled": "true"}}
 
-    def test_tests_config(self, project):
+    def test_project_tests_config(self, project):
         deprecations.reset_deprecations()
         assert deprecations.active_deprecations == set()
         run_dbt(["parse"])
         expected = {"project-test-config"}
         assert expected == deprecations.active_deprecations
 
-    def test_tests_config_fail(self, project):
+    def test_project_tests_config_fail(self, project):
         deprecations.reset_deprecations()
         assert deprecations.active_deprecations == set()
         with pytest.raises(CompilationError) as exc:
@@ -48,16 +49,24 @@ class TestTestsConfigDeprecation:
 class TestSchemaTestDeprecation:
     @pytest.fixture(scope="class")
     def models(self):
-        return {"model.sql": models_trivial__model_sql, "schema.yml": old_tests_yaml}
+        return {
+            "model.sql": models_trivial__model_sql,
+            "versioned_model.sql": models_trivial__model_sql,
+            "schema.yml": old_tests_yml,
+        }
 
-    def test_tests_config(self, project):
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"custom.sql": macros__custom_test_sql}
+
+    def test_generic_tests_config(self, project):
         deprecations.reset_deprecations()
         assert deprecations.active_deprecations == set()
         run_dbt(["parse"])
         expected = {"project-test-config"}
         assert expected == deprecations.active_deprecations
 
-    def test_schema_tests_fail(self, project):
+    def test_generic_tests_fail(self, project):
         deprecations.reset_deprecations()
         assert deprecations.active_deprecations == set()
         with pytest.raises(CompilationError) as exc:
@@ -66,11 +75,19 @@ class TestSchemaTestDeprecation:
         expected_msg = "The `tests` config has been renamed to `data_tests`"
         assert expected_msg in exc_str
 
+    def test_generic_data_test_parsing(self, project):
+        results = run_dbt(["list", "--resource-type", "test"])
+        assert len(results) == 4
+
 
 class TestSourceSchemaTestDeprecation:
     @pytest.fixture(scope="class")
     def models(self):
         return {"schema.yml": sources_old_tests_yaml}
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"custom.sql": macros__custom_test_sql}
 
     @pytest.fixture(scope="class")
     def seeds(self):
@@ -81,15 +98,14 @@ class TestSourceSchemaTestDeprecation:
     def test_source_tests_config(self, project):
         deprecations.reset_deprecations()
         assert deprecations.active_deprecations == set()
-        run_dbt(["seed"])
         run_dbt(["parse"])
         expected = {"project-test-config"}
         assert expected == deprecations.active_deprecations
 
-    def test_schema_tests(self, project):
+    def test_generic_data_tests(self, project):
         run_dbt(["seed"])
         results = run_dbt(["test"])
-        assert len(results) == 1
+        assert len(results) == 2
 
 
 # test for failure with test and data_tests in the same file


### PR DESCRIPTION
resolves #9411

### Problem

We now expect data tests to be defined in blocks named `data_tests`. For back compat, we need to support `tests` (previous name). To that end, we've added logic for validation (can't have both) and renaming (old &rarr; new).

However, this is not working for tests defined at the model-level, and tests defined on specific `versions` of a versioned model.

### Solution

Generalize the validation/renaming logic, and apply it everywhere that a `tests` block can be defined.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
