### PR TITLE
add decorator

### DIFF
--- a/.changes/unreleased/Under the Hood-20240123-114855.yaml
+++ b/.changes/unreleased/Under the Hood-20240123-114855.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add the @requires.manifest decorator to the retry command.
+time: 2024-01-23T11:48:55.627982-06:00
+custom:
+  Author: emmyoop
+  Issue: "9426"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -602,6 +602,7 @@ def run(ctx, **kwargs):
 @requires.profile
 @requires.project
 @requires.runtime_config
+@requires.manifest
 def retry(ctx, **kwargs):
     """Retry the nodes that failed in the previous run."""
     task = RetryTask(


### PR DESCRIPTION
resolves #9426 


### Problem

`@requires.manifest` decorator is missing on retry

### Solution

Add the decorator

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
