### PR TITLE
Add `get_catalog_for_single_relation` to `MockAdapter`

### DIFF
--- a/tests/unit/mock_adapter.py
+++ b/tests/unit/mock_adapter.py
@@ -33,6 +33,9 @@ def adapter_factory():
         def get_columns_in_relation(self, *args, **kwargs):
             return self.responder.get_columns_in_relation(*args, **kwargs)
 
+        def get_catalog_for_single_relation(self, *args, **kwargs):
+            return self.responder.get_catalog_for_single_relation(*args, **kwargs)
+
         def expand_column_types(self, *args, **kwargs):
             return self.responder.expand_column_types(*args, **kwargs)
 


### PR DESCRIPTION
Example failing logs: 
```
        mock_mp_context = mock.MagicMock()
        adapter_class = adapter_factory()
>       return adapter_class(mock_config, mock_mp_context)
E       TypeError: Can't instantiate abstract class MockAdapter with abstract method get_catalog_for_single_relation

tests/unit/context/test_context.py:157: TypeError

---------- coverage: platform linux, python 3.11.9-final-0 -----------
Coverage XML written to file coverage.xml

=========================== short test summary info ============================
ERROR tests/unit/context/test_context.py::TestParseWrapper::test_unwrapped_method
ERROR tests/unit/context/test_context.py::TestParseWrapper::test_wrapped_method
ERROR tests/unit/context/test_context.py::TestRuntimeWrapper::test_unwrapped_method
```

Similar fix in `dbt-snowflake`: https://github.com/dbt-labs/dbt-snowflake/pull/1064/files#diff-89d74eae44795c1174908ac6de68178b1c8c27db47d7531a4533b72b42963856R36-R38