### PR TITLE
Update minimum req for dbt-common + dbt-adapters

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -75,8 +75,8 @@ setup(
         "minimal-snowplow-tracker>=0.0.2,<0.1",
         "dbt-semantic-interfaces>=0.5.1,<0.6",
         # Minor versions for these are expected to be backwards-compatible
-        "dbt-common>=1.0.2,<2.0",
-        "dbt-adapters>=0.1.0a2,<2.0",
+        "dbt-common>=1.0.4,<2.0",
+        "dbt-adapters>=1.1.1,<2.0",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
         "packaging>20.9",


### PR DESCRIPTION
prevent #10122 from happening to more people

### Problem

If someone has older installs of `dbt-core` + `dbt-common` + `dbt-adapters`, and they `pip install dbt-core`, it won't automatically upgrade `dbt-common` + `dbt-adapters`.

But `dbt-core==1.8.0` actually requires `dbt-common>=1.0.4` and `dbt-adapters>=1.1.1`, given the change in #10094.

### Solution

Bump the minimum requirements for `dbt-common` + `dbt-adapters`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
