### PR TITLE
Fix add_ephemeral_prefix to identifier instead of name

### DIFF
--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -375,7 +375,7 @@ class Compiler:
 
             _extend_prepended_ctes(prepended_ctes, new_prepended_ctes)
 
-            new_cte_name = self.add_ephemeral_prefix(cte_model.name)
+            new_cte_name = self.add_ephemeral_prefix(cte_model.identifier)
             rendered_sql = cte_model._pre_injected_sql or cte_model.compiled_code
             sql = f" {new_cte_name} as (\n{rendered_sql}\n)"
 


### PR DESCRIPTION
### Problem

Functional tests for "dbt unit testing" are failing on database errors like so:

```
  An error occurred during execution of unit test 'test_my_model_version_ref'. There may be an error in the unit test definition: check the data types.
   Database Error
    relation "__dbt__cte__my_model_v2" does not exist
    LINE 21: ) select * from __dbt__cte__my_model_v2
```

This is related to this PR merged yesterday: https://github.com/dbt-labs/dbt-adapters/pull/236

### Solution

Pass in `cte_model.identifier` instead of `cte_model.name` to `add_ephemeral_prefix`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
