### PR TITLE
add predicate to EventCatcher test util

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,7 @@ from dbt_common.events.base_types import BaseEvent, EventMsg
 class EventCatcher:
     event_to_catch: BaseEvent
     caught_events: List[EventMsg] = field(default_factory=list)
-    predicate: Callable = lambda event: True
+    predicate: Callable[[EventMsg], bool] = lambda event: True
 
     def catch(self, event: EventMsg):
         if event.info.name == self.event_to_catch.__name__ and self.predicate(event):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import Callable, List
 
 from dbt_common.events.base_types import BaseEvent, EventMsg
 
@@ -8,9 +8,10 @@ from dbt_common.events.base_types import BaseEvent, EventMsg
 class EventCatcher:
     event_to_catch: BaseEvent
     caught_events: List[EventMsg] = field(default_factory=list)
+    predicate: Callable = lambda event: True
 
     def catch(self, event: EventMsg):
-        if event.info.name == self.event_to_catch.__name__:
+        if event.info.name == self.event_to_catch.__name__ and self.predicate(event):
             self.caught_events.append(event)
 
     def flush(self) -> None:


### PR DESCRIPTION
Resolves # N/A

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
The `EventCatcher` module is great for catching specific event types and ensuring they were fired during execution. However, if you want to ensure that specific instantiations of that event type were fired, the mechanism is not flexible enough

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Add an optional `predicate` field to `EventCatcher`. It should be a callable that accepts an `EventMsg` and returns a boolean so we can do more flexible event catching (e.g. `predicate=lambda event: event.data.something == "something!"`)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ x This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
