### PR TITLE
[Backport 1.1.latest] pin macos test runners to macos-12 (#10031)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,7 +123,7 @@ jobs:
           - python-version: 3.8
             os: windows-latest
           - python-version: 3.8
-            os: macos-latest
+            os: macos-12
 
     env:
       TOXENV: integration


### PR DESCRIPTION
Backport https://github.com/dbt-labs/dbt-core/commit/bcbde3ac4204f00d964a3ea60896b6af1df18c71 from https://github.com/dbt-labs/dbt-core/pull/10031.