### PR TITLE
Fix Calls to pre_model_hook()

### DIFF
--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -127,7 +127,7 @@ class TestRunner(CompileRunner):
     def execute_data_test(self, data_test: TestNode, manifest: Manifest) -> TestResultData:
         context = generate_runtime_model_context(data_test, self.config, manifest)
 
-        hook_ctx = self.adapter.pre_model_hook(context)
+        hook_ctx = self.adapter.pre_model_hook(context["config"])
 
         materialization_macro = manifest.find_materialization_macro_by_name(
             self.config.project_name, data_test.get_materialization(), self.adapter.type()
@@ -205,7 +205,7 @@ class TestRunner(CompileRunner):
         # materialization, not compile the node.compiled_code
         context = generate_runtime_model_context(unit_test_node, self.config, unit_test_manifest)
 
-        hook_ctx = self.adapter.pre_model_hook(context)
+        hook_ctx = self.adapter.pre_model_hook(context["config"])
 
         materialization_macro = unit_test_manifest.find_materialization_macro_by_name(
             self.config.project_name, unit_test_node.get_materialization(), self.adapter.type()


### PR DESCRIPTION
This fixes two calls to pre_model_hook() which pass objects of the wrong type. The type used in other places this function is called is RuntimeConfigObject, but here a context dictionary was passed. This was causing errors for me in a very specific testing scenario, but looks like a more general problem.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
