### PR TITLE
Fix #9593: Validation of unit test parsing for incremental models

### DIFF
--- a/.changes/unreleased/Fixes-20240317-005611.yaml
+++ b/.changes/unreleased/Fixes-20240317-005611.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: ' Validation of unit test parsing for incremental models'
+time: 2024-03-17T00:56:11.855232-07:00
+custom:
+  Author: aranke
+  Issue: "9593"

--- a/.changes/unreleased/Fixes-20240317-005611.yaml
+++ b/.changes/unreleased/Fixes-20240317-005611.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: ' Validation of unit test parsing for incremental models'
+body: 'Validation of unit test parsing for incremental models'
 time: 2024-03-17T00:56:11.855232-07:00
 custom:
   Author: aranke

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -420,7 +420,6 @@ def find_tested_model_node(
 def process_models_for_unit_test(
     manifest: Manifest, current_project: str, unit_test_def: UnitTestDefinition, models_to_versions
 ):
-
     # If the unit tests doesn't have a depends_on.nodes[0] then we weren't able to resolve
     # the model, either because versions hadn't been processed yet, or it's not a valid model name
     if not unit_test_def.depends_on.nodes:
@@ -438,6 +437,31 @@ def process_models_for_unit_test(
     target_model_id = unit_test_def.depends_on.nodes[0]
     target_model = manifest.nodes[target_model_id]
     assert isinstance(target_model, ModelNode)
+
+    target_model_is_incremental = "macro.dbt.is_incremental" in target_model.depends_on.macros
+    unit_test_def_has_incremental_override = unit_test_def.overrides and isinstance(
+        unit_test_def.overrides.macros.get("is_incremental"), bool
+    )
+
+    if target_model_is_incremental and (not unit_test_def_has_incremental_override):
+        raise ParsingError(
+            f"Boolean override for 'is_incremental' must be provided for unit testing model '{target_model.name}'"
+        )
+
+    unit_test_def_incremental_override_true = (
+        unit_test_def.overrides and unit_test_def.overrides.macros.get("is_incremental")
+    )
+    unit_test_def_has_this_input = "this" in [i.input for i in unit_test_def.given]
+
+    if (
+        target_model_is_incremental
+        and unit_test_def_incremental_override_true
+        and (not unit_test_def_has_this_input)
+    ):
+        raise ParsingError(
+            f"Unit test '{unit_test_def.name}' for incremental model '{target_model.name}' must have a 'this' input"
+        )
+
     # unit_test_versions = unit_test_def.versions
     # We're setting up unit tests for versioned models, so if
     # the model isn't versioned, we don't need to do anything

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -445,7 +445,7 @@ def process_models_for_unit_test(
 
     if target_model_is_incremental and (not unit_test_def_has_incremental_override):
         raise ParsingError(
-            f"Boolean override for 'is_incremental' must be provided for unit testing model '{target_model.name}'"
+            f"Boolean override for 'is_incremental' must be provided for unit test '{unit_test_def.name}' in model '{target_model.name}'"
         )
 
     unit_test_def_incremental_override_true = (

--- a/tests/functional/unit_testing/fixtures.py
+++ b/tests/functional/unit_testing/fixtures.py
@@ -266,7 +266,7 @@ where event_time > (select max(event_time) from {{ this }})
 {% endif %}
 """
 
-test_my_model_incremental_yml = """
+test_my_model_incremental_yml_basic = """
 unit_tests:
   - name: incremental_false
     model: my_incremental_model
@@ -294,6 +294,54 @@ unit_tests:
       - input: this
         rows:
           - {event_time: "2020-01-01", event: 1}
+    expect:
+      rows:
+        - {event_time: "2020-01-02", event: 2}
+        - {event_time: "2020-01-03", event: 3}
+"""
+
+test_my_model_incremental_yml_no_override = """
+unit_tests:
+  - name: incremental_false
+    model: my_incremental_model
+    given:
+      - input: ref('events')
+        rows:
+          - {event_time: "2020-01-01", event: 1}
+    expect:
+      rows:
+        - {event_time: "2020-01-01", event: 1}
+"""
+
+test_my_model_incremental_yml_wrong_override = """
+unit_tests:
+  - name: incremental_false
+    model: my_incremental_model
+    overrides:
+      macros:
+        is_incremental: foobar
+    given:
+      - input: ref('events')
+        rows:
+          - {event_time: "2020-01-01", event: 1}
+    expect:
+      rows:
+        - {event_time: "2020-01-01", event: 1}
+"""
+
+test_my_model_incremental_yml_no_this_input = """
+unit_tests:
+  - name: incremental_true
+    model: my_incremental_model
+    overrides:
+      macros:
+        is_incremental: true
+    given:
+      - input: ref('events')
+        rows:
+          - {event_time: "2020-01-01", event: 1}
+          - {event_time: "2020-01-02", event: 2}
+          - {event_time: "2020-01-03", event: 3}
     expect:
       rows:
         - {event_time: "2020-01-02", event: 2}

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -18,13 +18,16 @@ from fixtures import (  # noqa: F401
     datetime_test,
     my_incremental_model_sql,
     event_sql,
-    test_my_model_incremental_yml,
+    test_my_model_incremental_yml_basic,
     test_my_model_yml_invalid,
     test_my_model_yml_invalid_ref,
     valid_emails_sql,
     top_level_domains_sql,
     external_package__accounts_seed_csv,
     external_package,
+    test_my_model_incremental_yml_no_override,
+    test_my_model_incremental_yml_wrong_override,
+    test_my_model_incremental_yml_no_this_input,
 )
 
 
@@ -109,13 +112,13 @@ class TestUnitTests:
             run_dbt(["run", "--no-partial-parse", "--select", "my_model"])
 
 
-class TestUnitTestIncrementalModel:
+class TestUnitTestIncrementalModelBasic:
     @pytest.fixture(scope="class")
     def models(self):
         return {
             "my_incremental_model.sql": my_incremental_model_sql,
             "events.sql": event_sql,
-            "test_my_incremental_model.yml": test_my_model_incremental_yml,
+            "schema.yml": test_my_model_incremental_yml_basic,
         }
 
     def test_basic(self, project):
@@ -125,6 +128,57 @@ class TestUnitTestIncrementalModel:
         # Select by model name
         results = run_dbt(["test", "--select", "my_incremental_model"], expect_pass=True)
         assert len(results) == 2
+
+
+class TestUnitTestIncrementalModelNoOverride:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_incremental_model.sql": my_incremental_model_sql,
+            "events.sql": event_sql,
+            "schema.yml": test_my_model_incremental_yml_no_override,
+        }
+
+    def test_no_override(self, project):
+        with pytest.raises(
+            ParsingError,
+            match="Boolean override for 'is_incremental' must be provided for unit testing model 'my_incremental_model'",
+        ):
+            run_dbt(["parse"])
+
+
+class TestUnitTestIncrementalModelWrongOverride:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_incremental_model.sql": my_incremental_model_sql,
+            "events.sql": event_sql,
+            "schema.yml": test_my_model_incremental_yml_wrong_override,
+        }
+
+    def test_str_override(self, project):
+        with pytest.raises(
+            ParsingError,
+            match="Boolean override for 'is_incremental' must be provided for unit testing model 'my_incremental_model'",
+        ):
+            run_dbt(["parse"])
+
+
+class TestUnitTestIncrementalModelNoThisInput:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_incremental_model.sql": my_incremental_model_sql,
+            "events.sql": event_sql,
+            "schema.yml": test_my_model_incremental_yml_no_this_input,
+        }
+
+    def test_no_this_input(self, project):
+        with pytest.raises(
+            ParsingError,
+            match="Unit test 'incremental_true' for incremental model 'my_incremental_model' must have a 'this' input",
+        ):
+            run_dbt(["parse"])
 
 
 my_new_model = """

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -142,7 +142,7 @@ class TestUnitTestIncrementalModelNoOverride:
     def test_no_override(self, project):
         with pytest.raises(
             ParsingError,
-            match="Boolean override for 'is_incremental' must be provided for unit testing model 'my_incremental_model'",
+            match="Boolean override for 'is_incremental' must be provided for unit test 'incremental_false' in model 'my_incremental_model'",
         ):
             run_dbt(["parse"])
 
@@ -159,7 +159,7 @@ class TestUnitTestIncrementalModelWrongOverride:
     def test_str_override(self, project):
         with pytest.raises(
             ParsingError,
-            match="Boolean override for 'is_incremental' must be provided for unit testing model 'my_incremental_model'",
+            match="Boolean override for 'is_incremental' must be provided for unit test 'incremental_false' in model 'my_incremental_model'",
         ):
             run_dbt(["parse"])
 


### PR DESCRIPTION
resolves #9593

### Problem

Unclear error message when `is_incremental` override wasn't specified for a unit test 

### Solution

Add parse-time errors when:
* unit testing an incremental model but not providing an override for is_incremental
* unit testing an incremental model overriding is_incremental: true but NOT providing an input for this

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
