### PR TITLE
Fix unit tests for incremental models with alias

### DIFF
--- a/.changes/unreleased/Fixes-20240922-133527.yaml
+++ b/.changes/unreleased/Fixes-20240922-133527.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix unit tests for incremental model with alias
+time: 2024-09-22T13:35:27.991398741Z
+custom:
+    Author: katsugeneration
+    Issue: "10605"

--- a/.changes/unreleased/Fixes-20240922-133527.yaml
+++ b/.changes/unreleased/Fixes-20240922-133527.yaml
@@ -3,4 +3,4 @@ body: Fix unit tests for incremental model with alias
 time: 2024-09-22T13:35:27.991398741Z
 custom:
     Author: katsugeneration
-    Issue: "10605"
+    Issue: "10754"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1636,7 +1636,7 @@ class UnitTestContext(ModelContext):
         if self.model.this_input_node_unique_id:
             this_node = self.manifest.expect(self.model.this_input_node_unique_id)
             self.model.set_cte(this_node.unique_id, None)  # type: ignore
-            return self.adapter.Relation.add_ephemeral_prefix(this_node.name)
+            return self.adapter.Relation.add_ephemeral_prefix(this_node.identifier)  # type: ignore
         return None
 
 

--- a/tests/functional/unit_testing/fixtures.py
+++ b/tests/functional/unit_testing/fixtures.py
@@ -304,6 +304,20 @@ where event_time > (select max(event_time) from {{ this }})
 {% endif %}
 """
 
+my_incremental_model_with_alias_sql = """
+{{
+    config(
+        materialized='incremental',
+        alias='alias_name'
+    )
+}}
+
+select * from {{ ref('events') }}
+{% if is_incremental() %}
+where event_time > (select max(event_time) from {{ this }})
+{% endif %}
+"""
+
 test_my_model_incremental_yml_basic = """
 unit_tests:
   - name: incremental_false

--- a/tests/functional/unit_testing/fixtures.py
+++ b/tests/functional/unit_testing/fixtures.py
@@ -318,6 +318,14 @@ where event_time > (select max(event_time) from {{ this }})
 {% endif %}
 """
 
+my_incremental_model_versioned_yml = """
+models:
+  - name: my_incremental_model
+    latest_version: 1
+    versions:
+      - v: 1
+"""
+
 test_my_model_incremental_yml_basic = """
 unit_tests:
   - name: incremental_false

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -8,6 +8,7 @@ from fixtures import (  # noqa: F401
     external_package,
     external_package__accounts_seed_csv,
     my_incremental_model_sql,
+    my_incremental_model_versioned_yml,
     my_incremental_model_with_alias_sql,
     my_model_a_sql,
     my_model_b_sql,
@@ -279,6 +280,24 @@ class TestUnitTestIncrementalModelWithAlias:
             "my_incremental_model.sql": my_incremental_model_with_alias_sql,
             "events.sql": event_sql,
             "schema.yml": test_my_model_incremental_yml_basic,
+        }
+
+    def test_basic(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 2
+
+        # Select by model name
+        results = run_dbt(["test", "--select", "my_incremental_model"], expect_pass=True)
+        assert len(results) == 2
+
+
+class TestUnitTestIncrementalModelWithVersion:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_incremental_model.sql": my_incremental_model_sql,
+            "events.sql": event_sql,
+            "schema.yml": my_incremental_model_versioned_yml + test_my_model_incremental_yml_basic,
         }
 
     def test_basic(self, project):

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -8,6 +8,7 @@ from fixtures import (  # noqa: F401
     external_package,
     external_package__accounts_seed_csv,
     my_incremental_model_sql,
+    my_incremental_model_with_alias_sql,
     my_model_a_sql,
     my_model_b_sql,
     my_model_sql,
@@ -269,6 +270,24 @@ unit_tests:
       rows:
         - {id: 1, c: 7}
 """
+
+
+class TestUnitTestIncrementalModelWithAlias:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_incremental_model.sql": my_incremental_model_with_alias_sql,
+            "events.sql": event_sql,
+            "schema.yml": test_my_model_incremental_yml_basic,
+        }
+
+    def test_basic(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 2
+
+        # Select by model name
+        results = run_dbt(["test", "--select", "my_incremental_model"], expect_pass=True)
+        assert len(results) == 2
 
 
 class TestUnitTestExplicitSeed:


### PR DESCRIPTION
Resolves #10754 
Resolves #10763

### Problem

- Unit tests fail due to wrong input cte referrence name on incremental `this` models with alias
- Because cte name is based on alias name on ephemeral model. This change on dbt-adapters 1.4.1 by https://github.com/dbt-labs/dbt-adapters/pull/236

### Solution

- Fix `this` referrence name in UnitTestContext to based on alias name on incremental model

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
