### PR TITLE
Depend on Un-forked snowplow-tracker

### DIFF
--- a/.changes/unreleased/Under the Hood-20240806-155406.yaml
+++ b/.changes/unreleased/Under the Hood-20240806-155406.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Move from minimal-snowplow-tracker fork back to snowplow-tracker
+time: 2024-08-06T15:54:06.422444-04:00
+custom:
+  Author: peterallenwebb
+  Issue: "8409"

--- a/core/setup.py
+++ b/core/setup.py
@@ -59,6 +59,7 @@ setup(
         "networkx>=2.3,<4.0",
         "protobuf>=4.0.0,<5",
         "requests<3.0.0",  # should match dbt-common
+        "snowplow-tracker>=1.0.2,<2.0",
         # ----
         # These packages are major-version-0. Keep upper bounds on upcoming minor versions (which could have breaking changes)
         # and check compatibility / bump in each new minor version of dbt-core.
@@ -68,7 +69,6 @@ setup(
         # These are major-version-0 packages also maintained by dbt-labs.
         # Accept patches but avoid automatically updating past a set minor version range.
         "dbt-extractor>=0.5.0,<=0.6",
-        "minimal-snowplow-tracker>=0.0.2,<0.1",
         "dbt-semantic-interfaces>=0.6.11,<0.7",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.6.0,<2.0",


### PR DESCRIPTION
Resolves #8409 

### Problem

Our historical fork of snowplow-tracker, known as minimal-snowplow-tracker, is not well maintained, and causes issues for downstream consumers of dbt-core.

### Solution

Now that snowplow-tracker is more mature, with fewer dependencies, move back to using it directly.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
