### PR TITLE
Allow snapshots to be defined with YAML only.

### DIFF
--- a/.changes/unreleased/Features-20240920-110447.yaml
+++ b/.changes/unreleased/Features-20240920-110447.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Allow snapshots to be defined in YAML.
+time: 2024-09-20T11:04:47.703117-04:00
+custom:
+  Author: peterallenwebb
+  Issue: "10246"

--- a/tests/functional/snapshots/fixtures.py
+++ b/tests/functional/snapshots/fixtures.py
@@ -291,6 +291,19 @@ snapshots_pg__snapshot_sql = """
 {% endsnapshot %}
 """
 
+snapshots_pg__snapshot_yml = """
+version: 2
+snapshots:
+  - name: snapshot_actual
+    relation: "ref('seed')"
+    config:
+      unique_key: "id || '-' || first_name"
+      strategy: timestamp
+      updated_at: updated_at
+      meta:
+        owner: 'a_owner'
+"""
+
 snapshots_pg__snapshot_no_target_schema_sql = """
 {% snapshot snapshot_actual %}
 

--- a/tests/functional/snapshots/test_basic_snapshot.py
+++ b/tests/functional/snapshots/test_basic_snapshot.py
@@ -20,6 +20,7 @@ from tests.functional.snapshots.fixtures import (
     seeds__seed_newcol_csv,
     snapshots_pg__snapshot_no_target_schema_sql,
     snapshots_pg__snapshot_sql,
+    snapshots_pg__snapshot_yml,
     snapshots_pg_custom__snapshot_sql,
     snapshots_pg_custom_namespaced__snapshot_sql,
 )
@@ -372,3 +373,24 @@ class TestBasicUpdatedAtCheckCols(UpdatedAtCheckCols):
 class TestRefUpdatedAtCheckCols(UpdatedAtCheckCols):
     def test_updated_at_ref(self, project):
         ref_setup(project, num_snapshot_models=2)
+
+
+class BasicYaml(Basic):
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        """Overrides the same function in Basic to use the YAML method of
+        defining a snapshot."""
+        return {"snapshot.yml": snapshots_pg__snapshot_yml}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        """Overrides the same function in Basic to use a modified version of
+        schema.yml without snapshot config."""
+        return {
+            "ref_snapshot.sql": models__ref_snapshot_sql,
+        }
+
+
+class TestBasicSnapshotYaml(BasicYaml):
+    def test_basic_snapshot_yaml(self, project):
+        snapshot_setup(project, num_snapshot_models=1)


### PR DESCRIPTION
Resolves #10246

### Problem

Users had to awkwardly create jinja snapshot blocks in SQL files, even for very simple snapshots.

### Solution

Delight users by allowing snapshots to be defined intuitively, with just a few lines of YAML.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
