### PR TITLE
Fix query comments test

### DIFF
--- a/.changes/unreleased/Fixes-20240408-130646.yaml
+++ b/.changes/unreleased/Fixes-20240408-130646.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fixed query comments test
+time: 2024-04-08T13:06:46.648144+02:00
+custom:
+  Author: damian3031
+  Issue: "9860"

--- a/tests/functional/adapter/query_comment/fixtures.py
+++ b/tests/functional/adapter/query_comment/fixtures.py
@@ -10,7 +10,6 @@ MACROS__MACRO_SQL = """
   {%- set comment_dict = dict(
     app='dbt++',
     macro_version='0.1.0',
-    dbt_version=dbt_version,
     message='blah: '~ message) -%}
   {{ return(comment_dict) }}
 {%- endmacro -%}

--- a/tests/functional/adapter/query_comment/test_query_comment.py
+++ b/tests/functional/adapter/query_comment/test_query_comment.py
@@ -1,7 +1,6 @@
 import pytest
 import json
 from dbt.exceptions import DbtRuntimeError
-from dbt.version import __version__ as dbt_version
 from dbt.tests.util import run_dbt_and_capture
 from tests.functional.adapter.query_comment.fixtures import MACROS__MACRO_SQL, MODELS__X_SQL
 
@@ -59,7 +58,6 @@ class BaseMacroArgsQueryComments(BaseDefaultQueryComments):
         logs = self.run_get_json()
         expected_dct = {
             "app": "dbt++",
-            "dbt_version": dbt_version,
             "macro_version": "0.1.0",
             "message": f"blah: {project.adapter.config.target_name}",
         }


### PR DESCRIPTION
resolves #9860 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

`test_query_comments.py::BaseMacroArgsQueryComments::test_matches_comment ` is comparing dbt-core version with dbt adapter version, which is wrong assumption after decoupling dbt adapters from dbt-core version.

### Solution

Remove version comparison at, as it isn't related to query comment feature.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
