### PR TITLE
Fix `Check Artifact Changes` Action

### DIFF
--- a/.github/workflows/check-artifact-changes.yml
+++ b/.github/workflows/check-artifact-changes.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   check-artifact-changes:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'artifact_minor_upgrade') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -30,13 +31,13 @@ jobs:
           fi
 
       - name: Fail CI if artifacts have changed
-        if: env.CHANGED == 'true' && !contains(github.event.pull_request.labels.*.name, 'artifact_minor_upgrade')
+        if: env.CHANGED == 'true'
         run: |
           echo "CI failure: Artifact changes checked in core/dbt/artifacts directory."
           echo "To bypass this check, confirm that the change is not breaking (https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/artifacts/README.md#breaking-changes) and add the 'artifact_minor_upgrade' label to the PR."
           exit 1
 
       - name: CI check passed
-        if: env.CHANGED == 'false' || contains(github.event.pull_request.labels.*.name, 'artifact_minor_upgrade')
+        if: env.CHANGED == 'false'
         run: |
-          echo "No prohibited artifact changes checked in core/dbt/artifacts, or 'artifact_minor_upgrade' label found. CI check passed."
+          echo "No prohibited artifact changes checked in core/dbt/artifacts. CI check passed."

--- a/.github/workflows/check-artifact-changes.yml
+++ b/.github/workflows/check-artifact-changes.yml
@@ -18,26 +18,24 @@ jobs:
           fetch-depth: 0
 
       - name: Check for changes in core/dbt/artifacts
-        id: check_changes
-        run: |
-          # Check for changes in dbt/artifacts
-          CHANGED_FILES=$(git diff --name-only origin/${GITHUB_BASE_REF} origin/${GITHUB_HEAD_REF} | grep 'core/dbt/artifacts/')
-          if [ ! -z "$CHANGED_FILES" ]; then
-            echo "CHANGED=true" >> $GITHUB_ENV
-            echo "Changed files in core/dbt/artifacts:"
-            echo "$CHANGED_FILES"
-          else
-            echo "CHANGED=false" >> $GITHUB_ENV
-          fi
+        # https://github.com/marketplace/actions/paths-changes-filter
+        uses: dorny/paths-filter@v3
+        id: check_artifact_changes
+        with:
+          filters: |
+            artifacts_changed:
+              - 'core/dbt/artifacts/**'
+          list-files: shell
 
       - name: Fail CI if artifacts have changed
-        if: env.CHANGED == 'true'
+        if: steps.check_artifact_changes.outputs.artifacts_changed == 'true'
         run: |
           echo "CI failure: Artifact changes checked in core/dbt/artifacts directory."
+          echo "Files changed: ${{ steps.check_artifact_changes.outputs.artifacts_changed_files }}"
           echo "To bypass this check, confirm that the change is not breaking (https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/artifacts/README.md#breaking-changes) and add the 'artifact_minor_upgrade' label to the PR."
           exit 1
 
       - name: CI check passed
-        if: env.CHANGED == 'false'
+        if: steps.check_artifact_changes.outputs.artifacts_changed == 'false'
         run: |
-          echo "No prohibited artifact changes checked in core/dbt/artifacts. CI check passed."
+          echo "No prohibited artifact changes found in core/dbt/artifacts. CI check passed."

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -26,7 +26,7 @@ permissions: read-all
 
 env:
   LATEST_SCHEMA_PATH: ${{ github.workspace }}/new_schemas
-  SCHEMA_DIFF_ARTIFACT: ${{ github.workspace }}//schema_schanges.txt
+  SCHEMA_DIFF_ARTIFACT: ${{ github.workspace }}/schema_schanges.txt
   DBT_REPO_DIRECTORY: ${{ github.workspace }}/dbt
   SCHEMA_REPO_DIRECTORY: ${{ github.workspace }}/schemas.getdbt.com
 


### PR DESCRIPTION
resolves #9613

### Problem

We were using `git diff` to check if any files had changed in `core/dbt/artifacts`. However, our `git diff` usage was including any changes that happened on `main` which the PR branch did not have. This caused the check to error as it was detecting changes which weren't actually there.

### Solution

We've switched the check from using `git diff` to `dorny/paths-filter`, which is what we use for checking for changelog existence as well. The `dorny/paths-fitler` includes logic for excluding changes that are on main but not the PR branch (which is what want to happen).

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
