### PR TITLE
Track batch execution time for microbatch models

### DIFF
--- a/.changes/unreleased/Fixes-20241004-163908.yaml
+++ b/.changes/unreleased/Fixes-20241004-163908.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Begin tracking execution time of microbatch model batches
+time: 2024-10-04T16:39:08.464064-05:00
+custom:
+  Author: QMalcolm
+  Issue: "10825"

--- a/core/dbt/tests/util.py
+++ b/core/dbt/tests/util.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar, copy_context
 from datetime import datetime
 from io import StringIO
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 from unittest import mock
 
 import pytz
@@ -17,7 +17,7 @@ from dbt.cli.main import dbtRunner
 from dbt.contracts.graph.manifest import Manifest
 from dbt.materializations.incremental.microbatch import MicrobatchBuilder
 from dbt_common.context import _INVOCATION_CONTEXT_VAR, InvocationContext
-from dbt_common.events.base_types import EventLevel
+from dbt_common.events.base_types import EventLevel, EventMsg
 from dbt_common.events.functions import (
     capture_stdout_logs,
     fire_event,
@@ -76,6 +76,7 @@ from dbt_common.events.types import Note
 def run_dbt(
     args: Optional[List[str]] = None,
     expect_pass: bool = True,
+    callbacks: Optional[List[Callable[[EventMsg], None]]] = None,
 ):
     # reset global vars
     reset_metadata_vars()
@@ -93,7 +94,7 @@ def run_dbt(
         args.extend(["--project-dir", project_dir])
     if profiles_dir and "--profiles-dir" not in args:
         args.extend(["--profiles-dir", profiles_dir])
-    dbt = dbtRunner()
+    dbt = dbtRunner(callbacks=callbacks)
 
     res = dbt.invoke(args)
 

--- a/tests/functional/microbatch/test_microbatch.py
+++ b/tests/functional/microbatch/test_microbatch.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pytest
 
+from dbt.events.types import LogModelResult
 from dbt.tests.util import (
     get_artifact,
     patch_microbatch_end_time,
@@ -12,6 +13,7 @@ from dbt.tests.util import (
     run_dbt_and_capture,
     write_file,
 )
+from tests.utils import EventCatcher
 
 input_model_sql = """
 {{ config(materialized='table', event_time='event_time') }}
@@ -186,9 +188,15 @@ class TestMicrobatchCLI(BaseMicrobatchTest):
     @mock.patch.dict(os.environ, {"DBT_EXPERIMENTAL_MICROBATCH": "True"})
     def test_run_with_event_time(self, project):
         # run without --event-time-start or --event-time-end - 3 expected rows in output
+        catcher = EventCatcher(event_to_catch=LogModelResult)
+
         with patch_microbatch_end_time("2020-01-03 13:57:00"):
-            run_dbt(["run"])
+            run_dbt(["run"], callbacks=[catcher.catch])
         self.assert_row_count(project, "microbatch_model", 3)
+
+        for caught_event in catcher.caught_events:
+            if "batch" in caught_event.data.description:
+                assert caught_event.data.execution_time > 0
 
         # build model >= 2020-01-02
         with patch_microbatch_end_time("2020-01-03 13:57:00"):


### PR DESCRIPTION
Resolves #10825

### Problem

We weren't tracking the execution time of batches for microbatch models. Thus, we were always logging that they took no time to run (0.00 seconds) which didn't actually match reality.

### Solution

Begin tracking the time it takes for a batch to run, and propagate that information to the batch run result.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
