### PR TITLE
Issue #9656 Raise an error when check_cols has duplicated values

### DIFF
--- a/core/dbt/artifacts/resources/v1/snapshot.py
+++ b/core/dbt/artifacts/resources/v1/snapshot.py
@@ -52,6 +52,10 @@ class SnapshotConfig(NodeConfig):
         if data.get("materialized") and data.get("materialized") != "snapshot":
             raise ValidationError("A snapshot must have a materialized value of 'snapshot'")
 
+        # Validate if there are duplicate column names in check_cols.
+        if len(data.get("check_cols")) != len(set(data.get("check_cols"))):
+            raise ValidationError(f"Duplicate column names in 'check_cols': {data['check_cols']}.")
+
     # Called by "calculate_node_config_dict" in ContextConfigGenerator
     def finalize_and_validate(self):
         data = self.to_dict(omit_none=True)

--- a/tests/unit/test_contracts_graph_parsed.py
+++ b/tests/unit/test_contracts_graph_parsed.py
@@ -1474,6 +1474,14 @@ def test_missing_snapshot_configs(basic_check_snapshot_config_dict):
         SnapshotConfig.validate(wrong_fields)
 
 
+def test_duplicate_check_cols(basic_check_snapshot_config_dict):
+    duplicate_cols = basic_check_snapshot_config_dict
+    # Introducing duplicate column names
+    duplicate_cols["check_cols"] = ["col1", "col2", "col2"]
+    with pytest.raises(ValidationError, match=r"Duplicate column names in 'check_cols'"):
+        SnapshotConfig.validate(duplicate_cols)
+
+
 def test_invalid_check_value(basic_check_snapshot_config_dict):
     invalid_check_type = basic_check_snapshot_config_dict
     invalid_check_type["check_cols"] = "some"


### PR DESCRIPTION
resolves #9656


### Problem

> Currently, the check strategy for Snapshots does not throw an error if there are duplicate column names specified in the check_cols config, and accidentally specifying a column twice results in a record being inserted even if none of the column values changed.

Problem described in https://github.com/dbt-labs/dbt-core/issues/9656#issue-2151908098

### Solution

This PR adds validation to detect duplicate column names in the `check_cols` configuration of a snapshot. It raises an error if duplicates are found.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
