### PR TITLE
Tweak project-test-config deprecation test for misc deprecations

### DIFF
--- a/tests/functional/dependencies/test_local_dependency.py
+++ b/tests/functional/dependencies/test_local_dependency.py
@@ -390,5 +390,4 @@ class TestDependencyTestsConfig(BaseDependencyTest):
         run_dbt(["parse"])
         # Check that project-test-config is NOT in active deprecations, since "tests" is only
         # in a dependent project.
-        expected = set()
-        assert expected == deprecations.active_deprecations
+        assert "project-test-config" not in deprecations.active_deprecations


### PR DESCRIPTION
resolves #10389


### Problem

Test sometimes fails because of random other deprecations in global active deprecations variable

### Solution

Check that the config is not in set instead of equal to empty set

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
