### PR TITLE
Better error message for Private package definition

### DIFF
--- a/.changes/unreleased/Under the Hood-20240502-154430.yaml
+++ b/.changes/unreleased/Under the Hood-20240502-154430.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Clear error message for Private package in dbt-core
+time: 2024-05-02T15:44:30.713097-07:00
+custom:
+  Author: ChenyuLInx
+  Issue: "10083"

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -79,6 +79,16 @@ class GitPackage(Package):
 
 
 @dataclass
+class PrivatePackage(Package):
+    private: str
+    provider: Optional[str] = None
+    revision: Optional[RawVersion] = None
+    warn_unpinned: Optional[bool] = field(default=None, metadata={"alias": "warn-unpinned"})
+    subdirectory: Optional[str] = None
+    unrendered: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
 class RegistryPackage(Package):
     package: str
     version: Union[RawVersion, List[RawVersion]]
@@ -92,7 +102,7 @@ class RegistryPackage(Package):
             return [str(self.version)]
 
 
-PackageSpec = Union[LocalPackage, TarballPackage, GitPackage, RegistryPackage]
+PackageSpec = Union[LocalPackage, TarballPackage, GitPackage, RegistryPackage, PrivatePackage]
 
 
 @dataclass

--- a/core/dbt/deps/resolver.py
+++ b/core/dbt/deps/resolver.py
@@ -17,7 +17,7 @@ from dbt.deps.local import LocalUnpinnedPackage
 from dbt.deps.registry import RegistryUnpinnedPackage
 from dbt.deps.tarball import TarballUnpinnedPackage
 from dbt.exceptions import (
-    DbtInternalError,
+    DependencyError,
     DuplicateDependencyToRootError,
     DuplicateProjectDependencyError,
     MismatchedDependencyTypeError,
@@ -76,13 +76,13 @@ class PackageListing:
             elif isinstance(contract, GitPackage):
                 pkg = GitUnpinnedPackage.from_contract(contract)
             elif isinstance(contract, PrivatePackage):
-                raise DbtInternalError(
+                raise DependencyError(
                     f'Cannot resolve private package {contract.private} because git provider integration is missing. Please use a "git" package instead.'
                 )
             elif isinstance(contract, RegistryPackage):
                 pkg = RegistryUnpinnedPackage.from_contract(contract)
             else:
-                raise DbtInternalError("Invalid package type {}".format(type(contract)))
+                raise DependencyError("Invalid package type {}".format(type(contract)))
             self.incorporate(pkg)
 
     @classmethod

--- a/core/dbt/deps/resolver.py
+++ b/core/dbt/deps/resolver.py
@@ -7,6 +7,7 @@ from dbt.contracts.project import (
     GitPackage,
     LocalPackage,
     PackageSpec,
+    PrivatePackage,
     RegistryPackage,
     TarballPackage,
 )
@@ -74,6 +75,10 @@ class PackageListing:
                 pkg = TarballUnpinnedPackage.from_contract(contract)
             elif isinstance(contract, GitPackage):
                 pkg = GitUnpinnedPackage.from_contract(contract)
+            elif isinstance(contract, PrivatePackage):
+                raise DbtInternalError(
+                    f'Cannot resolve private package {contract.private} because git provider integration is missing. Please use a "git" package instead.'
+                )
             elif isinstance(contract, RegistryPackage):
                 pkg = RegistryUnpinnedPackage.from_contract(contract)
             else:

--- a/tests/functional/configs/test_custom_node_colors_configs.py
+++ b/tests/functional/configs/test_custom_node_colors_configs.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dbt.exceptions import ConfigUpdateError
 from dbt.tests.util import get_manifest, run_dbt
 from dbt_common.dataclass_schema import ValidationError
 
@@ -304,7 +305,7 @@ class TestCustomNodeColorIncorrectColorModelConfig:
         self,
         project,
     ):
-        with pytest.raises(ValidationError):
+        with pytest.raises((ValidationError, ConfigUpdateError)):
             run_dbt(["compile"])
 
 

--- a/tests/unit/test_deps.py
+++ b/tests/unit/test_deps.py
@@ -791,6 +791,19 @@ class TestPackageSpec(unittest.TestCase):
         self.assertEqual(resolved[1].name, "dbt-labs-test/b")
         self.assertEqual(resolved[1].version, "0.2.1")
 
+    def test_private_package_raise_error(self):
+        package_config = PackageConfig.from_dict(
+            {
+                "packages": [
+                    {"private": "dbt-labs-test/a", "subdirectory": "foo-bar"},
+                ],
+            }
+        )
+        with self.assertRaisesRegex(
+            dbt.exceptions.DbtInternalError, "Cannot resolve private package"
+        ):
+            resolve_packages(package_config.packages, mock.MagicMock(project_name="test"), {})
+
     def test_dependency_resolution_allow_prerelease(self):
         package_config = PackageConfig.from_dict(
             {

--- a/tests/unit/test_deps.py
+++ b/tests/unit/test_deps.py
@@ -800,7 +800,7 @@ class TestPackageSpec(unittest.TestCase):
             }
         )
         with self.assertRaisesRegex(
-            dbt.exceptions.DbtInternalError, "Cannot resolve private package"
+            dbt.exceptions.DependencyError, "Cannot resolve private package"
         ):
             resolve_packages(package_config.packages, mock.MagicMock(project_name="test"), {})
 


### PR DESCRIPTION
resolves #10083

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem
We are introducing better support for private package in dbt-cloud, which allows people to define a new package.
If we don't do anything in core, this would lead to core raising
```
  Validator Error:
  {'private': 'dbt-labs/audit_helper', 'revision': 'HEAD', 'subdirectory': 'audit_helper', 'unrendered': {'private': 'dbt-labs/audit_helper', 'revision': 'HEAD', 'subdirectory': 'audit_helper'}} is not valid under any of the given schemas
```
Instead, we should have a clear message telling people to define git package.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
