### PR TITLE
Check if ref'd resource is selected before favoring state

### DIFF
--- a/.changes/unreleased/Fixes-20240508-151127.yaml
+++ b/.changes/unreleased/Fixes-20240508-151127.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: 'Restore previous behavior for --favor-state: only favor defer_relation if not
+  selected in current command"'
+time: 2024-05-08T15:11:27.510912+02:00
+custom:
+  Author: jtcohen6
+  Issue: "10107"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -554,8 +554,11 @@ class RuntimeRefResolver(BaseRefResolver):
             and target_model.defer_relation
             and self.config.args.defer
             and (
-                # User has explicitly opted to prefer defer_relation
-                self.config.args.favor_state
+                # User has explicitly opted to prefer defer_relation for unselected resources
+                (
+                    self.config.args.favor_state
+                    and target_model.unique_id not in selected_resources.SELECTED_RESOURCES
+                )
                 # Or, this node's relation does not exist in the expected target location (cache lookup)
                 or not get_adapter(self.config).get_relation(
                     target_model.database, target_model.schema, target_model.identifier

--- a/tests/functional/defer_state/test_defer_state.py
+++ b/tests/functional/defer_state/test_defer_state.py
@@ -230,6 +230,26 @@ class TestRunDeferStateIFFNotExists(BaseDeferState):
         assert len(results) == 2
         assert other_schema not in results[0].node.compiled_code
 
+        # again with --favor-state, but this time select both the seed and the view
+        # because the seed is also selected, the view should select from the seed in our schema ('other_schema')
+        results = run_dbt(
+            [
+                "build",
+                "--state",
+                "state",
+                "--select",
+                "seed view_model",
+                "--resource-type",
+                "seed model",
+                "--defer",
+                "--favor-state",
+                "--target",
+                "otherschema",
+            ]
+        )
+        assert len(results) == 2
+        assert other_schema in results[1].node.compiled_code
+
 
 class TestDeferStateDeletedUpstream(BaseDeferState):
     def test_run_defer_deleted_upstream(self, project, unique_schema, other_schema):


### PR DESCRIPTION
resolves #10107

### Problem

Previous behavior of `--favor-state` + `--defer`, when selecting multiple resources that build on top of each other, was to favor state for only unselected resources.

The recent deferral refactors (https://github.com/dbt-labs/dbt-core/pull/9040 + https://github.com/dbt-labs/dbt-core/pull/9199) implicitly changed this behavior, by favoring state _always_.

### Solution

Check to see whether a referenced node is selected (using `selected_resources` global) before favoring state (`defer_relation`).

I have added a test case that:
- passes on `1.7.latest` (86df6551d0c897cf14813706efcc966cae03a07b)
- fails on current `main`
- passes again with the change in this PR (cb8c70229a8b6a97c4fc9c865d81b8ef6528ffd7)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
