### PR TITLE
Unit test selection method

### DIFF
--- a/.changes/unreleased/Features-20240507-162717.yaml
+++ b/.changes/unreleased/Features-20240507-162717.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: 'Add unit_test: selection method'
+time: 2024-05-07T16:27:17.047585-04:00
+custom:
+  Author: michelleark
+  Issue: "10053"

--- a/tests/unit/graph/test_selector_methods.py
+++ b/tests/unit/graph/test_selector_methods.py
@@ -30,6 +30,7 @@ from dbt.graph.selector_methods import (
     UnitTestSelectorMethod,
     VersionSelectorMethod,
 )
+from tests.unit.utils import replace_config
 from tests.unit.utils.manifest import (
     make_exposure,
     make_group,
@@ -41,8 +42,6 @@ from tests.unit.utils.manifest import (
     make_semantic_model,
     make_unit_test,
 )
-
-from .utils import replace_config
 
 
 def search_manifest_using_method(manifest, method, selection):

--- a/tests/unit/test_graph_selector_methods.py
+++ b/tests/unit/test_graph_selector_methods.py
@@ -27,6 +27,7 @@ from dbt.graph.selector_methods import (
     TagSelectorMethod,
     TestNameSelectorMethod,
     TestTypeSelectorMethod,
+    UnitTestSelectorMethod,
     VersionSelectorMethod,
 )
 from tests.unit.utils.manifest import (
@@ -38,6 +39,7 @@ from tests.unit.utils.manifest import (
     make_saved_query,
     make_seed,
     make_semantic_model,
+    make_unit_test,
 )
 
 from .utils import replace_config
@@ -584,6 +586,24 @@ def test_select_saved_query_by_tag(manifest: Manifest) -> None:
     assert isinstance(method, TagSelectorMethod)
     assert method.arguments == []
     search_manifest_using_method(manifest, method, "any_tag")
+
+
+def test_select_unit_test(manifest: Manifest) -> None:
+    test_model = make_model("test", "my_model", "select 1 as id")
+    unit_test = make_unit_test("test", "my_unit_test", test_model)
+    manifest.unit_tests[unit_test.unique_id] = unit_test
+    methods = MethodManager(manifest, None)
+    method = methods.get_method("unit_test", [])
+
+    assert isinstance(method, UnitTestSelectorMethod)
+    assert not search_manifest_using_method(manifest, method, "not_test_unit_test")
+    assert search_manifest_using_method(manifest, method, "*nit_test") == {unit_test.search_name}
+    assert search_manifest_using_method(manifest, method, "test.my_unit_test") == {
+        unit_test.search_name
+    }
+    assert search_manifest_using_method(manifest, method, "my_unit_test") == {
+        unit_test.search_name
+    }
 
 
 @pytest.fixture


### PR DESCRIPTION
resolves: #10053
resolves: https://github.com/dbt-labs/dbt-core/issues/9895
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
unit tests could not be passed in using --select `unit_test:*`

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

implement unit test selection method!

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions


Some additional 🎩 
```sh
❯ dbt ls --resource-type unit_test
20:41:11  Running with dbt=1.9.0-a1
20:41:11  target not specified in profile 'postgres', using 'default'
20:41:11  Registered adapter: postgres=1.9.0-a1
20:41:12  Found 15 models, 6 seeds, 20 data tests, 6 sources, 13 metrics, 684 macros, 6 semantic models, 4 unit tests
unit_test:jaffle_shop.test_supply_costs_sum_correctly
unit_test:jaffle_shop.test_order_items_compute_to_bools_correctly
unit_test:jaffle_shop.test_recursive_cte
unit_test:jaffle_shop.test_does_location_opened_at_trunc_to_date

❯ dbt ls --select unit_test:jaffle_shop.test_recursive_cte
20:41:18  Running with dbt=1.9.0-a1
20:41:18  target not specified in profile 'postgres', using 'default'
20:41:19  Registered adapter: postgres=1.9.0-a1
20:41:19  Found 15 models, 6 seeds, 20 data tests, 6 sources, 13 metrics, 684 macros, 6 semantic models, 4 unit tests
unit_test:jaffle_shop.test_recursive_cte

❯ dbt test --select unit_test:jaffle_shop.test_recursive_cte
20:41:24  Running with dbt=1.9.0-a1
20:41:24  target not specified in profile 'postgres', using 'default'
20:41:25  Registered adapter: postgres=1.9.0-a1
20:41:25  Found 15 models, 6 seeds, 20 data tests, 6 sources, 13 metrics, 684 macros, 6 semantic models, 4 unit tests
20:41:25  
20:41:26  Concurrency: 1 threads (target='default')
20:41:26  
20:41:26  1 of 1 START unit_test recursive_cte::test_recursive_cte ....................... [RUN]
20:41:26  1 of 1 PASS recursive_cte::test_recursive_cte .................................. [PASS in 0.14s]
20:41:26  
20:41:26  Finished running 1 unit test in 0 hours 0 minutes and 1.27 seconds (1.27s).
20:41:27  
20:41:27  Completed successfully
20:41:27  
20:41:27  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```
