### PR TITLE
[Backport 1.5.latest] Restrict protobuf to 4.* versions (MANUAL)

### DIFF
--- a/.changes/unreleased/Dependencies-20240222-102947.yaml
+++ b/.changes/unreleased/Dependencies-20240222-102947.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Restrict protobuf to 4.* versions
+time: 2024-02-22T10:29:47.595435-08:00
+custom:
+  Author: QMalcolm
+  PR: "9566"

--- a/core/setup.py
+++ b/core/setup.py
@@ -64,7 +64,7 @@ setup(
         "typing-extensions>=3.7.4",
         "werkzeug>=1,<3",
         "pathspec>=0.9,<0.12",
-        "protobuf>=4.0.0",
+        "protobuf>=4.0.0,<5",
         "pytz>=2015.7",
         # the following are all to match snowflake-connector-python
         "requests<3.0.0",


### PR DESCRIPTION
Backport e4fe839e4574187b574473596a471092267a9f2e from #9630. 