### PR TITLE
replace deprecated/removed distutils copy_tree with shutil copytree

### DIFF
--- a/tests/functional/fixtures/happy_path_fixture.py
+++ b/tests/functional/fixtures/happy_path_fixture.py
@@ -1,5 +1,5 @@
 import os
-from distutils.dir_util import copy_tree
+from shutil import copytree
 
 import pytest
 
@@ -19,7 +19,7 @@ def delete_files_in_directory(directory_path):
 def happy_path_project_files(project_root):
     # copy fixture files to the project root
     delete_files_in_directory(project_root)
-    copy_tree(
+    copytree(
         os.path.dirname(os.path.realpath(__file__)) + "/happy_path_project", str(project_root)
     )
 


### PR DESCRIPTION
Resolves #

There is no suitable issue template for external contributors, please create one if this seems useful.

### Problem
The deprecated (and in Python 3.12, removed) `distutils` is still referred to in `happy_path_fixture.py`. This could lead to problems in integration test runs.

### Solution
Replace `distutils.dir_util.copy_tree` with `shutil.copytree`, which has very similar behavior.

For reference, see [distutils docs](https://docs.python.org/3.11/distutils/apiref.html#distutils.dir_util.copy_tree):

> Copy an entire directory tree src to a new location dst. Both src and dst must be directory names. If src is not a directory, raise DistutilsFileError. If dst does not exist, it is created with [mkpath()](https://docs.python.org/3.11/distutils/apiref.html#distutils.dir_util.mkpath).

and [shutil docs](https://docs.python.org/3.11/distutils/apiref.html#distutils.dir_util.copy_tree):

> Recursively copy an entire directory tree rooted at src to a directory named dst and return the destination directory. All intermediate directories needed to contain dst will also be created by default.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
