### PR TITLE
[Tidy First] Re-lint imports section of `test_base_resource.py`

### DIFF
--- a/tests/unit/artifacts/test_base_resource.py
+++ b/tests/unit/artifacts/test_base_resource.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+
 import pytest
 
 from dbt.artifacts.resources.base import BaseResource


### PR DESCRIPTION
This was done by running `pre-commit run --all`. That this was needed is a temporary glitch in how our `Tests and Code Checks` github action works on PRs. Basically we added `isort` to the pre-commit hooks recently, and this does additional linting/formatting on our imports.

People reasonably have branches which were started prior to `isort` being part of the pre-commit hooks on main. Thus, unless those branches get caught up to main, the github action on associated PRs won't run `isort` because it doesn't exist on those branchs. Once everyone gets their local `main` branch updated (I suspect this might take a few days) this problem will go away.

