### PR TITLE
test env vars casing 1 6 latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ venv/
 
 # poetry
 poetry.lock
+.venv/

--- a/tests/functional/context_methods/test_env_vars_casing.py
+++ b/tests/functional/context_methods/test_env_vars_casing.py
@@ -1,0 +1,64 @@
+import os
+
+import pytest
+
+from dbt.tests.util import run_dbt
+
+context_sql = """
+
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+select
+    '{{ env_var("local_user", "") }}' as lowercase,
+    '{{ env_var("LOCAL_USER", "") }}' as uppercase,
+    '{{ env_var("lOcAl_UsEr", "") }}' as mixedcase
+"""
+
+
+class TestEnvVars:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"context.sql": context_sql}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self):
+        os.environ["local_user"] = "dan"
+        yield
+        del os.environ["local_user"]
+
+    def get_ctx_vars(self, project):
+        fields = [
+            "lowercase",
+            "uppercase",
+            "mixedcase",
+        ]
+        field_list = ", ".join(['"{}"'.format(f) for f in fields])
+        query = "select {field_list} from {schema}.context".format(
+            field_list=field_list, schema=project.test_schema
+        )
+        vals = project.run_sql(query, fetch="all")
+        ctx = dict([(k, v) for (k, v) in zip(fields, vals[0])])
+        return ctx
+
+    def test_env_vars(
+        self,
+        project,
+    ):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        ctx = self.get_ctx_vars(project)
+
+        assert ctx["lowercase"] == "dan"
+
+        # Windows env-vars are not case-sensitive, but Linux/macOS ones are
+        # So on Windows, the uppercase and mixedcase vars should also resolve to "dan"
+        if os.name == "nt":
+            assert ctx["uppercase"] == "dan"
+            assert ctx["mixedcase"] == "dan"
+        else:
+            assert ctx["uppercase"] == ""
+            assert ctx["mixedcase"] == ""


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions


[CT-2594]: https://dbtlabs.atlassian.net/browse/CT-2594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CT-1483]: https://dbtlabs.atlassian.net/browse/CT-1483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CT-2879]: https://dbtlabs.atlassian.net/browse/CT-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CT-2888]: https://dbtlabs.atlassian.net/browse/CT-2888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CT-3013]: https://dbtlabs.atlassian.net/browse/CT-3013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ