### PR TITLE
improve semantic manifest error message

### DIFF
--- a/.changes/unreleased/Fixes-20240510-121726.yaml
+++ b/.changes/unreleased/Fixes-20240510-121726.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add details to Semantic Manifest parsing error message
+time: 2024-05-10T12:17:26.691282-05:00
+custom:
+  Author: Klimmy
+  Issue: "9849"

--- a/core/dbt/contracts/graph/semantic_manifest.py
+++ b/core/dbt/contracts/graph/semantic_manifest.py
@@ -54,9 +54,9 @@ class SemanticManifest:
         #    )
 
         if validation_error_messages:
-            validation_error_msg = "\n".join(validation_error_messages)
+            validation_error_msg = "\n- ".join(validation_error_messages)
             raise ParsingError(
-                f"Semantic Manifest validation failed due to the following:\n{ validation_error_msg }"
+                f"Semantic Manifest validation failed due to the following:\n- { validation_error_msg }"
             )
 
     def write_json_to_file(self, file_path: str):

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -470,8 +470,7 @@ class ManifestLoader:
             self.check_valid_access_property()
 
             semantic_manifest = SemanticManifest(self.manifest)
-            if not semantic_manifest.validate():
-                raise dbt.exceptions.ParsingError("Semantic Manifest validation failed.")
+            semantic_manifest.validate()
 
             # update tracking data
             self._perf_info.process_manifest_elapsed = time.perf_counter() - start_process


### PR DESCRIPTION
resolves #9849 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
Improves [this](https://github.com/dbt-labs/dbt-core/blob/c95b1ea5e69ce578738bda165d467f2bb86589d6/core/dbt/parser/manifest.py#L491) error message to provide more details as to what is wrong with the Semantic Manifest.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

This PR moved the raising of an error to the validate() method and made it return `None` instead of `bool`.
From what I checked, this behavior aligns with other validations in the project ([example_1](https://github.com/dbt-labs/dbt-core/blob/994a089b1fe8df1fe7001caa79cfd323160069e2/core/dbt/config/profile.py#L126), [example_2](https://github.com/dbt-labs/dbt-core/blob/c95b1ea5e69ce578738bda165d467f2bb86589d6/core/dbt/artifacts/resources/v1/snapshot.py#L58), [example_3](https://github.com/dbt-labs/dbt-core/blob/c95b1ea5e69ce578738bda165d467f2bb86589d6/core/dbt/task/run.py#L107)).

Before the fix:
```bash
Encountered an error:
Parsing Error
  Semantic Manifest validation failed.
```

After the fix:
```bash
Encountered an error:
Parsing Error
  Semantic Manifest validation failed due to the following:
  - Invalid name `metric_time` - this name is reserved by MetricFlow. Reason: Used as the query input for creating time series metrics from measures with different time dimension names.
  - The semantic model orders contains dimensions, but it does not define a primary entity. Either add an entity with type PRIMARY or set a value for the primary_entity key.
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
