### PR TITLE
Enable calling a macro in a pre- or post-hook config in `properties.yml`

### DIFF
--- a/.changes/unreleased/Fixes-20240824-210903.yaml
+++ b/.changes/unreleased/Fixes-20240824-210903.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Late render pre- and post-hooks configs in properties / schema YAML files
+time: 2024-08-24T21:09:03.252733-06:00
+custom:
+  Author: dbeatty10
+  Issue: "10603"

--- a/core/dbt/parser/schema_renderer.py
+++ b/core/dbt/parser/schema_renderer.py
@@ -11,6 +11,7 @@ from dbt.config.renderer import BaseRenderer, Keypath
 # keyword args are rendered to capture refs in render_test_update.
 # Keyword args are finally rendered at compilation time.
 # Descriptions are not rendered until 'process_docs'.
+# Pre- and post-hooks in configs are late-rendered.
 class SchemaYamlRenderer(BaseRenderer):
     def __init__(self, context: Dict[str, Any], key: str) -> None:
         super().__init__(context)
@@ -41,6 +42,14 @@ class SchemaYamlRenderer(BaseRenderer):
 
         # columns descriptions and data_tests
         if len(keypath) == 2 and keypath[1] in ("tests", "data_tests", "description"):
+            return True
+
+        # pre- and post-hooks
+        if (
+            len(keypath) >= 2
+            and keypath[0] == "config"
+            and keypath[1] in ("pre_hook", "post_hook")
+        ):
             return True
 
         # versions

--- a/tests/functional/adapter/hooks/fixtures.py
+++ b/tests/functional/adapter/hooks/fixtures.py
@@ -27,9 +27,9 @@ select 1 as col
 """
 
 macros__before_and_after = """
-{% macro custom_run_hook(state, target, run_started_at, invocation_id) %}
+{% macro custom_run_hook(state, target, run_started_at, invocation_id, table_name="on_run_hook") %}
 
-   insert into {{ target.schema }}.on_run_hook (
+   insert into {{ target.schema }}.{{ table_name }} (
         test_state,
         target_dbname,
         target_host,
@@ -353,6 +353,26 @@ snapshots:
   - name: new_col
     data_tests:
     - not_null
+"""
+
+properties__model_hooks = """
+version: 2
+models:
+  - name: hooks
+    config:
+      pre_hook: "{{ custom_run_hook('start', target, run_started_at, invocation_id, table_name='on_model_hook') }}"
+      post_hook: "{{ custom_run_hook('end', target, run_started_at, invocation_id, table_name='on_model_hook') }}"
+"""
+
+properties__model_hooks_list = """
+version: 2
+models:
+  - name: hooks
+    config:
+      pre_hook:
+        - "{{ custom_run_hook('start', target, run_started_at, invocation_id, table_name='on_model_hook') }}"
+      post_hook:
+        - "{{ custom_run_hook('end', target, run_started_at, invocation_id, table_name='on_model_hook') }}"
 """
 
 seeds__example_seed_csv = """a,b,c


### PR DESCRIPTION
Resolves #7128

### Problem

Because pre- and post-hooks within `properties.yml` files are not late-rendered for models, seeds, etc., references to `{{ this }}`, macros, etc. don't work:

`properties.yml`

```yaml
seeds:
  - name: seed_name
    config:
      post_hook: "alter table {{ this }} alter column id set not null"
    columns:
      - name: id

models:
  - name: my_model
    config:
      pre_hook:
        - "{{ some_macro() }}"
```

The example seed post-hook above is just a single value (not a list), whereas the example model pre-hook is a list. [Both are valid](https://docs.getdbt.com/reference/resource-configs/pre-hook-post-hook#definition)! The former contains Jinja for the [`this`](https://docs.getdbt.com/reference/dbt-jinja-functions/this) context variable, and the latter contains a Jinja [macro](https://docs.getdbt.com/docs/build/jinja-macros).

### Solution

Late-render pre- and post-hooks within properties / schema YAML files (like [they are](https://github.com/dbt-labs/dbt-core/blob/c668846404c78ea7317dc0523b49703c61c9885f/core/dbt/config/renderer.py#L170) for `dbt_project.yml`)

### 🎩 Testing

Added [two new tests](https://github.com/dbt-labs/dbt-core/pull/10603/commits/70d7fc3cb38512dbf85ca1c4c4bd277f6bd59bcc) to handle the difference between a hook that is just a string vs. a list of hooks:
- `TestPrePostModelHooksWithMacros`
- `TestPrePostModelHooksListWithMacros`

❌ ❌  The two new tests failed (as we hoped) prior to the fix:

```
=========================== short test summary info ============================
FAILED tests/functional/adapter/hooks/test_model_hooks.py::TestPrePostModelHooksWithMacros::test_pre_and_post_run_hooks
FAILED tests/functional/adapter/hooks/test_model_hooks.py::TestPrePostModelHooksListWithMacros::test_pre_and_post_run_hooks
```

✅ ✅ And both succeed after the fix in fbe20e9beed56109f67d003929eb687a796b1688.

I also manually checked both the seeds and models examples listed above.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.).
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.