### PR TITLE
Fix #10098 by undoing conditional `agate` import in one place

### DIFF
--- a/core/dbt/artifacts/schemas/run/v5/run.py
+++ b/core/dbt/artifacts/schemas/run/v5/run.py
@@ -2,7 +2,13 @@ import copy
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, Optional, Sequence, Tuple
+
+# https://github.com/dbt-labs/dbt-core/issues/10098
+# Needed for Mashumaro serialization of RunResult below
+# TODO: investigate alternative approaches to restore conditional import
+# if TYPE_CHECKING:
+import agate
 
 from dbt.artifacts.resources import CompiledResource
 from dbt.artifacts.schemas.base import (
@@ -21,9 +27,6 @@ from dbt.artifacts.schemas.results import (
 from dbt.exceptions import scrub_secrets
 from dbt_common.clients.system import write_json
 from dbt_common.constants import SECRET_ENV_PREFIX
-
-if TYPE_CHECKING:
-    import agate
 
 
 @dataclass

--- a/tests/functional/artifacts/test_run_results.py
+++ b/tests/functional/artifacts/test_run_results.py
@@ -42,6 +42,22 @@ class TestRunResultsTimingFailure:
         assert len(results.results[0].timing) > 0
 
 
+class TestRunResultsSerializableInContext:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model.sql": good_model_sql}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "on-run-end": ["{% for result in results %}{{ log(result.to_dict()) }}{% endfor %}"]
+        }
+
+    def test_results_serializable(self, project):
+        results = run_dbt(["run"])
+        assert len(results.results) == 1
+
+
 # This test is failing due to the faulty assumptions that run_results.json would
 # be written multiple times. Temporarily disabling.
 @pytest.mark.skip()


### PR DESCRIPTION
resolves #10098

### Problem

Conditional import of `agate` for `TYPE_CHECKING` is leading to `mashumaro.exceptions.UnresolvedTypeReferenceError` during `RunResult.to_dict()` serialization

### Solution

Undo the conditional import for now, with a slight performance penalty.

Another approach could be to convert `results` from `List[RunResult]` to `List[NodeResult]` before we stick them in the Jinja context [here](https://github.com/dbt-labs/dbt-core/blob/fb6dbc848e50397abaf576e2a0fb00f5b742dd82/core/dbt/task/run.py#L470).

For now, this is the safest & simplest way to restore the previous behavior.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
