### PR TITLE
Standardize returning `ResourceTypeSelector` instances in `dbt list` and `dbt build`

### DIFF
--- a/.changes/unreleased/Under the Hood-20240918-170325.yaml
+++ b/.changes/unreleased/Under the Hood-20240918-170325.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Standardize returning `ResourceTypeSelector` instances in `dbt list` and `dbt
+  build`
+time: 2024-09-18T17:03:25.639516-06:00
+custom:
+  Author: dbeatty10
+  Issue: "10739"

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -196,13 +196,6 @@ class BuildTask(RunTask):
 
         resource_types = self.resource_types(no_unit_tests)
 
-        if resource_types == [NodeType.Test]:
-            return ResourceTypeSelector(
-                graph=self.graph,
-                manifest=self.manifest,
-                previous_state=self.previous_state,
-                resource_types=resource_types,
-            )
         return ResourceTypeSelector(
             graph=self.graph,
             manifest=self.manifest,

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -199,21 +199,13 @@ class ListTask(GraphRunnableTask):
     def get_node_selector(self) -> ResourceTypeSelector:
         if self.manifest is None or self.graph is None:
             raise DbtInternalError("manifest and graph must be set to get perform node selection")
-        if self.resource_types == [NodeType.Test]:
-            return ResourceTypeSelector(
-                graph=self.graph,
-                manifest=self.manifest,
-                previous_state=self.previous_state,
-                resource_types=self.resource_types,
-            )
-        else:
-            return ResourceTypeSelector(
-                graph=self.graph,
-                manifest=self.manifest,
-                previous_state=self.previous_state,
-                resource_types=self.resource_types,
-                include_empty_nodes=True,
-            )
+        return ResourceTypeSelector(
+            graph=self.graph,
+            manifest=self.manifest,
+            previous_state=self.previous_state,
+            resource_types=self.resource_types,
+            include_empty_nodes=True,
+        )
 
     def interpret_results(self, results):
         # list command should always return 0 as exit code

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -196,7 +196,7 @@ class ListTask(GraphRunnableTask):
         else:
             return self.args.select
 
-    def get_node_selector(self):
+    def get_node_selector(self) -> ResourceTypeSelector:
         if self.manifest is None or self.graph is None:
             raise DbtInternalError("manifest and graph must be set to get perform node selection")
         if self.resource_types == [NodeType.Test]:


### PR DESCRIPTION
Resolves NA

### Problem

There is some unnecessary code duplication as it relates to `ResourceTypeSelector`. The backstory is explained in the PR description for https://github.com/dbt-labs/dbt-core/pull/10718.

### Solution

Standardize the duplicated code.

### One wrinkle to confirm

The one thing that is technically different is [this line](https://github.com/dbt-labs/dbt-core/blame/3e437a67344469d51d7f2d4a4d0338a45c1de261/core/dbt/task/list.py#L215) that sets `include_empty_nodes=True` for `dbt list`. The `include_empty_nodes=True` line was introduced in https://github.com/dbt-labs/dbt-core/pull/7891/commits/51da3757b10fd1d51d2ce0c083c9b45ef87db1c9 (within https://github.com/dbt-labs/dbt-core/pull/7891), presumably to resolve https://github.com/dbt-labs/dbt-core/issues/7496.

There is a single case where it is false here: when `test` is the only selected resource. That would be an odd carve out! So I'm assuming that it is unintentional and we can safely make the change in this PR.

However, if we **do** want this carve out, then we should create a functional test for it, because we don't have any for it currently.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] Tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.).
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.