### PR TITLE
Automate labeling PRs as community sourced

### DIFF
--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -1,0 +1,37 @@
+# **what?**
+# Label a PR with a `community` label when a PR is opened by a user outside core/adapters
+
+# **why?**
+# To streamline triage and ensure that community contributions are recognized and prioritized
+
+# **when?**
+# When a PR is opened, not in draft or moved from draft to ready for review
+
+
+name: Label community PRs
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+    pull-requests: write # labels PRs
+
+jobs:
+  open_issues:
+    # If this PR already has the community label, no need to relabel it
+    # If this PR is opened and not draft, determine if it needs to be labeled
+    # if the PR is converted out of draft, determine if it needs to be labeled
+    if: |
+      (!contains(github.event.pull_request.labels.*.name, 'community') &&
+      (github.event.action == 'opened' && github.event.pull_request.draft == false ) ||
+       github.event.action == 'ready_for_review' )
+    uses: dbt-labs/actions/.github/workflows/label-community.yml@main
+    with:
+        github_team: "core"
+        label: 'community'
+    secrets: inherit

--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -32,6 +32,6 @@ jobs:
        github.event.action == 'ready_for_review' )
     uses: dbt-labs/actions/.github/workflows/label-community.yml@main
     with:
-        github_team: "core"
+        github_team: 'core'
         label: 'community'
     secrets: inherit


### PR DESCRIPTION
resolves https://dbtlabs.atlassian.net/browse/OSS-3

### Problem

GitHub doesn't have an easy way to filter out PRs that are created by the core/adapters team when tracking community PRs.

### Solution

Add a special "community" label to PRs opened in non-draft or converted from draft to ready for review when the author is not on the core or adapters team

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
