### PR TITLE
Support passing `args` as keyword argument for `run-operation` in programmatic invocations

### DIFF
--- a/.changes/unreleased/Features-20240722-133729.yaml
+++ b/.changes/unreleased/Features-20240722-133729.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support passing `--args` for `run-operation` in programmatic invocations
+time: 2024-07-22T13:37:29.285621-06:00
+custom:
+  Author: dbeatty10
+  Issue: "10473"

--- a/.changes/unreleased/Features-20240722-133729.yaml
+++ b/.changes/unreleased/Features-20240722-133729.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Support passing `--args` for `run-operation` in programmatic invocations
+body: Support passing `args` as keyword argument for `run-operation` in programmatic invocations
 time: 2024-07-22T13:37:29.285621-06:00
 custom:
   Author: dbeatty10

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -7,6 +7,7 @@ import click
 from click.exceptions import BadOptionUsage
 from click.exceptions import Exit as ClickExit
 from click.exceptions import NoSuchOption, UsageError
+
 from dbt.artifacts.schemas.catalog import CatalogArtifact
 from dbt.artifacts.schemas.run import RunExecutionResult
 from dbt.cli import params as p

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -7,7 +7,6 @@ import click
 from click.exceptions import BadOptionUsage
 from click.exceptions import Exit as ClickExit
 from click.exceptions import NoSuchOption, UsageError
-
 from dbt.artifacts.schemas.catalog import CatalogArtifact
 from dbt.artifacts.schemas.run import RunExecutionResult
 from dbt.cli import params as p
@@ -47,9 +46,9 @@ class dbtRunner:
             callbacks = []
         self.callbacks = callbacks
 
-    def invoke(self, args: List[str], /, **kwargs) -> dbtRunnerResult:
+    def invoke(self, invocation_args: List[str], /, **kwargs) -> dbtRunnerResult:
         try:
-            dbt_ctx = cli.make_context(cli.name, args.copy())
+            dbt_ctx = cli.make_context(cli.name, invocation_args.copy())
             dbt_ctx.obj = {
                 "manifest": self.manifest,
                 "callbacks": self.callbacks,

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -7,7 +7,6 @@ import click
 from click.exceptions import BadOptionUsage
 from click.exceptions import Exit as ClickExit
 from click.exceptions import NoSuchOption, UsageError
-
 from dbt.artifacts.schemas.catalog import CatalogArtifact
 from dbt.artifacts.schemas.run import RunExecutionResult
 from dbt.cli import params as p
@@ -47,7 +46,7 @@ class dbtRunner:
             callbacks = []
         self.callbacks = callbacks
 
-    def invoke(self, args: List[str], **kwargs) -> dbtRunnerResult:
+    def invoke(self, args: List[str], /, **kwargs) -> dbtRunnerResult:
         try:
             dbt_ctx = cli.make_context(cli.name, args.copy())
             dbt_ctx.obj = {

--- a/core/dbt/tests/util.py
+++ b/core/dbt/tests/util.py
@@ -70,30 +70,25 @@ from dbt_common.events.types import Note
 #   run_dbt(["run", "--vars", "seed_name: base"])
 # If the command is expected to fail, pass in "expect_pass=False"):
 #   run_dbt(["test"], expect_pass=False)
-def run_dbt(
-    args: Optional[List[str]] = None,
-    /,
-    expect_pass: bool = True,
-    **kwargs
-):
+def run_dbt(invocation_args: Optional[List[str]] = None, /, expect_pass: bool = True, **kwargs):
     # reset global vars
     reset_metadata_vars()
 
-    if args is None:
-        args = ["run"]
+    if invocation_args is None:
+        invocation_args = ["run"]
 
-    print("\n\nInvoking dbt with {}".format(args))
+    print("\n\nInvoking dbt with {}".format(invocation_args))
     from dbt.flags import get_flags
 
     flags = get_flags()
     project_dir = getattr(flags, "PROJECT_DIR", None)
     profiles_dir = getattr(flags, "PROFILES_DIR", None)
-    if project_dir and "--project-dir" not in args:
-        args.extend(["--project-dir", project_dir])
-    if profiles_dir and "--profiles-dir" not in args:
-        args.extend(["--profiles-dir", profiles_dir])
+    if project_dir and "--project-dir" not in invocation_args:
+        invocation_args.extend(["--project-dir", project_dir])
+    if profiles_dir and "--profiles-dir" not in invocation_args:
+        invocation_args.extend(["--profiles-dir", profiles_dir])
     dbt = dbtRunner()
-    res = dbt.invoke(args, **kwargs)
+    res = dbt.invoke(invocation_args, **kwargs)
 
     # the exception is immediately raised to be caught in tests
     # using a pattern like `with pytest.raises(SomeException):`
@@ -111,15 +106,12 @@ def run_dbt(
 # start with the "--debug" flag. The structured schema log CI test
 # will turn the logs into json, so you have to be prepared for that.
 def run_dbt_and_capture(
-    args: Optional[List[str]] = None,
-    /,
-    expect_pass: bool = True,
-    **kwargs
+    invocation_args: Optional[List[str]] = None, /, expect_pass: bool = True, **kwargs
 ):
     try:
         stringbuf = StringIO()
         capture_stdout_logs(stringbuf)
-        res = run_dbt(args, expect_pass=expect_pass, **kwargs)
+        res = run_dbt(invocation_args, expect_pass=expect_pass, **kwargs)
         stdout = stringbuf.getvalue()
 
     finally:

--- a/core/dbt/tests/util.py
+++ b/core/dbt/tests/util.py
@@ -72,7 +72,9 @@ from dbt_common.events.types import Note
 #   run_dbt(["test"], expect_pass=False)
 def run_dbt(
     args: Optional[List[str]] = None,
+    /,
     expect_pass: bool = True,
+    **kwargs
 ):
     # reset global vars
     reset_metadata_vars()
@@ -91,7 +93,7 @@ def run_dbt(
     if profiles_dir and "--profiles-dir" not in args:
         args.extend(["--profiles-dir", profiles_dir])
     dbt = dbtRunner()
-    res = dbt.invoke(args)
+    res = dbt.invoke(args, **kwargs)
 
     # the exception is immediately raised to be caught in tests
     # using a pattern like `with pytest.raises(SomeException):`
@@ -110,12 +112,14 @@ def run_dbt(
 # will turn the logs into json, so you have to be prepared for that.
 def run_dbt_and_capture(
     args: Optional[List[str]] = None,
+    /,
     expect_pass: bool = True,
+    **kwargs
 ):
     try:
         stringbuf = StringIO()
         capture_stdout_logs(stringbuf)
-        res = run_dbt(args, expect_pass=expect_pass)
+        res = run_dbt(args, expect_pass=expect_pass, **kwargs)
         stdout = stringbuf.getvalue()
 
     finally:

--- a/tests/functional/colors/test_colors.py
+++ b/tests/functional/colors/test_colors.py
@@ -34,7 +34,7 @@ class TestColors:
         )
 
     def assert_colors_used(self, flag, expect_colors):
-        _, stdout = run_dbt_and_capture(args=[flag, "run"], expect_pass=False)
+        _, stdout = run_dbt_and_capture([flag, "run"], expect_pass=False)
         # pattern to match formatted log output
         pattern = re.compile(r"\[31m.*|\[33m.*")
         stdout_contains_formatting_characters = bool(pattern.search(stdout))

--- a/tests/functional/list/test_list.py
+++ b/tests/functional/list/test_list.py
@@ -23,7 +23,7 @@ class TestList:
         full_args = ["ls"]
         if args is not None:
             full_args += args
-        result = run_dbt(args=full_args, expect_pass=expect_pass)
+        result = run_dbt(full_args, expect_pass=expect_pass)
 
         return result
 

--- a/tests/functional/run_operations/fixtures.py
+++ b/tests/functional/run_operations/fixtures.py
@@ -52,8 +52,8 @@ happy_macros_sql = """
 {% endmacro %}
 
 
-{% macro print_something() %}
-  {{ print("You're doing awesome!") }}
+{% macro print_something(message="You're doing awesome!") %}
+  {{ print(message) }}
 {% endmacro %}
 """
 

--- a/tests/functional/run_operations/test_run_operations.py
+++ b/tests/functional/run_operations/test_run_operations.py
@@ -75,6 +75,12 @@ class TestOperations:
         self.run_operation("table_name_args", table_name="my_fancy_table")
         check_table_does_exist(project.adapter, "my_fancy_table")
 
+    def test_args_as_keyword(self, project):
+        results, log_output = run_dbt_and_capture(
+            ["run-operation", "print_something"], args={"message": "Morning coffee"}
+        )
+        assert "Morning coffee" in log_output
+
     def test_macro_exception(self, project):
         self.run_operation("syntax_error", False)
 

--- a/tests/functional/threading/test_thread_count.py
+++ b/tests/functional/threading/test_thread_count.py
@@ -42,5 +42,5 @@ class TestThreadCount:
         return {"threads": 2}
 
     def test_threading_8x(self, project):
-        results = run_dbt(args=["run", "--threads", "16"])
+        results = run_dbt(["run", "--threads", "16"])
         assert len(results), 20


### PR DESCRIPTION
resolves #10355

### Problem

As described in #10355, there's a naming conflict between the first parameter of `dbtRunner.invoke()` and the `--args` CLI flag of the `run-operation` command.

### Solution

1. Make the first parameter [positional-only](https://docs.python.org/3.8/whatsnew/3.8.html#positional-only-parameters)
1. Rename the first parameter from `args` to `invocation_args`
1. Allow `run_dbt` and `run_dbt_and_capture` test utilities to take optional `kwargs` parameters for testing purposes
1. Update the small handful of places that were using a keyword parameter rather than positional

### Interface changes

These interface changes assume that the **intended** and dominant usage of `dbtRunner.invoke` is a positional first argument along with optional kwargs:

- Within `dbtRunner.invoke` rename `args` to `invocation_args` and explicitly make it positional
- Align `run_dbt` and `run_dbt_and_capture` with those same changes

If anyone has code like `dbtRunner().invoke(args=["run", ...])` they would need to update it by removing `args=`.

### Testing strategy

_Indirectly_ testing `dbtRunner().invoke()` via `run_dbt_and_capture` & `run_dbt` -- added this new test to verify that custom `args` makes it through:

```python
    def test_args_as_keyword(self, project):
        results, log_output = run_dbt_and_capture(
            ["run-operation", "print_something"], args={"message": "Morning coffee"}
        )
        assert "Morning coffee" in log_output
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has interface changes and it has already received feedback and approval from Product or DX
- [x] Modified function already includes [type annotations](https://docs.python.org/3/library/typing.html)
