### PR TITLE
[TIDY FIRST] Type `BaseRunner` class

### DIFF
--- a/.changes/unreleased/Under the Hood-20240826-141843.yaml
+++ b/.changes/unreleased/Under the Hood-20240826-141843.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add type hinting to BaseRunner class to increase stability guarnatees
+time: 2024-08-26T14:18:43.834018-05:00
+custom:
+  Author: QMalcolm
+  Issue: "10606"

--- a/.changes/unreleased/Under the Hood-20240826-141843.yaml
+++ b/.changes/unreleased/Under the Hood-20240826-141843.yaml
@@ -1,5 +1,5 @@
 kind: Under the Hood
-body: Add type hinting to BaseRunner class to increase stability guarnatees
+body: Add type hinting to BaseRunner class to increase stability guarantees
 time: 2024-08-26T14:18:43.834018-05:00
 custom:
   Author: QMalcolm

--- a/core/dbt/artifacts/schemas/results.py
+++ b/core/dbt/artifacts/schemas/results.py
@@ -81,9 +81,12 @@ class FreshnessStatus(StrEnum):
     RuntimeErr = NodeStatus.RuntimeErr
 
 
+ResultStatus = Union[RunStatus, TestStatus, FreshnessStatus]
+
+
 @dataclass
 class BaseResult(dbtClassMixin):
-    status: Union[RunStatus, TestStatus, FreshnessStatus]
+    status: ResultStatus
     timing: List[TimingInfo]
     thread_id: str
     execution_time: float

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -431,8 +431,8 @@ class BaseRunner(metaclass=ABCMeta):
 
         return None
 
-    def before_execute(self):
-        raise NotImplementedError()
+    def before_execute(self) -> None:
+        raise NotImplementedError("The `before_execute` function hasn't been implemented")
 
     def execute(self, compiled_node: ResultNode, manifest: Manifest) -> RunResult:
         raise NotImplementedError(msg="The `execute` function hasn't been implemented")
@@ -440,8 +440,8 @@ class BaseRunner(metaclass=ABCMeta):
     def run(self, compiled_node: ResultNode, manifest: Manifest) -> RunResult:
         return self.execute(compiled_node, manifest)
 
-    def after_execute(self, result):
-        raise NotImplementedError()
+    def after_execute(self, result: RunResult) -> None:
+        raise NotImplementedError("The `after_execute` function hasn't been implemented")
 
     def _skip_caused_by_ephemeral_failure(self):
         if self.skip_cause is None or self.skip_cause.node is None:

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -17,6 +17,7 @@ from dbt.adapters.base.impl import BaseAdapter
 from dbt.artifacts.resources.types import NodeType
 from dbt.artifacts.schemas.results import (
     NodeStatus,
+    ResultStatus,
     RunningStatus,
     RunStatus,
     TimingInfo,
@@ -231,7 +232,7 @@ class BaseRunner(metaclass=ABCMeta):
         self,
         node: ResultNode,
         start_time: float,
-        status: RunStatus,
+        status: ResultStatus,
         timing_info: List[TimingInfo],
         message: Optional[str] = None,
         agate_table: Optional[Table] = None,

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -448,7 +448,7 @@ class BaseRunner(metaclass=ABCMeta):
             return False
         return self.skip_cause.node.is_ephemeral_model
 
-    def on_skip(self):
+    def on_skip(self) -> RunResult:
         schema_name = getattr(self.node, "schema", "")
         node_name = self.node.name
 
@@ -464,7 +464,9 @@ class BaseRunner(metaclass=ABCMeta):
                         relation=node_name,
                         index=self.node_index,
                         total=self.num_nodes,
-                        status=self.skip_cause.status,
+                        status=(
+                            self.skip_cause.status if self.skip_cause is not None else "unknown"
+                        ),
                     )
                 )
                 # skip_cause here should be the run_result from the ephemeral model
@@ -498,7 +500,7 @@ class BaseRunner(metaclass=ABCMeta):
         node_result = RunResult.from_node(self.node, RunStatus.Skipped, error_message)
         return node_result
 
-    def do_skip(self, cause=None):
+    def do_skip(self, cause: Optional[RunResult] = None) -> None:
         self.skip = True
         self.skip_cause = cause
 

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -430,10 +430,10 @@ class BaseRunner(metaclass=ABCMeta):
     def before_execute(self):
         raise NotImplementedError()
 
-    def execute(self, compiled_node, manifest):
-        raise NotImplementedError()
+    def execute(self, compiled_node: ResultNode, manifest: Manifest) -> RunResult:
+        raise NotImplementedError(msg="The `execute` function hasn't been implemented")
 
-    def run(self, compiled_node, manifest):
+    def run(self, compiled_node: ResultNode, manifest: Manifest) -> RunResult:
         return self.execute(compiled_node, manifest)
 
     def after_execute(self, result):

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -443,7 +443,7 @@ class BaseRunner(metaclass=ABCMeta):
     def after_execute(self, result: RunResult) -> None:
         raise NotImplementedError("The `after_execute` function hasn't been implemented")
 
-    def _skip_caused_by_ephemeral_failure(self):
+    def _skip_caused_by_ephemeral_failure(self) -> bool:
         if self.skip_cause is None or self.skip_cause.node is None:
             return False
         return self.skip_cause.node.is_ephemeral_model

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -28,6 +28,7 @@ from dbt.config.profile import read_profile
 from dbt.constants import DBT_PROJECT_FILE_NAME
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.nodes import GraphMemberNode
+from dbt.contracts.results import BaseResult
 from dbt.events.types import (
     CatchableExceptionOnRun,
     GenericExceptionOnRun,
@@ -194,7 +195,7 @@ class BaseRunner(metaclass=ABCMeta):
     def _node_build_path(self) -> Optional[str]:
         return self.node.build_path if hasattr(self.node, "build_path") else None
 
-    def get_result_status(self, result) -> Dict[str, str]:
+    def get_result_status(self, result: BaseResult) -> Dict[str, str]:
         if result.status == NodeStatus.Error:
             return {"node_status": "error", "node_error": str(result.message)}
         elif result.status == NodeStatus.Skipped:

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -254,7 +254,13 @@ class BaseRunner(metaclass=ABCMeta):
             failures=failures,
         )
 
-    def error_result(self, node, message, start_time, timing_info):
+    def error_result(
+        self,
+        node: ManifestNode,
+        message: str,
+        start_time: float,
+        timing_info: List[TimingInfo],
+    ) -> RunResult:
         return self._build_run_result(
             node=node,
             start_time=start_time,
@@ -263,7 +269,12 @@ class BaseRunner(metaclass=ABCMeta):
             message=message,
         )
 
-    def ephemeral_result(self, node, start_time, timing_info):
+    def ephemeral_result(
+        self,
+        node: ManifestNode,
+        start_time: float,
+        timing_info: List[TimingInfo],
+    ) -> RunResult:
         return self._build_run_result(
             node=node,
             start_time=start_time,
@@ -272,7 +283,12 @@ class BaseRunner(metaclass=ABCMeta):
             message=None,
         )
 
-    def from_run_result(self, result, start_time, timing_info):
+    def from_run_result(
+        self,
+        result: RunResult,
+        start_time: float,
+        timing_info: List[TimingInfo],
+    ) -> RunResult:
         return self._build_run_result(
             node=result.node,
             start_time=start_time,

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Set
 import dbt.exceptions
 import dbt_common.exceptions.base
 from dbt import tracking
+from dbt.adapters.base.impl import BaseAdapter
 from dbt.artifacts.resources.types import NodeType
 from dbt.artifacts.schemas.results import (
     NodeStatus,
@@ -26,6 +27,7 @@ from dbt.config import RuntimeConfig
 from dbt.config.profile import read_profile
 from dbt.constants import DBT_PROJECT_FILE_NAME
 from dbt.contracts.graph.manifest import Manifest
+from dbt.contracts.graph.nodes import GraphMemberNode
 from dbt.events.types import (
     CatchableExceptionOnRun,
     GenericExceptionOnRun,
@@ -165,18 +167,25 @@ class ExecutionContext:
 
 
 class BaseRunner(metaclass=ABCMeta):
-    def __init__(self, config, adapter, node, node_index, num_nodes) -> None:
-        self.config = config
-        self.compiler = Compiler(config)
-        self.adapter = adapter
-        self.node = node
-        self.node_index = node_index
-        self.num_nodes = num_nodes
+    def __init__(
+        self,
+        config: RuntimeConfig,
+        adapter: BaseAdapter,
+        node: GraphMemberNode,
+        node_index: int,
+        num_nodes: int,
+    ) -> None:
+        self.config: RuntimeConfig = config
+        self.compiler: Compiler = Compiler(config)
+        self.adapter: BaseAdapter = adapter
+        self.node: GraphMemberNode = node
+        self.node_index: int = node_index
+        self.num_nodes: int = num_nodes
 
-        self.skip = False
+        self.skip: bool = False
         self.skip_cause: Optional[RunResult] = None
 
-        self.run_ephemeral_models = False
+        self.run_ephemeral_models: bool = False
 
     @abstractmethod
     def compile(self, manifest: Manifest) -> Any:

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -384,7 +384,7 @@ class BaseRunner(metaclass=ABCMeta):
             error = self._handle_generic_exception(e, ctx)
         return error
 
-    def safe_run(self, manifest):
+    def safe_run(self, manifest: Manifest) -> RunResult:
         started = time.time()
         ctx = ExecutionContext(self.node)
         error = None
@@ -415,7 +415,7 @@ class BaseRunner(metaclass=ABCMeta):
             result = self.ephemeral_result(ctx.node, started, ctx.timing)
         return result
 
-    def _safe_release_connection(self):
+    def _safe_release_connection(self) -> Optional[str]:
         """Try to release a connection. If an exception is hit, log and return
         the error string.
         """

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -301,7 +301,11 @@ class BaseRunner(metaclass=ABCMeta):
             failures=result.failures,
         )
 
-    def compile_and_execute(self, manifest, ctx):
+    def compile_and_execute(
+        self,
+        manifest: Manifest,
+        ctx: ExecutionContext,
+    ) -> Optional[RunResult]:
         result = None
         with (
             self.adapter.connection_named(self.node.unique_id, self.node)

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
+from agate import Table
+
 import dbt.exceptions
 import dbt_common.exceptions.base
 from dbt import tracking
@@ -227,15 +229,15 @@ class BaseRunner(metaclass=ABCMeta):
 
     def _build_run_result(
         self,
-        node,
-        start_time,
-        status,
-        timing_info,
-        message,
-        agate_table=None,
-        adapter_response=None,
-        failures=None,
-    ):
+        node: ManifestNode,
+        start_time: float,
+        status: RunStatus,
+        timing_info: List[TimingInfo],
+        message: Optional[str] = None,
+        agate_table: Optional[Table] = None,
+        adapter_response: Optional[Dict[str, Any]] = None,
+        failures: Optional[int] = None,
+    ) -> RunResult:
         execution_time = time.time() - start_time
         thread_id = threading.current_thread().name
         if adapter_response is None:

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -165,9 +165,9 @@ class ExecutionContext:
     timing information and the newest (compiled vs executed) form of the node.
     """
 
-    def __init__(self, node) -> None:
+    def __init__(self, node: ResultNode) -> None:
         self.timing: List[TimingInfo] = []
-        self.node = node
+        self.node: ResultNode = node
 
 
 class BaseRunner(metaclass=ABCMeta):

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -29,7 +29,7 @@ from dbt.config import RuntimeConfig
 from dbt.config.profile import read_profile
 from dbt.constants import DBT_PROJECT_FILE_NAME
 from dbt.contracts.graph.manifest import Manifest
-from dbt.contracts.graph.nodes import ManifestNode
+from dbt.contracts.graph.nodes import ResultNode
 from dbt.contracts.results import BaseResult
 from dbt.events.types import (
     CatchableExceptionOnRun,
@@ -174,14 +174,14 @@ class BaseRunner(metaclass=ABCMeta):
         self,
         config: RuntimeConfig,
         adapter: BaseAdapter,
-        node: ManifestNode,
+        node: ResultNode,
         node_index: int,
         num_nodes: int,
     ) -> None:
         self.config: RuntimeConfig = config
         self.compiler: Compiler = Compiler(config)
         self.adapter: BaseAdapter = adapter
-        self.node: ManifestNode = node
+        self.node: ResultNode = node
         self.node_index: int = node_index
         self.num_nodes: int = num_nodes
 
@@ -229,7 +229,7 @@ class BaseRunner(metaclass=ABCMeta):
 
     def _build_run_result(
         self,
-        node: ManifestNode,
+        node: ResultNode,
         start_time: float,
         status: RunStatus,
         timing_info: List[TimingInfo],
@@ -256,7 +256,7 @@ class BaseRunner(metaclass=ABCMeta):
 
     def error_result(
         self,
-        node: ManifestNode,
+        node: ResultNode,
         message: str,
         start_time: float,
         timing_info: List[TimingInfo],
@@ -271,7 +271,7 @@ class BaseRunner(metaclass=ABCMeta):
 
     def ephemeral_result(
         self,
-        node: ManifestNode,
+        node: ResultNode,
         start_time: float,
         timing_info: List[TimingInfo],
     ) -> RunResult:

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -27,7 +27,7 @@ from dbt.config import RuntimeConfig
 from dbt.config.profile import read_profile
 from dbt.constants import DBT_PROJECT_FILE_NAME
 from dbt.contracts.graph.manifest import Manifest
-from dbt.contracts.graph.nodes import GraphMemberNode
+from dbt.contracts.graph.nodes import ManifestNode
 from dbt.contracts.results import BaseResult
 from dbt.events.types import (
     CatchableExceptionOnRun,
@@ -172,14 +172,14 @@ class BaseRunner(metaclass=ABCMeta):
         self,
         config: RuntimeConfig,
         adapter: BaseAdapter,
-        node: GraphMemberNode,
+        node: ManifestNode,
         node_index: int,
         num_nodes: int,
     ) -> None:
         self.config: RuntimeConfig = config
         self.compiler: Compiler = Compiler(config)
         self.adapter: BaseAdapter = adapter
-        self.node: GraphMemberNode = node
+        self.node: ManifestNode = node
         self.node_index: int = node_index
         self.num_nodes: int = num_nodes
 
@@ -207,7 +207,7 @@ class BaseRunner(metaclass=ABCMeta):
         else:
             return {"node_status": "passed"}
 
-    def run_with_hooks(self, manifest):
+    def run_with_hooks(self, manifest: Manifest):
         if self.skip:
             return self.on_skip()
 


### PR DESCRIPTION
Resolves #10606

### Problem

The BaseRunner class is largely untyped. Given the prevalence of this class, not having it typed could mean that there are potential edge cases and/or runtime exceptions we are not aware of. By typing this class, we give ourselves a lot more guarantees

### Solution

Add typing. Of note, adding this typing uncovered a potential runtime exception in the `on_skip` method. We address this in [5adce38](https://github.com/dbt-labs/dbt-core/pull/10607/commits/5adce387a11424cb6a0930dc8b9a8eebc2d4d1a8).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
