### PR TITLE
Add fnMatch to group selectors

### DIFF
--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -277,7 +277,7 @@ class GroupSelectorMethod(SelectorMethod):
     def search(self, included_nodes: Set[UniqueId], selector: str) -> Iterator[UniqueId]:
         """yields nodes from included in the specified group"""
         for node, real_node in self.groupable_nodes(included_nodes):
-            if selector == real_node.config.get("group"):
+            if fnmatch(selector, real_node.config.get("group")):
                 yield node
 
 

--- a/tests/unit/test_graph_selector_methods.py
+++ b/tests/unit/test_graph_selector_methods.py
@@ -1056,6 +1056,7 @@ def test_select_group(manifest, view_model):
     assert method.arguments == []
 
     assert search_manifest_using_method(manifest, method, group_name) == {"view_model"}
+    assert search_manifest_using_method(manifest, method, "my?group") == {"view_model"}
     assert not search_manifest_using_method(manifest, method, "not_my_group")
 
 


### PR DESCRIPTION
resolves #https://github.com/dbt-labs/dbt-core/issues/9811

### Problem

Groups with spaces in them cannot be selected.

### Solution

This simple solution makes the group selector more similar to other selectors, and is a small additive change to the group method

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
