### PR TITLE
Do not allow hook node_info to persist past hook run

### DIFF
--- a/.changes/unreleased/Fixes-20240222-100958.yaml
+++ b/.changes/unreleased/Fixes-20240222-100958.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix node_info contextvar handling so incorrect node_info doesn't persist
+time: 2024-02-22T10:09:58.122809-05:00
+custom:
+  Author: gshank
+  Issue: "8866"

--- a/core/setup.py
+++ b/core/setup.py
@@ -72,7 +72,7 @@ setup(
         "dbt-extractor~=0.5.0",
         "minimal-snowplow-tracker~=0.0.2",
         "dbt-semantic-interfaces~=0.5.0a2",
-        "dbt-common~=0.1.3",
+        "dbt-common~=0.1.6",
         "dbt-adapters~=0.1.0a2",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.


### PR DESCRIPTION
resolves #8866

### Problem

The node_info from the on-run-end hook was persisting past the end of the dbtRunner.invoke call, which caused problems with sorting logging events and determining the run length.

### Solution

Part of the fix is in #db5-common/83, which fixed the "unset_contextvars" function. Part is in this pull request, which is using the log_contextvars context manager in the hook calls.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
