### PR TITLE
Fix #9511: Handle exceptions for failing `on-run-*` hooks in `source freshness`

### DIFF
--- a/.changes/unreleased/Fixes-20240316-231152.yaml
+++ b/.changes/unreleased/Fixes-20240316-231152.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Handle exceptions for failing on-run-* hooks in source freshness
+time: 2024-03-16T23:11:52.819014-07:00
+custom:
+  Author: aranke
+  Issue: "9511"

--- a/core/dbt/artifacts/schemas/freshness/v3/freshness.py
+++ b/core/dbt/artifacts/schemas/freshness/v3/freshness.py
@@ -107,7 +107,11 @@ class FreshnessExecutionResultArtifact(
 
     @classmethod
     def from_result(cls, base: FreshnessResult):
-        processed = [process_freshness_result(r) for r in base.results]
+        processed = [
+            process_freshness_result(r)
+            for r in base.results
+            if isinstance(r, SourceFreshnessResult)
+        ]
         return cls(
             metadata=base.metadata,
             results=processed,

--- a/tests/functional/sources/test_source_freshness.py
+++ b/tests/functional/sources/test_source_freshness.py
@@ -430,6 +430,44 @@ class TestHooksInSourceFreshness(SuccessfulSourceFreshnessTest):
         assert "on-run-end" in log_output
 
 
+class TestHooksInSourceFreshnessError:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": error_models_schema_yml,
+            "model.sql": error_models_model_sql,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "config-version": 2,
+            "on-run-start": ["select fake_column from table_does_not_exist"],
+            "flags": {
+                "source_freshness_run_project_hooks": True,
+            },
+        }
+
+    def test_hooks_do_not_run_for_source_freshness(
+        self,
+        project,
+    ):
+        run_result_error = None
+
+        def run_result_error_probe(e):
+            nonlocal run_result_error
+            if (
+                e.info.name == "RunResultError"
+                and e.info.level == "error"
+                and "on-run-start" in e.info.msg
+            ):
+                run_result_error = e.info.msg
+
+        runner = dbtRunner(callbacks=[run_result_error_probe])
+        runner.invoke(["source", "freshness"])
+        assert 'relation "table_does_not_exist" does not exist' in run_result_error
+
+
 class TestHooksInSourceFreshnessDisabled(SuccessfulSourceFreshnessTest):
     @pytest.fixture(scope="class")
     def project_config_update(self):


### PR DESCRIPTION
resolves #9511 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

`on-run-*` hooks were not handled in `source freshness`, leading to an `AttributeError` being thrown

### Solution

If a hook fails, re-raise the exception as a `DbtRuntimeError`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development, and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
