### PR TITLE
Fix issues with inline nodes and selectors

### DIFF
--- a/.changes/unreleased/Fixes-20240605-111652.yaml
+++ b/.changes/unreleased/Fixes-20240605-111652.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix issues with selectors and inline nodes
+time: 2024-06-05T11:16:52.187667-04:00
+custom:
+  Author: gshank
+  Issue: 8943 9269

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -289,6 +289,9 @@ class Flags:
             params_assigned_from_default, ["WARN_ERROR", "WARN_ERROR_OPTIONS"]
         )
 
+        if hasattr(self, "SELECT") and hasattr(self, "INLINE"):
+            self._assert_mutually_exclusive(params_assigned_from_default, ["SELECT", "INLINE"])
+
         # Support lower cased access for legacy code.
         params = set(
             x for x in dir(self) if not callable(getattr(self, x)) and not x.startswith("__")

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -319,7 +319,9 @@ class Flags:
         """
         set_flag = None
         for flag in group:
-            flag_set_by_user = hasattr(self, flag) and flag.lower() not in params_assigned_from_default
+            flag_set_by_user = (
+                hasattr(self, flag) and flag.lower() not in params_assigned_from_default
+            )
             if flag_set_by_user and set_flag:
                 raise DbtUsageException(
                     f"{flag.lower()}: not allowed with argument {set_flag.lower()}"

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -289,8 +289,14 @@ class Flags:
             params_assigned_from_default, ["WARN_ERROR", "WARN_ERROR_OPTIONS"]
         )
 
-        if hasattr(self, "SELECT") and hasattr(self, "INLINE"):
-            self._assert_mutually_exclusive(params_assigned_from_default, ["SELECT", "INLINE"])
+        # Handle arguments mutually exclusive with INLINE
+        if hasattr(self, "INLINE"):
+            if hasattr(self, "SELECT"):
+                self._assert_mutually_exclusive(params_assigned_from_default, ["SELECT", "INLINE"])
+            if hasattr(self, "SELECTOR") and self.SELECTOR is not None:
+                self._assert_mutually_exclusive(
+                    params_assigned_from_default, ["SELECTOR", "INLINE"]
+                )
 
         # Support lower cased access for legacy code.
         params = set(

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -290,13 +290,8 @@ class Flags:
         )
 
         # Handle arguments mutually exclusive with INLINE
-        if hasattr(self, "INLINE"):
-            if hasattr(self, "SELECT"):
-                self._assert_mutually_exclusive(params_assigned_from_default, ["SELECT", "INLINE"])
-            if hasattr(self, "SELECTOR") and self.SELECTOR is not None:
-                self._assert_mutually_exclusive(
-                    params_assigned_from_default, ["SELECTOR", "INLINE"]
-                )
+        self._assert_mutually_exclusive(params_assigned_from_default, ["SELECT", "INLINE"])
+        self._assert_mutually_exclusive(params_assigned_from_default, ["SELECTOR", "INLINE"])
 
         # Support lower cased access for legacy code.
         params = set(
@@ -324,7 +319,7 @@ class Flags:
         """
         set_flag = None
         for flag in group:
-            flag_set_by_user = flag.lower() not in params_assigned_from_default
+            flag_set_by_user = hasattr(self, flag) and flag.lower() not in params_assigned_from_default
             if flag_set_by_user and set_flag:
                 raise DbtUsageException(
                     f"{flag.lower()}: not allowed with argument {set_flag.lower()}"

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -104,6 +104,12 @@ class CompileTask(GraphRunnableTask):
                 )
                 sql_node = block_parser.parse_remote(self.args.inline, "inline_query")
                 process_node(self.config, self.manifest, sql_node)
+                # Special hack to remove disabled, if it's there. This would only happen
+                # if all models are disabled in dbt_project
+                if sql_node.config.enabled is False:
+                    sql_node.config.enabled = True
+                    self.manifest.disabled.pop(sql_node.unique_id)
+                    self.manifest.nodes[sql_node.unique_id] = sql_node
                 # keep track of the node added to the manifest
                 self._inline_node_id = sql_node.unique_id
             except CompilationError as exc:

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -5,7 +5,7 @@ from concurrent.futures import as_completed
 from datetime import datetime
 from multiprocessing.dummy import Pool as ThreadPool
 from pathlib import Path
-from typing import AbstractSet, Dict, Iterable, List, Optional, Set, Tuple
+from typing import AbstractSet, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import dbt.exceptions
 import dbt.tracking
@@ -108,7 +108,11 @@ class GraphRunnableTask(ConfiguredTask):
 
     def get_selection_spec(self) -> SelectionSpec:
         default_selector_name = self.config.get_default_selector_name()
-        if self.args.selector:
+        spec: Union[SelectionSpec, bool]
+        if self.args.inline:
+            # We want an empty selection spec.
+            spec = parse_difference(None, None)
+        elif self.args.selector:
             # use pre-defined selector (--selector)
             spec = self.config.get_selector(self.args.selector)
         elif not (self.selection_arg or self.exclusion_arg) and default_selector_name:

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -109,7 +109,7 @@ class GraphRunnableTask(ConfiguredTask):
     def get_selection_spec(self) -> SelectionSpec:
         default_selector_name = self.config.get_default_selector_name()
         spec: Union[SelectionSpec, bool]
-        if self.args.inline:
+        if hasattr(self.args, "inline") and self.args.inline:
             # We want an empty selection spec.
             spec = parse_difference(None, None)
         elif self.args.selector:

--- a/tests/functional/compile/test_compile.py
+++ b/tests/functional/compile/test_compile.py
@@ -226,3 +226,35 @@ class TestCompile:
             summary = json.load(summary_file)
             assert "_invocation_id" in summary
             assert "linked" in summary
+
+
+selectors_yml = """
+    selectors:
+      - name: test_selector
+        description: Exclude everything
+        default: true
+        definition:
+           method: package
+           value: "foo"
+    """
+
+
+class TestCompileInlineWithSelector:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "first_model.sql": first_model_sql,
+            "second_model.sql": second_model_sql,
+            "schema.yml": schema_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def selectors(self):
+        return selectors_yml
+
+    def test_inline_pass(self, project):
+        (results, log_output) = run_dbt_and_capture(
+            ["compile", "--inline", "select * from {{ ref('first_model') }}"]
+        )
+        assert len(results) == 1
+        assert "Compiled inline node is:" in log_output

--- a/tests/functional/compile/test_compile.py
+++ b/tests/functional/compile/test_compile.py
@@ -226,35 +226,3 @@ class TestCompile:
             summary = json.load(summary_file)
             assert "_invocation_id" in summary
             assert "linked" in summary
-
-
-selectors_yml = """
-    selectors:
-      - name: test_selector
-        description: Exclude everything
-        default: true
-        definition:
-           method: package
-           value: "foo"
-    """
-
-
-class TestCompileInlineWithSelector:
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "first_model.sql": first_model_sql,
-            "second_model.sql": second_model_sql,
-            "schema.yml": schema_yml,
-        }
-
-    @pytest.fixture(scope="class")
-    def selectors(self):
-        return selectors_yml
-
-    def test_inline_pass(self, project):
-        (results, log_output) = run_dbt_and_capture(
-            ["compile", "--inline", "select * from {{ ref('first_model') }}"]
-        )
-        assert len(results) == 1
-        assert "Compiled inline node is:" in log_output

--- a/tests/functional/dbt_runner/test_dbt_runner.py
+++ b/tests/functional/dbt_runner/test_dbt_runner.py
@@ -36,6 +36,9 @@ class TestDbtRunner:
         res = dbt.invoke(["deps", "--warn-error", "--warn-error-options", '{"include": "all"}'])
         assert type(res.exception) == DbtUsageException
 
+        res = dbt.invoke(["compile", "--select", "models", "--inline", "select 1 as id"])
+        assert type(res.exception) == DbtUsageException
+
     def test_invalid_command(self, dbt: dbtRunner) -> None:
         res = dbt.invoke(["invalid-command"])
         assert type(res.exception) == DbtUsageException

--- a/tests/functional/graph_selection/test_inline.py
+++ b/tests/functional/graph_selection/test_inline.py
@@ -1,0 +1,64 @@
+import pytest
+
+from dbt.cli.exceptions import DbtUsageException
+from dbt.tests.util import run_dbt, run_dbt_and_capture, write_file
+
+selectors_yml = """
+    selectors:
+      - name: test_selector
+        description: Exclude everything
+        default: true
+        definition:
+           method: package
+           value: "foo"
+    """
+
+dbt_project_yml = """
+name: test
+profile: test
+flags:
+  send_anonymous_usage_stats: false
+"""
+
+dbt_project_yml_disabled_models = """
+name: test
+profile: test
+flags:
+  send_anonymous_usage_stats: false
+models:
+  +enabled: false
+"""
+
+
+class TestCompileInlineWithSelector:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "first_model.sql": "select 1 as id",
+        }
+
+    @pytest.fixture(scope="class")
+    def selectors(self):
+        return selectors_yml
+
+    def test_inline_selectors(self, project):
+        (results, log_output) = run_dbt_and_capture(
+            ["compile", "--inline", "select * from {{ ref('first_model') }}"]
+        )
+        assert len(results) == 1
+        assert "Compiled inline node is:" in log_output
+
+        # Set all models to disabled, even inline model doesn't run
+        write_file(dbt_project_yml_disabled_models, project.project_root, "dbt_project.yml")
+        (results, log_output) = run_dbt_and_capture(["compile", "--inline", "select 1 as id"])
+        assert len(results) == 0
+
+        # put back non-disabled dbt_project and check for mutually exclusive error message
+        # for --select and --inline
+        write_file(dbt_project_yml, project.project_root, "dbt_project.yml")
+        with pytest.raises(DbtUsageException):
+            run_dbt(["compile", "--select", "first_model", "--inline", "select 1 as id"])
+
+        # check for mutually exclusive --selector and --inline
+        with pytest.raises(DbtUsageException):
+            run_dbt(["compile", "--selector", "test_selector", "--inline", "select 1 as id"])

--- a/tests/functional/graph_selection/test_inline.py
+++ b/tests/functional/graph_selection/test_inline.py
@@ -48,10 +48,10 @@ class TestCompileInlineWithSelector:
         assert len(results) == 1
         assert "Compiled inline node is:" in log_output
 
-        # Set all models to disabled, even inline model doesn't run
+        # Set all models to disabled, check that we still get inline result
         write_file(dbt_project_yml_disabled_models, project.project_root, "dbt_project.yml")
         (results, log_output) = run_dbt_and_capture(["compile", "--inline", "select 1 as id"])
-        assert len(results) == 0
+        assert len(results) == 1
 
         # put back non-disabled dbt_project and check for mutually exclusive error message
         # for --select and --inline


### PR DESCRIPTION
resolves #8943
resolves #9269

### Problem

The inline node wasn't executing because of interactions with selection mechanisms.

### Solution

We shouldn't use selectors at all when inline nodes are running. Add code in "get_selector" to make an exception for inline nodes. Add error message for using --select or --selector with --inline. Add hack to move inline node out of disabled if someone has disabled all model nodes in their project.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
