### PR TITLE
GitHub issue template for documentation internal to `dbt-core`

### DIFF
--- a/.github/ISSUE_TEMPLATE/code-docs.yml
+++ b/.github/ISSUE_TEMPLATE/code-docs.yml
@@ -1,0 +1,18 @@
+name: 📄 Code docs
+description: Report an issue for markdown files within this repo, such as README, ARCHITECTURE, etc.
+title: "[Code docs] <title>"
+labels: ["triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this code docs issue!
+  - type: textarea
+    attributes:
+      label: Please describe the issue and your proposals.
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Documentation
     url: https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose
-    about: Problems and issues with dbt documentation
+    about: Problems and issues with dbt product documentation hosted on docs.getdbt.com. Issues for markdown files within this repo, such as README, should be opened using the "Code docs" template.
   - name: Ask the community for help
     url: https://github.com/dbt-labs/docs.getdbt.com/discussions
     about: Need help troubleshooting? Check out our guide on how to ask
@@ -24,3 +24,4 @@ contact_links:
   - name: Create an issue for dbt-spark
     url: https://github.com/dbt-labs/dbt-spark/issues/new/choose
     about: Report a bug or request a feature for dbt-spark
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -24,4 +24,3 @@ contact_links:
   - name: Create an issue for dbt-spark
     url: https://github.com/dbt-labs/dbt-spark/issues/new/choose
     about: Report a bug or request a feature for dbt-spark
-


### PR DESCRIPTION
clarify documentation issue relates to dbt product docs.

resolves #10385
