### PR TITLE
Fix: SemanticModel.same_model compares model attribute

### DIFF
--- a/.changes/unreleased/Fixes-20240209-170146.yaml
+++ b/.changes/unreleased/Fixes-20240209-170146.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: only include unmodified semantic mdodels in state:modified selection
+time: 2024-02-09T17:01:46.676097-05:00
+custom:
+  Author: michelleark
+  Issue: "9548"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1525,7 +1525,7 @@ class SemanticModel(GraphNode[SemanticModelResource], SemanticModelResource):
         return self.depends_on.macros
 
     def same_model(self, old: "SemanticModel") -> bool:
-        return self.model == old.same_model
+        return self.model == old.model
 
     def same_node_relation(self, old: "SemanticModel") -> bool:
         return self.node_relation == old.node_relation

--- a/tests/functional/defer_state/fixtures.py
+++ b/tests/functional/defer_state/fixtures.py
@@ -360,6 +360,40 @@ snapshot_sql = """
 {% endsnapshot %}
 """
 
+
+semantic_model_schema_yml = """
+models:
+  - name: view_model
+    columns:
+      - name: id
+        data_tests:
+          - unique:
+              severity: error
+          - not_null
+      - name: name
+
+semantic_models:
+  - name: my_sm
+    model: ref('view_model')
+"""
+
+modified_semantic_model_schema_yml = """
+models:
+  - name: view_model
+    columns:
+      - name: id
+        data_tests:
+          - unique:
+              severity: error
+          - not_null
+      - name: name
+
+semantic_models:
+  - name: my_sm
+    model: ref('view_model')
+    description: modified description
+"""
+
 model_1_sql = """
 select * from {{ ref('seed') }}
 """
@@ -421,4 +455,8 @@ models:
   - name: model_2
     config:
       group: finance
+"""
+
+metricflow_time_spine_sql = """
+SELECT to_date('02/20/2023', 'mm/dd/yyyy') as date_day
 """

--- a/tests/functional/defer_state/test_modified_state.py
+++ b/tests/functional/defer_state/test_modified_state.py
@@ -38,6 +38,9 @@ from tests.functional.defer_state.fixtures import (
     table_model_now_view_sql,
     table_model_now_incremental_sql,
     view_model_now_table_sql,
+    metricflow_time_spine_sql,
+    semantic_model_schema_yml,
+    modified_semantic_model_schema_yml,
 )
 
 
@@ -993,3 +996,22 @@ class TestModifiedLatestVersion(BaseModifiedState):
 
         results = run_dbt(["list", "-s", "state:modified", "--state", "./state"])
         assert results == ["test.table_model.v1", "test.table_model.v2"]
+
+
+class TestChangedSemanticModelContents(BaseModifiedState):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "view_model.sql": view_model_sql,
+            "schema.yml": semantic_model_schema_yml,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
+
+    def test_changed_semantic_model_contents(self, project):
+        self.run_and_save_state()
+        results = run_dbt(["list", "-s", "state:modified", "--state", "./state"])
+        assert len(results) == 0
+
+        write_file(modified_semantic_model_schema_yml, "models", "schema.yml")
+        results = run_dbt(["list", "-s", "state:modified", "--state", "./state"])
+        assert len(results) == 1

--- a/tests/unit/test_semantic_models.py
+++ b/tests/unit/test_semantic_models.py
@@ -1,5 +1,5 @@
+from copy import deepcopy
 import pytest
-
 from typing import List
 
 from dbt.artifacts.resources import Dimension, Entity, Measure, Defaults
@@ -79,3 +79,16 @@ def test_checked_agg_time_dimension_for_measure_exception(default_semantic_model
         f"Aggregation time dimension for measure {measure.name} on semantic model {default_semantic_model.name}"
         in str(execinfo.value)
     )
+
+
+def test_semantic_model_same_contents(default_semantic_model: SemanticModel):
+    default_semantic_model_copy = deepcopy(default_semantic_model)
+
+    assert default_semantic_model.same_contents(default_semantic_model_copy)
+
+
+def test_semantic_model_same_contents_update_model(default_semantic_model: SemanticModel):
+    default_semantic_model_copy = deepcopy(default_semantic_model)
+    default_semantic_model_copy.model = "ref('test_another_model')"
+
+    assert not default_semantic_model.same_contents(default_semantic_model_copy)


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/9548

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem
* semantic models were always getting picked up as part of state:modifed because the SemanticModel.same_model was comparing the wrong things to each other (self.model == self.same_model (method)), which always returned false

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
* Fix SemanticModel.same_model to actually compare the right attributes!

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
