### PR TITLE
Fix conflict with newer versions of Snowplow tracker

### DIFF
--- a/.changes/unreleased/Fixes-20240206-152435.yaml
+++ b/.changes/unreleased/Fixes-20240206-152435.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix conflict with newer versions of Snowplow tracker
+time: 2024-02-06T15:24:35.778891-06:00
+custom:
+  Author: edgarrmondragon akurdyukov
+  Issue: "8719"

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -9,6 +9,7 @@ from typing import Optional
 import logbook
 import pytz
 import requests
+from packaging.version import Version
 from snowplow_tracker import Emitter, SelfDescribingJson, Subject, Tracker
 from snowplow_tracker import __version__ as snowplow_version  # type: ignore
 from snowplow_tracker import logger as sp_logger
@@ -50,8 +51,13 @@ RUNNABLE_TIMING = "iglu:com.dbt/runnable/jsonschema/1-0-0"
 RUN_MODEL_SPEC = "iglu:com.dbt/run_model/jsonschema/1-0-3"
 PLUGIN_GET_NODES = "iglu:com.dbt/plugin_get_nodes/jsonschema/1-0-0"
 
+SNOWPLOW_TRACKER_VERSION = Version(snowplow_version)
+
 # workaround in case real snowplow tracker is in the env
-INIT_KW_ARGS = {"buffer_size": 30} if snowplow_version == "0.0.2" else {"batch_size": 30}
+# the argument was renamed in https://github.com/snowplow/snowplow-python-tracker/commit/39fd50a3aff98a5efdd5c5c7fb5518fe4761305b
+INIT_KW_ARGS = (
+    {"buffer_size": 30} if SNOWPLOW_TRACKER_VERSION < Version("0.13.0") else {"batch_size": 30}
+)
 
 
 class TimeoutEmitter(Emitter):

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -51,7 +51,7 @@ RUN_MODEL_SPEC = "iglu:com.dbt/run_model/jsonschema/1-0-3"
 PLUGIN_GET_NODES = "iglu:com.dbt/plugin_get_nodes/jsonschema/1-0-0"
 
 # workaround in case real snowplow tracker is in the env
-INIT_KW_ARGS = {"buffer_size": 30} if snowplow_version == '0.0.2' else {"batch_size": 30}
+INIT_KW_ARGS = {"buffer_size": 30} if snowplow_version == "0.0.2" else {"batch_size": 30}
 
 
 class TimeoutEmitter(Emitter):
@@ -109,7 +109,7 @@ class TimeoutEmitter(Emitter):
 emitter = TimeoutEmitter()
 
 # workaround in case real snowplow tracker is in the env
-if snowplow_version == '0.0.2':
+if snowplow_version == "0.0.2":
     tracker = Tracker(
         emitter,
         namespace="cf",

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -10,7 +10,7 @@ import logbook
 import pytz
 import requests
 from snowplow_tracker import Emitter, SelfDescribingJson, Subject, Tracker
-from snowplow_tracker import __version__ as snowplow_version # type: ignore
+from snowplow_tracker import __version__ as snowplow_version  # type: ignore
 from snowplow_tracker import logger as sp_logger
 
 from dbt import version as dbt_version
@@ -107,20 +107,11 @@ class TimeoutEmitter(Emitter):
 
 
 emitter = TimeoutEmitter()
-
-# workaround in case real snowplow tracker is in the env
-if snowplow_version == "0.0.2":
-    tracker = Tracker(
-        emitter,
-        namespace="cf",
-        app_id="dbt",
-    )
-else:
-    tracker = Tracker(
-        "cf",
-        emitters=emitter,
-        app_id="dbt",
-    ) # type: ignore
+tracker = Tracker(
+    emitters=emitter,
+    namespace="cf",
+    app_id="dbt",
+)
 
 
 class User:

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -120,7 +120,7 @@ else:
         "cf",
         emitters=emitter,
         app_id="dbt",
-    )
+    ) # type: ignore
 
 
 class User:


### PR DESCRIPTION
resolves #8719, supersedes https://github.com/dbt-labs/dbt-core/pull/9528

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

Instaling `dbt-core` with `meltano` in the same virtualenv breaks dbt because contract conflict between `minimal-snowplow-tracker` (dependency of dbt) and `snowplow-python-tracker`.

### Solution

Adds explicit version check and use `minimal` or `full` contract call.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions

Based on https://github.com/dbt-labs/dbt-core/pull/8680, by @akurdyukov.
