### PR TITLE
Removing unwanted dev dependency

### DIFF
--- a/.changes/unreleased/Dependencies-20240331-103917.yaml
+++ b/.changes/unreleased/Dependencies-20240331-103917.yaml
@@ -1,6 +1,6 @@
 kind: Dependencies
-body: Remove unwanted dependency of protobuf in dev-requirements
+body: Remove duplicate dependency of protobuf in dev-requirements
 time: 2024-03-31T10:39:17.432017-07:00
 custom:
   Author: niteshy
-  PR: "9838"
+  Issue: "9830"

--- a/.changes/unreleased/Dependencies-20240331-103917.yaml
+++ b/.changes/unreleased/Dependencies-20240331-103917.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Remove unwanted dependency of protobuf in dev-requirements
+time: 2024-03-31T10:39:17.432017-07:00
+custom:
+  Author: niteshy
+  PR: "9838"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,6 @@ ipdb
 mypy==1.4.1
 pip-tools
 pre-commit
-protobuf>=4.0.0,<5.0.0
 pytest>=7.4,<8.0
 pytest-cov
 pytest-csv>=3.0,<4.0


### PR DESCRIPTION
resolves #9830

Avoid causing problem similar to #9830 

### Problem

protobuf is listed as dependencies in both [setup.py](https://github.com/dbt-labs/dbt-core/blob/main/core/setup.py#L64) & [dev-requirements.txt](https://github.com/dbt-labs/dbt-core/blob/main/dev-requirements.txt#L17). It cause problem as shown in #9830 

### Solution
Remove the duplicate entry from dev-requirements, as it is used in the prod code already.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
