### PR TITLE
Prevent error when `node.tags` is `None`

### DIFF
--- a/.changes/unreleased/Fixes-20240802-162205.yaml
+++ b/.changes/unreleased/Fixes-20240802-162205.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Prevent error when `node.tags` is `None`
+time: 2024-08-02T16:22:05.2458-07:00
+custom:
+  Author: dbeatty10
+  Issue: "10519"

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -274,7 +274,11 @@ class TagSelectorMethod(SelectorMethod):
     def search(self, included_nodes: Set[UniqueId], selector: str) -> Iterator[UniqueId]:
         """yields nodes from included that have the specified tag"""
         for unique_id, node in self.all_nodes(included_nodes):
-            if hasattr(node, "tags") and any(fnmatch(tag, selector) for tag in node.tags):
+            if (
+                hasattr(node, "tags")
+                and node.tags
+                and any(fnmatch(tag, selector) for tag in node.tags)
+            ):
                 yield unique_id
 
 


### PR DESCRIPTION
Resolves #10519

### Problem

Dagster runs into an error when a manifest node has `tags` defined but it is `None`.

### Solution

Skip iteration when `tags` is `None` or an empty list.

I didn't add any new tests here because I wasn't able to get an error when using the dbt CLI.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes.
- [x] This PR doesn't have any new and modified functions for type annotations to apply to.
