### PR TITLE
Propagate the measure label when using create_metric option

### DIFF
--- a/.changes/unreleased/Fixes-20240806-172110.yaml
+++ b/.changes/unreleased/Fixes-20240806-172110.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Propagate measure label when using create_metrics
+time: 2024-08-06T17:21:10.265494-07:00
+custom:
+    Author: aliceliu
+    Issue: "10536"

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -612,7 +612,7 @@ class SemanticModelParser(YamlReader):
     ) -> None:
         unparsed_metric = UnparsedMetric(
             name=measure.name,
-            label=measure.name,
+            label=measure.label or measure.name,
             type="simple",
             type_params=UnparsedMetricTypeParams(measure=measure.name, expr=measure.name),
             description=measure.description or f"Metric created from measure {measure.name}",

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -240,6 +240,12 @@ semantic_models:
         agg: sum
         agg_time_dimension: ds
         create_metric: true
+      - name: txn_revenue_with_label
+        label: "Transaction Revenue with label"
+        expr: revenue
+        agg: sum
+        agg_time_dimension: ds
+        create_metric: true
       - name: sum_of_things
         expr: 2
         agg: sum

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -38,11 +38,14 @@ class TestSemanticModelParsing:
             semantic_model.node_relation.relation_name
             == f'"dbt"."{project.test_schema}"."fct_revenue"'
         )
-        assert len(semantic_model.measures) == 6
-        # manifest should have one metric (that was created from a measure)
-        assert len(manifest.metrics) == 2
+        assert len(semantic_model.measures) == 7
+        # manifest should have two metrics created from measures
+        assert len(manifest.metrics) == 3
         metric = manifest.metrics["metric.test.txn_revenue"]
         assert metric.name == "txn_revenue"
+        metric_with_label = manifest.metrics["metric.test.txn_revenue_with_label"]
+        assert metric_with_label.name == "txn_revenue_with_label"
+        assert metric_with_label.label == "Transaction Revenue with label"
 
     def test_semantic_model_error(self, project):
         # Next, modify the default schema.yml to remove the semantic model.
@@ -107,6 +110,7 @@ class TestSemanticModelPartialParsing:
 
     def test_semantic_model_flipping_create_metric_partial_parsing(self, project):
         generated_metric = "metric.test.txn_revenue"
+        generated_metric_with_label = "metric.test.txn_revenue_with_label"
         # First, use the default schema.yml to define our semantic model, and
         # run the dbt parse command
         write_file(schema_yml, project.project_root, "models", "schema.yml")
@@ -117,6 +121,11 @@ class TestSemanticModelPartialParsing:
         # Verify the metric created by `create_metric: true` exists
         metric = result.result.metrics[generated_metric]
         assert metric.name == "txn_revenue"
+        assert metric.label == "txn_revenue"
+
+        metric_with_label = result.result.metrics[generated_metric_with_label]
+        assert metric_with_label.name == "txn_revenue_with_label"
+        assert metric_with_label.label == "Transaction Revenue with label"
 
         # --- Next, modify the default schema.yml to have no `create_metric: true` ---
         no_create_metric_schema_yml = schema_yml.replace(


### PR DESCRIPTION
Resolves #10538 

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
When using create_metric on a measure, the label of the measure is not propagated to the metric

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Set metric label to be measure label if it exists

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
