### PR TITLE
Standardize event catching during repository unit tests

### DIFF
--- a/tests/functional/configs/test_warn_error_options.py
+++ b/tests/functional/configs/test_warn_error_options.py
@@ -6,7 +6,7 @@ from dbt.cli.main import dbtRunner, dbtRunnerResult
 from dbt.events.types import DeprecatedModel
 from dbt.tests.util import update_config_file
 from dbt_common.events.base_types import EventLevel
-from tests.functional.utils import EventCatcher
+from tests.utils import EventCatcher
 
 ModelsDictSpec = Dict[str, Union[str, "ModelsDictSpec"]]
 

--- a/tests/functional/manifest_validations/test_check_for_spaces_in_model_names.py
+++ b/tests/functional/manifest_validations/test_check_for_spaces_in_model_names.py
@@ -10,7 +10,7 @@ from dbt.events.types import (
 )
 from dbt.tests.util import update_config_file
 from dbt_common.events.base_types import EventLevel
-from tests.functional.utils import EventCatcher
+from tests.utils import EventCatcher
 
 
 class TestSpacesInModelNamesHappyPath:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -6,6 +6,7 @@ from dbt.contracts.graph.nodes import SourceDefinition
 
 # All manifest related fixtures.
 from tests.unit.utils.adapter import *  # noqa
+from tests.unit.utils.event_manager import *  # noqa
 from tests.unit.utils.manifest import *  # noqa
 from tests.unit.utils.project import *  # noqa
 

--- a/tests/unit/events/test_logging.py
+++ b/tests/unit/events/test_logging.py
@@ -1,7 +1,10 @@
+from argparse import Namespace
 from copy import deepcopy
 
+from pytest_mock import MockerFixture
+
 from dbt.events.logging import setup_event_logger
-from dbt.flags import get_flags
+from dbt.flags import get_flags, set_from_args
 from dbt_common.events.base_types import BaseEvent
 from dbt_common.events.event_manager_client import get_event_manager
 from dbt_common.events.logger import LoggerConfig
@@ -24,3 +27,16 @@ class TestSetupEventLogger:
         setup_event_logger(flags=flags)
         assert len(manager.loggers) == 0
         assert len(manager.callbacks) == 0
+
+    def test_specify_max_bytes(
+        self,
+        mocker: MockerFixture,
+        mock_global_event_manager,
+    ) -> None:
+        patched_file_handler = mocker.patch("dbt_common.events.logger.RotatingFileHandler")
+        args = Namespace(log_file_max_bytes=1234567)
+        set_from_args(args, {})
+        setup_event_logger(get_flags())
+        patched_file_handler.assert_called_once_with(
+            filename="logs/dbt.log", encoding="utf8", maxBytes=1234567, backupCount=5
+        )

--- a/tests/unit/events/test_logging.py
+++ b/tests/unit/events/test_logging.py
@@ -8,7 +8,7 @@ from dbt.flags import get_flags, set_from_args
 from dbt_common.events.base_types import BaseEvent
 from dbt_common.events.event_manager_client import get_event_manager
 from dbt_common.events.logger import LoggerConfig
-from tests.functional.utils import EventCatcher
+from tests.utils import EventCatcher
 
 
 class TestSetupEventLogger:

--- a/tests/unit/events/test_logging.py
+++ b/tests/unit/events/test_logging.py
@@ -1,0 +1,26 @@
+from copy import deepcopy
+
+from dbt.events.logging import setup_event_logger
+from dbt.flags import get_flags
+from dbt_common.events.base_types import BaseEvent
+from dbt_common.events.event_manager_client import get_event_manager
+from dbt_common.events.logger import LoggerConfig
+from tests.functional.utils import EventCatcher
+
+
+class TestSetupEventLogger:
+    def test_clears_preexisting_event_manager_state(self, mock_global_event_manager) -> None:
+        manager = get_event_manager()
+        manager.add_logger(LoggerConfig(name="test_logger"))
+        manager.callbacks.append(EventCatcher(BaseEvent).catch)
+        assert len(manager.loggers) == 1
+        assert len(manager.callbacks) == 1
+
+        flags = deepcopy(get_flags())
+        # setting both of these to none guarantees that no logger will be added
+        object.__setattr__(flags, "LOG_LEVEL", "none")
+        object.__setattr__(flags, "LOG_LEVEL_FILE", "none")
+
+        setup_event_logger(flags=flags)
+        assert len(manager.loggers) == 0
+        assert len(manager.callbacks) == 0

--- a/tests/unit/events/test_logging.py
+++ b/tests/unit/events/test_logging.py
@@ -12,7 +12,7 @@ from tests.utils import EventCatcher
 
 
 class TestSetupEventLogger:
-    def test_clears_preexisting_event_manager_state(self, mock_global_event_manager) -> None:
+    def test_clears_preexisting_event_manager_state(self) -> None:
         manager = get_event_manager()
         manager.add_logger(LoggerConfig(name="test_logger"))
         manager.callbacks.append(EventCatcher(BaseEvent).catch)
@@ -31,7 +31,6 @@ class TestSetupEventLogger:
     def test_specify_max_bytes(
         self,
         mocker: MockerFixture,
-        mock_global_event_manager,
     ) -> None:
         patched_file_handler = mocker.patch("dbt_common.events.logger.RotatingFileHandler")
         args = Namespace(log_file_max_bytes=1234567)

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -7,7 +7,6 @@ import dbt.flags as flags
 from dbt.adapters.events.types import AdapterDeprecationWarning
 from dbt.events.logging import setup_event_logger
 from dbt.events.types import NoNodesForSelectionCriteria
-from dbt_common.events.event_manager import EventManager
 from dbt_common.events.functions import msg_to_dict, warn_or_error
 from dbt_common.events.types import InfoLevel, RetryExternalCall
 from dbt_common.exceptions import EventCompilationError
@@ -86,8 +85,9 @@ def test_msg_to_dict_handles_exceptions_gracefully():
         ), f"We expect `msg_to_dict` to gracefully handle exceptions, but it raised {exc}"
 
 
-def test_setup_event_logger_specify_max_bytes(mocker: MockerFixture) -> None:
-    mocker.patch("dbt_common.events.event_manager_client._EVENT_MANAGER", EventManager())
+def test_setup_event_logger_specify_max_bytes(
+    mocker: MockerFixture, mock_global_event_manager
+) -> None:
     patched_file_handler = mocker.patch("dbt_common.events.logger.RotatingFileHandler")
     args = Namespace(log_file_max_bytes=1234567)
     flags.set_from_args(args, {})

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,11 +1,9 @@
 from argparse import Namespace
 
 import pytest
-from pytest_mock import MockerFixture
 
 import dbt.flags as flags
 from dbt.adapters.events.types import AdapterDeprecationWarning
-from dbt.events.logging import setup_event_logger
 from dbt.events.types import NoNodesForSelectionCriteria
 from dbt_common.events.functions import msg_to_dict, warn_or_error
 from dbt_common.events.types import InfoLevel, RetryExternalCall
@@ -83,15 +81,3 @@ def test_msg_to_dict_handles_exceptions_gracefully():
         assert (
             False
         ), f"We expect `msg_to_dict` to gracefully handle exceptions, but it raised {exc}"
-
-
-def test_setup_event_logger_specify_max_bytes(
-    mocker: MockerFixture, mock_global_event_manager
-) -> None:
-    patched_file_handler = mocker.patch("dbt_common.events.logger.RotatingFileHandler")
-    args = Namespace(log_file_max_bytes=1234567)
-    flags.set_from_args(args, {})
-    setup_event_logger(flags.get_flags())
-    patched_file_handler.assert_called_once_with(
-        filename="logs/dbt.log", encoding="utf8", maxBytes=1234567, backupCount=5
-    )

--- a/tests/unit/utils/event_manager.py
+++ b/tests/unit/utils/event_manager.py
@@ -1,10 +1,8 @@
 import pytest
-from pytest_mock import MockerFixture
 
-from dbt_common.events.event_manager import EventManager
+from dbt_common.events.event_manager_client import cleanup_event_logger
 
 
-@pytest.fixture
-def mock_global_event_manager(mocker: MockerFixture) -> None:
-    """Mocks the global _EVENT_MANAGER so that unit tests can safely modify it without worry about other tests."""
-    mocker.patch("dbt_common.events.event_manager_client._EVENT_MANAGER", EventManager())
+@pytest.fixture(autouse=True)
+def always_clean_event_manager() -> None:
+    cleanup_event_logger()

--- a/tests/unit/utils/event_manager.py
+++ b/tests/unit/utils/event_manager.py
@@ -1,0 +1,10 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from dbt_common.events.event_manager import EventManager
+
+
+@pytest.fixture
+def mock_global_event_manager(mocker: MockerFixture) -> None:
+    """Mocks the global _EVENT_MANAGER so that unit tests can safely modify it without worry about other tests."""
+    mocker.patch("dbt_common.events.event_manager_client._EVENT_MANAGER", EventManager())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass, field
+from typing import List
+
+from dbt_common.events.base_types import BaseEvent, EventMsg
+
+
+@dataclass
+class EventCatcher:
+    event_to_catch: BaseEvent
+    caught_events: List[EventMsg] = field(default_factory=list)
+
+    def catch(self, event: EventMsg):
+        if event.info.name == self.event_to_catch.__name__:
+            self.caught_events.append(event)
+
+    def flush(self) -> None:
+        self.caught_events = []


### PR DESCRIPTION
resolves #9947

### Problem

* Any modifications to the global event manager during unit tests would affect other tests unless properly cleaned up
* There wasn't a good way to check what events were fired during unit tests

Previously if we modified the global event manager during unit tests, we then had to clean up the event manager at the end of the test.   No clean up necessary. We also moved the `EventCatcher` class 

### Solution

* In [67c87fd](https://github.com/dbt-labs/dbt-core/pull/10153/commits/67c87fdb1434920640279ad7295ab51421f84334) we added a new fixture `always_clean_event_manager` to the unit test suite
  * because we use `autouse=True` the fixture is used for every unit test. Thus every unit test will have clean state (so long as we aren't multi-threading our unit tests, which we currently don't)
* In bcb2efcf0f0f4bfb1a0c0e94ae7cdd329d5d4b68 we moved the `EventCatcher` class to `tests.utils`
  * The `EventCatcher.catch` can be added to the callbacks of the event manager to check that certain event types happen
  * Example [here](https://github.com/dbt-labs/dbt-core/blob/32a7f82772d90a4b9ab443908f5f4455d0aa2c73/tests/functional/manifest_validations/test_check_for_spaces_in_model_names.py#L18)

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
