### PR TITLE
Allow for dbt-adapters 1.0.0b1

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -75,7 +75,7 @@ setup(
         "dbt-semantic-interfaces>=0.5.0a2,<0.6",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common<2.0",
-        "dbt-adapters>=0.1.0a2,<1.0",
+        "dbt-adapters>=0.1.0a2,<2.0",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
         "packaging>20.9",


### PR DESCRIPTION
### Problem

We can't build `dbt-postgres` in current state because of internal dependency conflicts. We updated `dbt-adapters` to `1.0.0b1` on `main` and `dbt-core` has `dbt-adapters` pinned to `<1.0`. Tests on `dbt-postgres` require `dbt-core`. Hence `dbt-core@main` and `dbt-adapters@main` are in a version conflict.

### Solution

Allow for installing `dbt-adapters~=1.0`. I'm able to build and run tests against this branch.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
