### PR TITLE
Preserve model constraints when versioning models

### DIFF
--- a/.changes/unreleased/Fixes-20240207-150223.yaml
+++ b/.changes/unreleased/Fixes-20240207-150223.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: When patching versioned models, set constraints after config
+time: 2024-02-07T15:02:23.697345-05:00
+custom:
+  Author: gshank
+  Issue: "9364"

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -845,7 +845,9 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
                 # Includes alias recomputation
                 self.patch_node_config(versioned_model_node, versioned_model_patch)
 
-                # Need to reapply this here, in the case that 'contract: {enforced: true}' was during config-setting
+                # Need to reapply setting constraints and contract checksum here,
+                # in the case that 'contract: {enforced: true}' was changed during config-setting
+                self.patch_constraints(versioned_model_node, versioned_model_patch.constraints)
                 versioned_model_node.build_contract_checksum()
                 source_file.append_patch(
                     versioned_model_patch.yaml_key, versioned_model_node.unique_id
@@ -869,6 +871,7 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
                     unique_id=node.unique_id,
                     field_value=patch.access,
                 )
+        # These two will have to be reapplied after config is built for versioned models
         self.patch_constraints(node, patch.constraints)
         node.build_contract_checksum()
 

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -845,8 +845,9 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
                 # Includes alias recomputation
                 self.patch_node_config(versioned_model_node, versioned_model_patch)
 
-                # Need to reapply setting constraints and contract checksum here,
-                # in the case that 'contract: {enforced: true}' was changed during config-setting
+                # Need to reapply setting constraints and contract checksum here, because
+                # they depend on node.contract.enabled, which wouldn't be set when
+                # patch_node_properties was called if it wasn't set in the model file.
                 self.patch_constraints(versioned_model_node, versioned_model_patch.constraints)
                 versioned_model_node.build_contract_checksum()
                 source_file.append_patch(

--- a/tests/functional/configs/test_contract_configs.py
+++ b/tests/functional/configs/test_contract_configs.py
@@ -85,7 +85,6 @@ def model(dbt, _):
 """
 
 model_schema_yml = """
-version: 2
 models:
   - name: my_model
     config:
@@ -110,7 +109,6 @@ models:
 """
 
 model_schema_alias_types_false_yml = """
-version: 2
 models:
   - name: my_model
     config:
@@ -136,7 +134,6 @@ models:
 """
 
 model_schema_ignore_unsupported_yml = """
-version: 2
 models:
   - name: my_model
     config:
@@ -164,7 +161,6 @@ models:
 """
 
 model_schema_errors_yml = """
-version: 2
 models:
   - name: my_model
     config:
@@ -206,7 +202,6 @@ models:
 """
 
 model_schema_blank_yml = """
-version: 2
 models:
   - name: my_model
     config:
@@ -215,7 +210,6 @@ models:
 """
 
 model_schema_complete_datatypes_yml = """
-version: 2
 models:
   - name: my_model
     columns:
@@ -237,7 +231,6 @@ models:
 """
 
 model_schema_incomplete_datatypes_yml = """
-version: 2
 models:
   - name: my_model
     columns:

--- a/tests/functional/configs/test_versioned_model_constraint.py
+++ b/tests/functional/configs/test_versioned_model_constraint.py
@@ -1,0 +1,75 @@
+import pytest
+from dbt.tests.util import run_dbt, rm_file, write_file, get_manifest
+
+
+schema_yml = """
+models:
+  - name: foo
+    config:
+      materialized: table
+      contract:
+        enforced: true
+    constraints:
+      - type: primary_key
+        columns: [id, user_name]
+    columns:
+      - name: id
+        data_type: int
+        constraints:
+          - type: not_null
+      - name: user_name
+        data_type: text
+"""
+
+foo_sql = """
+select 1 as id, 'alice' as user_name
+"""
+
+versioned_schema_yml = """
+models:
+  - name: foo
+    latest_version: 1
+    config:
+      materialized: table
+      contract:
+        enforced: true
+    constraints:
+      - type: primary_key
+        columns: [id, user_name]
+    columns:
+      - name: id
+        data_type: int
+        constraints:
+          - type: not_null
+      - name: user_name
+        data_type: text
+    versions:
+      - v: 1
+"""
+
+
+class TestVersionedModelConstraints:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "foo.sql": foo_sql,
+            "schema.yml": schema_yml,
+        }
+
+    def test_versioned_model_constraints(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        manifest = get_manifest(project.project_root)
+        model_node = manifest.nodes["model.test.foo"]
+        assert len(model_node.constraints) == 1
+
+        # remove foo.sql and create foo_v1.sql
+        rm_file(project.project_root, "models", "foo.sql")
+        write_file(foo_sql, project.project_root, "models", "foo_v1.sql")
+        write_file(versioned_schema_yml, project.project_root, "models", "schema.yml")
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        manifest = get_manifest(project.project_root)
+        model_node = manifest.nodes["model.test.foo.v1"]
+        assert len(model_node.constraints) == 1

--- a/tests/functional/configs/test_versioned_model_constraint.py
+++ b/tests/functional/configs/test_versioned_model_constraint.py
@@ -72,4 +72,5 @@ class TestVersionedModelConstraints:
 
         manifest = get_manifest(project.project_root)
         model_node = manifest.nodes["model.test.foo.v1"]
+        assert model_node.contract.enforced is True
         assert len(model_node.constraints) == 1


### PR DESCRIPTION
resolves #9364

### Problem

When changing a model from non-versioned to versioned, the model constraints were being lost.

### Solution

Constraints were only being copied when the model contract.enabled was True, but when parsing versioned models the config hadn't been processed before handling constraints.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
