### PR TITLE
Stop mis-identifying `unit_test` config paths in `dbt_project.yaml` as unused

### DIFF
--- a/.changes/unreleased/Fixes-20240613-183117.yaml
+++ b/.changes/unreleased/Fixes-20240613-183117.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: DOn't warn on `unit_test` config paths that are properly used
+time: 2024-06-13T18:31:17.486497-07:00
+custom:
+  Author: QMalcolm
+  Issue: "10311"

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -988,6 +988,7 @@ class Manifest(MacroMethods, dbtClassMixin):
             self.metrics.values(),
             self.semantic_models.values(),
             self.saved_queries.values(),
+            self.unit_tests.values(),
         )
         for resource in all_resources:
             resource_type_plural = resource.resource_type.pluralize()

--- a/tests/unit/graph/test_selector_methods.py
+++ b/tests/unit/graph/test_selector_methods.py
@@ -113,6 +113,7 @@ def test_select_fqn(manifest):
     assert search_manifest_using_method(manifest, method, "*.*.*_model") == {
         "mynamespace.union_model",
         "mynamespace.ephemeral_model",
+        "test_semantic_model",
         "union_model",
         "unit_test_table_model",
     }

--- a/tests/unit/parser/test_manifest.py
+++ b/tests/unit/parser/test_manifest.py
@@ -7,10 +7,13 @@ from pytest_mock import MockerFixture
 from dbt.artifacts.resources.base import FileHash
 from dbt.config import RuntimeConfig
 from dbt.contracts.graph.manifest import Manifest, ManifestStateCheck
+from dbt.events.types import UnusedResourceConfigPath
 from dbt.flags import set_from_args
-from dbt.parser.manifest import ManifestLoader
+from dbt.parser.manifest import ManifestLoader, _warn_for_unused_resource_config_paths
 from dbt.parser.read_files import FileDiff
 from dbt.tracking import User
+from dbt_common.events.event_manager_client import add_callback_to_manager
+from tests.utils import EventCatcher
 
 
 class TestPartialParse:
@@ -191,3 +194,47 @@ class TestGetFullManifest:
         set_from_args(Namespace(PARTIAL_PARSE_FILE_DIFF=False), {})
         ManifestLoader.get_full_manifest(config=mock_project)
         assert mock_file_diff.called
+
+
+class TestWarnUnusedConfigs:
+    @pytest.mark.parametrize(
+        "resource_type,path,expect_used",
+        [
+            ("data_tests", "unused_path", False),
+            ("data_tests", "minimal", True),
+            ("metrics", "unused_path", False),
+            ("metrics", "test", True),
+            ("models", "unused_path", False),
+            ("models", "pkg", True),
+            ("saved_queries", "unused_path", False),
+            ("saved_queries", "test", True),
+            ("seeds", "unused_path", False),
+            ("seeds", "pkg", True),
+            ("semantic_models", "unused_path", False),
+            ("semantic_models", "test", True),
+            ("sources", "unused_path", False),
+            ("sources", "pkg", True),
+            ("unit_tests", "unused_path", False),
+            ("unit_tests", "pkg", True),
+        ],
+    )
+    def test_warn_for_unused_resource_config_paths(
+        self,
+        resource_type: str,
+        path: str,
+        expect_used: bool,
+        manifest: Manifest,
+        runtime_config: RuntimeConfig,
+    ) -> None:
+        catcher = EventCatcher(UnusedResourceConfigPath)
+        add_callback_to_manager(catcher.catch)
+
+        setattr(runtime_config, resource_type, {path: {"+materialized": "table"}})
+
+        _warn_for_unused_resource_config_paths(manifest=manifest, config=runtime_config)
+
+        if expect_used:
+            assert len(catcher.caught_events) == 0
+        else:
+            assert len(catcher.caught_events) == 1
+            assert f"{resource_type}.{path}" in str(catcher.caught_events[0].data)

--- a/tests/unit/utils/manifest.py
+++ b/tests/unit/utils/manifest.py
@@ -14,6 +14,8 @@ from dbt.artifacts.resources import (
     RefArgs,
     TestConfig,
     TestMetadata,
+    WhereFilter,
+    WhereFilterIntersection,
 )
 from dbt.artifacts.resources.v1.model import ModelConfig
 from dbt.contracts.files import AnySourceFile, FileHash
@@ -851,7 +853,11 @@ def saved_query() -> SavedQuery:
         query_params=QueryParams(
             metrics=["my_metric"],
             group_by=[],
-            where=None,
+            where=WhereFilterIntersection(
+                where_filters=[
+                    WhereFilter(where_sql_template="1=1"),
+                ]
+            ),
         ),
         exports=[],
         unique_id=f"saved_query.{pkg}.{name}",

--- a/tests/unit/utils/manifest.py
+++ b/tests/unit/utils/manifest.py
@@ -973,13 +973,18 @@ def unit_tests(unit_test_table_model) -> List[UnitTestDefinition]:
 
 
 @pytest.fixture
-def metrics() -> List[Metric]:
-    return []
+def metrics(metric: Metric) -> List[Metric]:
+    return [metric]
 
 
 @pytest.fixture
-def semantic_models() -> List[SemanticModel]:
-    return []
+def semantic_models(semantic_model: SemanticModel) -> List[SemanticModel]:
+    return [semantic_model]
+
+
+@pytest.fixture
+def saved_queries(saved_query: SavedQuery) -> List[SavedQuery]:
+    return [saved_query]
 
 
 @pytest.fixture
@@ -996,6 +1001,7 @@ def make_manifest(
     macros: List[Macro] = [],
     metrics: List[Metric] = [],
     nodes: List[ModelNode] = [],
+    saved_queries: List[SavedQuery] = [],
     selectors: Dict[str, Any] = {},
     semantic_models: List[SemanticModel] = [],
     sources: List[SourceDefinition] = [],
@@ -1015,6 +1021,7 @@ def make_manifest(
         selectors=selectors,
         groups={g.unique_id: g for g in groups},
         metadata=ManifestMetadata(adapter_type="postgres", project_name="pkg"),
+        saved_queries={s.unique_id: s for s in saved_queries},
     )
     manifest.build_parent_and_child_maps()
     return manifest
@@ -1031,6 +1038,7 @@ def manifest(
     metrics,
     semantic_models,
     files,
+    saved_queries,
 ) -> Manifest:
     return make_manifest(
         nodes=nodes,
@@ -1040,4 +1048,5 @@ def manifest(
         semantic_models=semantic_models,
         files=files,
         metrics=metrics,
+        saved_queries=saved_queries,
     )


### PR DESCRIPTION
resolves #10311

### Problem

`unit_tests` weren't being included in calls to `Manifest.get_resource_fqns`, it always appeared to `_warn_for_unused_resource_config_paths` that there were no unit tests in the manifest. Thus, `_warn_for_unused_resource_config_paths` always thought that _any_ `unit_test` config in `dbt_project.yaml` was unused.


### Solution

Include `unit_tests` in `Manifest.get_resource_fqns`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
