### PR TITLE
Fix `--resource-type test` for `dbt list` and `dbt build`

### DIFF
--- a/.changes/unreleased/Fixes-20240917-174446.yaml
+++ b/.changes/unreleased/Fixes-20240917-174446.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix `--resource-type test` for `dbt list` and `dbt build`
+time: 2024-09-17T17:44:46.121032-06:00
+custom:
+  Author: dbeatty10
+  Issue: "10730"

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -202,6 +202,7 @@ class BuildTask(RunTask):
                 graph=self.graph,
                 manifest=self.manifest,
                 previous_state=self.previous_state,
+                resource_types=resource_types,
             )
         return ResourceTypeSelector(
             graph=self.graph,

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -205,6 +205,7 @@ class ListTask(GraphRunnableTask):
                 graph=self.graph,
                 manifest=self.manifest,
                 previous_state=self.previous_state,
+                resource_types=self.resource_types,
             )
         else:
             return ResourceTypeSelector(

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -376,12 +376,14 @@ class TestRunner(CompileRunner):
 
 
 class TestSelector(ResourceTypeSelector):
-    def __init__(self, graph, manifest, previous_state) -> None:
+    def __init__(
+        self, graph, manifest, previous_state, resource_types=[NodeType.Test, NodeType.Unit]
+    ) -> None:
         super().__init__(
             graph=graph,
             manifest=manifest,
             previous_state=previous_state,
-            resource_types=[NodeType.Test, NodeType.Unit],
+            resource_types=resource_types,
         )
 
 

--- a/tests/functional/unit_testing/fixtures.py
+++ b/tests/functional/unit_testing/fixtures.py
@@ -50,6 +50,18 @@ END a_is_null
 FROM {{ ref('my_model_a') }}
 """
 
+test_my_model_a_yml = """
+models:
+  - name: my_model_a
+    columns:
+      - name: a
+        tests:
+          - not_null
+      - name: id
+        tests:
+          - not_null
+"""
+
 test_my_model_yml = """
 unit_tests:
   - name: test_my_model

--- a/tests/functional/unit_testing/fixtures.py
+++ b/tests/functional/unit_testing/fixtures.py
@@ -50,15 +50,6 @@ END a_is_null
 FROM {{ ref('my_model_a') }}
 """
 
-test_my_model_a_yml = """
-models:
-  - name: my_model_a
-    columns:
-      - name: id
-        tests:
-          - not_null
-"""
-
 test_my_model_yml = """
 unit_tests:
   - name: test_my_model

--- a/tests/functional/unit_testing/fixtures.py
+++ b/tests/functional/unit_testing/fixtures.py
@@ -50,6 +50,15 @@ END a_is_null
 FROM {{ ref('my_model_a') }}
 """
 
+test_my_model_a_yml = """
+models:
+  - name: my_model_a
+    columns:
+      - name: id
+        tests:
+          - not_null
+"""
+
 test_my_model_yml = """
 unit_tests:
   - name: test_my_model

--- a/tests/functional/unit_testing/test_ut_list.py
+++ b/tests/functional/unit_testing/test_ut_list.py
@@ -7,6 +7,7 @@ from fixtures import (  # noqa: F401
     my_model_a_sql,
     my_model_b_sql,
     my_model_vars_sql,
+    test_my_model_a_yml,
     test_my_model_yml,
 )
 
@@ -21,6 +22,7 @@ class TestUnitTestList:
             "my_model_a.sql": my_model_a_sql,
             "my_model_b.sql": my_model_b_sql,
             "test_my_model.yml": test_my_model_yml + datetime_test,
+            "test_my_model_a.yml": test_my_model_a_yml,
         }
 
     @pytest.fixture(scope="class")
@@ -32,13 +34,14 @@ class TestUnitTestList:
         results = run_dbt(["run"])
         assert len(results) == 3
         results = run_dbt(["test"], expect_pass=False)
-        assert len(results) == 5
+        assert len(results) == 6
 
         results = run_dbt(["list"])
         expected = [
             "test.my_model",
             "test.my_model_a",
             "test.my_model_b",
+            "test.not_null_my_model_a_id",
             "unit_test:test.test_my_model",
             "unit_test:test.test_my_model_datetime",
             "unit_test:test.test_my_model_empty",
@@ -81,3 +84,12 @@ class TestUnitTestList:
         for result in results:
             json_result = json.loads(result)
             assert json_result["model"] == "my_model"
+
+        results = run_dbt(["list", "--resource-type", "unit_test"])
+        assert len(results) == 5
+
+        results = run_dbt(["list", "--resource-type", "test"])
+        assert len(results) == 1
+
+        results = run_dbt(["list", "--resource-type", "unit_test", "test"])
+        assert len(results) == 6

--- a/tests/functional/unit_testing/test_ut_list.py
+++ b/tests/functional/unit_testing/test_ut_list.py
@@ -7,7 +7,6 @@ from fixtures import (  # noqa: F401
     my_model_a_sql,
     my_model_b_sql,
     my_model_vars_sql,
-    test_my_model_a_yml,
     test_my_model_yml,
 )
 
@@ -22,7 +21,6 @@ class TestUnitTestList:
             "my_model_a.sql": my_model_a_sql,
             "my_model_b.sql": my_model_b_sql,
             "test_my_model.yml": test_my_model_yml + datetime_test,
-            "test_my_model_a.yml": test_my_model_a_yml,
         }
 
     @pytest.fixture(scope="class")
@@ -34,14 +32,13 @@ class TestUnitTestList:
         results = run_dbt(["run"])
         assert len(results) == 3
         results = run_dbt(["test"], expect_pass=False)
-        assert len(results) == 6
+        assert len(results) == 5
 
         results = run_dbt(["list"])
         expected = [
             "test.my_model",
             "test.my_model_a",
             "test.my_model_b",
-            "test.not_null_my_model_a_id",
             "unit_test:test.test_my_model",
             "unit_test:test.test_my_model_datetime",
             "unit_test:test.test_my_model_empty",
@@ -84,12 +81,3 @@ class TestUnitTestList:
         for result in results:
             json_result = json.loads(result)
             assert json_result["model"] == "my_model"
-
-        results = run_dbt(["list", "--resource-type", "unit_test"])
-        assert len(results) == 5
-
-        results = run_dbt(["list", "--resource-type", "test"])
-        assert len(results) == 1
-
-        results = run_dbt(["list", "--resource-type", "unit_test", "test"])
-        assert len(results) == 6

--- a/tests/functional/unit_testing/test_ut_resource_types.py
+++ b/tests/functional/unit_testing/test_ut_resource_types.py
@@ -1,0 +1,73 @@
+import pytest
+from fixtures import (  # noqa: F401
+    my_model_a_sql,
+    my_model_b_sql,
+    my_model_sql,
+    test_my_model_a_yml,
+    test_my_model_pass_yml,
+)
+
+from dbt.tests.util import run_dbt
+
+EXPECTED_MODELS = [
+    "test.my_model",
+    "test.my_model_a",
+    "test.my_model_b",
+]
+
+EXPECTED_DATA_TESTS = [
+    "test.not_null_my_model_a_a",
+    "test.not_null_my_model_a_id",
+]
+
+EXPECTED_UNIT_TESTS = [
+    "unit_test:test.test_my_model",
+]
+
+
+class TestUnitTestResourceTypes:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "my_model_a.sql": my_model_a_sql,
+            "my_model_b.sql": my_model_b_sql,
+            "test_my_model.yml": test_my_model_pass_yml,
+            "test_my_model_a.yml": test_my_model_a_yml,
+        }
+
+    def test_unit_test_list(self, project):
+        results = run_dbt(["run"])
+
+        # unit tests
+        results = run_dbt(["list", "--resource-type", "unit_test"])
+        assert sorted(results) == EXPECTED_UNIT_TESTS
+
+        results = run_dbt(["list", "--exclude-resource-types", "model", "test"])
+        assert sorted(results) == EXPECTED_UNIT_TESTS
+
+        # data tests
+        results = run_dbt(["list", "--resource-type", "test"])
+        assert sorted(results) == EXPECTED_DATA_TESTS
+
+        results = run_dbt(["list", "--exclude-resource-types", "unit_test", "model"])
+        assert sorted(results) == EXPECTED_DATA_TESTS
+
+        results = run_dbt(["build", "--resource-type", "test"])
+        assert len(results) == len(EXPECTED_DATA_TESTS)
+
+        results = run_dbt(["build", "--exclude-resource-types", "unit_test", "model"])
+        assert len(results) == len(EXPECTED_DATA_TESTS)
+
+        # models
+        results = run_dbt(["list", "--resource-type", "model"])
+        assert len(results) == len(EXPECTED_MODELS)
+
+        results = run_dbt(["list", "--exclude-resource-type", "unit_test", "test"])
+        assert sorted(results) == EXPECTED_MODELS
+
+        results = run_dbt(["build", "--resource-type", "model"])
+        assert len(results) == len(EXPECTED_MODELS)
+
+        results = run_dbt(["build", "--exclude-resource-type", "unit_test", "test"])
+        assert len(results) == len(EXPECTED_MODELS)


### PR DESCRIPTION
Resolves #10727

### Problem

This command includes _both_ data tests _and_ unit tests (when it should _only_ include data tests):
```shell
dbt list --resource-type test
```

So does this:
```shell
dbt build --resource-type test
```

### Solution

Add a `resource_types` parameter to the constructor for the `TestSelector` class. Give it a default value of `[NodeType.Test, NodeType.Unit]`. Override the default parameter as-needed.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.).
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.