### PR TITLE
`--inline-direct` is an internal CLI flag

### DIFF
--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -490,7 +490,8 @@ inline = click.option(
 inline_direct = click.option(
     "--inline-direct",
     envvar=None,
-    help="Pass SQL inline to dbt show. Do not load the entire project or apply templating.",
+    help="Internal flag to pass SQL inline to dbt show. Do not load the entire project or apply templating.",
+    hidden=True,
 )
 
 # `--select` and `--models` are analogous for most commands except `dbt list` for legacy reasons.


### PR DESCRIPTION
Resolves NA

### Problem

`--inline-direct` is an internal CLI flag, but it will display via `--help`

### Solution

Two-part solution per discussion with @graciegoheen:
1. Describe it as an internal flag
2. Remove it from display via `--help`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [x] Tests are not required or relevant for this PR.
- [x] This PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
