### PR TITLE
ignore --empty in unit test ref/source calls

### DIFF
--- a/.changes/unreleased/Fixes-20240923-202024.yaml
+++ b/.changes/unreleased/Fixes-20240923-202024.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Ignore --empty in unit test ref/source rendering
+time: 2024-09-23T20:20:24.151285+01:00
+custom:
+  Author: michelleark
+  Issue: "10516"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -634,6 +634,11 @@ class OperationRefResolver(RuntimeRefResolver):
 
 
 class RuntimeUnitTestRefResolver(RuntimeRefResolver):
+    @property
+    def resolve_limit(self) -> Optional[int]:
+        # Unit tests should never respect --empty flag or provide a limit since they are based on fake data.
+        return None
+
     def resolve(
         self,
         target_name: str,
@@ -676,6 +681,11 @@ class RuntimeSourceResolver(BaseSourceResolver):
 
 
 class RuntimeUnitTestSourceResolver(BaseSourceResolver):
+    @property
+    def resolve_limit(self) -> Optional[int]:
+        # Unit tests should never respect --empty flag or provide a limit since they are based on fake data.
+        return None
+
     def resolve(self, source_name: str, table_name: str):
         target_source = self.manifest.resolve_source(
             source_name,

--- a/tests/functional/test_empty.py
+++ b/tests/functional/test_empty.py
@@ -27,6 +27,14 @@ select *
 from {{ source('seed_sources', 'raw_source') }}
 """
 
+model_no_ephemeral_ref_sql = """
+select *
+from {{ ref('model_input') }}
+union all
+select *
+from {{ source('seed_sources', 'raw_source') }}
+"""
+
 
 schema_sources_yml = """
 sources:
@@ -36,6 +44,28 @@ sources:
       - name: raw_source
 """
 
+unit_tests_yml = """
+unit_tests:
+  - name: test_my_model
+    model: model_no_ephemeral_ref
+    given:
+      - input: ref('model_input')
+        format: csv
+        rows: |
+          id
+          1
+      - input: source('seed_sources', 'raw_source')
+        format: csv
+        rows: |
+          id
+          2
+    expect:
+      format: csv
+      rows: |
+        id
+        1
+        2
+"""
 
 class TestEmptyFlag:
     @pytest.fixture(scope="class")
@@ -50,7 +80,9 @@ class TestEmptyFlag:
             "model_input.sql": model_input_sql,
             "ephemeral_model_input.sql": ephemeral_model_input_sql,
             "model.sql": model_sql,
+            "model_no_ephemeral_ref.sql": model_no_ephemeral_ref_sql,
             "sources.yml": schema_sources_yml,
+            "unit_tests.yml": unit_tests_yml,
         }
 
     def assert_row_count(self, project, relation_name: str, expected_row_count: int):

--- a/tests/functional/test_empty.py
+++ b/tests/functional/test_empty.py
@@ -67,6 +67,7 @@ unit_tests:
         2
 """
 
+
 class TestEmptyFlag:
     @pytest.fixture(scope="class")
     def seeds(self):


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/10516

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
The unit test ref and source resolvers inherit from the base resolvers, meaning they were getting `--empty` limit filters applied when used with the `--empty` flag. This causes tests to fail / behave unpredictably since the mocked data is no longer used to configure the unit test!

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

overwrite `resolve_limit` in unit test ref/source resolvers directly to always return `None` (no limit filter applied), as they are never needed in the unit testing context.
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
