### PR TITLE
bump sqlparse to 0.5

### DIFF
--- a/.changes/unreleased/Dependencies-20240415-202426.yaml
+++ b/.changes/unreleased/Dependencies-20240415-202426.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump sqlparse to >=0.5.0, <0.6.0
+time: 2024-04-15T20:24:26.768707-05:00
+custom:
+  Author: emmyoop
+  Issue: "9951"

--- a/core/setup.py
+++ b/core/setup.py
@@ -67,7 +67,7 @@ setup(
         # These packages are major-version-0. Keep upper bounds on upcoming minor versions (which could have breaking changes)
         # and check compatibility / bump in each new minor version of dbt-core.
         "pathspec>=0.9,<0.13",
-        "sqlparse>=0.2.3,<0.5",
+        "sqlparse>=0.5.0,<0.6.0",
         # ----
         # These are major-version-0 packages also maintained by dbt-labs.
         # Accept patches but avoid automatically updating past a set minor version range.


### PR DESCRIPTION
### Description

Bump sqlparse to 0.5 to 0.6

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
