### PR TITLE
Repository unit tests for `ManifestLoader.get_full_manifest`

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,6 +5,7 @@ from dbt.artifacts.resources.types import NodeType
 from dbt.contracts.graph.nodes import SourceDefinition
 
 # All manifest related fixtures.
+from tests.unit.utils.adapter import *  # noqa
 from tests.unit.utils.manifest import *  # noqa
 from tests.unit.utils.project import *  # noqa
 

--- a/tests/unit/parser/test_manifest.py
+++ b/tests/unit/parser/test_manifest.py
@@ -1,6 +1,7 @@
 from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 from pytest_mock import MockerFixture
 
 from dbt.config import RuntimeConfig
@@ -82,6 +83,7 @@ class TestFailedPartialParse:
 
 
 class TestGetFullManifest:
+    @pytest.fixture
     def set_required_mocks(
         self, mocker: MockerFixture, manifest: Manifest, mock_adapter: MagicMock
     ):
@@ -95,12 +97,10 @@ class TestGetFullManifest:
 
     def test_write_perf_info(
         self,
-        manifest: Manifest,
         mock_project: MagicMock,
-        mock_adapter: MagicMock,
         mocker: MockerFixture,
+        set_required_mocks,
     ) -> None:
-        self.set_required_mocks(mocker, manifest, mock_adapter)
         write_perf_info = mocker.patch("dbt.parser.manifest.ManifestLoader.write_perf_info")
 
         ManifestLoader.get_full_manifest(
@@ -117,12 +117,10 @@ class TestGetFullManifest:
 
     def test_reset(
         self,
-        manifest: Manifest,
         mock_project: MagicMock,
         mock_adapter: MagicMock,
-        mocker: MockerFixture,
+        set_required_mocks,
     ) -> None:
-        self.set_required_mocks(mocker, manifest, mock_adapter)
 
         ManifestLoader.get_full_manifest(
             config=mock_project,
@@ -141,12 +139,10 @@ class TestGetFullManifest:
 
     def test_partial_parse_file_diff_flag(
         self,
-        manifest: Manifest,
         mock_project: MagicMock,
-        mock_adapter: MagicMock,
         mocker: MockerFixture,
+        set_required_mocks,
     ) -> None:
-        self.set_required_mocks(mocker, manifest, mock_adapter)
 
         # FileDiff.from_dict is only called if PARTIAL_PARSE_FILE_DIFF == False
         # So we can track this function call to check if setting PARTIAL_PARSE_FILE_DIFF

--- a/tests/unit/parser/test_manifest.py
+++ b/tests/unit/parser/test_manifest.py
@@ -114,13 +114,9 @@ class TestFailedPartialParse:
 
 
 class TestGetFullManifest:
-    def test_write_perf_info(
-        self,
-        manifest: Manifest,
-        mock_project: MagicMock,
-        mock_adapter: MagicMock,
-        mocker: MockerFixture,
-    ) -> None:
+    def set_required_mocks(
+        self, mocker: MockerFixture, manifest: Manifest, mock_adapter: MagicMock
+    ):
         mocker.patch("dbt.parser.manifest.get_adapter").return_value = mock_adapter
         mocker.patch("dbt.parser.manifest.ManifestLoader.load").return_value = manifest
         mocker.patch("dbt.parser.manifest._check_manifest").return_value = None
@@ -128,6 +124,15 @@ class TestGetFullManifest:
             "dbt.parser.manifest.ManifestLoader.save_macros_to_adapter"
         ).return_value = None
         mocker.patch("dbt.tracking.active_user").return_value = User(None)
+
+    def test_write_perf_info(
+        self,
+        manifest: Manifest,
+        mock_project: MagicMock,
+        mock_adapter: MagicMock,
+        mocker: MockerFixture,
+    ) -> None:
+        self.set_required_mocks(mocker, manifest, mock_adapter)
         write_perf_info = mocker.patch("dbt.parser.manifest.ManifestLoader.write_perf_info")
 
         ManifestLoader.get_full_manifest(
@@ -149,13 +154,7 @@ class TestGetFullManifest:
         mock_adapter: MagicMock,
         mocker: MockerFixture,
     ) -> None:
-        mocker.patch("dbt.parser.manifest.get_adapter").return_value = mock_adapter
-        mocker.patch("dbt.parser.manifest.ManifestLoader.load").return_value = manifest
-        mocker.patch("dbt.parser.manifest._check_manifest").return_value = None
-        mocker.patch(
-            "dbt.parser.manifest.ManifestLoader.save_macros_to_adapter"
-        ).return_value = None
-        mocker.patch("dbt.tracking.active_user").return_value = User(None)
+        self.set_required_mocks(mocker, manifest, mock_adapter)
 
         ManifestLoader.get_full_manifest(
             config=mock_project,

--- a/tests/unit/parser/test_manifest.py
+++ b/tests/unit/parser/test_manifest.py
@@ -1,47 +1,14 @@
 from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
-import pytest
 from pytest_mock import MockerFixture
 
-from dbt.adapters.postgres import PostgresAdapter
-from dbt.adapters.sql import SQLConnectionManager
 from dbt.config import RuntimeConfig
 from dbt.contracts.graph.manifest import Manifest
 from dbt.flags import set_from_args
 from dbt.parser.manifest import ManifestLoader
 from dbt.parser.read_files import FileDiff
 from dbt.tracking import User
-
-
-@pytest.fixture
-def mock_project():
-    mock_project = MagicMock(RuntimeConfig)
-    mock_project.cli_vars = {}
-    mock_project.args = MagicMock()
-    mock_project.args.profile = "test"
-    mock_project.args.target = "test"
-    mock_project.project_env_vars = {}
-    mock_project.profile_env_vars = {}
-    mock_project.project_target_path = "mock_target_path"
-    mock_project.credentials = MagicMock()
-    mock_project.clear_dependencies = MagicMock()
-    return mock_project
-
-
-@pytest.fixture
-def mock_connection_manager():
-    mock_connection_manager = MagicMock(SQLConnectionManager)
-    mock_connection_manager.set_query_header = lambda query_header_context: None
-    return mock_connection_manager
-
-
-@pytest.fixture
-def mock_adapter(mock_connection_manager: MagicMock):
-    mock_adapter = MagicMock(PostgresAdapter)
-    mock_adapter.connections = mock_connection_manager
-    mock_adapter.clear_macro_resolver = MagicMock()
-    return mock_adapter
 
 
 class TestPartialParse:

--- a/tests/unit/utils/adapter.py
+++ b/tests/unit/utils/adapter.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from dbt.adapters.postgres import PostgresAdapter
+from dbt.adapters.sql import SQLConnectionManager
+
+
+@pytest.fixture
+def mock_connection_manager() -> MagicMock:
+    mock_connection_manager = MagicMock(SQLConnectionManager)
+    mock_connection_manager.set_query_header = lambda query_header_context: None
+    return mock_connection_manager
+
+
+@pytest.fixture
+def mock_adapter(mock_connection_manager: MagicMock) -> MagicMock:
+    mock_adapter = MagicMock(PostgresAdapter)
+    mock_adapter.connections = mock_connection_manager
+    mock_adapter.clear_macro_resolver = MagicMock()
+    return mock_adapter

--- a/tests/unit/utils/project.py
+++ b/tests/unit/utils/project.py
@@ -1,6 +1,9 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from dbt.adapters.contracts.connection import QueryComment
+from dbt.config import RuntimeConfig
 from dbt.config.project import Project, RenderComponents, VarProvider
 from dbt.config.selectors import SelectorConfig
 from dbt.contracts.project import PackageConfig
@@ -68,3 +71,18 @@ def project(selector_config: SelectorConfig) -> Project:
         restrict_access=False,
         dbt_cloud={},
     )
+
+
+@pytest.fixture
+def mock_project():
+    mock_project = MagicMock(RuntimeConfig)
+    mock_project.cli_vars = {}
+    mock_project.args = MagicMock()
+    mock_project.args.profile = "test"
+    mock_project.args.target = "test"
+    mock_project.project_env_vars = {}
+    mock_project.profile_env_vars = {}
+    mock_project.project_target_path = "mock_target_path"
+    mock_project.credentials = MagicMock()
+    mock_project.clear_dependencies = MagicMock()
+    return mock_project


### PR DESCRIPTION
resolves #9865

### Problem

[ManifestLoader.get_full_manifest](https://github.com/dbt-labs/dbt-core/blob/d21ff38ba1aafdee67e0165856f59b31d824d144/core/dbt/parser/manifest.py#L263) is one of the central functions of dbt-core. It is what is generally used for loading the manifest. However, previously we had no unit tests for it.

### Solution

Add unit tests for `ManifestLoader.get_full_manifest`. So in reality, `get_full_manifest` is more of an orchestrator method and thus offloads a fair bit of the work to other functions. We should separately ensure the sub functions get appropriately unit tested. With that said, `get_full_manifest` has itself some logical branches that we want to guarantee with testing. The tests we've added test these logical branches
* usage of the `reset` argument
* usage of the `write_perf_info` argument
* usage of the `PARTIAL_PARSE_FILE_DIFF` flag

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
