### PR TITLE
[Tidy first] Task config type

### DIFF
--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -396,11 +396,9 @@ def show(ctx, **kwargs):
 def debug(ctx, **kwargs):
     """Show information on the current dbt environment and check dependencies, then test the database connection. Not to be confused with the --debug option which increases verbosity."""
     from dbt.task.debug import DebugTask
-    from dbt.task.base import NoneConfig
 
     task = DebugTask(
         ctx.obj["flags"],
-        NoneConfig(),
     )
 
     results = task.run()
@@ -465,7 +463,7 @@ def init(ctx, **kwargs):
     """Initialize a new dbt project."""
     from dbt.task.init import InitTask
 
-    task = InitTask(ctx.obj["flags"], None)
+    task = InitTask(ctx.obj["flags"])
 
     results = task.run()
     success = task.interpret_results(results)

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -396,10 +396,11 @@ def show(ctx, **kwargs):
 def debug(ctx, **kwargs):
     """Show information on the current dbt environment and check dependencies, then test the database connection. Not to be confused with the --debug option which increases verbosity."""
     from dbt.task.debug import DebugTask
+    from dbt.task.base import NoneConfig
 
     task = DebugTask(
         ctx.obj["flags"],
-        None,
+        NoneConfig(),
     )
 
     results = task.run()

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -96,7 +96,7 @@ PackageSpec = Union[LocalPackage, TarballPackage, GitPackage, RegistryPackage]
 
 @dataclass
 class PackageConfig(dbtClassMixin):
-    packages: List[PackageSpec]
+    packages: List[Package]
 
     @classmethod
     def validate(cls, data):
@@ -119,7 +119,7 @@ class PackageConfig(dbtClassMixin):
 @dataclass
 class ProjectPackageMetadata:
     name: str
-    packages: List[PackageSpec]
+    packages: List[Package]
 
     @classmethod
     def from_project(cls, project):
@@ -231,7 +231,7 @@ class Project(dbtClassMixin):
             description="map project names to their vars override dicts",
         ),
     )
-    packages: List[PackageSpec] = field(default_factory=list)
+    packages: List[Package] = field(default_factory=list)
     query_comment: Optional[Union[QueryComment, NoValue, str]] = field(default_factory=NoValue)
     restrict_access: bool = False
     dbt_cloud: Optional[Dict[str, Any]] = None

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -96,7 +96,7 @@ PackageSpec = Union[LocalPackage, TarballPackage, GitPackage, RegistryPackage]
 
 @dataclass
 class PackageConfig(dbtClassMixin):
-    packages: List[Package]
+    packages: List[PackageSpec]
 
     @classmethod
     def validate(cls, data):
@@ -119,7 +119,7 @@ class PackageConfig(dbtClassMixin):
 @dataclass
 class ProjectPackageMetadata:
     name: str
-    packages: List[Package]
+    packages: List[PackageSpec]
 
     @classmethod
     def from_project(cls, project):
@@ -231,7 +231,7 @@ class Project(dbtClassMixin):
             description="map project names to their vars override dicts",
         ),
     )
-    packages: List[Package] = field(default_factory=list)
+    packages: List[PackageSpec] = field(default_factory=list)
     query_comment: Optional[Union[QueryComment, NoValue, str]] = field(default_factory=NoValue)
     restrict_access: bool = False
     dbt_cloud: Optional[Dict[str, Any]] = None

--- a/core/dbt/deps/resolver.py
+++ b/core/dbt/deps/resolver.py
@@ -17,7 +17,7 @@ from dbt.deps.git import GitUnpinnedPackage
 from dbt.deps.registry import RegistryUnpinnedPackage
 
 from dbt.contracts.project import (
-    Package,
+    PackageSpec,
     LocalPackage,
     TarballPackage,
     GitPackage,
@@ -67,7 +67,7 @@ class PackageListing:
         else:
             self.packages[key] = package
 
-    def update_from(self, src: List[Package]) -> None:
+    def update_from(self, src: List[PackageSpec]) -> None:
         pkg: UnpinnedPackage
         for contract in src:
             if isinstance(contract, LocalPackage):
@@ -83,7 +83,7 @@ class PackageListing:
             self.incorporate(pkg)
 
     @classmethod
-    def from_contracts(cls: Type["PackageListing"], src: List[Package]) -> "PackageListing":
+    def from_contracts(cls: Type["PackageListing"], src: List[PackageSpec]) -> "PackageListing":
         self = cls({})
         self.update_from(src)
         return self
@@ -111,7 +111,7 @@ def _check_for_duplicate_project_names(
 
 
 def resolve_packages(
-    packages: List[Package],
+    packages: List[PackageSpec],
     project: Project,
     cli_vars: Dict[str, Any],
 ) -> List[PinnedPackage]:
@@ -134,7 +134,7 @@ def resolve_packages(
     return resolved
 
 
-def resolve_lock_packages(packages: List[Package]) -> List[PinnedPackage]:
+def resolve_lock_packages(packages: List[PackageSpec]) -> List[PinnedPackage]:
     lock_packages = PackageListing.from_contracts(packages)
     final = PackageListing()
 

--- a/core/dbt/deps/resolver.py
+++ b/core/dbt/deps/resolver.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, List, NoReturn, Union, Type, Iterator, Set, Any
+from typing import Dict, List, NoReturn, Type, Iterator, Set, Any
 
 from dbt.exceptions import (
     DuplicateDependencyToRootError,
@@ -17,13 +17,12 @@ from dbt.deps.git import GitUnpinnedPackage
 from dbt.deps.registry import RegistryUnpinnedPackage
 
 from dbt.contracts.project import (
+    Package,
     LocalPackage,
     TarballPackage,
     GitPackage,
     RegistryPackage,
 )
-
-PackageContract = Union[LocalPackage, TarballPackage, GitPackage, RegistryPackage]
 
 
 @dataclass
@@ -68,7 +67,7 @@ class PackageListing:
         else:
             self.packages[key] = package
 
-    def update_from(self, src: List[PackageContract]) -> None:
+    def update_from(self, src: List[Package]) -> None:
         pkg: UnpinnedPackage
         for contract in src:
             if isinstance(contract, LocalPackage):
@@ -84,9 +83,7 @@ class PackageListing:
             self.incorporate(pkg)
 
     @classmethod
-    def from_contracts(
-        cls: Type["PackageListing"], src: List[PackageContract]
-    ) -> "PackageListing":
+    def from_contracts(cls: Type["PackageListing"], src: List[Package]) -> "PackageListing":
         self = cls({})
         self.update_from(src)
         return self
@@ -114,7 +111,7 @@ def _check_for_duplicate_project_names(
 
 
 def resolve_packages(
-    packages: List[PackageContract],
+    packages: List[Package],
     project: Project,
     cli_vars: Dict[str, Any],
 ) -> List[PinnedPackage]:
@@ -137,7 +134,7 @@ def resolve_packages(
     return resolved
 
 
-def resolve_lock_packages(packages: List[PackageContract]) -> List[PinnedPackage]:
+def resolve_lock_packages(packages: List[Package]) -> List[PinnedPackage]:
     lock_packages = PackageListing.from_contracts(packages)
     final = PackageListing()
 

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -6,14 +6,14 @@ from abc import ABCMeta, abstractmethod
 from contextlib import nullcontext
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Type, Union, Set
+from typing import Any, Dict, List, Optional, Set
 
 from dbt.compilation import Compiler
 import dbt_common.exceptions.base
 import dbt.exceptions
 from dbt import tracking
 from dbt.cli.flags import Flags
-from dbt.config import RuntimeConfig, Project
+from dbt.config import RuntimeConfig
 from dbt.config.profile import read_profile
 from dbt.constants import DBT_PROJECT_FILE_NAME
 from dbt.contracts.graph.manifest import Manifest
@@ -50,12 +50,6 @@ from dbt.logger import log_manager
 from dbt.task.printer import print_run_result_error
 
 
-class NoneConfig:
-    @classmethod
-    def from_args(cls, args: Flags):
-        return None
-
-
 def read_profiles(profiles_dir=None):
     """This is only used for some error handling"""
     if profiles_dir is None:
@@ -72,14 +66,11 @@ def read_profiles(profiles_dir=None):
 
 
 class BaseTask(metaclass=ABCMeta):
-    ConfigType: Union[Type[NoneConfig], Type[RuntimeConfig], Type[Project]] = NoneConfig
-
-    def __init__(
-        self, args: Flags, config: Union[NoneConfig, RuntimeConfig, Project], project=None
-    ) -> None:
+    def __init__(self, args: Flags) -> None:
         self.args = args
-        self.config = config
-        self.project = config if isinstance(config, Project) else project
+
+    #       self.config = config
+    #       self.project = config if isinstance(config, Project) else project
 
     @classmethod
     def pre_init_hook(cls, args: Flags):
@@ -95,23 +86,6 @@ class BaseTask(metaclass=ABCMeta):
             log_manager.format_json()
         else:
             log_manager.format_text()
-
-    @classmethod
-    def from_args(cls, args: Flags, *pargs, **kwargs):
-        try:
-            # This is usually RuntimeConfig
-            config = cls.ConfigType.from_args(args)
-        except dbt.exceptions.DbtProjectError as exc:
-            fire_event(LogDbtProjectError(exc=str(exc)))
-
-            tracking.track_invalid_invocation(args=args, result_type=exc.result_type)
-            raise dbt_common.exceptions.DbtRuntimeError("Could not run dbt") from exc
-        except dbt.exceptions.DbtProfileError as exc:
-            all_profile_names = list(read_profiles(get_flags().PROFILES_DIR).keys())
-            fire_event(LogDbtProfileError(exc=str(exc), profiles=all_profile_names))
-            tracking.track_invalid_invocation(args=args, result_type=exc.result_type)
-            raise dbt_common.exceptions.DbtRuntimeError("Could not run dbt") from exc
-        return cls(args, config, *pargs, **kwargs)
 
     @abstractmethod
     def run(self):
@@ -156,12 +130,11 @@ def move_to_nearest_project_dir(project_dir: Optional[str]) -> Path:
 # produce the same behavior. currently this class only contains manifest compilation,
 # holding a manifest, and moving direcories.
 class ConfiguredTask(BaseTask):
-    ConfigType = RuntimeConfig
-
     def __init__(
         self, args: Flags, config: RuntimeConfig, manifest: Optional[Manifest] = None
     ) -> None:
-        super().__init__(args, config)
+        super().__init__(args)
+        self.config = config
         self.graph: Optional[Graph] = None
         self.manifest = manifest
         self.compiler = Compiler(self.config)
@@ -181,7 +154,20 @@ class ConfiguredTask(BaseTask):
     @classmethod
     def from_args(cls, args: Flags, *pargs, **kwargs):
         move_to_nearest_project_dir(args.project_dir)
-        return super().from_args(args, *pargs, **kwargs)
+        try:
+            # This is usually RuntimeConfig
+            config = RuntimeConfig.from_args(args)
+        except dbt.exceptions.DbtProjectError as exc:
+            fire_event(LogDbtProjectError(exc=str(exc)))
+
+            tracking.track_invalid_invocation(args=args, result_type=exc.result_type)
+            raise dbt_common.exceptions.DbtRuntimeError("Could not run dbt") from exc
+        except dbt.exceptions.DbtProfileError as exc:
+            all_profile_names = list(read_profiles(get_flags().PROFILES_DIR).keys())
+            fire_event(LogDbtProfileError(exc=str(exc), profiles=all_profile_names))
+            tracking.track_invalid_invocation(args=args, result_type=exc.result_type)
+            raise dbt_common.exceptions.DbtRuntimeError("Could not run dbt") from exc
+        return cls(args, config, *pargs, **kwargs)
 
 
 class ExecutionContext:

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -72,9 +72,11 @@ def read_profiles(profiles_dir=None):
 
 
 class BaseTask(metaclass=ABCMeta):
-    ConfigType: Union[Type[NoneConfig], Type[Project]] = NoneConfig
+    ConfigType: Union[Type[NoneConfig], Type[RuntimeConfig], Type[Project]] = NoneConfig
 
-    def __init__(self, args: Flags, config, project=None) -> None:
+    def __init__(
+        self, args: Flags, config: Union[NoneConfig, RuntimeConfig, Project], project=None
+    ) -> None:
         self.args = args
         self.config = config
         self.project = config if isinstance(config, Project) else project
@@ -95,7 +97,7 @@ class BaseTask(metaclass=ABCMeta):
             log_manager.format_text()
 
     @classmethod
-    def from_args(cls, args, *pargs, **kwargs):
+    def from_args(cls, args: Flags, *pargs, **kwargs):
         try:
             # This is usually RuntimeConfig
             config = cls.ConfigType.from_args(args)
@@ -156,7 +158,9 @@ def move_to_nearest_project_dir(project_dir: Optional[str]) -> Path:
 class ConfiguredTask(BaseTask):
     ConfigType = RuntimeConfig
 
-    def __init__(self, args: Flags, config, manifest: Optional[Manifest] = None) -> None:
+    def __init__(
+        self, args: Flags, config: RuntimeConfig, manifest: Optional[Manifest] = None
+    ) -> None:
         super().__init__(args, config)
         self.graph: Optional[Graph] = None
         self.manifest = manifest

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -9,6 +9,8 @@ from .test import TestRunner as test_runner
 from dbt.artifacts.schemas.results import NodeStatus, RunStatus
 from dbt.artifacts.schemas.run import RunResult
 from dbt.cli.flags import Flags
+from dbt.config.runtime import RuntimeConfig
+from dbt.contracts.graph.manifest import Manifest
 from dbt.graph import ResourceTypeSelector, GraphQueue, Graph
 from dbt.node_types import NodeType
 from dbt.task.test import TestSelector
@@ -75,7 +77,7 @@ class BuildTask(RunTask):
     }
     ALL_RESOURCE_VALUES = frozenset({x for x in RUNNER_MAP.keys()})
 
-    def __init__(self, args: Flags, config, manifest) -> None:
+    def __init__(self, args: Flags, config: RuntimeConfig, manifest: Manifest) -> None:
         super().__init__(args, config, manifest)
         self.selected_unit_tests: Set = set()
         self.model_to_unit_test_map: Dict[str, List] = {}

--- a/core/dbt/task/clean.py
+++ b/core/dbt/task/clean.py
@@ -9,6 +9,8 @@ from dbt.events.types import (
     FinishedCleanPaths,
 )
 from dbt_common.exceptions import DbtRuntimeError
+from dbt.cli.flags import Flags
+from dbt.config.project import Project
 from dbt.task.base import (
     BaseTask,
     move_to_nearest_project_dir,
@@ -16,6 +18,11 @@ from dbt.task.base import (
 
 
 class CleanTask(BaseTask):
+    def __init__(self, args: Flags, config: Project):
+        super().__init__(args)
+        self.config = config
+        self.project = config
+
     def run(self):
         """
         This function takes all the paths in the target file

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -79,7 +79,8 @@ class DebugRunStatus(Flag):
 
 class DebugTask(BaseTask):
     def __init__(self, args: Flags, config: Project) -> None:
-        super().__init__(args, config)
+        super().__init__(args)
+        self.config = config
         self.profiles_dir = args.PROFILES_DIR
         self.profile_path = os.path.join(self.profiles_dir, "profiles.yml")
         try:
@@ -98,7 +99,7 @@ class DebugTask(BaseTask):
         self.profile: Optional[Profile] = None
         self.raw_profile_data: Optional[Dict[str, Any]] = None
         self.profile_name: Optional[str] = None
-        self.project: Optional[Project] = None
+        self.project: Project = self.config
 
     @property
     def project_profile(self):

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -78,7 +78,7 @@ class DebugRunStatus(Flag):
 
 
 class DebugTask(BaseTask):
-    def __init__(self, args: Flags, config) -> None:
+    def __init__(self, args: Flags, config: Project) -> None:
         super().__init__(args, config)
         self.profiles_dir = args.PROFILES_DIR
         self.profile_path = os.path.join(self.profiles_dir, "profiles.yml")

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -13,7 +13,7 @@ from dbt.constants import PACKAGE_LOCK_FILE_NAME, PACKAGE_LOCK_HASH_KEY
 from dbt.deps.base import downloads_directory
 from dbt.deps.resolver import resolve_lock_packages, resolve_packages
 from dbt.deps.registry import RegistryPinnedPackage
-from dbt.contracts.project import Package
+from dbt.contracts.project import PackageSpec
 
 
 from dbt_common.events.functions import fire_event
@@ -44,7 +44,7 @@ class dbtPackageDumper(yaml.Dumper):
         return super(dbtPackageDumper, self).increase_indent(flow, False)
 
 
-def _create_sha1_hash(packages: List[Package]) -> str:
+def _create_sha1_hash(packages: List[PackageSpec]) -> str:
     """Create a SHA1 hash of the packages list,
     this is used to determine if the packages for current execution matches
     the previous lock.

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -94,14 +94,15 @@ def _create_packages_yml_entry(package: str, version: Optional[str], source: str
 
 class DepsTask(BaseTask):
     def __init__(self, args: Any, project: Project) -> None:
+        super().__init__(args=args)
         # N.B. This is a temporary fix for a bug when using relative paths via
         # --project-dir with deps.  A larger overhaul of our path handling methods
         # is needed to fix this the "right" way.
         # See GH-7615
         project.project_root = str(Path(project.project_root).resolve())
+        self.project = project
 
         move_to_nearest_project_dir(project.project_root)
-        super().__init__(args=args, config=None, project=project)
         self.cli_vars = args.vars
 
     def track_package_install(

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -9,6 +9,8 @@ from dbt.contracts.graph.nodes import (
     UnitTestDefinition,
 )
 from dbt.cli.flags import Flags
+from dbt.config.runtime import RuntimeConfig
+from dbt.contracts.graph.manifest import Manifest
 from dbt.flags import get_flags
 from dbt.graph import ResourceTypeSelector
 from dbt.task.base import resource_types_from_args
@@ -55,7 +57,7 @@ class ListTask(GraphRunnableTask):
         )
     )
 
-    def __init__(self, args: Flags, config, manifest) -> None:
+    def __init__(self, args: Flags, config: RuntimeConfig, manifest: Manifest) -> None:
         super().__init__(args, config, manifest)
         if self.args.models:
             if self.args.select:

--- a/core/dbt/task/retry.py
+++ b/core/dbt/task/retry.py
@@ -63,7 +63,7 @@ CMD_DICT = {
 
 
 class RetryTask(ConfiguredTask):
-    def __init__(self, args: Flags, config) -> None:
+    def __init__(self, args: Flags, config: RuntimeConfig) -> None:
         # load previous run results
         state_path = args.state or config.target_path
         self.previous_results = load_result_state(

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -17,6 +17,7 @@ from dbt import utils
 from dbt.adapters.base import BaseRelation
 from dbt.cli.flags import Flags
 from dbt.clients.jinja import MacroGenerator
+from dbt.config.runtime import RuntimeConfig
 from dbt.context.providers import generate_runtime_model_context
 from dbt.contracts.graph.nodes import HookNode, ResultNode
 from dbt.artifacts.schemas.results import NodeStatus, RunStatus, RunningStatus, BaseResult
@@ -306,7 +307,7 @@ class ModelRunner(CompileRunner):
 
 
 class RunTask(CompileTask):
-    def __init__(self, args: Flags, config, manifest) -> None:
+    def __init__(self, args: Flags, config: RuntimeConfig, manifest) -> None:
         super().__init__(args, config, manifest)
         self.ran_hooks: List[HookNode] = []
         self._total_executed = 0

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -20,6 +20,7 @@ from dbt.clients.jinja import MacroGenerator
 from dbt.config.runtime import RuntimeConfig
 from dbt.context.providers import generate_runtime_model_context
 from dbt.contracts.graph.nodes import HookNode, ResultNode
+from dbt.contracts.graph.manifest import Manifest
 from dbt.artifacts.schemas.results import NodeStatus, RunStatus, RunningStatus, BaseResult
 from dbt.artifacts.schemas.run import RunResult
 from dbt.artifacts.resources import Hook
@@ -307,7 +308,7 @@ class ModelRunner(CompileRunner):
 
 
 class RunTask(CompileTask):
-    def __init__(self, args: Flags, config: RuntimeConfig, manifest) -> None:
+    def __init__(self, args: Flags, config: RuntimeConfig, manifest: Manifest) -> None:
         super().__init__(args, config, manifest)
         self.ran_hooks: List[HookNode] = []
         self._total_executed = 0

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -67,7 +67,7 @@ RUNNING_STATE = DbtProcessState("running")
 class GraphRunnableTask(ConfiguredTask):
     MARK_DEPENDENT_ERRORS_STATUSES = [NodeStatus.Error]
 
-    def __init__(self, args: Flags, config: RuntimeConfig, manifest) -> None:
+    def __init__(self, args: Flags, config: RuntimeConfig, manifest: Manifest) -> None:
         super().__init__(args, config, manifest)
         self.config = config
         self._flattened_nodes: Optional[List[ResultNode]] = None

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -126,7 +126,9 @@ class GraphRunnableTask(ConfiguredTask):
             # This is what's used with no default selector and no selection
             # use --select and --exclude args
             spec = parse_difference(self.selection_arg, self.exclusion_arg, indirect_selection)
-        return spec
+        # mypy complains because the return values of get_selector and parse_difference
+        # are different
+        return spec  # type: ignore
 
     @abstractmethod
     def get_node_selector(self) -> NodeSelector:

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -626,7 +626,9 @@ class GraphRunnableTask(ConfiguredTask):
         list_futures = []
         create_futures = []
 
-        with dbt_common.utils.executor(self.config) as tpe:
+        # TODO: following has a mypy issue because profile and project config
+        # defines threads as int and HasThreadingConfig defines it as Optional[int]
+        with dbt_common.utils.executor(self.config) as tpe:  # type: ignore
             for req in required_databases:
                 if req.database is None:
                     name = "list_schemas"

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -16,6 +16,7 @@ import dbt.utils
 from dbt.adapters.base import BaseRelation
 from dbt.adapters.factory import get_adapter
 from dbt.cli.flags import Flags
+from dbt.config.runtime import RuntimeConfig
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.nodes import ResultNode
 from dbt.artifacts.schemas.results import NodeStatus, RunningStatus, RunStatus, BaseResult
@@ -66,8 +67,9 @@ RUNNING_STATE = DbtProcessState("running")
 class GraphRunnableTask(ConfiguredTask):
     MARK_DEPENDENT_ERRORS_STATUSES = [NodeStatus.Error]
 
-    def __init__(self, args: Flags, config, manifest) -> None:
+    def __init__(self, args: Flags, config: RuntimeConfig, manifest) -> None:
         super().__init__(args, config, manifest)
+        self.config = config
         self._flattened_nodes: Optional[List[ResultNode]] = None
         self._raise_next_tick: Optional[DbtRuntimeError] = None
         self._skipped_children: Dict[str, Optional[RunResult]] = {}


### PR DESCRIPTION
Tidy first changes to add a type to "config" in the task hierarchy.

This involved moving a couple of things around because it had a badly constructed inheritance hierarchy, in which the base class did things that only applied to certain subclasses.