### PR TITLE
[Backport 1.8.latest] Fix unit tests for incremental models with alias

### DIFF
--- a/.changes/unreleased/Fixes-20240922-133527.yaml
+++ b/.changes/unreleased/Fixes-20240922-133527.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix unit tests for incremental model with alias
+time: 2024-09-22T13:35:27.991398741Z
+custom:
+    Author: katsugeneration
+    Issue: "10754"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1593,7 +1593,7 @@ class UnitTestContext(ModelContext):
         if self.model.this_input_node_unique_id:
             this_node = self.manifest.expect(self.model.this_input_node_unique_id)
             self.model.set_cte(this_node.unique_id, None)  # type: ignore
-            return self.adapter.Relation.add_ephemeral_prefix(this_node.name)
+            return self.adapter.Relation.add_ephemeral_prefix(this_node.identifier)  # type: ignore
         return None
 
 

--- a/tests/functional/unit_testing/fixtures.py
+++ b/tests/functional/unit_testing/fixtures.py
@@ -275,6 +275,28 @@ where event_time > (select max(event_time) from {{ this }})
 {% endif %}
 """
 
+my_incremental_model_with_alias_sql = """
+{{
+    config(
+        materialized='incremental',
+        alias='alias_name'
+    )
+}}
+
+select * from {{ ref('events') }}
+{% if is_incremental() %}
+where event_time > (select max(event_time) from {{ this }})
+{% endif %}
+"""
+
+my_incremental_model_versioned_yml = """
+models:
+  - name: my_incremental_model
+    latest_version: 1
+    versions:
+      - v: 1
+"""
+
 test_my_model_incremental_yml_basic = """
 unit_tests:
   - name: incremental_false

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -21,6 +21,8 @@ from fixtures import (  # noqa: F401
     test_my_model_yml,
     datetime_test,
     my_incremental_model_sql,
+    my_incremental_model_versioned_yml,
+    my_incremental_model_with_alias_sql,
     event_sql,
     test_my_model_incremental_yml_basic,
     test_my_model_yml_invalid,
@@ -259,6 +261,42 @@ unit_tests:
       rows:
         - {id: 1, c: 7}
 """
+
+
+class TestUnitTestIncrementalModelWithAlias:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_incremental_model.sql": my_incremental_model_with_alias_sql,
+            "events.sql": event_sql,
+            "schema.yml": test_my_model_incremental_yml_basic,
+        }
+
+    def test_basic(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 2
+
+        # Select by model name
+        results = run_dbt(["test", "--select", "my_incremental_model"], expect_pass=True)
+        assert len(results) == 2
+
+
+class TestUnitTestIncrementalModelWithVersion:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_incremental_model.sql": my_incremental_model_sql,
+            "events.sql": event_sql,
+            "schema.yml": my_incremental_model_versioned_yml + test_my_model_incremental_yml_basic,
+        }
+
+    def test_basic(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 2
+
+        # Select by model name
+        results = run_dbt(["test", "--select", "my_incremental_model"], expect_pass=True)
+        assert len(results) == 2
 
 
 class TestUnitTestExplicitSeed:


### PR DESCRIPTION
Backport a8d4ba2b4a04d76ad03e563aefd1fcf3ba86fe00 from #10755.