### PR TITLE
Enable use of env vars for --resource-types and --exclude-resource-types

### DIFF
--- a/.changes/unreleased/Features-20240312-140407.yaml
+++ b/.changes/unreleased/Features-20240312-140407.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Allow excluding resource types for build, list, and clone commands
+body: Allow excluding resource types for build, list, and clone commands, and provide env vars
 time: 2024-03-12T14:04:07.086017-04:00
 custom:
   Author: gshank

--- a/core/dbt/cli/option_types.py
+++ b/core/dbt/cli/option_types.py
@@ -80,7 +80,10 @@ class ChoiceTuple(Choice):
     name = "CHOICE_TUPLE"
 
     def convert(self, value, param, ctx):
-        for value_item in value:
-            super().convert(value_item, param, ctx)
+        if not isinstance(value, str):
+          for value_item in value:
+              super().convert(value_item, param, ctx)
+        else:
+            super().convert(value, param, ctx)
 
         return value

--- a/core/dbt/cli/option_types.py
+++ b/core/dbt/cli/option_types.py
@@ -81,8 +81,8 @@ class ChoiceTuple(Choice):
 
     def convert(self, value, param, ctx):
         if not isinstance(value, str):
-          for value_item in value:
-              super().convert(value_item, param, ctx)
+            for value_item in value:
+                super().convert(value_item, param, ctx)
         else:
             super().convert(value, param, ctx)
 

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -500,7 +500,7 @@ def resource_types_from_args(
             arg_resource_types.remove("default")
             arg_resource_types.update(default_resource_values)
         # Convert to a set of NodeTypes now that the non-NodeType strings are gone
-        resource_types = set([NodeType(rt) for rt in arg_resource_types])
+        resource_types = set([NodeType(rt) for rt in list(arg_resource_types)])
 
     if args.exclude_resource_types:
         # Convert from a list of strings to a set of NodeTypes

--- a/tests/functional/list/test_list.py
+++ b/tests/functional/list/test_list.py
@@ -703,6 +703,34 @@ class TestList:
             "test.outer",
         }
 
+    def expect_resource_type_env_var(self):
+        """Expect selected resources when --resource-type given multiple times"""
+        os.environ["DBT_RESOURCE_TYPES"] = "test model"
+        results = self.run_dbt_ls()
+        assert set(results) == {
+            "test.ephemeral",
+            "test.incremental",
+            "test.not_null_outer_id",
+            "test.outer",
+            "test.sub.inner",
+            "test.metricflow_time_spine",
+            "test.t",
+            "test.unique_outer_id",
+        }
+        del os.environ["DBT_RESOURCE_TYPES"]
+        os.environ[
+            "DBT_EXCLUDE_RESOURCE_TYPES"
+        ] = "test saved_query metric source semantic_model snapshot seed"
+        results = self.run_dbt_ls()
+        assert set(results) == {
+            "test.ephemeral",
+            "test.incremental",
+            "test.outer",
+            "test.sub.inner",
+            "test.metricflow_time_spine",
+        }
+        del os.environ["DBT_EXCLUDE_RESOURCE_TYPES"]
+
     def expect_selected_keys(self, project):
         """Expect selected fields of the the selected model"""
         expectations = [
@@ -798,6 +826,7 @@ class TestList:
         self.expect_test_output()
         self.expect_select()
         self.expect_resource_type_multiple()
+        self.expect_resource_type_env_var()
         self.expect_all_output()
         self.expect_selected_keys(project)
 

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 from unittest import mock
 from dbt.tests.util import (
     run_dbt,
@@ -65,6 +66,13 @@ class TestUnitTests:
             expect_pass=True,
         )
         assert len(results) == 1
+
+        # Exclude unit tests with environment variable
+        os.environ["DBT_EXCLUDE_RESOURCE_TYPES"] = "unit_test"
+        results = run_dbt(["build", "--select", "my_model"], expect_pass=True)
+        assert len(results) == 1
+
+        del os.environ["DBT_EXCLUDE_RESOURCE_TYPES"]
 
         # Test select by test name
         results = run_dbt(["test", "--select", "test_name:test_my_model_string_concat"])

--- a/tests/unit/test_cli_flags.py
+++ b/tests/unit/test_cli_flags.py
@@ -105,6 +105,14 @@ class TestFlags:
         flags = Flags(run_context)
         assert flags.SEND_ANONYMOUS_USAGE_STATS == expected_anonymous_usage_stats
 
+    def test_resource_types(self, monkeypatch):
+        monkeypatch.setenv("DBT_RESOURCE_TYPES", "model")
+        build_context = self.make_dbt_context("build", ["build"])
+        # Is there any point to this?
+        build_context.params["resource_types"] = ("unit_test",)
+        flags = Flags(build_context)
+        assert flags.resource_types == ("unit_test",)
+
     def test_empty_project_flags_uses_default(self, run_context, project_flags):
         flags = Flags(run_context, project_flags)
         assert flags.USE_COLORS == run_context.params["use_colors"]

--- a/tests/unit/test_cli_flags.py
+++ b/tests/unit/test_cli_flags.py
@@ -108,7 +108,6 @@ class TestFlags:
     def test_resource_types(self, monkeypatch):
         monkeypatch.setenv("DBT_RESOURCE_TYPES", "model")
         build_context = self.make_dbt_context("build", ["build"])
-        # Is there any point to this?
         build_context.params["resource_types"] = ("unit_test",)
         flags = Flags(build_context)
         assert flags.resource_types == ("unit_test",)


### PR DESCRIPTION
resolves #9237 (follow on pr)


### Problem

The MultiOption ChoiceTuple param type didn't support env vars.

### Solution

Fix ChoiceTuple to not split strings into characters

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
