### PR TITLE
empty unit test csv fixture values default to null

### DIFF
--- a/.changes/unreleased/Fixes-20240509-091411.yaml
+++ b/.changes/unreleased/Fixes-20240509-091411.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Unit test fixture (csv) returns null for empty value
+time: 2024-05-09T09:14:11.772709-04:00
+custom:
+  Author: michelleark
+  Issue: "9881"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1822,7 +1822,7 @@ class SQLCompiledPath(InfoLevel):
         return "Z026"
 
     def message(self) -> str:
-        return f"  compiled Code at {self.path}"
+        return f"  compiled code at {self.path}"
 
 
 class CheckNodeTestFailure(InfoLevel):

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -365,11 +365,17 @@ class UnitTestParser(YamlReader):
                 )
 
             if ut_fixture.fixture:
-                ut_fixture.rows = self.get_fixture_file_rows(
+                csv_rows = self.get_fixture_file_rows(
                     ut_fixture.fixture, self.project.project_name, unit_test_definition.unique_id
                 )
             else:
-                ut_fixture.rows = self._convert_csv_to_list_of_dicts(ut_fixture.rows)
+                csv_rows = self._convert_csv_to_list_of_dicts(ut_fixture.rows)
+
+            # Empty values (e.g. ,,) in a csv fixture should default to null, not ""
+            ut_fixture.rows = [
+                {k: (None if v == "" else v) for k, v in row.items()} for row in csv_rows
+            ]
+
         elif ut_fixture.format == UnitTestFormat.SQL:
             if not (isinstance(ut_fixture.rows, str) or isinstance(ut_fixture.fixture, str)):
                 raise ParsingError(

--- a/tests/functional/unit_testing/fixtures.py
+++ b/tests/functional/unit_testing/fixtures.py
@@ -41,6 +41,15 @@ SELECT
 'b' as string_b
 """
 
+my_model_check_null_sql = """
+SELECT
+CASE
+  WHEN a IS null THEN True
+  ELSE False
+END a_is_null
+FROM {{ ref('my_model_a') }}
+"""
+
 test_my_model_yml = """
 unit_tests:
   - name: test_my_model
@@ -505,6 +514,11 @@ test_my_model_fixture_csv = """id,b
 
 test_my_model_a_fixture_csv = """id,string_a
 1,a
+"""
+
+test_my_model_a_with_null_fixture_csv = """id,a
+1,
+2,3
 """
 
 test_my_model_a_empty_fixture_csv = """
@@ -1059,4 +1073,40 @@ unit_tests:
     expect:
       rows:
         - {id: 2}
+"""
+
+
+test_my_model_csv_null_yml = """
+unit_tests:
+  - name: test_my_model_check_null
+    model: my_model_check_null
+    given:
+      - input: ref('my_model_a')
+        format: csv
+        rows: |
+          id,a
+          1,
+          2,3
+    expect:
+      format: csv
+      rows: |
+        a_is_null
+        True
+        False
+"""
+
+test_my_model_file_csv_null_yml = """
+unit_tests:
+  - name: test_my_model_check_null
+    model: my_model_check_null
+    given:
+      - input: ref('my_model_a')
+        format: csv
+        fixture: test_my_model_a_with_null_fixture
+    expect:
+      format: csv
+      rows: |
+        a_is_null
+        True
+        False
 """

--- a/tests/functional/unit_testing/test_csv_fixtures.py
+++ b/tests/functional/unit_testing/test_csv_fixtures.py
@@ -5,15 +5,19 @@ from fixtures import (
     datetime_test_invalid_format_key,
     my_model_a_sql,
     my_model_b_sql,
+    my_model_check_null_sql,
     my_model_sql,
     test_my_model_a_empty_fixture_csv,
     test_my_model_a_fixture_csv,
     test_my_model_a_numeric_fixture_csv,
+    test_my_model_a_with_null_fixture_csv,
     test_my_model_b_fixture_csv,
     test_my_model_basic_fixture_csv,
     test_my_model_concat_fixture_csv,
+    test_my_model_csv_null_yml,
     test_my_model_csv_yml,
     test_my_model_duplicate_csv_yml,
+    test_my_model_file_csv_null_yml,
     test_my_model_file_csv_yml,
     test_my_model_fixture_csv,
     test_my_model_missing_csv_yml,
@@ -206,6 +210,50 @@ class TestUnitTestsWithMixedCSV:
         )
         with pytest.raises(ParsingError):
             results = run_dbt(["test", "--select", "my_model"], expect_pass=False)
+
+
+class TestUnitTestsInlineCSVEmptyValueIsNull:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_a.sql": my_model_a_sql,
+            "my_model_check_null.sql": my_model_check_null_sql,
+            "test_my_model_csv_null.yml": test_my_model_csv_null_yml,
+        }
+
+    def test_unit_test(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 2
+
+        # Select by model name
+        results = run_dbt(["test", "--select", "my_model_check_null"], expect_pass=True)
+        assert len(results) == 1
+
+
+class TestUnitTestsFileCSVEmptyValueIsNull:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_a.sql": my_model_a_sql,
+            "my_model_check_null.sql": my_model_check_null_sql,
+            "test_my_model_file_csv_null.yml": test_my_model_file_csv_null_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def tests(self):
+        return {
+            "fixtures": {
+                "test_my_model_a_with_null_fixture.csv": test_my_model_a_with_null_fixture_csv,
+            }
+        }
+
+    def test_unit_test(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 2
+
+        # Select by model name
+        results = run_dbt(["test", "--select", "my_model_check_null"], expect_pass=True)
+        assert len(results) == 1
 
 
 class TestUnitTestsMissingCSVFile:


### PR DESCRIPTION
resolves #9881

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

CSV fixtures with empty values are converted to "" instead of null -- which is inconsistent with the way seeds work.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

* Convert csv fixture rows from "" to null (None in python, converted to null later down in the framework) if detected. 
* Added the normalization to unit test parsing in `_validate_and_normalize_rows`
* Couldn't find a built-in way to handle this with csv.DictReader (https://stackoverflow.com/a/68305271)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
