### PR TITLE
[Backport 1.3.latest] Pin `pytest` in `dev-requirements.txt`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,9 +8,9 @@ ipdb
 mypy==0.971
 pip-tools
 pre-commit
-pytest
+pytest~=7.4
 pytest-cov
-pytest-csv
+pytest-csv~=3.0
 pytest-dotenv
 pytest-logbook
 pytest-mock


### PR DESCRIPTION
Backport 1cbc6d333d79f4408ed620c5aef18b18a216e6c3 from #9473.