### PR TITLE
support local/package level and serializable python modules/macros. (…

### DIFF
--- a/core/dbt/artifacts/resources/types.py
+++ b/core/dbt/artifacts/resources/types.py
@@ -28,6 +28,7 @@ class NodeType(StrEnum):
     Documentation = "doc"
     Source = "source"
     Macro = "macro"
+    PythonModule = "python_module"
     Exposure = "exposure"
     Metric = "metric"
     Group = "group"

--- a/core/dbt/artifacts/resources/v1/macro.py
+++ b/core/dbt/artifacts/resources/v1/macro.py
@@ -18,7 +18,7 @@ class MacroArgument(dbtClassMixin):
 @dataclass
 class Macro(BaseResource):
     macro_sql: str
-    resource_type: Literal[NodeType.Macro]
+    resource_type: Literal[NodeType.PythonModule, NodeType.Macro]
     depends_on: MacroDependsOn = field(default_factory=MacroDependsOn)
     description: str = ""
     meta: Dict[str, Any] = field(default_factory=dict)

--- a/core/dbt/contracts/files.py
+++ b/core/dbt/contracts/files.py
@@ -13,6 +13,7 @@ from .util import SourceKey
 
 class ParseFileType(StrEnum):
     Macro = "macro"
+    PythonModule = "python_module"
     Model = "model"
     Snapshot = "snapshot"
     Analysis = "analysis"
@@ -27,6 +28,7 @@ class ParseFileType(StrEnum):
 
 parse_file_type_to_parser = {
     ParseFileType.Macro: "MacroParser",
+    ParseFileType.PythonModule: "PythonModuleParser",
     ParseFileType.Model: "ModelParser",
     ParseFileType.Snapshot: "SnapshotParser",
     ParseFileType.Analysis: "AnalysisParser",

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -30,6 +30,7 @@ mssat_files = (
 
 mg_files = (
     ParseFileType.Macro,
+    ParseFileType.PythonModule,
     ParseFileType.GenericTest,
 )
 

--- a/core/dbt/parser/read_files.py
+++ b/core/dbt/parser/read_files.py
@@ -389,6 +389,11 @@ def get_file_types_for_project(project):
             "extensions": [".sql"],
             "parser": "MacroParser",
         },
+        ParseFileType.PythonModule: {
+            "paths": project.macro_paths,
+            "extensions": [".py"],
+            "parser": "PythonModuleParser",
+        },
         ParseFileType.Model: {
             "paths": project.model_paths,
             "extensions": [".sql", ".py"],

--- a/tests/unit/test_node_types.py
+++ b/tests/unit/test_node_types.py
@@ -13,6 +13,7 @@ node_type_pluralizations = {
     NodeType.Documentation: "docs",
     NodeType.Source: "sources",
     NodeType.Macro: "macros",
+    NodeType.PythonModule: "python_modules",
     NodeType.Exposure: "exposures",
     NodeType.Metric: "metrics",
     NodeType.Group: "groups",


### PR DESCRIPTION
…#10078)

resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->
Suppose that we need to remove (dedent) the same number of leading whitespaces in each line of a sql command or a string of documentation. I've been googling for jinja solutions however that's quite complicated. And it would be quite ease if we can invoke a python module/function.
The proposed method is, we can write a macro in a python file "macros/my_python_module.py":
```
from textwrap import dedent
```
and then we call call the defined module/function in our model "models/test1.sql":
```
{% set query_cmd %}
    select col_1,
              col_2
    from table_name
    where col3=1
        and col4=2
{% endset %}
{{ my_python_module.dedent(query_cmd) }}
````
What's more, as the implementation of this python macro is within the project locally, we can call the macro using `my_project.my_python_module.dedent` if this project is imported to other projects as a package, just as what we do with a jinja macro.


### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
add a `PythonModule` class in additional to the `Macro` class, which can I parsed and serialized.
However there are some limitations:
1. the macro written in python is in package level which is the same as jinja macros, and should be called with the heading package name if we need to call the python macro in other projects.
2. Each directory (python module) should have a "__init__.py" file inside except for the "macros" directory.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
