### PR TITLE
[TIDY FIRST] Fix `core/dbt/version.py` type hinting

### DIFF
--- a/.changes/unreleased/Under the Hood-20240827-105014.yaml
+++ b/.changes/unreleased/Under the Hood-20240827-105014.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Additional type hints for `core/dbt/version.py`
+time: 2024-08-27T10:50:14.047859-05:00
+custom:
+  Author: QMalcolm
+  Issue: "10612"

--- a/core/dbt/version.py
+++ b/core/dbt/version.py
@@ -49,7 +49,10 @@ def get_latest_version(
     return semver.VersionSpecifier.from_version_string(version_string)
 
 
-def _get_core_msg_lines(installed, latest) -> Tuple[List[List[str]], str]:
+def _get_core_msg_lines(
+    installed: semver.VersionSpecifier,
+    latest: Optional[semver.VersionSpecifier],
+) -> Tuple[List[List[str]], str]:
     installed_s = installed.to_version_string(skip_matcher=True)
     installed_line = ["installed", installed_s, ""]
     update_info = ""
@@ -208,7 +211,7 @@ def _get_dbt_plugins_info() -> Iterator[Tuple[str, str]]:
         except ImportError:
             # not an adapter
             continue
-        yield plugin_name, mod.version  # type: ignore
+        yield plugin_name, mod.version
 
 
 def _get_adapter_plugin_names() -> Iterator[str]:


### PR DESCRIPTION
Resolves #10612 


### Problem

There were type errors in `core/dbt/version.py`

### Solution

Fix the type errors

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
