### PR TITLE
[Tidy first] rename node, realnode to unique_id, node in selector_methods.py

### DIFF
--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -257,37 +257,35 @@ class QualifiedNameSelectorMethod(SelectorMethod):
         :param str selector: The selector or node name
         """
         non_source_nodes = list(self.non_source_nodes(included_nodes))
-        for node, real_node in non_source_nodes:
-            if self.node_is_match(selector, real_node.fqn, real_node.is_versioned):
-                yield node
+        for unique_id, node in non_source_nodes:
+            if self.node_is_match(selector, node.fqn, node.is_versioned):
+                yield unique_id
 
 
 class TagSelectorMethod(SelectorMethod):
     def search(self, included_nodes: Set[UniqueId], selector: str) -> Iterator[UniqueId]:
         """yields nodes from included that have the specified tag"""
-        for node, real_node in self.all_nodes(included_nodes):
-            if hasattr(real_node, "tags") and any(
-                fnmatch(tag, selector) for tag in real_node.tags
-            ):
-                yield node
+        for unique_id, node in self.all_nodes(included_nodes):
+            if hasattr(node, "tags") and any(fnmatch(tag, selector) for tag in node.tags):
+                yield unique_id
 
 
 class GroupSelectorMethod(SelectorMethod):
     def search(self, included_nodes: Set[UniqueId], selector: str) -> Iterator[UniqueId]:
         """yields nodes from included in the specified group"""
-        for node, real_node in self.groupable_nodes(included_nodes):
-            if selector == real_node.config.get("group"):
-                yield node
+        for unique_id, node in self.groupable_nodes(included_nodes):
+            if selector == node.config.get("group"):
+                yield unique_id
 
 
 class AccessSelectorMethod(SelectorMethod):
     def search(self, included_nodes: Set[UniqueId], selector: str) -> Iterator[UniqueId]:
         """yields model nodes matching the specified access level"""
-        for node, real_node in self.parsed_nodes(included_nodes):
-            if not isinstance(real_node, ModelNode):
+        for unique_id, node in self.parsed_nodes(included_nodes):
+            if not isinstance(node, ModelNode):
                 continue
-            if selector == real_node.access:
-                yield node
+            if selector == node.access:
+                yield unique_id
 
 
 class SourceSelectorMethod(SelectorMethod):
@@ -310,14 +308,14 @@ class SourceSelectorMethod(SelectorMethod):
             ).format(selector)
             raise DbtRuntimeError(msg)
 
-        for node, real_node in self.source_nodes(included_nodes):
-            if not fnmatch(real_node.package_name, target_package):
+        for unique_id, node in self.source_nodes(included_nodes):
+            if not fnmatch(node.package_name, target_package):
                 continue
-            if not fnmatch(real_node.source_name, target_source):
+            if not fnmatch(node.source_name, target_source):
                 continue
-            if not fnmatch(real_node.name, target_table):
+            if not fnmatch(node.name, target_table):
                 continue
-            yield node
+            yield unique_id
 
 
 class ExposureSelectorMethod(SelectorMethod):
@@ -336,13 +334,13 @@ class ExposureSelectorMethod(SelectorMethod):
             ).format(selector)
             raise DbtRuntimeError(msg)
 
-        for node, real_node in self.exposure_nodes(included_nodes):
-            if not fnmatch(real_node.package_name, target_package):
+        for unique_id, node in self.exposure_nodes(included_nodes):
+            if not fnmatch(node.package_name, target_package):
                 continue
-            if not fnmatch(real_node.name, target_name):
+            if not fnmatch(node.name, target_name):
                 continue
 
-            yield node
+            yield unique_id
 
 
 class MetricSelectorMethod(SelectorMethod):
@@ -361,13 +359,13 @@ class MetricSelectorMethod(SelectorMethod):
             ).format(selector)
             raise DbtRuntimeError(msg)
 
-        for node, real_node in self.metric_nodes(included_nodes):
-            if not fnmatch(real_node.package_name, target_package):
+        for unique_id, node in self.metric_nodes(included_nodes):
+            if not fnmatch(node.package_name, target_package):
                 continue
-            if not fnmatch(real_node.name, target_name):
+            if not fnmatch(node.name, target_name):
                 continue
 
-            yield node
+            yield unique_id
 
 
 class SemanticModelSelectorMethod(SelectorMethod):
@@ -386,13 +384,13 @@ class SemanticModelSelectorMethod(SelectorMethod):
             ).format(selector)
             raise DbtRuntimeError(msg)
 
-        for node, real_node in self.semantic_model_nodes(included_nodes):
-            if not fnmatch(real_node.package_name, target_package):
+        for unique_id, node in self.semantic_model_nodes(included_nodes):
+            if not fnmatch(node.package_name, target_package):
                 continue
-            if not fnmatch(real_node.name, target_name):
+            if not fnmatch(node.name, target_name):
                 continue
 
-            yield node
+            yield unique_id
 
 
 class SavedQuerySelectorMethod(SelectorMethod):
@@ -411,13 +409,13 @@ class SavedQuerySelectorMethod(SelectorMethod):
             ).format(selector)
             raise DbtRuntimeError(msg)
 
-        for node, real_node in self.saved_query_nodes(included_nodes):
-            if not fnmatch(real_node.package_name, target_package):
+        for unique_id, node in self.saved_query_nodes(included_nodes):
+            if not fnmatch(node.package_name, target_package):
                 continue
-            if not fnmatch(real_node.name, target_name):
+            if not fnmatch(node.name, target_name):
                 continue
 
-            yield node
+            yield unique_id
 
 
 class PathSelectorMethod(SelectorMethod):
@@ -430,35 +428,35 @@ class PathSelectorMethod(SelectorMethod):
         else:
             root = Path.cwd()
         paths = set(p.relative_to(root) for p in root.glob(selector))
-        for node, real_node in self.all_nodes(included_nodes):
-            ofp = Path(real_node.original_file_path)
+        for unique_id, node in self.all_nodes(included_nodes):
+            ofp = Path(node.original_file_path)
             if ofp in paths:
-                yield node
-            if hasattr(real_node, "patch_path") and real_node.patch_path:  # type: ignore
-                pfp = real_node.patch_path.split("://")[1]  # type: ignore
+                yield unique_id
+            if hasattr(node, "patch_path") and node.patch_path:  # type: ignore
+                pfp = node.patch_path.split("://")[1]  # type: ignore
                 ymlfp = Path(pfp)
                 if ymlfp in paths:
-                    yield node
+                    yield unique_id
             if any(parent in paths for parent in ofp.parents):
-                yield node
+                yield unique_id
 
 
 class FileSelectorMethod(SelectorMethod):
     def search(self, included_nodes: Set[UniqueId], selector: str) -> Iterator[UniqueId]:
         """Yields nodes from included that match the given file name."""
-        for node, real_node in self.all_nodes(included_nodes):
-            if fnmatch(Path(real_node.original_file_path).name, selector):
-                yield node
-            elif fnmatch(Path(real_node.original_file_path).stem, selector):
-                yield node
+        for unique_id, node in self.all_nodes(included_nodes):
+            if fnmatch(Path(node.original_file_path).name, selector):
+                yield unique_id
+            elif fnmatch(Path(node.original_file_path).stem, selector):
+                yield unique_id
 
 
 class PackageSelectorMethod(SelectorMethod):
     def search(self, included_nodes: Set[UniqueId], selector: str) -> Iterator[UniqueId]:
         """Yields nodes from included that have the specified package"""
-        for node, real_node in self.all_nodes(included_nodes):
-            if fnmatch(real_node.package_name, selector):
-                yield node
+        for unique_id, node in self.all_nodes(included_nodes):
+            if fnmatch(node.package_name, selector):
+                yield unique_id
 
 
 def _getattr_descend(obj: Any, attrs: List[str]) -> Any:
@@ -500,9 +498,9 @@ class ConfigSelectorMethod(SelectorMethod):
         # search sources is kind of useless now source configs only have
         # 'enabled', which you can't really filter on anyway, but maybe we'll
         # add more someday, so search them anyway.
-        for node, real_node in self.configurable_nodes(included_nodes):
+        for unique_id, node in self.configurable_nodes(included_nodes):
             try:
-                value = _getattr_descend(real_node.config, parts)
+                value = _getattr_descend(node.config, parts)
             except AttributeError:
                 continue
             else:
@@ -512,7 +510,7 @@ class ConfigSelectorMethod(SelectorMethod):
                         or (CaseInsensitive(selector) == "true" and True in value)
                         or (CaseInsensitive(selector) == "false" and False in value)
                     ):
-                        yield node
+                        yield unique_id
                 else:
                     if (
                         (selector == value)
@@ -520,7 +518,7 @@ class ConfigSelectorMethod(SelectorMethod):
                         or (CaseInsensitive(selector) == "false")
                         and value is False
                     ):
-                        yield node
+                        yield unique_id
 
 
 class ResourceTypeSelectorMethod(SelectorMethod):
@@ -529,9 +527,9 @@ class ResourceTypeSelectorMethod(SelectorMethod):
             resource_type = NodeType(selector)
         except ValueError as exc:
             raise DbtRuntimeError(f'Invalid resource_type selector "{selector}"') from exc
-        for node, real_node in self.all_nodes(included_nodes):
-            if real_node.resource_type == resource_type:
-                yield node
+        for unique_id, node in self.all_nodes(included_nodes):
+            if node.resource_type == resource_type:
+                yield unique_id
 
 
 class TestNameSelectorMethod(SelectorMethod):
@@ -761,9 +759,9 @@ class ResultSelectorMethod(SelectorMethod):
         matches = set(
             result.unique_id for result in self.previous_state.results if result.status == selector
         )
-        for node, real_node in self.all_nodes(included_nodes):
-            if node in matches:
-                yield node
+        for unique_id, node in self.all_nodes(included_nodes):
+            if unique_id in matches:
+                yield unique_id
 
 
 class SourceStatusSelectorMethod(SelectorMethod):
@@ -815,37 +813,37 @@ class SourceStatusSelectorMethod(SelectorMethod):
                 ):
                     matches.remove(unique_id)
 
-        for node, real_node in self.all_nodes(included_nodes):
-            if node in matches:
-                yield node
+        for unique_id, node in self.all_nodes(included_nodes):
+            if unique_id in matches:
+                yield unique_id
 
 
 class VersionSelectorMethod(SelectorMethod):
     def search(self, included_nodes: Set[UniqueId], selector: str) -> Iterator[UniqueId]:
-        for node, real_node in self.parsed_nodes(included_nodes):
-            if isinstance(real_node, ModelNode):
+        for unique_id, node in self.parsed_nodes(included_nodes):
+            if isinstance(node, ModelNode):
                 if selector == "latest":
-                    if real_node.is_latest_version:
-                        yield node
+                    if node.is_latest_version:
+                        yield unique_id
                 elif selector == "prerelease":
                     if (
-                        real_node.version
-                        and real_node.latest_version
-                        and UnparsedVersion(v=real_node.version)
-                        > UnparsedVersion(v=real_node.latest_version)
+                        node.version
+                        and node.latest_version
+                        and UnparsedVersion(v=node.version)
+                        > UnparsedVersion(v=node.latest_version)
                     ):
-                        yield node
+                        yield unique_id
                 elif selector == "old":
                     if (
-                        real_node.version
-                        and real_node.latest_version
-                        and UnparsedVersion(v=real_node.version)
-                        < UnparsedVersion(v=real_node.latest_version)
+                        node.version
+                        and node.latest_version
+                        and UnparsedVersion(v=node.version)
+                        < UnparsedVersion(v=node.latest_version)
                     ):
-                        yield node
+                        yield unique_id
                 elif selector == "none":
-                    if real_node.version is None:
-                        yield node
+                    if node.version is None:
+                        yield unique_id
                 else:
                     raise DbtRuntimeError(
                         f'Invalid version type selector {selector}: expected one of: "latest", "prerelease", "old", or "none"'


### PR DESCRIPTION
Tidy first change:  rename `node, realnode` to `unique_id, node` in selector_methods.py