### PR TITLE
Fix case-sensitivity in validation warning

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -69,7 +69,7 @@ setup(
         # These are major-version-0 packages also maintained by dbt-labs.
         # Accept patches but avoid automatically updating past a set minor version range.
         "dbt-extractor>=0.5.0,<=0.6",
-        "dbt-semantic-interfaces>=0.7.2,<0.8",
+        "dbt-semantic-interfaces>=0.7.3,<0.8",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.9.0,<2.0",
         "dbt-adapters>=1.7.0,<2.0",


### PR DESCRIPTION
### Problem
In DSI 0.7.2, we released a validation warning that was triggered if a user added a lowercase granularity to a filter in their YAML. This should not have been case sensitive. 

### Solution
DSI 0.7.3 fixes that issue, so this PR bumps to that version of DSI. See the commit that fixes it here: https://github.com/dbt-labs/dbt-semantic-interfaces/pull/352

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
