### PR TITLE
more defensive node.all_constraints access

### DIFF
--- a/.changes/unreleased/Fixes-20240731-095152.yaml
+++ b/.changes/unreleased/Fixes-20240731-095152.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: fix all_constraints access
+time: 2024-07-31T09:51:52.751135-04:00
+custom:
+  Author: michelleark
+  Issue: "10509"

--- a/.changes/unreleased/Fixes-20240731-095152.yaml
+++ b/.changes/unreleased/Fixes-20240731-095152.yaml
@@ -2,5 +2,5 @@ kind: Fixes
 body: fix all_constraints access
 time: 2024-07-31T09:51:52.751135-04:00
 custom:
-  Author: michelleark
+  Author: michelleark gshank
   Issue: "10509"

--- a/.changes/unreleased/Fixes-20240731-095152.yaml
+++ b/.changes/unreleased/Fixes-20240731-095152.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: fix all_constraints access
+body: fix all_constraints access, disabled node parsing of non-uniquely named resources
 time: 2024-07-31T09:51:52.751135-04:00
 custom:
   Author: michelleark gshank

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -442,7 +442,7 @@ class Compiler:
             node.relation_name = relation_name
 
         # Compile 'ref' and 'source' expressions in foreign key constraints
-        if node.resource_type == NodeType.Model and isinstance(node, ModelNode):
+        if isinstance(node, ModelNode):
             for constraint in node.all_constraints:
                 if constraint.type == ConstraintType.foreign_key and constraint.to:
                     constraint.to = self._compile_relation_for_foreign_key_constraint_to(

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -21,6 +21,7 @@ from dbt.contracts.graph.nodes import (
     InjectedCTE,
     ManifestNode,
     ManifestSQLNode,
+    ModelNode,
     SeedNode,
     UnitTestDefinition,
     UnitTestNode,
@@ -441,7 +442,7 @@ class Compiler:
             node.relation_name = relation_name
 
         # Compile 'ref' and 'source' expressions in foreign key constraints
-        if node.resource_type == NodeType.Model:
+        if node.resource_type == NodeType.Model and isinstance(node, ModelNode):
             for constraint in node.all_constraints:
                 if constraint.type == ConstraintType.foreign_key and constraint.to:
                     constraint.to = self._compile_relation_for_foreign_key_constraint_to(

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -430,8 +430,8 @@ class DisabledLookup(dbtClassMixin):
         self,
         search_name,
         package: Optional[PackageName],
-        resource_types: Optional[List[NodeType]] = None,
         version: Optional[NodeVersion] = None,
+        resource_types: Optional[List[NodeType]] = None,
     ):
         if version:
             search_name = f"{search_name}.v{version}"
@@ -1312,7 +1312,10 @@ class Manifest(MacroMethods, dbtClassMixin):
             # it's possible that the node is disabled
             if disabled is None:
                 disabled = self.disabled_lookup.find(
-                    target_model_name, pkg, REFABLE_NODE_TYPES, target_model_version
+                    target_model_name,
+                    pkg,
+                    version=target_model_version,
+                    resource_types=REFABLE_NODE_TYPES,
                 )
 
         if disabled:

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -451,7 +451,7 @@ class DisabledLookup(dbtClassMixin):
             nodes = pkg_dct[package]
         else:
             return None
-        if not resource_types:
+        if resource_types is None:
             return nodes
         else:
             new_nodes = []

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -413,11 +413,11 @@ class DisabledLookup(dbtClassMixin):
         self.storage: Dict[str, Dict[PackageName, List[Any]]] = {}
         self.populate(manifest)
 
-    def populate(self, manifest):
+    def populate(self, manifest: "Manifest"):
         for node in list(chain.from_iterable(manifest.disabled.values())):
             self.add_node(node)
 
-    def add_node(self, node):
+    def add_node(self, node: GraphMemberNode) -> None:
         if node.search_name not in self.storage:
             self.storage[node.search_name] = {}
         if node.package_name not in self.storage[node.search_name]:
@@ -432,7 +432,7 @@ class DisabledLookup(dbtClassMixin):
         package: Optional[PackageName],
         version: Optional[NodeVersion] = None,
         resource_types: Optional[List[NodeType]] = None,
-    ):
+    ) -> Optional[List[Any]]:
         if version:
             search_name = f"{search_name}.v{version}"
 
@@ -451,6 +451,7 @@ class DisabledLookup(dbtClassMixin):
             nodes = pkg_dct[package]
         else:
             return None
+
         if resource_types is None:
             return nodes
         else:

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -378,6 +378,10 @@ class ParsedNode(ParsedResource, NodeInfoMixin, ParsedNodeMandatory, Serializabl
     def is_external_node(self):
         return False
 
+    @property
+    def all_constraints(self) -> List[Union[ModelLevelConstraint, ColumnLevelConstraint]]:
+        return []
+
 
 @dataclass
 class CompiledNode(CompiledResource, ParsedNode):

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -378,10 +378,6 @@ class ParsedNode(ParsedResource, NodeInfoMixin, ParsedNodeMandatory, Serializabl
     def is_external_node(self):
         return False
 
-    @property
-    def all_constraints(self) -> List[Union[ModelLevelConstraint, ColumnLevelConstraint]]:
-        return []
-
 
 @dataclass
 class CompiledNode(CompiledResource, ParsedNode):

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -701,8 +701,6 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
                 # to append with the unique id
                 source_file.append_patch(patch.yaml_key, found_nodes[0].unique_id)
                 for node in found_nodes:
-                    # if patch.yaml_key == "models" and node.resource_type != NodeType.Model:
-                    #    continue
                     node.patch_path = source_file.file_id
                     # re-calculate the node config with the patch config.  Always do this
                     # for the case when no config is set to ensure the default of true gets captured

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -917,10 +917,12 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
         return UnparsedModelUpdate
 
     def patch_node_properties(self, node, patch: "ParsedNodePatch") -> None:
+        super().patch_node_properties(node, patch)
+
+        # Remaining patch properties are only relevant to ModelNode objects
         if not isinstance(node, ModelNode):
             return
 
-        super().patch_node_properties(node, patch)
         node.version = patch.version
         node.latest_version = patch.latest_version
         node.deprecation_date = patch.deprecation_date

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -917,6 +917,9 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
         return UnparsedModelUpdate
 
     def patch_node_properties(self, node, patch: "ParsedNodePatch") -> None:
+        if not isinstance(node, ModelNode):
+            return
+
         super().patch_node_properties(node, patch)
         node.version = patch.version
         node.latest_version = patch.latest_version
@@ -934,7 +937,7 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
         self.patch_time_spine(node, patch.time_spine)
         node.build_contract_checksum()
 
-    def patch_constraints(self, node, constraints: List[Dict[str, Any]]) -> None:
+    def patch_constraints(self, node: ModelNode, constraints: List[Dict[str, Any]]) -> None:
         contract_config = node.config.get("contract")
         if contract_config.enforced is True:
             self._validate_constraint_prerequisites(node)
@@ -970,7 +973,7 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
                 else:
                     model_node.sources.append(ref_or_source)
 
-    def patch_time_spine(self, node, time_spine: Optional[TimeSpine]) -> None:
+    def patch_time_spine(self, node: ModelNode, time_spine: Optional[TimeSpine]) -> None:
         node.time_spine = time_spine
 
     def _validate_pk_constraints(

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -69,18 +69,20 @@ from dbt_common.events.functions import warn_or_error
 from dbt_common.exceptions import DbtValidationError
 from dbt_common.utils import deep_merge
 
-schema_file_keys = (
-    "models",
-    "seeds",
-    "snapshots",
-    "sources",
-    "macros",
-    "analyses",
-    "exposures",
-    "metrics",
-    "semantic_models",
-    "saved_queries",
-)
+schema_file_keys_to_resource_types = {
+    "models": NodeType.Model,
+    "seeds": NodeType.Seed,
+    "snapshots": NodeType.Snapshot,
+    "sources": NodeType.Source,
+    "macros": NodeType.Macro,
+    "analyses": NodeType.Analysis,
+    "exposures": NodeType.Exposure,
+    "metrics": NodeType.Metric,
+    "semantic_models": NodeType.SemanticModel,
+    "saved_queries": NodeType.SavedQuery,
+}
+
+schema_file_keys = list(schema_file_keys_to_resource_types.keys())
 
 
 # ===============================================================================
@@ -678,8 +680,9 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
         # handle disabled nodes
         if unique_id is None:
             # Node might be disabled. Following call returns list of matching disabled nodes
+            resource_type = schema_file_keys_to_resource_types[patch.yaml_key]
             found_nodes = self.manifest.disabled_lookup.find(
-                patch.name, patch.package_name, [NodeType.Model]
+                patch.name, patch.package_name, [resource_type]
             )
             if found_nodes:
                 if len(found_nodes) > 1 and patch.config.get("enabled"):

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -682,7 +682,7 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
             # Node might be disabled. Following call returns list of matching disabled nodes
             resource_type = schema_file_keys_to_resource_types[patch.yaml_key]
             found_nodes = self.manifest.disabled_lookup.find(
-                patch.name, patch.package_name, [resource_type]
+                patch.name, patch.package_name, resource_types=[resource_type]
             )
             if found_nodes:
                 if len(found_nodes) > 1 and patch.config.get("enabled"):
@@ -816,7 +816,7 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
                 if versioned_model_unique_id is None:
                     # Node might be disabled. Following call returns list of matching disabled nodes
                     found_nodes = self.manifest.disabled_lookup.find(
-                        versioned_model_name, None, [NodeType.Model]
+                        versioned_model_name, None, resource_types=[NodeType.Model]
                     )
                     if found_nodes:
                         if len(found_nodes) > 1 and target.config.get("enabled"):

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -949,6 +949,9 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
         Populate model_node.refs and model_node.sources based on foreign-key constraint references,
         whether defined at the model-level or column-level.
         """
+        if not isinstance(model_node, ModelNode):
+            return
+
         for constraint in model_node.all_constraints:
             if constraint.type == ConstraintType.foreign_key and constraint.to:
                 try:

--- a/tests/functional/configs/test_disabled_configs.py
+++ b/tests/functional/configs/test_disabled_configs.py
@@ -88,3 +88,47 @@ class TestDisabledConfigs(BaseConfigProject):
         assert len(results) == 2
         results = run_dbt(["test"])
         assert len(results) == 5
+
+
+my_analysis_sql = """
+{{
+    config(enabled=False)
+}}
+select 1 as id
+"""
+
+
+schema_yml = """
+models:
+  - name: my_analysis
+    description: "A Sample model"
+    config:
+        meta:
+          owner: Joe
+
+analyses:
+  - name: my_analysis
+    description: "A sample analysis"
+    config:
+      enabled: false
+"""
+
+
+class TestDisabledConfigsSameName:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_analysis.sql": my_analysis_sql,
+            "schema.yml": schema_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def analyses(self):
+        return {
+            "my_analysis.sql": my_analysis_sql,
+        }
+
+    def test_disabled_analysis(self, project):
+        manifest = run_dbt(["parse"])
+        assert len(manifest.disabled) == 2
+        assert len(manifest.nodes) == 0


### PR DESCRIPTION
Resolves #https://github.com/dbt-labs/dbt-core/issues/10509

This PR introduces:
* dummy `all_constraints` property on ParsedNode
* fix for DisabledLookup.find, which could return nodes of any type as long as the name was the same. This meant a non-model node could make its way to the `ModelPatchParser`.
