### PR TITLE
Add more accurate RSS high water mark measurement for Linux

### DIFF
--- a/.changes/unreleased/Under the Hood-20240519-155946.yaml
+++ b/.changes/unreleased/Under the Hood-20240519-155946.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Make RSS high water mark measurement more accurate on Linux
+time: 2024-05-19T15:59:46.700842315-04:00
+custom:
+    Author: peterallenwebb
+    Issue: "10177"

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -149,9 +149,6 @@ def postflight(func):
                 import resource
 
                 rusage = resource.getrusage(resource.RUSAGE_SELF)
-                max_rss = try_get_max_rss_kb()
-                if max_rss is None:
-                    max_rss = rusage.ru_maxrss
                 fire_event(
                     ResourceReport(
                         command_name=ctx.command.name,
@@ -159,7 +156,7 @@ def postflight(func):
                         command_wall_clock_time=time.perf_counter() - start_func,
                         process_user_time=rusage.ru_utime,
                         process_kernel_time=rusage.ru_stime,
-                        process_mem_max_rss=max_rss,
+                        process_mem_max_rss=try_get_max_rss_kb() or rusage.ru_maxrss,
                         process_in_blocks=rusage.ru_inblock,
                         process_out_blocks=rusage.ru_oublock,
                     ),

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -386,3 +386,21 @@ def strtobool(val: str) -> bool:
         return False
     else:
         raise ValueError("invalid truth value %r" % (val,))
+
+
+def try_get_max_rss_kb() -> Optional[int]:
+    """Attempts to get the high water mark for this process's memory use via
+    the most reliable and accurate mechanism available through the host OS.
+    Currently only implemented for Linux."""
+    try:
+        # On Linux, the most reliable documented mechanism for getting the RSS
+        # high-water-mark comes from the line confusingly labeled VmHWM in the
+        # /proc/self/status virtual file.
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmHWM:"):
+                    return int(str.split(line)[1])
+    except Exception:
+        pass
+
+    return None

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -5,6 +5,7 @@ import functools
 import itertools
 import json
 import os
+import sys
 from enum import Enum
 from pathlib import PosixPath, WindowsPath
 from typing import (
@@ -392,15 +393,16 @@ def try_get_max_rss_kb() -> Optional[int]:
     """Attempts to get the high water mark for this process's memory use via
     the most reliable and accurate mechanism available through the host OS.
     Currently only implemented for Linux."""
-    try:
-        # On Linux, the most reliable documented mechanism for getting the RSS
-        # high-water-mark comes from the line confusingly labeled VmHWM in the
-        # /proc/self/status virtual file.
-        with open("/proc/self/status") as f:
-            for line in f:
-                if line.startswith("VmHWM:"):
-                    return int(str.split(line)[1])
-    except Exception:
-        pass
+    if sys.platform == "linux" and os.path.isfile("/proc/self/status"):
+        try:
+            # On Linux, the most reliable documented mechanism for getting the RSS
+            # high-water-mark comes from the line confusingly labeled VmHWM in the
+            # /proc/self/status virtual file.
+            with open("/proc/self/status") as f:
+                for line in f:
+                    if line.startswith("VmHWM:"):
+                        return int(str.split(line)[1])
+        except Exception:
+            pass
 
     return None


### PR DESCRIPTION
resolves #10120

### Problem

Memory measurement on Linux reflected the maximum RSS level of not just the current process, but all parent processes.

### Solution

Measure max RSS on Linux via a platform-specific mechanism that does not have this defect.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
