### PR TITLE
Throw ParsingError for invalid PK definition on constraints

### DIFF
--- a/.changes/unreleased/Fixes-20240228-135928.yaml
+++ b/.changes/unreleased/Fixes-20240228-135928.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Throw a ParsingError if a primary key constraint is defined on multiple columns
+  or at both the column and model level.
+time: 2024-02-28T13:59:28.728561-06:00
+custom:
+  Author: emmyoop
+  Issue: "9581"

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -887,7 +887,7 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
     def patch_constraints(self, node, constraints):
         contract_config = node.config.get("contract")
         if contract_config.enforced is True:
-            self._validate_constraint_prerequisites(node)
+            self._validate_constraint_prerequisites(node, constraints)
 
             if any(
                 c for c in constraints if "type" not in c or not ConstraintType.is_valid(c["type"])
@@ -897,9 +897,11 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
                     f"Type must be one of {[ct.value for ct in ConstraintType]}"
                 )
 
-            node.constraints = [ModelLevelConstraint.from_dict(c) for c in constraints]
+        node.constraints = [ModelLevelConstraint.from_dict(c) for c in constraints]
 
-    def _validate_constraint_prerequisites(self, model_node: ModelNode):
+    def _validate_constraint_prerequisites(
+        self, model_node: ModelNode, constraints: List[Dict[str, Any]]
+    ):
 
         column_warn_unsupported = [
             constraint.warn_unsupported
@@ -926,6 +928,28 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
 
         if str(model_node.language) != "sql":
             errors.append(f"Language Error: Expected 'sql' but found '{model_node.language}'")
+
+        # check for primary key constraints defined at the column level
+        pk_col: List[str] = []
+        for col in model_node.columns.values():
+            for constraint in col.constraints:
+                if constraint.type == "primary_key":
+                    pk_col.append(col.name)
+
+        if len(pk_col) > 1:
+            errors.append(
+                f"Found {len(pk_col)} columns ({pk_col}) with primary key constraints defined. "
+                "Primary keys for multiple columns must be defined as a model level constraint."
+            )
+
+        if len(pk_col) > 0 and (
+            any(constraint.type == "primary_key" for constraint in model_node.constraints)
+            or any(constraint["type"] == "primary_key" for constraint in constraints)
+        ):
+            errors.append(
+                "Primary key constraints defined at the model level and the columns level. "
+                "Primary keys can be defined at the model level or the column level, not both."
+            )
 
         if errors:
             raise ParsingError(

--- a/tests/functional/configs/test_versioned_model_constraint.py
+++ b/tests/functional/configs/test_versioned_model_constraint.py
@@ -1,5 +1,6 @@
 import pytest
 from dbt.tests.util import run_dbt, rm_file, write_file, get_manifest
+from dbt.exceptions import ParsingError
 
 
 schema_yml = """
@@ -25,6 +26,10 @@ foo_sql = """
 select 1 as id, 'alice' as user_name
 """
 
+foo_v2_sql = """
+select 1 as id, 'alice' as user_name, 2 as another_pk
+"""
+
 versioned_schema_yml = """
 models:
   - name: foo
@@ -45,6 +50,69 @@ models:
         data_type: text
     versions:
       - v: 1
+"""
+
+versioned_pk_model_column_schema_yml = """
+models:
+  - name: foo
+    latest_version: 2
+    config:
+      materialized: table
+      contract:
+        enforced: true
+    constraints:
+      - type: primary_key
+        columns: [id]
+    columns:
+      - name: id
+        data_type: int
+        constraints:
+          - type: not_null
+      - name: user_name
+        data_type: text
+    versions:
+      - v: 1
+      - v: 2
+        columns:
+          - name: id
+            data_type: int
+            constraints:
+              - type: not_null
+              - type: primary_key
+          - name: user_name
+            data_type: text
+"""
+
+versioned_pk_mult_columns_schema_yml = """
+models:
+  - name: foo
+    latest_version: 2
+    config:
+      materialized: table
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        data_type: int
+        constraints:
+          - type: not_null
+          - type: primary_key
+      - name: user_name
+        data_type: text
+    versions:
+      - v: 1
+      - v: 2
+        columns:
+          - name: id
+            data_type: int
+            constraints:
+              - type: not_null
+              - type: primary_key
+          - name: user_name
+            data_type: text
+            constraints:
+              - type: primary_key
+
 """
 
 
@@ -74,3 +142,85 @@ class TestVersionedModelConstraints:
         model_node = manifest.nodes["model.test.foo.v1"]
         assert model_node.contract.enforced is True
         assert len(model_node.constraints) == 1
+
+
+# test primary key defined across model and column level constraints, expect error
+class TestPrimaryKeysModelAndColumnLevelConstraints:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "foo.sql": foo_sql,
+            "schema.yml": schema_yml,
+        }
+
+    def test_model_column_pk_error(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        manifest = get_manifest(project.project_root)
+        model_node = manifest.nodes["model.test.foo"]
+        assert len(model_node.constraints) == 1
+
+        # remove foo.sql and create foo_v1.sql
+        rm_file(project.project_root, "models", "foo.sql")
+        write_file(foo_sql, project.project_root, "models", "foo_v1.sql")
+        write_file(versioned_schema_yml, project.project_root, "models", "schema.yml")
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        manifest = get_manifest(project.project_root)
+        model_node = manifest.nodes["model.test.foo.v1"]
+        assert model_node.contract.enforced is True
+        assert len(model_node.constraints) == 1
+
+        # add foo_v2.sql
+        write_file(foo_sql, project.project_root, "models", "foo_v2.sql")
+        write_file(
+            versioned_pk_model_column_schema_yml, project.project_root, "models", "schema.yml"
+        )
+
+        expected_error = "Primary key constraints defined at the model level and the columns level"
+        with pytest.raises(ParsingError) as exc_info:
+            run_dbt(["run"])
+        assert expected_error in str(exc_info.value)
+
+
+# test primary key defined across multiple columns, expect error
+class TestPrimaryKeysMultipleColumns:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "foo.sql": foo_sql,
+            "schema.yml": schema_yml,
+        }
+
+    def test_pk_multiple_columns(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        manifest = get_manifest(project.project_root)
+        model_node = manifest.nodes["model.test.foo"]
+        assert len(model_node.constraints) == 1
+
+        # remove foo.sql and create foo_v1.sql
+        rm_file(project.project_root, "models", "foo.sql")
+        write_file(foo_sql, project.project_root, "models", "foo_v1.sql")
+        write_file(versioned_schema_yml, project.project_root, "models", "schema.yml")
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        manifest = get_manifest(project.project_root)
+        model_node = manifest.nodes["model.test.foo.v1"]
+        assert model_node.contract.enforced is True
+        assert len(model_node.constraints) == 1
+
+        # add foo_v2.sql
+        write_file(foo_sql, project.project_root, "models", "foo_v2.sql")
+        write_file(
+            versioned_pk_mult_columns_schema_yml, project.project_root, "models", "schema.yml"
+        )
+
+        expected_error = (
+            "Found 2 columns (['id', 'user_name']) with primary key constraints defined"
+        )
+        with pytest.raises(ParsingError) as exc_info:
+            run_dbt(["run"])
+        assert expected_error in str(exc_info.value)


### PR DESCRIPTION
resolves #9581

### Problem

Users receive database errors when PKs are defined on multiple columns or at both the model  and column levels.

### Solution

Throw a parsing error before it hits the DB

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
