### PR TITLE
[Backport 1.8.latest] Stop mis-identifying unit_test config paths in dbt_project.yaml as unused

### DIFF
--- a/.changes/unreleased/Fixes-20240613-183117.yaml
+++ b/.changes/unreleased/Fixes-20240613-183117.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: DOn't warn on `unit_test` config paths that are properly used
+time: 2024-06-13T18:31:17.486497-07:00
+custom:
+  Author: QMalcolm
+  Issue: "10311"

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -986,6 +986,7 @@ class Manifest(MacroMethods, dbtClassMixin):
             self.metrics.values(),
             self.semantic_models.values(),
             self.saved_queries.values(),
+            self.unit_tests.values(),
         )
         for resource in all_resources:
             resource_type_plural = resource.resource_type.pluralize()

--- a/tests/unit/graph/test_selector_methods.py
+++ b/tests/unit/graph/test_selector_methods.py
@@ -113,6 +113,7 @@ def test_select_fqn(manifest):
     assert search_manifest_using_method(manifest, method, "*.*.*_model") == {
         "mynamespace.union_model",
         "mynamespace.ephemeral_model",
+        "test_semantic_model",
         "union_model",
         "unit_test_table_model",
     }

--- a/tests/unit/utils/manifest.py
+++ b/tests/unit/utils/manifest.py
@@ -1,4 +1,5 @@
 from argparse import Namespace
+from typing import List
 import pytest
 
 from dbt.artifacts.resources.v1.model import ModelConfig
@@ -976,13 +977,18 @@ def unit_tests(unit_test_table_model) -> list:
 
 
 @pytest.fixture
-def metrics() -> list:
-    return []
+def metrics(metric: Metric) -> List[Metric]:
+    return [metric]
 
 
 @pytest.fixture
-def semantic_models() -> list:
-    return []
+def semantic_models(semantic_model: SemanticModel) -> List[SemanticModel]:
+    return [semantic_model]
+
+
+@pytest.fixture
+def saved_queries(saved_query: SavedQuery) -> List[SavedQuery]:
+    return [saved_query]
 
 
 @pytest.fixture
@@ -1001,6 +1007,7 @@ def manifest(
     metrics,
     semantic_models,
     files,
+    saved_queries,
 ) -> Manifest:
     manifest = Manifest(
         nodes={n.unique_id: n for n in nodes},
@@ -1012,6 +1019,7 @@ def manifest(
         files=files,
         exposures={},
         metrics={m.unique_id: m for m in metrics},
+        saved_queries={s.unique_id: s for s in saved_queries},
         disabled={},
         selectors={},
         groups={},

--- a/tests/unit/utils/manifest.py
+++ b/tests/unit/utils/manifest.py
@@ -33,6 +33,8 @@ from dbt.artifacts.resources import (
     TestConfig,
     TestMetadata,
     RefArgs,
+    WhereFilter,
+    WhereFilterIntersection,
 )
 from dbt.contracts.graph.unparsed import (
     UnitTestInputFixture,
@@ -855,7 +857,11 @@ def saved_query() -> SavedQuery:
         query_params=QueryParams(
             metrics=["my_metric"],
             group_by=[],
-            where=None,
+            where=WhereFilterIntersection(
+                where_filters=[
+                    WhereFilter(where_sql_template="1=1"),
+                ]
+            ),
         ),
         exports=[],
         unique_id=f"saved_query.{pkg}.{name}",


### PR DESCRIPTION
This is a _manual_ backport of #10312 to 1.8.latest. This backport was done by cherry-picking the commits from the original branch, [qmalcolm--10311-stop-mis-identifying-unit-test-config-paths-as-unused](https://github.com/dbt-labs/dbt-core/tree/qmalcolm--10311-stop-mis-identifying-unit-test-config-paths-as-unused), instead of from the squash commit from main. Specifically I:

1. ran `git cherry-pick 58990aa~..ffd1272`
2. managed merge conflicts and made adjustments to handle not existent fixtures (by commit)