### PR TITLE
remove uses of Replaceable class

### DIFF
--- a/.changes/unreleased/Under the Hood-20240216-104002.yaml
+++ b/.changes/unreleased/Under the Hood-20240216-104002.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove uses of Replaceable class
+time: 2024-02-16T10:40:02.25455-06:00
+custom:
+  Author: emmyoop
+  Issue: "7802"

--- a/core/dbt/artifacts/resources/base.py
+++ b/core/dbt/artifacts/resources/base.py
@@ -1,13 +1,12 @@
 from dataclasses import dataclass
 from dbt_common.dataclass_schema import dbtClassMixin
-from dbt_common.contracts.util import Replaceable
 from typing import List
 
 from dbt.artifacts.resources.types import NodeType
 
 
 @dataclass
-class BaseResource(dbtClassMixin, Replaceable):
+class BaseResource(dbtClassMixin):
     name: str
     resource_type: NodeType
     package_name: str

--- a/core/dbt/artifacts/resources/v1/components.py
+++ b/core/dbt/artifacts/resources/v1/components.py
@@ -4,7 +4,7 @@ from dbt.artifacts.resources.types import TimePeriod
 from dbt.artifacts.resources.v1.macro import MacroDependsOn
 from dbt_common.contracts.config.properties import AdditionalPropertiesMixin
 from dbt_common.contracts.constraints import ColumnLevelConstraint
-from dbt_common.contracts.util import Mergeable, Replaceable
+from dbt_common.contracts.util import Mergeable
 from dbt_common.dataclass_schema import dbtClassMixin, ExtensibleDbtClassMixin
 from typing import Any, Dict, List, Optional, Union
 
@@ -43,7 +43,7 @@ class RefArgs(dbtClassMixin):
 
 
 @dataclass
-class ColumnInfo(AdditionalPropertiesMixin, ExtensibleDbtClassMixin, Replaceable):
+class ColumnInfo(AdditionalPropertiesMixin, ExtensibleDbtClassMixin):
     """Used in all ManifestNodes and SourceDefinition"""
 
     name: str
@@ -101,7 +101,7 @@ class FreshnessThreshold(dbtClassMixin, Mergeable):
 
 
 @dataclass
-class HasRelationMetadata(dbtClassMixin, Replaceable):
+class HasRelationMetadata(dbtClassMixin):
     database: Optional[str]
     schema: str
 

--- a/core/dbt/artifacts/resources/v1/docs.py
+++ b/core/dbt/artifacts/resources/v1/docs.py
@@ -1,10 +1,9 @@
 from dataclasses import dataclass
 from dbt_common.dataclass_schema import dbtClassMixin
-from dbt_common.contracts.util import Replaceable
 from typing import Optional
 
 
 @dataclass
-class Docs(dbtClassMixin, Replaceable):
+class Docs(dbtClassMixin):
     show: bool = True
     node_color: Optional[str] = None

--- a/core/dbt/artifacts/resources/v1/macro.py
+++ b/core/dbt/artifacts/resources/v1/macro.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass, field
 import time
 from typing import Literal, List, Dict, Optional, Any
 
-from dbt_common.contracts.util import Replaceable
 from dbt_common.dataclass_schema import dbtClassMixin
 from dbt.artifacts.resources.base import BaseResource
 from dbt.artifacts.resources.types import NodeType, ModelLanguage
@@ -17,7 +16,7 @@ class MacroArgument(dbtClassMixin):
 
 
 @dataclass
-class MacroDependsOn(dbtClassMixin, Replaceable):
+class MacroDependsOn(dbtClassMixin):
     macros: List[str] = field(default_factory=list)
 
     # 'in' on lists is O(n) so this is O(n^2) for # of macros

--- a/core/dbt/artifacts/resources/v1/owner.py
+++ b/core/dbt/artifacts/resources/v1/owner.py
@@ -2,10 +2,9 @@ from dataclasses import dataclass
 from typing import Optional
 
 from dbt_common.contracts.config.properties import AdditionalPropertiesAllowed
-from dbt_common.contracts.util import Replaceable
 
 
 @dataclass
-class Owner(AdditionalPropertiesAllowed, Replaceable):
+class Owner(AdditionalPropertiesAllowed):
     email: Optional[str] = None
     name: Optional[str] = None

--- a/core/dbt/artifacts/resources/v1/source_definition.py
+++ b/core/dbt/artifacts/resources/v1/source_definition.py
@@ -11,13 +11,13 @@ from dbt.artifacts.resources.v1.components import (
 )
 from dbt_common.contracts.config.base import BaseConfig
 from dbt_common.contracts.config.properties import AdditionalPropertiesAllowed
-from dbt_common.contracts.util import Mergeable, Replaceable
+from dbt_common.contracts.util import Mergeable
 from dbt_common.exceptions import CompilationError
 from typing import Any, Dict, List, Literal, Optional, Union
 
 
 @dataclass
-class ExternalPartition(AdditionalPropertiesAllowed, Replaceable):
+class ExternalPartition(AdditionalPropertiesAllowed):
     name: str = ""
     description: str = ""
     data_type: str = ""

--- a/core/dbt/artifacts/schemas/catalog/v1/catalog.py
+++ b/core/dbt/artifacts/schemas/catalog/v1/catalog.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 from dbt_common.dataclass_schema import dbtClassMixin
 from dbt_common.utils.formatting import lowercase
-from dbt_common.contracts.util import Replaceable
 from dbt.artifacts.schemas.base import ArtifactMixin, BaseArtifactMetadata, schema_version
 
 Primitive = Union[bool, str, float, None]
@@ -49,7 +48,7 @@ class TableMetadata(dbtClassMixin):
 
 
 @dataclass
-class CatalogTable(dbtClassMixin, Replaceable):
+class CatalogTable(dbtClassMixin):
     metadata: TableMetadata
     columns: ColumnMap
     stats: StatsDict

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1,6 +1,6 @@
 import enum
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from itertools import chain, islice
 from mashumaro.mixins.msgpack import DataClassMessagePackMixin
 from multiprocessing.synchronize import Lock
@@ -1385,14 +1385,14 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
                 )
             ):
                 merged.add(unique_id)
-                self.nodes[unique_id] = node.replace(deferred=True)
+                self.nodes[unique_id] = replace(node, deferred=True)
 
             # for all other nodes, add 'defer_relation'
             elif current and node.resource_type in refables and not node.is_ephemeral:
                 defer_relation = DeferRelation(
                     node.database, node.schema, node.alias, node.relation_name
                 )
-                self.nodes[unique_id] = current.replace(defer_relation=defer_relation)
+                self.nodes[unique_id] = replace(current, defer_relation=defer_relation)
 
         # Rebuild the flat_graph, which powers the 'graph' context variable,
         # now that we've deferred some nodes

--- a/core/dbt/contracts/graph/model_config.py
+++ b/core/dbt/contracts/graph/model_config.py
@@ -18,7 +18,7 @@ from dbt_common.dataclass_schema import (
 )
 from dbt.contracts.graph.unparsed import Docs
 from dbt.contracts.graph.utils import validate_color
-from dbt.contracts.util import Replaceable, list_str
+from dbt.contracts.util import list_str
 from dbt import hooks
 from dbt.node_types import NodeType, AccessType
 from mashumaro.jsonschema.annotations import Pattern
@@ -43,13 +43,13 @@ class Severity(str):
 
 
 @dataclass
-class ContractConfig(dbtClassMixin, Replaceable):
+class ContractConfig(dbtClassMixin):
     enforced: bool = False
     alias_types: bool = True
 
 
 @dataclass
-class Hook(dbtClassMixin, Replaceable):
+class Hook(dbtClassMixin):
     sql: str
     transaction: bool = True
     index: Optional[int] = None

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -39,7 +39,6 @@ from dbt.contracts.graph.unparsed import (
     UnitTestNodeVersions,
 )
 from dbt.contracts.graph.node_args import ModelNodeArgs
-from dbt.contracts.util import Replaceable
 from dbt_common.events.functions import warn_or_error
 from dbt.exceptions import ParsingError, ContractBreakingChangeError, ValidationError
 from dbt.events.types import (
@@ -181,7 +180,7 @@ class GraphNode(GraphResource, BaseNode):
 
 
 @dataclass
-class Contract(dbtClassMixin, Replaceable):
+class Contract(dbtClassMixin):
     enforced: bool = False
     alias_types: bool = True
     checksum: Optional[str] = None
@@ -198,7 +197,7 @@ class DeferRelation(HasRelationMetadataResource):
 
 
 @dataclass
-class ParsedNodeMandatory(GraphNode, HasRelationMetadataResource, Replaceable):
+class ParsedNodeMandatory(GraphNode, HasRelationMetadataResource):
     alias: str
     checksum: FileHash
     config: NodeConfig = field(default_factory=NodeConfig)
@@ -399,7 +398,7 @@ class ParsedNode(NodeInfoMixin, ParsedNodeMandatory, SerializableType):
 
 
 @dataclass
-class InjectedCTE(dbtClassMixin, Replaceable):
+class InjectedCTE(dbtClassMixin):
     """Used in CompiledNodes as part of ephemeral model processing"""
 
     id: str
@@ -927,7 +926,7 @@ class SingularTestNode(TestShouldStoreFailures, CompiledNode):
 
 
 @dataclass
-class TestMetadata(dbtClassMixin, Replaceable):
+class TestMetadata(dbtClassMixin):
     __test__ = False
 
     name: str
@@ -1606,7 +1605,7 @@ class SavedQuery(NodeInfoMixin, GraphNode, SavedQueryResource):
 
 
 @dataclass
-class ParsedPatch(HasYamlMetadata, Replaceable):
+class ParsedPatch(HasYamlMetadata):
     name: str
     description: str
     meta: Dict[str, Any]

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -22,7 +22,6 @@ from dbt.artifacts.resources import (
     MaturityType,
     MeasureAggregationParameters,
 )
-from dbt.contracts.util import Replaceable
 
 # trigger the PathEncoder
 import dbt_common.helper_types  # noqa:F401
@@ -37,7 +36,7 @@ from typing import Optional, List, Union, Dict, Any, Sequence, Literal
 
 
 @dataclass
-class UnparsedBaseNode(dbtClassMixin, Replaceable):
+class UnparsedBaseNode(dbtClassMixin):
     package_name: str
     path: str
     original_file_path: str
@@ -84,7 +83,7 @@ class UnparsedRunHook(UnparsedNode):
 
 
 @dataclass
-class HasColumnProps(AdditionalPropertiesMixin, ExtensibleDbtClassMixin, Replaceable):
+class HasColumnProps(AdditionalPropertiesMixin, ExtensibleDbtClassMixin):
     name: str
     description: str = ""
     meta: Dict[str, Any] = field(default_factory=dict)
@@ -112,12 +111,12 @@ class UnparsedColumn(HasColumnAndTestProps):
 
 
 @dataclass
-class HasColumnDocs(dbtClassMixin, Replaceable):
+class HasColumnDocs(dbtClassMixin):
     columns: Sequence[HasColumnProps] = field(default_factory=list)
 
 
 @dataclass
-class HasColumnTests(dbtClassMixin, Replaceable):
+class HasColumnTests(dbtClassMixin):
     columns: Sequence[UnparsedColumn] = field(default_factory=list)
 
 
@@ -280,7 +279,7 @@ class UnparsedSourceTableDefinition(HasColumnTests, HasColumnAndTestProps):
 
 
 @dataclass
-class UnparsedSourceDefinition(dbtClassMixin, Replaceable):
+class UnparsedSourceDefinition(dbtClassMixin):
     name: str
     description: str = ""
     meta: Dict[str, Any] = field(default_factory=dict)
@@ -336,7 +335,7 @@ class SourceTablePatch(dbtClassMixin):
 
 
 @dataclass
-class SourcePatch(dbtClassMixin, Replaceable):
+class SourcePatch(dbtClassMixin):
     name: str = field(
         metadata=dict(description="The name of the source to override"),
     )
@@ -379,7 +378,7 @@ class SourcePatch(dbtClassMixin, Replaceable):
 
 
 @dataclass
-class UnparsedDocumentation(dbtClassMixin, Replaceable):
+class UnparsedDocumentation(dbtClassMixin):
     package_name: str
     path: str
     original_file_path: str
@@ -428,7 +427,7 @@ class Maturity(StrEnum):
 
 
 @dataclass
-class UnparsedExposure(dbtClassMixin, Replaceable):
+class UnparsedExposure(dbtClassMixin):
     name: str
     type: ExposureType
     owner: Owner
@@ -454,7 +453,7 @@ class UnparsedExposure(dbtClassMixin, Replaceable):
 
 
 @dataclass
-class MetricFilter(dbtClassMixin, Replaceable):
+class MetricFilter(dbtClassMixin):
     field: str
     operator: str
     # TODO : Can we make this Any?
@@ -558,7 +557,7 @@ class UnparsedMetric(dbtClassMixin):
 
 
 @dataclass
-class UnparsedGroup(dbtClassMixin, Replaceable):
+class UnparsedGroup(dbtClassMixin):
     name: str
     owner: Owner
 

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -1,5 +1,5 @@
 from dbt import deprecations
-from dbt.contracts.util import Replaceable, list_str, Identifier
+from dbt.contracts.util import list_str, Identifier
 from dbt.adapters.contracts.connection import QueryComment
 from dbt_common.helper_types import NoValue
 from dbt_common.contracts.util import Mergeable
@@ -41,7 +41,7 @@ class Quoting(dbtClassMixin, Mergeable):
 
 
 @dataclass
-class Package(dbtClassMixin, Replaceable):
+class Package(dbtClassMixin):
     pass
 
 
@@ -95,7 +95,7 @@ PackageSpec = Union[LocalPackage, TarballPackage, GitPackage, RegistryPackage]
 
 
 @dataclass
-class PackageConfig(dbtClassMixin, Replaceable):
+class PackageConfig(dbtClassMixin):
     packages: List[PackageSpec]
 
     @classmethod
@@ -127,7 +127,7 @@ class ProjectPackageMetadata:
 
 
 @dataclass
-class Downloads(ExtensibleDbtClassMixin, Replaceable):
+class Downloads(ExtensibleDbtClassMixin):
     tarball: str
 
 
@@ -185,7 +185,7 @@ BANNED_PROJECT_NAMES = {
 
 
 @dataclass
-class Project(dbtClassMixin, Replaceable):
+class Project(dbtClassMixin):
     _hyphenated: ClassVar[bool] = True
     # Annotated is used by mashumaro for jsonschema generation
     name: Annotated[Identifier, Pattern(r"^[^\d\W]\w*$")]
@@ -295,7 +295,7 @@ class Project(dbtClassMixin, Replaceable):
 
 
 @dataclass
-class ProjectFlags(ExtensibleDbtClassMixin, Replaceable):
+class ProjectFlags(ExtensibleDbtClassMixin):
     cache_selected_only: Optional[bool] = None
     debug: Optional[bool] = None
     fail_fast: Optional[bool] = None
@@ -324,7 +324,7 @@ class ProjectFlags(ExtensibleDbtClassMixin, Replaceable):
 
 
 @dataclass
-class ProfileConfig(dbtClassMixin, Replaceable):
+class ProfileConfig(dbtClassMixin):
     profile_name: str
     target_name: str
     threads: int
@@ -333,7 +333,7 @@ class ProfileConfig(dbtClassMixin, Replaceable):
 
 
 @dataclass
-class ConfiguredQuoting(Quoting, Replaceable):
+class ConfiguredQuoting(Quoting):
     identifier: bool = True
     schema: bool = True
     database: Optional[bool] = None

--- a/core/dbt/contracts/util.py
+++ b/core/dbt/contracts/util.py
@@ -2,8 +2,8 @@ from typing import List, Any, Tuple
 
 from dbt_common.dataclass_schema import ValidatedStringMixin, ValidationError
 
-# Leave imports of `Mergeable` and `Replaceable` to preserve import paths
-from dbt_common.contracts.util import Mergeable, Replaceable  # noqa:F401
+# Leave imports of `Mergeable` to preserve import paths
+from dbt_common.contracts.util import Mergeable  # noqa:F401
 
 
 SourceKey = Tuple[str, str]

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 import itertools
 from pathlib import Path
 from typing import Iterable, Dict, Optional, Set, Any, List
@@ -122,7 +123,7 @@ class SourcePatcher:
 
         source = UnparsedSourceDefinition.from_dict(source_dct)
         table = UnparsedSourceTableDefinition.from_dict(table_dct)
-        return unpatched.replace(source=source, table=table, patch_path=patch_path)
+        return replace(unpatched, source=source, table=table, patch_path=patch_path)
 
     # This converts an UnpatchedSourceDefinition to a SourceDefinition
     def parse_source(self, target: UnpatchedSourceDefinition) -> SourceDefinition:

--- a/core/dbt/task/docs/generate.py
+++ b/core/dbt/task/docs/generate.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from dataclasses import replace
 from datetime import datetime
 from typing import Dict, List, Any, Optional, Tuple, Set, Iterable
 import agate
@@ -131,7 +132,7 @@ class Catalog(Dict[CatalogKey, CatalogTable]):
             if key in node_map:
                 unique_id = node_map[key]
                 if selected_node_ids is None or unique_id in selected_node_ids:
-                    nodes[unique_id] = table.replace(unique_id=unique_id)
+                    nodes[unique_id] = replace(table, unique_id=unique_id)
 
             unique_ids = source_map.get(table.key(), set())
             for unique_id in unique_ids:
@@ -142,7 +143,7 @@ class Catalog(Dict[CatalogKey, CatalogTable]):
                         table.to_dict(omit_none=True),
                     )
                 elif selected_node_ids is None or unique_id in selected_node_ids:
-                    sources[unique_id] = table.replace(unique_id=unique_id)
+                    sources[unique_id] = replace(table, unique_id=unique_id)
         return nodes, sources
 
 

--- a/tests/unit/test_contracts_graph_compiled.py
+++ b/tests/unit/test_contracts_graph_compiled.py
@@ -1,6 +1,8 @@
 import pickle
 import pytest
 
+from dataclasses import replace
+
 from dbt.artifacts.resources import ColumnInfo
 from dbt.contracts.files import FileHash
 from dbt.contracts.graph.nodes import (
@@ -264,44 +266,46 @@ def test_invalid_bad_type_model(minimal_uncompiled_dict):
 
 
 unchanged_compiled_models = [
-    lambda u: (u, u.replace(description="a description")),
-    lambda u: (u, u.replace(tags=["mytag"])),
-    lambda u: (u, u.replace(meta={"cool_key": "cool value"})),
+    lambda u: (u, replace(u, description="a description")),
+    lambda u: (u, replace(u, tags=["mytag"])),
+    lambda u: (u, replace(u, meta={"cool_key": "cool value"})),
     # changing the final alias/schema/datbase isn't a change - could just be target changing!
-    lambda u: (u, u.replace(database="nope")),
-    lambda u: (u, u.replace(schema="nope")),
-    lambda u: (u, u.replace(alias="nope")),
+    lambda u: (u, replace(u, database="nope")),
+    lambda u: (u, replace(u, schema="nope")),
+    lambda u: (u, replace(u, alias="nope")),
     # None -> False is a config change even though it's pretty much the same
     lambda u: (
-        u.replace(config=u.config.replace(persist_docs={"relation": False})),
-        u.replace(config=u.config.replace(persist_docs={"relation": False})),
+        replace(u, config=replace(u.config, persist_docs={"relation": False})),
+        replace(u, config=replace(u.config, persist_docs={"relation": False})),
     ),
     lambda u: (
-        u.replace(config=u.config.replace(persist_docs={"columns": False})),
-        u.replace(config=u.config.replace(persist_docs={"columns": False})),
+        replace(u, config=replace(u.config, persist_docs={"columns": False})),
+        replace(u, config=replace(u.config, persist_docs={"columns": False})),
     ),
     # True -> True
     lambda u: (
-        u.replace(config=u.config.replace(persist_docs={"relation": True})),
-        u.replace(config=u.config.replace(persist_docs={"relation": True})),
+        replace(u, config=replace(u.config, persist_docs={"relation": True})),
+        replace(u, config=replace(u.config, persist_docs={"relation": True})),
     ),
     lambda u: (
-        u.replace(config=u.config.replace(persist_docs={"columns": True})),
-        u.replace(config=u.config.replace(persist_docs={"columns": True})),
+        replace(u, config=replace(u.config, persist_docs={"columns": True})),
+        replace(u, config=replace(u.config, persist_docs={"columns": True})),
     ),
     # only columns docs enabled, but description changed
     lambda u: (
-        u.replace(config=u.config.replace(persist_docs={"columns": True})),
-        u.replace(
-            config=u.config.replace(persist_docs={"columns": True}),
+        replace(u, config=replace(u.config, persist_docs={"columns": True})),
+        replace(
+            u,
+            config=replace(u.config, persist_docs={"columns": True}),
             description="a model description",
         ),
     ),
     # only relation docs eanbled, but columns changed
     lambda u: (
-        u.replace(config=u.config.replace(persist_docs={"relation": True})),
-        u.replace(
-            config=u.config.replace(persist_docs={"relation": True}),
+        replace(u, config=replace(u.config, persist_docs={"relation": True})),
+        replace(
+            u,
+            config=replace(u.config, persist_docs={"relation": True}),
             columns={"a": ColumnInfo(name="a", description="a column description")},
         ),
     ),
@@ -310,10 +314,11 @@ unchanged_compiled_models = [
 
 changed_compiled_models = [
     lambda u: (u, None),
-    lambda u: (u, u.replace(raw_code="select * from wherever")),
+    lambda u: (u, replace(u, raw_code="select * from wherever")),
     lambda u: (
         u,
-        u.replace(
+        replace(
+            u,
             fqn=["test", "models", "subdir", "foo"],
             original_file_path="models/subdir/foo.sql",
             path="/root/models/subdir/foo.sql",
@@ -617,17 +622,17 @@ def test_invalid_resource_type_schema_test(minimal_schema_test_dict):
 
 unchanged_schema_tests = [
     # for tests, raw_code isn't a change (because it's always the same for a given test macro)
-    lambda u: u.replace(raw_code="select * from wherever"),
-    lambda u: u.replace(description="a description"),
-    lambda u: u.replace(tags=["mytag"]),
-    lambda u: u.replace(meta={"cool_key": "cool value"}),
+    lambda u: replace(u, raw_code="select * from wherever"),
+    lambda u: replace(u, description="a description"),
+    lambda u: replace(u, tags=["mytag"]),
+    lambda u: replace(u, meta={"cool_key": "cool value"}),
     # these values don't even mean anything on schema tests!
     lambda u: replace_config(u, alias="nope"),
     lambda u: replace_config(u, database="nope"),
     lambda u: replace_config(u, schema="nope"),
-    lambda u: u.replace(database="other_db"),
-    lambda u: u.replace(schema="other_schema"),
-    lambda u: u.replace(alias="foo"),
+    lambda u: replace(u, database="other_db"),
+    lambda u: replace(u, schema="other_schema"),
+    lambda u: replace(u, alias="foo"),
     lambda u: replace_config(u, full_refresh=True),
     lambda u: replace_config(u, post_hook=["select 1 as id"]),
     lambda u: replace_config(u, pre_hook=["select 1 as id"]),
@@ -637,16 +642,17 @@ unchanged_schema_tests = [
 
 changed_schema_tests = [
     lambda u: None,
-    lambda u: u.replace(
+    lambda u: replace(
+        u,
         fqn=["test", "models", "subdir", "foo"],
         original_file_path="models/subdir/foo.sql",
         path="/root/models/subdir/foo.sql",
     ),
     lambda u: replace_config(u, severity="warn"),
     # If we checked test metadata, these would caount. But we don't, because these changes would all change the unique ID, so it's irrelevant.
-    # lambda u: u.replace(test_metadata=u.test_metadata.replace(namespace='something')),
-    # lambda u: u.replace(test_metadata=u.test_metadata.replace(name='bar')),
-    # lambda u: u.replace(test_metadata=u.test_metadata.replace(kwargs={'arg': 'value'})),
+    # lambda u: replace(u, test_metadata=replace(u.test_metadata, namespace='something')),
+    # lambda u: replace(u, test_metadata=replace(u.test_metadata, name='bar')),
+    # lambda u: replace(u, test_metadata=replace(u.test_metadata, kwargs={'arg': 'value'})),
 ]
 
 
@@ -667,8 +673,8 @@ def test_compare_to_compiled(basic_uncompiled_schema_test_node, basic_compiled_s
     uncompiled = basic_uncompiled_schema_test_node
     compiled = basic_compiled_schema_test_node
     assert not uncompiled.same_contents(compiled, "postgres")
-    fixed_config = compiled.config.replace(severity=uncompiled.config.severity)
-    fixed_compiled = compiled.replace(
-        config=fixed_config, unrendered_config=uncompiled.unrendered_config
+    fixed_config = replace(compiled.config, severity=uncompiled.config.severity)
+    fixed_compiled = replace(
+        compiled, config=fixed_config, unrendered_config=uncompiled.unrendered_config
     )
     assert uncompiled.same_contents(fixed_compiled, "postgres")

--- a/tests/unit/test_contracts_graph_parsed.py
+++ b/tests/unit/test_contracts_graph_parsed.py
@@ -1,6 +1,7 @@
 import pickle
 import pytest
 
+from dataclasses import replace
 from hypothesis import given
 from hypothesis.strategies import builds, lists
 
@@ -400,8 +401,8 @@ def test_invalid_bad_materialized(base_parsed_model_dict):
 
 
 unchanged_nodes = [
-    lambda u: (u, u.replace(tags=["mytag"])),
-    lambda u: (u, u.replace(meta={"something": 1000})),
+    lambda u: (u, replace(u, tags=["mytag"])),
+    lambda u: (u, replace(u, meta={"something": 1000})),
     # True -> True
     lambda u: (
         replace_config(u, persist_docs={"relation": True}),
@@ -414,30 +415,32 @@ unchanged_nodes = [
     # only columns docs enabled, but description changed
     lambda u: (
         replace_config(u, persist_docs={"columns": True}),
-        replace_config(u, persist_docs={"columns": True}).replace(
-            description="a model description"
+        replace(
+            replace_config(u, persist_docs={"columns": True}), description="a model description"
         ),
     ),
     # only relation docs eanbled, but columns changed
     lambda u: (
         replace_config(u, persist_docs={"relation": True}),
-        replace_config(u, persist_docs={"relation": True}).replace(
-            columns={"a": ColumnInfo(name="a", description="a column description")}
+        replace(
+            replace_config(u, persist_docs={"relation": True}),
+            columns={"a": ColumnInfo(name="a", description="a column description")},
         ),
     ),
     # not tracked, we track config.alias/config.schema/config.database
-    lambda u: (u, u.replace(alias="other")),
-    lambda u: (u, u.replace(schema="other")),
-    lambda u: (u, u.replace(database="other")),
+    lambda u: (u, replace(u, alias="other")),
+    lambda u: (u, replace(u, schema="other")),
+    lambda u: (u, replace(u, database="other")),
     # unchanged ref representations - protected is default
-    lambda u: (u, u.replace(access=AccessType.Protected)),
+    lambda u: (u, replace(u, access=AccessType.Protected)),
 ]
 
 
 changed_nodes = [
     lambda u: (
         u,
-        u.replace(
+        replace(
+            u,
             fqn=["test", "models", "subdir", "foo"],
             original_file_path="models/subdir/foo.sql",
             path="/root/models/subdir/foo.sql",
@@ -449,15 +452,16 @@ changed_nodes = [
     # persist docs was true for the relation and we changed the model description
     lambda u: (
         replace_config(u, persist_docs={"relation": True}),
-        replace_config(u, persist_docs={"relation": True}).replace(
-            description="a model description"
+        replace(
+            replace_config(u, persist_docs={"relation": True}), description="a model description"
         ),
     ),
     # persist docs was true for columns and we changed the model description
     lambda u: (
         replace_config(u, persist_docs={"columns": True}),
-        replace_config(u, persist_docs={"columns": True}).replace(
-            columns={"a": ColumnInfo(name="a", description="a column description")}
+        replace(
+            replace_config(u, persist_docs={"columns": True}),
+            columns={"a": ColumnInfo(name="a", description="a column description")},
         ),
     ),
     # not tracked, we track config.alias/config.schema/config.database
@@ -682,8 +686,8 @@ def test_seed_complex(complex_parsed_seed_dict, complex_parsed_seed_object):
 
 
 unchanged_seeds = [
-    lambda u: (u, u.replace(tags=["mytag"])),
-    lambda u: (u, u.replace(meta={"something": 1000})),
+    lambda u: (u, replace(u, tags=["mytag"])),
+    lambda u: (u, replace(u, meta={"something": 1000})),
     # True -> True
     lambda u: (
         replace_config(u, persist_docs={"relation": True}),
@@ -696,27 +700,29 @@ unchanged_seeds = [
     # only columns docs enabled, but description changed
     lambda u: (
         replace_config(u, persist_docs={"columns": True}),
-        replace_config(u, persist_docs={"columns": True}).replace(
-            description="a model description"
+        replace(
+            replace_config(u, persist_docs={"columns": True}), description="a model description"
         ),
     ),
     # only relation docs eanbled, but columns changed
     lambda u: (
         replace_config(u, persist_docs={"relation": True}),
-        replace_config(u, persist_docs={"relation": True}).replace(
-            columns={"a": ColumnInfo(name="a", description="a column description")}
+        replace(
+            replace_config(u, persist_docs={"relation": True}),
+            columns={"a": ColumnInfo(name="a", description="a column description")},
         ),
     ),
-    lambda u: (u, u.replace(alias="other")),
-    lambda u: (u, u.replace(schema="other")),
-    lambda u: (u, u.replace(database="other")),
+    lambda u: (u, replace(u, alias="other")),
+    lambda u: (u, replace(u, schema="other")),
+    lambda u: (u, replace(u, database="other")),
 ]
 
 
 changed_seeds = [
     lambda u: (
         u,
-        u.replace(
+        replace(
+            u,
             fqn=["test", "models", "subdir", "foo"],
             original_file_path="models/subdir/foo.sql",
             path="/root/models/subdir/foo.sql",
@@ -728,15 +734,16 @@ changed_seeds = [
     # persist docs was true for the relation and we changed the model description
     lambda u: (
         replace_config(u, persist_docs={"relation": True}),
-        replace_config(u, persist_docs={"relation": True}).replace(
-            description="a model description"
+        replace(
+            replace_config(u, persist_docs={"relation": True}), description="a model description"
         ),
     ),
     # persist docs was true for columns and we changed the model description
     lambda u: (
         replace_config(u, persist_docs={"columns": True}),
-        replace_config(u, persist_docs={"columns": True}).replace(
-            columns={"a": ColumnInfo(name="a", description="a column description")}
+        replace(
+            replace_config(u, persist_docs={"columns": True}),
+            columns={"a": ColumnInfo(name="a", description="a column description")},
         ),
     ),
     lambda u: (u, replace_config(u, alias="other")),
@@ -2082,27 +2089,30 @@ def test_source_no_freshness(complex_parsed_source_definition_object):
 
 
 unchanged_source_definitions = [
-    lambda u: (u, u.replace(tags=["mytag"])),
-    lambda u: (u, u.replace(meta={"a": 1000})),
+    lambda u: (u, replace(u, tags=["mytag"])),
+    lambda u: (u, replace(u, meta={"a": 1000})),
 ]
 
 changed_source_definitions = [
     lambda u: (
         u,
-        u.replace(
+        replace(
+            u,
             freshness=FreshnessThreshold(warn_after=Time(period=TimePeriod.hour, count=1)),
             loaded_at_field="loaded_at",
         ),
     ),
-    lambda u: (u, u.replace(loaded_at_field="loaded_at")),
+    lambda u: (u, replace(u, loaded_at_field="loaded_at")),
     lambda u: (
         u,
-        u.replace(freshness=FreshnessThreshold(error_after=Time(period=TimePeriod.hour, count=1))),
+        replace(
+            u, freshness=FreshnessThreshold(error_after=Time(period=TimePeriod.hour, count=1))
+        ),
     ),
-    lambda u: (u, u.replace(quoting=Quoting(identifier=True))),
-    lambda u: (u, u.replace(database="other_database")),
-    lambda u: (u, u.replace(schema="other_schema")),
-    lambda u: (u, u.replace(identifier="identifier")),
+    lambda u: (u, replace(u, quoting=Quoting(identifier=True))),
+    lambda u: (u, replace(u, database="other_database")),
+    lambda u: (u, replace(u, schema="other_schema")),
+    lambda u: (u, replace(u, identifier="identifier")),
 ]
 
 
@@ -2267,13 +2277,13 @@ unchanged_parsed_exposures = [
 
 
 changed_parsed_exposures = [
-    lambda u: (u, u.replace(fqn=u.fqn[:-1] + ["something", u.fqn[-1]])),
-    lambda u: (u, u.replace(type=ExposureType.ML)),
-    lambda u: (u, u.replace(owner=u.owner.replace(name="My Name"))),
-    lambda u: (u, u.replace(maturity=MaturityType.Medium)),
-    lambda u: (u, u.replace(url="https://example.com/dashboard/1")),
-    lambda u: (u, u.replace(description="My description")),
-    lambda u: (u, u.replace(depends_on=DependsOn(nodes=["model.test.blah"]))),
+    lambda u: (u, replace(u, fqn=u.fqn[:-1] + ["something", u.fqn[-1]])),
+    lambda u: (u, replace(u, type=ExposureType.ML)),
+    lambda u: (u, replace(u, owner=replace(u.owner, name="My Name"))),
+    lambda u: (u, replace(u, maturity=MaturityType.Medium)),
+    lambda u: (u, replace(u, url="https://example.com/dashboard/1")),
+    lambda u: (u, replace(u, description="My description")),
+    lambda u: (u, replace(u, depends_on=DependsOn(nodes=["model.test.blah"]))),
 ]
 
 

--- a/tests/unit/test_graph_selector_methods.py
+++ b/tests/unit/test_graph_selector_methods.py
@@ -1,5 +1,5 @@
 import copy
-
+from dataclasses import replace
 import pytest
 from unittest import mock
 
@@ -1036,9 +1036,7 @@ def test_select_group(manifest, view_model):
     manifest.groups[group.unique_id] = group
     change_node(
         manifest,
-        view_model.replace(
-            config={"materialized": "view", "group": group_name},
-        ),
+        replace(view_model, config={"materialized": "view", "group": group_name}),
     )
     methods = MethodManager(manifest, None)
     method = methods.get_method("group", [])
@@ -1052,9 +1050,7 @@ def test_select_group(manifest, view_model):
 def test_select_access(manifest, view_model):
     change_node(
         manifest,
-        view_model.replace(
-            access="public",
-        ),
+        replace(view_model, access="public"),
     )
     methods = MethodManager(manifest, None)
     method = methods.get_method("access", [])
@@ -1507,7 +1503,7 @@ def test_select_state_added_model(manifest, previous_state):
 
 
 def test_select_state_changed_model_sql(manifest, previous_state, view_model):
-    change_node(manifest, view_model.replace(raw_code="select 1 as id"))
+    change_node(manifest, replace(view_model, raw_code="select 1 as id"))
     method = statemethod(manifest, previous_state)
 
     # both of these
@@ -1526,7 +1522,7 @@ def test_select_state_changed_model_sql(manifest, previous_state, view_model):
 
 def test_select_state_changed_model_fqn(manifest, previous_state, view_model):
     change_node(
-        manifest, view_model.replace(fqn=view_model.fqn[:-1] + ["nested"] + view_model.fqn[-1:])
+        manifest, replace(view_model, fqn=view_model.fqn[:-1] + ["nested"] + view_model.fqn[-1:])
     )
     method = statemethod(manifest, previous_state)
     assert search_manifest_using_method(manifest, method, "modified") == {"view_model"}
@@ -1549,7 +1545,7 @@ def test_select_state_added_seed(manifest, previous_state):
 
 
 def test_select_state_changed_seed_checksum_sha_to_sha(manifest, previous_state, seed):
-    change_node(manifest, seed.replace(checksum=FileHash.from_contents("changed")))
+    change_node(manifest, replace(seed, checksum=FileHash.from_contents("changed")))
     method = statemethod(manifest, previous_state)
     assert search_manifest_using_method(manifest, method, "modified") == {"seed"}
     assert not search_manifest_using_method(manifest, method, "new")
@@ -1559,10 +1555,10 @@ def test_select_state_changed_seed_checksum_sha_to_sha(manifest, previous_state,
 def test_select_state_changed_seed_checksum_path_to_path(manifest, previous_state, seed):
     change_node(
         previous_state.manifest,
-        seed.replace(checksum=FileHash(name="path", checksum=seed.original_file_path)),
+        replace(seed, checksum=FileHash(name="path", checksum=seed.original_file_path)),
     )
     change_node(
-        manifest, seed.replace(checksum=FileHash(name="path", checksum=seed.original_file_path))
+        manifest, replace(seed, checksum=FileHash(name="path", checksum=seed.original_file_path))
     )
     method = statemethod(manifest, previous_state)
     with mock.patch("dbt.contracts.graph.nodes.warn_or_error") as warn_or_error_patch:
@@ -1589,7 +1585,7 @@ def test_select_state_changed_seed_checksum_path_to_path(manifest, previous_stat
 
 def test_select_state_changed_seed_checksum_sha_to_path(manifest, previous_state, seed):
     change_node(
-        manifest, seed.replace(checksum=FileHash(name="path", checksum=seed.original_file_path))
+        manifest, replace(seed, checksum=FileHash(name="path", checksum=seed.original_file_path))
     )
     method = statemethod(manifest, previous_state)
     with mock.patch("dbt.contracts.graph.nodes.warn_or_error") as warn_or_error_patch:
@@ -1617,7 +1613,7 @@ def test_select_state_changed_seed_checksum_sha_to_path(manifest, previous_state
 def test_select_state_changed_seed_checksum_path_to_sha(manifest, previous_state, seed):
     change_node(
         previous_state.manifest,
-        seed.replace(checksum=FileHash(name="path", checksum=seed.original_file_path)),
+        replace(seed, checksum=FileHash(name="path", checksum=seed.original_file_path)),
     )
     method = statemethod(manifest, previous_state)
     with mock.patch("dbt.contracts.graph.nodes.warn_or_error") as warn_or_error_patch:
@@ -1635,7 +1631,7 @@ def test_select_state_changed_seed_checksum_path_to_sha(manifest, previous_state
 
 
 def test_select_state_changed_seed_fqn(manifest, previous_state, seed):
-    change_node(manifest, seed.replace(fqn=seed.fqn[:-1] + ["nested"] + seed.fqn[-1:]))
+    change_node(manifest, replace(seed, fqn=seed.fqn[:-1] + ["nested"] + seed.fqn[-1:]))
     method = statemethod(manifest, previous_state)
     assert search_manifest_using_method(manifest, method, "modified") == {"seed"}
     assert not search_manifest_using_method(manifest, method, "new")
@@ -1658,7 +1654,7 @@ def test_select_state_changed_seed_relation_documented(manifest, previous_state,
 
 def test_select_state_changed_seed_relation_documented_nodocs(manifest, previous_state, seed):
     seed_doc_relation = replace_config(seed, persist_docs={"relation": True})
-    seed_doc_relation_documented = seed_doc_relation.replace(description="a description")
+    seed_doc_relation_documented = replace(seed_doc_relation, description="a description")
     change_node(previous_state.manifest, seed_doc_relation)
     change_node(manifest, seed_doc_relation_documented)
     method = statemethod(manifest, previous_state)
@@ -1674,7 +1670,7 @@ def test_select_state_changed_seed_relation_documented_nodocs(manifest, previous
 
 def test_select_state_changed_seed_relation_documented_withdocs(manifest, previous_state, seed):
     seed_doc_relation = replace_config(seed, persist_docs={"relation": True})
-    seed_doc_relation_documented = seed_doc_relation.replace(description="a description")
+    seed_doc_relation_documented = replace(seed_doc_relation, description="a description")
     change_node(previous_state.manifest, seed_doc_relation_documented)
     change_node(manifest, seed_doc_relation)
     method = statemethod(manifest, previous_state)
@@ -1702,7 +1698,8 @@ def test_select_state_changed_seed_columns_documented(manifest, previous_state, 
 
 def test_select_state_changed_seed_columns_documented_nodocs(manifest, previous_state, seed):
     seed_doc_columns = replace_config(seed, persist_docs={"columns": True})
-    seed_doc_columns_documented_columns = seed_doc_columns.replace(
+    seed_doc_columns_documented_columns = replace(
+        seed_doc_columns,
         columns={"a": ColumnInfo(name="a", description="a description")},
     )
 
@@ -1722,7 +1719,8 @@ def test_select_state_changed_seed_columns_documented_nodocs(manifest, previous_
 
 def test_select_state_changed_seed_columns_documented_withdocs(manifest, previous_state, seed):
     seed_doc_columns = replace_config(seed, persist_docs={"columns": True})
-    seed_doc_columns_documented_columns = seed_doc_columns.replace(
+    seed_doc_columns_documented_columns = replace(
+        seed_doc_columns,
         columns={"a": ColumnInfo(name="a", description="a description")},
     )
 
@@ -1743,8 +1741,8 @@ def test_select_state_changed_seed_columns_documented_withdocs(manifest, previou
 def test_select_state_changed_test_macro_sql(
     manifest, previous_state, macro_default_test_not_null
 ):
-    manifest.macros[macro_default_test_not_null.unique_id] = macro_default_test_not_null.replace(
-        macro_sql="lalala"
+    manifest.macros[macro_default_test_not_null.unique_id] = replace(
+        macro_default_test_not_null, macro_sql="lalala"
     )
     method = statemethod(manifest, previous_state)
     assert search_manifest_using_method(manifest, method, "modified") == {
@@ -1763,7 +1761,7 @@ def test_select_state_changed_test_macro_sql(
 def test_select_state_changed_test_macros(manifest, previous_state):
     changed_macro = make_macro("dbt", "changed_macro", "blablabla")
     add_macro(manifest, changed_macro)
-    add_macro(previous_state.manifest, changed_macro.replace(macro_sql="something different"))
+    add_macro(previous_state.manifest, replace(changed_macro, macro_sql="something different"))
 
     unchanged_macro = make_macro("dbt", "unchanged_macro", "blablabla")
     add_macro(manifest, unchanged_macro)
@@ -1804,7 +1802,7 @@ def test_select_state_changed_test_macros(manifest, previous_state):
 def test_select_state_changed_test_macros_with_upstream_change(manifest, previous_state):
     changed_macro = make_macro("dbt", "changed_macro", "blablabla")
     add_macro(manifest, changed_macro)
-    add_macro(previous_state.manifest, changed_macro.replace(macro_sql="something different"))
+    add_macro(previous_state.manifest, replace(changed_macro, macro_sql="something different"))
 
     unchanged_macro1 = make_macro("dbt", "unchanged_macro", "blablabla")
     add_macro(manifest, unchanged_macro1)

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -379,7 +379,10 @@ def dict_replace(dct, **kwargs):
 
 
 def replace_config(n, **kwargs):
-    return n.replace(
+    from dataclasses import replace
+
+    return replace(
+        n,
         config=n.config.replace(**kwargs),
         unrendered_config=dict_replace(n.unrendered_config, **kwargs),
     )


### PR DESCRIPTION
resolves #7802 

### Problem

We pull in a Replaceable class which contains a "replace" method in a lot of our classes. This method is designed to replace the current object with a newly constructed one based on kwargs, and is in general not a very good idea. If we want to replace a current object it would be better to be a lot more explicit and intentional about what's happening.

### Solution

Remove the usage Replaceable class where it's found in dbt-core

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
