### PR TITLE
Replace `TestSelector` with `ResourceTypeSelector`

### DIFF
--- a/.changes/unreleased/Under the Hood-20240916-102201.yaml
+++ b/.changes/unreleased/Under the Hood-20240916-102201.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Replace `TestSelector` with `ResourceTypeSelector`
+time: 2024-09-16T10:22:01.339462-06:00
+custom:
+  Author: dbeatty10
+  Issue: "10718"

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -201,7 +201,7 @@ class BuildTask(RunTask):
                 graph=self.graph,
                 manifest=self.manifest,
                 previous_state=self.previous_state,
-                resource_types=resource_types,
+                resource_types=[NodeType.Test, NodeType.Unit],
             )
         return ResourceTypeSelector(
             graph=self.graph,

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -11,7 +11,6 @@ from dbt.exceptions import DbtInternalError
 from dbt.graph import Graph, GraphQueue, ResourceTypeSelector
 from dbt.node_types import NodeType
 from dbt.task.base import BaseRunner, resource_types_from_args
-from dbt.task.test import TestSelector
 from dbt_common.events.functions import fire_event
 
 from .run import ModelRunner as run_model_runner
@@ -198,10 +197,11 @@ class BuildTask(RunTask):
         resource_types = self.resource_types(no_unit_tests)
 
         if resource_types == [NodeType.Test]:
-            return TestSelector(
+            return ResourceTypeSelector(
                 graph=self.graph,
                 manifest=self.manifest,
                 previous_state=self.previous_state,
+                resource_types=resource_types,
             )
         return ResourceTypeSelector(
             graph=self.graph,

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -201,7 +201,7 @@ class BuildTask(RunTask):
                 graph=self.graph,
                 manifest=self.manifest,
                 previous_state=self.previous_state,
-                resource_types=[NodeType.Test, NodeType.Unit],
+                resource_types=resource_types,
             )
         return ResourceTypeSelector(
             graph=self.graph,

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -17,7 +17,6 @@ from dbt.graph import ResourceTypeSelector
 from dbt.node_types import NodeType
 from dbt.task.base import resource_types_from_args
 from dbt.task.runnable import GraphRunnableTask
-from dbt.task.test import TestSelector
 from dbt_common.events.contextvars import task_contextvars
 from dbt_common.events.functions import fire_event, warn_or_error
 from dbt_common.events.types import PrintEvent
@@ -201,10 +200,11 @@ class ListTask(GraphRunnableTask):
         if self.manifest is None or self.graph is None:
             raise DbtInternalError("manifest and graph must be set to get perform node selection")
         if self.resource_types == [NodeType.Test]:
-            return TestSelector(
+            return ResourceTypeSelector(
                 graph=self.graph,
                 manifest=self.manifest,
                 previous_state=self.previous_state,
+                resource_types=self.resource_types,
             )
         else:
             return ResourceTypeSelector(

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -204,7 +204,7 @@ class ListTask(GraphRunnableTask):
                 graph=self.graph,
                 manifest=self.manifest,
                 previous_state=self.previous_state,
-                resource_types=[NodeType.Test, NodeType.Unit],
+                resource_types=self.resource_types,
             )
         else:
             return ResourceTypeSelector(

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -204,7 +204,7 @@ class ListTask(GraphRunnableTask):
                 graph=self.graph,
                 manifest=self.manifest,
                 previous_state=self.previous_state,
-                resource_types=self.resource_types,
+                resource_types=[NodeType.Test, NodeType.Unit],
             )
         else:
             return ResourceTypeSelector(

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -375,16 +375,6 @@ class TestRunner(CompileRunner):
         return rendered
 
 
-class TestSelector(ResourceTypeSelector):
-    def __init__(self, graph, manifest, previous_state) -> None:
-        super().__init__(
-            graph=graph,
-            manifest=manifest,
-            previous_state=previous_state,
-            resource_types=[NodeType.Test, NodeType.Unit],
-        )
-
-
 class TestTask(RunTask):
     """
     Testing:
@@ -397,13 +387,14 @@ class TestTask(RunTask):
     def raise_on_first_error(self) -> bool:
         return False
 
-    def get_node_selector(self) -> TestSelector:
+    def get_node_selector(self) -> ResourceTypeSelector:
         if self.manifest is None or self.graph is None:
             raise DbtInternalError("manifest and graph must be set to get perform node selection")
-        return TestSelector(
+        return ResourceTypeSelector(
             graph=self.graph,
             manifest=self.manifest,
             previous_state=self.previous_state,
+            resource_types=[NodeType.Test, NodeType.Unit],
         )
 
     def get_runner_type(self, _) -> Optional[Type[BaseRunner]]:


### PR DESCRIPTION
Resolves NA

### Problem

The `TestSelector` class was introduced in https://github.com/dbt-labs/dbt-core/pull/2628, but it doesn't need to offer anything differentiated anymore.

### Solution

Simplify by standardizing upon the `ResourceTypeSelector`.

This was accomplished by:
1. replacing all instances of `TestSelector` with `ResourceTypeSelector`
1. removing the `TestSelector` class

### Some history of the `TestSelector` class

To help us avoid a [Chesterton's fence](https://sketchplanations.com/chestertons-fence) situation:

1. was first introduced in [#2628](https://github.com/dbt-labs/dbt-core/pull/2628) merged on 2020-07-20
    - contained two differentiated attributes: `data` and `schema`
    - contained a differentiated method: `expand_selection`
2. modified 1 day later in [#2629](https://github.com/dbt-labs/dbt-core/pull/2629)
    - removed differentiated attributes: `data` and `schema`
3. modified 9 months later in [#3235](https://github.com/dbt-labs/dbt-core/pull/3235)
    - removed differentiated method: `expand_selection`

### Additional information


Doing this simple refactor makes it easy to see the root cause of the bug report in https://github.com/dbt-labs/dbt-core/issues/10727.

Refactoring first will make it easier to review the code changes in https://github.com/dbt-labs/dbt-core/pull/10706 (which will also resolve https://github.com/dbt-labs/dbt-core/issues/10727).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] Tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.).
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.