### PR TITLE
Stop trying to parse deleted schema files

### DIFF
--- a/.changes/unreleased/Fixes-20240301-135536.yaml
+++ b/.changes/unreleased/Fixes-20240301-135536.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix partial parsing `KeyError` on deleted schema files
+time: 2024-03-01T13:55:36.533176-08:00
+custom:
+  Author: QMalcolm
+  Issue: "8860"

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -467,7 +467,11 @@ class PartialParsing:
 
     def _schedule_for_parsing(self, dict_key: str, element, name, delete: Callable) -> None:
         file_id = element.file_id
-        if file_id in self.saved_files and file_id not in self.file_diff["deleted"]:
+        if (
+            file_id in self.saved_files
+            and file_id not in self.file_diff["deleted"]
+            and file_id not in self.file_diff["deleted_schema_files"]
+        ):
             schema_file = self.saved_files[file_id]
             elements = []
             assert isinstance(schema_file, SchemaSourceFile)

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -211,6 +211,7 @@ class PartialParsing:
         if (
             file_id not in self.project_parser_files[project_name][parser_name]
             and file_id not in self.file_diff["deleted"]
+            and file_id not in self.file_diff["deleted_schema_files"]
         ):
             self.project_parser_files[project_name][parser_name].append(file_id)
 

--- a/tests/functional/partial_parsing/fixtures.py
+++ b/tests/functional/partial_parsing/fixtures.py
@@ -452,6 +452,60 @@ semantic_models:
       agg_time_dimension: created_at
 """
 
+people_sl_yml = """
+version: 2
+
+semantic_models:
+  - name: semantic_people
+    model: ref('people')
+    dimensions:
+      - name: favorite_color
+        type: categorical
+      - name: created_at
+        type: TIME
+        type_params:
+          time_granularity: day
+    measures:
+      - name: years_tenure
+        agg: SUM
+        expr: tenure
+      - name: people
+        agg: count
+        expr: id
+    entities:
+      - name: id
+        type: primary
+    defaults:
+      agg_time_dimension: created_at
+
+metrics:
+
+  - name: number_of_people
+    description: Total count of people
+    label: "Number of people"
+    type: simple
+    type_params:
+      measure: people
+    meta:
+        my_meta: 'testing'
+
+  - name: collective_tenure
+    description: Total number of years of team experience
+    label: "Collective tenure"
+    type: simple
+    type_params:
+      measure:
+        name: years_tenure
+        filter: "{{ Dimension('id__loves_dbt') }} is true"
+
+  - name: average_tenure
+    label: Average Tenure
+    type: ratio
+    type_params:
+      numerator: collective_tenure
+      denominator: number_of_people
+"""
+
 env_var_metrics_yml = """
 
 metrics:


### PR DESCRIPTION
resolves #8860

### Problem

Waaaay back (in https://github.com/dbt-labs/dbt-core/commit/7563b997c2a595ef0c4ddc13ca72955d2d988953) deleted schema files started being separated out from deleted non-schema files. However, ever since when it came to scheduling files for re-parsing, we've only done so for deleted non-schema files. We even missed this when we refactored the scheduling code in https://github.com/dbt-labs/dbt-core/commit/b37e5b5198036cfcd2c3cf611f75d0d8be5456ac. This means when schema files got deleted and then the project went through partial parsing, you were likely to see an error like the following
```
05:53:11 Traceback (most recent call last):
  File "/venv/dbt-1.6.0-latest/lib/python3.8/site-packages/dbt/cli/requires.py", line 87, in wrapper
    result, success = func(*args, **kwargs)
  File "/venv/dbt-1.6.0-latest/lib/python3.8/site-packages/dbt/cli/requires.py", line 72, in wrapper
    return func(*args, **kwargs)
  File "/venv/dbt-1.6.0-latest/lib/python3.8/site-packages/dbt/cli/requires.py", line 143, in wrapper
    return func(*args, **kwargs)
  File "/venv/dbt-1.6.0-latest/lib/python3.8/site-packages/dbt/cli/requires.py", line 172, in wrapper
    return func(*args, **kwargs)
  File "/venv/dbt-1.6.0-latest/lib/python3.8/site-packages/dbt/cli/requires.py", line 219, in wrapper
    return func(*args, **kwargs)
  File "/venv/dbt-1.6.0-latest/lib/python3.8/site-packages/dbt/cli/requires.py", line 246, in wrapper
    manifest = ManifestLoader.get_full_manifest(
  File "/venv/dbt-1.6.0-latest/lib/python3.8/site-packages/dbt/parser/manifest.py", line 316, in get_full_manifest
    manifest = loader.load()
  File "/venv/dbt-1.6.0-latest/lib/python3.8/site-packages/dbt/parser/manifest.py", line 492, in load
    self.parse_project(
  File "/venv/dbt-1.6.0-latest/lib/python3.8/site-packages/dbt/parser/manifest.py", line 659, in parse_project
    block = FileBlock(self.manifest.files[file_id])
KeyError: 'salesforce_opportunity://models/marts/core/metrics.yml'
```
We've over the years added more things you could define in schema files, which in turn means schema files have been changing (and getting deleted) more frequently. Thus we've been seeing this error crop up more and more.

### Solution

Not scheduling deleted schema files for parsing (like we've always been doing for deleted non-schema files)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
