### PR TITLE
Remove try/except logic for importing `Empty` from `queue` library

### DIFF
--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -20,12 +20,7 @@ from dbt.contracts.project import ProjectFlags
 from dbt.graph import NodeSelector, parse_difference
 from dbt.events.logging import setup_event_logger
 from dbt.mp_context import get_mp_context
-
-try:
-    from queue import Empty
-except ImportError:
-    from Queue import Empty
-
+from queue import Empty
 from .utils import config_from_parts_or_dicts, generate_name_macros, inject_plugin
 
 

--- a/tests/unit/test_linker.py
+++ b/tests/unit/test_linker.py
@@ -4,14 +4,9 @@ import unittest
 from unittest import mock
 
 from dbt import compilation
-
-try:
-    from queue import Empty
-except ImportError:
-    from Queue import Empty
-
 from dbt.graph.selector import NodeSelector
 from dbt.graph.cli import parse_difference
+from queue import Empty
 
 
 def _mock_manifest(nodes):


### PR DESCRIPTION
resolves #9876

### Problem

Following [PEP8](https://peps.python.org/pep-0008/#package-and-module-names) the Python 2 library `Queue` was renamed to `queue` in [Python 3](https://peps.python.org/pep-3108/#pep-8-violations-done). Our try/except logic was to ensure the `Empty` class was imported without error when running Python 2. Python 2 went EOL January 1st, 2020 and we haven't supported Python 2 in a very long time. As such, it seems past time to remove this relic.

### Solution

Delete the legacy try/except code that is no longer needed

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
