### PR TITLE
Fix a column name for the customers schema in the jaffle example

### DIFF
--- a/tests/fixtures/jaffle_shop.py
+++ b/tests/fixtures/jaffle_shop.py
@@ -200,7 +200,7 @@ models:
       - name: number_of_orders
         description: Count of the number of orders a customer has placed
 
-      - name: total_order_amount
+      - name: customer_lifetime_value
         description: Total value (AUD) of a customer's orders
 
   - name: orders


### PR DESCRIPTION
Resolves #

It would be an overkill for this change.

### Problem

This PR fixes a typo in the jaffle example: one column was not named properly in the schema.

### Solution

Update the name to match the one in the sql.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
