### PR TITLE
[BACKPORT 1.6.latest] pin proto-types to match proto pin (#9999)

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -27,7 +27,7 @@ types-PyYAML
 types-freezegun
 types-Jinja2
 types-mock
-types-protobuf
+types-protobuf>=4.0.0,<5.0.0
 types-python-dateutil
 types-pytz
 types-requests < 2.31.0  # types-requests 2.31.0.8 requires urllib3>=2, but we pin urllib3 ~= 1.0 because of openssl requirement for requests


### PR DESCRIPTION
backport d33158c2067da9c6cd999959e15a3a24345531e0 to 1.6.latest