### PR TITLE
[TIDY-FIRST] Fix isort for dbt-semantic-interfaces

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,4 @@
 [settings]
 profile=black
 extend_skip_glob=.github/*,third-party-stubs/*,scripts/*
-known_first_party=dbt,dbt_adapters,dbt_common,dbt_extractor,dbt_semantic_interface
+known_first_party=dbt,dbt_adapters,dbt_common,dbt_extractor,dbt_semantic_interfaces

--- a/core/dbt/artifacts/resources/v1/metric.py
+++ b/core/dbt/artifacts/resources/v1/metric.py
@@ -2,14 +2,6 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Literal, Optional
 
-from dbt_semantic_interfaces.references import MeasureReference, MetricReference
-from dbt_semantic_interfaces.type_enums import (
-    ConversionCalculationType,
-    MetricType,
-    PeriodAggregation,
-    TimeGranularity,
-)
-
 from dbt.artifacts.resources.base import GraphResource
 from dbt.artifacts.resources.types import NodeType
 from dbt.artifacts.resources.v1.components import DependsOn, RefArgs
@@ -19,6 +11,13 @@ from dbt.artifacts.resources.v1.semantic_layer_components import (
 )
 from dbt_common.contracts.config.base import BaseConfig, CompareBehavior, MergeBehavior
 from dbt_common.dataclass_schema import dbtClassMixin
+from dbt_semantic_interfaces.references import MeasureReference, MetricReference
+from dbt_semantic_interfaces.type_enums import (
+    ConversionCalculationType,
+    MetricType,
+    PeriodAggregation,
+    TimeGranularity,
+)
 
 """
 The following classes are dataclasses which are used to construct the Metric

--- a/core/dbt/artifacts/resources/v1/saved_query.py
+++ b/core/dbt/artifacts/resources/v1/saved_query.py
@@ -4,10 +4,6 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Literal, Optional
 
-from dbt_semantic_interfaces.type_enums.export_destination_type import (
-    ExportDestinationType,
-)
-
 from dbt.artifacts.resources.base import GraphResource
 from dbt.artifacts.resources.types import NodeType
 from dbt.artifacts.resources.v1.components import DependsOn, RefArgs
@@ -17,6 +13,9 @@ from dbt.artifacts.resources.v1.semantic_layer_components import (
 )
 from dbt_common.contracts.config.base import BaseConfig, CompareBehavior, MergeBehavior
 from dbt_common.dataclass_schema import dbtClassMixin
+from dbt_semantic_interfaces.type_enums.export_destination_type import (
+    ExportDestinationType,
+)
 
 
 @dataclass

--- a/core/dbt/artifacts/resources/v1/semantic_layer_components.py
+++ b/core/dbt/artifacts/resources/v1/semantic_layer_components.py
@@ -1,12 +1,11 @@
 from dataclasses import dataclass
 from typing import List, Sequence, Tuple
 
+from dbt_common.dataclass_schema import dbtClassMixin
 from dbt_semantic_interfaces.call_parameter_sets import FilterCallParameterSets
 from dbt_semantic_interfaces.parsing.where_filter.where_filter_parser import (
     WhereFilterParser,
 )
-
-from dbt_common.dataclass_schema import dbtClassMixin
 
 
 @dataclass

--- a/core/dbt/artifacts/resources/v1/semantic_model.py
+++ b/core/dbt/artifacts/resources/v1/semantic_model.py
@@ -2,6 +2,11 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Sequence
 
+from dbt.artifacts.resources import SourceFileMetadata
+from dbt.artifacts.resources.base import GraphResource
+from dbt.artifacts.resources.v1.components import DependsOn, RefArgs
+from dbt_common.contracts.config.base import BaseConfig, CompareBehavior, MergeBehavior
+from dbt_common.dataclass_schema import dbtClassMixin
 from dbt_semantic_interfaces.references import (
     DimensionReference,
     EntityReference,
@@ -16,12 +21,6 @@ from dbt_semantic_interfaces.type_enums import (
     EntityType,
     TimeGranularity,
 )
-
-from dbt.artifacts.resources import SourceFileMetadata
-from dbt.artifacts.resources.base import GraphResource
-from dbt.artifacts.resources.v1.components import DependsOn, RefArgs
-from dbt_common.contracts.config.base import BaseConfig, CompareBehavior, MergeBehavior
-from dbt_common.dataclass_schema import dbtClassMixin
 
 """
 The classes in this file are dataclasses which are used to construct the Semantic

--- a/core/dbt/contracts/graph/metrics.py
+++ b/core/dbt/contracts/graph/metrics.py
@@ -1,8 +1,7 @@
 from typing import Any, Dict, Iterator, List
 
-from dbt_semantic_interfaces.type_enums import MetricType
-
 from dbt.contracts.graph.manifest import Manifest, Metric
+from dbt_semantic_interfaces.type_enums import MetricType
 
 DERIVED_METRICS = [MetricType.DERIVED, MetricType.RATIO]
 BASE_METRICS = [MetricType.SIMPLE, MetricType.CUMULATIVE, MetricType.CONVERSION]

--- a/core/dbt/contracts/graph/semantic_manifest.py
+++ b/core/dbt/contracts/graph/semantic_manifest.py
@@ -1,3 +1,9 @@
+from dbt.constants import TIME_SPINE_MODEL_NAME
+from dbt.events.types import SemanticValidationFailure
+from dbt.exceptions import ParsingError
+from dbt_common.clients.system import write_file
+from dbt_common.events.base_types import EventLevel
+from dbt_common.events.functions import fire_event
 from dbt_semantic_interfaces.implementations.metric import PydanticMetric
 from dbt_semantic_interfaces.implementations.project_configuration import (
     PydanticProjectConfiguration,
@@ -14,13 +20,6 @@ from dbt_semantic_interfaces.type_enums import TimeGranularity
 from dbt_semantic_interfaces.validations.semantic_manifest_validator import (
     SemanticManifestValidator,
 )
-
-from dbt.constants import TIME_SPINE_MODEL_NAME
-from dbt.events.types import SemanticValidationFailure
-from dbt.exceptions import ParsingError
-from dbt_common.clients.system import write_file
-from dbt_common.events.base_types import EventLevel
-from dbt_common.events.functions import fire_event
 
 
 class SemanticManifest:

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -4,11 +4,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Sequence, Union
 
-from dbt_semantic_interfaces.type_enums import (
-    ConversionCalculationType,
-    PeriodAggregation,
-)
-
 # trigger the PathEncoder
 import dbt_common.helper_types  # noqa:F401
 from dbt import deprecations
@@ -42,6 +37,10 @@ from dbt_common.dataclass_schema import (
     dbtClassMixin,
 )
 from dbt_common.exceptions import DbtInternalError
+from dbt_semantic_interfaces.type_enums import (
+    ConversionCalculationType,
+    PeriodAggregation,
+)
 
 
 @dataclass

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -10,8 +10,6 @@ from itertools import chain
 from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Type, Union
 
 import msgpack
-from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
-from dbt_semantic_interfaces.type_enums import MetricType
 
 import dbt.deprecations
 import dbt.exceptions
@@ -119,6 +117,8 @@ from dbt_common.events.functions import fire_event, get_invocation_id, warn_or_e
 from dbt_common.events.types import Note
 from dbt_common.exceptions.base import DbtValidationError
 from dbt_common.helper_types import PathSet
+from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
+from dbt_semantic_interfaces.type_enums import MetricType
 
 PERF_INFO_FILE_NAME = "perf_info.json"
 

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -1,15 +1,5 @@
 from typing import Any, Dict, List, Optional, Union
 
-from dbt_semantic_interfaces.type_enums import (
-    AggregationType,
-    ConversionCalculationType,
-    DimensionType,
-    EntityType,
-    MetricType,
-    PeriodAggregation,
-    TimeGranularity,
-)
-
 from dbt.artifacts.resources import (
     ConversionTypeParams,
     CumulativeTypeParams,
@@ -67,6 +57,15 @@ from dbt.parser.common import YamlBlock
 from dbt.parser.schemas import ParseResult, SchemaParser, YamlReader
 from dbt_common.dataclass_schema import ValidationError
 from dbt_common.exceptions import DbtInternalError
+from dbt_semantic_interfaces.type_enums import (
+    AggregationType,
+    ConversionCalculationType,
+    DimensionType,
+    EntityType,
+    MetricType,
+    PeriodAggregation,
+    TimeGranularity,
+)
 
 
 def parse_where_filter(

--- a/tests/functional/metrics/test_metrics.py
+++ b/tests/functional/metrics/test_metrics.py
@@ -1,12 +1,12 @@
 import pytest
-from dbt_semantic_interfaces.type_enums.period_agg import PeriodAggregation
-from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
 from dbt.artifacts.resources.v1.metric import CumulativeTypeParams, MetricTimeWindow
 from dbt.cli.main import dbtRunner
 from dbt.contracts.graph.manifest import Manifest
 from dbt.exceptions import ParsingError
 from dbt.tests.util import get_manifest, run_dbt
+from dbt_semantic_interfaces.type_enums.period_agg import PeriodAggregation
+from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from tests.functional.metrics.fixtures import (
     basic_metrics_yml,
     conversion_metric_yml,

--- a/tests/functional/saved_queries/test_configs.py
+++ b/tests/functional/saved_queries/test_configs.py
@@ -1,10 +1,10 @@
 import pytest
-from dbt_semantic_interfaces.type_enums.export_destination_type import (
-    ExportDestinationType,
-)
 
 from dbt.contracts.graph.manifest import Manifest
 from dbt.tests.util import update_config_file
+from dbt_semantic_interfaces.type_enums.export_destination_type import (
+    ExportDestinationType,
+)
 from tests.functional.assertions.test_runner import dbtTestRunner
 from tests.functional.configs.fixtures import BaseConfigProject
 from tests.functional.saved_queries.fixtures import (

--- a/tests/functional/saved_queries/test_saved_query_parsing.py
+++ b/tests/functional/saved_queries/test_saved_query_parsing.py
@@ -3,13 +3,13 @@ import shutil
 from typing import List
 
 import pytest
-from dbt_semantic_interfaces.type_enums.export_destination_type import (
-    ExportDestinationType,
-)
 
 from dbt.contracts.graph.manifest import Manifest
 from dbt.tests.util import run_dbt, write_file
 from dbt_common.events.base_types import BaseEvent
+from dbt_semantic_interfaces.type_enums.export_destination_type import (
+    ExportDestinationType,
+)
 from tests.functional.assertions.test_runner import dbtTestRunner
 from tests.functional.saved_queries.fixtures import (
     saved_queries_with_defaults_yml,

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -1,11 +1,11 @@
 from typing import List
 
 import pytest
-from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
 from dbt.contracts.graph.manifest import Manifest
 from dbt.tests.util import write_file
 from dbt_common.events.base_types import BaseEvent
+from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from tests.functional.assertions.test_runner import dbtTestRunner
 from tests.functional.semantic_models.fixtures import (
     fct_revenue_sql,

--- a/tests/unit/contracts/graph/test_manifest.py
+++ b/tests/unit/contracts/graph/test_manifest.py
@@ -9,7 +9,6 @@ from unittest import mock
 
 import freezegun
 import pytest
-from dbt_semantic_interfaces.type_enums import MetricType
 
 import dbt.flags
 import dbt.version
@@ -42,6 +41,7 @@ from dbt.exceptions import AmbiguousResourceNameRefError
 from dbt.flags import set_from_args
 from dbt.node_types import NodeType
 from dbt_common.events.functions import reset_metadata_vars
+from dbt_semantic_interfaces.type_enums import MetricType
 from tests.unit.utils import (
     MockDocumentation,
     MockGenerateMacro,

--- a/tests/unit/contracts/graph/test_nodes_parsed.py
+++ b/tests/unit/contracts/graph/test_nodes_parsed.py
@@ -3,7 +3,6 @@ from argparse import Namespace
 from dataclasses import replace
 
 import pytest
-from dbt_semantic_interfaces.type_enums import MetricType
 from hypothesis import given
 from hypothesis.strategies import builds, lists
 
@@ -53,6 +52,7 @@ from dbt.contracts.graph.nodes import (
 )
 from dbt.node_types import AccessType, NodeType
 from dbt_common.dataclass_schema import ValidationError
+from dbt_semantic_interfaces.type_enums import MetricType
 from tests.unit.utils import (
     ContractTestCase,
     assert_fails_validation,

--- a/tests/unit/graph/test_nodes.py
+++ b/tests/unit/graph/test_nodes.py
@@ -3,12 +3,6 @@ from datetime import datetime
 from typing import List
 
 import pytest
-from dbt_semantic_interfaces.references import MeasureReference
-from dbt_semantic_interfaces.type_enums import (
-    AggregationType,
-    DimensionType,
-    EntityType,
-)
 from freezegun import freeze_time
 
 from dbt.artifacts.resources import (
@@ -27,6 +21,12 @@ from dbt_common.contracts.constraints import (
     ColumnLevelConstraint,
     ConstraintType,
     ModelLevelConstraint,
+)
+from dbt_semantic_interfaces.references import MeasureReference
+from dbt_semantic_interfaces.type_enums import (
+    AggregationType,
+    DimensionType,
+    EntityType,
 )
 from tests.unit.fixtures import generic_test_node, model_node
 

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -2,21 +2,6 @@ import copy
 from typing import Protocol, runtime_checkable
 
 import pytest
-from dbt_semantic_interfaces.protocols import WhereFilter as WhereFilterProtocol
-from dbt_semantic_interfaces.protocols import dimension as DimensionProtocols
-from dbt_semantic_interfaces.protocols import entity as EntityProtocols
-from dbt_semantic_interfaces.protocols import measure as MeasureProtocols
-from dbt_semantic_interfaces.protocols import metadata as MetadataProtocols
-from dbt_semantic_interfaces.protocols import metric as MetricProtocols
-from dbt_semantic_interfaces.protocols import saved_query as SavedQueryProtocols
-from dbt_semantic_interfaces.protocols import semantic_model as SemanticModelProtocols
-from dbt_semantic_interfaces.type_enums import (
-    AggregationType,
-    DimensionType,
-    EntityType,
-    MetricType,
-    TimeGranularity,
-)
 from hypothesis import given
 from hypothesis.strategies import builds, none, text
 
@@ -43,6 +28,21 @@ from dbt.artifacts.resources import (
 )
 from dbt.contracts.graph.nodes import Metric, SavedQuery, SemanticModel
 from dbt.node_types import NodeType
+from dbt_semantic_interfaces.protocols import WhereFilter as WhereFilterProtocol
+from dbt_semantic_interfaces.protocols import dimension as DimensionProtocols
+from dbt_semantic_interfaces.protocols import entity as EntityProtocols
+from dbt_semantic_interfaces.protocols import measure as MeasureProtocols
+from dbt_semantic_interfaces.protocols import metadata as MetadataProtocols
+from dbt_semantic_interfaces.protocols import metric as MetricProtocols
+from dbt_semantic_interfaces.protocols import saved_query as SavedQueryProtocols
+from dbt_semantic_interfaces.protocols import semantic_model as SemanticModelProtocols
+from dbt_semantic_interfaces.type_enums import (
+    AggregationType,
+    DimensionType,
+    EntityType,
+    MetricType,
+    TimeGranularity,
+)
 
 
 @runtime_checkable

--- a/tests/unit/utils/manifest.py
+++ b/tests/unit/utils/manifest.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, List
 
 import pytest
-from dbt_semantic_interfaces.type_enums import MetricType
 
 from dbt.artifacts.resources import (
     ExposureType,
@@ -43,6 +42,7 @@ from dbt.contracts.graph.nodes import (
 )
 from dbt.contracts.graph.unparsed import UnitTestInputFixture, UnitTestOutputFixture
 from dbt.node_types import NodeType
+from dbt_semantic_interfaces.type_enums import MetricType
 
 
 def make_model(


### PR DESCRIPTION
resolves #N/A

### Problem

We've been grouping internal package imports by using `isort`. However, imports from `dbt_semantic_interfaces` weren't being grouped because I typo'd it as `dbt_semantic_interfaces` in the isort config.

### Solution

Fix the typo and rerun isort

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [X] I have run this code in development and it appears to resolve the stated issue  
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
