### PR TITLE
Add ability to import other YML files

### DIFF
--- a/core/dbt/clients/yaml_helper.py
+++ b/core/dbt/clients/yaml_helper.py
@@ -1,9 +1,10 @@
-from typing import Any, Dict, Optional
+import os
+from functools import cached_property
+from typing import Any, Dict, List, Optional, Union, overload
 
 import yaml
 
 import dbt_common.exceptions
-import dbt_common.exceptions.base
 
 # the C version is faster, but it doesn't always exist
 try:
@@ -52,8 +53,33 @@ def contextualized_yaml_error(raw_contents, error):
     )
 
 
+class LoaderWithInclude(Loader):
+    """Loader with a name being set."""
+
+    def __init__(self, stream: Any) -> None:
+        """Initialize a safe line loader."""
+        self.stream = stream
+
+        # Set name in same way as the Python loader does in yaml.reader.__init__
+        if isinstance(stream, str):
+            self.name = "<unicode string>"
+        elif isinstance(stream, bytes):
+            self.name = "<byte string>"
+        else:
+            self.name = getattr(stream, "name", "<file>")
+
+        super().__init__(stream)
+
+    @cached_property
+    def get_name(self) -> str:
+        """Get the name of the loader."""
+        return self.name
+
+
 def safe_load(contents) -> Optional[Dict[str, Any]]:
-    return yaml.load(contents, Loader=SafeLoader)
+    loader = LoaderWithInclude
+    loader.add_constructor("!include", _include_yaml)
+    return yaml.load(contents, Loader=loader)
 
 
 def load_yaml_text(contents, path=None):
@@ -66,3 +92,80 @@ def load_yaml_text(contents, path=None):
             error = str(e)
 
         raise dbt_common.exceptions.base.DbtValidationError(error)
+
+
+JSON_TYPE = Union[List, Dict, str]
+
+
+def parse_yaml(content: Any, secrets=None) -> JSON_TYPE:
+    """Parse YAML with the fastest available loader."""
+    return _parse_yaml(LoaderWithInclude, content, secrets)
+
+
+def _parse_yaml(
+    loader: LoaderWithInclude,
+    content: Any,
+    secrets: Optional[str] = None,
+) -> JSON_TYPE:
+    """Load a YAML file."""
+    return yaml.load(content, LoaderWithInclude)  # type: ignore[arg-type]
+
+
+def load_yaml(fname: Any) -> Optional[JSON_TYPE]:
+    """Load a YAML file."""
+    try:
+        with open(fname, encoding="utf-8") as conf_file:
+            return parse_yaml(conf_file, None)
+    except UnicodeDecodeError as exc:
+        raise dbt_common.exceptions.base.DbtValidationError(str(exc))
+
+
+@overload
+def _add_reference(
+    obj: list,
+    loader: LoaderWithInclude,
+    node: yaml.nodes.Node,
+) -> list: ...
+
+
+@overload
+def _add_reference(
+    obj: str,
+    loader: LoaderWithInclude,
+    node: yaml.nodes.Node,
+) -> str: ...
+
+
+@overload
+def _add_reference(obj: dict, loader: LoaderWithInclude, node: yaml.nodes.Node) -> dict: ...
+
+
+def _add_reference(obj, loader: LoaderWithInclude, node: yaml.nodes.Node):  # type: ignore[no-untyped-def]
+    """Add file reference information to an object."""
+    if isinstance(obj, list):
+        obj = obj
+    if isinstance(obj, str):
+        obj = obj
+    try:  # noqa: SIM105 suppress is much slower
+        setattr(obj, "__config_file__", loader.get_name)
+        setattr(obj, "__line__", node.start_mark.line + 1)
+    except AttributeError:
+        pass
+    return obj
+
+
+def _include_yaml(loader: LoaderWithInclude, node: yaml.nodes.Node) -> JSON_TYPE:
+    """Load another YAML file and embed it using the !include tag.
+
+    Example:
+        +schema: !include schema_config.yml
+
+    """
+    fname = os.path.join(os.path.dirname(loader.get_name), node.value)
+    try:
+        loaded_yaml = load_yaml(fname)
+        if loaded_yaml is None:
+            loaded_yaml = {}
+        return _add_reference(loaded_yaml, loader, node)
+    except FileNotFoundError as exc:
+        raise dbt_common.exceptions.base.DbtValidationError(str(exc))


### PR DESCRIPTION
Resolves #9695 (WIP code)

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
Today, we don't allow people to reuse "snippets'' of YAML across files. We can use YAML anchors but they are limited to a single file. This lead to non-DRY configuration where changing some configuration might require changing multiple files

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Add the ability to type`!include <filepath.yml>` to include the YAML of `filepath.yml` in the current section of the code.

e.g. with a (too) simple example

```
models:

  dbt_project_evaluator_integration_tests:
    +materialized: ephemeral
  dbt_project_evaluator:
    +schema: !include ./incl.yml
```

and `incl.yml` being
```
test_schema_123
```

This would work with nested YAML as well.

### TODO

The attached code worked on my machine with the example above, but this is really a WIP and not ready to ship.
Pending would be :

- [ ] adding tests
- [ ] fixing mypy issues
- [ ] handling partial parsing - right now, if the content of the included file is changed, if partial parsing is on, the new value will not be reflected

Anyone wanting to handle the above is welcome to take over this PR 😄 


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
