### PR TITLE
Fix exception when `version` is missing when installing from the Hub package index

### DIFF
--- a/.changes/unreleased/Fixes-20240425-174024.yaml
+++ b/.changes/unreleased/Fixes-20240425-174024.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix exception when `version` is missing when installing from the Hub package
+  index
+time: 2024-04-25T17:40:24.465839-06:00
+custom:
+  Author: dbeatty10
+  Issue: "10048"

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -116,7 +116,7 @@ class PackageConfig(dbtClassMixin):
                         "A git package is missing the value. It is a required property."
                     )
             if isinstance(package, dict) and package.get("package"):
-                if not package["version"]:
+                if not package.get("version"):
                     raise ValidationError(
                         f"{package['package']} is missing the version. When installing from the Hub "
                         "package index, version is a required property"


### PR DESCRIPTION
resolves #10048

### Problem

When `version` is missing, it raises an exception that spits out an ugly stacktrace.

This is because the Python here will fail when `version` is completely missing:
https://github.com/dbt-labs/dbt-core/blob/bcbde3ac4204f00d964a3ea60896b6af1df18c71/core/dbt/contracts/project.py#L119

It looks like the tests in the original implementation (https://github.com/dbt-labs/dbt-core/pull/5812) weren't covering this case.

### Solution

Allow it to be completely missing so we can raise the appropriate error message.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] Tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)