### PR TITLE
Fix plurals in FoundStats message

### DIFF
--- a/.changes/unreleased/Fixes-20240126-134234.yaml
+++ b/.changes/unreleased/Fixes-20240126-134234.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix node type plurals in FoundStats log message
+time: 2024-01-26T13:42:34.651033+01:00
+custom:
+  Author: jtcohen6
+  Issue: "9464"

--- a/core/dbt/artifacts/resources/types.py
+++ b/core/dbt/artifacts/resources/types.py
@@ -18,7 +18,7 @@ class AccessType(StrEnum):
 class NodeType(StrEnum):
     Model = "model"
     Analysis = "analysis"
-    Test = "test"
+    Test = "test"  # renamed to 'data_test'; preserved as 'test' here for back-compat
     Snapshot = "snapshot"
     Operation = "operation"
     Seed = "seed"
@@ -41,6 +41,8 @@ class NodeType(StrEnum):
             return "analyses"
         elif self is self.SavedQuery:
             return "saved_queries"
+        elif self is self.Test:
+            return "data_tests"
         return f"{self}s"
 
 

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -45,7 +45,7 @@ import sqlparse
 graph_file_name = "graph.gpickle"
 
 
-def print_compile_stats(stats):
+def print_compile_stats(stats: Dict[NodeType, int]):
     # create tracking event for resource_counts
     if dbt.tracking.active_user is not None:
         resource_counts = {k.pluralize(): v for k, v in stats.items()}
@@ -64,7 +64,7 @@ def _node_enabled(node: ManifestNode):
         return True
 
 
-def _generate_stats(manifest: Manifest):
+def _generate_stats(manifest: Manifest) -> Dict[NodeType, int]:
     stats: Dict[NodeType, int] = defaultdict(int)
     for node in manifest.nodes.values():
         if _node_enabled(node):

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -71,8 +71,7 @@ def print_compile_stats(stats):
         dbt.tracking.track_resource_counts(resource_counts)
 
     # do not include resource types that are not actually defined in the project
-    stat_line = ", ".join([pluralize(ct, names.get(t)) for t, ct in stats.items() if t in names])
-
+    stat_line = ", ".join([pluralize(ct, t) for t, ct in stats.items() if t in names])
     fire_event(FoundStats(stat_line=stat_line))
 
 

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -46,32 +46,13 @@ graph_file_name = "graph.gpickle"
 
 
 def print_compile_stats(stats):
-    names = {
-        NodeType.Model: "model",
-        NodeType.Test: "data test",
-        NodeType.Unit: "unit test",
-        NodeType.Snapshot: "snapshot",
-        NodeType.Analysis: "analysis",
-        NodeType.Macro: "macro",
-        NodeType.Operation: "operation",
-        NodeType.Seed: "seed",
-        NodeType.Source: "source",
-        NodeType.Exposure: "exposure",
-        NodeType.SemanticModel: "semantic model",
-        NodeType.Metric: "metric",
-        NodeType.Group: "group",
-    }
-
-    results = {k: 0 for k in names.keys()}
-    results.update(stats)
-
     # create tracking event for resource_counts
     if dbt.tracking.active_user is not None:
-        resource_counts = {k.pluralize(): v for k, v in results.items()}
+        resource_counts = {k.pluralize(): v for k, v in stats.items()}
         dbt.tracking.track_resource_counts(resource_counts)
 
     # do not include resource types that are not actually defined in the project
-    stat_line = ", ".join([pluralize(ct, t) for t, ct in stats.items() if t in names])
+    stat_line = ", ".join([pluralize(ct, t) for t, ct in stats.items() if ct != 0])
     fire_event(FoundStats(stat_line=stat_line))
 
 

--- a/tests/functional/minimal_cli/test_minimal_cli.py
+++ b/tests/functional/minimal_cli/test_minimal_cli.py
@@ -35,7 +35,7 @@ class TestLS(BaseConfigProject):
         ls_result = runner.invoke(cli, ["ls"])
         assert "1 seed" in ls_result.output
         assert "1 model" in ls_result.output
-        assert "5 data tests" in ls_result.output
+        assert "5 data_tests" in ls_result.output
         assert "1 snapshot" in ls_result.output
 
 

--- a/tests/functional/schema_tests/test_schema_v2_tests.py
+++ b/tests/functional/schema_tests/test_schema_v2_tests.py
@@ -906,7 +906,7 @@ class TestGenericTestsCollide:
         """These tests collide, since only the configs differ"""
         with pytest.raises(DuplicateResourceNameError) as exc:
             run_dbt()
-        assert "dbt found two tests with the name" in str(exc.value)
+        assert "dbt found two data_tests with the name" in str(exc.value)
 
 
 class TestGenericTestsConfigCustomMacros:

--- a/tests/unit/test_node_types.py
+++ b/tests/unit/test_node_types.py
@@ -4,7 +4,7 @@ from dbt.node_types import NodeType
 node_type_pluralizations = {
     NodeType.Model: "models",
     NodeType.Analysis: "analyses",
-    NodeType.Test: "tests",
+    NodeType.Test: "data_tests",
     NodeType.Snapshot: "snapshots",
     NodeType.Operation: "operations",
     NodeType.Seed: "seeds",


### PR DESCRIPTION
resolves #9464

### Problem

As part of moving the event system & log formatting logic into `dbt-common`, we introduced a "cosmetic regression" that prints the plural of `analysis` as `analysiss` in the `FoundStats` line.

### Solution

Following the new logic in `dbt_common.events.format.pluralize`, pass the `NodeType` enum object into `pluralize`, rather than its (manually mapped) string name.

While this fixes the issue with `analyses`, it does mean that we'll be printing multi-word node types with an underscore instead of a space:
```
... data_tests, ... saved_queries, ... semantic_models, ... unit_tests
```
I think that's fine — it's more consistent with how these appear elsewhere — and it's definitely better than `saved querys` ;)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
