### PR TITLE
Restrict protobuf to 4.* versions

### DIFF
--- a/.changes/unreleased/Dependencies-20240222-102947.yaml
+++ b/.changes/unreleased/Dependencies-20240222-102947.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Restrict protobuf to 4.* versions
+time: 2024-02-22T10:29:47.595435-08:00
+custom:
+  Author: QMalcolm
+  PR: "9566"

--- a/core/setup.py
+++ b/core/setup.py
@@ -77,7 +77,7 @@ setup(
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
         "packaging>20.9",
-        "protobuf>=4.0.0",
+        "protobuf>=4.0.0,<5",
         "pytz>=2015.7",
         "pyyaml>=6.0",
         "daff>=1.3.46",


### PR DESCRIPTION
resolves #9566 

### Problem

Protobuf v5 has breaking changes.

### Solution

Restrict the protobuf dependency to one major version, 4, so that we don't have to patch over handling 2 different major versions of protobuf.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
