### PR TITLE
pin proto-types to match proto pin

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -29,7 +29,7 @@ types-docutils
 types-PyYAML
 types-Jinja2
 types-mock
-types-protobuf
+types-protobuf>=4.0.0,<5.0.0
 types-pytz
 types-requests
 types-setuptools


### PR DESCRIPTION


### Problem

`protobuf` is pinned to <4,>5 but `protobuf-types` is unpinned and can cause false type check failures as a result

### Solution

`protobuf-types` pin should match to avoid false failures. Skipping changelog since this is just a dev dependency.

This should be backported through 1.5 to prevent false backport code check failures in the future

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
