### PR TITLE
[1.7 backport] buffer deprecations to respect --quiet and --warn-error-options

### DIFF
--- a/.changes/unreleased/Fixes-20240806-194843.yaml
+++ b/.changes/unreleased/Fixes-20240806-194843.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: respect --quiet and --warn-error-options for flag deprecations
+time: 2024-08-06T19:48:43.399453-04:00
+custom:
+  Author: michelleark
+  Issue: "10105"

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -15,7 +15,7 @@ from dbt.cli.types import Command as CliCommand
 from dbt.config.project import read_project_flags
 from dbt.contracts.project import ProjectFlags
 from dbt.exceptions import DbtInternalError
-from dbt.deprecations import renamed_env_var
+from dbt.deprecations import fire_buffered_deprecations, renamed_env_var
 from dbt.helper_types import WarnErrorOptions
 
 if os.name != "nt":
@@ -301,6 +301,8 @@ class Flags:
         # It is necessary to remove this attr from the class so it does
         # not get pickled when written to disk as json.
         object.__delattr__(self, "deprecated_env_var_warnings")
+
+        fire_buffered_deprecations()
 
     @classmethod
     def from_dict(cls, command: CliCommand, args_dict: Dict[str, Any]) -> "Flags":

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -819,8 +819,8 @@ def read_project_flags(project_dir: str, profiles_dir: str) -> ProjectFlags:
 
         if profile_project_flags:
             # This can't use WARN_ERROR or WARN_ERROR_OPTIONS because they're in
-            # the config that we're loading. Uses special "warn" method.
-            deprecations.warn("project-flags-moved")
+            # the config that we're loading. Uses special "buffer" method and fired after flags are initialized in preflight.
+            deprecations.buffer("project-flags-moved")
             project_flags = profile_project_flags
 
         if project_flags is not None:

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -2,7 +2,7 @@ import pytest
 
 from dbt import deprecations
 import dbt.exceptions
-from dbt.tests.util import run_dbt, write_file
+from dbt.tests.util import run_dbt, run_dbt_and_capture, write_file
 import yaml
 
 
@@ -160,7 +160,7 @@ class TestExposureNameDeprecation:
         assert expected_msg in exc_str
 
 
-class TestPrjectFlagsMovedDeprecation:
+class TestProjectFlagsMovedDeprecation:
     @pytest.fixture(scope="class")
     def profiles_config_update(self):
         return {
@@ -183,6 +183,45 @@ class TestPrjectFlagsMovedDeprecation:
     def test_profile_config_deprecation(self, project):
         deprecations.reset_deprecations()
         assert deprecations.active_deprecations == set()
-        run_dbt(["parse"])
-        expected = {"project-flags-moved"}
-        assert expected == deprecations.active_deprecations
+
+        _, logs = run_dbt_and_capture(["parse"])
+
+        assert (
+            "User config should be moved from the 'config' key in profiles.yml to the 'flags' key in dbt_project.yml."
+            in logs
+        )
+        assert deprecations.active_deprecations == {"project-flags-moved"}
+
+
+class TestProjectFlagsMovedDeprecationQuiet(TestProjectFlagsMovedDeprecation):
+    def test_profile_config_deprecation(self, project):
+        deprecations.reset_deprecations()
+        assert deprecations.active_deprecations == set()
+
+        _, logs = run_dbt_and_capture(["--quiet", "parse"])
+
+        assert (
+            "User config should be moved from the 'config' key in profiles.yml to the 'flags' key in dbt_project.yml."
+            not in logs
+        )
+        assert deprecations.active_deprecations == {"project-flags-moved"}
+
+
+class TestProjectFlagsMovedDeprecationWarnErrorOptions(TestProjectFlagsMovedDeprecation):
+    def test_profile_config_deprecation(self, project):
+        deprecations.reset_deprecations()
+        with pytest.raises(dbt.exceptions.EventCompilationError):
+            run_dbt(["--warn-error-options", "{'include': 'all'}", "parse"])
+
+        with pytest.raises(dbt.exceptions.EventCompilationError):
+            run_dbt(
+                ["--warn-error-options", "{'include': ['ProjectFlagsMovedDeprecation']}", "parse"]
+            )
+
+        _, logs = run_dbt_and_capture(
+            ["--warn-error-options", "{'silence': ['ProjectFlagsMovedDeprecation']}", "parse"]
+        )
+        assert (
+            "User config should be moved from the 'config' key in profiles.yml to the 'flags' key in dbt_project.yml."
+            not in logs
+        )

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -217,11 +217,3 @@ class TestProjectFlagsMovedDeprecationWarnErrorOptions(TestProjectFlagsMovedDepr
             run_dbt(
                 ["--warn-error-options", "{'include': ['ProjectFlagsMovedDeprecation']}", "parse"]
             )
-
-        _, logs = run_dbt_and_capture(
-            ["--warn-error-options", "{'silence': ['ProjectFlagsMovedDeprecation']}", "parse"]
-        )
-        assert (
-            "User config should be moved from the 'config' key in profiles.yml to the 'flags' key in dbt_project.yml."
-            not in logs
-        )

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -1,15 +1,36 @@
-from dbt.internal_deprecations import deprecated
-from dbt.flags import set_from_args
-from argparse import Namespace
+import pytest
+
+import dbt.deprecations as deprecations
 
 
-@deprecated(reason="just because", version="1.23.0", suggested_action="Make some updates")
-def to_be_decorated():
-    return 5
+@pytest.fixture(scope="function")
+def active_deprecations():
+    assert not deprecations.active_deprecations
+
+    yield deprecations.active_deprecations
+
+    deprecations.reset_deprecations()
 
 
-# simple test that the return value is not modified
-def test_deprecated_func():
-    set_from_args(Namespace(WARN_ERROR=False), None)
-    assert hasattr(to_be_decorated, "__wrapped__")
-    assert to_be_decorated() == 5
+@pytest.fixture(scope="function")
+def buffered_deprecations():
+    assert not deprecations.buffered_deprecations
+
+    yield deprecations.buffered_deprecations
+
+    deprecations.buffered_deprecations.clear()
+
+
+def test_buffer_deprecation(active_deprecations, buffered_deprecations):
+    deprecations.buffer("project-flags-moved")
+
+    assert active_deprecations == set()
+    assert len(buffered_deprecations) == 1
+
+
+def test_fire_buffered_deprecations(active_deprecations, buffered_deprecations):
+    deprecations.buffer("project-flags-moved")
+    deprecations.fire_buffered_deprecations()
+
+    assert active_deprecations == set(["project-flags-moved"])
+    assert len(buffered_deprecations) == 0

--- a/tests/unit/test_internal_deprecations.py
+++ b/tests/unit/test_internal_deprecations.py
@@ -1,0 +1,15 @@
+from dbt.internal_deprecations import deprecated
+from dbt.flags import set_from_args
+from argparse import Namespace
+
+
+@deprecated(reason="just because", version="1.23.0", suggested_action="Make some updates")
+def to_be_decorated():
+    return 5
+
+
+# simple test that the return value is not modified
+def test_deprecated_func():
+    set_from_args(Namespace(WARN_ERROR=False), None)
+    assert hasattr(to_be_decorated, "__wrapped__")
+    assert to_be_decorated() == 5


### PR DESCRIPTION
Manual backport of https://github.com/dbt-labs/dbt-core/pull/10534 to 1.7