### PR TITLE
[Backport 1.7.latest] [Bug] Use a list instead of a set for index changes to perserve order (dbt-postgres#73)

### DIFF
--- a/.changes/unreleased/Fixes-20240425-133401.yaml
+++ b/.changes/unreleased/Fixes-20240425-133401.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix issue where index updates were occassionally happening out of order
+time: 2024-04-25T13:34:01.018399-04:00
+custom:
+  Author: mikealfare
+  Issue: "72"

--- a/.changes/unreleased/Fixes-20240425-133401.yaml
+++ b/.changes/unreleased/Fixes-20240425-133401.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: Fix issue where index updates were occassionally happening out of order
+body: Replace usage of `Set` with `List` to fix issue with index updates intermittently happening out of order
 time: 2024-04-25T13:34:01.018399-04:00
 custom:
   Author: mikealfare

--- a/plugins/postgres/dbt/adapters/postgres/relation_configs/materialized_view.py
+++ b/plugins/postgres/dbt/adapters/postgres/relation_configs/materialized_view.py
@@ -102,7 +102,7 @@ class PostgresMaterializedViewConfig(RelationConfigBase, RelationConfigValidatio
 
 @dataclass
 class PostgresMaterializedViewConfigChangeCollection:
-    indexes: Set[PostgresIndexConfigChange] = field(default_factory=set)
+    indexes: List[PostgresIndexConfigChange] = field(default_factory=list)
 
     @property
     def requires_full_refresh(self) -> bool:
@@ -110,4 +110,4 @@ class PostgresMaterializedViewConfigChangeCollection:
 
     @property
     def has_changes(self) -> bool:
-        return self.indexes != set()
+        return self.indexes != []

--- a/tests/unit/test_postgres_adapter.py
+++ b/tests/unit/test_postgres_adapter.py
@@ -662,16 +662,19 @@ class TestPostgresAdapterConversions(TestAdapterConversions):
 
 def test_index_config_changes():
     index_0_old = {
+        "name": "my_index_0",
         "column_names": {"column_0"},
         "unique": True,
         "method": "btree",
     }
     index_1_old = {
+        "name": "my_index_1",
         "column_names": {"column_1"},
         "unique": True,
         "method": "btree",
     }
     index_2_old = {
+        "name": "my_index_2",
         "column_names": {"column_2"},
         "unique": True,
         "method": "btree",
@@ -684,6 +687,7 @@ def test_index_config_changes():
     index_2_new = deepcopy(index_2_old)
     index_2_new.update(method="hash")
     index_3_new = {
+        "name": "my_index_3",
         "column_names": {"column_3"},
         "unique": True,
         "method": "hash",

--- a/tests/unit/test_postgres_adapter.py
+++ b/tests/unit/test_postgres_adapter.py
@@ -657,8 +657,6 @@ class TestPostgresAdapterConversions(TestAdapterConversions):
         for col_idx, expect in enumerate(expected):
             assert PostgresAdapter.convert_time_type(agate_table, col_idx) == expect
 
-        return self.indexes != []
-
 
 def test_index_config_changes():
     index_0_old = {

--- a/tests/unit/test_postgres_adapter.py
+++ b/tests/unit/test_postgres_adapter.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import dataclasses
 
 import agate
@@ -10,10 +11,16 @@ from dbt.contracts.relation import Path
 from dbt.task.debug import DebugTask
 
 from dbt.adapters.base.query_headers import MacroQueryStringSetter
-from dbt.adapters.postgres import PostgresAdapter
-from dbt.adapters.postgres import Plugin as PostgresPlugin
+from dbt.adapters.postgres import (
+    Plugin as PostgresPlugin,
+    PostgresAdapter,
+    PostgresRelation,
+)
+from dbt.adapters.postgres.relation_configs import PostgresIndexConfig
+from dbt.adapters.relation_configs.config_change import RelationConfigChangeAction
 from dbt.contracts.files import FileHash
 from dbt.contracts.graph.manifest import ManifestStateCheck
+from dbt.contracts.relation import RelationType
 from dbt.clients import agate_helper
 from dbt.exceptions import DbtValidationError, DbtConfigError
 from psycopg2 import extensions as psycopg2_extensions
@@ -649,3 +656,54 @@ class TestPostgresAdapterConversions(TestAdapterConversions):
         expected = ["time", "time", "time"]
         for col_idx, expect in enumerate(expected):
             assert PostgresAdapter.convert_time_type(agate_table, col_idx) == expect
+
+        return self.indexes != []
+
+
+def test_index_config_changes():
+    index_0_old = {
+        "column_names": {"column_0"},
+        "unique": True,
+        "method": "btree",
+    }
+    index_1_old = {
+        "column_names": {"column_1"},
+        "unique": True,
+        "method": "btree",
+    }
+    index_2_old = {
+        "column_names": {"column_2"},
+        "unique": True,
+        "method": "btree",
+    }
+    existing_indexes = frozenset(
+        PostgresIndexConfig.from_dict(index) for index in [index_0_old, index_1_old, index_2_old]
+    )
+
+    index_0_new = deepcopy(index_0_old)
+    index_2_new = deepcopy(index_2_old)
+    index_2_new.update(method="hash")
+    index_3_new = {
+        "column_names": {"column_3"},
+        "unique": True,
+        "method": "hash",
+    }
+    new_indexes = frozenset(
+        PostgresIndexConfig.from_dict(index) for index in [index_0_new, index_2_new, index_3_new]
+    )
+
+    relation = PostgresRelation.create(
+        database="my_database",
+        schema="my_schema",
+        identifier="my_materialized_view",
+        type=RelationType.MaterializedView,
+    )
+
+    index_changes = relation._get_index_config_changes(existing_indexes, new_indexes)
+
+    assert isinstance(index_changes, list)
+    assert len(index_changes) == len(["drop 1", "drop 2", "create 2", "create 3"])
+    assert index_changes[0].action == RelationConfigChangeAction.drop
+    assert index_changes[1].action == RelationConfigChangeAction.drop
+    assert index_changes[2].action == RelationConfigChangeAction.create
+    assert index_changes[3].action == RelationConfigChangeAction.create


### PR DESCRIPTION
Backport dbt-labs/dbt-postgres#73