### PR TITLE
[Backport 1.4.latest] pin macos test runners to macos-12 (#10031)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,7 @@ jobs:
           - python-version: 3.8
             os: windows-latest
           - python-version: 3.8
-            os: macos-latest
+            os: macos-12
 
     env:
       TOXENV: integration

--- a/.github/workflows/test-repeater.yml
+++ b/.github/workflows/test-repeater.yml
@@ -36,7 +36,7 @@ on:
         type: choice
         options:
           - 'ubuntu-latest'
-          - 'macos-latest'
+          - 'macos-12'
           - 'windows-latest'
       num_runs_per_batch:
         description: 'Max number of times to run the test per batch.  We always run 10 batches.'
@@ -101,7 +101,7 @@ jobs:
 
         # mac and windows don't use make due to limitations with docker with those runners in GitHub
       - name: "Set up postgres (macos)"
-        if: inputs.os == 'macos-latest'
+        if: inputs.os == 'macos-12'
         uses: ./.github/actions/setup-postgres-macos
 
       - name: "Set up postgres (windows)"


### PR DESCRIPTION
Backport https://github.com/dbt-labs/dbt-core/commit/bcbde3ac4204f00d964a3ea60896b6af1df18c71 from https://github.com/dbt-labs/dbt-core/pull/10031.