### PR TITLE
Fix typing for artifact schemas

### DIFF
--- a/.changes/unreleased/Fixes-20240714-100254.yaml
+++ b/.changes/unreleased/Fixes-20240714-100254.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix typing for artifact schemas
+time: 2024-07-14T10:02:54.452099+09:00
+custom:
+    Author: nakamichiworks
+    Issue: "10442"

--- a/core/dbt/artifacts/schemas/base.py
+++ b/core/dbt/artifacts/schemas/base.py
@@ -77,8 +77,11 @@ class BaseArtifactMetadata(dbtClassMixin):
 #   remote-compile-result
 #   remote-execution-result
 #   remote-run-result
+S = TypeVar("S", bound="VersionedSchema")
+
+
 def schema_version(name: str, version: int):
-    def inner(cls: Type[VersionedSchema]):
+    def inner(cls: Type[S]):
         cls.dbt_schema_version = SchemaVersion(
             name=name,
             version=version,


### PR DESCRIPTION
resolves #10442 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

Types of artifact schemas decorated with `@schema_version()` are incorrectly inferred to be `VersionedSchema`.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Fixes a type hint in `schema_version()` function.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
