### PR TITLE
Upgrade Jinja2 dependency version specification to address CVE-2024-22195

### DIFF
--- a/.changes/unreleased/Security-20240222-152445.yaml
+++ b/.changes/unreleased/Security-20240222-152445.yaml
@@ -1,0 +1,6 @@
+kind: Security
+body: Update Jinja2 to >= 3.1.3 to address CVE-2024-22195
+time: 2024-02-22T15:24:45.158305-08:00
+custom:
+  Author: QMalcolm
+  PR: CVE-2024-22195

--- a/core/setup.py
+++ b/core/setup.py
@@ -50,7 +50,7 @@ setup(
         # dbt-core uses these packages deeply, throughout the codebase, and there have been breaking changes in past patch releases (even though these are major-version-one).
         # Pin to the patch or minor version, and bump in each new minor version of dbt-core.
         "agate~=1.7.0",
-        "Jinja2~=3.1.2",
+        "Jinja2>=3.1.3,<4",
         "mashumaro[msgpack]~=3.9",
         # ----
         # Legacy: This package has not been updated since 2019, and it is unused in dbt's logging system (since v1.0)


### PR DESCRIPTION
resolves CVE-2024-22195

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

CVE-2024-22195 identified an issue in Jinja2 versions <= 3.1.2. 

### Solution

We've gone changed our dependency requirement specification to be 3.1.3 or greater (but less than 4).

Note: Preivously we were using the `~=` version specifier. However due to some issues with the `~=` we've moved to using `>=` in combination with `<`. This gives us the same range that `~=` gave us, but avoids a pip resolution issue when multiple packages in an environment use `~=` for the same dependency.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
