### PR TITLE
Add '--inline-direct' parameter to 'dbt show'.

### DIFF
--- a/.changes/unreleased/Features-20240924-152922.yaml
+++ b/.changes/unreleased/Features-20240924-152922.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Added the --inline-direct parameter to 'dbt show'
+time: 2024-09-24T15:29:22.874496-04:00
+custom:
+  Author: aranke peterallenwebb
+  Issue: "10770"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -8,12 +8,15 @@ from click.exceptions import BadOptionUsage
 from click.exceptions import Exit as ClickExit
 from click.exceptions import NoSuchOption, UsageError
 
+from dbt.adapters.factory import register_adapter
 from dbt.artifacts.schemas.catalog import CatalogArtifact
 from dbt.artifacts.schemas.run import RunExecutionResult
 from dbt.cli import params as p
 from dbt.cli import requires
 from dbt.cli.exceptions import DbtInternalException, DbtUsageException
+from dbt.cli.requires import setup_manifest
 from dbt.contracts.graph.manifest import Manifest
+from dbt.mp_context import get_mp_context
 from dbt_common.events.base_types import EventMsg
 
 
@@ -354,6 +357,7 @@ def compile(ctx, **kwargs):
 @p.select
 @p.selector
 @p.inline
+@p.inline_direct
 @p.target_path
 @p.threads
 @p.vars
@@ -362,17 +366,26 @@ def compile(ctx, **kwargs):
 @requires.profile
 @requires.project
 @requires.runtime_config
-@requires.manifest
 def show(ctx, **kwargs):
     """Generates executable SQL for a named resource or inline query, runs that SQL, and returns a preview of the
     results. Does not materialize anything to the warehouse."""
-    from dbt.task.show import ShowTask
+    from dbt.task.show import ShowTask, ShowTaskDirect
 
-    task = ShowTask(
-        ctx.obj["flags"],
-        ctx.obj["runtime_config"],
-        ctx.obj["manifest"],
-    )
+    if ctx.obj["flags"].inline_direct:
+        # Issue the inline query directly, wit no templating. Does not require
+        # loading the mainfest.
+        register_adapter(ctx.obj["runtime_config"], get_mp_context())
+        task = ShowTaskDirect(
+            ctx.obj["flags"],
+            ctx.obj["runtime_config"],
+        )
+    else:
+        setup_manifest(ctx)
+        task = ShowTask(
+            ctx.obj["flags"],
+            ctx.obj["runtime_config"],
+            ctx.obj["manifest"],
+        )
 
     results = task.run()
     success = task.interpret_results(results)

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -372,8 +372,8 @@ def show(ctx, **kwargs):
     from dbt.task.show import ShowTask, ShowTaskDirect
 
     if ctx.obj["flags"].inline_direct:
-        # Issue the inline query directly, wit no templating. Does not require
-        # loading the mainfest.
+        # Issue the inline query directly, with no templating. Does not require
+        # loading the manifest.
         register_adapter(ctx.obj["runtime_config"], get_mp_context())
         task = ShowTaskDirect(
             ctx.obj["flags"],

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -487,6 +487,12 @@ inline = click.option(
     help="Pass SQL inline to dbt compile and show",
 )
 
+inline_direct = click.option(
+    "--inline-direct",
+    envvar=None,
+    help="Pass SQL inline to dbt show. Do not load the entire project or apply templating.",
+)
+
 # `--select` and `--models` are analogous for most commands except `dbt list` for legacy reasons.
 # Most CLI arguments should use the combined `select` option that aliases `--models` to `--select`.
 # However, if you need to split out these separators (like `dbt ls`), use the `models` and `raw_select` options instead.

--- a/tests/functional/show/test_show.py
+++ b/tests/functional/show/test_show.py
@@ -120,6 +120,23 @@ class TestShowInline(ShowBase):
         assert "sample_bool" in log_output
 
 
+class TestShowInlineDirect(ShowBase):
+
+    def test_inline_direct_pass(self, project):
+        query = f"select * from {project.test_schema}.sample_seed"
+        (_, log_output) = run_dbt_and_capture(["show", "--inline-direct", query])
+        assert "Previewing inline node" in log_output
+        assert "sample_num" in log_output
+        assert "sample_bool" in log_output
+
+        # This is a bit of a hack. Unfortunately, the test teardown code
+        # expects that dbt loaded an adapter with a macro context the last
+        # time it was called. The '--inline-direct' parameter used on the
+        # previous run explicitly disables macros. So now we call 'dbt seed',
+        # which will load the adapter fully and satisfy the teardown code.
+        run_dbt(["seed"])
+
+
 class TestShowInlineFail(ShowBase):
     def test_inline_fail(self, project):
         with pytest.raises(DbtException, match="Error parsing inline query"):

--- a/tests/functional/show/test_show.py
+++ b/tests/functional/show/test_show.py
@@ -120,6 +120,18 @@ class TestShowInline(ShowBase):
         assert "sample_bool" in log_output
 
 
+class TestShowInlineFail(ShowBase):
+    def test_inline_fail(self, project):
+        with pytest.raises(DbtException, match="Error parsing inline query"):
+            run_dbt(["show", "--inline", "select * from {{ ref('third_model') }}"])
+
+
+class TestShowInlineFailDB(ShowBase):
+    def test_inline_fail_database_error(self, project):
+        with pytest.raises(DbtRuntimeError, match="Database Error"):
+            run_dbt(["show", "--inline", "slect asdlkjfsld;j"])
+
+
 class TestShowInlineDirect(ShowBase):
 
     def test_inline_direct_pass(self, project):
@@ -137,16 +149,14 @@ class TestShowInlineDirect(ShowBase):
         run_dbt(["seed"])
 
 
-class TestShowInlineFail(ShowBase):
-    def test_inline_fail(self, project):
-        with pytest.raises(DbtException, match="Error parsing inline query"):
-            run_dbt(["show", "--inline", "select * from {{ ref('third_model') }}"])
+class TestShowInlineDirectFail(ShowBase):
 
-
-class TestShowInlineFailDB(ShowBase):
     def test_inline_fail_database_error(self, project):
         with pytest.raises(DbtRuntimeError, match="Database Error"):
-            run_dbt(["show", "--inline", "slect asdlkjfsld;j"])
+            run_dbt(["show", "--inline-direct", "slect asdlkjfsld;j"])
+
+        # See prior test for explanation of why this is here
+        run_dbt(["seed"])
 
 
 class TestShowEphemeral(ShowBase):


### PR DESCRIPTION
resolves #10778

### Problem

The 'dbt show' command loaded the manifest and ran jinja templating, even when these steps were not needed.

### Solution

Add a new "--inline-direct" parameter to skip the manifest load and templating steps.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
