### PR TITLE
Fixed inconsistencies in --help

### DIFF
--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -24,7 +24,7 @@ from dbt_common.events.base_types import EventMsg
 
 @dataclass
 class dbtRunnerResult:
-    """Contains the result of an invocation of the dbtRunner"""
+    """Contains the result of an invocation of the dbtRunner."""
 
     success: bool
 
@@ -162,7 +162,7 @@ def global_flags(func):
 @p.show_resource_report
 def cli(ctx, **kwargs):
     """An ELT tool for managing your SQL transformations and data models.
-    For more documentation on these commands, visit: docs.getdbt.com
+    For more documentation on these commands, visit: docs.getdbt.com.
     """
 
 
@@ -193,7 +193,7 @@ def cli(ctx, **kwargs):
 @requires.runtime_config
 @requires.manifest
 def build(ctx, **kwargs):
-    """Run all seeds, models, snapshots, and tests in DAG order"""
+    """Run all seeds, models, snapshots, and tests in DAG order."""
     from dbt.task.build import BuildTask
 
     task = BuildTask(
@@ -221,7 +221,7 @@ def build(ctx, **kwargs):
 @requires.unset_profile
 @requires.project
 def clean(ctx, **kwargs):
-    """Delete all folders in the clean-targets list (usually the dbt_packages and target directories.)"""
+    """Delete all folders in the clean-targets list (usually the dbt_packages and target directories)."""
     from dbt.task.clean import CleanTask
 
     task = CleanTask(ctx.obj["flags"], ctx.obj["project"])
@@ -236,7 +236,7 @@ def clean(ctx, **kwargs):
 @click.pass_context
 @global_flags
 def docs(ctx, **kwargs):
-    """Generate or serve the documentation website for your project"""
+    """Generate or serve the documentation website for your project."""
 
 
 # dbt docs generate
@@ -261,7 +261,7 @@ def docs(ctx, **kwargs):
 @requires.runtime_config
 @requires.manifest(write=False)
 def docs_generate(ctx, **kwargs):
-    """Generate the documentation website for your project"""
+    """Generate the documentation website for your project."""
     from dbt.task.docs.generate import GenerateTask
 
     task = GenerateTask(
@@ -291,7 +291,7 @@ def docs_generate(ctx, **kwargs):
 @requires.project
 @requires.runtime_config
 def docs_serve(ctx, **kwargs):
-    """Serve the documentation website for your project"""
+    """Serve the documentation website for your project."""
     from dbt.task.docs.serve import ServeTask
 
     task = ServeTask(
@@ -330,7 +330,7 @@ def docs_serve(ctx, **kwargs):
 @requires.manifest
 def compile(ctx, **kwargs):
     """Generates executable SQL from source, model, test, and analysis files. Compiled SQL files are written to the
-    target/ directory."""
+    target/directory."""
     from dbt.task.compile import CompileTask
 
     task = CompileTask(
@@ -494,7 +494,7 @@ def init(ctx, **kwargs):
 @requires.runtime_config
 @requires.manifest
 def list(ctx, **kwargs):
-    """List the resources in your project"""
+    """List the resources in your project."""
     from dbt.task.list import ListTask
 
     task = ListTask(
@@ -530,7 +530,7 @@ cli.add_command(ls, "ls")
 @requires.runtime_config
 @requires.manifest(write_perf_info=True)
 def parse(ctx, **kwargs):
-    """Parses the project and provides information on performance"""
+    """Parses the project and provides information on performance."""
     # manifest generation and writing happens in @requires.manifest
     return ctx.obj["manifest"], True
 
@@ -721,7 +721,7 @@ def seed(ctx, **kwargs):
 @requires.runtime_config
 @requires.manifest
 def snapshot(ctx, **kwargs):
-    """Execute snapshots defined in your project"""
+    """Execute snapshots defined in your project."""
     from dbt.task.snapshot import SnapshotTask
 
     task = SnapshotTask(
@@ -740,7 +740,7 @@ def snapshot(ctx, **kwargs):
 @click.pass_context
 @global_flags
 def source(ctx, **kwargs):
-    """Manage your project's sources"""
+    """Manage your project's sources."""
 
 
 # dbt source freshness
@@ -763,7 +763,7 @@ def source(ctx, **kwargs):
 @requires.runtime_config
 @requires.manifest
 def freshness(ctx, **kwargs):
-    """check the current freshness of the project's sources"""
+    """Check the current freshness of the project's sources."""
     from dbt.task.freshness import FreshnessTask
 
     task = FreshnessTask(
@@ -803,7 +803,7 @@ cli.commands["source"].add_command(snapshot_freshness, "snapshot-freshness")  # 
 @requires.runtime_config
 @requires.manifest
 def test(ctx, **kwargs):
-    """Runs tests on data in deployed models. Run this after `dbt run`"""
+    """Runs tests on data in deployed models. Run this after `dbt run`."""
     from dbt.task.test import TestTask
 
     task = TestTask(

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -8,7 +8,7 @@ from dbt.version import get_version_information
 
 add_package = click.option(
     "--add-package",
-    help="Add a package to current package spec, specify it as package-name@version. Change the source with --source flag.",
+    help="Add a package to current package spec, specify it as package-name@version. Change the source with `--source` flag.",
     envvar=None,
     type=Package(),
 )
@@ -22,7 +22,7 @@ args = click.option(
 browser = click.option(
     "--browser/--no-browser",
     envvar=None,
-    help="Wether or not to open a local web browser after starting the server",
+    help="Wether or not to open a local web browser after starting the server.",
     default=True,
 )
 
@@ -35,14 +35,14 @@ cache_selected_only = click.option(
 introspect = click.option(
     "--introspect/--no-introspect",
     envvar="DBT_INTROSPECT",
-    help="Whether to scaffold introspective queries as part of compilation",
+    help="Whether to scaffold introspective queries as part of compilation.",
     default=True,
 )
 
 compile_docs = click.option(
     "--compile/--no-compile",
     envvar=None,
-    help="Whether or not to run 'dbt compile' as part of docs generation",
+    help="Whether or not to run 'dbt compile' as part of docs generation.",
     default=True,
 )
 
@@ -57,7 +57,7 @@ compile_inject_ephemeral_ctes = click.option(
 config_dir = click.option(
     "--config-dir",
     envvar=None,
-    help="Print a system-specific command to access the directory that the current dbt project is searching for a profiles.yml. Then, exit. This flag renders other debug step flags no-ops.",
+    help="Print a system-specific command to access the directory that the current dbt project is searching for a 'profiles.yml'. Then, exit. This flag renders other debug step flags no-ops.",
     is_flag=True,
 )
 
@@ -72,7 +72,7 @@ debug = click.option(
 defer = click.option(
     "--defer/--no-defer",
     envvar="DBT_DEFER",
-    help="If set, resolve unselected nodes by deferring to the manifest within the --state directory.",
+    help="If set, resolve unselected nodes by deferring to the manifest within the `--state` directory.",
 )
 
 deprecated_defer = click.option(
@@ -108,7 +108,7 @@ exclude = click.option(
 export_saved_queries = click.option(
     "--export-saved-queries/--no-export-saved-queries",
     envvar="DBT_EXPORT_SAVED_QUERIES",
-    help="Export saved queries within the 'build' command, otherwise no-op",
+    help="Export saved queries within the 'build' command, otherwise no-op.",
     is_flag=True,
     hidden=True,
 )
@@ -164,7 +164,7 @@ log_cache_events = click.option(
 log_format = click.option(
     "--log-format",
     envvar="DBT_LOG_FORMAT",
-    help="Specify the format of logging to the console and the log file. Use --log-format-file to configure the format for the log file differently than the console.",
+    help="Specify the format of logging to the console and the log file. Use `--log-format-file` to configure the format for the log file differently than the console.",
     type=click.Choice(["text", "debug", "json", "default"], case_sensitive=False),
     default="default",
 )
@@ -172,7 +172,7 @@ log_format = click.option(
 log_format_file = click.option(
     "--log-format-file",
     envvar="DBT_LOG_FORMAT_FILE",
-    help="Specify the format of logging to the log file by overriding the default value and the general --log-format setting.",
+    help="Specify the format of logging to the log file by overriding the default value and the general `--log-format` setting.",
     type=click.Choice(["text", "debug", "json", "default"], case_sensitive=False),
     default="debug",
 )
@@ -180,7 +180,7 @@ log_format_file = click.option(
 log_level = click.option(
     "--log-level",
     envvar="DBT_LOG_LEVEL",
-    help="Specify the minimum severity of events that are logged to the console and the log file. Use --log-level-file to configure the severity for the log file differently than the console.",
+    help="Specify the minimum severity of events that are logged to the console and the log file. Use `--log-level-file` to configure the severity for the log file differently than the console.",
     type=click.Choice(["debug", "info", "warn", "error", "none"], case_sensitive=False),
     default="info",
 )
@@ -188,7 +188,7 @@ log_level = click.option(
 log_level_file = click.option(
     "--log-level-file",
     envvar="DBT_LOG_LEVEL_FILE",
-    help="Specify the minimum severity of events that are logged to the log file by overriding the default value and the general --log-level setting.",
+    help="Specify the minimum severity of events that are logged to the log file by overriding the default value and the general `--log-level` setting.",
     type=click.Choice(["debug", "info", "warn", "error", "none"], case_sensitive=False),
     default="debug",
 )
@@ -196,21 +196,21 @@ log_level_file = click.option(
 use_colors = click.option(
     "--use-colors/--no-use-colors",
     envvar="DBT_USE_COLORS",
-    help="Specify whether log output is colorized in the console and the log file. Use --use-colors-file/--no-use-colors-file to colorize the log file differently than the console.",
+    help="Specify whether log output is colorized in the console and the log file. Use `--use-colors-file`/`--no-use-colors-file` to colorize the log file differently than the console.",
     default=True,
 )
 
 use_colors_file = click.option(
     "--use-colors-file/--no-use-colors-file",
     envvar="DBT_USE_COLORS_FILE",
-    help="Specify whether log file output is colorized by overriding the default value and the general --use-colors/--no-use-colors setting.",
+    help="Specify whether log file output is colorized by overriding the default value and the general `--use-colors`/`--no-use-colors` setting.",
     default=True,
 )
 
 log_file_max_bytes = click.option(
     "--log-file-max-bytes",
     envvar="DBT_LOG_FILE_MAX_BYTES",
-    help="Configure the max file size in bytes for a single dbt.log file, before rolling over. 0 means no limit.",
+    help="Configure the max file size in bytes for a single 'dbt.log' file, before rolling over. 0 means no limit.",
     default=10 * 1024 * 1024,  # 10mb
     type=click.INT,
     hidden=True,
@@ -234,7 +234,7 @@ macro_debugging = click.option(
 output = click.option(
     "--output",
     envvar=None,
-    help="Specify the output format: either JSON or a newline-delimited list of selectors, paths, or names",
+    help="Specify the output format: either JSON or a newline-delimited list of selectors, paths, or names.",
     type=click.Choice(["json", "name", "path", "selector"], case_sensitive=False),
     default="selector",
 )
@@ -242,7 +242,7 @@ output = click.option(
 show_output_format = click.option(
     "--output",
     envvar=None,
-    help="Output format for dbt compile and dbt show",
+    help="Output format for dbt compile and dbt show.",
     type=click.Choice(["json", "text"], case_sensitive=False),
     default="text",
 )
@@ -250,7 +250,7 @@ show_output_format = click.option(
 show_limit = click.option(
     "--limit",
     envvar=None,
-    help="Limit the number of results returned by dbt show",
+    help="Limit the number of results returned by dbt show.",
     type=click.INT,
     default=5,
 )
@@ -260,7 +260,7 @@ output_keys = click.option(
     envvar=None,
     help=(
         "Space-delimited listing of node properties to include as custom keys for JSON output "
-        "(e.g. `--output json --output-keys name resource_type description`)"
+        "(e.g. `--output json --output-keys name resource_type description`)."
     ),
     type=tuple,
     cls=MultiOption,
@@ -272,7 +272,7 @@ output_path = click.option(
     "--output",
     "-o",
     envvar=None,
-    help="Specify the output path for the JSON report. By default, outputs to 'target/sources.json'",
+    help="Specify the output path for the JSON report. By default, outputs to 'target/sources.json'.",
     type=click.Path(file_okay=True, dir_okay=False, writable=True),
     default=None,
 )
@@ -287,7 +287,7 @@ partial_parse = click.option(
 partial_parse_file_path = click.option(
     "--partial-parse-file-path",
     envvar="DBT_PARTIAL_PARSE_FILE_PATH",
-    help="Internal flag for path to partial_parse.manifest file.",
+    help="Internal flag for path to 'partial_parse.manifest' file.",
     default=None,
     hidden=True,
     type=click.Path(exists=True, dir_okay=False, resolve_path=True),
@@ -311,7 +311,7 @@ populate_cache = click.option(
 port = click.option(
     "--port",
     envvar=None,
-    help="Specify the port number for the docs server",
+    help="Specify the port number for the docs server. Default is 8080.",
     default=8080,
     type=click.INT,
 )
@@ -335,7 +335,7 @@ deprecated_print = click.option(
 printer_width = click.option(
     "--printer-width",
     envvar="DBT_PRINTER_WIDTH",
-    help="Sets the width of terminal output",
+    help="Sets the width of terminal output.",
     type=click.INT,
     default=80,
 )
@@ -343,24 +343,24 @@ printer_width = click.option(
 profile = click.option(
     "--profile",
     envvar="DBT_PROFILE",
-    help="Which existing profile to load. Overrides setting in dbt_project.yml.",
+    help="Which existing profile to load. Overrides setting in 'dbt_project.yml'.",
 )
 
 profiles_dir = click.option(
     "--profiles-dir",
     envvar="DBT_PROFILES_DIR",
-    help="Which directory to look in for the profiles.yml file. If not set, dbt will look in the current working directory first, then HOME/.dbt/",
+    help="Which directory to look in for the 'profiles.yml' file. If not set, dbt will look in the current working directory first, then `HOME/.dbt/`.",
     default=default_profiles_dir,
     type=click.Path(exists=True),
 )
 
-# `dbt debug` uses this because it implements custom behaviour for non-existent profiles.yml directories
+# `dbt debug` uses this because it implements custom behavior for non-existent profiles.yml directories
 # `dbt deps` does not load a profile at all
 # `dbt init` will write profiles.yml if it doesn't yet exist
 profiles_dir_exists_false = click.option(
     "--profiles-dir",
     envvar="DBT_PROFILES_DIR",
-    help="Which directory to look in for the profiles.yml file. If not set, dbt will look in the current working directory first, then HOME/.dbt/",
+    help="Which directory to look in for the 'profiles.yml' file. If not set, dbt will look in the current working directory first, then `HOME/.dbt/`",
     default=default_profiles_dir,
     type=click.Path(exists=False),
 )
@@ -368,7 +368,7 @@ profiles_dir_exists_false = click.option(
 project_dir = click.option(
     "--project-dir",
     envvar="DBT_PROJECT_DIR",
-    help="Which directory to look in for the dbt_project.yml file. Default is the current working directory and its parents.",
+    help="Which directory to look in for the 'dbt_project.yml' file. Default is the current working directory and its parents.",
     default=default_project_dir,
     type=click.Path(exists=True),
 )
@@ -384,7 +384,7 @@ record_timing_info = click.option(
     "--record-timing-info",
     "-r",
     envvar=None,
-    help="When this option is passed, dbt will output low-level timing stats to the specified file. Example: `--record-timing-info output.profile`",
+    help="When this option is passed, dbt will output low-level timing stats to the specified file. Example: `--record-timing-info output.profile`.",
     type=click.Path(exists=False),
 )
 
@@ -392,7 +392,7 @@ resource_type = click.option(
     "--resource-types",
     "--resource-type",
     envvar="DBT_RESOURCE_TYPES",
-    help="Restricts the types of resources that dbt will include",
+    help="Restricts the types of resources that dbt will include.",
     type=ChoiceTuple(
         [
             "metric",
@@ -420,7 +420,7 @@ exclude_resource_type = click.option(
     "--exclude-resource-types",
     "--exclude-resource-type",
     envvar="DBT_EXCLUDE_RESOURCE_TYPES",
-    help="Specify the types of resources that dbt will exclude",
+    help="Specify the types of resources that dbt will exclude.",
     type=ChoiceTuple(
         [
             "metric",
@@ -447,7 +447,7 @@ exclude_resource_type = click.option(
 deprecated_include_saved_query = click.option(
     "--include-saved-query/--no-include-saved-query",
     envvar="DBT_INCLUDE_SAVED_QUERY",
-    help="Include saved queries in the list of resources to be selected for build command",
+    help="Include saved queries in the list of resources to be selected for build command.",
     is_flag=True,
     hidden=True,
 )
@@ -465,7 +465,7 @@ select_attrs = {
 inline = click.option(
     "--inline",
     envvar=None,
-    help="Pass SQL inline to dbt compile and show",
+    help="Pass SQL inline to dbt compile and show.",
 )
 
 # `--select` and `--models` are analogous for most commands except `dbt list` for legacy reasons.
@@ -479,7 +479,7 @@ select = click.option(*select_decls, *model_decls, **select_attrs)  # type: igno
 selector = click.option(
     "--selector",
     envvar=None,
-    help="The selector name to use, as defined in selectors.yml",
+    help="The selector name to use, as defined in 'selectors.yml'.",
 )
 
 send_anonymous_usage_stats = click.option(
@@ -499,7 +499,7 @@ clean_project_files_only = click.option(
 show = click.option(
     "--show",
     envvar=None,
-    help="Show a sample of the loaded data in the terminal",
+    help="Show a sample of the loaded data in the terminal.",
     is_flag=True,
 )
 
@@ -526,7 +526,7 @@ skip_profile_setup = click.option(
 
 empty_catalog = click.option(
     "--empty-catalog",
-    help="If specified, generate empty catalog.json file during the `dbt docs generate` command.",
+    help="If specified, generate empty 'catalog.json' file during the `dbt docs generate` command.",
     default=False,
     is_flag=True,
 )
@@ -541,7 +541,7 @@ source = click.option(
 
 static = click.option(
     "--static",
-    help="Generate an additional static_index.html with manifest and catalog built-in.",
+    help="Generate an additional 'static_index.html' with manifest and catalog built-in.",
     default=False,
     is_flag=True,
 )
@@ -596,7 +596,7 @@ static_parser = click.option(
 store_failures = click.option(
     "--store-failures",
     envvar="DBT_STORE_FAILURES",
-    help="Store test results (failing rows) in the database",
+    help="Store test results (failing rows) in the database.",
     is_flag=True,
 )
 
@@ -604,7 +604,7 @@ target = click.option(
     "--target",
     "-t",
     envvar="DBT_TARGET",
-    help="Which target to load for the given profile",
+    help="Which target to load for the given profile.",
 )
 
 target_path = click.option(
@@ -631,7 +631,7 @@ debug_connection = click.option(
 threads = click.option(
     "--threads",
     envvar=None,
-    help="Specify number of threads to use while executing models. Overrides settings in profiles.yml.",
+    help="Specify number of threads to use while executing models. Overrides settings in 'profiles.yml'.",
     default=None,
     type=click.INT,
 )
@@ -645,7 +645,7 @@ use_experimental_parser = click.option(
 vars = click.option(
     "--vars",
     envvar=None,
-    help="Supply variables to the project. This argument overrides variables defined in your dbt_project.yml file. This argument should be a YAML string, eg. '{my_variable: my_value}'",
+    help="Supply variables to the project. This argument overrides variables defined in your 'dbt_project.yml' file. This argument should be a YAML string, eg. '{my_variable: my_value}'",
     type=YAML(),
     default="{}",
 )
@@ -667,7 +667,7 @@ version = click.option(
     callback=_version_callback,
     envvar=None,
     expose_value=False,
-    help="Show version information and exit",
+    help="Show version information and exit.",
     is_eager=True,
     is_flag=True,
 )
@@ -675,14 +675,14 @@ version = click.option(
 version_check = click.option(
     "--version-check/--no-version-check",
     envvar="DBT_VERSION_CHECK",
-    help="If set, ensure the installed dbt version matches the require-dbt-version specified in the dbt_project.yml file (if any). Otherwise, allow them to differ.",
+    help="If set, ensure the installed dbt version matches the require-dbt-version specified in the 'dbt_project.yml' file (if any). Otherwise, allow them to differ.",
     default=True,
 )
 
 warn_error = click.option(
     "--warn-error",
     envvar="DBT_WARN_ERROR",
-    help="If dbt would normally warn, instead raise an exception. Examples include --select that selects nothing, deprecations, configurations with no associated models, invalid test configurations, and missing sources/refs in tests.",
+    help="If dbt would normally warn, instead raise an exception. Examples include `--select` that selects nothing, deprecations, configurations with no associated models, invalid test configurations, and missing sources/refs in tests.",
     default=None,
     is_flag=True,
 )
@@ -691,15 +691,15 @@ warn_error_options = click.option(
     "--warn-error-options",
     envvar="DBT_WARN_ERROR_OPTIONS",
     default="{}",
-    help="""If dbt would normally warn, instead raise an exception based on include/exclude configuration. Examples include --select that selects nothing, deprecations, configurations with no associated models, invalid test configurations,
-    and missing sources/refs in tests. This argument should be a YAML string, with keys 'include' or 'exclude'. eg. '{"include": "all", "exclude": ["NoNodesForSelectionCriteria"]}'""",
+    help="""If dbt would normally warn, instead raise an exception based on include/exclude configuration. Examples include `--select` that selects nothing, deprecations, configurations with no associated models, invalid test configurations,
+    and missing sources/refs in tests. This argument should be a YAML string, with keys 'include' or 'exclude'. eg. '{"include": "all", "exclude": ["NoNodesForSelectionCriteria"]}'.""",
     type=WarnErrorOptionsType(),
 )
 
 write_json = click.option(
     "--write-json/--no-write-json",
     envvar="DBT_WRITE_JSON",
-    help="Whether or not to write the manifest.json and run_results.json files to the target directory",
+    help="Whether or not to write the 'manifest.json' and 'run_results.json' files to the target directory.",
     default=True,
 )
 

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -108,7 +108,7 @@ exclude = click.option(
 export_saved_queries = click.option(
     "--export-saved-queries/--no-export-saved-queries",
     envvar="DBT_EXPORT_SAVED_QUERIES",
-    help="Export saved queries within the 'build' command, otherwise no-op.",
+    help="Export saved queries within the `build` command, otherwise no-op.",
     is_flag=True,
     hidden=True,
 )
@@ -272,7 +272,7 @@ output_path = click.option(
     "--output",
     "-o",
     envvar=None,
-    help="Specify the output path for the JSON report. By default, outputs to 'target/sources.json'.",
+    help="Specify the output path for the JSON report. By default, outputs to 'target.json` or `sources.json'.",
     type=click.Path(file_okay=True, dir_okay=False, writable=True),
     default=None,
 )
@@ -692,7 +692,7 @@ warn_error_options = click.option(
     envvar="DBT_WARN_ERROR_OPTIONS",
     default="{}",
     help="""If dbt would normally warn, instead raise an exception based on include/exclude configuration. Examples include `--select` that selects nothing, deprecations, configurations with no associated models, invalid test configurations,
-    and missing sources/refs in tests. This argument should be a YAML string, with keys 'include' or 'exclude'. eg. '{"include": "all", "exclude": ["NoNodesForSelectionCriteria"]}'.""",
+    and missing sources/refs in tests. This argument should be a YAML string, with keys `include` or `exclude`. eg. '{"include": "all", "exclude": ["NoNodesForSelectionCriteria"]}'.""",
     type=WarnErrorOptionsType(),
 )
 


### PR DESCRIPTION
resolves #10073

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem
 When using dbt --help, there are inconsistencies with punctuation and descriptions of files, with or without single quotes ' ', and flags with or without ticks `.


```
Specify the format of logging to the console and the log file. Use --log-format-file to configure the format for the log file differently than the console.
```
```
Whether or not to run 'dbt compile' as part of docs generation
```
```        
Space-delimited listing of node properties to include as custom keys for JSON output (e.g. `--output json --output-keys name resource_type description`)
 ```
```
Specify number of threads to use while executing models. Overrides settings in profiles.yml.
```


<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
I have fixed and formatted all help options. Now, files are using single quotes ```'``` and commands and their parts are using single ticks ``` ` ```.
Examples:
```Specify number of threads to use while executing models. Overrides settings in 'profiles.yml'.```
```Specify the format of logging to the log file by overriding the default value and the general `--log-format` setting.```
### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
