### PR TITLE
Bump DSI version

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -69,7 +69,7 @@ setup(
         # These are major-version-0 packages also maintained by dbt-labs.
         # Accept patches but avoid automatically updating past a set minor version range.
         "dbt-extractor>=0.5.0,<=0.6",
-        "dbt-semantic-interfaces>=0.6.11,<0.7",
+        "dbt-semantic-interfaces>=0.7.0,<0.8",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.6.0,<2.0",
         "dbt-adapters>=1.3.0,<2.0",


### PR DESCRIPTION
### Description
Bump DSI version. This is needed to enable development in MetricFlow against new DSI versions. Note that there are no breaking changes in the DSI jump to 0.7.0. There are only a couple small added features which will need to be added to the core parser before they impact users, so this PR will not impact core at all.
For context, the reason this blocks development in MF is that we rely on core adapters in MF tests. So if we upgrade to a version of DSI in MF that's incompatible with core, we're unable to run tests.

### Checklist
- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
