### PR TITLE
Migrate from custom `_error_tag` to `dbt-common` defined `error_tag`

### DIFF
--- a/.changes/unreleased/Under the Hood-20240412-134502.yaml
+++ b/.changes/unreleased/Under the Hood-20240412-134502.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Migrate to using `error_tag` provided by `dbt-common`
+time: 2024-04-12T13:45:02.879023-07:00
+custom:
+  Author: QMalcolm
+  Issue: "9914"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1,7 +1,7 @@
 import json
 
 from dbt.constants import MAXIMUM_SEED_SIZE_NAME, PIN_PACKAGE_URL
-from dbt_common.ui import warning_tag, line_wrap_message, green, yellow, red
+from dbt_common.ui import error_tag, warning_tag, line_wrap_message, green, yellow, red
 from dbt_common.events.base_types import EventLevel
 from dbt_common.events.format import (
     format_fancy_output_line,
@@ -9,11 +9,6 @@ from dbt_common.events.format import (
     pluralize,
 )
 from dbt.events.base_types import WarnLevel, InfoLevel, DebugLevel, ErrorLevel, DynamicLevel
-
-
-# TODO Move this to dbt_common.ui
-def _error_tag(msg: str) -> str:
-    return f'[{red("ERROR")}]: {msg}'
 
 
 # Event codes have prefixes which follow this table
@@ -430,7 +425,7 @@ class SpacesInModelNameDeprecation(DynamicLevel):
         )
 
         if self.level == EventLevel.ERROR.value:
-            description = _error_tag(description)
+            description = error_tag(description)
         elif self.level == EventLevel.WARN.value:
             description = warning_tag(description)
 
@@ -448,7 +443,7 @@ class TotalModelNamesWithSpacesDeprecation(DynamicLevel):
             description += " Run again with `--debug` to see them all."
 
         if self.level == EventLevel.ERROR.value:
-            description = _error_tag(description)
+            description = error_tag(description)
         elif self.level == EventLevel.WARN.value:
             description = warning_tag(description)
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -75,7 +75,7 @@ setup(
         "minimal-snowplow-tracker>=0.0.2,<0.1",
         "dbt-semantic-interfaces>=0.5.1,<0.6",
         # Minor versions for these are expected to be backwards-compatible
-        "dbt-common<2.0",
+        "dbt-common>=1.0.1,<2.0",
         "dbt-adapters>=0.1.0a2,<2.0",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.


### PR DESCRIPTION
resolves #9914

### Problem

In https://github.com/dbt-labs/dbt-core/pull/9886  we added a stop gap `_error_tag` which really should have been in `dbt-common`. We have since added it to `dbt-common` as `error_tag` and the release of `dbt-common 1.0.1` made it publicly available. Thus we needed to clean things up by migrating to that newly `dbt-common` provided function

### Solution

* Upgrade to dbt-common 1.0.1
* drop custom `_error_tag`
* use dbt-common provided `error_tag`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
