### PR TITLE
Fix #10471 unused add_ephemeral_model_prefix

### DIFF
--- a/.changes/unreleased/Fixes-20240816-112820.yaml
+++ b/.changes/unreleased/Fixes-20240816-112820.yaml
@@ -1,0 +1,5 @@
+kind: Fixes
+time: 2024-08-16T11:28:20.0982+05:30
+custom:
+    Author: donjin-master
+    Issue: "10471"

--- a/.changes/unreleased/Fixes-20240816-112820.yaml
+++ b/.changes/unreleased/Fixes-20240816-112820.yaml
@@ -1,5 +1,0 @@
-kind: Fixes
-time: 2024-08-16T11:28:20.0982+05:30
-custom:
-    Author: donjin-master
-    Issue: "10471"

--- a/.changes/unreleased/Fixes-20240816-135257.yaml
+++ b/.changes/unreleased/Fixes-20240816-135257.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove unused add_ephemeral_model_prefix
+time: 2024-08-16T13:52:57.035183+05:30
+custom:
+    Author: donjin-master
+    Issue: "10471"

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -137,8 +137,8 @@ class memoized:
         return functools.partial(self.__call__, obj)
 
 
-def add_ephemeral_model_prefix(s: str) -> str:
-    return "__dbt__cte__{}".format(s)
+def add_ephemeral_prefix(name: str):
+    return f"__dbt__cte__{name}"
 
 
 def timestring() -> str:


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/10471

Problem
This method appears to be unused across dbt-core, dbt-common, and dbt-adapters:

Solution
Removed the method add_ephemeral_model_prefix
Replaced this method with

    def add_ephemeral_prefix(name: str):
        return f"__dbt__cte__{name}"
Checklist
 I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
 I have run this code in development, and it appears to resolve the stated issue.