### PR TITLE
Add `order_by` and `limit` fields to saved queries

### DIFF
--- a/.changes/unreleased/Features-20240806-144859.yaml
+++ b/.changes/unreleased/Features-20240806-144859.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add `order_by` and `limit` fields to saved queries.
+time: 2024-08-06T14:48:59.035914-07:00
+custom:
+  Author: plypaul
+  Issue: "10531"

--- a/core/dbt/artifacts/resources/v1/saved_query.py
+++ b/core/dbt/artifacts/resources/v1/saved_query.py
@@ -44,6 +44,8 @@ class QueryParams(dbtClassMixin):
     metrics: List[str]
     group_by: List[str]
     where: Optional[WhereFilterIntersection]
+    order_by: List[str] = field(default_factory=list)
+    limit: Optional[int] = None
 
 
 @dataclass

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -720,6 +720,8 @@ class UnparsedQueryParams(dbtClassMixin):
     group_by: List[str] = field(default_factory=list)
     # Note: `Union` must be the outermost part of the type annotation for serialization to work properly.
     where: Union[str, List[str], None] = None
+    order_by: List[str] = field(default_factory=list)
+    limit: Optional[int] = None
 
 
 @dataclass

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -788,6 +788,8 @@ class SavedQueryParser(YamlReader):
             group_by=unparsed.group_by,
             metrics=unparsed.metrics,
             where=parse_where_filter(unparsed.where),
+            order_by=unparsed.order_by,
+            limit=unparsed.limit,
         )
 
     def parse_saved_query(self, unparsed: UnparsedSavedQuery) -> None:

--- a/schemas/dbt/catalog/v1.json
+++ b/schemas/dbt/catalog/v1.json
@@ -12,7 +12,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.9.0a1"
+          "default": "1.9.0b2"
         },
         "generated_at": {
           "type": "string"

--- a/schemas/dbt/manifest/v12.json
+++ b/schemas/dbt/manifest/v12.json
@@ -13,7 +13,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.9.0a1"
+          "default": "1.9.0b2"
         },
         "generated_at": {
           "type": "string"
@@ -701,6 +701,12 @@
                 "type": "number"
               },
               "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "unrendered_config_call_dict": {
                 "type": "object",
                 "propertyNames": {
                   "type": "string"
@@ -1739,6 +1745,12 @@
                   "type": "string"
                 }
               },
+              "unrendered_config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
               "relation_name": {
                 "anyOf": [
                   {
@@ -2382,6 +2394,12 @@
                 "type": "number"
               },
               "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "unrendered_config_call_dict": {
                 "type": "object",
                 "propertyNames": {
                   "type": "string"
@@ -3167,6 +3185,12 @@
                 "type": "number"
               },
               "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "unrendered_config_call_dict": {
                 "type": "object",
                 "propertyNames": {
                   "type": "string"
@@ -3971,6 +3995,12 @@
                 "type": "number"
               },
               "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "unrendered_config_call_dict": {
                 "type": "object",
                 "propertyNames": {
                   "type": "string"
@@ -5331,6 +5361,12 @@
                   "type": "string"
                 }
               },
+              "unrendered_config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
               "relation_name": {
                 "anyOf": [
                   {
@@ -5974,6 +6010,12 @@
                 "type": "number"
               },
               "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "unrendered_config_call_dict": {
                 "type": "object",
                 "propertyNames": {
                   "type": "string"
@@ -6937,6 +6979,12 @@
                 "type": "number"
               },
               "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "unrendered_config_call_dict": {
                 "type": "object",
                 "propertyNames": {
                   "type": "string"
@@ -10543,6 +10591,12 @@
                         "type": "string"
                       }
                     },
+                    "unrendered_config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
                     "relation_name": {
                       "anyOf": [
                         {
@@ -11576,6 +11630,12 @@
                         "type": "string"
                       }
                     },
+                    "unrendered_config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
                     "relation_name": {
                       "anyOf": [
                         {
@@ -12219,6 +12279,12 @@
                       "type": "number"
                     },
                     "config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "unrendered_config_call_dict": {
                       "type": "object",
                       "propertyNames": {
                         "type": "string"
@@ -13004,6 +13070,12 @@
                       "type": "number"
                     },
                     "config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "unrendered_config_call_dict": {
                       "type": "object",
                       "propertyNames": {
                         "type": "string"
@@ -13808,6 +13880,12 @@
                       "type": "number"
                     },
                     "config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "unrendered_config_call_dict": {
                       "type": "object",
                       "propertyNames": {
                         "type": "string"
@@ -15168,6 +15246,12 @@
                         "type": "string"
                       }
                     },
+                    "unrendered_config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
                     "relation_name": {
                       "anyOf": [
                         {
@@ -15811,6 +15895,12 @@
                       "type": "number"
                     },
                     "config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "unrendered_config_call_dict": {
                       "type": "object",
                       "propertyNames": {
                         "type": "string"
@@ -16774,6 +16864,12 @@
                       "type": "number"
                     },
                     "config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "unrendered_config_call_dict": {
                       "type": "object",
                       "propertyNames": {
                         "type": "string"
@@ -19542,6 +19638,23 @@
                               "type": "null"
                             }
                           ]
+                        },
+                        "order_by": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "limit": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
                         }
                       },
                       "additionalProperties": false,
@@ -21076,6 +21189,23 @@
                     "type": "null"
                   }
                 ]
+              },
+              "order_by": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "limit": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
               }
             },
             "additionalProperties": false,

--- a/schemas/dbt/run-results/v6.json
+++ b/schemas/dbt/run-results/v6.json
@@ -12,7 +12,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.9.0a1"
+          "default": "1.9.0b2"
         },
         "generated_at": {
           "type": "string"

--- a/schemas/dbt/sources/v3.json
+++ b/schemas/dbt/sources/v3.json
@@ -12,7 +12,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.9.0a1"
+          "default": "1.9.0b2"
         },
         "generated_at": {
           "type": "string"

--- a/tests/functional/saved_queries/fixtures.py
+++ b/tests/functional/saved_queries/fixtures.py
@@ -16,6 +16,10 @@ saved_queries:
             - "{{ TimeDimension('id__ds', 'DAY') }} <= now()"
             - "{{ TimeDimension('id__ds', 'DAY') }} >= '2023-01-01'"
             - "{{ Metric('txn_revenue', ['id']) }} > 1"
+        order_by:
+            - "Metric('simple_metric')"
+            - "Dimension('id__ds')"
+        limit: 10
     exports:
         - name: my_export
           config:

--- a/tests/functional/saved_queries/test_saved_query_parsing.py
+++ b/tests/functional/saved_queries/test_saved_query_parsing.py
@@ -66,6 +66,10 @@ class TestSavedQueryParsing:
         assert len(saved_query.query_params.group_by) == 1
         assert len(saved_query.query_params.where.where_filters) == 3
         assert len(saved_query.depends_on.nodes) == 1
+
+        assert len(saved_query.query_params.order_by) == 2
+        assert saved_query.query_params.limit is not None
+
         assert saved_query.description == "My SavedQuery Description"
         assert len(saved_query.exports) == 1
         assert saved_query.exports[0].name == "my_export"


### PR DESCRIPTION
Resolves #10531

### Problem

Saved queries do not allow specification of a limit to the number of rows returns or items to order the results.

Related: https://github.com/dbt-labs/metricflow/issues/1113

### Solution

Add `order_by` and `limit` fields to the saved query definition.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
