### PR TITLE
add script to override dev dependencies in tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/dbt-labs/dbt-adapters.git
+git+https://github.com/dbt-labs/dbt-adapters.git@main
 git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git@main
 git+https://github.com/dbt-labs/dbt-postgres.git@main

--- a/scripts/update_dev_packages.sh
+++ b/scripts/update_dev_packages.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+set -e
+
+repo=$1
+ref=$2
+target_req_file="dev-requirements.txt"
+
+req_sed_pattern="s|${repo}.git@main|${repo}.git@${ref}|g"
+if [[ "$OSTYPE" == darwin* ]]; then
+ # mac ships with a different version of sed that requires a delimiter arg
+ sed -i "" "$req_sed_pattern" $target_req_file
+else
+ sed -i "$req_sed_pattern" $target_req_file
+fi


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-common/issues/104


### Problem

Sometimes we want to test dbt-core in CI against branches of dependencies.  

### Solution

Add a script to update the dependencies in `dev-requirements.txt`

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
