### PR TITLE
test minor artifact changes for backward + forward compatability

### DIFF
--- a/core/dbt/artifacts/README.md
+++ b/core/dbt/artifacts/README.md
@@ -33,9 +33,11 @@ All existing resources are defined under `dbt/artifacts/resources/v1`.
 ### Non-breaking changes
 
 Freely make incremental, non-breaking changes in-place to the latest major version of any artifact in mantle (via minor or patch bumps). The only changes that are fully forward and backward compatible are: 
-* Adding a new field with a default
-* Deleting a field with a default
+1. Adding a new field with a default
+2. Deleting a field with a default
   * This is compatible in terms of serialization and deserialization in mashumaro, but still may be surprising for consumers relying on the fields existence (e.g. `manifest["deleted_field]` will stop working unless the access was implemented safely )
+
+These types of minor, non-reabking changes are tested by [tests/unit/artifacts/test_base_resource.py::TestMinorSchemaChange](https://github.com/dbt-labs/dbt-core/blob/main/tests/unit/artifacts/test_base_resource.py).
 
 ### Breaking changes
 A breaking change is anything that: 

--- a/core/dbt/artifacts/README.md
+++ b/core/dbt/artifacts/README.md
@@ -34,7 +34,8 @@ All existing resources are defined under `dbt/artifacts/resources/v1`.
 
 Freely make incremental, non-breaking changes in-place to the latest major version of any artifact in mantle (via minor or patch bumps). The only changes that are fully forward and backward compatible are: 
 * Adding a new field with a default
-* Deleting an __optional__ field
+* Deleting a field with a default
+  * This is compatible in terms of serialization and deserialization in mashumaro, but still may be surprising for consumers relying on the fields existence (e.g. `manifest["deleted_field]` will stop working unless the access was implemented safely )
 
 ### Breaking changes
 A breaking change is anything that: 

--- a/core/dbt/artifacts/README.md
+++ b/core/dbt/artifacts/README.md
@@ -35,9 +35,11 @@ All existing resources are defined under `dbt/artifacts/resources/v1`.
 Freely make incremental, non-breaking changes in-place to the latest major version of any artifact in mantle (via minor or patch bumps). The only changes that are fully forward and backward compatible are: 
 1. Adding a new field with a default
 2. Deleting a field with a default
-  * This is compatible in terms of serialization and deserialization in mashumaro, but still may be surprising for consumers relying on the fields existence (e.g. `manifest["deleted_field]` will stop working unless the access was implemented safely )
+  * This is compatible in terms of serialization and deserialization, but still may be lead to suprising behaviour:
+    * For artifact consumers relying on the fields existence (e.g. `manifest["deleted_field"]` will stop working unless the access was implemented safely)
+    * Old code (e.g. in dbt-core) that relies on the value of the deleted field may have surprising behaviour given only the default value will be set when instantiated from the new schema
 
-These types of minor, non-reabking changes are tested by [tests/unit/artifacts/test_base_resource.py::TestMinorSchemaChange](https://github.com/dbt-labs/dbt-core/blob/main/tests/unit/artifacts/test_base_resource.py).
+These types of minor, non-breaking changes are tested by [tests/unit/artifacts/test_base_resource.py::TestMinorSchemaChange](https://github.com/dbt-labs/dbt-core/blob/main/tests/unit/artifacts/test_base_resource.py).
 
 ### Breaking changes
 A breaking change is anything that: 

--- a/tests/unit/artifacts/test_base_resource.py
+++ b/tests/unit/artifacts/test_base_resource.py
@@ -7,7 +7,7 @@ from dbt.artifacts.resources.types import NodeType
 
 @dataclass
 class BaseResourceWithDefaultField(BaseResource):
-    new_field_with_default: bool = True
+    field_with_default: bool = True
 
 
 class TestMinorSchemaChange:
@@ -31,7 +31,7 @@ class TestMinorSchemaChange:
             path="test_path",
             original_file_path="test_original_file_path",
             unique_id="test_unique_id",
-            new_field_with_default=False,
+            field_with_default=False,
         )
 
     def test_serializing_new_default_field_is_backward_compatabile(
@@ -46,7 +46,9 @@ class TestMinorSchemaChange:
 
     def test_serializing_removed_default_field_is_backward_compatabile(self, base_resource):
         # old code (using old class with default field) can create an instance of itself given new data (class w/o default field)
-        BaseResourceWithDefaultField.from_dict(base_resource.to_dict())
+        old_resource = BaseResourceWithDefaultField.from_dict(base_resource.to_dict())
+        # set to the default value when not provided in data
+        assert old_resource.field_with_default is True
 
     def test_serializing_removed_default_field_is_forward_compatible(
         self, base_resource_new_default_field

--- a/tests/unit/artifacts/test_base_resource.py
+++ b/tests/unit/artifacts/test_base_resource.py
@@ -34,12 +34,22 @@ class TestMinorSchemaChange:
             new_field_with_default=False,
         )
 
-    def test_serializing_minor_change_new_default_field_is_backward_compatabile(
+    def test_serializing_new_default_field_is_backward_compatabile(
         self, base_resource_new_default_field
     ):
         # old code (using old class) can create an instance of itself given new data (new class)
         BaseResource.from_dict(base_resource_new_default_field.to_dict())
 
-    def test_serializing_minor_change_new_default_field_is_forward_compatible(self, base_resource):
+    def test_serializing_new_default_field_is_forward_compatible(self, base_resource):
         # new code (using new class) can create an instance of itself given old data (old class)
         BaseResourceWithDefaultField.from_dict(base_resource.to_dict())
+
+    def test_serializing_removed_default_field_is_backward_compatabile(self, base_resource):
+        # old code (using old class with default field) can create an instance of itself given new data (class w/o default field)
+        BaseResourceWithDefaultField.from_dict(base_resource.to_dict())
+
+    def test_serializing_removed_default_field_is_forward_compatible(
+        self, base_resource_new_default_field
+    ):
+        # new code (using class without default field) can create an instance of itself given old data (class with old field)
+        BaseResource.from_dict(base_resource_new_default_field.to_dict())

--- a/tests/unit/artifacts/test_base_resource.py
+++ b/tests/unit/artifacts/test_base_resource.py
@@ -1,0 +1,43 @@
+import pytest
+
+from dbt.artifacts.resources.base import BaseResource
+from dbt.artifacts.resources.types import NodeType
+
+
+class BaseResourceNewDefaultField(BaseResource):
+    new_field_with_default: bool = True
+
+
+class TestMinorSchemaChange:
+    @pytest.fixture
+    def base_resource(self):
+        return BaseResource(
+            name="test",
+            resource_type=NodeType.Model,
+            package_name="test_package",
+            path="test_path",
+            original_file_path="test_original_file_path",
+            unique_id="test_unique_id",
+        )
+
+    @pytest.fixture
+    def base_resource_new_default_field(self):
+        return BaseResourceNewDefaultField(
+            name="test",
+            resource_type=NodeType.Model,
+            package_name="test_package",
+            path="test_path",
+            original_file_path="test_original_file_path",
+            unique_id="test_unique_id",
+            new_field_with_default=False,
+        )
+
+    def test_serializing_minor_change_new_default_field_is_backward_compatabile(
+        self, base_resource_new_default_field
+    ):
+        # old code (using old class) can create an instance of itself given new data (new class)
+        BaseResource.from_dict(base_resource_new_default_field.to_dict())
+
+    def test_serializing_minor_change_new_default_field_is_forward_compatible(self, base_resource):
+        # new code (using new class) can create an instance of itself given old data (old class)
+        BaseResourceNewDefaultField.from_dict(base_resource.to_dict())

--- a/tests/unit/artifacts/test_base_resource.py
+++ b/tests/unit/artifacts/test_base_resource.py
@@ -1,10 +1,12 @@
+from dataclasses import dataclass
 import pytest
 
 from dbt.artifacts.resources.base import BaseResource
 from dbt.artifacts.resources.types import NodeType
 
 
-class BaseResourceNewDefaultField(BaseResource):
+@dataclass
+class BaseResourceWithDefaultField(BaseResource):
     new_field_with_default: bool = True
 
 
@@ -22,7 +24,7 @@ class TestMinorSchemaChange:
 
     @pytest.fixture
     def base_resource_new_default_field(self):
-        return BaseResourceNewDefaultField(
+        return BaseResourceWithDefaultField(
             name="test",
             resource_type=NodeType.Model,
             package_name="test_package",
@@ -40,4 +42,4 @@ class TestMinorSchemaChange:
 
     def test_serializing_minor_change_new_default_field_is_forward_compatible(self, base_resource):
         # new code (using new class) can create an instance of itself given old data (old class)
-        BaseResourceNewDefaultField.from_dict(base_resource.to_dict())
+        BaseResourceWithDefaultField.from_dict(base_resource.to_dict())


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/9615

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

mashumaro (and so our `BaseResource`) class has support for forward and backward-compatible changes: 
1. adding a field with a default value
2. removing a field with a default value

as in -- these changes are possible within a minor schema evolution, and would not break serialization / deserialization

However, if we are going to rely on these guaruntees we ought to test and document them!

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Add unit tests for forward and backward compatability of minor schema evolutions, and update development docs to be more thorough.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
