### PR TITLE
Add new validations for custom granularities

### DIFF
--- a/.changes/unreleased/Features-20240926-151057.yaml
+++ b/.changes/unreleased/Features-20240926-151057.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Adds validations for custom_granularities to ensure unique naming.
+time: 2024-09-26T15:10:57.907694-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "9265"

--- a/core/setup.py
+++ b/core/setup.py
@@ -69,7 +69,7 @@ setup(
         # These are major-version-0 packages also maintained by dbt-labs.
         # Accept patches but avoid automatically updating past a set minor version range.
         "dbt-extractor>=0.5.0,<=0.6",
-        "dbt-semantic-interfaces>=0.7.1,<0.8",
+        "dbt-semantic-interfaces>=0.7.2,<0.8",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.9.0,<2.0",
         "dbt-adapters>=1.7.0,<2.0",


### PR DESCRIPTION
Resolves #9265

### Description
Upgrade DSI version. This DSI version contains new validations for custom granularities that ensure unique naming. The custom granularity feature has not been released to customers yet, so new validations will not be breaking. Upgrading to this version in mantle will ensure that when the feature is released, customers will automatically get these validations.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
