### PR TITLE
Adding logic to TestSelector to remove unit tests if they are in excluded_resource_types

### DIFF
--- a/.changes/unreleased/Features-20240903-132428.yaml
+++ b/.changes/unreleased/Features-20240903-132428.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Adding logic to TestSelector to remove unit tests if they are in excluded_resource_types
+time: 2024-09-03T13:24:28.592837+01:00
+custom:
+    Author: TowardOliver
+    Issue: "10656"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -783,6 +783,7 @@ cli.commands["source"].add_command(snapshot_freshness, "snapshot-freshness")  # 
 @click.pass_context
 @global_flags
 @p.exclude
+@p.exclude_resource_type
 @p.profiles_dir
 @p.project_dir
 @p.select

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -76,6 +76,13 @@ class TestUnitTests:
         )
         assert len(results) == 1
 
+        # Run test command but specify no unit tests
+        results = run_dbt(
+            ["test", "--select", "my_model", "--exclude-resource-types", "unit_test"],
+            expect_pass=True,
+        )
+        assert len(results) == 0
+
         # Exclude unit tests with environment variable for build command
         os.environ["DBT_EXCLUDE_RESOURCE_TYPES"] = "unit_test"
         results = run_dbt(["build", "--select", "my_model"], expect_pass=True)

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -76,10 +76,14 @@ class TestUnitTests:
         )
         assert len(results) == 1
 
-        # Exclude unit tests with environment variable
+        # Exclude unit tests with environment variable for build command
         os.environ["DBT_EXCLUDE_RESOURCE_TYPES"] = "unit_test"
         results = run_dbt(["build", "--select", "my_model"], expect_pass=True)
         assert len(results) == 1
+
+        # Exclude unit tests with environment variable for test command
+        results = run_dbt(["test", "--select", "my_model"], expect_pass=True)
+        assert len(results) == 0
 
         del os.environ["DBT_EXCLUDE_RESOURCE_TYPES"]
 


### PR DESCRIPTION
Resolves #10656 

### Problem

Currently, including "unit_test" in the `DBT_EXCLUDE_RESOURCE_TYPES` env variable (or passing via `--exclude-resource-type`) will prevent unit tests from running when using the `dbt build`, `list` and `clone` commands **ONLY**. 

I want to extend this to also prevent unit tests from running when using the `dbt test` command.

### Solution

I've added a check to the TestSelector, to check the if unit_test has been set in the exclusion list. If it has, then it only allows data tests to run.

Default behaviour is to run both unit and data tests.

It's only a small / simple change. But it will get the job done of preventing unit tests from running on our Prod environments when running `dbt test`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
