### PR TITLE
fix retry as CLI

### DIFF
--- a/.changes/unreleased/Fixes-20240124-142522.yaml
+++ b/.changes/unreleased/Fixes-20240124-142522.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix retry command run from CLI
+time: 2024-01-24T14:25:22.846199-08:00
+custom:
+  Author: ChenyuLInx
+  Issue: "9444"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -608,7 +608,7 @@ def retry(ctx, **kwargs):
     task = RetryTask(
         ctx.obj["flags"],
         ctx.obj["runtime_config"],
-        ctx.obj["manifest"],
+        None,
     )
 
     results = task.run()

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -608,7 +608,6 @@ def retry(ctx, **kwargs):
     task = RetryTask(
         ctx.obj["flags"],
         ctx.obj["runtime_config"],
-        None,
     )
 
     results = task.run()

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -602,9 +602,9 @@ def run(ctx, **kwargs):
 @requires.profile
 @requires.project
 @requires.runtime_config
-@requires.manifest
 def retry(ctx, **kwargs):
     """Retry the nodes that failed in the previous run."""
+    # Retry will parse manifest inside the task after we consolidate the flags
     task = RetryTask(
         ctx.obj["flags"],
         ctx.obj["runtime_config"],

--- a/core/dbt/task/retry.py
+++ b/core/dbt/task/retry.py
@@ -63,7 +63,7 @@ CMD_DICT = {
 
 
 class RetryTask(ConfiguredTask):
-    def __init__(self, args, config, manifest) -> None:
+    def __init__(self, args, config) -> None:
         # load previous run results
         state_path = args.state or config.target_path
         self.previous_results = load_result_state(


### PR DESCRIPTION
Resolves: #9444
Our integration test right now goes through dbtRunner, which will add the `manifest` as None in `ctx.obj`.
When running retry as a CLI command, current code would just fail.

We should add some test to run each command as CLI command just to make sure CLI works.
