### PR TITLE
fix team name

### DIFF
--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -11,7 +11,8 @@
 name: Label community PRs
 
 on:
-  pull_request:
+  # have to use pull_request_target since community PRs come from forks
+  pull_request_target:
     types: [opened, ready_for_review]
 
 defaults:

--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -21,6 +21,7 @@ defaults:
 
 permissions:
     pull-requests: write # labels PRs
+    contents: read # reads team membership
 
 jobs:
   open_issues:

--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -32,6 +32,6 @@ jobs:
        github.event.action == 'ready_for_review' )
     uses: dbt-labs/actions/.github/workflows/label-community.yml@main
     with:
-        github_team: 'core'
+        github_team: 'core-group'
         label: 'community'
     secrets: inherit


### PR DESCRIPTION
resolves OSS-3

### Problem

The core group is `core-group` not `core`.  When GitHub found nothing it gave permission error.

### Solution

Use the right id for the team.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
