### PR TITLE
Filter out empty nodes after graph selection

### DIFF
--- a/.changes/unreleased/Fixes-20240816-140807.yaml
+++ b/.changes/unreleased/Fixes-20240816-140807.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Filter out empty nodes after graph selection to support consistent selection of nodes that depend on upstream public models
+time: 2024-08-16T14:08:07.426235-07:00
+custom:
+  Author: jtcohen6
+  Issue: "8987"

--- a/tests/unit/graph/test_selector.py
+++ b/tests/unit/graph/test_selector.py
@@ -319,3 +319,7 @@ class TestNodeSelector:
         selector = NodeSelector(graph, manifest)
         spec = graph_selector.SelectionCriteria.from_single_spec("model_one+")
         assert selector.get_selected(spec) == {"model.pkg.model_two"}
+
+        # Ensure that --indirect-selection empty returns the same result
+        spec.indirect_selection = graph_selector.IndirectSelection.Empty
+        assert selector.get_selected(spec) == {"model.pkg.model_two"}

--- a/tests/unit/graph/test_selector.py
+++ b/tests/unit/graph/test_selector.py
@@ -297,3 +297,25 @@ class TestNodeSelector:
                 queue.get(block=False)
             queue.mark_done(got.unique_id)
         assert queue.empty()
+
+    def test_select_downstream_of_empty_model(self, runtime_config: RuntimeConfig):
+        # empty model
+        model_one = make_model(pkg="other", name="model_one", code="")
+        # non-empty model
+        model_two = make_model(
+            pkg="pkg",
+            name="model_two",
+            code="""select * from {{ref('model_one')}}""",
+            refs=[model_one],
+        )
+        models = [model_one, model_two]
+        manifest = make_manifest(nodes=models)
+
+        # Get the graph
+        compiler = dbt.compilation.Compiler(runtime_config)
+        graph = compiler.compile(manifest)
+
+        # Ensure that model_two is selected as downstream of model_one
+        selector = NodeSelector(graph, manifest)
+        spec = graph_selector.SelectionCriteria.from_single_spec("model_one+")
+        assert selector.get_selected(spec) == {"model.pkg.model_two"}


### PR DESCRIPTION
Resolves #8987

### Problem

Empty nodes are filtered out before graph selection, including for parent/child relationships, which makes it impossible to select downstream project models that depend on an upstream public model. Additionally, this behavior is inconsistent for `list` and `run`.

### Solution

Filter out empty nodes after selection is complete, rather than before.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
