### PR TITLE
[Backport 1.7.latest] Set query headers when manifest is passed in to dbtRunner

### DIFF
--- a/.changes/unreleased/Fixes-20240212-165619.yaml
+++ b/.changes/unreleased/Fixes-20240212-165619.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Store node_info in node associated logging events
+time: 2024-02-12T16:56:19.954358-05:00
+custom:
+  Author: gshank
+  Issue: "9557"

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -1,6 +1,6 @@
 import dbt.tracking
 from dbt.version import installed as installed_version
-from dbt.adapters.factory import adapter_management, register_adapter
+from dbt.adapters.factory import adapter_management, register_adapter, get_adapter
 from dbt.flags import set_flags, get_flag_dict
 from dbt.cli.exceptions import (
     ExceptionExit,
@@ -273,6 +273,8 @@ def manifest(*args0, write=True, write_perf_info=False):
                 )
             else:
                 register_adapter(runtime_config)
+                adapter = get_adapter(runtime_config)
+                adapter.connections.set_query_header(ctx.obj["manifest"])
             return func(*args, **kwargs)
 
         return update_wrapper(wrapper, func)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 black==23.3.0
 bumpversion
-ddtrace==2.1.7
+ddtrace==2.3.0
 docutils
 flake8
 flaky


### PR DESCRIPTION
Backport 5841d52792c2acfa27b299c330dd4e5c573d2a3c from #9556