### PR TITLE
Add custom granularities to YAML spec

### DIFF
--- a/.changes/unreleased/Features-20240904-182320.yaml
+++ b/.changes/unreleased/Features-20240904-182320.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add custom_granularities to YAML spec for time spines.
+time: 2024-09-04T18:23:20.234952-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "9265"

--- a/core/dbt/artifacts/resources/v1/model.py
+++ b/core/dbt/artifacts/resources/v1/model.py
@@ -23,8 +23,15 @@ class ModelConfig(NodeConfig):
 
 
 @dataclass
+class CustomGranularity(dbtClassMixin):
+    name: str
+    column_name: Optional[str] = None
+
+
+@dataclass
 class TimeSpine(dbtClassMixin):
     standard_granularity_column: str
+    custom_granularities: List[CustomGranularity] = field(default_factory=list)
 
 
 @dataclass

--- a/core/dbt/contracts/graph/semantic_manifest.py
+++ b/core/dbt/contracts/graph/semantic_manifest.py
@@ -24,6 +24,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
 from dbt_semantic_interfaces.implementations.time_spine import (
     PydanticTimeSpine,
+    PydanticTimeSpineCustomGranularityColumn,
     PydanticTimeSpinePrimaryColumn,
 )
 from dbt_semantic_interfaces.implementations.time_spine_table_configuration import (
@@ -105,6 +106,12 @@ class SemanticManifest:
                     name=time_spine.standard_granularity_column,
                     time_granularity=standard_granularity_column.granularity,
                 ),
+                custom_granularities=[
+                    PydanticTimeSpineCustomGranularityColumn(
+                        name=custom_granularity.name, column_name=custom_granularity.column_name
+                    )
+                    for custom_granularity in time_spine.custom_granularities
+                ],
             )
             pydantic_time_spines.append(pydantic_time_spine)
             if (

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -208,8 +208,15 @@ class UnparsedNodeUpdate(HasConfig, HasColumnTests, HasColumnAndTestProps, HasYa
 
 
 @dataclass
+class UnparsedCustomGranularity(dbtClassMixin):
+    name: str
+    column_name: Optional[str] = None
+
+
+@dataclass
 class UnparsedTimeSpine(dbtClassMixin):
     standard_granularity_column: str
+    custom_granularities: List[UnparsedCustomGranularity] = field(default_factory=list)
 
 
 @dataclass
@@ -254,11 +261,26 @@ class UnparsedModelUpdate(UnparsedNodeUpdate):
                     f"column name '{self.time_spine.standard_granularity_column}' for model '{self.name}'. Valid names"
                     f"{' for latest version' if self.latest_version else ''}: {list(column_names_to_columns.keys())}."
                 )
-            column = column_names_to_columns[self.time_spine.standard_granularity_column]
-            if not column.granularity:
+            standard_column = column_names_to_columns[self.time_spine.standard_granularity_column]
+            if not standard_column.granularity:
                 raise ParsingError(
                     f"Time spine standard granularity column must have a granularity defined. Please add one for "
                     f"column '{self.time_spine.standard_granularity_column}' in model '{self.name}'."
+                )
+            custom_granularity_columns_not_found = []
+            for custom_granularity in self.time_spine.custom_granularities:
+                column_name = (
+                    custom_granularity.column_name
+                    if custom_granularity.column_name
+                    else custom_granularity.name
+                )
+                if column_name not in column_names_to_columns:
+                    custom_granularity_columns_not_found.append(column_name)
+            if custom_granularity_columns_not_found:
+                raise ParsingError(
+                    "Time spine custom granularity columns do not exist in the model. "
+                    f"Columns not found: {custom_granularity_columns_not_found}; "
+                    f"Available columns: {list(column_names_to_columns.keys())}"
                 )
 
     def get_columns_for_version(self, version: NodeVersion) -> List[UnparsedColumn]:

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -21,6 +21,7 @@ from dbt.artifacts.resources import (
     NodeVersion,
     Owner,
     Quoting,
+    TimeSpine,
     UnitTestInputFixture,
     UnitTestNodeVersions,
     UnitTestOutputFixture,
@@ -208,25 +209,13 @@ class UnparsedNodeUpdate(HasConfig, HasColumnTests, HasColumnAndTestProps, HasYa
 
 
 @dataclass
-class UnparsedCustomGranularity(dbtClassMixin):
-    name: str
-    column_name: Optional[str] = None
-
-
-@dataclass
-class UnparsedTimeSpine(dbtClassMixin):
-    standard_granularity_column: str
-    custom_granularities: List[UnparsedCustomGranularity] = field(default_factory=list)
-
-
-@dataclass
 class UnparsedModelUpdate(UnparsedNodeUpdate):
     quote_columns: Optional[bool] = None
     access: Optional[str] = None
     latest_version: Optional[NodeVersion] = None
     versions: Sequence[UnparsedVersion] = field(default_factory=list)
     deprecation_date: Optional[datetime.datetime] = None
-    time_spine: Optional[UnparsedTimeSpine] = None
+    time_spine: Optional[TimeSpine] = None
 
     def __post_init__(self) -> None:
         if self.latest_version:

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, Type,
 
 from dbt import deprecations
 from dbt.artifacts.resources import RefArgs
-from dbt.artifacts.resources.v1.model import TimeSpine
+from dbt.artifacts.resources.v1.model import CustomGranularity, TimeSpine
 from dbt.clients.jinja_static import statically_parse_ref_or_source
 from dbt.clients.yaml_helper import load_yaml_text
 from dbt.config import RuntimeConfig
@@ -627,7 +627,14 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
             deprecation_date = block.target.deprecation_date
             time_spine = (
                 TimeSpine(
-                    standard_granularity_column=block.target.time_spine.standard_granularity_column
+                    standard_granularity_column=block.target.time_spine.standard_granularity_column,
+                    custom_granularities=[
+                        CustomGranularity(
+                            name=custom_granularity.name,
+                            column_name=custom_granularity.column_name,
+                        )
+                        for custom_granularity in block.target.time_spine.custom_granularities
+                    ],
                 )
                 if block.target.time_spine
                 else None

--- a/core/setup.py
+++ b/core/setup.py
@@ -69,7 +69,7 @@ setup(
         # These are major-version-0 packages also maintained by dbt-labs.
         # Accept patches but avoid automatically updating past a set minor version range.
         "dbt-extractor>=0.5.0,<=0.6",
-        "dbt-semantic-interfaces>=0.7.0,<0.8",
+        "dbt-semantic-interfaces>=0.7.1,<0.8",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.6.0,<2.0",
         "dbt-adapters>=1.3.0,<2.0",

--- a/schemas/dbt/manifest/v12.json
+++ b/schemas/dbt/manifest/v12.json
@@ -4618,6 +4618,33 @@
                     "properties": {
                       "standard_granularity_column": {
                         "type": "string"
+                      },
+                      "custom_granularities": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "title": "CustomGranularity",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "column_name": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "name"
+                          ]
+                        }
                       }
                     },
                     "additionalProperties": false,
@@ -14233,6 +14260,33 @@
                           "properties": {
                             "standard_granularity_column": {
                               "type": "string"
+                            },
+                            "custom_granularities": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "title": "CustomGranularity",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "column_name": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "default": null
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "name"
+                                ]
+                              }
                             }
                           },
                           "additionalProperties": false,

--- a/tests/functional/time_spines/fixtures.py
+++ b/tests/functional/time_spines/fixtures.py
@@ -54,9 +54,16 @@ models:
   - name: metricflow_time_spine
     time_spine:
       standard_granularity_column: date_day
+      custom_granularities:
+        - name: retail_month
+        - name: martian_year
+          column_name: martian__year_xyz
     columns:
       - name: date_day
         granularity: day
+      - name: retail_month
+      - name: martian__year_xyz
+
 """
 
 missing_time_spine_yml = """
@@ -76,11 +83,23 @@ models:
       - name: ts_second
 """
 
-time_spine_missing_column_yml = """
+time_spine_missing_standard_column_yml = """
 models:
   - name: metricflow_time_spine_second
     time_spine:
       standard_granularity_column: ts_second
     columns:
       - name: date_day
+"""
+
+time_spine_missing_custom_column_yml = """
+models:
+  - name: metricflow_time_spine_second
+    time_spine:
+      standard_granularity_column: date_day
+      custom_granularities:
+        - name: retail_month
+    columns:
+      - name: date_day
+        granularity: day
 """


### PR DESCRIPTION
Resolves #9265

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Description
The semantic layer is in the process of adding a custom calendar feature that will allow users to query using custom granularities like `retail_month`. This requires an addition to the YAML spec for models that looks like this:
```
models:
 - name: my_time_spine
   description: "my favorite time spine"
   time_spine:
      standard_granularity_column: date_day
      custom_granularities:
        - name: fiscal_year
          column_name: fiscal_year_column
```
The only new piece here is `custom_granularities` and everything nested under that key. This spec has been approved by the core product team. 

The corresponding change to schemas.getdbt.com is [here](https://github.com/dbt-labs/schemas.getdbt.com/pull/51).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
