### PR TITLE
flags & tracking from dbt/artifacts

### DIFF
--- a/.changes/unreleased/Under the Hood-20240222-115245.yaml
+++ b/.changes/unreleased/Under the Hood-20240222-115245.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove references to dbt.tracking and dbt.flags from dbt/artifacts
+time: 2024-02-22T11:52:45.044853-06:00
+custom:
+  Author: emmyoop
+  Issue: "9390"

--- a/core/dbt/artifacts/schemas/manifest/v12/manifest.py
+++ b/core/dbt/artifacts/schemas/manifest/v12/manifest.py
@@ -20,8 +20,6 @@ from dbt.artifacts.resources import (
 )
 
 # TODO: remove usage of dbt modules other than dbt.artifacts
-from dbt import tracking
-from dbt.flags import get_flags
 from dbt.contracts.graph.nodes import (
     GraphMemberNode,
     ManifestNode,
@@ -69,16 +67,6 @@ class ManifestMetadata(BaseArtifactMetadata):
         default=None,
         metadata=dict(description="The type name of the adapter"),
     )
-
-    def __post_init__(self):
-        if tracking.active_user is None:
-            return
-
-        if self.user_id is None:
-            self.user_id = tracking.active_user.id
-
-        if self.send_anonymous_usage_stats is None:
-            self.send_anonymous_usage_stats = get_flags().SEND_ANONYMOUS_USAGE_STATS
 
     @classmethod
     def default(cls):

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -15,6 +15,7 @@ from typing import (
     Type,
 )
 
+from dbt import tracking
 from dbt.adapters.factory import get_include_paths, get_relation_class_by_name
 from dbt.adapters.contracts.connection import AdapterRequiredConfig, Credentials, HasCredentials
 from dbt.adapters.contracts.relation import ComponentName
@@ -283,6 +284,10 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
         return ManifestMetadata(
             project_name=self.project_name,
             project_id=self.hashed_name(),
+            user_id=tracking.active_user.id if tracking.active_user else None,
+            send_anonymous_usage_stats=get_flags().SEND_ANONYMOUS_USAGE_STATS
+            if tracking.active_user
+            else None,
             adapter_type=self.credentials.type,
         )
 

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1024,6 +1024,10 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
                     group_map[node.group].append(node.unique_id)
         self.group_map = group_map
 
+    def fill_tracking_metadata(self):
+        self.metadata.user_id = tracking.active_user.id if tracking.active_user else None
+        self.metadata.send_anonymous_usage_stats = get_flags().SEND_ANONYMOUS_USAGE_STATS
+
     @classmethod
     def _map_nodes_to_map_resources(cls, nodes_map: MutableMapping[str, NodeClassT]):
         return {node_id: node.to_resource() for node_id, node in nodes_map.items()}
@@ -1031,6 +1035,8 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
     def writable_manifest(self) -> "WritableManifest":
         self.build_parent_and_child_maps()
         self.build_group_map()
+        self.fill_tracking_metadata()
+
         return WritableManifest(
             nodes=self.nodes,
             sources=self._map_nodes_to_map_resources(self.sources),

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -23,6 +23,7 @@ from typing import (
 )
 from typing_extensions import Protocol
 
+from dbt import tracking
 from dbt.contracts.graph.nodes import (
     BaseNode,
     Documentation,
@@ -43,6 +44,7 @@ from dbt.contracts.graph.nodes import (
     UnitTestFileFixture,
 )
 from dbt.contracts.graph.unparsed import SourcePatch, UnparsedVersion
+from dbt.flags import get_flags
 
 # to preserve import paths
 from dbt.artifacts.resources import NodeVersion, DeferRelation
@@ -1578,7 +1580,12 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
 class MacroManifest(MacroMethods):
     def __init__(self, macros) -> None:
         self.macros = macros
-        self.metadata = ManifestMetadata()
+        self.metadata = ManifestMetadata(
+            user_id=tracking.active_user.id if tracking.active_user else None,
+            send_anonymous_usage_stats=get_flags().SEND_ANONYMOUS_USAGE_STATS
+            if tracking.active_user
+            else None,
+        )
         # This is returned by the 'graph' context property
         # in the ProviderContext class.
         self.flat_graph: Dict[str, Any] = {}


### PR DESCRIPTION
resolves #9390 

### Problem

dbt.tracking and dbt.flags from dbt/artifacts/schemas/manifest.py represent a dependency on dbt internals from an upstream component, meaning we could never package it separately.

### Solution

Use global values instead of replying on post_init.  Fix tests to account for new pattern.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
