### PR TITLE
Improve tree traversal of select_children

### DIFF
--- a/.changes/unreleased/Under the Hood-20240809-130234.yaml
+++ b/.changes/unreleased/Under the Hood-20240809-130234.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Improve speed of tree traversal when finding children, increasing build speed for some selectors
+time: 2024-08-09T13:02:34.759905-07:00
+custom:
+    Author: ttusing
+    Issue: "10434"

--- a/core/dbt/graph/graph.py
+++ b/core/dbt/graph/graph.py
@@ -67,7 +67,7 @@ class Graph:
         while len(selected) > 0 and (max_depth is None or i < max_depth):
             next_layer: Set[UniqueId] = set()
             for node in selected:
-                next_layer.update(self.graph.successors(node))
+                next_layer.update(self.graph.descendants(node))
             next_layer = next_layer - children  # Avoid re-searching
             children.update(next_layer)
             selected = next_layer
@@ -86,7 +86,7 @@ class Graph:
         while len(selected) > 0 and (max_depth is None or i < max_depth):
             next_layer: Set[UniqueId] = set()
             for node in selected:
-                next_layer.update(self.graph.predecessors(node))
+                next_layer.update(self.graph.ancestors(node))
             next_layer = next_layer - parents  # Avoid re-searching
             parents.update(next_layer)
             selected = next_layer

--- a/core/dbt/graph/graph.py
+++ b/core/dbt/graph/graph.py
@@ -56,14 +56,6 @@ class Graph:
         ancestors_for = self.select_children(selected) | selected
         return self.select_parents(ancestors_for) | ancestors_for
 
-    def select_relative(
-        self, selected: Set[UniqueId], method: str, max_depth: Optional[int] = None
-    ):
-        if method not in ("children", "parents", "childrens_parents"):
-            raise ValueError(
-                f"Invalid method: {method}. Must be one of 'children', 'parents', or 'childrens_parents'."
-            )
-
     def select_children(
         self, selected: Set[UniqueId], max_depth: Optional[int] = None
     ) -> Set[UniqueId]:

--- a/core/dbt/graph/graph.py
+++ b/core/dbt/graph/graph.py
@@ -67,7 +67,7 @@ class Graph:
         while len(selected) > 0 and (max_depth is None or i < max_depth):
             next_layer: Set[UniqueId] = set()
             for node in selected:
-                next_layer.update(self.graph.descendants(node))
+                next_layer.update(self.descendants(node, 1))
             next_layer = next_layer - children  # Avoid re-searching
             children.update(next_layer)
             selected = next_layer
@@ -86,7 +86,7 @@ class Graph:
         while len(selected) > 0 and (max_depth is None or i < max_depth):
             next_layer: Set[UniqueId] = set()
             for node in selected:
-                next_layer.update(self.graph.ancestors(node))
+                next_layer.update(self.ancestors(node, 1))
             next_layer = next_layer - parents  # Avoid re-searching
             parents.update(next_layer)
             selected = next_layer


### PR DESCRIPTION
Resolves #10434
https://github.com/dbt-labs/dbt-core/issues/10434
<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

DBT core performance was reported as degraded between `1.5` and `1.8` for some users with selectors of the style `tag:mytag+`. For selectors like this and for some large DAGs, the current implementation of getting descendants makes unnecessarily many calls to find children get the edge type, which I believe is a new check in finding children between `1.5` and `1.8`. Many nodes may have the same descendents; this implementation takes care not to check the same edge twice.

### Solution

This searches for descendents by stepping at a depth at 1 at a time, de-duplicating descendents by nature of Python sets, and removes nodes at each step that have already had their descendents searched.

I am looking for user testing to see if this improves performance and to apply this solution to parents as well if it is helpful.

I am seeing improved performance and will post my results in the issue thread.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
