### PR TITLE
Fix unexpected error message when git is not installed

### DIFF
--- a/.changes/unreleased/Fixes-20240215-103838.yaml
+++ b/.changes/unreleased/Fixes-20240215-103838.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix unexpected error message when git is not installed
+time: 2024-02-15T10:38:38.01821-07:00
+custom:
+  Author: jon-fearer
+  Issue: "9537"

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -406,6 +406,17 @@ class DebugTask(BaseTask):
                 details="git error",
                 summary_message="Error from git --help: {!s}".format(exc),
             )
+        except dbt_common.exceptions.CommandResultError as exc:
+            return SubtaskStatus(
+                log_msg=red("ERROR"),
+                run_status=RunStatus.Error,
+                details="git error",
+                summary_message=(
+                    "Error from git --help: {!s}\n"
+                    "Make sure that `git` is installed in your shell "
+                    "and that `git --help` can execute successfully."
+                ).format(exc),
+            )
         else:
             return SubtaskStatus(
                 log_msg=green("OK found"),


### PR DESCRIPTION
resolves #9537 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

The `dbt debug` command returns an unexpected error message when git is not installed 

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Update the `test_git` method to handle the `CommandResultError` exception that is thrown when git is not installed.

Output when git is installed:

<img width="701" alt="image" src="https://github.com/dbt-labs/dbt-core/assets/27651344/171aff77-5eb5-4f92-b064-c4cc27161af3">

Output when git is **not** installed (updated behavior):

<img width="1083" alt="image" src="https://github.com/dbt-labs/dbt-core/assets/27651344/3ea0ff89-dab9-4b0a-aea3-73de976dc961">

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
