### PR TITLE
Update repository unit tests to have `Project` fixture and do additional `Project` testing

### DIFF
--- a/tests/unit/config/test_project.py
+++ b/tests/unit/config/test_project.py
@@ -30,7 +30,7 @@ from tests.unit.config import (
 )
 
 
-class TestProjectWithPytest:
+class TestProjectMethods:
     @pytest.fixture(scope="function")
     def selector_config(self) -> SelectorConfig:
         return SelectorConfig.selectors_from_dict(
@@ -150,7 +150,7 @@ class TestProjectWithPytest:
         assert project.hashed_name() == "6e72a69d5c5cca8f0400338441c022e4"
 
 
-class TestProject(BaseConfigTest):
+class TestProjectInitialization(BaseConfigTest):
     def test_defaults(self):
         project = project_from_config_norender(
             self.default_project_data, project_root=self.project_dir

--- a/tests/unit/config/test_project.py
+++ b/tests/unit/config/test_project.py
@@ -146,6 +146,9 @@ class TestProjectWithPytest:
         other.project_name = "other project"
         assert project != other
 
+    def test_hashed_name(self, project: Project):
+        assert project.hashed_name() == "6e72a69d5c5cca8f0400338441c022e4"
+
 
 class TestProject(BaseConfigTest):
     def test_defaults(self):
@@ -193,12 +196,6 @@ class TestProject(BaseConfigTest):
             set(project.docs_paths),
             set(["other-models", "seeds", "snapshots", "analyses", "macros"]),
         )
-
-    def test_hashed_name(self):
-        project = project_from_config_norender(
-            self.default_project_data, project_root=self.project_dir
-        )
-        self.assertEqual(project.hashed_name(), "754cd47eac1d6f50a5f7cd399ec43da4")
 
     def test_all_overrides(self):
         # log-path is not tested because it is set exclusively from flags, not cfg

--- a/tests/unit/config/test_project.py
+++ b/tests/unit/config/test_project.py
@@ -137,6 +137,15 @@ class TestProjectWithPytest:
     def test_project_target_path(self, project: Project):
         assert project.project_target_path == "doesnt/actually/exist/target"
 
+    def test_eq(self, project: Project):
+        other = deepcopy(project)
+        assert project == other
+
+    def test_neq(self, project: Project):
+        other = deepcopy(project)
+        other.project_name = "other project"
+        assert project != other
+
 
 class TestProject(BaseConfigTest):
     def test_defaults(self):
@@ -170,21 +179,6 @@ class TestProject(BaseConfigTest):
         # just make sure str() doesn't crash anything, that's always
         # embarrassing
         str(project)
-
-    def test_eq(self):
-        project = project_from_config_norender(
-            self.default_project_data, project_root=self.project_dir
-        )
-        other = project_from_config_norender(
-            self.default_project_data, project_root=self.project_dir
-        )
-        self.assertEqual(project, other)
-
-    def test_neq(self):
-        project = project_from_config_norender(
-            self.default_project_data, project_root=self.project_dir
-        )
-        self.assertNotEqual(project, object())
 
     def test_implicit_overrides(self):
         self.default_project_data.update(


### PR DESCRIPTION
resolves #9870

### Problem

Writing unit tests is hard, so we're trying to build more fixtures that are common needs. The `Project` fixture is a commonly needed fixture, so adding it makes future writing of unit tests easier

### Solution

Create a `Project` fixture in unit tests.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
