### PR TITLE
Fix #8948: Add target-path to retry

### DIFF
--- a/.changes/unreleased/Fixes-20240223-162107.yaml
+++ b/.changes/unreleased/Fixes-20240223-162107.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add target-path to retry
+time: 2024-02-23T16:21:07.83639Z
+custom:
+  Author: aranke
+  Issue: "8948"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -595,6 +595,7 @@ def run(ctx, **kwargs):
 @p.vars
 @p.profile
 @p.target
+@p.target_path
 @p.threads
 @p.full_refresh
 @requires.postflight

--- a/tests/functional/retry/test_retry.py
+++ b/tests/functional/retry/test_retry.py
@@ -354,11 +354,14 @@ class TestRetryTargetPathFlag:
             "sample_model.sql": models__sample_model,
         }
 
-    def test_retry_target_path_env_var(self, project, monkeypatch):
-        run_dbt(["run"], expect_pass=False)
+    def test_retry_target_path_flag(self, project):
+        run_dbt(["run", "--target-path", "target"], expect_pass=False)
+
+        project_root = project.project_root
+        move(project_root / "target", project_root / "artifacts")
 
         write_file(models__second_model, "models", "sample_model.sql")
 
-        results = run_dbt(["retry", "--target-path", "artifacts"])
+        results = run_dbt(["retry", "--state", "artifacts", "--target-path", "my_target_path"])
         assert len(results) == 1
-        assert Path("artifacts").is_dir()
+        assert Path("my_target_path").is_dir()

--- a/tests/functional/retry/test_retry.py
+++ b/tests/functional/retry/test_retry.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from shutil import copytree, move
 
 import pytest
@@ -327,3 +328,22 @@ class TestRetryFullRefresh:
         # ...and so should this one, since the effect of the full-refresh parameter should persist.
         results = run_dbt(["retry"], expect_pass=False)
         assert len(results) == 1
+
+
+class TestRetryEnvVar:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "sample_model.sql": models__sample_model,
+        }
+
+    def test_retry_env_var(self, project, monkeypatch):
+        monkeypatch.setenv("DBT_TARGET_PATH", "artifacts")
+        run_dbt(["run"], expect_pass=False)
+
+        write_file(models__second_model, "models", "sample_model.sql")
+
+        results = run_dbt(["retry"])
+        assert len(results) == 1
+        assert Path("artifacts").is_dir()
+        assert not Path("target").is_dir()

--- a/tests/functional/retry/test_retry.py
+++ b/tests/functional/retry/test_retry.py
@@ -330,14 +330,14 @@ class TestRetryFullRefresh:
         assert len(results) == 1
 
 
-class TestRetryEnvVar:
+class TestRetryTargetPathEnvVar:
     @pytest.fixture(scope="class")
     def models(self):
         return {
             "sample_model.sql": models__sample_model,
         }
 
-    def test_retry_env_var(self, project, monkeypatch):
+    def test_retry_target_path_env_var(self, project, monkeypatch):
         monkeypatch.setenv("DBT_TARGET_PATH", "artifacts")
         run_dbt(["run"], expect_pass=False)
 
@@ -345,5 +345,20 @@ class TestRetryEnvVar:
 
         results = run_dbt(["retry"])
         assert len(results) == 1
+
+
+class TestRetryTargetPathFlag:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "sample_model.sql": models__sample_model,
+        }
+
+    def test_retry_target_path_env_var(self, project, monkeypatch):
+        run_dbt(["run"], expect_pass=False)
+
+        write_file(models__second_model, "models", "sample_model.sql")
+
+        results = run_dbt(["retry", "--target-path", "artifacts"])
+        assert len(results) == 1
         assert Path("artifacts").is_dir()
-        assert not Path("target").is_dir()


### PR DESCRIPTION
resolves #8948

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

`retry` didn't support the `target-path` flag

### Solution

Add the `target-path` flag to `retry` as well as tests

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
