### PR TITLE
[Backport 1.0.latest] pin macos test runners to macos-12 (#10031)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,7 +170,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-12, windows-latest]
         python-version: [3.7, 3.8]
 
     steps:


### PR DESCRIPTION
Backport https://github.com/dbt-labs/dbt-core/commit/bcbde3ac4204f00d964a3ea60896b6af1df18c71 from https://github.com/dbt-labs/dbt-core/pull/10031.