### PR TITLE
Fix #9385: Add a workflow to check if artifacts have changed

### DIFF
--- a/.github/workflows/check-artifact-changes.yml
+++ b/.github/workflows/check-artifact-changes.yml
@@ -2,10 +2,8 @@ name: Check Artifact Changes
 
 on:
   pull_request:
-    types:
-      - labeled
-    paths:
-      - 'core/dbt/artifacts/**'
+    types: [ opened, reopened, labeled, unlabeled, synchronize ]
+    paths-ignore: [ '.changes/**', '.github/**', 'tests/**', '**.md', '**.yml' ]
 
 jobs:
   check-artifact-changes:

--- a/.github/workflows/check-artifact-changes.yml
+++ b/.github/workflows/check-artifact-changes.yml
@@ -1,0 +1,40 @@
+name: Check Artifact Changes
+
+on:
+  pull_request:
+    paths:
+      - 'core/dbt/artifacts/**'
+
+jobs:
+  check-artifact-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes in dbt/artifacts
+        id: check_changes
+        run: |
+          # Check for changes in dbt/artifacts
+          CHANGED_FILES=$(git diff --name-only origin/${GITHUB_BASE_REF} origin/${GITHUB_HEAD_REF} | grep 'core/dbt/artifacts/')
+          if [ ! -z "$CHANGED_FILES" ]; then
+            echo "CHANGED=true" >> $GITHUB_ENV
+            echo "Changed files in dbt/artifacts:"
+            echo "$CHANGED_FILES"
+          else
+            echo "CHANGED=false" >> $GITHUB_ENV
+          fi
+
+      - name: Fail CI if artifacts have changed
+        if: env.CHANGED == 'true' && !contains(github.event.pull_request.labels.*.name, 'artifact_minor_upgrade')
+        run: |
+          echo "CI failure: Artifact changes checked in dbt/artifacts directory."
+          echo "To bypass this check, add the 'artifact_minor_upgrade' label to the PR."
+          exit 1
+
+      - name: CI check passed
+        if: env.CHANGED == 'false' || contains(github.event.pull_request.labels.*.name, 'artifact_minor_upgrade')
+        run: |
+          echo "No prohibited artifact changes checked in dbt/artifacts, or 'artifact_minor_upgrade' label found. CI check passed."

--- a/.github/workflows/check-artifact-changes.yml
+++ b/.github/workflows/check-artifact-changes.yml
@@ -2,6 +2,8 @@ name: Check Artifact Changes
 
 on:
   pull_request:
+    types:
+      - labeled
     paths:
       - 'core/dbt/artifacts/**'
 

--- a/.github/workflows/check-artifact-changes.yml
+++ b/.github/workflows/check-artifact-changes.yml
@@ -5,6 +5,8 @@ on:
     types: [ opened, reopened, labeled, unlabeled, synchronize ]
     paths-ignore: [ '.changes/**', '.github/**', 'tests/**', '**.md', '**.yml' ]
 
+  workflow_dispatch:
+
 jobs:
   check-artifact-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-artifact-changes.yml
+++ b/.github/workflows/check-artifact-changes.yml
@@ -14,14 +14,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check for changes in dbt/artifacts
+      - name: Check for changes in core/dbt/artifacts
         id: check_changes
         run: |
           # Check for changes in dbt/artifacts
           CHANGED_FILES=$(git diff --name-only origin/${GITHUB_BASE_REF} origin/${GITHUB_HEAD_REF} | grep 'core/dbt/artifacts/')
           if [ ! -z "$CHANGED_FILES" ]; then
             echo "CHANGED=true" >> $GITHUB_ENV
-            echo "Changed files in dbt/artifacts:"
+            echo "Changed files in core/dbt/artifacts:"
             echo "$CHANGED_FILES"
           else
             echo "CHANGED=false" >> $GITHUB_ENV
@@ -30,11 +30,11 @@ jobs:
       - name: Fail CI if artifacts have changed
         if: env.CHANGED == 'true' && !contains(github.event.pull_request.labels.*.name, 'artifact_minor_upgrade')
         run: |
-          echo "CI failure: Artifact changes checked in dbt/artifacts directory."
+          echo "CI failure: Artifact changes checked in core/dbt/artifacts directory."
           echo "To bypass this check, add the 'artifact_minor_upgrade' label to the PR."
           exit 1
 
       - name: CI check passed
         if: env.CHANGED == 'false' || contains(github.event.pull_request.labels.*.name, 'artifact_minor_upgrade')
         run: |
-          echo "No prohibited artifact changes checked in dbt/artifacts, or 'artifact_minor_upgrade' label found. CI check passed."
+          echo "No prohibited artifact changes checked in core/dbt/artifacts, or 'artifact_minor_upgrade' label found. CI check passed."

--- a/.github/workflows/check-artifact-changes.yml
+++ b/.github/workflows/check-artifact-changes.yml
@@ -33,7 +33,7 @@ jobs:
         if: env.CHANGED == 'true' && !contains(github.event.pull_request.labels.*.name, 'artifact_minor_upgrade')
         run: |
           echo "CI failure: Artifact changes checked in core/dbt/artifacts directory."
-          echo "To bypass this check, add the 'artifact_minor_upgrade' label to the PR."
+          echo "To bypass this check, confirm that the change is not breaking (https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/artifacts/README.md#breaking-changes) and add the 'artifact_minor_upgrade' label to the PR."
           exit 1
 
       - name: CI check passed


### PR DESCRIPTION
resolves #9385 

### Problem

It isn't always clear when a file in the `core/dbt/artifacts` directory has been changed.

### Solution

This PR adds a CI check that:
1. Fails if any file in `core/dbt/artifacts` has been changed
2. Can be overridden by adding the `artifact_minor_upgrade` tag to the PR.

This solution currently uses `git diff` and doesn't rely on any external actions.

Run history: 
1. Example failure: https://github.com/dbt-labs/dbt-core/actions/runs/7866653246/job/21461212098?pr=9553
2. Example success (with label): https://github.com/dbt-labs/dbt-core/actions/runs/7866663319/job/21461233620?pr=9553
3. All runs: https://github.com/dbt-labs/dbt-core/actions/workflows/check-artifact-changes.yml

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
