### PR TITLE
Disambiguate FreshnessConfigProblem error message

### DIFF
--- a/.changes/unreleased/Fixes-20240412-095718.yaml
+++ b/.changes/unreleased/Fixes-20240412-095718.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Disambiguiate FreshnessConfigProblem error message
+time: 2024-04-12T09:57:18.417882-07:00
+custom:
+  Author: michelleark
+  Issue: "9891"

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -202,7 +202,7 @@ class SourcePatcher:
             # runtime.
             fire_event(
                 FreshnessConfigProblem(
-                    msg=f"The configured adapter does not support metadata-based freshness. A loaded_at_field must be specified for source '{source.name}'."
+                    msg=f"The configured adapter does not support metadata-based freshness. A loaded_at_field must be specified for source '{source.name}.{table.name}'."
                 )
             )
 


### PR DESCRIPTION
resolves: https://github.com/dbt-labs/dbt-core/issues/9913

given yaml: 
```yaml
sources:
  - name: ecom
    schema: jaffle_shop_raw
    description: E-commerce data for the Jaffle Shop
    freshness:
      warn_after:
        count: 24
        period: hour
    tables:
      - name: raw_customers
        description: One record per person who has purchased one or more items
      - name: raw_orders
        description: One record per order (consisting of one or more order items)
        loaded_at_field: ordered_at
      - name: raw_items
        description: Items included in an order
      - name: raw_stores
        loaded_at_field: opened_at
      - name: raw_products
        description: One record per SKU for items sold in stores
      - name: raw_supplies
        description: One record per supply per SKU of items sold in stores
```
before: 
```sh
❯ dbt --no-partial-parse  parse
23:26:14  Running with dbt=1.8.0-b2
23:26:14  target not specified in profile 'postgres', using 'default'
23:26:15  Registered adapter: postgres=1.8.0-b2
23:26:16  [WARNING]: Deprecated functionality
The `tests` config has been renamed to `data_tests`. Please see
https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax for more
information.
23:26:16  The configured adapter does not support metadata-based freshness. A loaded_at_field must be specified for source 'ecom'.
23:26:16  The configured adapter does not support metadata-based freshness. A loaded_at_field must be specified for source 'ecom'.
23:26:16  The configured adapter does not support metadata-based freshness. A loaded_at_field must be specified for source 'ecom'.
23:26:16  The configured adapter does not support metadata-based freshness. A loaded_at_field must be specified for source 'ecom'.
```
after:
```
❯ dbt parse
23:23:46  Running with dbt=1.8.0-b2
23:23:46  target not specified in profile 'postgres', using 'default'
23:23:47  Registered adapter: postgres=1.8.0-b2
23:23:48  [WARNING]: Deprecated functionality
The `tests` config has been renamed to `data_tests`. Please see
https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax for more
information.
23:23:48  The configured adapter does not support metadata-based freshness. A loaded_at_field must be specified for source 'ecom.raw_customers'.
23:23:48  The configured adapter does not support metadata-based freshness. A loaded_at_field must be specified for source 'ecom.raw_items'.
23:23:48  The configured adapter does not support metadata-based freshness. A loaded_at_field must be specified for source 'ecom.raw_products'.
23:23:48  The configured adapter does not support metadata-based freshness. A loaded_at_field must be specified for source 'ecom.raw_supplies'.
23:23:48  Performance info: /Users/michelleark/src/jaffle-shop/target/perf_info.json
```
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
