### PR TITLE
Add test for source names with quotes

### DIFF
--- a/.changes/unreleased/Under the Hood-20240821-095516.yaml
+++ b/.changes/unreleased/Under the Hood-20240821-095516.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add test for sources tables with quotes
+time: 2024-08-21T09:55:16.038101-04:00
+custom:
+  Author: gshank
+  Issue: "10582"

--- a/tests/functional/sources/test_name_chars.py
+++ b/tests/functional/sources/test_name_chars.py
@@ -1,0 +1,31 @@
+from dbt.tests.util import get_manifest, run_dbt, write_file
+from tests.fixtures.jaffle_shop import JaffleShopProject
+
+# Note: in an actual file (as opposed to a string that we write into a files)
+# there would only be a single backslash.
+sources_yml = """
+sources:
+  - name: something_else
+    database: raw
+    schema: jaffle_shop
+    tables:
+      - name: "\\"/test/orders\\""
+      - name: customers
+"""
+
+
+class TestNameChars(JaffleShopProject):
+    def test_quotes_in_table_names(self, project):
+        # Write out a sources definition that includes a table name with quotes and a forward slash
+        # Note: forward slashes are not legal in filenames in Linux (or Windows),
+        # so we won't see forward slashes in model names, because they come from file names.
+        write_file(sources_yml, project.project_root, "models", "sources.yml")
+        manifest = run_dbt(["parse"])
+        assert len(manifest.sources) == 2
+        assert 'source.jaffle_shop.something_else."/test/orders"' in manifest.sources.keys()
+        # We've written out the manifest.json artifact, we want to ensure
+        # that it can be read in again (the json is valid).
+        # Note: the key in the json actually looks like: "source.jaffle_shop.something_else.\"/test/orders\""
+        new_manifest = get_manifest(project.project_root)
+        assert new_manifest
+        assert 'source.jaffle_shop.something_else."/test/orders"' in new_manifest.sources.keys()


### PR DESCRIPTION
Resolves #10582


### Problem

We did not have tests for source names with characters requiring escaping in json.

### Solution

Create a test case.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
