### PR TITLE
Global CLI flag should override env var flag

### DIFF
--- a/.changes/unreleased/Fixes-20240709-172440.yaml
+++ b/.changes/unreleased/Fixes-20240709-172440.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: CLI flags should take precedence over env var flags
+time: 2024-07-09T17:24:40.918977-04:00
+custom:
+  Author: gshank
+  Issue: "10304"

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -182,9 +182,10 @@ class Flags:
 
                 flag_name = (new_name or param_name).upper()
 
-                # envvar flags are always assigned to "parent" command, so if the flag has
-                # already been encountered as a non-parent flag, we don't want to overwrite,
-                # since the commandline flag takes precedence.
+                # envvar flags are assigned in either parent or child context if there
+                # isn't an overriding cli command flag.
+                # If the flag has been encountered as a child cli flag, we don't
+                # want to overwrite with parent envvar, since the commandline flag takes precedence.
                 if (is_duplicate and not (is_default or is_envvar)) or not is_duplicate:
                     object.__setattr__(self, flag_name, param_value)
 

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -92,6 +92,8 @@ class Flags:
         # Set the default flags.
         for key, value in FLAGS_DEFAULTS.items():
             object.__setattr__(self, key, value)
+        # Use to handle duplicate params in _assign_params
+        flags_defaults_list = list(FLAGS_DEFAULTS.keys())
 
         if ctx is None:
             ctx = get_current_context()
@@ -176,7 +178,16 @@ class Flags:
                 # end deprecated_params
 
                 # Set the flag value.
-                is_duplicate = hasattr(self, param_name.upper())
+                is_duplicate = (
+                    hasattr(self, param_name.upper())
+                    and param_name.upper() not in flags_defaults_list
+                )
+                # First time through, set as though FLAGS_DEFAULTS hasn't been set, so not a duplicate.
+                # Subsequent pass (to process "parent" params) should be treated as duplicates.
+                if param_name.upper() in flags_defaults_list:
+                    flags_defaults_list.remove(param_name.upper())
+                # Note: the following determines whether parameter came from click default,
+                # not from FLAGS_DEFAULTS in __init__.
                 is_default = ctx.get_parameter_source(param_name) == ParameterSource.DEFAULT
                 is_envvar = ctx.get_parameter_source(param_name) == ParameterSource.ENVIRONMENT
 

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -173,13 +173,19 @@ class Flags:
                         old_name=dep_param.envvar,
                         new_name=new_param.envvar,
                     )
+                # end deprecated_params
 
                 # Set the flag value.
                 is_duplicate = hasattr(self, param_name.upper())
                 is_default = ctx.get_parameter_source(param_name) == ParameterSource.DEFAULT
+                is_envvar = ctx.get_parameter_source(param_name) == ParameterSource.ENVIRONMENT
+
                 flag_name = (new_name or param_name).upper()
 
-                if (is_duplicate and not is_default) or not is_duplicate:
+                # envvar flags are always assigned to "parent" command, so if the flag has
+                # already been encountered as a non-parent flag, we don't want to overwrite,
+                # since the commandline flag takes precedence.
+                if (is_duplicate and not (is_default or is_envvar)) or not is_duplicate:
                     object.__setattr__(self, flag_name, param_value)
 
                 # Track default assigned params.

--- a/tests/unit/cli/test_flags.py
+++ b/tests/unit/cli/test_flags.py
@@ -380,6 +380,22 @@ class TestFlags:
 
         assert flags_a.USE_COLORS == flags_b.USE_COLORS
 
+    def test_global_flag_with_env_var(self, monkeypatch):
+        # The environment variable is used for whichever parent or child
+        # does not have a cli command.
+        # Test that "child" global flag overrides env var
+        monkeypatch.setenv("DBT_QUIET", "0")
+        parent_context = self.make_dbt_context("parent", ["--no-use-colors"])
+        child_context = self.make_dbt_context("child", ["--quiet"], parent_context)
+        flags = Flags(child_context)
+        assert flags.QUIET is True
+
+        # Test that "parent" global flag overrides env var
+        parent_context = self.make_dbt_context("parent", ["--quiet"])
+        child_context = self.make_dbt_context("child", ["--no-use-colors"], parent_context)
+        flags = Flags(child_context)
+        assert flags.QUIET is True
+
     def test_set_project_only_flags(self, project_flags, run_context):
         flags = Flags(run_context, project_flags)
 


### PR DESCRIPTION
resolves #10304

### Problem

When both an environment variable and a command line flag are provided, the cli flag should override the environment variable. This wasn't happening for "global" flags, which can occur both before and after the sub command, when the flag came after the command.

### Solution

The click context contains a "child" context for command options and a "parent" context for flags which occur before the command. If there was no "cli" setting for a flag, it would use the env var. When processing the parent context flags we add code to check if the source of this parameter is an env var, and do not overwrite the value of the param if it has already been set by the user.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
