### PR TITLE
Split out model vs microbatch execution

### DIFF
--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -350,6 +350,47 @@ class ModelRunner(CompileRunner):
         )
         raise CompilationError(msg, node=model)
 
+    def _execute_model(
+        self,
+        hook_ctx: Any,
+        context_config: Any,
+        model: ModelNode,
+        context: Dict[str, Any],
+        materialization_macro: MacroProtocol,
+    ) -> RunResult:
+        try:
+            result = MacroGenerator(
+                materialization_macro, context, stack=context["context_macro_stack"]
+            )()
+            for relation in self._materialization_relations(result, model):
+                self.adapter.cache_added(relation.incorporate(dbt_created=True))
+        finally:
+            self.adapter.post_model_hook(context_config, hook_ctx)
+
+        return self._build_run_model_result(model, context)
+
+    def _execute_microbatch_model(
+        self,
+        hook_ctx: Any,
+        context_config: Any,
+        model: ModelNode,
+        manifest: Manifest,
+        context: Dict[str, Any],
+        materialization_macro: MacroProtocol,
+    ) -> RunResult:
+        batch_results = None
+        try:
+            batch_results = self._execute_microbatch_materialization(
+                model, manifest, context, materialization_macro
+            )
+        finally:
+            self.adapter.post_model_hook(context_config, hook_ctx)
+
+        if batch_results is not None:
+            return self._build_run_microbatch_model_result(model, batch_results)
+        else:
+            return self._build_run_model_result(model, context)
+
     def execute(self, model, manifest):
         context = generate_runtime_model_context(model, self.config, manifest)
 
@@ -378,29 +419,19 @@ class ModelRunner(CompileRunner):
             )
 
         hook_ctx = self.adapter.pre_model_hook(context_config)
-        batch_results = None
-        try:
-            if (
-                os.environ.get("DBT_EXPERIMENTAL_MICROBATCH")
-                and model.config.materialized == "incremental"
-                and model.config.incremental_strategy == "microbatch"
-            ):
-                batch_results = self._execute_microbatch_materialization(
-                    model, manifest, context, materialization_macro
-                )
-            else:
-                result = MacroGenerator(
-                    materialization_macro, context, stack=context["context_macro_stack"]
-                )()
-                for relation in self._materialization_relations(result, model):
-                    self.adapter.cache_added(relation.incorporate(dbt_created=True))
-        finally:
-            self.adapter.post_model_hook(context_config, hook_ctx)
 
-        if batch_results:
-            return self._build_run_microbatch_model_result(model, batch_results)
-
-        return self._build_run_model_result(model, context)
+        if (
+            os.environ.get("DBT_EXPERIMENTAL_MICROBATCH")
+            and model.config.materialized == "incremental"
+            and model.config.incremental_strategy == "microbatch"
+        ):
+            return self._execute_microbatch_model(
+                hook_ctx, context_config, model, manifest, context, materialization_macro
+            )
+        else:
+            return self._execute_model(
+                hook_ctx, context_config, model, context, materialization_macro
+            )
 
     def _execute_microbatch_materialization(
         self,

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -362,10 +362,11 @@ class ModelRunner(CompileRunner):
             result = MacroGenerator(
                 materialization_macro, context, stack=context["context_macro_stack"]
             )()
-            for relation in self._materialization_relations(result, model):
-                self.adapter.cache_added(relation.incorporate(dbt_created=True))
         finally:
             self.adapter.post_model_hook(context_config, hook_ctx)
+
+        for relation in self._materialization_relations(result, model):
+            self.adapter.cache_added(relation.incorporate(dbt_created=True))
 
         return self._build_run_model_result(model, context)
 


### PR DESCRIPTION
Resolves #N/A


### Description

In #10677 we added microbatch model execution logic to the `ModelRunner.execute`. In doing so we changed the order of operations of some normal model execution steps. This PR splits the logic so that we can return the order of operations for normal model execution back to what it was previously while still supporting microbatch model execution. We don't know if the change of order operations that happened in #10677 was problematic, but moving it back is being done out caution.


### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
