### PR TITLE
Update `pytest` examples for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,9 +170,9 @@ Finally, you can also run a specific test or group of tests using [`pytest`](htt
 
 ```sh
 # run all unit tests in a file
-python3 -m pytest tests/unit/test_base_column.py
+python3 -m pytest tests/unit/test_invocation_id.py
 # run a specific unit test
-python3 -m pytest tests/unit/test_base_column.py::TestNumericType::test__numeric_type
+python3 -m pytest tests/unit/test_invocation_id.py::TestInvocationId::test_invocation_id
 # run specific Postgres functional tests
 python3 -m pytest tests/functional/sources
 ```


### PR DESCRIPTION
resolves #9788 (again)

### Problem

[These](https://github.com/dbt-labs/dbt-core/blob/79ad0a32432dcc0cb4603d8ede0613327cdb5e99/CONTRIBUTING.md?plain=1#L173-L175) `pytest` example commands don't work for me when following the contributing instructions, presumably because these tests moved to the `dbt-adapters` repo:
```shell
# run all unit tests in a file
python3 -m pytest tests/unit/test_base_column.py
# run a specific unit test
python3 -m pytest tests/unit/test_base_column.py::TestNumericType::test__numeric_type
# run specific Postgres functional tests
python3 -m pytest tests/functional/sources
```

Instead, I get errors.

### Solution

These would probably be better examples to use (and they worked for me):
```shell
# run all unit tests in a file
python3 -m pytest tests/unit/test_invocation_id.py
# run a specific unit test
python3 -m pytest tests/unit/test_invocation_id.py::TestInvocationId::test_invocation_id
# run specific Postgres functional tests
python3 -m pytest tests/functional/sources
```

### Testing

Manual testing of the code examples within `CONTRIBUTING.md` is sufficient to complete this issue since it doesn't affect the delivered code.

I tested that the updated example commands run without any errors.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [x] I have run this code in development and it appears to resolve the stated issue  
- [x] Tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)
- [x] This PR does not include any new [type annotations](https://docs.python.org/3/library/typing.html) because there are not any new and modified functions
