### PR TITLE
Ct 10485/env var none

### DIFF
--- a/.changes/unreleased/Features-20240828-214201.yaml
+++ b/.changes/unreleased/Features-20240828-214201.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: env_var() default can now be none
+time: 2024-08-28T21:42:01.241444-05:00
+custom:
+  Author: kentkr
+  Issue: "10485"

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -6,7 +6,18 @@ import json
 import os
 import re
 import threading
-from typing import Any, Callable, Dict, Iterable, List, Mapping, NoReturn, Optional, Set, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    NoReturn,
+    Optional,
+    Set,
+    Union,
+)
 
 # These modules are added to the context. Consider alternative
 # approaches which will extend well to potentially many modules
@@ -307,7 +318,7 @@ class BaseContext(metaclass=ContextMeta):
         """The env_var() function. Return the environment variable named 'var'.
         If there is no such environment variable set, return the default.
 
-        The default can be None but is required. If nothing is passed in 
+        The default can be None but is required. If nothing is passed in
         raise an exception for an undefined variable.
         """
         return_value = None

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -307,7 +307,8 @@ class BaseContext(metaclass=ContextMeta):
         """The env_var() function. Return the environment variable named 'var'.
         If there is no such environment variable set, return the default.
 
-        If the default is None, raise an exception for an undefined variable.
+        The default can be None but is required. If nothing is passed in 
+        raise an exception for an undefined variable.
         """
         return_value = None
         if var.startswith(SECRET_ENV_PREFIX):

--- a/core/dbt/context/configured.py
+++ b/core/dbt/context/configured.py
@@ -75,6 +75,7 @@ class SchemaYamlVars:
 
 class SchemaYamlContext(ConfiguredContext):
     _ENV_VAR_NOT_SET = object()
+
     # subclass is DocsRuntimeContext
     def __init__(self, config, project_name: str, schema_yaml_vars: Optional[SchemaYamlVars]):
         super().__init__(config)
@@ -90,7 +91,7 @@ class SchemaYamlContext(ConfiguredContext):
         """The env_var() function. Return the environment variable named 'var'.
         If there is no such environment variable set, return the default.
 
-        The default can be None but is required. If nothing is passed in 
+        The default can be None but is required. If nothing is passed in
         raise an exception for an undefined variable.
         """
         return_value = None

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -811,6 +811,7 @@ T = TypeVar("T")
 # Base context collection, used for parsing configs.
 class ProviderContext(ManifestContext):
     _ENV_VAR_NOT_SET: Any = object()
+
     # subclasses are MacroContext, ModelContext, TestContext
     def __init__(
         self,
@@ -1385,7 +1386,7 @@ class ProviderContext(ManifestContext):
         """The env_var() function. Return the environment variable named 'var'.
         If there is no such environment variable set, return the default.
 
-        The default can be None but is required. If nothing is passed in 
+        The default can be None but is required. If nothing is passed in
         raise an exception for an undefined variable.
         """
         return_value = None
@@ -1407,8 +1408,7 @@ class ProviderContext(ManifestContext):
         # If this is compiling, do not save because it's irrelevant to parsing.
         compiling = (
             True
-            if hasattr(self.model, "compiled")
-            and getattr(self.model, "compiled", False) is True
+            if hasattr(self.model, "compiled") and getattr(self.model, "compiled", False) is True
             else False
         )
         if self.model and not compiling:
@@ -1416,9 +1416,7 @@ class ProviderContext(ManifestContext):
             # that so we can skip partial parsing.  Otherwise the file will be scheduled for
             # reparsing. If the default changes, the file will have been updated and therefore
             # will be scheduled for reparsing anyways.
-            self.manifest.env_vars[var] = (
-                return_value if var in env else DEFAULT_ENV_PLACEHOLDER
-            )
+            self.manifest.env_vars[var] = return_value if var in env else DEFAULT_ENV_PLACEHOLDER
 
             # hooks come from dbt_project.yml which doesn't have a real file_id
             if self.model.file_id in self.manifest.files:
@@ -1589,7 +1587,7 @@ class UnitTestContext(ModelContext):
 
         If there is no such environment variable set, return the default.
 
-        The default can be None but is required. If nothing is passed in 
+        The default can be None but is required. If nothing is passed in
         raise an exception for an undefined variable.
         """
         if self.model.overrides and var in self.model.overrides.env_vars:
@@ -1813,6 +1811,7 @@ def generate_parse_semantic_models(
 # the TestMacroNamespace
 class TestContext(ProviderContext):
     _ENV_VAR_NOT_SET = object()
+
     def __init__(
         self,
         model,
@@ -1882,9 +1881,7 @@ class TestContext(ProviderContext):
             # that so we can skip partial parsing.  Otherwise the file will be scheduled for
             # reparsing. If the default changes, the file will have been updated and therefore
             # will be scheduled for reparsing anyways.
-            self.manifest.env_vars[var] = (
-                return_value if var in env else DEFAULT_ENV_PLACEHOLDER
-            )
+            self.manifest.env_vars[var] = return_value if var in env else DEFAULT_ENV_PLACEHOLDER
             # the "model" should only be test nodes, but just in case, check
             # TODO CT-211
             if self.model.resource_type == NodeType.Test and self.model.file_key_name:  # type: ignore[union-attr] # noqa

--- a/core/dbt/context/secret.py
+++ b/core/dbt/context/secret.py
@@ -11,6 +11,7 @@ from .base import BaseContext, contextmember
 class SecretContext(BaseContext):
     """This context is used in profiles.yml + packages.yml. It can render secret
     env vars that aren't usable elsewhere"""
+
     _ENV_VAR_NOT_SET = object()
 
     @contextmember()
@@ -18,7 +19,7 @@ class SecretContext(BaseContext):
         """The env_var() function. Return the environment variable named 'var'.
         If there is no such environment variable set, return the default.
 
-        The default can be None but is required. If nothing is passed in 
+        The default can be None but is required. If nothing is passed in
         raise an exception for an undefined variable.
 
         In this context *only*, env_var will accept env vars prefixed with DBT_ENV_SECRET_.

--- a/core/dbt/context/secret.py
+++ b/core/dbt/context/secret.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Union
 
 from dbt.constants import DEFAULT_ENV_PLACEHOLDER, SECRET_PLACEHOLDER
 from dbt.exceptions import EnvVarMissingError
@@ -11,13 +11,15 @@ from .base import BaseContext, contextmember
 class SecretContext(BaseContext):
     """This context is used in profiles.yml + packages.yml. It can render secret
     env vars that aren't usable elsewhere"""
+    _ENV_VAR_NOT_SET = object()
 
     @contextmember()
-    def env_var(self, var: str, default: Optional[str] = None) -> str:
+    def env_var(self, var: str, default: Any = _ENV_VAR_NOT_SET) -> Union[str, None]:
         """The env_var() function. Return the environment variable named 'var'.
         If there is no such environment variable set, return the default.
 
-        If the default is None, raise an exception for an undefined variable.
+        The default can be None but is required. If nothing is passed in 
+        raise an exception for an undefined variable.
 
         In this context *only*, env_var will accept env vars prefixed with DBT_ENV_SECRET_.
         It will return the name of the secret env var, wrapped in 'start' and 'end' identifiers.
@@ -34,22 +36,23 @@ class SecretContext(BaseContext):
 
         if var in env:
             return_value = env[var]
-        elif default is not None:
+        # sentinel approach allows `none` to be passed in
+        # if nothing is passed in the below error is thrown
+        elif default is self._ENV_VAR_NOT_SET:
+            raise EnvVarMissingError(var)
+        else:
             return_value = default
 
-        if return_value is not None:
-            # store env vars in the internal manifest to power partial parsing
-            # if it's a 'secret' env var, we shouldn't even get here
-            # but just to be safe, don't save secrets
-            if not var.startswith(SECRET_ENV_PREFIX):
-                # If the environment variable is set from a default, store a string indicating
-                # that so we can skip partial parsing.  Otherwise the file will be scheduled for
-                # reparsing. If the default changes, the file will have been updated and therefore
-                # will be scheduled for reparsing anyways.
-                self.env_vars[var] = return_value if var in env else DEFAULT_ENV_PLACEHOLDER
-            return return_value
-        else:
-            raise EnvVarMissingError(var)
+        # store env vars in the internal manifest to power partial parsing
+        # if it's a 'secret' env var, we shouldn't even get here
+        # but just to be safe, don't save secrets
+        if not var.startswith(SECRET_ENV_PREFIX):
+            # If the environment variable is set from a default, store a string indicating
+            # that so we can skip partial parsing.  Otherwise the file will be scheduled for
+            # reparsing. If the default changes, the file will have been updated and therefore
+            # will be scheduled for reparsing anyways.
+            self.env_vars[var] = return_value if var in env else DEFAULT_ENV_PLACEHOLDER
+        return return_value
 
 
 def generate_secret_context(cli_vars: Dict[str, Any]) -> Dict[str, Any]:

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -839,7 +839,7 @@ class Manifest(MacroMethods, dbtClassMixin):
     state_check: ManifestStateCheck = field(default_factory=ManifestStateCheck)
     source_patches: MutableMapping[SourceKey, SourcePatch] = field(default_factory=dict)
     disabled: MutableMapping[str, List[GraphMemberNode]] = field(default_factory=dict)
-    env_vars: MutableMapping[str, str] = field(default_factory=dict)
+    env_vars: MutableMapping[str, Any] = field(default_factory=dict)
     semantic_models: MutableMapping[str, SemanticModel] = field(default_factory=dict)
     unit_tests: MutableMapping[str, UnitTestDefinition] = field(default_factory=dict)
     saved_queries: MutableMapping[str, SavedQuery] = field(default_factory=dict)


### PR DESCRIPTION
Resolves #10485 

### Problem

`none` is not acceptable as a default for `env_var`. It throws an error saying the env var is not defined. This behavior is unexpected and different than `var`

### Solution

I used a sentinel approach: the default is an empty object. If that object gets overwritten with `None` it's ok. If not it throws the env var missing exception.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
