### PR TITLE
Set query headers when manifest is passed in to dbtRunner

### DIFF
--- a/.changes/unreleased/Fixes-20240212-144733.yaml
+++ b/.changes/unreleased/Fixes-20240212-144733.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Set query headers when manifest is passed in to dbtRunner
+time: 2024-02-12T14:47:33.092877-05:00
+custom:
+  Author: gshank
+  Issue: "9546"

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -290,6 +290,7 @@ def manifest(*args0, write=True, write_perf_info=False):
                 adapter = get_adapter(runtime_config)
                 adapter.set_macro_context_generator(generate_runtime_macro_context)
                 adapter.set_macro_resolver(ctx.obj["manifest"])
+                adapter.connections.set_query_header(ctx.obj["manifest"])
             return func(*args, **kwargs)
 
         return update_wrapper(wrapper, func)

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -15,6 +15,7 @@ from dbt.cli.exceptions import (
 from dbt.cli.flags import Flags
 from dbt.config import RuntimeConfig
 from dbt.config.runtime import load_project, load_profile, UnsetProfile
+from dbt.context.manifest import generate_query_header_context
 
 from dbt_common.events.base_types import EventLevel
 from dbt_common.events.functions import (
@@ -290,7 +291,10 @@ def manifest(*args0, write=True, write_perf_info=False):
                 adapter = get_adapter(runtime_config)
                 adapter.set_macro_context_generator(generate_runtime_macro_context)
                 adapter.set_macro_resolver(ctx.obj["manifest"])
-                adapter.connections.set_query_header(ctx.obj["manifest"])
+                query_header_context = generate_query_header_context(
+                    adapter.config, ctx.obj["manifest"]
+                )
+                adapter.connections.set_query_header(query_header_context)
             return func(*args, **kwargs)
 
         return update_wrapper(wrapper, func)

--- a/tests/functional/dbt_runner/test_dbt_runner.py
+++ b/tests/functional/dbt_runner/test_dbt_runner.py
@@ -6,7 +6,7 @@ from dbt.cli.exceptions import DbtUsageException
 from dbt.cli.main import dbtRunner
 from dbt.exceptions import DbtProjectError
 from dbt.adapters.factory import reset_adapters, FACTORY
-from dbt.tests.util import read_file, rm_file
+from dbt.tests.util import read_file, write_file
 from dbt.version import __version__ as dbt_version
 
 
@@ -114,7 +114,7 @@ class TestDbtRunnerQueryComments:
         dbt = dbtRunner()
         dbt.invoke(["build", "--select", "models"])
         result = dbt.invoke(["parse"])
-        rm_file(logs_dir, "dbt.log")
+        write_file("", logs_dir, "dbt.log")
         # pass in manifest from parse command
         dbt = dbtRunner(result.result)
         dbt.invoke(["build", "--select", "models"])

--- a/tests/functional/dbt_runner/test_dbt_runner.py
+++ b/tests/functional/dbt_runner/test_dbt_runner.py
@@ -6,6 +6,8 @@ from dbt.cli.exceptions import DbtUsageException
 from dbt.cli.main import dbtRunner
 from dbt.exceptions import DbtProjectError
 from dbt.adapters.factory import reset_adapters, FACTORY
+from dbt.tests.util import read_file, rm_file
+from dbt.version import __version__ as dbt_version
 
 
 class TestDbtRunner:
@@ -90,3 +92,31 @@ class TestDbtRunner:
         # Check that the adapters are registered again.
         assert result.success
         assert len(FACTORY.adapters) == 1
+
+
+class TestDbtRunnerQueryComments:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "models.sql": "select 1 as id",
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "query-comment": {
+                "comment": f"comment: {dbt_version}",
+                "append": True,
+            }
+        }
+
+    def test_query_comment_saved_manifest(self, project, logs_dir):
+        dbt = dbtRunner()
+        dbt.invoke(["build", "--select", "models"])
+        result = dbt.invoke(["parse"])
+        rm_file(logs_dir, "dbt.log")
+        # pass in manifest from parse command
+        dbt = dbtRunner(result.result)
+        dbt.invoke(["build", "--select", "models"])
+        log_file = read_file(logs_dir, "dbt.log")
+        assert f"comment: {dbt_version}" in log_file


### PR DESCRIPTION
resolves #9546

### Problem

The query headers were set in the "get_full_manifest" function, but this function isn't called when a manifest is passed in to dbtRunner, so query comments were missing in the logs.

### Solution

Call "adapter.connections.set_query_header" in core/dbt/cli/requires.py when a manifest is passed in.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
