### PR TITLE
add cache to SavedQueryConfig

### DIFF
--- a/.changes/unreleased/Features-20240215-145814.yaml
+++ b/.changes/unreleased/Features-20240215-145814.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add cache to SavedQuery config
+time: 2024-02-15T14:58:14.834651-06:00
+custom:
+  Author: emmyoop
+  Issue: "9540"

--- a/core/dbt/artifacts/resources/v1/saved_query.py
+++ b/core/dbt/artifacts/resources/v1/saved_query.py
@@ -41,6 +41,11 @@ class QueryParams(dbtClassMixin):
 
 
 @dataclass
+class SavedQueryCache(dbtClassMixin):
+    enabled: bool = False
+
+
+@dataclass
 class SavedQueryConfig(BaseConfig):
     """Where config options for SavedQueries are stored.
 
@@ -61,6 +66,7 @@ class SavedQueryConfig(BaseConfig):
     )
     export_as: Optional[ExportDestinationType] = None
     schema: Optional[str] = None
+    cache: SavedQueryCache = field(default_factory=SavedQueryCache)
 
 
 @dataclass

--- a/tests/functional/saved_queries/fixtures.py
+++ b/tests/functional/saved_queries/fixtures.py
@@ -91,3 +91,27 @@ saved_queries:
     exports:
         - name: my_export
 """
+
+saved_query_with_cache_configs_defined_yml = """
+saved_queries:
+  - name: test_saved_query
+    description: "{{ doc('saved_query_description') }}"
+    label: Test Saved Query
+    config:
+      cache:
+        enabled: True
+    query_params:
+        metrics:
+            - simple_metric
+        group_by:
+            - "Dimension('user__ds')"
+        where:
+            - "{{ Dimension('user__ds', 'DAY') }} <= now()"
+            - "{{ Dimension('user__ds', 'DAY') }} >= '2023-01-01'"
+    exports:
+        - name: my_export
+          config:
+            alias: my_export_alias
+            export_as: table
+            schema: my_export_schema_name
+"""

--- a/tests/functional/saved_queries/test_configs.py
+++ b/tests/functional/saved_queries/test_configs.py
@@ -8,6 +8,7 @@ from tests.functional.configs.fixtures import BaseConfigProject
 from tests.functional.saved_queries.fixtures import (
     saved_queries_yml,
     saved_query_description,
+    saved_query_with_cache_configs_defined_yml,
     saved_query_with_extra_config_attributes_yml,
     saved_query_with_export_configs_defined_at_saved_query_level_yml,
     saved_query_without_export_configs_defined_yml,
@@ -29,6 +30,7 @@ class TestSavedQueryConfigs(BaseConfigProject):
                         "+enabled": True,
                         "+export_as": ExportDestinationType.VIEW.value,
                         "+schema": "my_default_export_schema",
+                        "+cache": {"enabled": True},
                     }
                 },
             },
@@ -58,6 +60,7 @@ class TestSavedQueryConfigs(BaseConfigProject):
         saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
         assert saved_query.config.export_as == ExportDestinationType.VIEW
         assert saved_query.config.schema == "my_default_export_schema"
+        assert saved_query.config.cache.enabled == True
 
         # disable the saved_query via project config and rerun
         config_patch = {"saved-queries": {"test": {"test_saved_query": {"+enabled": False}}}}
@@ -65,6 +68,33 @@ class TestSavedQueryConfigs(BaseConfigProject):
         result = runner.invoke(["parse"])
         assert result.success
         assert len(result.result.saved_queries) == 0
+
+
+# Test that the cache will default to enabled = false if not set in the saved_query config
+class TestSavedQueryDefaultCacheConfigs(BaseConfigProject):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "saved_queries.yml": saved_query_with_extra_config_attributes_yml,
+            "schema.yml": schema_yml,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "docs.md": saved_query_description,
+        }
+
+    def test_basic_saved_query_config(
+        self,
+        project,
+    ):
+        runner = dbtTestRunner()
+
+        # parse with default fixture project config
+        result = runner.invoke(["parse"])
+        assert result.success
+        assert isinstance(result.result, Manifest)
+        assert len(result.result.saved_queries) == 1
+        saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
+        assert saved_query.config.cache.enabled == False
 
 
 class TestExportConfigsWithAdditionalProperties(BaseConfigProject):
@@ -184,3 +214,78 @@ class TestInheritingExportConfigsFromProject(BaseConfigProject):
         assert len(result.result.saved_queries) == 1
         saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
         assert saved_query.config.export_as == ExportDestinationType.TABLE
+
+
+# cache can be specified in a SavedQuery config
+class TestSavedQueryLevelCacheConfigs(BaseConfigProject):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "saved_queries.yml": saved_query_with_cache_configs_defined_yml,
+            "schema.yml": schema_yml,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "docs.md": saved_query_description,
+        }
+
+    def test_basic_saved_query_config(
+        self,
+        project,
+    ):
+        runner = dbtTestRunner()
+
+        # parse with default fixture project config
+        result = runner.invoke(["parse"])
+        assert result.success
+        assert isinstance(result.result, Manifest)
+        assert len(result.result.saved_queries) == 1
+        saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
+        assert saved_query.config.cache.enabled == True
+
+
+# the cache defined in yaml for the SavedQuery overrides settings from the dbt_project.toml
+class TestSavedQueryCacheConfigsOverride(BaseConfigProject):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "saved-queries": {
+                "test": {
+                    "test_saved_query": {
+                        "+cache": {"enabled": True},
+                    }
+                },
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "saved_queries.yml": saved_query_with_cache_configs_defined_yml,
+            "schema.yml": schema_yml,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "docs.md": saved_query_description,
+        }
+
+    def test_override_saved_query_config(
+        self,
+        project,
+    ):
+        runner = dbtTestRunner()
+
+        # parse with default fixture project config
+        result = runner.invoke(["parse"])
+        assert result.success
+        assert isinstance(result.result, Manifest)
+        assert len(result.result.saved_queries) == 1
+        saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
+        assert saved_query.config.cache.enabled == True
+
+        # set cache to False via project config but since it's set to true at teh saved_query level, it should stay enabled
+        config_patch = {
+            "saved-queries": {"test": {"test_saved_query": {"+cache": {"enabled": False}}}}
+        }
+        update_config_file(config_patch, project.project_root, "dbt_project.yml")
+        result = runner.invoke(["parse"])
+        assert result.success
+        assert saved_query.config.cache.enabled == True

--- a/tests/functional/saved_queries/test_configs.py
+++ b/tests/functional/saved_queries/test_configs.py
@@ -60,7 +60,7 @@ class TestSavedQueryConfigs(BaseConfigProject):
         saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
         assert saved_query.config.export_as == ExportDestinationType.VIEW
         assert saved_query.config.schema == "my_default_export_schema"
-        assert saved_query.config.cache.enabled == True
+        assert saved_query.config.cache.enabled is True
 
         # disable the saved_query via project config and rerun
         config_patch = {"saved-queries": {"test": {"test_saved_query": {"+enabled": False}}}}
@@ -94,7 +94,7 @@ class TestSavedQueryDefaultCacheConfigs(BaseConfigProject):
         assert isinstance(result.result, Manifest)
         assert len(result.result.saved_queries) == 1
         saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
-        assert saved_query.config.cache.enabled == False
+        assert saved_query.config.cache.enabled is False
 
 
 class TestExportConfigsWithAdditionalProperties(BaseConfigProject):
@@ -240,7 +240,7 @@ class TestSavedQueryLevelCacheConfigs(BaseConfigProject):
         assert isinstance(result.result, Manifest)
         assert len(result.result.saved_queries) == 1
         saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
-        assert saved_query.config.cache.enabled == True
+        assert saved_query.config.cache.enabled is True
 
 
 # the cache defined in yaml for the SavedQuery overrides settings from the dbt_project.toml
@@ -279,7 +279,7 @@ class TestSavedQueryCacheConfigsOverride(BaseConfigProject):
         assert isinstance(result.result, Manifest)
         assert len(result.result.saved_queries) == 1
         saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
-        assert saved_query.config.cache.enabled == True
+        assert saved_query.config.cache.enabled is True
 
         # set cache to False via project config but since it's set to true at teh saved_query level, it should stay enabled
         config_patch = {
@@ -288,4 +288,4 @@ class TestSavedQueryCacheConfigsOverride(BaseConfigProject):
         update_config_file(config_patch, project.project_root, "dbt_project.yml")
         result = runner.invoke(["parse"])
         assert result.success
-        assert saved_query.config.cache.enabled == True
+        assert saved_query.config.cache.enabled is True

--- a/tests/functional/saved_queries/test_configs.py
+++ b/tests/functional/saved_queries/test_configs.py
@@ -216,7 +216,7 @@ class TestInheritingExportConfigsFromProject(BaseConfigProject):
         assert saved_query.config.export_as == ExportDestinationType.TABLE
 
 
-# cache can be specified in a SavedQuery config
+# cache can be specified just in a SavedQuery config
 class TestSavedQueryLevelCacheConfigs(BaseConfigProject):
     @pytest.fixture(scope="class")
     def models(self):
@@ -281,7 +281,8 @@ class TestSavedQueryCacheConfigsOverride(BaseConfigProject):
         saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
         assert saved_query.config.cache.enabled is True
 
-        # set cache to False via project config but since it's set to true at teh saved_query level, it should stay enabled
+        # set cache to enabled=False via project config but since it's set to true at the saved_query
+        # level, it should stay enabled
         config_patch = {
             "saved-queries": {"test": {"test_saved_query": {"+cache": {"enabled": False}}}}
         }


### PR DESCRIPTION
resolves #9540 

### Problem

SL needs us to support a cache property for SavedQuery

### Solution

Add cache to SavedQueryConfig.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
