### PR TITLE
add empty to context flags

### DIFF
--- a/.changes/unreleased/Features-20240617-103948.yaml
+++ b/.changes/unreleased/Features-20240617-103948.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: add --empty value to jinja context as flags.EMPTY
+time: 2024-06-17T10:39:48.275801-04:00
+custom:
+  Author: michelleark
+  Issue: "10317"

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -68,6 +68,7 @@ def get_flag_dict():
         "target_path",
         "log_path",
         "invocation_command",
+        "empty",
     }
     return {key: getattr(GLOBAL_FLAGS, key.upper(), None) for key in flag_attr}
 

--- a/tests/unit/context/test_base.py
+++ b/tests/unit/context/test_base.py
@@ -21,3 +21,34 @@ class TestBaseContext:
             BaseContext.log({"fact1": "I like cats"}, info=True)
         except Exception as e:
             assert False, f"Logging while a `DBT_ENV_SECRET` was set raised an exception: {e}"
+
+    def test_flags(self):
+        expected_context_flags = {
+            "use_experimental_parser",
+            "static_parser",
+            "warn_error",
+            "warn_error_options",
+            "write_json",
+            "partial_parse",
+            "use_colors",
+            "profiles_dir",
+            "debug",
+            "log_format",
+            "version_check",
+            "fail_fast",
+            "send_anonymous_usage_stats",
+            "printer_width",
+            "indirect_selection",
+            "log_cache_events",
+            "quiet",
+            "no_print",
+            "cache_selected_only",
+            "introspect",
+            "target_path",
+            "log_path",
+            "invocation_command",
+            "empty",
+        }
+        flags = BaseContext(cli_vars={}).flags
+        for expected_flag in expected_context_flags:
+            assert hasattr(flags, expected_flag.upper())


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/10317

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
We are missing the --empty flag value from the jinja context flags, making it tricky to overwrite the ref macro in a way that incorporates the value of --empty

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Add empty to jinja `flags` + unit test

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions

🎩 
(adding `{{ log(flags.EMPTY, info=True) }}` to locations.sql)
```
❯ dbt run --empty  --select locations
...
14:42:08  1 of 1 START sql view model test_arky.locations ................................ [RUN]
14:42:08  True
```

```
❯ dbt run --select locations
...
14:42:08  1 of 1 START sql view model test_arky.locations ................................ [RUN]
14:42:08  False
```
