### PR TITLE
Fix multiple semantic models with generated metrics

### DIFF
--- a/.changes/unreleased/Fixes-20240716-133703.yaml
+++ b/.changes/unreleased/Fixes-20240716-133703.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix over deletion of generated_metrics in partial parsing
+time: 2024-07-16T13:37:03.49651-04:00
+custom:
+  Author: gshank
+  Issue: "10450"

--- a/core/dbt/contracts/files.py
+++ b/core/dbt/contracts/files.py
@@ -275,7 +275,7 @@ class SchemaSourceFile(BaseSourceFile):
             parts = metric_unique_id.split(".")
             metric_name = parts[-1]
             if "semantic_models" in self.dict_from_yaml:
-                for sem_model in self.dict_from_yaml["semantic_model"]:
+                for sem_model in self.dict_from_yaml["semantic_models"]:
                     if "measures" in sem_model:
                         for measure in sem_model["measures"]:
                             if measure["name"] == metric_name:

--- a/core/dbt/contracts/files.py
+++ b/core/dbt/contracts/files.py
@@ -192,8 +192,12 @@ class SchemaSourceFile(BaseSourceFile):
     sources: List[str] = field(default_factory=list)
     exposures: List[str] = field(default_factory=list)
     metrics: List[str] = field(default_factory=list)
-    # metrics generated from semantic_model measures
+    # The following field will no longer be used. Leaving
+    # here to avoid breaking existing projects. To be removed
+    # later if possible.
     generated_metrics: List[str] = field(default_factory=list)
+    # metrics generated from semantic_model measures. The key is
+    # the name of the semantic_model, so that we can find it later.
     metrics_from_measures: Dict[str, Any] = field(default_factory=dict)
     groups: List[str] = field(default_factory=list)
     # node patches contain models, seeds, snapshots, analyses
@@ -262,17 +266,29 @@ class SchemaSourceFile(BaseSourceFile):
 
     def add_metrics_from_measures(self, semantic_model_name: str, metric_unique_id: str):
         if self.generated_metrics:
+            # Probably not needed, but for safety sake, convert the
+            # old generated_metrics to metrics_from_measures.
             self.fix_metrics_from_measures()
         if semantic_model_name not in self.metrics_from_measures:
             self.metrics_from_measures[semantic_model_name] = []
         self.metrics_from_measures[semantic_model_name].append(metric_unique_id)
 
     def fix_metrics_from_measures(self):
-        # Loop through yaml dictionary looking for matching generated metrics
+        # Temporary method to fix up existing projects with a partial parse file.
+        # This should only be called if SchemaSourceFile in a msgpack
+        # pack manifest has an existing "generated_metrics" list, to turn it
+        # it into a "metrics_from_measures" dictionary, so that we can
+        # correctly partially parse.
+        # This code can be removed when "generated_metrics" is removed.
         generated_metrics = self.generated_metrics
-        self.generated_metrics = []
+        self.generated_metrics = []  # Should never be needed again
+        # For each metric_unique_id we loop through the semantic models
+        # looking for the name of the "measure" which generated the metric.
+        # When it's found, add it to "metrics_from_measures", with a key
+        # of the semantic_model name, and a list of metrics.
         for metric_unique_id in generated_metrics:
             parts = metric_unique_id.split(".")
+            # get the metric_name
             metric_name = parts[-1]
             if "semantic_models" in self.dict_from_yaml:
                 for sem_model in self.dict_from_yaml["semantic_models"]:

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1565,13 +1565,15 @@ class Manifest(MacroMethods, dbtClassMixin):
         self.exposures[exposure.unique_id] = exposure
         source_file.exposures.append(exposure.unique_id)
 
-    def add_metric(self, source_file: SchemaSourceFile, metric: Metric, generated: bool = False):
+    def add_metric(
+        self, source_file: SchemaSourceFile, metric: Metric, generated_from: Optional[str] = None
+    ):
         _check_duplicates(metric, self.metrics)
         self.metrics[metric.unique_id] = metric
-        if not generated:
+        if not generated_from:
             source_file.metrics.append(metric.unique_id)
         else:
-            source_file.generated_metrics.append(metric.unique_id)
+            source_file.add_metrics_from_measures(generated_from, metric.unique_id)
 
     def add_group(self, source_file: SchemaSourceFile, group: Group):
         _check_duplicates(group, self.groups)

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -968,13 +968,15 @@ class PartialParsing:
             elif unique_id in self.saved_manifest.disabled:
                 self.delete_disabled(unique_id, schema_file.file_id)
 
-        metrics = schema_file.generated_metrics.copy()
-        for unique_id in metrics:
-            if unique_id in self.saved_manifest.metrics:
-                self.saved_manifest.metrics.pop(unique_id)
-                schema_file.generated_metrics.remove(unique_id)
-            elif unique_id in self.saved_manifest.disabled:
-                self.delete_disabled(unique_id, schema_file.file_id)
+        if schema_file.generated_metrics:
+            schema_file.fix_metrics_from_measures()
+        if semantic_model_name in schema_file.metrics_from_measures:
+            for unique_id in schema_file.metrics_from_measures[semantic_model_name]:
+                if unique_id in self.saved_manifest.metrics:
+                    self.saved_manifest.metrics.pop(unique_id)
+                elif unique_id in self.saved_manifest.disabled:
+                    self.delete_disabled(unique_id, schema_file.file_id)
+            del schema_file.metrics_from_measures[semantic_model_name]
 
     def delete_schema_unit_test(self, schema_file, unit_test_dict):
         unit_test_name = unit_test_dict["name"]

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -969,6 +969,8 @@ class PartialParsing:
                 self.delete_disabled(unique_id, schema_file.file_id)
 
         if schema_file.generated_metrics:
+            # If this partial parse file has an old "generated_metrics" list,
+            # call code to fix it up before processing.
             schema_file.fix_metrics_from_measures()
         if semantic_model_name in schema_file.metrics_from_measures:
             for unique_id in schema_file.metrics_from_measures[semantic_model_name]:

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -389,7 +389,7 @@ class MetricParser(YamlReader):
             # input_measures=?,
         )
 
-    def parse_metric(self, unparsed: UnparsedMetric, generated: bool = False) -> None:
+    def parse_metric(self, unparsed: UnparsedMetric, generated_from: Optional[str] = None) -> None:
         package_name = self.project.project_name
         unique_id = f"{NodeType.Metric}.{package_name}.{unparsed.name}"
         path = self.yaml.path.relative_path
@@ -446,7 +446,7 @@ class MetricParser(YamlReader):
         # if the metric is disabled we do not want it included in the manifest, only in the disabled dict
         assert isinstance(self.yaml.file, SchemaSourceFile)
         if parsed.config.enabled:
-            self.manifest.add_metric(self.yaml.file, parsed, generated)
+            self.manifest.add_metric(self.yaml.file, parsed, generated_from)
         else:
             self.manifest.add_disabled(self.yaml.file, parsed)
 
@@ -601,7 +601,12 @@ class SemanticModelParser(YamlReader):
             )
         return measures
 
-    def _create_metric(self, measure: UnparsedMeasure, enabled: bool) -> None:
+    def _create_metric(
+        self,
+        measure: UnparsedMeasure,
+        enabled: bool,
+        semantic_model_name: str,
+    ) -> None:
         unparsed_metric = UnparsedMetric(
             name=measure.name,
             label=measure.name,
@@ -612,7 +617,7 @@ class SemanticModelParser(YamlReader):
         )
 
         parser = MetricParser(self.schema_parser, yaml=self.yaml)
-        parser.parse_metric(unparsed=unparsed_metric, generated=True)
+        parser.parse_metric(unparsed=unparsed_metric, generated_from=semantic_model_name)
 
     def _generate_semantic_model_config(
         self, target: UnparsedSemanticModel, fqn: List[str], package_name: str, rendered: bool
@@ -708,7 +713,9 @@ class SemanticModelParser(YamlReader):
         # Create a metric for each measure with `create_metric = True`
         for measure in unparsed.measures:
             if measure.create_metric is True:
-                self._create_metric(measure=measure, enabled=parsed.config.enabled)
+                self._create_metric(
+                    measure=measure, enabled=parsed.config.enabled, semantic_model_name=parsed.name
+                )
 
     def parse(self) -> None:
         for data in self.get_key_dicts():

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -319,3 +319,81 @@ final as (
 select *
 from final
 """
+
+multi_sm_schema_yml = """
+models:
+  - name: fct_revenue
+    description: This is the model fct_revenue.
+
+semantic_models:
+  - name: revenue
+    description: This is the first semantic model.
+    model: ref('fct_revenue')
+
+    defaults:
+      agg_time_dimension: ds
+
+    measures:
+      - name: txn_revenue
+        expr: revenue
+        agg: sum
+        agg_time_dimension: ds
+        create_metric: true
+      - name: sum_of_things
+        expr: 2
+        agg: sum
+        agg_time_dimension: ds
+
+    dimensions:
+      - name: ds
+        type: time
+        expr: created_at
+        type_params:
+          time_granularity: day
+
+    entities:
+      - name: user
+        type: foreign
+        expr: user_id
+      - name: id
+        type: primary
+
+  - name: alt_revenue
+    description: This is the second revenue semantic model.
+    model: ref('fct_revenue')
+
+    defaults:
+      agg_time_dimension: ads
+
+    measures:
+      - name: alt_txn_revenue
+        expr: revenue
+        agg: sum
+        agg_time_dimension: ads
+        create_metric: true
+      - name: alt_sum_of_things
+        expr: 2
+        agg: sum
+        agg_time_dimension: ads
+
+    dimensions:
+      - name: ads
+        type: time
+        expr: created_at
+        type_params:
+          time_granularity: day
+
+    entities:
+      - name: user
+        type: foreign
+        expr: user_id
+      - name: id
+        type: primary
+
+metrics:
+  - name: simple_metric
+    label: Simple Metric
+    type: simple
+    type_params:
+      measure: sum_of_things
+"""

--- a/tests/unit/contracts/files/test_schema_source_file.py
+++ b/tests/unit/contracts/files/test_schema_source_file.py
@@ -1,0 +1,155 @@
+from dbt.contracts.files import SchemaSourceFile
+
+def test_fix_metrics_from_measure():
+    # This is a test for converting "generated_metrics" to "metrics_from_measures"
+    schema_source_file = {
+        "path": {
+            "searched_path": "models",
+            "relative_path": "schema.yml",
+            "modification_time": 1721228094.7544806,
+            "project_root": "/Users/a_user/sample_project"
+        },
+        "checksum": {
+            "name": "sha256",
+            "checksum": "63130d480a44a481aa0adc0a8469dccbb72ea36cc09f06683a584a31339f362e"
+        },
+        "project_name": "test",
+        "parse_file_type": "schema",
+        "dfy": {
+            "models": [
+                {
+                    "name": "fct_revenue",
+                    "description": "This is the model fct_revenue."
+                }
+            ],
+            "semantic_models": [
+                {
+                    "name": "revenue",
+                    "description": "This is the FIRST semantic model.",
+                    "model": "ref('fct_revenue')",
+                    "defaults": {
+                        "agg_time_dimension": "ds"
+                    },
+                    "measures": [
+                        {
+                            "name": "txn_revenue",
+                            "expr": "revenue",
+                            "agg": "sum",
+                            "agg_time_dimension": "ds",
+                            "create_metric": True
+                        },
+                        {
+                            "name": "sum_of_things",
+                            "expr": 2,
+                            "agg": "sum",
+                            "agg_time_dimension": "ds"
+                        }
+                    ],
+                    "dimensions": [
+                        {
+                            "name": "ds",
+                            "type": "time",
+                            "expr": "created_at",
+                            "type_params": {
+                                "time_granularity": "day"
+                            }
+                        }
+                    ],
+                    "entities": [
+                        {
+                            "name": "user",
+                            "type": "foreign",
+                            "expr": "user_id"
+                        },
+                        {
+                            "name": "id",
+                            "type": "primary"
+                        }
+                    ]
+                },
+                {
+                    "name": "alt_revenue",
+                    "description": "This is the second revenue semantic model.",
+                    "model": "ref('fct_revenue')",
+                    "defaults": {
+                        "agg_time_dimension": "ads"
+                    },
+                    "measures": [
+                        {
+                            "name": "alt_txn_revenue",
+                            "expr": "revenue",
+                            "agg": "sum",
+                            "agg_time_dimension": "ads",
+                            "create_metric": True
+                        },
+                        {
+                            "name": "alt_sum_of_things",
+                            "expr": 2,
+                            "agg": "sum",
+                            "agg_time_dimension": "ads"
+                        }
+                    ],
+                    "dimensions": [
+                        {
+                            "name": "ads",
+                            "type": "time",
+                            "expr": "created_at",
+                            "type_params": {
+                                "time_granularity": "day"
+                            }
+                        }
+                    ],
+                    "entities": [
+                        {
+                            "name": "user",
+                            "type": "foreign",
+                            "expr": "user_id"
+                        },
+                        {
+                            "name": "id",
+                            "type": "primary"
+                        }
+                    ]
+                }
+            ],
+            "metrics": [
+                {
+                    "name": "simple_metric",
+                    "label": "Simple Metric",
+                    "type": "simple",
+                    "type_params": {
+                        "measure": "sum_of_things"
+                    }
+                }
+            ]
+        },
+        "data_tests": {},
+        "metrics": [
+            "metric.test.simple_metric"
+        ],
+        "generated_metrics": ["metric.test.txn_revenue", "metric.test.alt_txn_revenue"],
+        "metrics_from_measures": {},
+        "ndp": [
+            "model.test.fct_revenue"
+        ],
+        "semantic_models": [
+            "semantic_model.test.revenue",
+            "semantic_model.test.alt_revenue"
+        ],
+        "mcp": {},
+        "env_vars": {}
+    }
+
+    expected_metrics_from_measures = {
+        "revenue": [
+            "metric.test.txn_revenue"
+        ],
+        "alt_revenue": [
+            "metric.test.alt_txn_revenue"
+        ]
+    }
+    ssf = SchemaSourceFile.from_dict(schema_source_file)
+    assert ssf
+    ssf.fix_metrics_from_measures()
+    assert ssf.generated_metrics == []
+    assert ssf.metrics_from_measures == expected_metrics_from_measures

--- a/tests/unit/contracts/files/test_schema_source_file.py
+++ b/tests/unit/contracts/files/test_schema_source_file.py
@@ -1,5 +1,6 @@
 from dbt.contracts.files import SchemaSourceFile
 
+
 def test_fix_metrics_from_measure():
     # This is a test for converting "generated_metrics" to "metrics_from_measures"
     schema_source_file = {
@@ -7,146 +8,106 @@ def test_fix_metrics_from_measure():
             "searched_path": "models",
             "relative_path": "schema.yml",
             "modification_time": 1721228094.7544806,
-            "project_root": "/Users/a_user/sample_project"
+            "project_root": "/Users/a_user/sample_project",
         },
         "checksum": {
             "name": "sha256",
-            "checksum": "63130d480a44a481aa0adc0a8469dccbb72ea36cc09f06683a584a31339f362e"
+            "checksum": "63130d480a44a481aa0adc0a8469dccbb72ea36cc09f06683a584a31339f362e",
         },
         "project_name": "test",
         "parse_file_type": "schema",
         "dfy": {
-            "models": [
-                {
-                    "name": "fct_revenue",
-                    "description": "This is the model fct_revenue."
-                }
-            ],
+            "models": [{"name": "fct_revenue", "description": "This is the model fct_revenue."}],
             "semantic_models": [
                 {
                     "name": "revenue",
                     "description": "This is the FIRST semantic model.",
                     "model": "ref('fct_revenue')",
-                    "defaults": {
-                        "agg_time_dimension": "ds"
-                    },
+                    "defaults": {"agg_time_dimension": "ds"},
                     "measures": [
                         {
                             "name": "txn_revenue",
                             "expr": "revenue",
                             "agg": "sum",
                             "agg_time_dimension": "ds",
-                            "create_metric": True
+                            "create_metric": True,
                         },
                         {
                             "name": "sum_of_things",
                             "expr": 2,
                             "agg": "sum",
-                            "agg_time_dimension": "ds"
-                        }
+                            "agg_time_dimension": "ds",
+                        },
                     ],
                     "dimensions": [
                         {
                             "name": "ds",
                             "type": "time",
                             "expr": "created_at",
-                            "type_params": {
-                                "time_granularity": "day"
-                            }
+                            "type_params": {"time_granularity": "day"},
                         }
                     ],
                     "entities": [
-                        {
-                            "name": "user",
-                            "type": "foreign",
-                            "expr": "user_id"
-                        },
-                        {
-                            "name": "id",
-                            "type": "primary"
-                        }
-                    ]
+                        {"name": "user", "type": "foreign", "expr": "user_id"},
+                        {"name": "id", "type": "primary"},
+                    ],
                 },
                 {
                     "name": "alt_revenue",
                     "description": "This is the second revenue semantic model.",
                     "model": "ref('fct_revenue')",
-                    "defaults": {
-                        "agg_time_dimension": "ads"
-                    },
+                    "defaults": {"agg_time_dimension": "ads"},
                     "measures": [
                         {
                             "name": "alt_txn_revenue",
                             "expr": "revenue",
                             "agg": "sum",
                             "agg_time_dimension": "ads",
-                            "create_metric": True
+                            "create_metric": True,
                         },
                         {
                             "name": "alt_sum_of_things",
                             "expr": 2,
                             "agg": "sum",
-                            "agg_time_dimension": "ads"
-                        }
+                            "agg_time_dimension": "ads",
+                        },
                     ],
                     "dimensions": [
                         {
                             "name": "ads",
                             "type": "time",
                             "expr": "created_at",
-                            "type_params": {
-                                "time_granularity": "day"
-                            }
+                            "type_params": {"time_granularity": "day"},
                         }
                     ],
                     "entities": [
-                        {
-                            "name": "user",
-                            "type": "foreign",
-                            "expr": "user_id"
-                        },
-                        {
-                            "name": "id",
-                            "type": "primary"
-                        }
-                    ]
-                }
+                        {"name": "user", "type": "foreign", "expr": "user_id"},
+                        {"name": "id", "type": "primary"},
+                    ],
+                },
             ],
             "metrics": [
                 {
                     "name": "simple_metric",
                     "label": "Simple Metric",
                     "type": "simple",
-                    "type_params": {
-                        "measure": "sum_of_things"
-                    }
+                    "type_params": {"measure": "sum_of_things"},
                 }
-            ]
+            ],
         },
         "data_tests": {},
-        "metrics": [
-            "metric.test.simple_metric"
-        ],
+        "metrics": ["metric.test.simple_metric"],
         "generated_metrics": ["metric.test.txn_revenue", "metric.test.alt_txn_revenue"],
         "metrics_from_measures": {},
-        "ndp": [
-            "model.test.fct_revenue"
-        ],
-        "semantic_models": [
-            "semantic_model.test.revenue",
-            "semantic_model.test.alt_revenue"
-        ],
+        "ndp": ["model.test.fct_revenue"],
+        "semantic_models": ["semantic_model.test.revenue", "semantic_model.test.alt_revenue"],
         "mcp": {},
-        "env_vars": {}
+        "env_vars": {},
     }
 
     expected_metrics_from_measures = {
-        "revenue": [
-            "metric.test.txn_revenue"
-        ],
-        "alt_revenue": [
-            "metric.test.alt_txn_revenue"
-        ]
+        "revenue": ["metric.test.txn_revenue"],
+        "alt_revenue": ["metric.test.alt_txn_revenue"],
     }
     ssf = SchemaSourceFile.from_dict(schema_source_file)
     assert ssf


### PR DESCRIPTION
resolves #10450


### Problem

When partial parsing, all generated metrics in a file were being deleted instead of just for the changed semantic model.

### Solution

Use a dictionary in SchemaSourceFile, with the semantic model name for the key and a list containing metric unique ids for the value.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
