### PR TITLE
Initialize invocation context before test fixture creation.

### DIFF
--- a/.changes/unreleased/Fixes-20240206-161331.yaml
+++ b/.changes/unreleased/Fixes-20240206-161331.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Initialize invocation context before test fixtures are built.
+time: 2024-02-06T16:13:31.04575-05:00
+custom:
+  Author: peterallenwebb
+  Issue: '#9489'


### PR DESCRIPTION
### Problem

The code used to set up test fixtures sometimes uses environment variables via the new InvocationContext mechanism, but it was not always initialized in time.

### Solution

Add an initialization function to the test fixtures, and set an invocation context in that function.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
