### PR TITLE
Fix listing saved queries

### DIFF
--- a/.changes/unreleased/Fixes-20240307-142459.yaml
+++ b/.changes/unreleased/Fixes-20240307-142459.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Support saved queries in `dbt list`
+time: 2024-03-07T14:24:59.530072-05:00
+custom:
+  Author: QMalcolm jtcohen6
+  Issue: "9532"

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -397,6 +397,7 @@ resource_type = click.option(
         [
             "metric",
             "semantic_model",
+            "saved_query",
             "source",
             "analysis",
             "model",

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -4,6 +4,7 @@ from dbt.contracts.graph.nodes import (
     Exposure,
     SourceDefinition,
     Metric,
+    SavedQuery,
     SemanticModel,
     UnitTestDefinition,
 )
@@ -31,6 +32,7 @@ class ListTask(GraphRunnableTask):
             NodeType.Source,
             NodeType.Exposure,
             NodeType.Metric,
+            NodeType.SavedQuery,
             NodeType.SemanticModel,
             NodeType.Unit,
         )
@@ -83,6 +85,8 @@ class ListTask(GraphRunnableTask):
                 yield self.manifest.semantic_models[unique_id]
             elif unique_id in self.manifest.unit_tests:
                 yield self.manifest.unit_tests[unique_id]
+            elif unique_id in self.manifest.saved_queries:
+                yield self.manifest.saved_queries[unique_id]
             else:
                 raise DbtRuntimeError(
                     f'Got an unexpected result from node selection: "{unique_id}"'
@@ -106,6 +110,10 @@ class ListTask(GraphRunnableTask):
                 # metrics are searched for by pkg.metric_name
                 metric_selector = ".".join([node.package_name, node.name])
                 yield f"metric:{metric_selector}"
+            elif node.resource_type == NodeType.SavedQuery:
+                assert isinstance(node, SavedQuery)
+                saved_query_selector = ".".join([node.package_name, node.name])
+                yield f"saved_query:{saved_query_selector}"
             elif node.resource_type == NodeType.SemanticModel:
                 assert isinstance(node, SemanticModel)
                 semantic_model_selector = ".".join([node.package_name, node.name])

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -90,7 +90,7 @@ class ListTask(GraphRunnableTask):
             else:
                 raise DbtRuntimeError(
                     f'Got an unexpected result from node selection: "{unique_id}"'
-                    f"Expected a source or a node!"
+                    f"Listing this node type is not yet supported!"
                 )
 
     def generate_selectors(self):

--- a/tests/functional/list/fixtures.py
+++ b/tests/functional/list/fixtures.py
@@ -145,6 +145,24 @@ metrics:
 """
 
 
+saved_queries__sq_yml = """
+saved_queries:
+  - name: my_saved_query
+    label: My Saved Query
+    query_params:
+        metrics:
+            - total_outer
+        group_by:
+            - "Dimension('my_entity__created_at')"
+    exports:
+        - name: my_export
+          config:
+            alias: my_export_alias
+            export_as: table
+            schema: my_export_schema_name
+"""
+
+
 @pytest.fixture(scope="class")
 def snapshots():
     return {"snapshot.sql": snapshots__snapshot_sql}
@@ -164,6 +182,7 @@ def models():
         "docs.md": models__docs_md,
         "outer.sql": models__outer_sql,
         "metricflow_time_spine.sql": models__metric_flow,
+        "sq.yml": saved_queries__sq_yml,
         "sm.yml": semantic_models__sm_yml,
         "m.yml": metrics__m_yml,
         "sub": {"inner.sql": models__sub__inner_sql},
@@ -193,6 +212,11 @@ def semantic_models():
 @pytest.fixture(scope="class")
 def metrics():
     return {"m.yml": metrics__m_yml}
+
+
+@pytest.fixture(scope="class")
+def saved_queries():
+    return {"sq.yml": saved_queries__sq_yml}
 
 
 @pytest.fixture(scope="class")

--- a/tests/functional/list/test_list.py
+++ b/tests/functional/list/test_list.py
@@ -14,6 +14,7 @@ from tests.functional.list.fixtures import (  # noqa: F401
     analyses,
     semantic_models,
     metrics,
+    saved_queries,
     project_files,
 )
 
@@ -596,6 +597,7 @@ class TestList:
             "test.t",
             "semantic_model:test.my_sm",
             "metric:test.total_outer",
+            "saved_query:test.my_saved_query",
         }
         # analyses have their type inserted into their fqn like tests
         expected_all = expected_default | {"test.analysis.a"}
@@ -625,6 +627,9 @@ class TestList:
 
         results = self.run_dbt_ls(["--resource-type", "metric"])
         assert set(results) == {"metric:test.total_outer"}
+
+        results = self.run_dbt_ls(["--resource-type", "saved_query"])
+        assert set(results) == {"saved_query:test.my_saved_query"}
 
         results = self.run_dbt_ls(["--resource-type", "model", "--select", "outer+"])
         assert set(results) == {"test.outer", "test.sub.inner"}


### PR DESCRIPTION
resolves #9532

### Problem

SavedQuery nodes weren't showing up in `dbt list`

### Solution

Add `saved_query` as a `resource_type` option and ensure they are looked up / iterated over in `list.py`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
