### PR TITLE
Bump DSI version to release new time spine validations

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -69,7 +69,7 @@ setup(
         # Accept patches but avoid automatically updating past a set minor version range.
         "dbt-extractor>=0.5.0,<=0.6",
         "minimal-snowplow-tracker>=0.0.2,<0.1",
-        "dbt-semantic-interfaces>=0.6.10,<0.7",
+        "dbt-semantic-interfaces>=0.6.11,<0.7",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.6.0,<2.0",
         "dbt-adapters>=1.3.0,<2.0",


### PR DESCRIPTION
### Description
Some validation warnings were recently added to DSI to improve the experience of setting new time spine configs. This bumps the minimum version of DSI up to the one that has those validations to ensure that versionless users start seeing them.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
