### PR TITLE
[Tidy First] Remove `wheel` and `twine` from `dev-requirements.txt`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -24,7 +24,6 @@ pytest-split
 pytest-xdist
 sphinx
 tox>=3.13
-twine
 types-docutils
 types-PyYAML
 types-Jinja2
@@ -33,5 +32,4 @@ types-protobuf>=4.0.0,<5.0.0
 types-pytz
 types-requests
 types-setuptools
-wheel
 mocker


### PR DESCRIPTION
### Problem

Many of the pip installation failures seem to be because of hashes not matching for a library called `jaraco.context`, sample log ([link](https://github.com/dbt-labs/dbt-core/actions/runs/9080171975/job/24950981355))

```
Collecting jaraco.context (from keyring>=15.1->twine->-r dev-requirements.txt (line 19))
ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
    unknown package:
        Expected sha256 9f5f5a74085d9a81a1f9c78081d60a0040c3efb3f28e5c9912b900adf59a16e6
             Got        b9cb75a7ae04f6204166e8523044ea7c6512c20dd30c5643b1e334031a6cf714
```

It looks like the only place we're using `twine` is in this GitHub integrity reference check: https://github.com/dbt-labs/dbt-core/blob/751139d8c14503dfe1fa74295502e07c3b21b3d1/.github/workflows/main.yml#L282

And we already install `twine` separately here: https://github.com/dbt-labs/dbt-core/blob/751139d8c14503dfe1fa74295502e07c3b21b3d1/.github/workflows/main.yml#L271

So there's no need to keep `twine` in `dev-requirements.txt`.

### Solution

Remove `twine` from `dev-requirements.txt`. 
While I was at it, also removed `wheel` for a similar reason.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
