### PR TITLE
Move `protobuf` dep to a more applicable section of `setup.py`

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -61,6 +61,7 @@ setup(
         # with major versions in each new minor version of dbt-core.
         "click>=8.0.2,<9.0",
         "networkx>=2.3,<4.0",
+        "protobuf>=4.0.0,<5",
         "requests<3.0.0",  # should match dbt-common
         # ----
         # These packages are major-version-0. Keep upper bounds on upcoming minor versions (which could have breaking changes)
@@ -79,7 +80,6 @@ setup(
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
         "packaging>20.9",
-        "protobuf>=4.0.0,<5",
         "pytz>=2015.7",
         "pyyaml>=6.0",
         "daff>=1.3.46",


### PR DESCRIPTION
resolves #9785 

### Problem

Our `protobuf` dep was in the section of `setup.py` which we delineate as expecting all future versions of it to be compatible. However, this is no longer actually the case, and in e4fe839e4574187b574473596a471092267a9f2e we restricted it to major version 4.

### Solution

Move the dependency up a few lines 👍 

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
