### PR TITLE
[Tidy First] Update PR template punctuation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
-resolves #
+Resolves #
 
 <!---
-  Include the number of the issue addressed by this PR above if applicable.
+  Include the number of the issue addressed by this PR above, if applicable.
   PRs for code changes without an associated issue *will not be merged*.
   See CONTRIBUTING.md for more information.
 
@@ -26,8 +26,8 @@ resolves #
 
 ### Checklist
 
-- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
-- [ ] I have run this code in development and it appears to resolve the stated issue  
-- [ ] This PR includes tests, or tests are not required/relevant for this PR
-- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
-- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions
+- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
+- [ ] I have run this code in development, and it appears to resolve the stated issue.
+- [ ] This PR includes tests, or tests are not required or relevant for this PR.
+- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
+- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.


### PR DESCRIPTION
My [language linter](https://languagetool.org) pops up several grammar suggestions every time I create a PR.

The goal of this PR is to fix those suggestions, so I don't see them again.