### PR TITLE
Remove deprecated `track_struct_event`

### DIFF
--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -12,6 +12,7 @@ from packaging.version import Version
 from snowplow_tracker import Emitter, SelfDescribingJson, Subject, Tracker
 from snowplow_tracker import __version__ as snowplow_version  # type: ignore
 from snowplow_tracker import logger as sp_logger
+from snowplow_tracker.events import StructuredEvent
 
 from dbt import version as dbt_version
 from dbt.adapters.exceptions import FailedToConnectError
@@ -215,12 +216,12 @@ def get_dbt_env_context():
 def track(user, *args, **kwargs):
     if user.do_not_track:
         return
-    else:
-        fire_event(SendingEvent(kwargs=str(kwargs)))
-        try:
-            tracker.track_struct_event(*args, **kwargs)
-        except Exception:
-            fire_event(SendEventFailure())
+
+    fire_event(SendingEvent(kwargs=str(kwargs)))
+    try:
+        tracker.track(StructuredEvent(*args, **kwargs))
+    except Exception:
+        fire_event(SendEventFailure())
 
 
 def track_project_id(options):


### PR DESCRIPTION
### Problem

`snowplow_tracking` is deprecating `track_struct_event`.

### Solution

Per the suggestion in the deprecation warning, use `StructuredEvent` instead.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
