### PR TITLE
Bump dbt-adapters to 1.3.0

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -72,7 +72,7 @@ setup(
         "dbt-semantic-interfaces>=0.6.8,<0.7",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.6.0,<2.0",
-        "dbt-adapters>=1.1.1,<2.0",
+        "dbt-adapters>=1.3.0,<2.0",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
         "packaging>20.9",


### PR DESCRIPTION
Bump dbt-adapters to 1.3.0 to bring in `get_catalog_for_single_relation` macro

https://github.com/dbt-labs/dbt-adapters/blob/4b2755dd129c54f04c3d467cd7e83a46d0afc01a/.changes/1.3.0.md