### PR TITLE
Fix Schema Check path for 1.6.latest

### DIFF
--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -26,7 +26,7 @@ permissions: read-all
 
 env:
   LATEST_SCHEMA_PATH: ${{ github.workspace }}/new_schemas
-  SCHEMA_DIFF_ARTIFACT: ${{ github.workspace }}//schema_schanges.txt
+  SCHEMA_DIFF_ARTIFACT: ${{ github.workspace }}/schema_changes.txt
   DBT_REPO_DIRECTORY: ${{ github.workspace }}/dbt
   SCHEMA_REPO_DIRECTORY: ${{ github.workspace }}/schemas.getdbt.com
 

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -13,13 +13,11 @@
 name: Artifact Schema Check
 
 on:
+  pull_request:
+    types: [ opened, reopened, labeled, unlabeled, synchronize ]
+    paths-ignore: [ '.changes/**', '.github/**', 'tests/**', '**.md', '**.yml' ]
+
   workflow_dispatch:
-  pull_request: #TODO: remove before merging
-  push:
-    branches:
-      - "develop"
-      - "*.latest"
-      - "releases/*"
 
 # no special access is needed
 permissions: read-all
@@ -46,7 +44,24 @@ jobs:
         with:
             path: ${{ env.DBT_REPO_DIRECTORY }}
 
+      - name: Check for changes in core/dbt/artifacts
+        # https://github.com/marketplace/actions/paths-changes-filter
+        uses: dorny/paths-filter@v3
+        id: check_artifact_changes
+        with:
+          filters: |
+            artifacts_changed:
+              - 'core/dbt/artifacts/**'
+          list-files: shell
+          working-directory: ${{ env.DBT_REPO_DIRECTORY }}
+
+      - name: Succeed if no artifacts have changed
+        if: steps.check_artifact_changes.outputs.artifacts_changed == 'false'
+        run: |
+          echo "No artifact changes found in core/dbt/artifacts. CI check passed."
+
       - name: Checkout schemas.getdbt.com repo
+        if: steps.check_artifact_changes.outputs.artifacts_changed == 'true'
         uses: actions/checkout@v4
         with:
           repository: dbt-labs/schemas.getdbt.com
@@ -54,6 +69,7 @@ jobs:
           path: ${{ env.SCHEMA_REPO_DIRECTORY }}
 
       - name: Generate current schema
+        if: steps.check_artifact_changes.outputs.artifacts_changed == 'true'
         run: |
           cd ${{ env.DBT_REPO_DIRECTORY }}
           python3 -m venv env
@@ -64,8 +80,9 @@ jobs:
 
       # Copy generated schema files into the schemas.getdbt.com repo
       # Do a git diff to find any changes
-      # Ignore any date or version changes though
+      # Ignore any lines with date-like (yyyy-mm-dd) or version-like (x.y.z) changes
       - name: Compare schemas
+        if: steps.check_artifact_changes.outputs.artifacts_changed == 'true'
         run: |
           cp -r ${{ env.LATEST_SCHEMA_PATH }}/dbt ${{ env.SCHEMA_REPO_DIRECTORY }}
           cd ${{ env.SCHEMA_REPO_DIRECTORY }}
@@ -73,7 +90,7 @@ jobs:
 
       - name: Upload schema diff
         uses: actions/upload-artifact@v4
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.check_artifact_changes.outputs.artifacts_changed == 'true' }}
         with:
-          name: 'schema_schanges.txt'
+          name: 'schema_changes.txt'
           path: '${{ env.SCHEMA_DIFF_ARTIFACT }}'


### PR DESCRIPTION
### Problem

Artifact schema check fails due to double slash in path.

### Solution

Fix path to be valid.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
