### PR TITLE
Fix nightly release & Docker drafts

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: write # this is the permission that allows creating a new release
+  packages: write # this is the permission that allows Docker release
 
 defaults:
   run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
     # We cannot release to docker on a test run because it uses the tag in GitHub as
     # what we need to release but draft releases don't actually tag the commit so it
     # finds nothing to release
-    if: ${{ !inputs.test_run || inputs.only_docker }}
+    if: ${{ !failure() && !cancelled() && (!inputs.test_run || inputs.only_docker) }}
     strategy:
       matrix: ${{fromJson(needs.determine-docker-package.outputs.matrix)}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,11 @@ on:
         type: boolean
         default: false
         required: false
+      only_docker:
+        description: "Only release Docker image, skip GitHub & PyPI"
+        type: boolean
+        default: false
+        required: false
 
 permissions:
   contents: write # this is the permission that allows creating a new release
@@ -99,6 +104,7 @@ jobs:
   bump-version-generate-changelog:
     name: Bump package version, Generate changelog
     needs: [job-setup]
+    if: ${{ !inputs.only_docker}}
 
     uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@main
 
@@ -114,7 +120,7 @@ jobs:
 
   log-outputs-bump-version-generate-changelog:
     name: "[Log output] Bump package version, Generate changelog"
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ !failure() && !cancelled() && !inputs.only_docker}}
 
     needs: [bump-version-generate-changelog]
 
@@ -128,7 +134,7 @@ jobs:
 
   build-test-package:
     name: Build, Test, Package
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ !failure() && !cancelled() && !inputs.only_docker}}
     needs: [job-setup, bump-version-generate-changelog]
 
     uses: dbt-labs/dbt-release/.github/workflows/build.yml@main
@@ -149,7 +155,7 @@ jobs:
 
   github-release:
     name: GitHub Release
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ !failure() && !cancelled() && !inputs.only_docker}}
 
     needs: [bump-version-generate-changelog, build-test-package]
 
@@ -180,6 +186,7 @@ jobs:
     # dbt-postgres exists within dbt-core for versions 1.7 and earlier but is a separate package for 1.8 and later.
     # determine if we need to release dbt-core or both dbt-core and dbt-postgres
     name: Determine Docker Package
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     needs: [pypi-release]
     outputs:
@@ -204,6 +211,10 @@ jobs:
   docker-release:
     name: "Docker Release for ${{ matrix.package }}"
     needs: [determine-docker-package]
+    # We cannot release to docker on a test run because it uses the tag in GitHub as
+    # what we need to release but draft releases don't actually tag the commit so it
+    # finds nothing to release
+    if: ${{ !inputs.test_run || inputs.only_docker }}
     strategy:
       matrix: ${{fromJson(needs.determine-docker-package.outputs.matrix)}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
   bump-version-generate-changelog:
     name: Bump package version, Generate changelog
     needs: [job-setup]
-    if: ${{ !inputs.only_docker}}
+    if: ${{ !inputs.only_docker }}
 
     uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@main
 
@@ -121,7 +121,7 @@ jobs:
 
   log-outputs-bump-version-generate-changelog:
     name: "[Log output] Bump package version, Generate changelog"
-    if: ${{ !failure() && !cancelled() && !inputs.only_docker}}
+    if: ${{ !failure() && !cancelled() && !inputs.only_docker }}
 
     needs: [bump-version-generate-changelog]
 
@@ -135,7 +135,7 @@ jobs:
 
   build-test-package:
     name: Build, Test, Package
-    if: ${{ !failure() && !cancelled() && !inputs.only_docker}}
+    if: ${{ !failure() && !cancelled() && !inputs.only_docker }}
     needs: [job-setup, bump-version-generate-changelog]
 
     uses: dbt-labs/dbt-release/.github/workflows/build.yml@main
@@ -156,7 +156,7 @@ jobs:
 
   github-release:
     name: GitHub Release
-    if: ${{ !failure() && !cancelled() && !inputs.only_docker}}
+    if: ${{ !failure() && !cancelled() && !inputs.only_docker }}
 
     needs: [bump-version-generate-changelog, build-test-package]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,11 @@ on:
         type: boolean
         default: false
         required: false
+      only_docker:
+        description: "Only release Docker image, skip GitHub & PyPI"
+        type: boolean
+        default: false
+        required: false
   workflow_call:
     inputs:
       target_branch:
@@ -56,11 +61,6 @@ on:
         required: false
       nightly_release:
         description: "Nightly release to dev environment"
-        type: boolean
-        default: false
-        required: false
-      only_docker:
-        description: "Only release Docker image, skip GitHub & PyPI"
         type: boolean
         default: false
         required: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
           echo The release version number:         ${{ inputs.version_number }}
           echo Test run:                           ${{ inputs.test_run }}
           echo Nightly release:                    ${{ inputs.nightly_release }}
+          echo Only Docker:                        ${{ inputs.only_docker }}
 
       - name: "Checkout target branch"
         uses: actions/checkout@v4


### PR DESCRIPTION
resolves #


### Problem

Nightly releases failed for having the wrong permissions.

Additionally, Docker released fail on a draft release since the tag does not exist.

### Solution

Add the `package: write` permission to the nightly release
Do not release to Docker when we are running the release as a test
Allow the release to _only_ release to Docker when a flag is flipped.  This will allow us to release to Docker as needed if the final release already exists.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
