### PR TITLE
Fix #9117: Bump version of dbt-semantic-interfaces

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -72,7 +72,7 @@ setup(
         # Accept patches but avoid automatically updating past a set minor version range.
         "dbt-extractor>=0.5.0,<=0.6",
         "minimal-snowplow-tracker>=0.0.2,<0.1",
-        "dbt-semantic-interfaces>=0.5.0a2,<0.6",
+        "dbt-semantic-interfaces>=0.5.0,<0.6",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common<2.0",
         "dbt-adapters>=0.1.0a2,<2.0",


### PR DESCRIPTION
resolves #9117 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

We want to not be on a pre-release version of dbt-semantic-interfaces when we cut the production release of dbt-core `1.8.0`

### Solution

Exclude pre-lease versions of dbt-semantic-interfaces in the setup.py

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
