### PR TITLE
 [#9570] Fix fixtures in fixtures/subfolders throwing parsing error

### DIFF
--- a/.changes/unreleased/Fixes-20240301-000355.yaml
+++ b/.changes/unreleased/Fixes-20240301-000355.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix traceback parsing for exceptions raised due to csv fixtures moved into or
+  out of fixture/subfolders.
+time: 2024-03-01T00:03:55.753473609+01:00
+custom:
+  Author: slothkong
+  Issue: "9570"

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -79,7 +79,7 @@ from dbt.context.docs import generate_runtime_docs_context
 from dbt.context.macro_resolver import MacroResolver, TestMacroNamespace
 from dbt.context.configured import generate_macro_context
 from dbt.context.providers import ParseProvider, generate_runtime_macro_context
-from dbt.contracts.files import FileHash, ParseFileType, SchemaSourceFile
+from dbt.contracts.files import ParseFileType, SchemaSourceFile
 from dbt.parser.read_files import (
     ReadFilesFromFileSystem,
     load_source_file,
@@ -107,7 +107,7 @@ from dbt.contracts.graph.nodes import (
     ResultNode,
     ModelNode,
 )
-from dbt.artifacts.resources import NodeRelation, NodeVersion
+from dbt.artifacts.resources import NodeRelation, NodeVersion, FileHash
 from dbt.artifacts.schemas.base import Writable
 from dbt.exceptions import (
     TargetNotFoundError,

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -79,7 +79,7 @@ from dbt.context.docs import generate_runtime_docs_context
 from dbt.context.macro_resolver import MacroResolver, TestMacroNamespace
 from dbt.context.configured import generate_macro_context
 from dbt.context.providers import ParseProvider, generate_runtime_macro_context
-from dbt.contracts.files import ParseFileType, SchemaSourceFile
+from dbt.contracts.files import FileHash, ParseFileType, SchemaSourceFile
 from dbt.parser.read_files import (
     ReadFilesFromFileSystem,
     load_source_file,
@@ -107,7 +107,7 @@ from dbt.contracts.graph.nodes import (
     ResultNode,
     ModelNode,
 )
-from dbt.artifacts.resources import NodeRelation, NodeVersion, FileHash
+from dbt.artifacts.resources import NodeRelation, NodeVersion
 from dbt.artifacts.schemas.base import Writable
 from dbt.exceptions import (
     TargetNotFoundError,
@@ -401,15 +401,13 @@ class ManifestLoader:
                         )
                     )
 
-                    # Get traceback info
                     tb_info = traceback.format_exc()
-                    formatted_lines = tb_info.splitlines()
-                    (_, line, method) = formatted_lines[-3].split(", ")
+                    tb_last_frame = traceback.extract_tb(exc.__traceback__)[-1]
                     exc_info = {
                         "traceback": tb_info,
-                        "exception": formatted_lines[-1],
-                        "code": formatted_lines[-2],
-                        "location": f"{line} {method}",
+                        "exception": tb_info.splitlines()[-1],
+                        "code": tb_last_frame.line,  # if the source is not available, it is None.
+                        "location": f"line {tb_last_frame.lineno} in {tb_last_frame.name}",
                     }
 
                     # get file info for local logs

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -270,6 +270,7 @@ class ManifestLoader:
         # have been enabled, but not happening because of some issue.
         self.partially_parsing = False
         self.partial_parser: Optional[PartialParsing] = None
+        self.skip_parsing = False
 
         # This is a saved manifest from a previous run that's used for partial parsing
         self.saved_manifest: Optional[Manifest] = self.read_manifest_for_partial_parse()
@@ -374,71 +375,15 @@ class ManifestLoader:
         self._perf_info.path_count = len(self.manifest.files)
         self._perf_info.read_files_elapsed = time.perf_counter() - start_read_files
 
-        skip_parsing = False
-        if self.saved_manifest is not None:
-            self.partial_parser = PartialParsing(self.saved_manifest, self.manifest.files)
-            skip_parsing = self.partial_parser.skip_parsing()
-            if skip_parsing:
-                # nothing changed, so we don't need to generate project_parser_files
-                self.manifest = self.saved_manifest
-            else:
-                # create child_map and parent_map
-                self.saved_manifest.build_parent_and_child_maps()
-                # create group_map
-                self.saved_manifest.build_group_map()
-                # files are different, we need to create a new set of
-                # project_parser_files.
-                try:
-                    project_parser_files = self.partial_parser.get_parsing_files()
-                    self.partially_parsing = True
-                    self.manifest = self.saved_manifest
-                except Exception as exc:
-                    # pp_files should still be the full set and manifest is new manifest,
-                    # since get_parsing_files failed
-                    fire_event(
-                        UnableToPartialParse(
-                            reason="an error occurred. Switching to full reparse."
-                        )
-                    )
-
-                    # Get traceback info
-                    tb_info = traceback.format_exc()
-                    # index last stack frame in traceback (i.e. lastest exception and its context)
-                    tb_last_frame = traceback.extract_tb(exc.__traceback__)[-1]
-                    exc_info = {
-                        "traceback": tb_info,
-                        "exception": tb_info.splitlines()[-1],
-                        "code": tb_last_frame.line,  # if the source is not available, it is None
-                        "location": f"line {tb_last_frame.lineno} in {tb_last_frame.name}",
-                    }
-
-                    # get file info for local logs
-                    parse_file_type: str = ""
-                    file_id = self.partial_parser.processing_file
-                    if file_id:
-                        source_file = None
-                        if file_id in self.saved_manifest.files:
-                            source_file = self.saved_manifest.files[file_id]
-                        elif file_id in self.manifest.files:
-                            source_file = self.manifest.files[file_id]
-                        if source_file:
-                            parse_file_type = source_file.parse_file_type
-                            fire_event(PartialParsingErrorProcessingFile(file=file_id))
-                    exc_info["parse_file_type"] = parse_file_type
-                    fire_event(PartialParsingError(exc_info=exc_info))
-
-                    # Send event
-                    if dbt.tracking.active_user is not None:
-                        exc_info["full_reparse_reason"] = ReparseReason.exception
-                        dbt.tracking.track_partial_parser(exc_info)
-
-                    if os.environ.get("DBT_PP_TEST"):
-                        raise exc
+        self.skip_parsing = False
+        project_parser_files = self.safe_update_project_parser_files_partially(
+            project_parser_files
+        )
 
         if self.manifest._parsing_info is None:
             self.manifest._parsing_info = ParsingInfo()
 
-        if skip_parsing:
+        if self.skip_parsing:
             fire_event(PartialParsingSkipParsing())
         else:
             # Load Macros and tests
@@ -556,7 +501,7 @@ class ManifestLoader:
 
         # Inject any available external nodes, reprocess refs if changes to the manifest were made.
         external_nodes_modified = False
-        if skip_parsing:
+        if self.skip_parsing:
             # If we didn't skip parsing, this will have already run because it must run
             # before process_refs. If we did skip parsing, then it's possible that only
             # external nodes have changed and we need to run this to capture that.
@@ -570,13 +515,75 @@ class ManifestLoader:
                 )
                 # parent and child maps will be rebuilt by write_manifest
 
-        if not skip_parsing or external_nodes_modified:
+        if not self.skip_parsing or external_nodes_modified:
             # write out the fully parsed manifest
             self.write_manifest_for_partial_parse()
 
         self.check_for_model_deprecations()
 
         return self.manifest
+
+    def safe_update_project_parser_files_partially(self, project_parser_files: Dict) -> Dict:
+        if self.saved_manifest is None:
+            return project_parser_files
+
+        self.partial_parser = PartialParsing(self.saved_manifest, self.manifest.files)  # type: ignore[arg-type]
+        self.skip_parsing = self.partial_parser.skip_parsing()
+        if self.skip_parsing:
+            # nothing changed, so we don't need to generate project_parser_files
+            self.manifest = self.saved_manifest  # type: ignore[assignment]
+        else:
+            # create child_map and parent_map
+            self.saved_manifest.build_parent_and_child_maps()  # type: ignore[union-attr]
+            # create group_map
+            self.saved_manifest.build_group_map()  # type: ignore[union-attr]
+            # files are different, we need to create a new set of
+            # project_parser_files.
+            try:
+                project_parser_files = self.partial_parser.get_parsing_files()
+                self.partially_parsing = True
+                self.manifest = self.saved_manifest  # type: ignore[assignment]
+            except Exception as exc:
+                # pp_files should still be the full set and manifest is new manifest,
+                # since get_parsing_files failed
+                fire_event(
+                    UnableToPartialParse(reason="an error occurred. Switching to full reparse.")
+                )
+
+                # Get traceback info
+                tb_info = traceback.format_exc()
+                # index last stack frame in traceback (i.e. lastest exception and its context)
+                tb_last_frame = traceback.extract_tb(exc.__traceback__)[-1]
+                exc_info = {
+                    "traceback": tb_info,
+                    "exception": tb_info.splitlines()[-1],
+                    "code": tb_last_frame.line,  # if the source is not available, it is None
+                    "location": f"line {tb_last_frame.lineno} in {tb_last_frame.name}",
+                }
+
+                # get file info for local logs
+                parse_file_type: str = ""
+                file_id = self.partial_parser.processing_file
+                if file_id:
+                    source_file = None
+                    if file_id in self.saved_manifest.files:
+                        source_file = self.saved_manifest.files[file_id]
+                    elif file_id in self.manifest.files:
+                        source_file = self.manifest.files[file_id]
+                    if source_file:
+                        parse_file_type = source_file.parse_file_type
+                        fire_event(PartialParsingErrorProcessingFile(file=file_id))
+                exc_info["parse_file_type"] = parse_file_type
+                fire_event(PartialParsingError(exc_info=exc_info))
+                # Send event
+                if dbt.tracking.active_user is not None:
+                    exc_info["full_reparse_reason"] = ReparseReason.exception
+                    dbt.tracking.track_partial_parser(exc_info)
+
+                if os.environ.get("DBT_PP_TEST"):
+                    raise exc
+
+        return project_parser_files
 
     def check_for_model_deprecations(self):
         for node in self.manifest.nodes.values():

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -401,12 +401,14 @@ class ManifestLoader:
                         )
                     )
 
+                    # Get traceback info
                     tb_info = traceback.format_exc()
+                    # index last stack frame in traceback (i.e. lastest exception and its context)
                     tb_last_frame = traceback.extract_tb(exc.__traceback__)[-1]
                     exc_info = {
                         "traceback": tb_info,
                         "exception": tb_info.splitlines()[-1],
-                        "code": tb_last_frame.line,  # if the source is not available, it is None.
+                        "code": tb_last_frame.line,  # if the source is not available, it is None
                         "location": f"line {tb_last_frame.lineno} in {tb_last_frame.name}",
                     }
 

--- a/tests/unit/test_parse_manifest.py
+++ b/tests/unit/test_parse_manifest.py
@@ -121,3 +121,46 @@ class TestPartialParse(unittest.TestCase):
         ManifestLoader(mock_project, {})
         # if specified in flags, we use the specified path
         patched_open.assert_called_with("specified_partial_parse_path", "rb")
+
+
+class TestFailedPartialParse(unittest.TestCase):
+    @patch("dbt.tracking.track_partial_parser")
+    @patch("dbt.tracking.active_user")
+    @patch("dbt.parser.manifest.PartialParsing")
+    @patch("dbt.parser.manifest.ManifestLoader.read_manifest_for_partial_parse")
+    @patch("dbt.parser.manifest.ManifestLoader.build_manifest_state_check")
+    def test_partial_parse_safe_update_project_parser_files_partially(
+        self,
+        patched_state_check,
+        patched_read_manifest_for_partial_parse,
+        patched_partial_parsing,
+        patched_active_user,
+        patched_track_partial_parser,
+    ):
+        mock_instance = MagicMock()
+        mock_instance.skip_parsing.return_value = False
+        mock_instance.get_parsing_files.side_effect = KeyError("Whoopsie!")
+        patched_partial_parsing.return_value = mock_instance
+
+        mock_project = MagicMock(RuntimeConfig)
+        mock_project.project_target_path = "mock_target_path"
+
+        mock_saved_manifest = MagicMock(Manifest)
+        mock_saved_manifest.files = {}
+        patched_read_manifest_for_partial_parse.return_value = mock_saved_manifest
+
+        set_from_args(Namespace(), {})
+        loader = ManifestLoader(mock_project, {})
+        loader.safe_update_project_parser_files_partially({})
+
+        patched_track_partial_parser.assert_called_once()
+        exc_info = patched_track_partial_parser.call_args[0][0]
+        self.assertIn("traceback", exc_info)
+        self.assertIn("exception", exc_info)
+        self.assertIn("code", exc_info)
+        self.assertIn("location", exc_info)
+        self.assertIn("full_reparse_reason", exc_info)
+        self.assertEqual("KeyError: 'Whoopsie!'", exc_info["exception"])
+        self.assertTrue(
+            isinstance(exc_info["code"], str) or isinstance(exc_info["code"], type(None))
+        )


### PR DESCRIPTION
Resolves #9570 


### Problem

Given that:
1. The user has a valid unit test definition using csv fixtures
2. The user stores the csv fixtures under `tests/fixtures` directory
3. The execution of  `dbt build` succeeds (`target/manifest.json` is created)
4. The execution of  `dbt test` also succeeds
5. The user moves the csv fixtures to a subdirectory, such as `tests/fixtures/my_model` 

Then:
When the user attempts to run once more  `dbt test`  the execution fails with an unexpected error, like:
```
 File "/path/to/my/site-packages/dbt/parser/manifest.py", line 407, in load
    (_, line, method) = formatted_lines[-3].split(", ")
    ^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 3, got 1)
```

--
Although at first glance, this looked to me like the `PartialParsing` class was not doing a good job at detecting changes or deleting fixture nodes in-between compilations, after further testing I managed to reproduce the issue in two different scenarios:
* When the csv fixtures are moved to a subdirectory.
* When the csv fixtures are initially located in subdirectories but then are pulled up to `test/fixtures`.  

So the issue is somewhat more general than was originally reported. That leads me to believe is rather related to the logic that triggers partial parsing and what happens after that logic exits, e.g. error handling within the `ManifestLoader` class.  In said class,  the traceback is being parsed under the assumption that frames in the stack conform to an strict format:
https://github.com/dbt-labs/dbt-core/blob/e4fe839e4574187b574473596a471092267a9f2e/core/dbt/parser/manifest.py#L407

However, in this particular case the assumption does not seem to hold, plausibly due to the exception type, how/where it was thrown, or even the presence of extra newline ('\n') or caret ('^') characters in the traceback. As a result, the exception is not gracefully caught.

In this state, the user is left with only a few options, with the easier ones perhaps being:
a) Run `dbt clean` before proceeding (to trick the `ManifestLoader`  into skipping partial parsing altogether) 
b) Move the csv fixture back to their original directory — needless to say, a downgrade of the feature scope
 
### Solution

Instead of making too many assumptions about what the  `traceback.format_exc()` statement in [line 405](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/parser/manifest.py#L405) could return (in regard to list item order or string content and form), I am suggesting to change the `ManifestLoader` to use `Exception` object attributes and `traceback`  object functions/attributes to zero-in on the last frame in the stack of the traceback, and extract from it the last exception details, i.e. the values of `code`,  `line` and `method`  that should be added to the [exc_info](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/parser/manifest.py#L408) dictionary for graceful exception catching and logging.

I argue this should be a safer alternative to adding some additional logic like if-else statements and string comparisons to deal with edge-cases where extra newlines or caret characters are present or missing.

The approach does not affect any function API either, and the content of the [exc_info](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/parser/manifest.py#L408) dictionary is filled as I believe it should, something along the lines of:
```python
# example evaluation of  `exc_info` dictionary in line 408 of manifest.py
exc_info = {
    "traceback": """Traceback (most recent call last):
      File "/path/to/my/site-packages/dbt-core/core/dbt/parser/manifest.py", line 398, in load

      ...

      unit_test = self.saved_manifest.unit_tests.pop(unique_id)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      KeyError: 'unit_test.my_dbt_project.my_model.test_is_valid_email_address'""",
    "exception": "KeyError: 'unit_test.my_dbt_project.my_model.test_is_valid_email_address'", 
    "code": "    unit_test = self.saved_manifest.unit_tests.pop(unique_id)", 
    "location": "line 616 in delete_fixture_node"
}
```

Last but not least, with the code changes I suggest, the user can of now freely move the csv fixture to subdirectories or out of them, since whenever partial parsing runs and fails due to a fixture node no longer existing, any exception traceback would be properly parsed and full parsing will kick in to ensure a working `manifest.json` is created as part of the unit test execution.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions

### Additional Context
* I debugged, developed and successfully tested integration with help of the `postgresql` adapter.
*  After code changes where staged, `make test` and `pre-commit run` were successfully executed.
*  My development dbt project structure looks like:
```
.
├── dbt_project.yml
├── models
│   ├── my_model.sql
│   ├── my_model.yml
│   ├── top_level_domains.sql
│   ├── top_level_domains.yml
│   ├── unit_test.yml
│   ├── users.sql
│   └── users.yml
├── profiles.yml
└── tests
    └── fixtures
        ├── my_model_mock_output.csv
        ├── top_level_domains_mock_input.csv
        └── users_mock_input.csv
```
* The development `my_model.sql` definition I used:
```sql
select
  users.user_id,
  users.email,
  case
    when regexp_like(users.email,'^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$') = true
      and accepted_email_domains.tld is not null
        then true
     else false
  end as is_valid_email_address
from {{ ref('users')}} users
left join {{ ref('top_level_domains') }} accepted_email_domains
on users.email_top_level_domain = lower(accepted_email_domains.tld)
```
* The development `unit_test.yml` definition I used:
```yaml
unit_tests:
  - name: test_is_valid_email_address
    model: my_model
    given:
      - input: ref('users')
        format: csv
        fixture: users_mock_input
      - input: ref('top_level_domains')
        format: csv
        fixture: top_level_domains_mock_input
    expect:
      format: csv
      fixture: my_model_mock_output
```