### PR TITLE
update dependencies

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -61,6 +61,7 @@ setup(
         # with major versions in each new minor version of dbt-core.
         "click>=8.0.2,<9",
         "networkx>=2.3,<4",
+        "requests<3.0.0",  # should match dbt-common
         # ----
         # These packages are major-version-0. Keep upper bounds on upcoming minor versions (which could have breaking changes)
         # and check compatibility / bump in each new minor version of dbt-core.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,16 +23,12 @@ pytest-xdist
 sphinx
 tox>=3.13
 twine
-types-docutils
 types-PyYAML
-types-freezegun
 types-Jinja2
-types-jsonschema
 types-mock
 types-protobuf
-types-python-dateutil
 types-pytz
-types-requests<2.31.0 # types-requests 2.31.0.8 requires urllib3>=2, but we pin urllib3 ~= 1.0 because of openssl requirement for requests
+types-requests
 types-setuptools
 wheel
 mocker

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,6 +23,7 @@ pytest-xdist
 sphinx
 tox>=3.13
 twine
+types-docutils
 types-PyYAML
 types-Jinja2
 types-mock


### PR DESCRIPTION
resolves #8790 


### Problem

We had to hard pin a type check because of dependency resolution

### Solution

Stop pinning it
add back requests dependency because core uses it
remove other type checkers we no longer need

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
