### PR TITLE
Add ability to `silence` warnings AND allow `error` and `warn` to be used for `include` and `exclude`

### DIFF
--- a/.changes/unreleased/Features-20240426-233126.yaml
+++ b/.changes/unreleased/Features-20240426-233126.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Abillity to `silence` warnings via `warn_error_options`
+body: Ability to `silence` warnings via `warn_error_options`
 time: 2024-04-26T23:31:26.601057-05:00
 custom:
   Author: QMalcolm

--- a/.changes/unreleased/Features-20240426-233126.yaml
+++ b/.changes/unreleased/Features-20240426-233126.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Abillity to `silence` warnings via `warn_error_options`
+time: 2024-04-26T23:31:26.601057-05:00
+custom:
+  Author: QMalcolm
+  Issue: "9644"

--- a/.changes/unreleased/Features-20240426-233208.yaml
+++ b/.changes/unreleased/Features-20240426-233208.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Allow aliases `error` for `include` and `warn` for `exclude` in `warn_error_options`
+time: 2024-04-26T23:32:08.771114-05:00
+custom:
+  Author: QMalcolm
+  Issue: "9644"

--- a/core/dbt/cli/option_types.py
+++ b/core/dbt/cli/option_types.py
@@ -56,6 +56,7 @@ class WarnErrorOptionsType(YAML):
         return WarnErrorOptions(
             include=include_exclude.get("include", []),
             exclude=include_exclude.get("exclude", []),
+            silence=include_exclude.get("silence", []),
             valid_error_names=ALL_EVENT_NAMES,
         )
 

--- a/core/dbt/cli/option_types.py
+++ b/core/dbt/cli/option_types.py
@@ -51,8 +51,12 @@ class WarnErrorOptionsType(YAML):
     def convert(self, value, param, ctx):
         # this function is being used by param in click
         include_exclude = super().convert(value, param, ctx)
-        exclusive_primary_alt_value_setting(include_exclude, "include", "error")
-        exclusive_primary_alt_value_setting(include_exclude, "exclude", "warn")
+        exclusive_primary_alt_value_setting(
+            include_exclude, "include", "error", "warn_error_options"
+        )
+        exclusive_primary_alt_value_setting(
+            include_exclude, "exclude", "warn", "warn_error_options"
+        )
 
         return WarnErrorOptions(
             include=include_exclude.get("include", []),

--- a/core/dbt/cli/option_types.py
+++ b/core/dbt/cli/option_types.py
@@ -1,11 +1,10 @@
 from click import ParamType, Choice
 
-from dbt.config.utils import parse_cli_yaml_string
+from dbt.config.utils import parse_cli_yaml_string, exclusive_primary_alt_value_setting
 from dbt.events import ALL_EVENT_NAMES
 from dbt.exceptions import ValidationError, OptionNotYamlDictError
-from dbt_common.exceptions import DbtConfigError, DbtValidationError
+from dbt_common.exceptions import DbtValidationError
 from dbt_common.helper_types import WarnErrorOptions
-from typing import Any, Dict
 
 
 class YAML(ParamType):
@@ -42,28 +41,6 @@ class Package(ParamType):
             return {"name": package_name, "version": package_version}
         except ValueError:
             return {"name": value, "version": None}
-
-
-def exclusive_primary_alt_value_setting(
-    dictionary: Dict[str, Any], primary: str, alt: str
-) -> None:
-    """Munges in place under the primary the options for the primary and alt values
-
-    Sometimes we allow setting something via TWO keys, but not at the same time. If both the primary
-    key and alt key have values, an error gets raised. If the alt key has values, then we update
-    the dictionary to ensure the primary key contains the values. If neither are set, nothing happens.
-    """
-
-    primary_options = dictionary.get(primary)
-    alt_options = dictionary.get(alt)
-
-    if primary_options and alt_options:
-        raise DbtConfigError(
-            f"Only `{alt}` or `{primary}` can be specified in `warn_error_options`, not both"
-        )
-
-    if alt_options:
-        dictionary[primary] = alt_options
 
 
 class WarnErrorOptionsType(YAML):

--- a/core/dbt/cli/option_types.py
+++ b/core/dbt/cli/option_types.py
@@ -3,9 +3,9 @@ from click import ParamType, Choice
 from dbt.config.utils import parse_cli_yaml_string
 from dbt.events import ALL_EVENT_NAMES
 from dbt.exceptions import ValidationError, OptionNotYamlDictError
-from dbt_common.exceptions import DbtValidationError
-
+from dbt_common.exceptions import DbtConfigError, DbtValidationError
 from dbt_common.helper_types import WarnErrorOptions
+from typing import Any, Dict
 
 
 class YAML(ParamType):
@@ -44,6 +44,28 @@ class Package(ParamType):
             return {"name": value, "version": None}
 
 
+def exclusive_primary_alt_value_setting(
+    dictionary: Dict[str, Any], primary: str, alt: str
+) -> None:
+    """Munges in place under the primary the options for the primary and alt values
+
+    Sometimes we allow setting something via TWO keys, but not at the same time. If both the primary
+    key and alt key have values, an error gets raised. If the alt key has values, then we update
+    the dictionary to ensure the primary key contains the values. If neither are set, nothing happens.
+    """
+
+    primary_options = dictionary.get(primary)
+    alt_options = dictionary.get(alt)
+
+    if primary_options and alt_options:
+        raise DbtConfigError(
+            f"Only `{alt}` or `{primary}` can be specified in `warn_error_options`, not both"
+        )
+
+    if alt_options:
+        dictionary[primary] = alt_options
+
+
 class WarnErrorOptionsType(YAML):
     """The Click WarnErrorOptions type. Converts YAML strings into objects."""
 
@@ -52,6 +74,8 @@ class WarnErrorOptionsType(YAML):
     def convert(self, value, param, ctx):
         # this function is being used by param in click
         include_exclude = super().convert(value, param, ctx)
+        exclusive_primary_alt_value_setting(include_exclude, "include", "error")
+        exclusive_primary_alt_value_setting(include_exclude, "exclude", "warn")
 
         return WarnErrorOptions(
             include=include_exclude.get("include", []),

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -26,8 +26,8 @@ from dbt_common.clients.system import path_exists, load_file_contents
 from dbt.clients.yaml_helper import load_yaml_text
 from dbt.adapters.contracts.connection import QueryComment
 from dbt.exceptions import (
-    DbtConfigError,
     DbtProjectError,
+    DbtWarnErrorOptionsError,
     ProjectContractBrokenError,
     ProjectContractError,
     DbtRuntimeError,
@@ -846,7 +846,7 @@ def read_project_flags(project_dir: str, profiles_dir: str) -> ProjectFlags:
 
             ProjectFlags.validate(project_flags)
             return ProjectFlags.from_dict(project_flags)
-    except (DbtProjectError, DbtConfigError) as exc:
+    except (DbtProjectError, DbtWarnErrorOptionsError) as exc:
         # We don't want to eat the DbtProjectError for UserConfig to ProjectFlags or
         # DbtConfigError for warn_error_options munging
         raise exc

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -27,7 +27,7 @@ from dbt.clients.yaml_helper import load_yaml_text
 from dbt.adapters.contracts.connection import QueryComment
 from dbt.exceptions import (
     DbtProjectError,
-    DbtWarnErrorOptionsError,
+    DbtExclusivePropertyUseError,
     ProjectContractBrokenError,
     ProjectContractError,
     DbtRuntimeError,
@@ -840,12 +840,16 @@ def read_project_flags(project_dir: str, profiles_dir: str) -> ProjectFlags:
             # handle collapsing `include` and `error` as well as collapsing `exclude` and `warn`
             # for warn_error_options
             warn_error_options = project_flags.get("warn_error_options")
-            exclusive_primary_alt_value_setting(warn_error_options, "include", "error")
-            exclusive_primary_alt_value_setting(warn_error_options, "exclude", "warn")
+            exclusive_primary_alt_value_setting(
+                warn_error_options, "include", "error", "warn_error_options"
+            )
+            exclusive_primary_alt_value_setting(
+                warn_error_options, "exclude", "warn", "warn_error_options"
+            )
 
             ProjectFlags.validate(project_flags)
             return ProjectFlags.from_dict(project_flags)
-    except (DbtProjectError, DbtWarnErrorOptionsError) as exc:
+    except (DbtProjectError, DbtExclusivePropertyUseError) as exc:
         # We don't want to eat the DbtProjectError for UserConfig to ProjectFlags or
         # DbtConfigError for warn_error_options munging
         raise exc

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -837,12 +837,11 @@ def read_project_flags(project_dir: str, profiles_dir: str) -> ProjectFlags:
             project_flags = profile_project_flags
 
         if project_flags is not None:
-            # if warn_error_options are set, handle collapsing `include` and `error` as well as
-            # collapsing `exclude` and `warn`
+            # handle collapsing `include` and `error` as well as collapsing `exclude` and `warn`
+            # for warn_error_options
             warn_error_options = project_flags.get("warn_error_options")
-            if warn_error_options:
-                exclusive_primary_alt_value_setting(warn_error_options, "include", "error")
-                exclusive_primary_alt_value_setting(warn_error_options, "exclude", "warn")
+            exclusive_primary_alt_value_setting(warn_error_options, "include", "error")
+            exclusive_primary_alt_value_setting(warn_error_options, "exclude", "warn")
 
             ProjectFlags.validate(project_flags)
             return ProjectFlags.from_dict(project_flags)

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -26,6 +26,7 @@ from dbt_common.clients.system import path_exists, load_file_contents
 from dbt.clients.yaml_helper import load_yaml_text
 from dbt.adapters.contracts.connection import QueryComment
 from dbt.exceptions import (
+    DbtConfigError,
     DbtProjectError,
     ProjectContractBrokenError,
     ProjectContractError,
@@ -39,6 +40,7 @@ from dbt.version import get_installed_version
 from dbt.utils import MultiDict, md5, coerce_dict_str
 from dbt.node_types import NodeType
 from dbt.config.selectors import SelectorDict
+from dbt.config.utils import exclusive_primary_alt_value_setting
 from dbt.contracts.project import (
     Project as ProjectContract,
     SemverString,
@@ -835,10 +837,18 @@ def read_project_flags(project_dir: str, profiles_dir: str) -> ProjectFlags:
             project_flags = profile_project_flags
 
         if project_flags is not None:
+            # if warn_error_options are set, handle collapsing `include` and `error` as well as
+            # collapsing `exclude` and `warn`
+            warn_error_options = project_flags.get("warn_error_options")
+            if warn_error_options:
+                exclusive_primary_alt_value_setting(warn_error_options, "include", "error")
+                exclusive_primary_alt_value_setting(warn_error_options, "exclude", "warn")
+
             ProjectFlags.validate(project_flags)
             return ProjectFlags.from_dict(project_flags)
-    except (DbtProjectError) as exc:
-        # We don't want to eat the DbtProjectError for UserConfig to ProjectFlags
+    except (DbtProjectError, DbtConfigError) as exc:
+        # We don't want to eat the DbtProjectError for UserConfig to ProjectFlags or
+        # DbtConfigError for warn_error_options munging
         raise exc
     except (DbtRuntimeError, ValidationError):
         pass

--- a/core/dbt/config/utils.py
+++ b/core/dbt/config/utils.py
@@ -5,7 +5,7 @@ from dbt.clients import yaml_helper
 from dbt_common.events.functions import fire_event
 from dbt.events.types import InvalidOptionYAML
 from dbt.exceptions import OptionNotYamlDictError
-from dbt_common.exceptions import DbtValidationError
+from dbt_common.exceptions import DbtConfigError, DbtValidationError
 
 
 def parse_cli_vars(var_string: str) -> Dict[str, Any]:
@@ -23,3 +23,25 @@ def parse_cli_yaml_string(var_string: str, cli_option_name: str) -> Dict[str, An
     except (DbtValidationError, OptionNotYamlDictError):
         fire_event(InvalidOptionYAML(option_name=cli_option_name))
         raise
+
+
+def exclusive_primary_alt_value_setting(
+    dictionary: Dict[str, Any], primary: str, alt: str
+) -> None:
+    """Munges in place under the primary the options for the primary and alt values
+
+    Sometimes we allow setting something via TWO keys, but not at the same time. If both the primary
+    key and alt key have values, an error gets raised. If the alt key has values, then we update
+    the dictionary to ensure the primary key contains the values. If neither are set, nothing happens.
+    """
+
+    primary_options = dictionary.get(primary)
+    alt_options = dictionary.get(alt)
+
+    if primary_options and alt_options:
+        raise DbtConfigError(
+            f"Only `{alt}` or `{primary}` can be specified in `warn_error_options`, not both"
+        )
+
+    if alt_options:
+        dictionary[primary] = alt_options

--- a/core/dbt/config/utils.py
+++ b/core/dbt/config/utils.py
@@ -4,8 +4,8 @@ from typing import Any, Dict
 from dbt.clients import yaml_helper
 from dbt_common.events.functions import fire_event
 from dbt.events.types import InvalidOptionYAML
-from dbt.exceptions import OptionNotYamlDictError
-from dbt_common.exceptions import DbtConfigError, DbtValidationError
+from dbt.exceptions import DbtWarnErrorOptionsError, OptionNotYamlDictError
+from dbt_common.exceptions import DbtValidationError
 
 
 def parse_cli_vars(var_string: str) -> Dict[str, Any]:
@@ -39,7 +39,7 @@ def exclusive_primary_alt_value_setting(
     alt_options = dictionary.get(alt)
 
     if primary_options and alt_options:
-        raise DbtConfigError(
+        raise DbtWarnErrorOptionsError(
             f"Only `{alt}` or `{primary}` can be specified in `warn_error_options`, not both"
         )
 

--- a/core/dbt/config/utils.py
+++ b/core/dbt/config/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
 from dbt.clients import yaml_helper
@@ -26,7 +26,7 @@ def parse_cli_yaml_string(var_string: str, cli_option_name: str) -> Dict[str, An
 
 
 def exclusive_primary_alt_value_setting(
-    dictionary: Dict[str, Any], primary: str, alt: str
+    dictionary: Optional[Dict[str, Any]], primary: str, alt: str
 ) -> None:
     """Munges in place under the primary the options for the primary and alt values
 
@@ -34,6 +34,9 @@ def exclusive_primary_alt_value_setting(
     key and alt key have values, an error gets raised. If the alt key has values, then we update
     the dictionary to ensure the primary key contains the values. If neither are set, nothing happens.
     """
+
+    if dictionary is None:
+        return
 
     primary_options = dictionary.get(primary)
     alt_options = dictionary.get(alt)

--- a/core/dbt/config/utils.py
+++ b/core/dbt/config/utils.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 from dbt.clients import yaml_helper
 from dbt_common.events.functions import fire_event
 from dbt.events.types import InvalidOptionYAML
-from dbt.exceptions import DbtWarnErrorOptionsError, OptionNotYamlDictError
+from dbt.exceptions import DbtExclusivePropertyUseError, OptionNotYamlDictError
 from dbt_common.exceptions import DbtValidationError
 
 
@@ -26,7 +26,10 @@ def parse_cli_yaml_string(var_string: str, cli_option_name: str) -> Dict[str, An
 
 
 def exclusive_primary_alt_value_setting(
-    dictionary: Optional[Dict[str, Any]], primary: str, alt: str
+    dictionary: Optional[Dict[str, Any]],
+    primary: str,
+    alt: str,
+    parent_config: Optional[str] = None,
 ) -> None:
     """Munges in place under the primary the options for the primary and alt values
 
@@ -42,8 +45,9 @@ def exclusive_primary_alt_value_setting(
     alt_options = dictionary.get(alt)
 
     if primary_options and alt_options:
-        raise DbtWarnErrorOptionsError(
-            f"Only `{alt}` or `{primary}` can be specified in `warn_error_options`, not both"
+        where = f" in `{parent_config}`" if parent_config is not None else ""
+        raise DbtExclusivePropertyUseError(
+            f"Only `{alt}` or `{primary}` can be specified{where}, not both"
         )
 
     if alt_options:

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -113,6 +113,10 @@ class DbtProfileError(DbtConfigError):
     pass
 
 
+class DbtWarnErrorOptionsError(DbtConfigError):
+    pass
+
+
 class InvalidSelectorError(DbtRuntimeError):
     def __init__(self, name: str) -> None:
         self.name = name

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -113,7 +113,7 @@ class DbtProfileError(DbtConfigError):
     pass
 
 
-class DbtWarnErrorOptionsError(DbtConfigError):
+class DbtExclusivePropertyUseError(DbtConfigError):
     pass
 
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -75,7 +75,7 @@ setup(
         "minimal-snowplow-tracker>=0.0.2,<0.1",
         "dbt-semantic-interfaces>=0.5.1,<0.6",
         # Minor versions for these are expected to be backwards-compatible
-        "dbt-common>=1.0.1,<2.0",
+        "dbt-common>=1.0.2,<2.0",
         "dbt-adapters>=0.1.0a2,<2.0",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.

--- a/tests/functional/configs/test_warn_error_options.py
+++ b/tests/functional/configs/test_warn_error_options.py
@@ -27,7 +27,7 @@ class TestWarnErrorOptionsFromCLI:
         runner.invoke(["run"])
         assert len(catcher.caught_events) == 1
 
-        catcher.caught_events = []
+        catcher.flush()
         runner.invoke(
             ["run", "--warn-error-options", "{'include': 'all', 'silence': ['DeprecatedModel']}"]
         )

--- a/tests/functional/configs/test_warn_error_options.py
+++ b/tests/functional/configs/test_warn_error_options.py
@@ -1,0 +1,34 @@
+import pytest
+
+from dbt.cli.main import dbtRunner
+from dbt.events.types import DeprecatedModel
+from tests.functional.utils import EventCatcher
+from typing import Dict, Union
+
+ModelsDictSpec = Dict[str, Union[str, "ModelsDictSpec"]]
+
+my_model_sql = """SELECT 1 AS id, 'cats are cute' AS description"""
+schema_yml = """
+version: 2
+models:
+  - name: my_model
+    deprecation_date: 2020-01-01
+"""
+
+
+class TestWarnErrorOptionsFromCLI:
+    @pytest.fixture(scope="class")
+    def models(self) -> ModelsDictSpec:
+        return {"my_model.sql": my_model_sql, "schema.yml": schema_yml}
+
+    def test_can_silence(self, project) -> None:
+        catcher = EventCatcher(event_to_catch=DeprecatedModel)
+        runner = dbtRunner(callbacks=[catcher.catch])
+        runner.invoke(["run"])
+        assert len(catcher.caught_events) == 1
+
+        catcher.caught_events = []
+        runner.invoke(
+            ["run", "--warn-error-options", "{'include': 'all', 'silence': ['DeprecatedModel']}"]
+        )
+        assert len(catcher.caught_events) == 0

--- a/tests/functional/configs/test_warn_error_options.py
+++ b/tests/functional/configs/test_warn_error_options.py
@@ -175,3 +175,31 @@ class TestWarnErrorOptionsFromProject:
         catcher.flush()
         result = runner.invoke(["run"])
         assert_deprecation_warning(result, catcher)
+
+    def test_cant_set_both_include_and_error(
+        self, project, clear_project_flags, project_root, runner: dbtRunner
+    ) -> None:
+        exclude_options = {"flags": {"warn_error_options": {"include": "all", "error": "all"}}}
+        update_config_file(exclude_options, project_root, "dbt_project.yml")
+        result = runner.invoke(["run"])
+        assert not result.success
+        assert result.exception is not None
+        assert "Only `error` or `include` can be specified" in str(result.exception)
+
+    def test_cant_set_both_exclude_and_warn(
+        self, project, clear_project_flags, project_root, runner: dbtRunner
+    ) -> None:
+        exclude_options = {
+            "flags": {
+                "warn_error_options": {
+                    "include": "all",
+                    "exclude": ["DeprecatedModel"],
+                    "warn": ["DeprecatedModel"],
+                }
+            }
+        }
+        update_config_file(exclude_options, project_root, "dbt_project.yml")
+        result = runner.invoke(["run"])
+        assert not result.success
+        assert result.exception is not None
+        assert "Only `warn` or `exclude` can be specified" in str(result.exception)

--- a/tests/functional/manifest_validations/test_check_for_spaces_in_model_names.py
+++ b/tests/functional/manifest_validations/test_check_for_spaces_in_model_names.py
@@ -1,21 +1,11 @@
 import pytest
 
-from dataclasses import dataclass, field
 from dbt.cli.main import dbtRunner
-from dbt_common.events.base_types import BaseEvent, EventLevel, EventMsg
+from dbt_common.events.base_types import EventLevel
 from dbt.events.types import SpacesInModelNameDeprecation, TotalModelNamesWithSpacesDeprecation
 from dbt.tests.util import update_config_file
-from typing import Dict, List
-
-
-@dataclass
-class EventCatcher:
-    event_to_catch: BaseEvent
-    caught_events: List[EventMsg] = field(default_factory=list)
-
-    def catch(self, event: EventMsg):
-        if event.info.name == self.event_to_catch.__name__:
-            self.caught_events.append(event)
+from tests.functional.utils import EventCatcher
+from typing import Dict
 
 
 class TestSpacesInModelNamesHappyPath:

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -1,7 +1,9 @@
 import os
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional
+from dbt_common.events.base_types import BaseEvent, EventMsg
+from typing import List, Optional
 from pathlib import Path
 
 
@@ -17,3 +19,13 @@ def up_one(return_path: Optional[Path] = None):
 
 def is_aware(dt: datetime) -> bool:
     return dt.tzinfo is not None and dt.tzinfo.utcoffset(dt) is not None
+
+
+@dataclass
+class EventCatcher:
+    event_to_catch: BaseEvent
+    caught_events: List[EventMsg] = field(default_factory=list)
+
+    def catch(self, event: EventMsg):
+        if event.info.name == self.event_to_catch.__name__:
+            self.caught_events.append(event)

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -29,3 +29,6 @@ class EventCatcher:
     def catch(self, event: EventMsg):
         if event.info.name == self.event_to_catch.__name__:
             self.caught_events.append(event)
+
+    def flush(self) -> None:
+        self.caught_events = []

--- a/tests/unit/config/test_utils.py
+++ b/tests/unit/config/test_utils.py
@@ -1,0 +1,41 @@
+import pytest
+
+from dbt.config.utils import exclusive_primary_alt_value_setting
+from dbt.exceptions import DbtWarnErrorOptionsError
+
+
+class TestExclusivePrimaryAltValueSetting:
+    @pytest.fixture(scope="class")
+    def primary_key(self) -> str:
+        return "key_a"
+
+    @pytest.fixture(scope="class")
+    def alt_key(self) -> str:
+        return "key_b"
+
+    @pytest.fixture(scope="class")
+    def value(self) -> str:
+        return "I LIKE CATS"
+
+    def test_primary_set(self, primary_key: str, alt_key: str, value: str):
+        test_dict = {primary_key: value}
+        exclusive_primary_alt_value_setting(test_dict, primary_key, alt_key)
+        assert test_dict.get(primary_key) == value
+        assert test_dict.get(alt_key) is None
+
+    def test_alt_set(self, primary_key: str, alt_key: str, value: str):
+        test_dict = {alt_key: value}
+        exclusive_primary_alt_value_setting(test_dict, primary_key, alt_key)
+        assert test_dict.get(primary_key) == value
+        assert test_dict.get(alt_key) == value
+
+    def test_primary_and_alt_set(self, primary_key: str, alt_key: str, value: str):
+        test_dict = {primary_key: value, alt_key: value}
+        with pytest.raises(DbtWarnErrorOptionsError):
+            exclusive_primary_alt_value_setting(test_dict, primary_key, alt_key)
+
+    def test_neither_primary_nor_alt_set(self, primary_key: str, alt_key: str):
+        test_dict = {}
+        exclusive_primary_alt_value_setting(test_dict, primary_key, alt_key)
+        assert test_dict.get(primary_key) is None
+        assert test_dict.get(alt_key) is None

--- a/tests/unit/config/test_utils.py
+++ b/tests/unit/config/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dbt.config.utils import exclusive_primary_alt_value_setting
-from dbt.exceptions import DbtWarnErrorOptionsError
+from dbt.exceptions import DbtExclusivePropertyUseError
 
 
 class TestExclusivePrimaryAltValueSetting:
@@ -31,7 +31,7 @@ class TestExclusivePrimaryAltValueSetting:
 
     def test_primary_and_alt_set(self, primary_key: str, alt_key: str, value: str):
         test_dict = {primary_key: value, alt_key: value}
-        with pytest.raises(DbtWarnErrorOptionsError):
+        with pytest.raises(DbtExclusivePropertyUseError):
             exclusive_primary_alt_value_setting(test_dict, primary_key, alt_key)
 
     def test_neither_primary_nor_alt_set(self, primary_key: str, alt_key: str):


### PR DESCRIPTION
resolves #9644

### Problem

* People wanted to be able to silence warnings
* People wanted to be able to use `error` instead of `include`
* People wanted to be able to use `warn` instead of `exclude`

### Solution

* Bumped dbt_common to 1.0.2 which added `silence` to `WarnErrorOptions`
* Support `silence` arg to `warn_error_options` via CLI args and `dbt_project.yml`
* Support `error` and `warn` to `warn_error_options` as alternatives to `include` and `exclude

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
