### PR TITLE
Attempt to skip saved query processing when no semantic manifest changes

### DIFF
--- a/.changes/unreleased/Fixes-20240926-101220.yaml
+++ b/.changes/unreleased/Fixes-20240926-101220.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Attempt to skip saved query processing when no semantic manifest changes
+time: 2024-09-26T10:12:20.193453-04:00
+custom:
+  Author: gshank
+  Issue: "10563"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1693,6 +1693,7 @@ Resource = Union[
 
 TestNode = Union[SingularTestNode, GenericTestNode]
 
+SemanticManifestNode = Union[SavedQuery, SemanticModel, Metric]
 
 RESOURCE_CLASS_TO_NODE_CLASS: Dict[Type[BaseResource], Type[BaseNode]] = {
     node_class.resource_class(): node_class

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1145,12 +1145,18 @@ class ManifestLoader:
         # Note: This will also capture various nodes which have been re-parsed
         # because they refer to some other changed node, so there will be
         # false positives. Ideally we would compare actual changes.
+        semantic_manifest_changed = False
         semantic_manifest_nodes: chain[SemanticManifestNode] = chain(
             self.manifest.saved_queries.values(),
             self.manifest.semantic_models.values(),
             self.manifest.metrics.values(),
         )
-        if any(node.created_at > self.started_at for node in semantic_manifest_nodes):
+        for node in semantic_manifest_nodes:
+            # Check if this node has been modified in this parsing run
+            if node.created_at > self.started_at:
+                semantic_manifest_changed = True
+                break  # as soon as we run into one changed node we can stop
+        if semantic_manifest_changed is False:
             return
 
         current_project = config.project_name

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1141,6 +1141,24 @@ class ManifestLoader:
 
     def process_saved_queries(self, config: RuntimeConfig):
         """Processes SavedQuery nodes to populate their `depends_on`."""
+        # Note: This will also capture various nodes which have been re-parsed
+        # because they refer to some other changed node, so there will be
+        # false positives. Ideally we would compare actual changes.
+        semantic_manifest_changed = False
+        SemanticManifestNode = Union[SavedQuery, SemanticModel, Metric]
+        semantic_manifest_nodes: chain[SemanticManifestNode] = chain(
+            self.manifest.saved_queries.values(),
+            self.manifest.semantic_models.values(),
+            self.manifest.metrics.values(),
+        )
+        for node in semantic_manifest_nodes:
+            # Check if this node has been modified in this parsing run
+            if node.created_at > self.started_at:
+                semantic_manifest_changed = True
+                break  # as soon as we run into one changed node we can stop
+        if semantic_manifest_changed is False:
+            return
+
         current_project = config.project_name
         for saved_query in self.manifest.saved_queries.values():
             # TODO:

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -57,6 +57,7 @@ from dbt.contracts.graph.nodes import (
     ResultNode,
     SavedQuery,
     SeedNode,
+    SemanticManifestNode,
     SemanticModel,
     SourceDefinition,
 )
@@ -1144,19 +1145,12 @@ class ManifestLoader:
         # Note: This will also capture various nodes which have been re-parsed
         # because they refer to some other changed node, so there will be
         # false positives. Ideally we would compare actual changes.
-        semantic_manifest_changed = False
-        SemanticManifestNode = Union[SavedQuery, SemanticModel, Metric]
         semantic_manifest_nodes: chain[SemanticManifestNode] = chain(
             self.manifest.saved_queries.values(),
             self.manifest.semantic_models.values(),
             self.manifest.metrics.values(),
         )
-        for node in semantic_manifest_nodes:
-            # Check if this node has been modified in this parsing run
-            if node.created_at > self.started_at:
-                semantic_manifest_changed = True
-                break  # as soon as we run into one changed node we can stop
-        if semantic_manifest_changed is False:
+        if any(node.created_at > self.started_at for node in semantic_manifest_nodes):
             return
 
         current_project = config.project_name


### PR DESCRIPTION
Resolves #10563

### Problem

We run "process_saved_queries" even when nothing has changed in the semantic manifest.

### Solution

Check for changes to saved queries, semantic models, and metrics before executing process saved queries. This will have false positives because of cascading re-parsing, but will enable us to skip at least some unnecessary saved query processing.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
