### PR TITLE
Fix Docker release process for `dbt-postgres`

### DIFF
--- a/.changes/unreleased/Fixes-20240327-150013.yaml
+++ b/.changes/unreleased/Fixes-20240327-150013.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: '"Fix Docker release process to account for both historical and current versions
+  of `dbt-postgres`'
+time: 2024-03-27T15:00:13.388268-04:00
+custom:
+  Author: mikealfare
+  Issue: "9827"

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -69,17 +69,9 @@ jobs:
         id: build_arg
         run: |
           repo_arg=$(echo ${{ inputs.package }} | sed 's/\-/_/g')
-          if [[ ${{ inputs.version_number }} < 1.8.0 ]];
-          then
-            repo_value=$(echo ${{ inputs.package }} | sed 's/postgres/core/g')
-            dbt_postgres_subdirectory="&subdirectory=plugins/postgres"
-          else
-            repo_value=${{ inputs.package }}
-            dbt_postgres_subdirectory=""
-          fi
+          repo_value=$(echo ${{ inputs.package }} | sed 's/postgres/core/g')
           echo "repo_arg=$repo_arg" >> $GITHUB_OUTPUT
-          echo "repo_value=$repo_value" >> $GITHUB_OUTPUT
-          echo "dbt_postgres_subdirectory=$dbt_postgres_subdirectory" >> $GITHUB_OUTPUT
+          echo "repo-value=$repo_value" >> $GITHUB_OUTPUT
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -104,7 +96,5 @@ jobs:
           file: docker/Dockerfile
           push: True
           target: ${{ inputs.package }}
-          build-args: |
-            ${{ steps.build_arg.outputs.repo_arg }}_ref=${{ steps.build_arg.outputs.repo_value }}@v${{ inputs.version_number }}
-            dbt_postgres_subdirectory=${{ steps.build_arg.outputs.dbt_postgres_subdirectory }}
+          build-args: ${{ steps.build_arg.outputs.repo-arg }}_ref=${{ steps.build_arg.outputs.repo-value }}@v${{ inputs.version_number }}
           tags: ${{ needs.version_metadata.outputs.fully_qualified_tags }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -68,10 +68,18 @@ jobs:
       - name: Get docker build arg
         id: build_arg
         run: |
-          BUILD_ARG_NAME=$(echo ${{ inputs.package }} | sed 's/\-/_/g')
-          BUILD_ARG_VALUE=$(echo ${{ inputs.package }} | sed 's/postgres/core/g')
-          echo "name=$BUILD_ARG_NAME" >> $GITHUB_OUTPUT
-          echo "value=$BUILD_ARG_VALUE" >> $GITHUB_OUTPUT
+          repo_arg=$(echo ${{ inputs.package }} | sed 's/\-/_/g')
+          if [[ ${{ inputs.version_number }} < 1.8.0 ]];
+          then
+            repo_value=$(echo ${{ inputs.package }} | sed 's/postgres/core/g')
+            dbt_postgres_subdirectory="&subdirectory=plugins/postgres"
+          else
+            repo_value=${{ inputs.package }}
+            dbt_postgres_subdirectory=""
+          fi
+          echo "repo_arg=$repo_arg" >> $GITHUB_OUTPUT
+          echo "repo_value=$repo_value" >> $GITHUB_OUTPUT
+          echo "dbt_postgres_subdirectory=$dbt_postgres_subdirectory" >> $GITHUB_OUTPUT
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -96,5 +104,7 @@ jobs:
           file: docker/Dockerfile
           push: True
           target: ${{ inputs.package }}
-          build-args: ${{ steps.build_arg.outputs.name }}_ref=${{ steps.build_arg.outputs.value }}@v${{ inputs.version_number }}
+          build-args: |
+            ${{ steps.build_arg.outputs.repo_arg }}_ref=${{ steps.build_arg.outputs.repo_value }}@v${{ inputs.version_number }}
+            dbt_postgres_subdirectory=${{ steps.build_arg.outputs.dbt_postgres_subdirectory }}
           tags: ${{ needs.version_metadata.outputs.fully_qualified_tags }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -68,10 +68,10 @@ jobs:
       - name: Get docker build arg
         id: build_arg
         run: |
-          repo_arg=$(echo ${{ inputs.package }} | sed 's/\-/_/g')
-          repo_value=$(echo ${{ inputs.package }} | sed 's/postgres/core/g')
-          echo "repo_arg=$repo_arg" >> $GITHUB_OUTPUT
-          echo "repo-value=$repo_value" >> $GITHUB_OUTPUT
+          BUILD_ARG_NAME=$(echo ${{ inputs.package }} | sed 's/\-/_/g')
+          BUILD_ARG_VALUE=$(echo ${{ inputs.package }} | sed 's/postgres/core/g')
+          echo "name=$BUILD_ARG_NAME" >> $GITHUB_OUTPUT
+          echo "value=$BUILD_ARG_VALUE" >> $GITHUB_OUTPUT
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -96,5 +96,5 @@ jobs:
           file: docker/Dockerfile
           push: True
           target: ${{ inputs.package }}
-          build-args: ${{ steps.build_arg.outputs.repo-arg }}_ref=${{ steps.build_arg.outputs.repo-value }}@v${{ inputs.version_number }}
+          build-args: ${{ steps.build_arg.outputs.name }}_ref=${{ steps.build_arg.outputs.value }}@v${{ inputs.version_number }}
           tags: ${{ needs.version_metadata.outputs.fully_qualified_tags }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -130,4 +130,4 @@ RUN apt-get update \
   RUN python -m pip install --no-cache "git+https://github.com/dbt-labs/${dbt_bigquery_ref}#egg=dbt-bigquery"
   RUN python -m pip install --no-cache "git+https://github.com/dbt-labs/${dbt_snowflake_ref}#egg=dbt-snowflake"
   RUN python -m pip install --no-cache "git+https://github.com/dbt-labs/${dbt_spark_ref}#egg=dbt-spark[${dbt_spark_version}]"
-  RUN python -m pip install --no-cache "git+https://github.com/dbt-labs/${dbt_postgres_ref}#egg=dbt-postgres${dbt_postgres_subdirectory}"
+  RUN python -m pip install --no-cache "git+https://github.com/dbt-labs/${dbt_postgres_ref}#egg=dbt-postgres&subdirectory=plugins/postgres"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,6 @@ ARG dbt_bigquery_ref=dbt-bigquery@v1.8.0b1
 ARG dbt_snowflake_ref=dbt-snowflake@v1.8.0b1
 ARG dbt_spark_ref=dbt-spark@v1.8.0b1
 # special case args
-ARG dbt_postgres_subdirectory=""
 ARG dbt_spark_version=all
 ARG dbt_third_party
 
@@ -63,7 +62,7 @@ RUN python -m pip install --no-cache-dir "git+https://github.com/dbt-labs/${dbt_
 # dbt-postgres
 ##
 FROM base as dbt-postgres
-RUN python -m pip install --no-cache-dir "git+https://github.com/dbt-labs/${dbt_postgres_ref}#egg=dbt-postgres${dbt_postgres_subdirectory}"
+RUN python -m pip install --no-cache-dir "git+https://github.com/dbt-labs/${dbt_postgres_ref}#egg=dbt-postgres&subdirectory=plugins/postgres"
 
 
 ##

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,7 @@ ARG dbt_bigquery_ref=dbt-bigquery@v1.8.0b1
 ARG dbt_snowflake_ref=dbt-snowflake@v1.8.0b1
 ARG dbt_spark_ref=dbt-spark@v1.8.0b1
 # special case args
+ARG dbt_postgres_subdirectory=""
 ARG dbt_spark_version=all
 ARG dbt_third_party
 
@@ -62,7 +63,7 @@ RUN python -m pip install --no-cache-dir "git+https://github.com/dbt-labs/${dbt_
 # dbt-postgres
 ##
 FROM base as dbt-postgres
-RUN python -m pip install --no-cache-dir "git+https://github.com/dbt-labs/${dbt_postgres_ref}#egg=dbt-postgres"
+RUN python -m pip install --no-cache-dir "git+https://github.com/dbt-labs/${dbt_postgres_ref}#egg=dbt-postgres${dbt_postgres_subdirectory}"
 
 
 ##
@@ -130,4 +131,4 @@ RUN apt-get update \
   RUN python -m pip install --no-cache "git+https://github.com/dbt-labs/${dbt_bigquery_ref}#egg=dbt-bigquery"
   RUN python -m pip install --no-cache "git+https://github.com/dbt-labs/${dbt_snowflake_ref}#egg=dbt-snowflake"
   RUN python -m pip install --no-cache "git+https://github.com/dbt-labs/${dbt_spark_ref}#egg=dbt-spark[${dbt_spark_version}]"
-  RUN python -m pip install --no-cache "git+https://github.com/dbt-labs/${dbt_postgres_ref}#egg=dbt-postgres"
+  RUN python -m pip install --no-cache "git+https://github.com/dbt-labs/${dbt_postgres_ref}#egg=dbt-postgres${dbt_postgres_subdirectory}"


### PR DESCRIPTION
resolves #9827

### Problem

We updated the Docker release process for the new location of `dbt-postgres`. This broke the process for previous versions of `dbt-postgres`, which still live in `dbt-core`'s repo.

### Solution

- add the subdirectory back to the repo reference, which only works for `dbt-postgres<1.8`
- handle the docker releases for `dbt-postgres>=1.8` in the new `dbt-postgres` repo

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
