### PR TITLE
[Tests] reset deprecations prior to usage in unit tests

### DIFF
--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -5,6 +5,7 @@ import dbt.deprecations as deprecations
 
 @pytest.fixture(scope="function")
 def active_deprecations():
+    deprecations.reset_deprecations()
     assert not deprecations.active_deprecations
 
     yield deprecations.active_deprecations
@@ -14,6 +15,7 @@ def active_deprecations():
 
 @pytest.fixture(scope="function")
 def buffered_deprecations():
+    deprecations.buffered_deprecations.clear()
     assert not deprecations.buffered_deprecations
 
     yield deprecations.buffered_deprecations


### PR DESCRIPTION
**Problem**
It's possible for the test_deprecations unit tests to fail if another test has mutated the global `deprecations` or `buffered_deprecations` without cleanup. 

**Solution**
Clear deprecations prior to access in test_deprecations