### PR TITLE
Fix retry of a command with defer

### DIFF
--- a/.changes/unreleased/Fixes-20240318-153338.yaml
+++ b/.changes/unreleased/Fixes-20240318-153338.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix use of retry command on command using defer
+time: 2024-03-18T15:33:38.90058-04:00
+custom:
+  Author: gshank
+  Issue: "9770"

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -28,6 +28,7 @@ if os.name != "nt":
 FLAGS_DEFAULTS = {
     "INDIRECT_SELECTION": "eager",
     "TARGET_PATH": None,
+    "DEFER_STATE": None,  # necessary because of retry construction of flags
     "WARN_ERROR": None,
     # Cli args without project_flags or env var option.
     "FULL_REFRESH": False,

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -677,7 +677,7 @@ class GraphRunnableTask(ConfiguredTask):
             )
 
         if not state.manifest:
-            raise DbtRuntimeError(f'Could not find manifest in --state path: "{state}"')
+            raise DbtRuntimeError(f'Could not find manifest in --state path: "{state.state_path}"')
         return state.manifest
 
     def _get_deferred_manifest(self) -> Optional[Manifest]:

--- a/tests/functional/defer_state/test_defer_state.py
+++ b/tests/functional/defer_state/test_defer_state.py
@@ -305,6 +305,9 @@ class TestDeferStateFlag(BaseDeferState):
             expect_pass=False,
         )
 
+        # Test that retry of a defer command works
+        run_dbt(["retry"], expect_pass=False)
+
         # this will fail because we haven't passed in --state
         with pytest.raises(
             DbtRuntimeError, match="Got a state selector method, but no comparison manifest"

--- a/tests/unit/test_cli_flags.py
+++ b/tests/unit/test_cli_flags.py
@@ -394,10 +394,12 @@ class TestFlags:
         args_dict = {
             "print": True,
             "state": "some/path",
+            "defer_state": None,
         }
         result = self._create_flags_from_dict(Command.BUILD, args_dict)
         assert result.print is True
         assert "some/path" in str(result.state)
+        assert result.defer_state is None
 
     def test_from_dict__seed(self):
         args_dict = {"use_colors": False, "exclude": ["model_three"]}


### PR DESCRIPTION
resolves #9770

### Problem


Retry of a command that contained "defer" was failing with an error message: Could not find manifest in --state path:

### Solution


Include DEFER_STATE in the dictionary of args with defaults so that it won't change to PosixPath('None')

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
