### PR TITLE
Fix setting `silence` of `warn_error_options` via `dbt_project.yaml` flags

### DIFF
--- a/.changes/unreleased/Fixes-20240624-171729.yaml
+++ b/.changes/unreleased/Fixes-20240624-171729.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix setting `silence` of `warn_error_options` via `dbt_project.yaml` flags
+time: 2024-06-24T17:17:29.464865-07:00
+custom:
+  Author: QMalcolm
+  Issue: "10160"

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -57,6 +57,7 @@ def convert_config(config_name, config_value):
         ret = WarnErrorOptions(
             include=config_value.get("include", []),
             exclude=config_value.get("exclude", []),
+            silence=config_value.get("silence", []),
             valid_error_names=ALL_EVENT_NAMES,
         )
     return ret

--- a/tests/functional/configs/test_warn_error_options.py
+++ b/tests/functional/configs/test_warn_error_options.py
@@ -53,9 +53,8 @@ class TestWarnErrorOptionsFromCLI:
         assert_deprecation_warning(result, catcher)
 
         catcher.flush()
-        runner.invoke(
-            ["run", "--warn-error-options", "{'include': 'all', 'silence': ['DeprecatedModel']}"]
-        )
+        result = runner.invoke(["run", "--warn-error-options", "{'silence': ['DeprecatedModel']}"])
+        assert result.success
         assert len(catcher.caught_events) == 0
 
     def test_can_raise_warning_to_error(
@@ -131,13 +130,12 @@ class TestWarnErrorOptionsFromProject:
         result = runner.invoke(["run"])
         assert_deprecation_warning(result, catcher)
 
-        silence_options = {
-            "flags": {"warn_error_options": {"include": "all", "silence": ["DeprecatedModel"]}}
-        }
+        silence_options = {"flags": {"warn_error_options": {"silence": ["DeprecatedModel"]}}}
         update_config_file(silence_options, project_root, "dbt_project.yml")
 
         catcher.flush()
-        runner.invoke(["run"])
+        result = runner.invoke(["run"])
+        assert result.success
         assert len(catcher.caught_events) == 0
 
     def test_can_raise_warning_to_error(


### PR DESCRIPTION
resolves #10160 

### Problem

Specifying `silence` of `warn_error_options` in `dbt_project.yaml` flags wasn't silencing warnings.

### Solution

Ensure `silence` is used during instantiation of `WarnErrorOptions` from `dbt_project.yaml`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
