### PR TITLE
Remove duplicate dependencies already specified in dbt-common

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -47,12 +47,6 @@ setup(
     },
     install_requires=[
         # ----
-        # dbt-core uses these packages deeply, throughout the codebase, and there have been breaking changes in past patch releases (even though these are major-version-one).
-        # Pin to the patch or minor version, and bump in each new minor version of dbt-core.
-        "agate>=1.7.0,<1.8",
-        "Jinja2>=3.1.3,<4",
-        "mashumaro[msgpack]>=3.9,<4.0",
-        # ----
         # Legacy: This package has not been updated since 2019, and it is unused in dbt's logging system (since v1.0)
         # The dependency here will be removed along with the removal of 'legacy logging', in a future release of dbt-core
         "logbook>=1.5,<1.6",
@@ -61,11 +55,9 @@ setup(
         # with major versions in each new minor version of dbt-core.
         "click>=8.0.2,<9.0",
         "networkx>=2.3,<4.0",
-        "requests<3.0.0",  # should match dbt-common
         # ----
         # These packages are major-version-0. Keep upper bounds on upcoming minor versions (which could have breaking changes)
         # and check compatibility / bump in each new minor version of dbt-core.
-        "pathspec>=0.9,<0.12",
         "sqlparse>=0.2.3,<0.5",
         # ----
         # These are major-version-0 packages also maintained by dbt-labs.
@@ -79,11 +71,9 @@ setup(
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
         "packaging>20.9",
-        "protobuf>=4.0.0,<5",
         "pytz>=2015.7",
         "pyyaml>=6.0",
         "daff>=1.3.46",
-        "typing-extensions>=4.4",
         # ----
     ],
     zip_safe=False,


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-common/issues/14

### Problem

Remove duplicate dependencies between `dbt-common` and `dbt-core`.
 
### Solution

Analysis here: https://docs.google.com/spreadsheets/d/1vl8-kFEk6z_xEpzh5tmtTRuYaMGmV22V9ZnrFDJuvfo/edit?usp=sharing

We can safely remove the `agate`, `Jinja2`, `mashumaro[msgpack]`, `requests`, `pathspec`, `protobuf`, `typing-extensions` dependencies in `dbt-core` since these should now come in transitively via `dbt-common`.

My idea here is to keep `dbt-common` as the single source of truth for dependencies, since every dependency required in `dbt-common` is also required in `dbt-core` (except maybe `typing-extensions`).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
