### PR TITLE
Removing unused add_ephemeral_model_prefix method

### DIFF
--- a/.changes/unreleased/Fixes-20240816-112820.yaml
+++ b/.changes/unreleased/Fixes-20240816-112820.yaml
@@ -1,0 +1,5 @@
+kind: Fixes
+time: 2024-08-16T11:28:20.0982+05:30
+custom:
+    Author: donjin-master
+    Issue: "10471"

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -137,8 +137,8 @@ class memoized:
         return functools.partial(self.__call__, obj)
 
 
-def add_ephemeral_model_prefix(s: str) -> str:
-    return "__dbt__cte__{}".format(s)
+def add_ephemeral_prefix(name: str):
+    return f"__dbt__cte__{name}"
 
 
 def timestring() -> str:


### PR DESCRIPTION
Resolves #10471

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

  This method appears to be unused across dbt-core, dbt-common, and dbt-adapters:


### Solution

Removed the method `add_ephemeral_model_prefix`
Replaced this method with 
```
    def add_ephemeral_prefix(name: str):
        return f"__dbt__cte__{name}"
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.

