### PR TITLE
Fix incremental delete+insert SQL

### DIFF
--- a/.changes/unreleased/Fixes-20240125-163601.yaml
+++ b/.changes/unreleased/Fixes-20240125-163601.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix incremental delete+insert SQL
+time: 2024-01-25T16:36:43.253228-05:00
+custom:
+  Author: ataft
+  Issue: "9279"

--- a/core/dbt/include/global_project/macros/materializations/models/incremental/merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/models/incremental/merge.sql
@@ -61,34 +61,23 @@
     {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
 
     {% if unique_key %}
-        {% if unique_key is sequence and unique_key is not string %}
-            delete from {{target }}
-            using {{ source }}
-            where (
-                {% for key in unique_key %}
-                    {{ source }}.{{ key }} = {{ target }}.{{ key }}
-                    {{ "and " if not loop.last}}
-                {% endfor %}
-                {% if incremental_predicates %}
-                    {% for predicate in incremental_predicates %}
-                        and {{ predicate }}
-                    {% endfor %}
-                {% endif %}
-            );
-        {% else %}
-            delete from {{ target }}
-            where (
-                {{ unique_key }}) in (
-                select ({{ unique_key }})
-                from {{ source }}
-            )
-            {%- if incremental_predicates %}
-                {% for predicate in incremental_predicates %}
-                    and {{ predicate }}
-                {% endfor %}
-            {%- endif -%};
-
+        {% if unique_key is string %}
+        {% set unique_key = [unique_key] %}
         {% endif %}
+
+        {%- set unique_key_str = unique_key|join(', ') -%}
+
+        delete from {{ target }}
+        where ({{ unique_key_str }}) in (
+            select distinct {{ unique_key_str }}
+            from {{ source }}
+        )
+        {%- if incremental_predicates %}
+            {% for predicate in incremental_predicates %}
+                and {{ predicate }}
+            {% endfor %}
+        {%- endif -%};
+
     {% endif %}
 
     insert into {{ target }} ({{ dest_cols_csv }})


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-adapters/issues/150

### Problem

The delete query for the 'delete+insert' incremental_strategy with 2+ unique_key columns is VERY inefficient. In many cases, it will hang and never return for deleting small amounts of data (<100K rows).

### Solution

Improve the query by switching to a much more efficient delete strategy:
```
delete from table1
where (col1, col2) in (
    select distinct col1, col2 from table1_tmp
)

```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
