### PR TITLE
Fix test after dbt-utils release

### DIFF
--- a/tests/functional/dependencies/test_dependency_options.py
+++ b/tests/functional/dependencies/test_dependency_options.py
@@ -33,16 +33,14 @@ class TestDepsOptions(object):
         assert os.path.exists("package-lock.yml")
         with open("package-lock.yml") as fp:
             contents = fp.read()
-        assert (
-            contents
-            == """packages:
-  - package: fivetran/fivetran_utils
-    version: 0.4.7
-  - package: dbt-labs/dbt_utils
-    version: 1.2.0
-sha1_hash: 71304bca2138cf8004070b3573a1e17183c0c1a8
-"""
-        )
+
+        fivetran_package = "- package: fivetran/fivetran_utils\n    version: 0.4.7"
+        # dbt-utils is a dep in fivetran so we can't check for a specific version or this test fails everytime a new dbt-utils version comes out
+        dbt_labs_package = "- package: dbt-labs/dbt_utils"
+        package_sha = "sha1_hash: 71304bca2138cf8004070b3573a1e17183c0c1a8"
+        assert fivetran_package in contents
+        assert dbt_labs_package in contents
+        assert package_sha in contents
 
     def test_deps_default(self, clean_start):
         run_dbt(["deps"])
@@ -50,16 +48,13 @@ sha1_hash: 71304bca2138cf8004070b3573a1e17183c0c1a8
         assert os.path.exists("package-lock.yml")
         with open("package-lock.yml") as fp:
             contents = fp.read()
-        assert (
-            contents
-            == """packages:
-  - package: fivetran/fivetran_utils
-    version: 0.4.7
-  - package: dbt-labs/dbt_utils
-    version: 1.2.0
-sha1_hash: 71304bca2138cf8004070b3573a1e17183c0c1a8
-"""
-        )
+        fivetran_package = "- package: fivetran/fivetran_utils\n    version: 0.4.7"
+        # dbt-utils is a dep in fivetran so we can't check for a specific version or this test fails everytime a new dbt-utils version comes out
+        dbt_labs_package = "- package: dbt-labs/dbt_utils"
+        package_sha = "sha1_hash: 71304bca2138cf8004070b3573a1e17183c0c1a8"
+        assert fivetran_package in contents
+        assert dbt_labs_package in contents
+        assert package_sha in contents
 
     def test_deps_add(self, clean_start):
         run_dbt(["deps", "--add-package", "dbt-labs/audit_helper@0.9.0"])


### PR DESCRIPTION
### Problem

This test depended on a specific version of dbt-utils as a downstream dependency.  dbt-utils had a new release and it broke our test assertion.

### Solution

Skip over looking at the dbt-utils string.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
