### PR TITLE
Scrub secret vars

### DIFF
--- a/.changes/unreleased/Features-20240307-153622.yaml
+++ b/.changes/unreleased/Features-20240307-153622.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support scrubbing secret vars
+time: 2024-03-07T15:36:22.754627+01:00
+custom:
+  Author: nielspardon
+  Issue: "7247"

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -17,6 +17,8 @@ from dbt.node_types import NodeType, AccessType, REFABLE_NODE_TYPES
 
 from dbt_common.dataclass_schema import ValidationError
 
+from dbt.constants import SECRET_ENV_PREFIX
+
 
 if TYPE_CHECKING:
     import agate
@@ -333,7 +335,10 @@ class RequiredVarNotFoundError(CompilationError):
         pretty_vars = json.dumps(dct, sort_keys=True, indent=4)
 
         msg = f"Required var '{self.var_name}' not found in config:\nVars supplied to {node_name} = {pretty_vars}"
-        return msg
+        return scrub_secrets(msg, self.var_secrets())
+
+    def var_secrets(self) -> List[str]:
+        return [v for k, v in self.merged.items() if k.startswith(SECRET_ENV_PREFIX) and v.strip()]
 
 
 class PackageNotFoundForMacroError(CompilationError):

--- a/tests/unit/test_parse_manifest.py
+++ b/tests/unit/test_parse_manifest.py
@@ -108,7 +108,7 @@ class TestLoader(unittest.TestCase):
 class TestPartialParse(unittest.TestCase):
     def setUp(self) -> None:
         mock_project = MagicMock(RuntimeConfig)
-        mock_project.cli_vars = ""
+        mock_project.cli_vars = {}
         mock_project.args = MagicMock()
         mock_project.args.profile = "test"
         mock_project.args.target = "test"


### PR DESCRIPTION
resolves #7247 


### Problem

Currently, dbt only supports secret env variables and only scrubs the values of those secret env variables from log messages. Secret variables being provided via the `--vars` flag are not being scrubbed and the plaintext values appear in a couple of places.

### Solution

With this PR secret variables being provided via the `--vars` flag are also scrubbed just like env variables reusing the same prefix as for env variables.

- Scrubs secret vars in RequiredVarNotFoundError
- Scrubs secret vars in StateCheckVarsHash event
- Scrubs secret vars in run results

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
