### PR TITLE
Refactor functional microbatch tests.

### DIFF
--- a/core/dbt/tests/util.py
+++ b/core/dbt/tests/util.py
@@ -647,3 +647,19 @@ def safe_set_invocation_context():
 def patch_microbatch_end_time(dt_str: str):
     dt = datetime.strptime(dt_str, "%Y-%m-%d %H:%M:%S")
     return mock.patch.object(BaseResolver, "_build_end_time", return_value=dt)
+
+
+# Quoted type hint to prevent circular import issues.
+def assert_row_count(project: "TestProjInfo", relation_name: str, expected_row_count: int) -> None:
+    """
+    Assert if a relation in a project has the correct number of rows. If not,
+    prints the relation and raises an AssertionError.
+    """
+    relation = relation_from_name(project.adapter, relation_name)
+    result = project.run_sql(f"select count(*) as num_rows from {relation}", fetch="one")
+
+    if result[0] != expected_row_count:
+        # running show for debugging
+        run_dbt(["show", "--inline", f"select * from {relation}"])
+
+        assert result[0] == expected_row_count

--- a/tests/functional/test_empty.py
+++ b/tests/functional/test_empty.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dbt.tests.util import relation_from_name, run_dbt
+from dbt.tests.util import run_dbt, assert_row_count
 
 model_input_sql = """
 select 1 as id
@@ -53,30 +53,25 @@ class TestEmptyFlag:
             "sources.yml": schema_sources_yml,
         }
 
-    def assert_row_count(self, project, relation_name: str, expected_row_count: int):
-        relation = relation_from_name(project.adapter, relation_name)
-        result = project.run_sql(f"select count(*) as num_rows from {relation}", fetch="one")
-        assert result[0] == expected_row_count
-
     def test_run_with_empty(self, project):
         # create source from seed
         run_dbt(["seed"])
 
         # run without empty - 3 expected rows in output - 1 from each input
         run_dbt(["run"])
-        self.assert_row_count(project, "model", 3)
+        assert_row_count(project, "model", 3)
 
         # run with empty - 0 expected rows in output
         run_dbt(["run", "--empty"])
-        self.assert_row_count(project, "model", 0)
+        assert_row_count(project, "model", 0)
 
         # build without empty - 3 expected rows in output - 1 from each input
         run_dbt(["build"])
-        self.assert_row_count(project, "model", 3)
+        assert_row_count(project, "model", 3)
 
         # build with empty - 0 expected rows in output
         run_dbt(["build", "--empty"])
-        self.assert_row_count(project, "model", 0)
+        assert_row_count(project, "model", 0)
 
         # ensure dbt compile supports --empty flag
         run_dbt(["compile", "--empty"])


### PR DESCRIPTION
Resolves #

I know there should be an associated issue, but there is no issue suitable issue template accessible to external contributors. Feel free to create one of type Implementation if this seems worthwhile.

### Problem

1. The functional test file `test_microbatch.py` has accumulated quite a bit of duplication. Especially regarding the assertion of relation row counts.
2. `os.environ` is mocked for temporarily changing the environment variables. PyTest offers a [more robust mechanism](https://docs.pytest.org/en/6.2.x/monkeypatch.html#monkeypatching-environment-variables).

### Solution

1. Deduplicate `assert_row_count()`
* Move duplicated method `assert_row_count()` to function `assert_row_count()` in `core/dbt/tests/util.py`.
* Add documentation and type hints to this function.
* Replace relevant method calls in `tests/functional/microbatch/test_microbatch.py` and `tests/functional/test_empty.py` with this function.
* Remove redundant (method) definitions of `assert_row_count()` in these two test files.

2. Use PyTest's `monkeypatch.setenv()` instead of patching `os.environ`
* Create autouse fixture in `tests/functional/microbatch/test_microbatch.py` to automatically set `DBT_EXPERIMENTAL_MICROBATCH` to `True`, which is what most tests require.
* Remove redundant `os.environ` patches.

3. Replace similar patches to `valid_incremental_strategies` with a new utility function `_mock_valid_incremental_strategies()` in `tests/functional/microbatch/test_microbatch.py`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
