### PR TITLE
pin versions so CI and local dev match

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,12 @@ repos:
       - "markdown"
   - id: check-case-conflict
 - repo: https://github.com/pycqa/isort
-  rev: 5.12.0
+  # rev must match what's in dev-requirements.txt
+  rev: 5.13.2
   hooks:
     - id: isort
 - repo: https://github.com/psf/black
+  # rev must match what's in dev-requirements.txt
   rev: 22.3.0
   hooks:
   - id: black
@@ -34,6 +36,7 @@ repos:
     - "--check"
     - "--diff"
 - repo: https://github.com/pycqa/flake8
+  # rev must match what's in dev-requirements.txt
   rev: 4.0.1
   hooks:
   - id: flake8
@@ -41,6 +44,7 @@ repos:
     alias: flake8-check
     stages: [manual]
 - repo: https://github.com/pre-commit/mirrors-mypy
+  # rev must match what's in dev-requirements.txt
   rev: v1.4.1
   hooks:
   - id: mypy

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,16 +2,20 @@ git+https://github.com/dbt-labs/dbt-adapters.git@main
 git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git@main
 git+https://github.com/dbt-labs/dbt-postgres.git@main
-black>=24.3.0,<25.0
+# black must match what's in .pre-commit-config.yaml to be sure local env matches CI
+black==22.3.0
 bumpversion
 ddtrace==2.3.0
 docutils
-flake8
+# flake8 must match what's in .pre-commit-config.yaml to be sure local env matches CI
+flake8==4.0.1
 flaky
 freezegun>=1.4.0,<1.5
 hypothesis
 ipdb
-isort>=5.12,<6
+# isort must match what's in .pre-commit-config.yaml to be sure local env matches CI
+isort==5.13.2
+# mypy must match what's in .pre-commit-config.yaml to be sure local env matches CI
 mypy==1.4.1
 pip-tools
 pre-commit


### PR DESCRIPTION
resolves #


### Problem

Requirements for pre-commit hooks were unpinned in `dev-requirements.txt` resulting in differences for local development and CI.

### Solution

Pin the requirements in dev-requirements so that local development matches CI.

Bump isort because there was no breaking change.

black breaks and requires other code changes for major version 24 so I left the pin as is for now
flake8 also finds more problems on 1.10 so left that as well

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
