### PR TITLE
[BACKPORT 1.7] bump sqlparse

### DIFF
--- a/.changes/unreleased/Dependencies-20240415-202426.yaml
+++ b/.changes/unreleased/Dependencies-20240415-202426.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump sqlparse to >=0.5.0, <0.6.0
+time: 2024-04-15T20:24:26.768707-05:00
+custom:
+  Author: emmyoop
+  Issue: "9951"

--- a/.changes/unreleased/Dependencies-20240415-202426.yaml
+++ b/.changes/unreleased/Dependencies-20240415-202426.yaml
@@ -1,6 +1,0 @@
-kind: Dependencies
-body: Bump sqlparse to >=0.5.0, <0.6.0
-time: 2024-04-15T20:24:26.768707-05:00
-custom:
-  Author: emmyoop
-  Issue: "9951"

--- a/.changes/unreleased/Security-20240417-141316.yaml
+++ b/.changes/unreleased/Security-20240417-141316.yaml
@@ -1,0 +1,6 @@
+kind: Security
+body: Bump sqlparse to >=0.5.0, <0.6.0 to address GHSA-2m57-hf25-phgg
+time: 2024-04-17T14:13:16.896353-05:00
+custom:
+  Author: emmoop
+  Issue: "9951"

--- a/.changes/unreleased/Security-20240417-141316.yaml
+++ b/.changes/unreleased/Security-20240417-141316.yaml
@@ -3,4 +3,4 @@ body: Bump sqlparse to >=0.5.0, <0.6.0 to address GHSA-2m57-hf25-phgg
 time: 2024-04-17T14:13:16.896353-05:00
 custom:
   Author: emmoop
-  Issue: "9951"
+  PR: "9951"

--- a/core/setup.py
+++ b/core/setup.py
@@ -68,7 +68,7 @@ setup(
         "pathspec>=0.9,<0.12",
         "isodate>=0.6,<0.7",
         # ----
-        "sqlparse>=0.2.3,<0.5",
+        "sqlparse>=0.5.0,<0.6.0",
         # ----
         # These are major-version-0 packages also maintained by dbt-labs. Accept patches.
         "dbt-extractor~=0.5.0",


### PR DESCRIPTION
Backport df2bf132fd77a777875fe5a8f640fe3c11c28321 and 3f52cc4278f0e3fb456049a2b0e14f99b37da92a to 1.7.latest