### PR TITLE
Remove deprecation warning to change "tests:" config to "data_tests:"

### DIFF
--- a/.changes/unreleased/Fixes-20240905-180248.yaml
+++ b/.changes/unreleased/Fixes-20240905-180248.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: 'Remove deprecation for tests: to data_tests: change'
+time: 2024-09-05T18:02:48.086421-04:00
+custom:
+  Author: gshank
+  Issue: "10564"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -18,7 +18,6 @@ from typing import (
 
 from mashumaro.types import SerializableType
 
-from dbt import deprecations
 from dbt.adapters.base import ConstraintSupport
 from dbt.adapters.factory import get_adapter_constraint_support
 from dbt.artifacts.resources import Analysis as AnalysisResource
@@ -1148,12 +1147,6 @@ class UnpatchedSourceDefinition(BaseNode):
                 "Invalid test config: cannot have both 'tests' and 'data_tests' defined"
             )
         if self.tests:
-            if is_root_project:
-                deprecations.warn(
-                    "project-test-config",
-                    deprecated_path="tests",
-                    exp_path="data_tests",
-                )
             self.data_tests.extend(self.tests)
             self.tests.clear()
 
@@ -1164,12 +1157,6 @@ class UnpatchedSourceDefinition(BaseNode):
                     "Invalid test config: cannot have both 'tests' and 'data_tests' defined"
                 )
             if column.tests:
-                if is_root_project:
-                    deprecations.warn(
-                        "project-test-config",
-                        deprecated_path="tests",
-                        exp_path="data_tests",
-                    )
                 column.data_tests.extend(column.tests)
                 column.tests.clear()
 

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -5,7 +5,6 @@ from mashumaro.jsonschema.annotations import Pattern
 from mashumaro.types import SerializableType
 from typing_extensions import Annotated
 
-from dbt import deprecations
 from dbt.adapters.contracts.connection import QueryComment
 from dbt.contracts.util import Identifier, list_str
 from dbt_common.contracts.util import Mergeable
@@ -311,10 +310,6 @@ class Project(dbtClassMixin):
         if data.get("tests", None) and data.get("data_tests", None):
             raise ValidationError(
                 "Invalid project config: cannot have both 'tests' and 'data_tests' defined"
-            )
-        if "tests" in data:
-            deprecations.warn(
-                "project-test-config", deprecated_path="tests", exp_path="data_tests"
             )
 
 

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -98,11 +98,6 @@ class CollectFreshnessReturnSignature(DBTDeprecation):
     _event = "CollectFreshnessReturnSignature"
 
 
-class TestsConfigDeprecation(DBTDeprecation):
-    _name = "project-test-config"
-    _event = "TestsConfigDeprecation"
-
-
 class ProjectFlagsMovedDeprecation(DBTDeprecation):
     _name = "project-flags-moved"
     _event = "ProjectFlagsMovedDeprecation"
@@ -167,7 +162,6 @@ deprecations_list: List[DBTDeprecation] = [
     ConfigLogPathDeprecation(),
     ConfigTargetPathDeprecation(),
     CollectFreshnessReturnSignature(),
-    TestsConfigDeprecation(),
     ProjectFlagsMovedDeprecation(),
     PackageMaterializationOverrideDeprecation(),
     ResourceNamesWithSpacesDeprecation(),

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -388,6 +388,9 @@ class ConfigTargetPathDeprecation(WarnLevel):
         return line_wrap_message(warning_tag(f"Deprecated functionality\n\n{description}"))
 
 
+# Note: this deprecation has been removed, but we are leaving
+# the event class here, because users may have specified it in
+# warn_error_options.
 class TestsConfigDeprecation(WarnLevel):
     def code(self) -> str:
         return "D012"

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -4,7 +4,6 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, Type, TypeVar
 
-from dbt import deprecations
 from dbt.artifacts.resources import RefArgs
 from dbt.artifacts.resources.v1.model import TimeSpine
 from dbt.clients.jinja_static import statically_parse_ref_or_source
@@ -567,12 +566,6 @@ class PatchParser(YamlReader, Generic[NonSourceTarget, Parsed]):
                 if "tests" in data and "data_tests" in data:
                     raise ValidationError(
                         "Invalid test config: cannot have both 'tests' and 'data_tests' defined"
-                    )
-                if is_root_project:
-                    deprecations.warn(
-                        "project-test-config",
-                        deprecated_path="tests",
-                        exp_path="data_tests",
                     )
                 data["data_tests"] = data.pop("tests")
 

--- a/tests/functional/deprecations/test_config_deprecations.py
+++ b/tests/functional/deprecations/test_config_deprecations.py
@@ -32,7 +32,7 @@ class TestTestsConfigDeprecation:
         deprecations.reset_deprecations()
         assert deprecations.active_deprecations == set()
         run_dbt(["parse"])
-        expected = {"project-test-config"}
+        expected = set()
         assert expected == deprecations.active_deprecations
 
     def test_project_tests_config_fail(self, project):
@@ -41,7 +41,7 @@ class TestTestsConfigDeprecation:
         with pytest.raises(CompilationError) as exc:
             run_dbt(["--warn-error", "--no-partial-parse", "parse"])
         exc_str = " ".join(str(exc.value).split())  # flatten all whitespace
-        expected_msg = "The `tests` config has been renamed to `data_tests`"
+        expected_msg = "Configuration paths exist in your dbt_project.yml file which do not apply to any resources. There are 1 unused configuration paths: - data_tests"
         assert expected_msg in exc_str
 
 
@@ -62,17 +62,13 @@ class TestSchemaTestDeprecation:
         deprecations.reset_deprecations()
         assert deprecations.active_deprecations == set()
         run_dbt(["parse"])
-        expected = {"project-test-config"}
+        expected = set()
         assert expected == deprecations.active_deprecations
 
     def test_generic_tests_fail(self, project):
         deprecations.reset_deprecations()
         assert deprecations.active_deprecations == set()
-        with pytest.raises(CompilationError) as exc:
-            run_dbt(["--warn-error", "--no-partial-parse", "parse"])
-        exc_str = " ".join(str(exc.value).split())  # flatten all whitespace
-        expected_msg = "The `tests` config has been renamed to `data_tests`"
-        assert expected_msg in exc_str
+        run_dbt(["--warn-error", "--no-partial-parse", "parse"])
 
     def test_generic_data_test_parsing(self, project):
         results = run_dbt(["list", "--resource-type", "test"])
@@ -98,7 +94,7 @@ class TestSourceSchemaTestDeprecation:
         deprecations.reset_deprecations()
         assert deprecations.active_deprecations == set()
         run_dbt(["parse"])
-        expected = {"project-test-config"}
+        expected = set()
         assert expected == deprecations.active_deprecations
 
     def test_generic_data_tests(self, project):


### PR DESCRIPTION
Resolves #10564


### Problem

The decision was made that we are not deprecating the "tests:" config and it will not be removed in the future, so issuing a deprecation warning is no longer functional.

### Solution

Remove the code that issues the warning. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
