### PR TITLE
Button to open an issue for the docs.getdbt.com documentation repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Documentation
+    url: https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose
+    about: Problems and issues with dbt documentation
   - name: Ask the community for help
     url: https://github.com/dbt-labs/docs.getdbt.com/discussions
     about: Need help troubleshooting? Check out our guide on how to ask


### PR DESCRIPTION
Per suggestion in https://github.com/dbt-labs/docs.getdbt.com/issues/5577#issuecomment-2137472538

### Problem

On the new issue template page https://github.com/dbt-labs/dbt-core/issues/new/choose, there is no documentation category, so users may not know that https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose is the place.

### Solution

When choosing the type of issue to open, add a button that links to https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] Tests are not required/relevant for this PR
- [x] This PR has already received feedback and approval from Product or DX