### PR TITLE
Fix: Order-insensitive unit test equality assertion for expected/actual with multiple nulls

### DIFF
--- a/.changes/unreleased/Fixes-20240522-182855.yaml
+++ b/.changes/unreleased/Fixes-20240522-182855.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: 'Fix: Order-insensitive unit test equality assertion for expected/actual with
+  multiple nulls'
+time: 2024-05-22T18:28:55.91733-04:00
+custom:
+  Author: michelleark
+  Issue: "10167"

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -341,11 +341,11 @@ class TestRunner(CompileRunner):
         expected_daff_table = daff.PythonTableView(list_rows_from_table(expected, sort=True))
         actual_daff_table = daff.PythonTableView(list_rows_from_table(actual, sort=True))
 
-        alignment = daff.Coopy.compareTables(expected_daff_table, actual_daff_table).align()
-        result = daff.PythonTableView([])
-
         flags = daff.CompareFlags()
         flags.ordered = ordered
+
+        alignment = daff.Coopy.compareTables(expected_daff_table, actual_daff_table, flags).align()
+        result = daff.PythonTableView([])
 
         diff = daff.TableDiff(alignment, flags)
         diff.hilite(result)

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -338,6 +338,8 @@ class TestRunner(CompileRunner):
     def _get_daff_diff(
         self, expected: "agate.Table", actual: "agate.Table", ordered: bool = False
     ) -> daff.TableDiff:
+        # Sort expected and actual inputs prior to creating daff diff to ensure order insensitivity
+        # https://github.com/paulfitz/daff/issues/200
         expected_daff_table = daff.PythonTableView(list_rows_from_table(expected, sort=True))
         actual_daff_table = daff.PythonTableView(list_rows_from_table(actual, sort=True))
 

--- a/tests/functional/unit_testing/test_ut_diffing.py
+++ b/tests/functional/unit_testing/test_ut_diffing.py
@@ -1,0 +1,113 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+my_input_model = """
+SELECT 1 as id, 'some string' as status
+"""
+
+my_model = """
+SELECT * FROM {{ ref("my_input_model") }}
+"""
+
+test_my_model_order_insensitive = """
+unit_tests:
+  - name: unordered_no_nulls
+    model: my_model
+    given:
+      - input: ref("my_input_model")
+        rows:
+          - {"id": 1, "status": 'B'}
+          - {"id": 2, "status": 'B'}
+          - {"id": 3, "status": 'A'}
+    expect:
+        rows:
+          - {"id": 3, "status": 'A'}
+          - {"id": 2, "status": 'B'}
+          - {"id": 1, "status": 'B'}
+
+  - name: unordered_with_nulls
+    model: my_model
+    given:
+      - input: ref("my_input_model")
+        rows:
+          - {"id":  , "status": 'B'}
+          - {"id":  , "status": 'B'}
+          - {"id": 3, "status": 'A'}
+    expect:
+        rows:
+          - {"id": 3, "status": 'A'}
+          - {"id":  , "status": 'B'}
+          - {"id":  , "status": 'B'}
+
+  - name: unordered_with_nulls_2
+    model: my_model
+    given:
+      - input: ref("my_input_model")
+        rows:
+          - {"id": 3, "status": 'A'}
+          - {"id":  , "status": 'B'}
+          - {"id":  , "status": 'B'}
+    expect:
+        rows:
+          - {"id":  , "status": 'B'}
+          - {"id":  , "status": 'B'}
+          - {"id": 3, "status": 'A'}
+
+  - name: unordered_with_nulls_mixed_columns
+    model: my_model
+    given:
+      - input: ref("my_input_model")
+        rows:
+          - {"id": 3, "status": 'A'}
+          - {"id":  , "status": 'B'}
+          - {"id": 1, "status": }
+    expect:
+        rows:
+          - {"id": 1, "status": }
+          - {"id":  , "status": 'B'}
+          - {"id": 3, "status": 'A'}
+
+  - name: unordered_with_null
+    model: my_model
+    given:
+      - input: ref("my_input_model")
+        rows:
+          - {"id": 3, "status": 'A'}
+          - {"id":  , "status": 'B'}
+    expect:
+        rows:
+          - {"id":  , "status": 'B'}
+          - {"id": 3, "status": 'A'}
+
+  - name: ordered_with_nulls
+    model: my_model
+    given:
+      - input: ref("my_input_model")
+        rows:
+          - {"id": 3, "status": 'A'}
+          - {"id":  , "status": 'B'}
+          - {"id":  , "status": 'B'}
+    expect:
+        rows:
+          - {"id": 3, "status": 'A'}
+          - {"id":  , "status": 'B'}
+          - {"id":  , "status": 'B'}
+"""
+
+
+class TestUnitTestingDiffIsOrderAgnostic:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_input_model.sql": my_input_model,
+            "my_model.sql": my_model,
+            "test_my_model.yml": test_my_model_order_insensitive,
+        }
+
+    def test_unit_testing_diff_is_order_insensitive(self, project):
+        run_dbt(["run"])
+
+        # Select by model name
+        results = run_dbt(["test", "--select", "my_model"], expect_pass=True)
+        assert len(results) == 6

--- a/tests/unit/task/test_test.py
+++ b/tests/unit/task/test_test.py
@@ -1,0 +1,71 @@
+import agate
+import pytest
+
+from dbt.task.test import list_rows_from_table
+
+
+class TestListRowsFromTable:
+    @pytest.mark.parametrize(
+        "agate_table_cols,agate_table_rows,expected_list_rows",
+        [
+            (["a", "b", "c"], [], [["a", "b", "c"]]),  # no rows
+            (["a", "b", "c"], [[1, 2, 3]], [["a", "b", "c"], [1, 2, 3]]),  # single row, no nulls
+            (
+                ["a", "b", "c"],
+                [[1, 2, 3], [2, 3, 4]],
+                [["a", "b", "c"], [1, 2, 3], [2, 3, 4]],
+            ),  # multiple rows
+            (
+                ["a", "b", "c"],
+                [[None, 2, 3], [2, None, 4]],
+                [["a", "b", "c"], [None, 2, 3], [2, None, 4]],
+            ),  # multiple rows, with nulls
+        ],
+    )
+    def test_list_rows_from_table_no_sort(
+        self, agate_table_cols, agate_table_rows, expected_list_rows
+    ):
+        table = agate.Table(rows=agate_table_rows, column_names=agate_table_cols)
+
+        list_rows = list_rows_from_table(table)
+        assert list_rows == expected_list_rows
+
+    @pytest.mark.parametrize(
+        "agate_table_cols,agate_table_rows,expected_list_rows",
+        [
+            (["a", "b", "c"], [], [["a", "b", "c"]]),  # no rows
+            (["a", "b", "c"], [[1, 2, 3]], [["a", "b", "c"], [1, 2, 3]]),  # single row, no nulls
+            (
+                ["a", "b", "c"],
+                [[1, 2, 3], [2, 3, 4]],
+                [["a", "b", "c"], [1, 2, 3], [2, 3, 4]],
+            ),  # multiple rows, in order
+            (
+                ["a", "b", "c"],
+                [[2, 3, 4], [1, 2, 3]],
+                [["a", "b", "c"], [1, 2, 3], [2, 3, 4]],
+            ),  # multiple rows, out of order
+            (
+                ["a", "b", "c"],
+                [[None, 2, 3], [2, 3, 4]],
+                [["a", "b", "c"], [2, 3, 4], [None, 2, 3]],
+            ),  # multiple rows, out of order with nulls in first position
+            (
+                ["a", "b", "c"],
+                [[4, 5, 6], [1, None, 3]],
+                [["a", "b", "c"], [1, None, 3], [4, 5, 6]],
+            ),  # multiple rows, out of order with null in non-first position
+            (
+                ["a", "b", "c"],
+                [[None, 5, 6], [1, None, 3]],
+                [["a", "b", "c"], [1, None, 3], [None, 5, 6]],
+            ),  # multiple rows, out of order with nulls in many positions
+        ],
+    )
+    def test_list_rows_from_table_with_sort(
+        self, agate_table_cols, agate_table_rows, expected_list_rows
+    ):
+        table = agate.Table(rows=agate_table_rows, column_names=agate_table_cols)
+
+        list_rows = list_rows_from_table(table, sort=True)
+        assert list_rows == expected_list_rows


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/10167

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

TableDiff.hasDifference unexpectedly returns True when comparing two input tables that have multiple identical rows with containing None, even if CompareFlags.orderis set toFalse`.

### Solution
* Confirmed underlying daff bug and opened an issue in there: https://github.com/paulfitz/daff/issues/200
* Pre-sorted fixture row inputs prior to feeding them into daff for diffing
* Still kept around the `flags.ordered` as a backstop + in the hope that we can remove the custom sorting if daff has a fix

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
