### PR TITLE
update dbt_utils version to 1.2.0

### DIFF
--- a/tests/functional/dependencies/test_dependency_options.py
+++ b/tests/functional/dependencies/test_dependency_options.py
@@ -39,7 +39,7 @@ class TestDepsOptions(object):
   - package: fivetran/fivetran_utils
     version: 0.4.7
   - package: dbt-labs/dbt_utils
-    version: 1.1.1
+    version: 1.2.0
 sha1_hash: 71304bca2138cf8004070b3573a1e17183c0c1a8
 """
         )
@@ -56,7 +56,7 @@ sha1_hash: 71304bca2138cf8004070b3573a1e17183c0c1a8
   - package: fivetran/fivetran_utils
     version: 0.4.7
   - package: dbt-labs/dbt_utils
-    version: 1.1.1
+    version: 1.2.0
 sha1_hash: 71304bca2138cf8004070b3573a1e17183c0c1a8
 """
         )


### PR DESCRIPTION
### Problem

Tests were failing because of dbt-utils version bump to 1.2.0

### Solution

Update test to use dbt-utils version 1.2.0

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
