### PR TITLE
Add Snowplow tracking for behavior flags

### DIFF
--- a/.changes/unreleased/Under the Hood-20240911-162730.yaml
+++ b/.changes/unreleased/Under the Hood-20240911-162730.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add Snowplow tracking for behavior flag deprecations
+time: 2024-09-11T16:27:30.293832-04:00
+custom:
+  Author: mikealfare
+  Issue: "10552"

--- a/core/dbt/events/logging.py
+++ b/core/dbt/events/logging.py
@@ -2,7 +2,7 @@ import os
 from functools import partial
 from typing import Callable, List
 
-from dbt.tracking import track_behavior_deprecation_warn
+from dbt.tracking import track_behavior_change_warn
 from dbt_common.events.base_types import EventLevel, EventMsg
 from dbt_common.events.event_manager_client import (
     add_callback_to_manager,
@@ -70,7 +70,7 @@ def setup_event_logger(flags, callbacks: List[Callable[[EventMsg], None]] = []) 
     make_log_dir_if_missing(flags.LOG_PATH)
     event_manager = get_event_manager()
     event_manager.callbacks = callbacks.copy()
-    add_callback_to_manager(track_behavior_deprecation_warn)
+    add_callback_to_manager(track_behavior_change_warn)
 
     if flags.LOG_LEVEL != "none":
         line_format = _line_format_from_str(flags.LOG_FORMAT, LineFormat.PlainText)

--- a/core/dbt/events/logging.py
+++ b/core/dbt/events/logging.py
@@ -70,6 +70,7 @@ def setup_event_logger(flags, callbacks: List[Callable[[EventMsg], None]] = []) 
     make_log_dir_if_missing(flags.LOG_PATH)
     event_manager = get_event_manager()
     event_manager.callbacks = callbacks.copy()
+    add_callback_to_manager(track_behavior_deprecation_warn)
 
     if flags.LOG_LEVEL != "none":
         line_format = _line_format_from_str(flags.LOG_FORMAT, LineFormat.PlainText)
@@ -90,8 +91,6 @@ def setup_event_logger(flags, callbacks: List[Callable[[EventMsg], None]] = []) 
             # being sent to stdout.
             console_config.output_stream = get_capture_stream()
         add_logger_to_manager(console_config)
-
-        add_callback_to_manager(track_behavior_deprecation_warn)
 
     if flags.LOG_LEVEL_FILE != "none":
         # create and add the file logger to the event manager

--- a/core/dbt/events/logging.py
+++ b/core/dbt/events/logging.py
@@ -2,8 +2,10 @@ import os
 from functools import partial
 from typing import Callable, List
 
+from dbt.tracking import track_behavior_deprecation_warn
 from dbt_common.events.base_types import EventLevel, EventMsg
 from dbt_common.events.event_manager_client import (
+    add_callback_to_manager,
     add_logger_to_manager,
     cleanup_event_logger,
     get_event_manager,
@@ -88,6 +90,8 @@ def setup_event_logger(flags, callbacks: List[Callable[[EventMsg], None]] = []) 
             # being sent to stdout.
             console_config.output_stream = get_capture_stream()
         add_logger_to_manager(console_config)
+
+        add_callback_to_manager(track_behavior_deprecation_warn)
 
     if flags.LOG_LEVEL_FILE != "none":
         # create and add the file logger to the event manager

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -367,15 +367,10 @@ def track_deprecation_warn(options):
 
 
 def track_behavior_deprecation_warn(msg: EventMsg) -> None:
-    if msg.info.name != "BehaviorDeprecationEvent":
-        return
-
-    if active_user is None:
-        # cannot track deprecation warnings when active user is None
+    if msg.info.name != "BehaviorDeprecationEvent" or active_user is None:
         return
 
     context = [SelfDescribingJson(BEHAVIOR_DEPRECATION_WARN_SPEC, msg_to_dict(msg))]
-
     track(
         active_user,
         category="dbt",

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -26,7 +26,7 @@ from dbt.events.types import (
     TrackingInitializeFailure,
 )
 from dbt_common.events.base_types import EventMsg
-from dbt_common.events.functions import fire_event, get_invocation_id
+from dbt_common.events.functions import fire_event, get_invocation_id, msg_to_dict
 from dbt_common.exceptions import NotImplementedError
 
 sp_logger.setLevel(100)
@@ -374,22 +374,13 @@ def track_behavior_deprecation_warn(msg: EventMsg) -> None:
         # cannot track deprecation warnings when active user is None
         return
 
-    data = {
-        "flag_name": getattr(msg.data, "flag_name"),
-        "flag_source": getattr(msg.data, "flag_source"),
-        "deprecation_version": getattr(msg.data, "deprecation_version", ""),
-        "deprecation_message": getattr(msg.data, "deprecation_message", ""),
-        "docs_url": getattr(msg.data, "docs_url", ""),
-    }
-
-    context = [SelfDescribingJson(BEHAVIOR_DEPRECATION_WARN_SPEC, data)]
+    context = [SelfDescribingJson(BEHAVIOR_DEPRECATION_WARN_SPEC, msg_to_dict(msg))]
 
     track(
         active_user,
         category="dbt",
         action="behavior_deprecation",
         label=get_invocation_id(),
-        property_=getattr(msg.data, "flag_name"),
         context=context,
     )
 

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -37,7 +37,7 @@ DBT_INVOCATION_ENV = "DBT_INVOCATION_ENV"
 
 ADAPTER_INFO_SPEC = "iglu:com.dbt/adapter_info/jsonschema/1-0-1"
 DEPRECATION_WARN_SPEC = "iglu:com.dbt/deprecation_warn/jsonschema/1-0-0"
-BEHAVIOR_DEPRECATION_WARN_SPEC = "iglu:com.dbt/behavior_deprecation_warn/jsonschema/1-0-0"
+BEHAVIOR_CHANGE_WARN_SPEC = "iglu:com.dbt/behavior_change_warn/jsonschema/1-0-0"
 EXPERIMENTAL_PARSER = "iglu:com.dbt/experimental_parser/jsonschema/1-0-0"
 INVOCATION_ENV_SPEC = "iglu:com.dbt/invocation_env/jsonschema/1-0-0"
 INVOCATION_SPEC = "iglu:com.dbt/invocation/jsonschema/1-0-2"
@@ -366,11 +366,11 @@ def track_deprecation_warn(options):
     )
 
 
-def track_behavior_deprecation_warn(msg: EventMsg) -> None:
-    if msg.info.name != "BehaviorDeprecationEvent" or active_user is None:
+def track_behavior_change_warn(msg: EventMsg) -> None:
+    if msg.info.name != "BehaviorChangeEvent" or active_user is None:
         return
 
-    context = [SelfDescribingJson(BEHAVIOR_DEPRECATION_WARN_SPEC, msg_to_dict(msg))]
+    context = [SelfDescribingJson(BEHAVIOR_CHANGE_WARN_SPEC, msg_to_dict(msg))]
     track(
         active_user,
         category="dbt",

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -379,7 +379,7 @@ def track_behavior_deprecation_warn(msg: EventMsg) -> None:
     track(
         active_user,
         category="dbt",
-        action="behavior_deprecation",
+        action=msg.info.name,
         label=get_invocation_id(),
         context=context,
     )

--- a/tests/unit/events/test_logging.py
+++ b/tests/unit/events/test_logging.py
@@ -23,7 +23,7 @@ class TestSetupEventLogger:
 
         setup_event_logger(get_flags())
         assert len(manager.loggers) == 0
-        assert len(manager.callbacks) == 0
+        assert len(manager.callbacks) == 1  # snowplow tracker for behavior flags
 
     def test_specify_max_bytes(
         self,

--- a/tests/unit/test_behavior_flags.py
+++ b/tests/unit/test_behavior_flags.py
@@ -1,0 +1,59 @@
+import pytest
+
+from dbt.tracking import (
+    disable_tracking,
+    initialize_from_flags,
+    track_behavior_deprecation_warn,
+)
+from dbt_common.behavior_flags import Behavior
+from dbt_common.events.event_manager_client import (
+    add_callback_to_manager,
+    cleanup_event_logger,
+)
+
+
+@pytest.fixture
+def snowplow_tracker(mocker):
+    # initialize `active_user` without writing the cookie to disk
+    initialize_from_flags(True, "")
+    mocker.patch("dbt.tracking.User.set_cookie").return_value = {"id": 42}
+
+    # add the relevant callback to the event manager
+    add_callback_to_manager(track_behavior_deprecation_warn)
+
+    # don't make a call, catch the request
+    snowplow_tracker = mocker.patch("dbt.tracking.tracker.track_struct_event")
+
+    yield snowplow_tracker
+
+    # teardown
+    cleanup_event_logger()
+    disable_tracking()
+
+
+def test_false_evaluation_triggers_snowplow_tracking(snowplow_tracker):
+    behavior = Behavior([{"name": "my_flag", "default": False}], {})
+    if behavior.my_flag:
+        # trigger a False evaluation
+        assert False, "This flag should evaluate to false and skip this line"
+    assert snowplow_tracker.called
+
+
+def test_true_evaluation_does_not_trigger_snowplow_tracking(snowplow_tracker):
+    behavior = Behavior([{"name": "my_flag", "default": True}], {})
+    if behavior.my_flag:
+        pass
+    else:
+        # trigger a True evaluation
+        assert False, "This flag should evaluate to false and skip this line"
+    assert not snowplow_tracker.called
+
+
+def test_false_evaluation_does_not_trigger_snowplow_tracking_when_disabled(snowplow_tracker):
+    disable_tracking()
+
+    behavior = Behavior([{"name": "my_flag", "default": False}], {})
+    if behavior.my_flag:
+        # trigger a False evaluation
+        assert False, "This flag should evaluate to false and skip this line"
+    assert not snowplow_tracker.called

--- a/tests/unit/test_behavior_flags.py
+++ b/tests/unit/test_behavior_flags.py
@@ -32,7 +32,9 @@ def snowplow_tracker(mocker):
 
 
 def test_false_evaluation_triggers_snowplow_tracking(snowplow_tracker):
-    behavior = Behavior([{"name": "my_flag", "default": False}], {})
+    behavior = Behavior(
+        [{"name": "my_flag", "default": False, "description": "This is a false flag."}], {}
+    )
     if behavior.my_flag:
         # trigger a False evaluation
         assert False, "This flag should evaluate to false and skip this line"
@@ -40,7 +42,9 @@ def test_false_evaluation_triggers_snowplow_tracking(snowplow_tracker):
 
 
 def test_true_evaluation_does_not_trigger_snowplow_tracking(snowplow_tracker):
-    behavior = Behavior([{"name": "my_flag", "default": True}], {})
+    behavior = Behavior(
+        [{"name": "my_flag", "default": True, "description": "This is a true flag."}], {}
+    )
     if behavior.my_flag:
         pass
     else:
@@ -52,7 +56,9 @@ def test_true_evaluation_does_not_trigger_snowplow_tracking(snowplow_tracker):
 def test_false_evaluation_does_not_trigger_snowplow_tracking_when_disabled(snowplow_tracker):
     disable_tracking()
 
-    behavior = Behavior([{"name": "my_flag", "default": False}], {})
+    behavior = Behavior(
+        [{"name": "my_flag", "default": False, "description": "This is a false flag."}], {}
+    )
     if behavior.my_flag:
         # trigger a False evaluation
         assert False, "This flag should evaluate to false and skip this line"

--- a/tests/unit/test_behavior_flags.py
+++ b/tests/unit/test_behavior_flags.py
@@ -3,7 +3,7 @@ import pytest
 from dbt.tracking import (
     disable_tracking,
     initialize_from_flags,
-    track_behavior_deprecation_warn,
+    track_behavior_change_warn,
 )
 from dbt_common.behavior_flags import Behavior
 from dbt_common.events.event_manager_client import (
@@ -19,7 +19,7 @@ def snowplow_tracker(mocker):
     mocker.patch("dbt.tracking.User.set_cookie").return_value = {"id": 42}
 
     # add the relevant callback to the event manager
-    add_callback_to_manager(track_behavior_deprecation_warn)
+    add_callback_to_manager(track_behavior_change_warn)
 
     # don't make a call, catch the request
     snowplow_tracker = mocker.patch("dbt.tracking.tracker.track_struct_event")


### PR DESCRIPTION
resolves #10552

### Problem

We need to track deprecated states of behavior flags in Snowplow so that we get telemetry for both Cloud and Core users.

### Solution

Handle the event that is already firing for logging with a callback that tracks the event in Snowplow.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
