### PR TITLE
Allow metrics in semantic layer filters

### DIFF
--- a/.changes/unreleased/Features-20240322-103124.yaml
+++ b/.changes/unreleased/Features-20240322-103124.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Allow metrics in semantic layer filters.
+time: 2024-03-22T10:31:24.76978-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "9804"

--- a/core/setup.py
+++ b/core/setup.py
@@ -73,7 +73,7 @@ setup(
         # Accept patches but avoid automatically updating past a set minor version range.
         "dbt-extractor>=0.5.0,<=0.6",
         "minimal-snowplow-tracker>=0.0.2,<0.1",
-        "dbt-semantic-interfaces>=0.5.0,<0.6",
+        "dbt-semantic-interfaces>=0.5.1,<0.6",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common<2.0",
         "dbt-adapters>=0.1.0a2,<2.0",

--- a/tests/functional/metrics/fixtures.py
+++ b/tests/functional/metrics/fixtures.py
@@ -88,6 +88,14 @@ metrics:
       metrics:
         - average_tenure
       expr: "average_tenure + 1"
+
+  - name: tenured_people
+    label: Tenured People
+    description: People who have been here more than 1 year
+    type: simple
+    type_params:
+      measure: people
+    filter: "{{ Metric('collective_tenure', ['id']) }} > 2"
 """
 
 metricflow_time_spine_sql = """

--- a/tests/functional/saved_queries/fixtures.py
+++ b/tests/functional/saved_queries/fixtures.py
@@ -17,6 +17,7 @@ saved_queries:
         where:
             - "{{ Dimension('user__ds', 'DAY') }} <= now()"
             - "{{ Dimension('user__ds', 'DAY') }} >= '2023-01-01'"
+            - "{{ Metric('txn_revenue', ['id']) }} > 1"
     exports:
         - name: my_export
           config:

--- a/tests/functional/saved_queries/test_saved_query_parsing.py
+++ b/tests/functional/saved_queries/test_saved_query_parsing.py
@@ -41,7 +41,7 @@ class TestSavedQueryParsing:
         assert saved_query.name == "test_saved_query"
         assert len(saved_query.query_params.metrics) == 1
         assert len(saved_query.query_params.group_by) == 1
-        assert len(saved_query.query_params.where.where_filters) == 2
+        assert len(saved_query.query_params.where.where_filters) == 3
         assert len(saved_query.depends_on.nodes) == 1
         assert saved_query.description == "My SavedQuery Description"
         assert len(saved_query.exports) == 1


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/9804
resolves SL-1794

### Description
Bump DSI version to get a new feature into core - allowing metrics in filters for metrics, measures, and saved queries. You can see the changes to DSI [here](https://github.com/dbt-labs/dbt-semantic-interfaces/pull/275). This change is purely additive.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
