### PR TITLE
Fix changlogs, remove PR reference

### DIFF
--- a/.changes/1.8.0/Dependencies-20231005-151848.yaml
+++ b/.changes/1.8.0/Dependencies-20231005-151848.yaml
@@ -3,4 +3,4 @@ body: "Bump actions/checkout from 3 to 4"
 time: 2023-10-05T15:18:48.00000Z
 custom:
   Author: dependabot[bot]
-  PR: 8781
+  Issue: 8781

--- a/.changes/1.8.0/Dependencies-20231031-131954.yaml
+++ b/.changes/1.8.0/Dependencies-20231031-131954.yaml
@@ -3,4 +3,4 @@ body: Begin using DSI 0.4.x
 time: 2023-10-31T13:19:54.750009-07:00
 custom:
   Author: QMalcolm peterallenwebb
-  PR: "8892"
+  Issue: "8892"

--- a/.changes/1.8.0/Dependencies-20231106-130051.yaml
+++ b/.changes/1.8.0/Dependencies-20231106-130051.yaml
@@ -3,4 +3,4 @@ body: Update typing-extensions version to >=4.4
 time: 2023-11-06T13:00:51.062386-08:00
 custom:
   Author: tlento
-  PR: "9012"
+  Issue: "9012"

--- a/.changes/1.8.0/Dependencies-20231122-001840.yaml
+++ b/.changes/1.8.0/Dependencies-20231122-001840.yaml
@@ -3,4 +3,4 @@ body: "Bump ddtrace from 2.1.7 to 2.3.0"
 time: 2023-11-22T00:18:40.00000Z
 custom:
   Author: dependabot[bot]
-  PR: 9132
+  Issue: 9132

--- a/.changes/1.8.0/Dependencies-20231204-000945.yaml
+++ b/.changes/1.8.0/Dependencies-20231204-000945.yaml
@@ -3,4 +3,4 @@ body: "Bump freezegun from 0.3.12 to 1.3.0"
 time: 2023-12-04T00:09:45.00000Z
 custom:
   Author: dependabot[bot]
-  PR: 9197
+  Issue: 9197

--- a/.changes/1.8.0/Dependencies-20231211-005651.yaml
+++ b/.changes/1.8.0/Dependencies-20231211-005651.yaml
@@ -3,4 +3,4 @@ body: "Bump actions/setup-python from 4 to 5"
 time: 2023-12-11T00:56:51.00000Z
 custom:
   Author: dependabot[bot]
-  PR: 9267
+  Issue: 9267

--- a/.changes/1.8.0/Dependencies-20240115-012030.yaml
+++ b/.changes/1.8.0/Dependencies-20240115-012030.yaml
@@ -3,4 +3,4 @@ body: "Bump actions/download-artifact from 3 to 4"
 time: 2024-01-15T01:20:30.00000Z
 custom:
   Author: dependabot[bot]
-  PR: 9374
+  Issue: 9374

--- a/.changes/1.8.0/Dependencies-20240123-105843.yaml
+++ b/.changes/1.8.0/Dependencies-20240123-105843.yaml
@@ -3,4 +3,4 @@ body: remove dbt/adapters and add dependency on dbt-adapters
 time: 2024-01-23T10:58:43.286952-08:00
 custom:
   Author: colin-rogers-dbt
-  PR: "9430"
+  Issue: "9430"

--- a/.changes/1.8.0/Dependencies-20240129-005734.yaml
+++ b/.changes/1.8.0/Dependencies-20240129-005734.yaml
@@ -3,4 +3,4 @@ body: "Bump actions/upload-artifact from 3 to 4"
 time: 2024-01-29T00:57:34.00000Z
 custom:
   Author: dependabot[bot]
-  PR: 9470
+  Issue: 9470

--- a/.changes/1.8.0/Dependencies-20240129-005743.yaml
+++ b/.changes/1.8.0/Dependencies-20240129-005743.yaml
@@ -3,4 +3,4 @@ body: "Bump actions/cache from 3 to 4"
 time: 2024-01-29T00:57:43.00000Z
 custom:
   Author: dependabot[bot]
-  PR: 9471
+  Issue: 9471

--- a/.changes/1.8.0/Dependencies-20240212-011324.yaml
+++ b/.changes/1.8.0/Dependencies-20240212-011324.yaml
@@ -3,4 +3,4 @@ body: "Bump peter-evans/create-pull-request from 5 to 6"
 time: 2024-02-12T01:13:24.00000Z
 custom:
   Author: dependabot[bot]
-  PR: 9552
+  Issue: 9552

--- a/.changes/1.8.0/Dependencies-20240222-102947.yaml
+++ b/.changes/1.8.0/Dependencies-20240222-102947.yaml
@@ -3,4 +3,4 @@ body: Restrict protobuf to 4.* versions
 time: 2024-02-22T10:29:47.595435-08:00
 custom:
   Author: QMalcolm
-  PR: "9566"
+  Issue: "9566"

--- a/.changes/1.8.0/Dependencies-20240226-004412.yaml
+++ b/.changes/1.8.0/Dependencies-20240226-004412.yaml
@@ -3,4 +3,4 @@ body: "Bump codecov/codecov-action from 3 to 4"
 time: 2024-02-26T00:44:12.00000Z
 custom:
   Author: dependabot[bot]
-  PR: 9659
+  Issue: 9659

--- a/.changes/1.8.0/Dependencies-20240226-123502.yaml
+++ b/.changes/1.8.0/Dependencies-20240226-123502.yaml
@@ -3,4 +3,4 @@ body: Cap dbt-semantic-interfaces version range to <0.6
 time: 2024-02-26T12:35:02.643779-08:00
 custom:
   Author: tlento
-  PR: "9671"
+  Issue: "9671"

--- a/.changes/1.8.0/Dependencies-20240227-151115.yaml
+++ b/.changes/1.8.0/Dependencies-20240227-151115.yaml
@@ -3,4 +3,4 @@ body: bump dbt-common to accept major version 1
 time: 2024-02-27T15:11:15.583604-05:00
 custom:
   Author: michelleark
-  PR: "9690"
+  Issue: "9690"

--- a/.changes/1.8.0/Security-20240222-152445.yaml
+++ b/.changes/1.8.0/Security-20240222-152445.yaml
@@ -3,4 +3,4 @@ body: Update Jinja2 to >= 3.1.3 to address CVE-2024-22195
 time: 2024-02-22T15:24:45.158305-08:00
 custom:
   Author: QMalcolm
-  PR: CVE-2024-22195
+  Issue: 9638

--- a/.changes/unreleased/Dependencies-20240117-100818.yaml
+++ b/.changes/unreleased/Dependencies-20240117-100818.yaml
@@ -3,4 +3,4 @@ body: Relax pathspec upper bound version restriction
 time: 2024-01-17T10:08:18.009949641+01:00
 custom:
   Author: rzjfr
-  PR: "9373"
+  Issue: "9373"

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -31,43 +31,7 @@ kinds:
       - {{.Body}} ({{ range $index, $element := $IssueList }}{{if $index}}, {{end}}{{$element}}{{end}})
   - label: Under the Hood
   - label: Dependencies
-    changeFormat: |-
-      {{- $PRList := list }}
-      {{- $changes := splitList " " $.Custom.PR }}
-      {{- range $pullrequest := $changes }}
-        {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-core/pull/nbr)" | replace "nbr" $pullrequest }}
-        {{- $PRList = append $PRList $changeLink  }}
-      {{- end -}}
-      - {{.Body}} ({{ range $index, $element := $PRList }}{{if $index}}, {{end}}{{$element}}{{end}})
-    skipGlobalChoices: true
-    additionalChoices:
-      - key: Author
-        label: GitHub Username(s) (separated by a single space if multiple)
-        type: string
-        minLength: 3
-      - key: PR
-        label: GitHub Pull Request Number (separated by a single space if multiple)
-        type: string
-        minLength: 1
   - label: Security
-    changeFormat: |-
-      {{- $PRList := list }}
-      {{- $changes := splitList " " $.Custom.PR }}
-      {{- range $pullrequest := $changes }}
-        {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-core/pull/nbr)" | replace "nbr" $pullrequest }}
-        {{- $PRList = append $PRList $changeLink  }}
-      {{- end -}}
-      - {{.Body}} ({{ range $index, $element := $PRList }}{{if $index}}, {{end}}{{$element}}{{end}})
-    skipGlobalChoices: true
-    additionalChoices:
-      - key: Author
-        label: GitHub Username(s) (separated by a single space if multiple)
-        type: string
-        minLength: 3
-      - key: PR
-        label: GitHub Pull Request Number (separated by a single space if multiple)
-        type: string
-        minLength: 1
 
 newlines:
   afterChangelogHeader: 1
@@ -106,18 +70,10 @@ footerFormat: |
         {{- $changeList := splitList " " $change.Custom.Author }}
           {{- $IssueList := list }}
           {{- $changeLink := $change.Kind }}
-          {{- if or (eq $change.Kind "Dependencies") (eq $change.Kind "Security") }}
-            {{- $changes := splitList " " $change.Custom.PR }}
-            {{- range $issueNbr := $changes }}
-              {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-core/pull/nbr)" | replace "nbr" $issueNbr }}
-              {{- $IssueList = append $IssueList $changeLink  }}
-            {{- end -}}
-          {{- else }}
-            {{- $changes := splitList " " $change.Custom.Issue }}
-            {{- range $issueNbr := $changes }}
-              {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-core/issues/nbr)" | replace "nbr" $issueNbr }}
-              {{- $IssueList = append $IssueList $changeLink  }}
-            {{- end -}}
+          {{- $changes := splitList " " $change.Custom.Issue }}
+          {{- range $issueNbr := $changes }}
+            {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-core/issues/nbr)" | replace "nbr" $issueNbr }}
+            {{- $IssueList = append $IssueList $changeLink  }}
           {{- end }}
           {{- /* check if this contributor has other changes associated with them already */}}
           {{- if hasKey $contributorDict $author }}

--- a/.github/workflows/bot-changelog.yml
+++ b/.github/workflows/bot-changelog.yml
@@ -56,4 +56,4 @@ jobs:
         commit_message: "Add automated changelog yaml from template for bot PR"
         changie_kind: ${{ matrix.changie_kind }}
         label: ${{ matrix.label }}
-        custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n  PR: ${{ github.event.pull_request.number }}"
+        custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n  Issue: ${{ github.event.pull_request.number }}"


### PR DESCRIPTION
resolves #

### Problem

A `Dependency` changelog referenced an Issue instead of a PR.  This caused changelog generation to fail because the PR tag was missing but required.

### Solution

Since GitHub treats PRs and Issue as the same thing, I removed all references to PR and only use Issue in the yaml files.  The links will still build correctly because issues and prs are the same thing under the hood for GitHub.  

I also updated the bot changelog to use Issue instead of PR in the yaml it auto generates.

This was tested by locally running the changie batch commands to ensure changelogs can be generated.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
