### PR TITLE
Only create the `packages-install-path` / `dbt_packages` folder during `dbt deps`

### DIFF
--- a/.changes/unreleased/Fixes-20240323-124558.yaml
+++ b/.changes/unreleased/Fixes-20240323-124558.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Only create the packages-install-path / dbt_packages folder during dbt deps
+time: 2024-03-23T12:45:58.159017-06:00
+custom:
+  Author: dbeatty10
+  Issue: 6985 9584

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -274,7 +274,6 @@ class Compiler:
 
     def initialize(self):
         make_directory(self.config.project_target_path)
-        make_directory(self.config.packages_install_path)
 
     # creates a ModelContext which is converted to
     # a dict for jinja rendering of SQL

--- a/tests/functional/list/test_list.py
+++ b/tests/functional/list/test_list.py
@@ -37,6 +37,13 @@ class TestList:
             },
         }
 
+    def test_packages_install_path_does_not_exist(self, project):
+        run_dbt(["list"])
+        packages_install_path = "dbt_packages"
+
+        # the packages-install-path should not be created by `dbt list`
+        assert not os.path.exists(packages_install_path)
+
     def run_dbt_ls(self, args=None, expect_pass=True):
         log_manager.stdout_console()
         full_args = ["ls"]


### PR DESCRIPTION
resolves #6985
resolves #9584

### Problem

dbt commands other than `dbt deps` are making sure a directory exists at this configured `packages-install-path` (which defaults to "dbt_packages").

This is leading to the surprising behavior reported in #6985 and #9584.

### Solution

Only create the [`packages-install-path`](https://docs.getdbt.com/reference/project-configs/packages-install-path) / `dbt_packages` folder when running `dbt deps`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
