### PR TITLE
[Backport 1.5.latest] Upgrade Jinja2 dependency version specification to address CVE-2024-22195

### DIFF
--- a/.changes/unreleased/Security-20240222-152445.yaml
+++ b/.changes/unreleased/Security-20240222-152445.yaml
@@ -1,0 +1,6 @@
+kind: Security
+body: Update Jinja2 to >= 3.1.3 to address CVE-2024-22195
+time: 2024-02-22T15:24:45.158305-08:00
+custom:
+  Author: QMalcolm
+  PR: CVE-2024-22195

--- a/core/setup.py
+++ b/core/setup.py
@@ -46,7 +46,7 @@ setup(
         "console_scripts": ["dbt = dbt.cli.main:cli"],
     },
     install_requires=[
-        "Jinja2==3.1.2",
+        "Jinja2>=3.1.3,<4",
         "agate>=1.6,<1.7.1",
         # temporarily pinning click for mypy failures: https://github.com/pallets/click/issues/2558
         "click<9",


### PR DESCRIPTION
Manual backport of https://github.com/dbt-labs/dbt-core/commit/7ea46708327260c85460d8034ef6ab84fe3d1b78 from https://github.com/dbt-labs/dbt-core/pull/9638.