### PR TITLE
Use dbt-postgres repo to install postgres plugin

### DIFF
--- a/.changes/unreleased/Under the Hood-20240703-132347.yaml
+++ b/.changes/unreleased/Under the Hood-20240703-132347.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Fix repo location for dockerfile postgres adapter
+time: 2024-07-03T13:23:47.635016+10:00
+custom:
+    Author: mwkha
+    Issue: NA

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,7 @@ HEALTHCHECK CMD dbt --version || exit 1
 WORKDIR /usr/app/dbt/
 ENTRYPOINT ["dbt"]
 
-RUN python -m pip install --no-cache-dir "dbt-postgres @ git+https://github.com/dbt-labs/dbt-core@${commit_ref}#subdirectory=plugins/postgres"
+RUN python -m pip install --no-cache-dir "dbt-postgres @ git+https://github.com/dbt-labs/dbt-postgres@${commit_ref}"
 
 
 FROM dbt-core as dbt-third-party


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

When attempting to create a docker image via the provided Dokcerfile using main branch, install of postgres plugin fails due to main branch missing plugins folder: 
*ERROR: dbt-postgres@ git+https://github.com/dbt-labs/dbt-core@main#subdirectory=plugins/postgres from git+https://github.com/dbt-labs/dbt-core@main#subdirectory=plugins/postgres does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.*

### Solution

Instead point towared the dbt-postgres repo which contains the plugin.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
