### PR TITLE
Fix assorted source freshness edgecases so check is run or actionable information

### DIFF
--- a/.changes/unreleased/Fixes-20240326-162100.yaml
+++ b/.changes/unreleased/Fixes-20240326-162100.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix assorted source freshness edgecases so check is run or actionable information
+  is given
+time: 2024-03-26T16:21:00.008936-07:00
+custom:
+  Author: QMalcolm
+  Issue: "9078"

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -207,6 +207,9 @@ class BaseRunner(metaclass=ABCMeta):
     def compile(self, manifest: Manifest) -> Any:
         pass
 
+    def _node_build_path(self) -> Optional[str]:
+        return self.node.build_path if hasattr(self.node, "build_path") else None
+
     def get_result_status(self, result) -> Dict[str, str]:
         if result.status == NodeStatus.Error:
             return {"node_status": "error", "node_error": str(result.message)}
@@ -339,7 +342,7 @@ class BaseRunner(metaclass=ABCMeta):
     def _handle_internal_exception(self, e, ctx):
         fire_event(
             InternalErrorOnRun(
-                build_path=self.node.build_path, exc=str(e), node_info=get_node_info()
+                build_path=self._node_build_path(), exc=str(e), node_info=get_node_info()
             )
         )
         return str(e)
@@ -347,7 +350,7 @@ class BaseRunner(metaclass=ABCMeta):
     def _handle_generic_exception(self, e, ctx):
         fire_event(
             GenericExceptionOnRun(
-                build_path=self.node.build_path,
+                build_path=self._node_build_path(),
                 unique_id=self.node.unique_id,
                 exc=str(e),
                 node_info=get_node_info(),

--- a/core/dbt/task/freshness.py
+++ b/core/dbt/task/freshness.py
@@ -132,8 +132,9 @@ class FreshnessRunner(BaseRunner):
 
                 status = compiled_node.freshness.status(freshness["age"])
             else:
-                status = FreshnessStatus.Warn
-                fire_event(Note(msg=f"Skipping freshness for source {compiled_node.name}."))
+                raise DbtRuntimeError(
+                    f"Could not compute freshness for source {compiled_node.name}: no 'loaded_at_field' provided and {self.adapter.type()} adapter does not support metadata-based freshness checks."
+                )
 
         # adapter_response was not returned in previous versions, so this will be None
         # we cannot call to_dict() on NoneType

--- a/core/dbt/task/freshness.py
+++ b/core/dbt/task/freshness.py
@@ -120,9 +120,9 @@ class FreshnessRunner(BaseRunner):
                 if compiled_node.freshness.filter is not None:
                     fire_event(
                         Note(
-                            f"A filter cannot be applied to a metadata freshness check on source '{compiled_node.name}'.",
-                            EventLevel.WARN,
-                        )
+                            msg=f"A filter cannot be applied to a metadata freshness check on source '{compiled_node.name}'."
+                        ),
+                        EventLevel.WARN,
                     )
 
                 adapter_response, freshness = self.adapter.calculate_freshness_from_metadata(
@@ -133,9 +133,7 @@ class FreshnessRunner(BaseRunner):
                 status = compiled_node.freshness.status(freshness["age"])
             else:
                 status = FreshnessStatus.Warn
-                fire_event(
-                    Note(f"Skipping freshness for source {compiled_node.name}."),
-                )
+                fire_event(Note(msg=f"Skipping freshness for source {compiled_node.name}."))
 
         # adapter_response was not returned in previous versions, so this will be None
         # we cannot call to_dict() on NoneType

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,29 @@
+import pytest
+
+from dbt.artifacts.resources import Quoting, SourceConfig
+from dbt.artifacts.resources.types import NodeType
+from dbt.contracts.graph.nodes import SourceDefinition
+
+
+@pytest.fixture
+def basic_parsed_source_definition_object():
+    return SourceDefinition(
+        columns={},
+        database="some_db",
+        description="",
+        fqn=["test", "source", "my_source", "my_source_table"],
+        identifier="my_source_table",
+        loader="stitch",
+        name="my_source_table",
+        original_file_path="/root/models/sources.yml",
+        package_name="test",
+        path="/root/models/sources.yml",
+        quoting=Quoting(),
+        resource_type=NodeType.Source,
+        schema="some_schema",
+        source_description="my source description",
+        source_name="my_source",
+        unique_id="test.source.my_source.my_source_table",
+        tags=[],
+        config=SourceConfig(),
+    )

--- a/tests/unit/task/test_base.py
+++ b/tests/unit/task/test_base.py
@@ -1,0 +1,24 @@
+from dbt.task.base import BaseRunner
+from dbt.contracts.graph.nodes import SourceDefinition
+
+
+class MockRunner(BaseRunner):
+    def compile(self):
+        pass
+
+
+class TestBaseRunner:
+    def test_handle_generic_exception_handles_nodes_without_build_path(
+        self, basic_parsed_source_definition_object: SourceDefinition
+    ):
+        # Source definition nodes don't have `build_path` attributes. Thus, this
+        # test will fail if _handle_generic_exception doesn't account for this
+        runner = MockRunner(
+            config=None,
+            adapter=None,
+            node=basic_parsed_source_definition_object,
+            node_index=None,
+            num_nodes=None,
+        )
+        assert not hasattr(basic_parsed_source_definition_object, "build_path")
+        runner._handle_generic_exception(Exception("bad thing happened"), ctx=None)

--- a/tests/unit/test_contracts_graph_parsed.py
+++ b/tests/unit/test_contracts_graph_parsed.py
@@ -1955,30 +1955,6 @@ def basic_parsed_source_definition_dict():
 
 
 @pytest.fixture
-def basic_parsed_source_definition_object():
-    return SourceDefinition(
-        columns={},
-        database="some_db",
-        description="",
-        fqn=["test", "source", "my_source", "my_source_table"],
-        identifier="my_source_table",
-        loader="stitch",
-        name="my_source_table",
-        original_file_path="/root/models/sources.yml",
-        package_name="test",
-        path="/root/models/sources.yml",
-        quoting=Quoting(),
-        resource_type=NodeType.Source,
-        schema="some_schema",
-        source_description="my source description",
-        source_name="my_source",
-        unique_id="test.source.my_source.my_source_table",
-        tags=[],
-        config=SourceConfig(),
-    )
-
-
-@pytest.fixture
 def complex_parsed_source_definition_dict():
     return {
         "package_name": "test",


### PR DESCRIPTION
resolves #9078

### Problem

We were hitting multiple edge cases in the source freshness task which were raising unhelpful error messages.

### Solution

* update `BaseTask` to gracefully handle nodes without `build_path`
* ensure invocations of `Note` events use keyword params
* raise a runtime error when a source freshness task is missing `loaded_at_field` AND the project adapter doesn't support metadata checks
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
