### PR TITLE
Fix edge case where `summary_message` is not assigned in `dbt debug`

### DIFF
--- a/.changes/unreleased/Fixes-20240124-071545.yaml
+++ b/.changes/unreleased/Fixes-20240124-071545.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix edge case where `summary_message` is not assigned
+time: 2024-01-24T07:15:45.054862-07:00
+custom:
+  Author: dbeatty10
+  Issue: "9436"

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -231,6 +231,9 @@ class DebugTask(BaseTask):
                     self.target_name = self._choose_target_name(profile_name)
                     self.profile = profile
 
+        if len(profile_names) == 0:
+            profile_errors.append(summary_message)
+
         if profile_errors:
             details = "\n\n".join(profile_errors)
             return SubtaskStatus(

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -273,6 +273,7 @@ class DebugTask(BaseTask):
         # try to guess
 
         profiles = []
+        summary_message = f" profile path <{self.profile_path}> not found\n"
         if self.raw_profile_data:
             profiles = [k for k in self.raw_profile_data if k != "config"]
             if project_profile is None:


### PR DESCRIPTION
resolves #9436

### Problem

When running `dbt debug` in [certain circumstances](#9436), I get a python stack trace that ends in the following:
```
UnboundLocalError: local variable 'summary_message' referenced before assignment
```

### Solution

Two parts to the solution:
1. [Add a default `summary_message`](https://github.com/dbt-labs/dbt-core/commit/ab049cc6020f650bd70ae8a1bf84c20acc75ba5a)
2. [Consider it an error if no profile names are found](https://github.com/dbt-labs/dbt-core/commit/6a452e85a3a9e758cd049add91b67ce8fa1b27af)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
