### PR TITLE
[1.3.latest] Remove upper pin on packaging

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -58,7 +58,7 @@ setup(
         "minimal-snowplow-tracker==0.0.2",
         "networkx>=2.3,<2.8.1;python_version<'3.8'",
         "networkx>=2.3,<3;python_version>='3.8'",
-        "packaging>=20.9,<22.0",
+        "packaging>=20.9",
         "sqlparse>=0.2.3,<0.4.4",
         "dbt-extractor~=0.4.1",
         "typing-extensions>=3.7.4",


### PR DESCRIPTION
We have no upper bounds on setuptools, which now requires packaging 22.0 or higher, so remove the upper bounds pin on packaging. 