### PR TITLE
[Backport 1.5.latest] Restrict to protobuf 4

### DIFF
--- a/.changes/unreleased/Under the Hood-20240221-104518.yaml
+++ b/.changes/unreleased/Under the Hood-20240221-104518.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Restrict protobuf to major version 4.
+time: 2024-02-21T10:45:18.315195-05:00
+custom:
+  Author: peterallenwebb
+  Issue: "9566"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ ipdb
 mypy==0.981
 pip-tools
 pre-commit
-protobuf>=4.0.0
+protobuf>=4.0.0,<5.0.0
 pytest~=7.4
 pytest-cov
 pytest-csv~=3.0


### PR DESCRIPTION
Manual backport of https://github.com/dbt-labs/dbt-core/pull/9614/commits/a7f84a3c40c501a19771f6ce6305ec4904b55113 and https://github.com/dbt-labs/dbt-core/pull/9614/commits/72024c5a60559ea8fc96cb7f6dfdb69641fa19ad from https://github.com/dbt-labs/dbt-core/pull/9614