### PR TITLE
Fix Docker release to correctly publish `latest` and `1.x.latest` tags

### DIFF
--- a/.github/actions/latest-wrangler/action.yml
+++ b/.github/actions/latest-wrangler/action.yml
@@ -1,20 +1,21 @@
-name: "Github package 'latest' tag wrangler for containers"
-description: "Determines wether or not a given dbt container should be given a bare 'latest' tag (I.E. dbt-core:latest)"
+name: "GitHub package `latest` tag wrangler for containers"
+description: "Determines if the published image should include `latest` tags"
+
 inputs:
   package_name:
-    description: "Package to check (I.E. dbt-core, dbt-redshift, etc)"
+    description: "Package being published (i.e. `dbt-core`, `dbt-redshift`, etc.)"
     required: true
   new_version:
-    description: "Semver of the container being built (I.E. 1.0.4)"
+    description: "SemVer of the package being published (i.e. 1.7.2, 1.8.0a1, etc.)"
     required: true
-  gh_token:
-    description: "Auth token for github (must have view packages scope)"
+  github_token:
+    description: "Auth token for GitHub (must have view packages scope)"
     required: true
+
 outputs:
-  latest:
-    description: "Wether or not built container should be tagged latest (bool)"
-  minor_latest:
-    description: "Wether or not built container should be tagged minor.latest (bool)"
+  tags:
+    description: "A list of tags to associate with this version"
+
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/.github/actions/latest-wrangler/main.py
+++ b/.github/actions/latest-wrangler/main.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Tuple
 
 
 def main():
-    package_name: str = os.environ["INPUT_PACKAGE"]
+    package_name: str = os.environ["INPUT_PACKAGE_NAME"]
     new_version: Version = parse(os.environ["INPUT_NEW_VERSION"])
     github_token: str = os.environ["INPUT_GITHUB_TOKEN"]
 

--- a/.github/actions/latest-wrangler/main.py
+++ b/.github/actions/latest-wrangler/main.py
@@ -1,98 +1,75 @@
 import os
-import sys
+from packaging.version import Version, parse
 import requests
-from distutils.util import strtobool
-from typing import Union
-from packaging.version import parse, Version
+from typing import Any, Dict, List, Tuple
 
-if __name__ == "__main__":
 
-    # get inputs
-    package = os.environ["INPUT_PACKAGE"]
-    new_version = parse(os.environ["INPUT_NEW_VERSION"])
-    gh_token = os.environ["INPUT_GH_TOKEN"]
-    halt_on_missing = strtobool(os.environ.get("INPUT_HALT_ON_MISSING", "False"))
+def main():
+    package_name: str = os.environ["INPUT_PACKAGE"]
+    new_version: Version = parse(os.environ["INPUT_NEW_VERSION"])
+    github_token: str = os.environ["INPUT_GITHUB_TOKEN"]
 
+    package_metadata, status_code = _package_metadata(package_name, github_token)
+    _process_status_code(status_code, package_metadata["message"])
+    published_versions = _published_versions(package_metadata)
+    new_version_tags = _new_version_tags(new_version, published_versions)
+    _register_tags(new_version_tags, package_name)
+
+
+def _package_metadata(package_name: str, github_token: str) -> Tuple[Dict[Any, Any], int]:
     # get package metadata from github
     package_request = requests.get(
-        f"https://api.github.com/orgs/dbt-labs/packages/container/{package}/versions",
-        auth=("", gh_token),
+        f"https://api.github.com/orgs/dbt-labs/packages/container/{package_name}/versions",
+        auth=("", github_token),
     )
     package_meta = package_request.json()
+    status_code = package_request.status_code
+    return package_meta, status_code
 
-    # Log info if we don't get a 200
-    if package_request.status_code != 200:
-        print(f"Call to GH API failed: {package_request.status_code} {package_meta['message']}")
 
-    # Make an early exit if there is no matching package in github
-    if package_request.status_code == 404:
-        if halt_on_missing:
-            sys.exit(1)
-        # everything is the latest if the package doesn't exist
-        github_output = os.environ.get("GITHUB_OUTPUT")
-        with open(github_output, "at", encoding="utf-8") as gh_output:
-            gh_output.write("latest=True")
-            gh_output.write("minor_latest=True")
-        sys.exit(0)
+def _published_versions(package_meta) -> List[Version]:
+    return [
+        parse(tag)
+        for version in package_meta
+        for tag in version["metadata"]["container"]["tags"]
+        if "latest" not in tag
+    ]
 
-    # TODO: verify package meta is "correct"
-    # https://github.com/dbt-labs/dbt-core/issues/4640
 
-    # map versions and tags
-    version_tag_map = {
-        version["id"]: version["metadata"]["container"]["tags"] for version in package_meta
-    }
+def _new_version_tags(new_version: Version, published_versions: List[Version]) -> List[str]:
+    # the package version is always a tag
+    tags = [str(new_version)]
 
-    # is pre-release
-    pre_rel = True if any(x in str(new_version) for x in ["a", "b", "rc"]) else False
+    # pre-releases don't get tagged with `latest`
+    if new_version.is_prerelease:
+        return tags
 
-    # semver of current latest
-    for version, tags in version_tag_map.items():
-        if "latest" in tags:
-            # N.B. This seems counterintuitive, but we expect any version tagged
-            # 'latest' to have exactly three associated tags:
-            # latest, major.minor.latest, and major.minor.patch.
-            # Subtracting everything that contains the string 'latest' gets us
-            # the major.minor.patch which is what's needed for comparison.
-            current_latest = parse([tag for tag in tags if "latest" not in tag][0])
-        else:
-            current_latest = False
+    if new_version > max(published_versions):
+        tags.append("latest")
 
-    # semver of current_minor_latest
-    for version, tags in version_tag_map.items():
-        if f"{new_version.major}.{new_version.minor}.latest" in tags:
-            # Similar to above, only now we expect exactly two tags:
-            # major.minor.patch and major.minor.latest
-            current_minor_latest = parse([tag for tag in tags if "latest" not in tag][0])
-        else:
-            current_minor_latest = False
+    published_patches = [
+        version
+        for version in published_versions
+        if version.major == new_version.major and version.minor == new_version.minor
+    ]
+    if new_version > max(published_patches):
+        tags.append(f"{new_version.major}.{new_version.minor}.latest")
 
-    def is_latest(
-        pre_rel: bool, new_version: Version, remote_latest: Union[bool, Version]
-    ) -> bool:
-        """Determine if a given contaier should be tagged 'latest' based on:
-         - it's pre-release status
-         - it's version
-         - the version of a previously identified container tagged 'latest'
+    return tags
 
-        :param pre_rel: Wether or not the version of the new container is a pre-release
-        :param new_version: The version of the new container
-        :param remote_latest: The version of the previously identified container that's
-            already tagged latest or False
-        """
-        # is a pre-release = not latest
-        if pre_rel:
-            return False
-        # + no latest tag found = is latest
-        if not remote_latest:
-            return True
-        # + if remote version is lower than current = is latest, else not latest
-        return True if remote_latest <= new_version else False
 
-    latest = is_latest(pre_rel, new_version, current_latest)
-    minor_latest = is_latest(pre_rel, new_version, current_minor_latest)
-
+def _register_tags(tags: List[str], package_name: str) -> None:
+    fully_qualified_tags = ",".join([f"ghcr.io/dbt-labs/{package_name}:{tag}" for tag in tags])
     github_output = os.environ.get("GITHUB_OUTPUT")
     with open(github_output, "at", encoding="utf-8") as gh_output:
-        gh_output.write(f"latest={latest}")
-        gh_output.write(f"minor_latest={minor_latest}")
+        print(f"Registering {fully_qualified_tags}")
+        gh_output.write(f"fully_qualified_tags={fully_qualified_tags}")
+
+
+def _process_status_code(status_code: int, message: str) -> None:
+    if status_code != 200:
+        print(f"Call to GH API failed: {status_code} {message}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/latest-wrangler/main.py
+++ b/.github/actions/latest-wrangler/main.py
@@ -17,7 +17,7 @@ def main():
 
 
 def _package_metadata(package_name: str, github_token: str) -> requests.Response:
-    url = (f"https://api.github.com/orgs/dbt-labs/packages/container/{package_name}/versions",)
+    url = f"https://api.github.com/orgs/dbt-labs/packages/container/{package_name}/versions"
     return requests.get(url, auth=("", github_token))
 
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -44,7 +44,7 @@ jobs:
         id: tags
         uses: ./.github/actions/latest-wrangler
         with:
-          package: ${{ inputs.package }}
+          package_name: ${{ inputs.package }}
           new_version: ${{ inputs.version_number }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,15 +1,12 @@
 # **what?**
 # This workflow will generate a series of docker images for dbt and push them to the github container registry
-
+#
 # **why?**
-# Docker images for dbt are used in a number of important places throughout the dbt ecosystem.  This is how we keep those images up-to-date.
-
+# Docker images for dbt are used in a number of important places throughout the dbt ecosystem.
+# This is how we keep those images up-to-date.
+#
 # **when?**
 # This is triggered manually
-
-# **next steps**
-# - build this into the release workflow (or conversly, break out the different release methods into their own workflow files)
-
 name: Docker release
 
 permissions:
@@ -19,43 +16,32 @@ on:
   workflow_dispatch:
     inputs:
       package:
-       description: The package to release. _One_ of [dbt-core, dbt-redshift, dbt-bigquery, dbt-snowflake, dbt-spark, dbt-postgres]
-       required: true
+        description: The package to release. _One_ of [dbt-core, dbt-redshift, dbt-bigquery, dbt-snowflake, dbt-spark, dbt-postgres]
+        required: true
       version_number:
-       description: The release version number (i.e. 1.0.0b1). Do not include `latest` tags or a leading `v`!
-       required: true
+        description: The release version number (i.e. 1.0.0b1). Do not include `latest` tags or a leading `v`!
+        required: true
 
 jobs:
-  get_version_meta:
-    name: Get version meta
+  version_metadata:
+    name: Get version metadata
     runs-on: ubuntu-latest
     outputs:
-      major: ${{ steps.version.outputs.major }}
-      minor: ${{ steps.version.outputs.minor }}
-      patch: ${{ steps.version.outputs.patch }}
-      latest: ${{ steps.latest.outputs.latest }}
-      minor_latest: ${{ steps.latest.outputs.minor_latest }}
+      fully_qualified_tags: ${{ steps.tags.outputs.fully_qualified_tags }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Split version
-        id: version
-        run: |
-          IFS="." read -r MAJOR MINOR PATCH <<< ${{ github.event.inputs.version_number }}
-          echo "major=$MAJOR" >> $GITHUB_OUTPUT
-          echo "minor=$MINOR" >> $GITHUB_OUTPUT
-          echo "patch=$PATCH" >> $GITHUB_OUTPUT
+      - name: Check out the repo
+        uses: actions/checkout@v4
 
-      - name: Is pkg 'latest'
-        id: latest
+      - name: Get the tags to publish
+        id: tags
         uses: ./.github/actions/latest-wrangler
         with:
-          package: ${{ github.event.inputs.package }}
-          new_version: ${{ github.event.inputs.version_number }}
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
-          halt_on_missing: False
+          package: ${{ inputs.package }}
+          new_version: ${{ inputs.version_number }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   setup_image_builder:
-    name: Set up docker image builder
+    name: Set up Docker image builder
     runs-on: ubuntu-latest
     needs: [get_version_meta]
     steps:
@@ -65,54 +51,28 @@ jobs:
   build_and_push:
     name: Build images and push to GHCR
     runs-on: ubuntu-latest
-    needs: [setup_image_builder, get_version_meta]
+    needs: [setup_image_builder, version_metadata]
     steps:
       - name: Get docker build arg
         id: build_arg
         run: |
-          BUILD_ARG_NAME=$(echo ${{ github.event.inputs.package }} | sed 's/\-/_/g')
-          BUILD_ARG_VALUE=$(echo ${{ github.event.inputs.package }} | sed 's/postgres/core/g')
-          echo "build_arg_name=$BUILD_ARG_NAME" >> $GITHUB_OUTPUT
-          echo "build_arg_value=$BUILD_ARG_VALUE" >> $GITHUB_OUTPUT
+          BUILD_ARG_NAME=$(echo ${{ inputs.package }} | sed 's/\-/_/g')
+          BUILD_ARG_VALUE=$(echo ${{ inputs.package }} | sed 's/postgres/core/g')
+          echo "name=$BUILD_ARG_NAME" >> $GITHUB_OUTPUT
+          echo "value=$BUILD_ARG_VALUE" >> $GITHUB_OUTPUT
 
-      - name: Log in to the GHCR
+      - name: Log in to GHCR
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push MAJOR.MINOR.PATCH tag
+      - name: Build and push `${{ inputs.package }}:${{ tag }}`
         uses: docker/build-push-action@v5
         with:
           file: docker/Dockerfile
           push: True
-          target: ${{ github.event.inputs.package }}
-          build-args: |
-            ${{ steps.build_arg.outputs.build_arg_name }}_ref=${{ steps.build_arg.outputs.build_arg_value }}@v${{ github.event.inputs.version_number }}
-          tags: |
-            ghcr.io/dbt-labs/${{ github.event.inputs.package }}:${{ github.event.inputs.version_number }}
-
-      - name: Build and push MINOR.latest tag
-        uses: docker/build-push-action@v5
-        if: ${{ needs.get_version_meta.outputs.minor_latest == 'True' }}
-        with:
-          file: docker/Dockerfile
-          push: True
-          target: ${{ github.event.inputs.package }}
-          build-args: |
-            ${{ steps.build_arg.outputs.build_arg_name }}_ref=${{ steps.build_arg.outputs.build_arg_value }}@v${{ github.event.inputs.version_number }}
-          tags: |
-            ghcr.io/dbt-labs/${{ github.event.inputs.package }}:${{ needs.get_version_meta.outputs.major }}.${{ needs.get_version_meta.outputs.minor }}.latest
-
-      - name: Build and push latest tag
-        uses: docker/build-push-action@v5
-        if: ${{ needs.get_version_meta.outputs.latest == 'True' }}
-        with:
-          file: docker/Dockerfile
-          push: True
-          target: ${{ github.event.inputs.package }}
-          build-args: |
-            ${{ steps.build_arg.outputs.build_arg_name }}_ref=${{ steps.build_arg.outputs.build_arg_value }}@v${{ github.event.inputs.version_number }}
-          tags: |
-            ghcr.io/dbt-labs/${{ github.event.inputs.package }}:latest
+          target: ${{ inputs.package }}
+          build-args: ${{ steps.build_arg.outputs.name }}_ref=${{ steps.build_arg.outputs.value }}@v${{ inputs.version_number }}
+          tags: ${{ needs.version_metadata.outputs.fully_qualified_tags }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -29,6 +29,10 @@ on:
       version_number:
         description: The version number to release as a SemVer (e.g. 1.0.0b1, without `latest` or `v`)
         required: true
+      dry_run:
+        description: Dry Run (don't publish)
+        type: boolean
+        default: false
 
 jobs:
   version_metadata:
@@ -86,7 +90,7 @@ jobs:
           echo Build Arg Value:  ${{ steps.build_arg.outputs.value }}
 
       - name: Build and push `${{ inputs.package }}`
-        if: success() && failure()
+        if: ${{ !inputs.dry_run }}
         uses: docker/build-push-action@v5
         with:
           file: docker/Dockerfile

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -51,7 +51,7 @@ jobs:
   setup_image_builder:
     name: Set up Docker image builder
     runs-on: ubuntu-latest
-    needs: [get_version_meta]
+    needs: [version_metadata]
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -58,7 +58,7 @@ jobs:
     needs: [version_metadata]
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
   build_and_push:
     name: Build images and push to GHCR
@@ -74,7 +74,7 @@ jobs:
           echo "value=$BUILD_ARG_VALUE" >> $GITHUB_OUTPUT
 
       - name: Log in to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -16,10 +16,18 @@ on:
   workflow_dispatch:
     inputs:
       package:
-        description: The package to release. _One_ of [dbt-core, dbt-redshift, dbt-bigquery, dbt-snowflake, dbt-spark, dbt-postgres]
+        description: The package to release
+        type: choice
+        options:
+          - dbt-core
+          - dbt-bigquery
+          - dbt-postgres
+          - dbt-redshift
+          - dbt-snowflake
+          - dbt-spark
         required: true
       version_number:
-        description: The release version number (i.e. 1.0.0b1). Do not include `latest` tags or a leading `v`!
+        description: The version number to release as a SemVer (e.g. 1.0.0b1, without `latest` or `v`)
         required: true
 
 jobs:
@@ -68,7 +76,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push `${{ inputs.package }}:${{ tag }}`
+      - name: Log publishing configuration
+        shell: bash
+        run: |
+          echo Package:          ${{ inputs.package }}
+          echo Version:          ${{ inputs.version_number }}
+          echo Tags:             ${{ needs.version_metadata.outputs.fully_qualified_tags }}
+          echo Build Arg Name:   ${{ steps.build_arg.outputs.name }}
+          echo Build Arg Value:  ${{ steps.build_arg.outputs.value }}
+
+      - name: Build and push `${{ inputs.package }}`
+        if: success() && failure()
         uses: docker/build-push-action@v5
         with:
           file: docker/Dockerfile


### PR DESCRIPTION
resolves #7571

### Problem

We're not publishing `latest` and `1.x.latest` tags. It appears the current logic looks to see if the last published version has a `latest` tag to determine if the current one should. Once this chain is broken by an unexpected publishing order, this leaves the `latest` tags locked where they are. This is confusing users and could result in users installing an unexpected version of `dbt-core` or `dbt-<adapter>`.

Further exacerbating this issue, GitHub does not allow the removal or deletion of a tag. The only way to do so is to publish another package with the tag to delete and then pull down said package.

### Solution

- Rework the code to be more readable and more modular
- Use `packaging.Version` to manage versions instead of string parsing
- Compare the current version to all published version, making this more resilient to unexpected publishing order

I don't have a great way to test this without trying to publish. I'm open to suggestions.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions