### PR TITLE
Dbt Docs, Use user provided index.html

### DIFF
--- a/core/dbt/task/docs/generate.py
+++ b/core/dbt/task/docs/generate.py
@@ -3,6 +3,7 @@ import shutil
 from dataclasses import replace
 from datetime import datetime
 from itertools import chain
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import agate
@@ -213,6 +214,15 @@ def get_unique_id_mapping(
 
 
 class GenerateTask(CompileTask):
+
+    def get_docs_index_file_path(self, ) -> str:
+        for docs_dir in self.config.docs_paths:
+            index_html = Path(self.config.project_root).joinpath(docs_dir).joinpath("index.html")
+            if index_html.is_file() and index_html.exists():
+                # click.echo(f"Using user provided documentation page: {index_html.as_posix()}")
+                return index_html.as_posix()
+        return DOCS_INDEX_FILE_PATH
+
     def run(self) -> CatalogArtifact:
         compile_results = None
         if self.args.compile:
@@ -228,7 +238,7 @@ class GenerateTask(CompileTask):
                 )
 
         shutil.copyfile(
-            DOCS_INDEX_FILE_PATH, os.path.join(self.config.project_target_path, "index.html")
+            self.get_docs_index_file_path(), os.path.join(self.config.project_target_path, "index.html")
         )
 
         for asset_path in self.config.asset_paths:
@@ -321,7 +331,7 @@ class GenerateTask(CompileTask):
             read_catalog_data = load_file_contents(catalog_path)
 
             # Create new static index file contents
-            index_data = load_file_contents(DOCS_INDEX_FILE_PATH)
+            index_data = load_file_contents(self.get_docs_index_file_path())
             index_data = index_data.replace('"MANIFEST.JSON INLINE DATA"', read_manifest_data)
             index_data = index_data.replace('"CATALOG.JSON INLINE DATA"', read_catalog_data)
 


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-docs/issues/50

### Problem
Currently its not possible to customize `index.html` file when generating dbt docs. It will be nice feature to be able to change its CSS and HTML content.

### Solution
with this change if any of the `dbt-docs` folders containing `index.html` then this will be used, instead of dbt provided default file.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
