### PR TITLE
Fix `compiled_code`, reimplement `sql` as wrapper

### DIFF
--- a/.changes/unreleased/Fixes-20240201-124701.yaml
+++ b/.changes/unreleased/Fixes-20240201-124701.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Update 'compiled_code' context member logic to route based on command ('clone'
+  or not). Reimplement 'sql' context member as wrapper of 'compiled_code'.
+time: 2024-02-01T12:47:01.488085+01:00
+custom:
+  Author: jtcohen6
+  Issue: "9502"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1458,31 +1458,22 @@ class ModelContext(ProviderContext):
         ]
 
     @contextproperty()
-    def sql(self) -> Optional[str]:
-        # only doing this in sql model for backward compatible
-        if self.model.language == ModelLanguage.sql:  # type: ignore[union-attr]
-            # If the model is deferred and the adapter doesn't support zero-copy cloning, then select * from the prod
-            # relation
-            # TODO: avoid routing on args.which if possible
-            if getattr(self.model, "defer_relation", None) and self.config.args.which == "clone":
-                # TODO https://github.com/dbt-labs/dbt-core/issues/7976
-                return f"select * from {self.model.defer_relation.relation_name or str(self.defer_relation)}"  # type: ignore[union-attr]
-            elif getattr(self.model, "extra_ctes_injected", None):
-                # TODO CT-211
-                return self.model.compiled_code  # type: ignore[union-attr]
-            else:
-                return None
-        else:
-            return None
-
-    @contextproperty()
     def compiled_code(self) -> Optional[str]:
-        if getattr(self.model, "defer_relation", None):
+        # TODO: avoid routing on args.which if possible
+        if getattr(self.model, "defer_relation", None) and self.config.args.which == "clone":
             # TODO https://github.com/dbt-labs/dbt-core/issues/7976
             return f"select * from {self.model.defer_relation.relation_name or str(self.defer_relation)}"  # type: ignore[union-attr]
         elif getattr(self.model, "extra_ctes_injected", None):
             # TODO CT-211
             return self.model.compiled_code  # type: ignore[union-attr]
+        else:
+            return None
+
+    @contextproperty()
+    def sql(self) -> Optional[str]:
+        # only set this for sql models, for backward compatibility
+        if self.model.language == ModelLanguage.sql:  # type: ignore[union-attr]
+            return self.compiled_code
         else:
             return None
 


### PR DESCRIPTION
resolves #9502

### Problem

- #9040 added `defer_relation` to all nodes any time `--defer` was provided
- We had routing logic for the `clone` command that depended on the presence of `defer_relation`
- #9040 updated this logic for `sql` context member, but not for `compiled_code`

### Solution

- Update the logic for `compiled_code` context member
- Reimplement `sql` context member as a wrapper around `compiled_code`, to prevent future divergence

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
