### PR TITLE
Fix mock in unit test after removing deprecated snowplow method

### DIFF
--- a/tests/unit/test_behavior_flags.py
+++ b/tests/unit/test_behavior_flags.py
@@ -22,7 +22,8 @@ def snowplow_tracker(mocker):
     add_callback_to_manager(track_behavior_change_warn)
 
     # don't make a call, catch the request
-    snowplow_tracker = mocker.patch("dbt.tracking.tracker.track_struct_event")
+    # to avoid confusion, this is snowplow_tracker's track, not our wrapper that's also named track
+    snowplow_tracker = mocker.patch("dbt.tracking.tracker.track")
 
     yield snowplow_tracker
 


### PR DESCRIPTION
### Problem

We removed a deprecated method, `snowplow_tracker.Tracker.track_struct_event()`, and replaced it with the suggested method `snowplow_tracker.Tracker.track()`. The former was mocked in a unit test and it was expected to be called. After the update, it did not get called as this method no longer existed.

### Solution

Update the mock to reference the new method.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
