### PR TITLE
[CT-10785] Microbatch models  should respect `full_refresh` model config

### DIFF
--- a/.changes/unreleased/Features-20240926-153210.yaml
+++ b/.changes/unreleased/Features-20240926-153210.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Ensure microbatch models respect `full_refresh` model config
+time: 2024-09-26T15:32:10.202789-05:00
+custom:
+  Author: QMalcolm
+  Issue: "10785"

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -550,12 +550,17 @@ class ModelRunner(CompileRunner):
         relation = self.adapter.get_relation(
             relation_info.database, relation_info.schema, relation_info.name
         )
-        return (
+        if (
             relation is not None
             and relation.type == "table"
             and model.config.materialized == "incremental"
-            and not (getattr(self.config.args, "FULL_REFRESH", False) or model.config.full_refresh)
-        )
+        ):
+            if model.config.full_refresh is not None:
+                return not model.config.full_refresh
+            else:
+                return not getattr(self.config.args, "FULL_REFRESH", False)
+        else:
+            return False
 
 
 class RunTask(CompileTask):


### PR DESCRIPTION
Resolves #10785 

### Problem

In dbt-core, it is generally expected that values passed via CLI flags take
precedence over model level configs. However, `full_refresh` on a model is an
exception to this rule, where in the model config takes precedence. This
config exists specifically to _prevent_ accidental full refreshes of large
incremental models, as doing so can be costly. **_It is actually best
practice_** to set `full_refresh=False` on incremental models.

Prior to this commit, for microbatch models, the above was not happening. The
CLI flag `--full-refresh` was taking precedence over the model config
`full_refresh`. That meant that if `--full-refresh` was supplied, then the
microbatch model **_would full refresh_** even if `full_refresh=False` was
set on the model. This commit solves that problem.

### Solution

Update `_is_incremental` to prefer the `model.config.full_refresh` value over the `RuntimeConfig.args.FULL_REFRESH` value provided by CLI flags.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
