### PR TITLE
Simplify core release inputs

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      commit_sha: ${{ steps.resolve-commit-sha.outputs.release_commit }}
       version_number: ${{ steps.nightly-release-version.outputs.number }}
       release_branch: ${{ steps.release-branch.outputs.name }}
 
@@ -42,12 +41,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_BRANCH }}
-
-      - name: "Resolve Commit To Release"
-        id: resolve-commit-sha
-        run: |
-          commit_sha=$(git rev-parse HEAD)
-          echo "release_commit=$commit_sha" >> $GITHUB_OUTPUT
 
       - name: "Get Current Version Number"
         id: version-number-sources
@@ -88,7 +81,6 @@ jobs:
     steps:
       - name: "[DEBUG] Log Outputs"
         run: |
-          echo commit_sha    : ${{ needs.aggregate-release-data.outputs.commit_sha }}
           echo version_number: ${{ needs.aggregate-release-data.outputs.version_number }}
           echo release_branch: ${{ needs.aggregate-release-data.outputs.release_branch }}
 
@@ -97,13 +89,8 @@ jobs:
 
     uses: ./.github/workflows/release.yml
     with:
-      sha: ${{ needs.aggregate-release-data.outputs.commit_sha }}
       target_branch: ${{ needs.aggregate-release-data.outputs.release_branch }}
       version_number: ${{ needs.aggregate-release-data.outputs.version_number }}
-      build_script_path: "scripts/build-dist.sh"
-      env_setup_script_path: "scripts/env-setup.sh"
-      s3_bucket_name: "core-team-artifacts"
-      package_test_command: "dbt --version"
       test_run: true
       nightly_release: true
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,22 +65,12 @@ defaults:
   run:
     shell: bash
 
-env:
-  build_script_path: "scripts/build-dist.sh"
-  env_setup_script_path: "scripts/env-setup.sh"
-  s3_bucket_name: "core-team-artifacts"
-  package_test_command: "dbt --version"
-
 jobs:
   job-setup:
     name: Log Inputs
     runs-on: ubuntu-latest
     outputs:
       starting_sha: ${{ steps.set_sha.outputs.changelog_path }}
-      build_script_path: ${{ steps.set_path.outputs.build_script_path }}
-      env_setup_script_path: ${{ steps.set_path.outputs.env_setup_script_path }}
-      s3_bucket_name: ${{ steps.set_path.outputs.s3_bucket_name }}
-      package_test_command: ${{ steps.set_path.outputs.package_test_command }}
     steps:
       - name: "[DEBUG] Print Variables"
         run: |
@@ -89,19 +79,6 @@ jobs:
           echo The release version number:         ${{ inputs.version_number }}
           echo Test run:                           ${{ inputs.test_run }}
           echo Nightly release:                    ${{ inputs.nightly_release }}
-          echo Env vars
-          echo Build script path:                  ${{ env.build_script_path }}
-          echo Environment setup script path:      ${{ env.env_setup_script_path }}
-          echo AWS S3 bucket name:                 ${{ env.s3_bucket_name }}
-          echo Package test command:               ${{ env.package_test_command }}
-
-      - name: "Set paths"
-        id: set_path
-        run: |
-          echo "build_script_path=${{ env.build_script_path }}" >> $GITHUB_ENV
-          echo "env_setup_script_path=${{ env.env_setup_script_path }}" >> $GITHUB_ENV
-          echo "s3_bucket_name=${{ env.s3_bucket_name }}" >> $GITHUB_ENV
-          echo "package_test_command=${{ env.package_test_command }}" >> $GITHUB_ENV
 
       - name: "Checkout target branch"
         uses: actions/checkout@v4
@@ -127,7 +104,7 @@ jobs:
       sha: ${{ needs.job-setup.outputs.starting_sha }}
       version_number: ${{ inputs.version_number }}
       target_branch: ${{ inputs.target_branch }}
-      env_setup_script_path: ${{ needs.job-setup.outputs.env_setup_script_path }}
+      env_setup_script_path: "scripts/env-setup.sh"
       test_run: ${{ inputs.test_run }}
       nightly_release: ${{ inputs.nightly_release }}
 
@@ -158,9 +135,9 @@ jobs:
       sha: ${{ needs.bump-version-generate-changelog.outputs.final_sha }}
       version_number: ${{ inputs.version_number }}
       changelog_path: ${{ needs.bump-version-generate-changelog.outputs.changelog_path }}
-      build_script_path: ${{ needs.job-setup.outputs.build_script_path }}
-      s3_bucket_name: ${{ needs.job-setup.outputs.s3_bucket_name }}
-      package_test_command: ${{ needs.job-setup.outputs.package_test_command }}
+      build_script_path: "scripts/build-dist.sh"
+      s3_bucket_name: "core-team-artifacts"
+      package_test_command: "dbt --version"
       test_run: ${{ inputs.test_run }}
       nightly_release: ${{ inputs.nightly_release }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,11 @@ jobs:
     name: Log Inputs
     runs-on: ubuntu-latest
     outputs:
-      starting_sha: ${{ steps.set_path.outputs.changelog_path }}
+      starting_sha: ${{ steps.set_sha.outputs.changelog_path }}
+      build_script_path: ${{ steps.set_path.outputs.build_script_path }}
+      env_setup_script_path: ${{ steps.set_path.outputs.env_setup_script_path }}
+      s3_bucket_name: ${{ steps.set_path.outputs.s3_bucket_name }}
+      package_test_command: ${{ steps.set_path.outputs.package_test_command }}
     steps:
       - name: "[DEBUG] Print Variables"
         run: |
@@ -91,6 +95,14 @@ jobs:
           echo AWS S3 bucket name:                 ${{ env.s3_bucket_name }}
           echo Package test command:               ${{ env.package_test_command }}
 
+      - name: "Set paths"
+        id: set_path
+        run: |
+          echo "build_script_path=${{ env.build_script_path }}" >> $GITHUB_ENV
+          echo "env_setup_script_path=${{ env.env_setup_script_path }}" >> $GITHUB_ENV
+          echo "s3_bucket_name=${{ env.s3_bucket_name }}" >> $GITHUB_ENV
+          echo "package_test_command=${{ env.package_test_command }}" >> $GITHUB_ENV
+
       - name: "Checkout target branch"
         uses: actions/checkout@v4
         with:
@@ -101,7 +113,7 @@ jobs:
       # The changes always get merged into the head so we can't use a specific commit fo
       # releases anyways.
       - name: "Capture sha"
-        id: set_path
+        id: set_sha
         run: |
           echo "starting_sha=$(git rev-parse HEAD) >> $GITHUB_OUTPUT
 
@@ -115,7 +127,7 @@ jobs:
       sha: ${{ needs.job-setup.outputs.starting_sha }}
       version_number: ${{ inputs.version_number }}
       target_branch: ${{ inputs.target_branch }}
-      env_setup_script_path: ${{ env.env_setup_script_path }}
+      env_setup_script_path: ${{ needs.job-setup.outputs.env_setup_script_path }}
       test_run: ${{ inputs.test_run }}
       nightly_release: ${{ inputs.nightly_release }}
 
@@ -138,7 +150,7 @@ jobs:
   build-test-package:
     name: Build, Test, Package
     if: ${{ !failure() && !cancelled() }}
-    needs: [bump-version-generate-changelog]
+    needs: [job-setup, bump-version-generate-changelog]
 
     uses: dbt-labs/dbt-release/.github/workflows/build.yml@main
 
@@ -146,9 +158,9 @@ jobs:
       sha: ${{ needs.bump-version-generate-changelog.outputs.final_sha }}
       version_number: ${{ inputs.version_number }}
       changelog_path: ${{ needs.bump-version-generate-changelog.outputs.changelog_path }}
-      build_script_path: ${{ env.build_script_path }}
-      s3_bucket_name: ${{ env.s3_bucket_name }}
-      package_test_command: ${{ env.package_test_command }}
+      build_script_path: ${{ needs.job-setup.outputs.build_script_path }}
+      s3_bucket_name: ${{ needs.job-setup.outputs.s3_bucket_name }}
+      package_test_command: ${{ needs.job-setup.outputs.package_test_command }}
       test_run: ${{ inputs.test_run }}
       nightly_release: ${{ inputs.nightly_release }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
 
       # release-prep.yml really shouldn't take in the sha but since core + all adapters
       # depend on it now this workaround lets us not input it manually with risk of error.
-      # The changes always get merged into the head so we can't use a specific commit fo
+      # The changes always get merged into the head so we can't use a specific commit for
       # releases anyways.
       - name: "Capture sha"
         id: set_sha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
       - name: "Capture sha"
         id: set_sha
         run: |
-          echo "starting_sha=$(git rev-parse HEAD) >> $GITHUB_OUTPUT
+          echo "starting_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
   bump-version-generate-changelog:
     name: Bump package version, Generate changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,6 @@ name: Release to GitHub and PyPI
 on:
   workflow_dispatch:
     inputs:
-      sha:
-        description: "The last commit sha in the release"
-        type: string
-        required: true
       target_branch:
         description: "The branch to release from"
         type: string
@@ -30,26 +26,6 @@ on:
       version_number:
         description: "The release version number (i.e. 1.0.0b1)"
         type: string
-        required: true
-      build_script_path:
-        description: "Build script path"
-        type: string
-        default: "scripts/build-dist.sh"
-        required: true
-      env_setup_script_path:
-        description: "Environment setup script path"
-        type: string
-        default: "scripts/env-setup.sh"
-        required: false
-      s3_bucket_name:
-        description: "AWS S3 bucket name"
-        type: string
-        default: "core-team-artifacts"
-        required: true
-      package_test_command:
-        description: "Package test command"
-        type: string
-        default: "dbt --version"
         required: true
       test_run:
         description: "Test run (Publish release as draft)"
@@ -63,10 +39,6 @@ on:
         required: false
   workflow_call:
     inputs:
-      sha:
-        description: "The last commit sha in the release"
-        type: string
-        required: true
       target_branch:
         description: "The branch to release from"
         type: string
@@ -74,26 +46,6 @@ on:
       version_number:
         description: "The release version number (i.e. 1.0.0b1)"
         type: string
-        required: true
-      build_script_path:
-        description: "Build script path"
-        type: string
-        default: "scripts/build-dist.sh"
-        required: true
-      env_setup_script_path:
-        description: "Environment setup script path"
-        type: string
-        default: "scripts/env-setup.sh"
-        required: false
-      s3_bucket_name:
-        description: "AWS S3 bucket name"
-        type: string
-        default: "core-team-artifacts"
-        required: true
-      package_test_command:
-        description: "Package test command"
-        type: string
-        default: "dbt --version"
         required: true
       test_run:
         description: "Test run (Publish release as draft)"
@@ -113,33 +65,57 @@ defaults:
   run:
     shell: bash
 
+env:
+  build_script_path: "scripts/build-dist.sh"
+  env_setup_script_path: "scripts/env-setup.sh"
+  s3_bucket_name: "core-team-artifacts"
+  package_test_command: "dbt --version"
+
 jobs:
-  log-inputs:
+  job-setup:
     name: Log Inputs
     runs-on: ubuntu-latest
+    outputs:
+      starting_sha: ${{ steps.set_path.outputs.changelog_path }}
     steps:
       - name: "[DEBUG] Print Variables"
         run: |
-          echo The last commit sha in the release: ${{ inputs.sha }}
+          echo Inputs
           echo The branch to release from:         ${{ inputs.target_branch }}
           echo The release version number:         ${{ inputs.version_number }}
-          echo Build script path:                  ${{ inputs.build_script_path }}
-          echo Environment setup script path:      ${{ inputs.env_setup_script_path }}
-          echo AWS S3 bucket name:                 ${{ inputs.s3_bucket_name }}
-          echo Package test command:               ${{ inputs.package_test_command }}
           echo Test run:                           ${{ inputs.test_run }}
           echo Nightly release:                    ${{ inputs.nightly_release }}
+          echo Env vars
+          echo Build script path:                  ${{ env.build_script_path }}
+          echo Environment setup script path:      ${{ env.env_setup_script_path }}
+          echo AWS S3 bucket name:                 ${{ env.s3_bucket_name }}
+          echo Package test command:               ${{ env.package_test_command }}
+
+      - name: "Checkout target branch"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_branch }}
+
+      # release-prep.yml really shouldn't take in the sha but since core + all adapters
+      # depend on it now this workaround lets us not input it manually with risk of error.
+      # The changes always get merged into the head so we can't use a specific commit fo
+      # releases anyways.
+      - name: "Capture sha"
+        id: set_path
+        run: |
+          echo "starting_sha=$(git rev-parse HEAD) >> $GITHUB_OUTPUT
 
   bump-version-generate-changelog:
     name: Bump package version, Generate changelog
+    needs: [job-setup]
 
     uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@main
 
     with:
-      sha: ${{ inputs.sha }}
+      sha: ${{ needs.job-setup.outputs.starting_sha }}
       version_number: ${{ inputs.version_number }}
       target_branch: ${{ inputs.target_branch }}
-      env_setup_script_path: ${{ inputs.env_setup_script_path }}
+      env_setup_script_path: ${{ env.env_setup_script_path }}
       test_run: ${{ inputs.test_run }}
       nightly_release: ${{ inputs.nightly_release }}
 
@@ -170,9 +146,9 @@ jobs:
       sha: ${{ needs.bump-version-generate-changelog.outputs.final_sha }}
       version_number: ${{ inputs.version_number }}
       changelog_path: ${{ needs.bump-version-generate-changelog.outputs.changelog_path }}
-      build_script_path: ${{ inputs.build_script_path }}
-      s3_bucket_name: ${{ inputs.s3_bucket_name }}
-      package_test_command: ${{ inputs.package_test_command }}
+      build_script_path: ${{ env.build_script_path }}
+      s3_bucket_name: ${{ env.s3_bucket_name }}
+      package_test_command: ${{ env.package_test_command }}
       test_run: ${{ inputs.test_run }}
       nightly_release: ${{ inputs.nightly_release }}
 


### PR DESCRIPTION
resolves #9431 
relates to https://github.com/dbt-labs/dbt-release/issues/69

### Problem

Release inputs are long and not all of them are really necessary or add value to being flexible.

![Screenshot 2024-01-23 at 12 45 52 PM](https://github.com/dbt-labs/dbt-core/assets/7070049/00885f5e-a184-49c4-91fc-6f99262f8911)


### Solution

Simplify inputs to only what's needed
![Screenshot 2024-01-23 at 12 45 36 PM](https://github.com/dbt-labs/dbt-core/assets/7070049/e4316928-1669-4e9a-816a-230723e4cc5d)

Nightly tests are also updated to reflect these changes.

Test run: https://github.com/dbt-labs/dbt-core/actions/runs/7630615252
### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
