### PR TITLE
stop bumping version in DockerFile

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -35,5 +35,3 @@ first_value = 1
 [bumpversion:file:core/setup.py]
 
 [bumpversion:file:core/dbt/version.py]
-
-[bumpversion:file:docker/Dockerfile]


### PR DESCRIPTION
resolves #


### Problem

We no longer define the version in the Dockerfile and it's causing an error during version bump

### Solution

Exclude it from the files to version bump.  This does not need to be backported.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
