### PR TITLE
TestGenerateCatalogWithExternalNodes

### DIFF
--- a/.changes/unreleased/Fixes-20240125-182243.yaml
+++ b/.changes/unreleased/Fixes-20240125-182243.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Add TestGenerateCatalogWithExternalNodes, include empty nodes in node selection
+  during docs generate
+time: 2024-01-25T18:22:43.253228-05:00
+custom:
+  Author: michelleark
+  Issue: "9456"

--- a/core/dbt/task/docs/generate.py
+++ b/core/dbt/task/docs/generate.py
@@ -343,6 +343,7 @@ class GenerateTask(CompileTask):
             manifest=self.manifest,
             previous_state=self.previous_state,
             resource_types=EXECUTABLE_NODE_TYPES,
+            include_empty_nodes=True,
         )
 
     def get_catalog_results(


### PR DESCRIPTION
resolves #9458

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem
catalog from docs generate does not include external nodes, even though that was the case in 1.6. This is because starting from 1.7, the docs generate task started using a ResourceSelector which filters out empty nodes (e.g. external ones) as opposed to iterating over the manifest directly.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

* Set `include_empty_nodes=True` in the `ResourceTypeSelector` for the generate task.
  * This indicates to the selector that 'empty' (e.g. nodes without raw_code, like external nodes) should be included in selection and make their way to the catalog
  * Same approach as was used to select external nodes in the ListCommand, which needed to select external nodes for the result even though they are not 'runnable': https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/task/list.py#L201
* Add a test that ensures generated catalogs include external nodes when those are available in the project

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
