### PR TITLE
Improve handling of error when loading schema file which is a list

### DIFF
--- a/.changes/unreleased/Fixes-20240610-132130.yaml
+++ b/.changes/unreleased/Fixes-20240610-132130.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Improve handling of error when loading schema file list
+time: 2024-06-10T13:21:30.963371-04:00
+custom:
+  Author: gshank
+  Issue: "10284"

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -117,6 +117,11 @@ def yaml_from_file(source_file: SchemaSourceFile) -> Optional[Dict[str, Any]]:
         if contents is None:
             return contents
 
+        if not isinstance(contents, dict):
+            raise DbtValidationError(
+                f"Contents of file '{source_file.original_file_path}' are not valid. Dictionary expected."
+            )
+
         # When loaded_loaded_at_field is defined as None or null, it shows up in
         # the dict but when it is not defined, it does not show up in the dict
         # We need to capture this to be able to override source level settings later.

--- a/tests/functional/configs/test_configs_in_schema_files.py
+++ b/tests/functional/configs/test_configs_in_schema_files.py
@@ -249,3 +249,23 @@ class TestSchemaFileConfigs:
         write_file(extra_alt__untagged2_yml, project.project_root, "models", "untagged.yml")
         with pytest.raises(CompilationError):
             run_dbt(["run"])
+
+
+list_schema_yml = """
+- name: my_name
+- name: alt_name
+"""
+
+
+class TestListSchemaFile:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": "select 1 as id",
+            "schema.yml": list_schema_yml,
+        }
+
+    def test_list_schema(self, project):
+        with pytest.raises(ParsingError) as excinfo:
+            run_dbt(["run"])
+        assert "Dictionary expected" in str(excinfo.value)


### PR DESCRIPTION
resolves #10284

### Problem

If a schema file which has a top level list is loaded, the exception that's thrown is not helpful.

### Solution

Throw a more useful exception if the loaded yaml is not a dictionary.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
