### PR TITLE
Add `report` ExposureType

### DIFF
--- a/.changes/unreleased/Features-20240728-115152.yaml
+++ b/.changes/unreleased/Features-20240728-115152.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add `report` exposure type.
+time: 2024-07-28T11:51:52.063187-05:00
+custom:
+  Author: menzenski
+  Issue: "10493"

--- a/core/dbt/artifacts/resources/v1/exposure.py
+++ b/core/dbt/artifacts/resources/v1/exposure.py
@@ -16,6 +16,7 @@ class ExposureType(StrEnum):
     Analysis = "analysis"
     ML = "ml"
     Application = "application"
+    Report = "report"
 
 
 class MaturityType(StrEnum):

--- a/tests/unit/contracts/graph/test_nodes_parsed.py
+++ b/tests/unit/contracts/graph/test_nodes_parsed.py
@@ -2143,6 +2143,106 @@ def test_complex_parsed_exposure(complex_parsed_exposure_dict, complex_parsed_ex
     assert_symmetric(complex_parsed_exposure_object, complex_parsed_exposure_dict, Exposure)
 
 
+exposure_type_mappings = [
+    ("analysis", ExposureType.Analysis),
+    ("application", ExposureType.Application),
+    ("dashboard", ExposureType.Dashboard),
+    ("ml", ExposureType.ML),
+    ("notebook", ExposureType.Notebook),
+    ("report", ExposureType.Report),
+]
+
+
+@pytest.fixture(params=exposure_type_mappings)
+def basic_parsed_exposure_dict_and_object(request):
+    """Fixture to provide a basic parsed exposure dict and object for each exposure type.
+
+    Accepts a request where request.param is a tuple containing the exposure type string and object, for example,
+    ("analysis", ExposureType.Analysis).
+
+    Returns:
+        Tuple[dict, dict, Exposure]: A throuple (three-tuple) containing minimal parsed exposure dict, basic parsed
+        exposure dict, and basic parsed exposure object, all with matching ExposureType values.
+    """
+    exposure_type_str, exposure_type = request.param
+
+    minimal_parsed_exposure_dict = {
+        "name": "my_exposure",
+        "type": exposure_type_str,
+        "owner": {
+            "email": "test@example.com",
+        },
+        "fqn": ["test", "exposures", "my_exposure"],
+        "unique_id": "exposure.test.my_exposure",
+        "package_name": "test",
+        "meta": {},
+        "tags": [],
+        "path": "models/something.yml",
+        "original_file_path": "models/something.yml",
+        "description": "",
+        "created_at": 1.0,
+        "resource_type": "exposure",
+    }
+
+    basic_parsed_exposure_dict = {
+        "name": "my_exposure",
+        "type": exposure_type_str,
+        "owner": {
+            "email": "test@example.com",
+        },
+        "resource_type": "exposure",
+        "depends_on": {
+            "nodes": [],
+            "macros": [],
+        },
+        "refs": [],
+        "sources": [],
+        "metrics": [],
+        "fqn": ["test", "exposures", "my_exposure"],
+        "unique_id": "exposure.test.my_exposure",
+        "package_name": "test",
+        "path": "models/something.yml",
+        "original_file_path": "models/something.yml",
+        "description": "",
+        "meta": {},
+        "tags": [],
+        "created_at": 1.0,
+        "config": {
+            "enabled": True,
+        },
+        "unrendered_config": {},
+    }
+
+    basic_parsed_exposure_object = Exposure(
+        name="my_exposure",
+        resource_type=NodeType.Exposure,
+        type=exposure_type,
+        fqn=["test", "exposures", "my_exposure"],
+        unique_id="exposure.test.my_exposure",
+        package_name="test",
+        path="models/something.yml",
+        original_file_path="models/something.yml",
+        owner=Owner(email="test@example.com"),
+        description="",
+        meta={},
+        tags=[],
+        config=ExposureConfig(),
+        unrendered_config={},
+    )
+
+    return minimal_parsed_exposure_dict, basic_parsed_exposure_dict, basic_parsed_exposure_object
+
+
+@pytest.mark.parametrize(
+    "basic_parsed_exposure_dict_and_object", exposure_type_mappings, indirect=True
+)
+def test_basic_parsed_exposure_all_exposure_types(basic_parsed_exposure_dict_and_object):
+    minimal_dict, basic_dict, basic_obj = basic_parsed_exposure_dict_and_object
+    assert_symmetric(basic_obj, basic_dict, Exposure)
+    assert_from_dict(basic_obj, minimal_dict, Exposure)
+    pickle.loads(pickle.dumps(basic_obj))
+
+
 unchanged_parsed_exposures = [
     lambda u: (u, u),
 ]


### PR DESCRIPTION
Addresses https://github.com/dbt-labs/dbt-core/issues/10493 - I haven't yet received feedback from project maintainers on this issue, but this seems like a small and straightforward change so opening the PR in case this is the right way to do this.

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

See linked issue for more detail, but the existing ExposureType enumeration is not granular enough to account for all types of downstream dbt project consumers.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Adds a new ExposureType enum value `report`.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
