### PR TITLE
update on_skip to adjust for node that do not have schema

### DIFF
--- a/.changes/unreleased/Fixes-20240612-124256.yaml
+++ b/.changes/unreleased/Fixes-20240612-124256.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Saved Query node fail during skip
+time: 2024-06-12T12:42:56.329073-07:00
+custom:
+  Author: ChenyuLInx
+  Issue: "10029"

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -410,7 +410,7 @@ class BaseRunner(metaclass=ABCMeta):
         return self.skip_cause.node.is_ephemeral_model
 
     def on_skip(self):
-        schema_name = self.node.schema
+        schema_name = getattr(self.node, "schema", "")
         node_name = self.node.name
 
         error_message = None

--- a/tests/unit/task/test_build.py
+++ b/tests/unit/task/test_build.py
@@ -1,0 +1,14 @@
+from dbt.contracts.graph.nodes import SavedQuery
+from dbt.task.build import SavedQueryRunner
+
+
+def test_saved_query_runner_on_skip(saved_query: SavedQuery):
+    runner = SavedQueryRunner(
+        config=None,
+        adapter=None,
+        node=saved_query,
+        node_index=None,
+        num_nodes=None,
+    )
+    # on_skip would work
+    runner.on_skip()


### PR DESCRIPTION
resolves #10029 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem
SavedQuery node do not have schema field, this cause on_skip to fail.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
During the on skip, we optionally get schema field.
The other way is to add schema to the saved_query node, but that is not a useful piece of information for this node.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
