### PR TITLE
Begin using `Mergeable` supplied by `dbt-common`

### DIFF
--- a/.changes/unreleased/Under the Hood-20240201-125416.yaml
+++ b/.changes/unreleased/Under the Hood-20240201-125416.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Start using `Mergeable` from dbt-common
+time: 2024-02-01T12:54:16.462414-08:00
+custom:
+  Author: QMalcolm
+  Issue: "9505"

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -7,6 +7,7 @@ from dbt_common.contracts.config.properties import (
     AdditionalPropertiesAllowed,
     AdditionalPropertiesMixin,
 )
+from dbt_common.contracts.util import Mergeable
 from dbt_common.exceptions import DbtInternalError, CompilationError
 from dbt_common.dataclass_schema import (
     dbtClassMixin,
@@ -22,10 +23,7 @@ from dbt.artifacts.resources import (
     MaturityType,
     MeasureAggregationParameters,
 )
-from dbt.contracts.util import (
-    Mergeable,
-    Replaceable,
-)
+from dbt.contracts.util import Replaceable
 
 # trigger the PathEncoder
 import dbt_common.helper_types  # noqa:F401

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -1,7 +1,8 @@
 from dbt import deprecations
-from dbt.contracts.util import Replaceable, Mergeable, list_str, Identifier
+from dbt.contracts.util import Replaceable, list_str, Identifier
 from dbt.adapters.contracts.connection import QueryComment
 from dbt_common.helper_types import NoValue
+from dbt_common.contracts.util import Mergeable
 from dbt_common.dataclass_schema import (
     dbtClassMixin,
     ValidationError,

--- a/core/dbt/contracts/util.py
+++ b/core/dbt/contracts/util.py
@@ -1,8 +1,9 @@
-import dataclasses
 from typing import List, Any, Tuple
 
 from dbt_common.dataclass_schema import ValidatedStringMixin, ValidationError
-from dbt_common.contracts.util import Replaceable
+
+# Leave imports of `Mergeable` and `Replaceable` to preserve import paths
+from dbt_common.contracts.util import Mergeable, Replaceable  # noqa:F401
 
 
 SourceKey = Tuple[str, str]
@@ -22,22 +23,6 @@ def list_str() -> List[str]:
     Because `list` could be any kind of list, I guess
     """
     return []
-
-
-class Mergeable(Replaceable):
-    def merged(self, *args):
-        """Perform a shallow merge, where the last non-None write wins. This is
-        intended to merge dataclasses that are a collection of optional values.
-        """
-        replacements = {}
-        cls = type(self)
-        for arg in args:
-            for field in dataclasses.fields(cls):
-                value = getattr(arg, field.name)
-                if value is not None:
-                    replacements[field.name] = value
-
-        return self.replace(**replacements)
 
 
 class Identifier(ValidatedStringMixin):


### PR DESCRIPTION
resolves #9505

### Problem

We need to begin using `Mergeable` from `dbt-common` so that we move some objects which depend on it to dbt/artifacts

### Solution

Replace `Mergeable` uses with `Mergeable` from dbt-common

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
