### PR TITLE
Allow env_var to be Used in More Contexts

### DIFF
--- a/core/dbt/context/manifest.py
+++ b/core/dbt/context/manifest.py
@@ -3,7 +3,7 @@ from typing import List
 from dbt.adapters.contracts.connection import AdapterRequiredConfig
 from dbt.clients.jinja import MacroStack
 from dbt.context.macro_resolver import TestMacroNamespace
-from dbt.contracts.graph.manifest import Manifest
+from dbt.contracts.graph.manifest import MacroManifest, Manifest
 
 from .base import contextproperty
 from .configured import ConfiguredContext
@@ -22,7 +22,7 @@ class ManifestContext(ConfiguredContext):
     def __init__(
         self,
         config: AdapterRequiredConfig,
-        manifest: Manifest,
+        manifest: Manifest | MacroManifest,
         search_package: str,
     ) -> None:
         super().__init__(config)

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -43,7 +43,7 @@ from dbt.context.exceptions_jinja import wrapped_exports
 from dbt.context.macro_resolver import MacroResolver, TestMacroNamespace
 from dbt.context.macros import MacroNamespace, MacroNamespaceBuilder
 from dbt.context.manifest import ManifestContext
-from dbt.contracts.graph.manifest import Disabled, Manifest
+from dbt.contracts.graph.manifest import Disabled, MacroManifest, Manifest
 from dbt.contracts.graph.metrics import MetricReference, ResolvedMetricReference
 from dbt.contracts.graph.nodes import (
     AccessType,
@@ -815,13 +815,15 @@ class ProviderContext(ManifestContext):
         self,
         model,
         config: RuntimeConfig,
-        manifest: Manifest,
+        manifest: Manifest | MacroManifest,
         provider: Provider,
         context_config: Optional[ContextConfig],
     ) -> None:
         if provider is None:
             raise DbtInternalError(f"Invalid provider given to context: {provider}")
+
         # mypy appeasement - we know it'll be a RuntimeConfig
+
         self.config: RuntimeConfig
         self.model: Union[Macro, ManifestNode] = model
         super().__init__(config, manifest, model.package_name)
@@ -1398,6 +1400,9 @@ class ProviderContext(ManifestContext):
             return_value = default
 
         if return_value is not None:
+            if isinstance(self.manifest, MacroManifest):
+                return return_value
+
             # Save the env_var value in the manifest and the var name in the source_file.
             # If this is compiling, do not save because it's irrelevant to parsing.
             compiling = (
@@ -1594,6 +1599,7 @@ class UnitTestContext(ModelContext):
 
     @contextproperty()
     def this(self) -> Optional[str]:
+        assert isinstance(self.manifest, Manifest)
         if self.model.this_input_node_unique_id:
             this_node = self.manifest.expect(self.model.this_input_node_unique_id)
             self.model.set_cte(this_node.unique_id, None)  # type: ignore
@@ -1868,6 +1874,7 @@ class TestContext(ProviderContext):
         if return_value is not None:
             # Save the env_var value in the manifest and the var name in the source_file
             if self.model:
+                assert isinstance(self.manifest, Manifest)
                 # If the environment variable is set from a default, store a string indicating
                 # that so we can skip partial parsing.  Otherwise the file will be scheduled for
                 # reparsing. If the default changes, the file will have been updated and therefore


### PR DESCRIPTION
Resolves #10599 

### Problem


### Solution


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
