### PR TITLE
[1.3.latest] Avoid packaging for semver

### DIFF
--- a/.changes/unreleased/Fixes-20230201-154418.yaml
+++ b/.changes/unreleased/Fixes-20230201-154418.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove pin on packaging and stop using it for prerelease comparisons
+time: 2023-02-01T15:44:18.279158-05:00
+custom:
+  Author: gshank
+  Issue: "6834"

--- a/.changes/unreleased/Fixes-20230224-001338.yaml
+++ b/.changes/unreleased/Fixes-20230224-001338.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix semver comparison logic by ensuring numeric values
+time: 2023-02-24T00:13:38.23242+01:00
+custom:
+  Author: jtcohen6
+  Issue: "7039"

--- a/core/dbt/semver.py
+++ b/core/dbt/semver.py
@@ -152,9 +152,9 @@ class VersionSpecifier(VersionSpecification):
                 # else is equal and will fall through
 
             else:  # major/minor/patch, should all be numbers
-                if a > b:
+                if int(a) > int(b):
                     return 1
-                elif a < b:
+                elif int(a) < int(b):
                     return -1
                 # else is equal and will fall through
 

--- a/core/dbt/semver.py
+++ b/core/dbt/semver.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 import re
 from typing import List
 
-from dbt.exceptions import VersionsNotCompatibleError
+from dbt.exceptions import VersionsNotCompatibleException
 import dbt.utils
 
 from dbt.dataclass_schema import dbtClassMixin, StrEnum

--- a/core/dbt/semver.py
+++ b/core/dbt/semver.py
@@ -1,11 +1,8 @@
 from dataclasses import dataclass
 import re
-import warnings
 from typing import List
 
-from packaging import version as packaging_version
-
-from dbt.exceptions import VersionsNotCompatibleException
+from dbt.exceptions import VersionsNotCompatibleError
 import dbt.utils
 
 from dbt.dataclass_schema import dbtClassMixin, StrEnum
@@ -68,6 +65,11 @@ $
 )
 
 _VERSION_REGEX = re.compile(_VERSION_REGEX_PAT_STR, re.VERBOSE)
+
+
+def _cmp(a, b):
+    """Return negative if a<b, zero if a==b, positive if a>b."""
+    return (a > b) - (a < b)
 
 
 @dataclass
@@ -142,13 +144,19 @@ class VersionSpecifier(VersionSpecification):
                     return 1
                 if b is None:
                     return -1
-            # This suppresses the LegacyVersion deprecation warning
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", category=DeprecationWarning)
-                if packaging_version.parse(a) > packaging_version.parse(b):
+
+                # Check the prerelease component only
+                prcmp = self._nat_cmp(a, b)
+                if prcmp != 0:  # either -1 or 1
+                    return prcmp
+                # else is equal and will fall through
+
+            else:  # major/minor/patch, should all be numbers
+                if a > b:
                     return 1
-                elif packaging_version.parse(a) < packaging_version.parse(b):
+                elif a < b:
                     return -1
+                # else is equal and will fall through
 
         equal = (
             self.matcher == Matchers.GREATER_THAN_OR_EQUAL
@@ -211,6 +219,29 @@ class VersionSpecifier(VersionSpecification):
     @property
     def is_exact(self):
         return self.matcher == Matchers.EXACT
+
+    @classmethod
+    def _nat_cmp(cls, a, b):
+        def cmp_prerelease_tag(a, b):
+            if isinstance(a, int) and isinstance(b, int):
+                return _cmp(a, b)
+            elif isinstance(a, int):
+                return -1
+            elif isinstance(b, int):
+                return 1
+            else:
+                return _cmp(a, b)
+
+        a, b = a or "", b or ""
+        a_parts, b_parts = a.split("."), b.split(".")
+        a_parts = [int(x) if re.match(r"^\d+$", x) else x for x in a_parts]
+        b_parts = [int(x) if re.match(r"^\d+$", x) else x for x in b_parts]
+        for sub_a, sub_b in zip(a_parts, b_parts):
+            cmp_result = cmp_prerelease_tag(sub_a, sub_b)
+            if cmp_result != 0:
+                return cmp_result
+        else:
+            return _cmp(len(a), len(b))
 
 
 @dataclass

--- a/core/setup.py
+++ b/core/setup.py
@@ -58,7 +58,7 @@ setup(
         "minimal-snowplow-tracker==0.0.2",
         "networkx>=2.3,<2.8.1;python_version<'3.8'",
         "networkx>=2.3,<3;python_version>='3.8'",
-        "packaging>=20.9,<22.0",
+        "packaging>20.9",
         "sqlparse>=0.2.3,<0.4.4",
         "dbt-extractor~=0.4.1",
         "typing-extensions>=3.7.4",

--- a/test/unit/test_semver.py
+++ b/test/unit/test_semver.py
@@ -200,6 +200,14 @@ class TestSemver(unittest.TestCase):
                 ['1.0.0', '1.1.0a1', '1.1.0', '1.2.0a1', '1.2.0']),
             '1.1.0')
 
+        self.assertEqual(
+            resolve_to_specific_version(
+                # https://github.com/dbt-labs/dbt-core/issues/7039
+                # 10 is greater than 9
+                create_range('>0.9.0', '<0.10.0'),
+                ['0.9.0', '0.9.1', '0.10.0']),
+            '0.9.1')
+
     def test__filter_installable(self):
         installable = filter_installable(
             ['1.1.0',  '1.2.0a1', '1.0.0','2.1.0-alpha','2.2.0asdf','2.1.0','2.2.0','2.2.0-fishtown-beta','2.2.0-2'],

--- a/test/unit/test_semver.py
+++ b/test/unit/test_semver.py
@@ -201,12 +201,16 @@ class TestSemver(unittest.TestCase):
             '1.1.0')
 
     def test__filter_installable(self):
-        assert filter_installable(
+        installable = filter_installable(
             ['1.1.0',  '1.2.0a1', '1.0.0','2.1.0-alpha','2.2.0asdf','2.1.0','2.2.0','2.2.0-fishtown-beta','2.2.0-2'],
             install_prerelease=True
-        ) == ['1.0.0', '1.1.0', '1.2.0a1','2.1.0-alpha','2.1.0','2.2.0asdf','2.2.0-fishtown-beta','2.2.0-2','2.2.0']
+        )
+        expected = ['1.0.0', '1.1.0', '1.2.0a1','2.1.0-alpha','2.1.0','2.2.0-2','2.2.0asdf','2.2.0-fishtown-beta','2.2.0']
+        assert installable == expected
 
-        assert filter_installable(
+        installable = filter_installable(
             ['1.1.0',  '1.2.0a1', '1.0.0','2.1.0-alpha','2.2.0asdf','2.1.0','2.2.0','2.2.0-fishtown-beta'],
             install_prerelease=False
-        ) == ['1.0.0', '1.1.0','2.1.0','2.2.0']
+        )
+        expected = ['1.0.0', '1.1.0','2.1.0','2.2.0']
+        assert installable == expected


### PR DESCRIPTION
The latest version of setuptools requires packaging > 22.0, but our old semver code depending on packaging < 22.0.  This was fixed in 1.4.latest, so this is a backport of those fixes.