### PR TITLE
Fix retry docs generate by marking certain args as False by default.

### DIFF
--- a/.changes/unreleased/Fixes-20240919-180837.yaml
+++ b/.changes/unreleased/Fixes-20240919-180837.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix NoSuchOption errors when running `dbt retry` after `dbt docs generate`.
+time: 2024-09-19T18:08:37.450919604+02:00
+custom:
+    Author: jordivandooren
+    Issue: "10741"

--- a/core/dbt/task/retry.py
+++ b/core/dbt/task/retry.py
@@ -84,7 +84,6 @@ class RetryTask(ConfiguredTask):
         cli_command = CMD_DICT.get(self.previous_command_name)  # type: ignore
         # Remove these args when their default values are present, otherwise they'll raise an exception
         args_to_remove = {
-            "show": lambda x: True,
             "resource_types": lambda x: x == [],
             "warn_error_options": lambda x: x == {"exclude": [], "include": []},
         }

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -329,7 +329,7 @@ class MultiDict(Mapping[str, Any]):
 # cli args and flags, which is more complete than just the cli args.
 # If new args are added that are false by default (particularly in the
 # global options) they should be added to the 'default_false_keys' list.
-def args_to_dict(args):
+def args_to_dict(args) -> dict:
     var_args = vars(args).copy()
     # update the args with the flags, which could also come from environment
     # variables or project_flags

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -357,6 +357,7 @@ def args_to_dict(args) -> dict:
             "use_experimental_parser",
             "static",
             "empty_catalog",
+            "show",
         )
         default_empty_yaml_dict_keys = ("vars", "warn_error_options")
         if key in default_false_keys and var_args[key] is False:

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -355,6 +355,8 @@ def args_to_dict(args):
             "log_cache_events",
             "store_failures",
             "use_experimental_parser",
+            "static",
+            "empty_catalog",
         )
         default_empty_yaml_dict_keys = ("vars", "warn_error_options")
         if key in default_false_keys and var_args[key] is False:

--- a/tests/unit/test_flag_translation.py
+++ b/tests/unit/test_flag_translation.py
@@ -1,0 +1,55 @@
+import click
+import pytest
+
+from dbt.cli import main as cli_main
+from dbt.cli.types import Command
+from dbt.task.retry import CMD_DICT
+from dbt.utils import args_to_dict
+
+
+def is_problematic_option(option: click.Option) -> bool:
+    return (
+        option.is_flag and not option.default and not option.secondary_opts and option.expose_value
+    )
+
+
+def get_problemetic_options_for_command(command: click.Command) -> list[str]:
+    """
+    Get boolean flags of a ClickCommand that are False by default, do not
+    have a secondary option (--no-*), and expose their value.
+    Why do we care? If not dealt with, these arguments are stored in run_results.json
+    and converted to non-existent --no-* options when running dbt retry.
+    """
+    return [
+        option.name
+        for option in command.params
+        if isinstance(option, click.Option) and is_problematic_option(option)
+    ]
+
+
+def get_commands_supported_by_retry() -> list[click.Command]:
+    command_names = [convert_enum_to_command_function_name(value) for value in CMD_DICT.values()]
+    return [getattr(cli_main, name) for name in command_names]
+
+
+def convert_enum_to_command_function_name(enum: Command) -> str:
+    return "_".join(enum.to_list()).replace("-", "_")
+
+
+class FlagsDummy:
+    def __init__(self, args: dict[str, bool]):
+        self.__dict__ = args
+
+
+@pytest.mark.parametrize("command", get_commands_supported_by_retry())
+def test_flags_problematic_for_retry_are_dealt_with(command: click.Command):
+    """
+    For each command supported by retry, get a list of flags that should
+    not be converted to --no-* when False, and assert if args_to_dict correctly
+    skips it.
+    """
+    flag_names = get_problemetic_options_for_command(command)
+    flags = FlagsDummy({name: False for name in flag_names})
+    args_dict = args_to_dict(flags)
+    for flag_name in flag_names:
+        assert flag_name not in args_dict, f"add {flag_name} to default_false_keys in args_to_dict"


### PR DESCRIPTION
Resolves #10741

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

`dbt retry` raises `NoSuchOption` after `dbt docs generate`
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
Add `static` and `empty_catalog` to the list of flags that are nog saved to the `run_results.json` file when they are absent.
A second strategy could have been to add the exceptions to `retry.py` top prevent these options (while present in the run results) to be translated into `--no-`.

### Checklist
Type hints could be better; I could not find a clean way to express args should be "dictable" (should have `__dict__`).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
