### PR TITLE
[Bugfix][Selection] yaml selector do not obey default overwrite

### DIFF
--- a/core/dbt/README.md
+++ b/core/dbt/README.md
@@ -58,3 +58,69 @@
 * parser
 * task
 * tests
+
+
+
+how the selector module gets loaded
+
+File "/Users/chenyuli/git/dbt-core/env_core/bin/dbt", line 33, in <module>
+    sys.exit(load_entry_point('dbt-core', 'console_scripts', 'dbt')())
+  File "/Users/chenyuli/git/dbt-core/env_core/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
+    return self.main(*args, **kwargs)
+  File "/Users/chenyuli/git/dbt-core/env_core/lib/python3.11/site-packages/click/core.py", line 1078, in main
+    rv = self.invoke(ctx)
+  File "/Users/chenyuli/git/dbt-core/env_core/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
+    return _process_result(sub_ctx.command.invoke(sub_ctx))
+  File "/Users/chenyuli/git/dbt-core/env_core/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
+    return ctx.invoke(self.callback, **ctx.params)
+  File "/Users/chenyuli/git/dbt-core/env_core/lib/python3.11/site-packages/click/core.py", line 783, in invoke
+    return __callback(*args, **kwargs)
+  File "/Users/chenyuli/git/dbt-core/env_core/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
+    return f(get_current_context(), *args, **kwargs)
+  File "/Users/chenyuli/git/dbt-core/core/dbt/cli/main.py", line 148, in wrapper
+    return func(*args, **kwargs)
+  File "/Users/chenyuli/git/dbt-core/core/dbt/cli/requires.py", line 106, in wrapper
+    result, success = func(*args, **kwargs)
+  File "/Users/chenyuli/git/dbt-core/core/dbt/cli/requires.py", line 91, in wrapper
+    return func(*args, **kwargs)
+  File "/Users/chenyuli/git/dbt-core/core/dbt/cli/requires.py", line 184, in wrapper
+    return func(*args, **kwargs)
+  File "/Users/chenyuli/git/dbt-core/core/dbt/cli/requires.py", line 200, in wrapper
+    project = load_project(
+  File "/Users/chenyuli/git/dbt-core/core/dbt/config/runtime.py", line 51, in load_project
+    project = Project.from_project_root(
+  File "/Users/chenyuli/git/dbt-core/core/dbt/config/project.py", line 765, in from_project_root
+    return partial.render(renderer)
+  File "/Users/chenyuli/git/dbt-core/core/dbt/config/project.py", line 333, in render
+    return self.create_project(rendered)
+  File "/Users/chenyuli/git/dbt-core/core/dbt/config/project.py", line 483, in create_project
+    selectors = selector_config_from_data(rendered.selectors_dict)
+  File "/Users/chenyuli/git/dbt-core/core/dbt/config/selectors.py", line 110, in selector_config_from_data
+    selectors = SelectorConfig.selectors_from_dict(selectors_data)
+  File "/Users/chenyuli/git/dbt-core/core/dbt/config/selectors.py", line 39, in selectors_from_dict
+    selectors = parse_from_selectors_definition(selector_file)
+  File "/Users/chenyuli/git/dbt-core/core/dbt/graph/cli.py", line 261, in parse_from_selectors_definition
+    "definition": parse_from_definition(
+  File "/Users/chenyuli/git/dbt-core/core/dbt/graph/cli.py", line 241, in parse_from_definition
+    return parse_union_definition(definition, result=result)
+  File "/Users/chenyuli/git/dbt-core/core/dbt/graph/cli.py", line 163, in parse_union_definition
+    union = SelectionUnion(components=include)
+  File "/Users/chenyuli/.asdf/installs/python/3.11.0/lib/python3.11/bdb.py", line 90, in trace_dispatch
+    return self.dispatch_line(frame)
+  File "/Users/chenyuli/.asdf/installs/python/3.11.0/lib/python3.11/bdb.py", line 114, in dispatch_line
+    self.user_line(frame)
+  File "/Users/chenyuli/.asdf/installs/python/3.11.0/lib/python3.11/pdb.py", line 340, in user_line
+    self.interaction(frame, None)
+  File "/Users/chenyuli/.asdf/installs/python/3.11.0/lib/python3.11/pdb.py", line 435, in interaction
+    self._cmdloop()
+  File "/Users/chenyuli/.asdf/installs/python/3.11.0/lib/python3.11/pdb.py", line 400, in _cmdloop
+    self.cmdloop()
+  File "/Users/chenyuli/.asdf/installs/python/3.11.0/lib/python3.11/cmd.py", line 138, in cmdloop
+    stop = self.onecmd(line)
+  File "/Users/chenyuli/.asdf/installs/python/3.11.0/lib/python3.11/pdb.py", line 500, in onecmd
+    return cmd.Cmd.onecmd(self, line)
+  File "/Users/chenyuli/.asdf/installs/python/3.11.0/lib/python3.11/cmd.py", line 216, in onecmd
+    return self.default(line)
+  File "/Users/chenyuli/.asdf/installs/python/3.11.0/lib/python3.11/pdb.py", line 459, in default
+    exec(code, globals, locals)
+  File "<stdin>", line 1, in <module>

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -108,13 +108,6 @@ class GraphRunnableTask(ConfiguredTask):
 
     def get_selection_spec(self) -> SelectionSpec:
         default_selector_name = self.config.get_default_selector_name()
-        # TODO:  The "eager" string below needs to be replaced with programatic access
-        #  to the default value for the indirect selection parameter in
-        # dbt.cli.params.indirect_selection
-        #
-        # Doing that is actually a little tricky, so I'm punting it to a new ticket GH #6397
-        indirect_selection = getattr(self.args, "INDIRECT_SELECTION", "eager")
-
         if self.args.selector:
             # use pre-defined selector (--selector)
             spec = self.config.get_selector(self.args.selector)
@@ -125,7 +118,7 @@ class GraphRunnableTask(ConfiguredTask):
         else:
             # This is what's used with no default selector and no selection
             # use --select and --exclude args
-            spec = parse_difference(self.selection_arg, self.exclusion_arg, indirect_selection)
+            spec = parse_difference(self.selection_arg, self.exclusion_arg)
         # mypy complains because the return values of get_selector and parse_difference
         # are different
         return spec  # type: ignore

--- a/tests/unit/graph/test_selector.py
+++ b/tests/unit/graph/test_selector.py
@@ -21,11 +21,216 @@ from dbt.graph import NodeSelector, parse_difference
 from dbt.events.logging import setup_event_logger
 from dbt.mp_context import get_mp_context
 from queue import Empty
-from .utils import config_from_parts_or_dicts, generate_name_macros, inject_plugin
+from tests.unit.utils import config_from_parts_or_dicts, generate_name_macros, inject_plugin
 
 from argparse import Namespace
 
+
+import pytest
+
+import string
+import dbt_common.exceptions
+import dbt.graph.selector as graph_selector
+import dbt.graph.cli as graph_cli
+from dbt.node_types import NodeType
+
+import networkx as nx
+
+
 set_from_args(Namespace(WARN_ERROR=False), None)
+
+
+def _get_graph():
+    integer_graph = nx.balanced_tree(2, 2, nx.DiGraph())
+
+    package_mapping = {
+        i: "m." + ("X" if i % 2 == 0 else "Y") + "." + letter
+        for (i, letter) in enumerate(string.ascii_lowercase)
+    }
+
+    # Edges: [(X.a, Y.b), (X.a, X.c), (Y.b, Y.d), (Y.b, X.e), (X.c, Y.f), (X.c, X.g)]
+    return graph_selector.Graph(nx.relabel_nodes(integer_graph, package_mapping))
+
+
+def _get_manifest(graph):
+    nodes = {}
+    for unique_id in graph:
+        fqn = unique_id.split(".")
+        node = MagicMock(
+            unique_id=unique_id,
+            fqn=fqn,
+            package_name=fqn[0],
+            tags=[],
+            resource_type=NodeType.Model,
+            empty=False,
+            config=MagicMock(enabled=True),
+            is_versioned=False,
+        )
+        nodes[unique_id] = node
+
+    nodes["m.X.a"].tags = ["abc"]
+    nodes["m.Y.b"].tags = ["abc", "bcef"]
+    nodes["m.X.c"].tags = ["abc", "bcef"]
+    nodes["m.Y.d"].tags = []
+    nodes["m.X.e"].tags = ["efg", "bcef"]
+    nodes["m.Y.f"].tags = ["efg", "bcef"]
+    nodes["m.X.g"].tags = ["efg"]
+    return MagicMock(nodes=nodes)
+
+
+@pytest.fixture
+def graph():
+    return _get_graph()
+
+
+@pytest.fixture
+def manifest(graph):
+    return _get_manifest(graph)
+
+
+def id_macro(arg):
+    if isinstance(arg, str):
+        return arg
+    try:
+        return "_".join(arg)
+    except TypeError:
+        return arg
+
+
+run_specs = [
+    # include by fqn
+    (["X.a"], [], {"m.X.a"}),
+    # include by tag
+    (["tag:abc"], [], {"m.X.a", "m.Y.b", "m.X.c"}),
+    # exclude by tag
+    (["*"], ["tag:abc"], {"m.Y.d", "m.X.e", "m.Y.f", "m.X.g"}),
+    # tag + fqn
+    (["tag:abc", "a"], [], {"m.X.a", "m.Y.b", "m.X.c"}),
+    (["tag:abc", "d"], [], {"m.X.a", "m.Y.b", "m.X.c", "m.Y.d"}),
+    # multiple node selection across packages
+    (["X.a", "b"], [], {"m.X.a", "m.Y.b"}),
+    (["X.a+"], ["b"], {"m.X.a", "m.X.c", "m.Y.d", "m.X.e", "m.Y.f", "m.X.g"}),
+    # children
+    (["X.c+"], [], {"m.X.c", "m.Y.f", "m.X.g"}),
+    (["X.a+1"], [], {"m.X.a", "m.Y.b", "m.X.c"}),
+    (["X.a+"], ["tag:efg"], {"m.X.a", "m.Y.b", "m.X.c", "m.Y.d"}),
+    # parents
+    (["+Y.f"], [], {"m.X.c", "m.Y.f", "m.X.a"}),
+    (["1+Y.f"], [], {"m.X.c", "m.Y.f"}),
+    # childrens parents
+    (["@X.c"], [], {"m.X.a", "m.X.c", "m.Y.f", "m.X.g"}),
+    # multiple selection/exclusion
+    (["tag:abc", "tag:bcef"], [], {"m.X.a", "m.Y.b", "m.X.c", "m.X.e", "m.Y.f"}),
+    (["tag:abc", "tag:bcef"], ["tag:efg"], {"m.X.a", "m.Y.b", "m.X.c"}),
+    (["tag:abc", "tag:bcef"], ["tag:efg", "a"], {"m.Y.b", "m.X.c"}),
+    # intersections
+    (["a,a"], [], {"m.X.a"}),
+    (["+c,c+"], [], {"m.X.c"}),
+    (["a,b"], [], set()),
+    (["tag:abc,tag:bcef"], [], {"m.Y.b", "m.X.c"}),
+    (["*,tag:abc,a"], [], {"m.X.a"}),
+    (["a,tag:abc,*"], [], {"m.X.a"}),
+    (["tag:abc,tag:bcef"], ["c"], {"m.Y.b"}),
+    (["tag:bcef,tag:efg"], ["tag:bcef,@b"], {"m.Y.f"}),
+    (["tag:bcef,tag:efg"], ["tag:bcef,@a"], set()),
+    (["*,@a,+b"], ["*,tag:abc,tag:bcef"], {"m.X.a"}),
+    (["tag:bcef,tag:efg", "*,tag:abc"], [], {"m.X.a", "m.Y.b", "m.X.c", "m.X.e", "m.Y.f"}),
+    (["tag:bcef,tag:efg", "*,tag:abc"], ["e"], {"m.X.a", "m.Y.b", "m.X.c", "m.Y.f"}),
+    (["tag:bcef,tag:efg", "*,tag:abc"], ["e"], {"m.X.a", "m.Y.b", "m.X.c", "m.Y.f"}),
+    (["tag:bcef,tag:efg", "*,tag:abc"], ["e", "f"], {"m.X.a", "m.Y.b", "m.X.c"}),
+    (["tag:bcef,tag:efg", "*,tag:abc"], ["tag:abc,tag:bcef"], {"m.X.a", "m.X.e", "m.Y.f"}),
+    (["tag:bcef,tag:efg", "*,tag:abc"], ["tag:abc,tag:bcef", "tag:abc,a"], {"m.X.e", "m.Y.f"}),
+]
+
+
+@pytest.mark.parametrize("include,exclude,expected", run_specs, ids=id_macro)
+def test_run_specs(include, exclude, expected, graph, manifest):
+    selector = graph_selector.NodeSelector(graph, manifest)
+    spec = graph_cli.parse_difference(include, exclude)
+    selected, _ = selector.select_nodes(spec)
+
+    assert selected == expected
+
+
+param_specs = [
+    ("a", False, None, False, None, "fqn", "a", False),
+    ("+a", True, None, False, None, "fqn", "a", False),
+    ("256+a", True, 256, False, None, "fqn", "a", False),
+    ("a+", False, None, True, None, "fqn", "a", False),
+    ("a+256", False, None, True, 256, "fqn", "a", False),
+    ("+a+", True, None, True, None, "fqn", "a", False),
+    ("16+a+32", True, 16, True, 32, "fqn", "a", False),
+    ("@a", False, None, False, None, "fqn", "a", True),
+    ("a.b", False, None, False, None, "fqn", "a.b", False),
+    ("+a.b", True, None, False, None, "fqn", "a.b", False),
+    ("256+a.b", True, 256, False, None, "fqn", "a.b", False),
+    ("a.b+", False, None, True, None, "fqn", "a.b", False),
+    ("a.b+256", False, None, True, 256, "fqn", "a.b", False),
+    ("+a.b+", True, None, True, None, "fqn", "a.b", False),
+    ("16+a.b+32", True, 16, True, 32, "fqn", "a.b", False),
+    ("@a.b", False, None, False, None, "fqn", "a.b", True),
+    ("a.b.*", False, None, False, None, "fqn", "a.b.*", False),
+    ("+a.b.*", True, None, False, None, "fqn", "a.b.*", False),
+    ("256+a.b.*", True, 256, False, None, "fqn", "a.b.*", False),
+    ("a.b.*+", False, None, True, None, "fqn", "a.b.*", False),
+    ("a.b.*+256", False, None, True, 256, "fqn", "a.b.*", False),
+    ("+a.b.*+", True, None, True, None, "fqn", "a.b.*", False),
+    ("16+a.b.*+32", True, 16, True, 32, "fqn", "a.b.*", False),
+    ("@a.b.*", False, None, False, None, "fqn", "a.b.*", True),
+    ("tag:a", False, None, False, None, "tag", "a", False),
+    ("+tag:a", True, None, False, None, "tag", "a", False),
+    ("256+tag:a", True, 256, False, None, "tag", "a", False),
+    ("tag:a+", False, None, True, None, "tag", "a", False),
+    ("tag:a+256", False, None, True, 256, "tag", "a", False),
+    ("+tag:a+", True, None, True, None, "tag", "a", False),
+    ("16+tag:a+32", True, 16, True, 32, "tag", "a", False),
+    ("@tag:a", False, None, False, None, "tag", "a", True),
+    ("source:a", False, None, False, None, "source", "a", False),
+    ("source:a+", False, None, True, None, "source", "a", False),
+    ("source:a+1", False, None, True, 1, "source", "a", False),
+    ("source:a+32", False, None, True, 32, "source", "a", False),
+    ("@source:a", False, None, False, None, "source", "a", True),
+]
+
+
+@pytest.mark.parametrize(
+    "spec,parents,parents_depth,children,children_depth,filter_type,filter_value,childrens_parents",
+    param_specs,
+    ids=id_macro,
+)
+def test_parse_specs(
+    spec,
+    parents,
+    parents_depth,
+    children,
+    children_depth,
+    filter_type,
+    filter_value,
+    childrens_parents,
+):
+    parsed = graph_selector.SelectionCriteria.from_single_spec(spec)
+    assert parsed.parents == parents
+    assert parsed.parents_depth == parents_depth
+    assert parsed.children == children
+    assert parsed.children_depth == children_depth
+    assert parsed.method == filter_type
+    assert parsed.value == filter_value
+    assert parsed.childrens_parents == childrens_parents
+
+
+invalid_specs = [
+    "@a+",
+    "@a.b+",
+    "@a.b*+",
+    "@tag:a+",
+    "@source:a+",
+]
+
+
+@pytest.mark.parametrize("invalid", invalid_specs, ids=lambda k: str(k))
+def test_invalid_specs(invalid):
+    with pytest.raises(dbt_common.exceptions.DbtRuntimeError):
+        graph_selector.SelectionCriteria.from_single_spec(invalid)
 
 
 class GraphTest(unittest.TestCase):
@@ -342,7 +547,12 @@ class GraphTest(unittest.TestCase):
         # dbt.cli.params.indirect_selection
         #
         # Doing that is actually a little tricky, so I'm punting it to a new ticket GH #6397
-        queue = selector.get_graph_queue(parse_difference(None, None, "eager"))
+        queue = selector.get_graph_queue(
+            parse_difference(
+                None,
+                None,
+            )
+        )
 
         for model_id in model_ids:
             self.assertFalse(queue.empty())

--- a/tests/unit/test_compilation.py
+++ b/tests/unit/test_compilation.py
@@ -75,7 +75,7 @@ class LinkerTest(unittest.TestCase):
         # dbt.cli.params.indirect_selection
         #
         # Doing that is actually a little tricky, so I'm punting it to a new ticket GH #6397
-        spec = parse_difference(include, exclude, "eager")
+        spec = parse_difference(include, exclude)
         return selector.get_graph_queue(spec)
 
     def test_linker_add_dependency(self):

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,12 +1,13 @@
 from argparse import Namespace
 import pytest
 
-# from unittest.mock import patch
+from unittest.mock import patch
 
 import dbt.flags as flags
 from dbt_common.events.functions import msg_to_dict, warn_or_error
+from dbt_common.events.event_manager_client import cleanup_event_logger
 
-# from dbt.events.logging import setup_event_logger
+from dbt.events.logging import setup_event_logger
 from dbt_common.events.types import InfoLevel
 from dbt_common.exceptions import EventCompilationError
 from dbt.events.types import NoNodesForSelectionCriteria
@@ -87,11 +88,13 @@ def test_msg_to_dict_handles_exceptions_gracefully():
         ), f"We expect `msg_to_dict` to gracefully handle exceptions, but it raised {exc}"
 
 
-# @patch("dbt_common.events.logger.RotatingFileHandler")
-# def test_setup_event_logger_specify_max_bytes(patched_file_handler):
-#     args = Namespace(log_file_max_bytes=1234567)
-#     flags.set_from_args(args, {})
-#     setup_event_logger(flags.get_flags())
-#     patched_file_handler.assert_called_once_with(
-#         filename="logs/dbt.log", encoding="utf8", maxBytes=1234567, backupCount=5
-#     )
+@patch("dbt_common.events.logger.RotatingFileHandler")
+def test_setup_event_logger_specify_max_bytes(patched_file_handler):
+    args = Namespace(log_file_max_bytes=1234567)
+    flags.set_from_args(args, {})
+    setup_event_logger(flags.get_flags())
+    patched_file_handler.assert_called_once_with(
+        filename="logs/dbt.log", encoding="utf8", maxBytes=1234567, backupCount=5
+    )
+    # XXX if we do not clean up event logger here we are going to affect other tests.
+    cleanup_event_logger()

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,9 +1,12 @@
 from argparse import Namespace
 import pytest
 
+# from unittest.mock import patch
+
 import dbt.flags as flags
 from dbt_common.events.functions import msg_to_dict, warn_or_error
-from dbt.events.logging import setup_event_logger
+
+# from dbt.events.logging import setup_event_logger
 from dbt_common.events.types import InfoLevel
 from dbt_common.exceptions import EventCompilationError
 from dbt.events.types import NoNodesForSelectionCriteria
@@ -84,11 +87,11 @@ def test_msg_to_dict_handles_exceptions_gracefully():
         ), f"We expect `msg_to_dict` to gracefully handle exceptions, but it raised {exc}"
 
 
-def test_setup_event_logger_specify_max_bytes(mocker):
-    patched_file_handler = mocker.patch("dbt_common.events.logger.RotatingFileHandler")
-    args = Namespace(log_file_max_bytes=1234567)
-    flags.set_from_args(args, {})
-    setup_event_logger(flags.get_flags())
-    patched_file_handler.assert_called_once_with(
-        filename="logs/dbt.log", encoding="utf8", maxBytes=1234567, backupCount=5
-    )
+# @patch("dbt_common.events.logger.RotatingFileHandler")
+# def test_setup_event_logger_specify_max_bytes(patched_file_handler):
+#     args = Namespace(log_file_max_bytes=1234567)
+#     flags.set_from_args(args, {})
+#     setup_event_logger(flags.get_flags())
+#     patched_file_handler.assert_called_once_with(
+#         filename="logs/dbt.log", encoding="utf8", maxBytes=1234567, backupCount=5
+#     )

--- a/tests/unit/test_graph_selection.py
+++ b/tests/unit/test_graph_selection.py
@@ -58,7 +58,7 @@ def _get_manifest(graph):
 
 @pytest.fixture
 def graph():
-    return graph_selector.Graph(_get_graph())
+    return _get_graph()
 
 
 @pytest.fixture
@@ -122,16 +122,9 @@ run_specs = [
 
 
 @pytest.mark.parametrize("include,exclude,expected", run_specs, ids=id_macro)
-def test_run_specs(include, exclude, expected):
-    graph = _get_graph()
-    manifest = _get_manifest(graph)
+def test_run_specs(include, exclude, expected, graph, manifest):
     selector = graph_selector.NodeSelector(graph, manifest)
-    # TODO:  The "eager" string below needs to be replaced with programatic access
-    #  to the default value for the indirect selection parameter in
-    # dbt.cli.params.indirect_selection
-    #
-    # Doing that is actually a little tricky, so I'm punting it to a new ticket GH #6397
-    spec = graph_cli.parse_difference(include, exclude, "eager")
+    spec = graph_cli.parse_difference(include, exclude)
     selected, _ = selector.select_nodes(spec)
 
     assert selected == expected


### PR DESCRIPTION
resolves #9776 #7673

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem
If user define a YAML selector and does not define indirect selection field on it. We would always use the default value `eager` instead of using the resolved default value of the CLI flag and env vars.(meaning the user cannot overwrite it)
See more detail in #7673


<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
This patch would cause a selector default to the resolved value of CLI, env var, specified by user.
This patch also removed the technical debt of always passing an indirect selection field across multiple layers where we should really just do one lookup when selector is created.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
