### PR TITLE
[Backport 1.6.latest] Upgrade Jinja2 dependency version specification to address CVE-2024-22195

### DIFF
--- a/.changes/unreleased/Security-20240222-152445.yaml
+++ b/.changes/unreleased/Security-20240222-152445.yaml
@@ -1,0 +1,6 @@
+kind: Security
+body: Update Jinja2 to >= 3.1.3 to address CVE-2024-22195
+time: 2024-02-22T15:24:45.158305-08:00
+custom:
+  Author: QMalcolm
+  PR: CVE-2024-22195

--- a/core/setup.py
+++ b/core/setup.py
@@ -50,7 +50,7 @@ setup(
         # dbt-core uses these packages deeply, throughout the codebase, and there have been breaking changes in past patch releases (even though these are major-version-one).
         # Pin to the patch or minor version, and bump in each new minor version of dbt-core.
         "agate~=1.7.0",
-        "Jinja2~=3.1.2",
+        "Jinja2>=3.1.3,<4",
         "mashumaro[msgpack]~=3.8.1",
         # ----
         # Legacy: This package has not been updated since 2019, and it is unused in dbt's logging system (since v1.0)


### PR DESCRIPTION
Manual backport of https://github.com/dbt-labs/dbt-core/commit/7ea46708327260c85460d8034ef6ab84fe3d1b78 from https://github.com/dbt-labs/dbt-core/pull/9638.