### PR TITLE
add --empty flag to dbt build

### DIFF
--- a/.changes/1.8.0/Features-20231116-234049.yaml
+++ b/.changes/1.8.0/Features-20231116-234049.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Support --empty flag for schema-only dry runs in dbt compile, run, and build
+body: Support --empty flag for schema-only dry runs
 time: 2023-11-16T23:40:49.96651-05:00
 custom:
   Author: michelleark

--- a/.changes/1.8.0/Features-20231116-234049.yaml
+++ b/.changes/1.8.0/Features-20231116-234049.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Support --empty flag for schema-only dry runs
+body: Support --empty flag for schema-only dry runs in dbt compile, run, and build
 time: 2023-11-16T23:40:49.96651-05:00
 custom:
   Author: michelleark

--- a/.changes/unreleased/Features-20240424-180639.yaml
+++ b/.changes/unreleased/Features-20240424-180639.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: add --empty flag to dbt build command
+time: 2024-04-24T18:06:39.438457-04:00
+custom:
+  Author: michelleark
+  Issue: "10026"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -170,6 +170,7 @@ def cli(ctx, **kwargs):
 @cli.command("build")
 @click.pass_context
 @global_flags
+@p.empty
 @p.exclude
 @p.export_saved_queries
 @p.full_refresh

--- a/tests/functional/test_empty.py
+++ b/tests/functional/test_empty.py
@@ -37,7 +37,7 @@ sources:
 """
 
 
-class BaseTestEmpty:
+class TestEmptyFlag:
     @pytest.fixture(scope="class")
     def seeds(self):
         return {
@@ -70,6 +70,13 @@ class BaseTestEmpty:
         run_dbt(["run", "--empty"])
         self.assert_row_count(project, "model", 0)
 
+        # build without empty - 3 expected rows in output - 1 from each input
+        run_dbt(["build"])
+        self.assert_row_count(project, "model", 3)
 
-class TestEmpty(BaseTestEmpty):
-    pass
+        # build with empty - 0 expected rows in output
+        run_dbt(["build", "--empty"])
+        self.assert_row_count(project, "model", 0)
+
+        # ensure dbt compile supports --empty flag
+        run_dbt(["compile", "--empty"])


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/10026

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
`dbt build` does not support `--empty`. This was just an oversight in development.

We even document it as supported already: https://docs.getdbt.com/reference/commands/build#details

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

* Add `--empty` to the CLI options for `dbt build`
* Move adapter-zone tests to `functional` for `test_empty`. Adapters can maintain having overridable tests, but we should have a baseline test here for the flag that is more general.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
