### PR TITLE
Ensure consistent `current_time` across microbatch models in an invocation

### DIFF
--- a/.changes/unreleased/Features-20241007-115853.yaml
+++ b/.changes/unreleased/Features-20241007-115853.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Ensure microbatch models use same `current_time` value
+time: 2024-10-07T11:58:53.460941-05:00
+custom:
+  Author: QMalcolm
+  Issue: "10819"

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -101,7 +101,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
     profile_name: str
     cli_vars: Dict[str, Any]
     dependencies: Optional[Mapping[str, "RuntimeConfig"]] = None
-    invocated_at: datetime = field(default_factory=lambda: datetime.now(pytz.UTC))
+    invoked_at: datetime = field(default_factory=lambda: datetime.now(pytz.UTC))
 
     def __post_init__(self):
         self.validate()

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -1,7 +1,8 @@
 import itertools
 import os
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import (
     Any,
@@ -14,6 +15,8 @@ from typing import (
     Tuple,
     Type,
 )
+
+import pytz
 
 from dbt import tracking
 from dbt.adapters.contracts.connection import (
@@ -98,6 +101,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
     profile_name: str
     cli_vars: Dict[str, Any]
     dependencies: Optional[Mapping[str, "RuntimeConfig"]] = None
+    invocated_at: datetime = field(default_factory=lambda: datetime.now(pytz.UTC))
 
     def __post_init__(self):
         self.validate()

--- a/core/dbt/materializations/incremental/microbatch.py
+++ b/core/dbt/materializations/incremental/microbatch.py
@@ -36,9 +36,7 @@ class MicrobatchBuilder:
             event_time_start.replace(tzinfo=pytz.UTC) if event_time_start else None
         )
         self.event_time_end = event_time_end.replace(tzinfo=pytz.UTC) if event_time_end else None
-        self.batch_current_time = (
-            batch_current_time if batch_current_time is not None else datetime.now(pytz.UTC)
-        )
+        self.batch_current_time = batch_current_time or datetime.now(pytz.UTC)
 
     def build_end_time(self):
         """Defaults the end_time to the current time in UTC unless a non `None` event_time_end was provided"""

--- a/core/dbt/materializations/incremental/microbatch.py
+++ b/core/dbt/materializations/incremental/microbatch.py
@@ -18,6 +18,7 @@ class MicrobatchBuilder:
         is_incremental: bool,
         event_time_start: Optional[datetime],
         event_time_end: Optional[datetime],
+        batch_current_time: Optional[datetime] = None,
     ):
         if model.config.incremental_strategy != "microbatch":
             raise DbtInternalError(
@@ -35,10 +36,13 @@ class MicrobatchBuilder:
             event_time_start.replace(tzinfo=pytz.UTC) if event_time_start else None
         )
         self.event_time_end = event_time_end.replace(tzinfo=pytz.UTC) if event_time_end else None
+        self.batch_current_time = (
+            batch_current_time if batch_current_time is not None else datetime.now(pytz.UTC)
+        )
 
     def build_end_time(self):
         """Defaults the end_time to the current time in UTC unless a non `None` event_time_end was provided"""
-        return self.event_time_end or datetime.now(tz=pytz.utc)
+        return self.event_time_end or self.batch_current_time
 
     def build_start_time(self, checkpoint: Optional[datetime]):
         """Create a start time based off the passed in checkpoint.

--- a/core/dbt/materializations/incremental/microbatch.py
+++ b/core/dbt/materializations/incremental/microbatch.py
@@ -18,7 +18,7 @@ class MicrobatchBuilder:
         is_incremental: bool,
         event_time_start: Optional[datetime],
         event_time_end: Optional[datetime],
-        batch_current_time: Optional[datetime] = None,
+        default_end_time: Optional[datetime] = None,
     ):
         if model.config.incremental_strategy != "microbatch":
             raise DbtInternalError(
@@ -36,11 +36,11 @@ class MicrobatchBuilder:
             event_time_start.replace(tzinfo=pytz.UTC) if event_time_start else None
         )
         self.event_time_end = event_time_end.replace(tzinfo=pytz.UTC) if event_time_end else None
-        self.batch_current_time = batch_current_time or datetime.now(pytz.UTC)
+        self.default_end_time = default_end_time or datetime.now(pytz.UTC)
 
     def build_end_time(self):
         """Defaults the end_time to the current time in UTC unless a non `None` event_time_end was provided"""
-        return self.event_time_end or self.batch_current_time
+        return self.event_time_end or self.default_end_time
 
     def build_start_time(self, checkpoint: Optional[datetime]):
         """Create a start time based off the passed in checkpoint.

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -487,6 +487,7 @@ class ModelRunner(CompileRunner):
                 is_incremental=self._is_incremental(model),
                 event_time_start=getattr(self.config.args, "EVENT_TIME_START", None),
                 event_time_end=getattr(self.config.args, "EVENT_TIME_END", None),
+                batch_current_time=self.config.invocated_at,
             )
             end = microbatch_builder.build_end_time()
             start = microbatch_builder.build_start_time(end)

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -487,7 +487,7 @@ class ModelRunner(CompileRunner):
                 is_incremental=self._is_incremental(model),
                 event_time_start=getattr(self.config.args, "EVENT_TIME_START", None),
                 event_time_end=getattr(self.config.args, "EVENT_TIME_END", None),
-                batch_current_time=self.config.invoked_at,
+                default_end_time=self.config.invoked_at,
             )
             end = microbatch_builder.build_end_time()
             start = microbatch_builder.build_start_time(end)

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -487,7 +487,7 @@ class ModelRunner(CompileRunner):
                 is_incremental=self._is_incremental(model),
                 event_time_start=getattr(self.config.args, "EVENT_TIME_START", None),
                 event_time_end=getattr(self.config.args, "EVENT_TIME_END", None),
-                batch_current_time=self.config.invocated_at,
+                batch_current_time=self.config.invoked_at,
             )
             end = microbatch_builder.build_end_time()
             start = microbatch_builder.build_start_time(end)

--- a/tests/functional/microbatch/test_microbatch.py
+++ b/tests/functional/microbatch/test_microbatch.py
@@ -1,7 +1,9 @@
 import os
+from datetime import datetime
 from unittest import mock
 
 import pytest
+import pytz
 
 from dbt.tests.util import (
     get_artifact,
@@ -36,6 +38,11 @@ select 3 as id, TIMESTAMP '2020-01-03 00:00:00-0' as event_time
 microbatch_model_sql = """
 {{ config(materialized='incremental', incremental_strategy='microbatch', unique_key='id', event_time='event_time', batch_size='day', begin=modules.datetime.datetime(2020, 1, 1, 0, 0, 0)) }}
 select * from {{ ref('input_model') }}
+"""
+
+microbatch_model_downstream_sql = """
+{{ config(materialized='incremental', incremental_strategy='microbatch', unique_key='id', event_time='event_time', batch_size='day', begin=modules.datetime.datetime(2020, 1, 1, 0, 0, 0)) }}
+select * from {{ ref('microbatch_model') }}
 """
 
 
@@ -657,3 +664,28 @@ class TestMicrobatchFullRefreshConfigFalse(BaseMicrobatchTest):
         with patch_microbatch_end_time("2020-01-03 13:57:00"):
             run_dbt(["run", "--full-refresh"])
         self.assert_row_count(project, "microbatch_model", 3)
+
+
+class TestMicrbobatchModelsRunWithSameCurrentTime(BaseMicrobatchTest):
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "input_model.sql": input_model_sql,
+            "microbatch_model.sql": microbatch_model_sql,
+            "second_microbatch_model.sql": microbatch_model_downstream_sql,
+        }
+
+    @mock.patch.dict(os.environ, {"DBT_EXPERIMENTAL_MICROBATCH": "True"})
+    def test_microbatch(self, project) -> None:
+        current_time = datetime.now(pytz.UTC)
+        run_dbt(["run", "--event-time-start", current_time.strftime("%Y-%m-%d")])
+
+        run_results = get_artifact(project.project_root, "target", "run_results.json")
+        microbatch_model_last_batch = run_results["results"][1]["batch_results"]["successful"][-1]
+        second_microbatch_model_last_batch = run_results["results"][2]["batch_results"][
+            "successful"
+        ][-1]
+
+        # they should have the same last batch because they are using the _same_ "current_time"
+        assert microbatch_model_last_batch == second_microbatch_model_last_batch


### PR DESCRIPTION
Resolves #10819

### Problem

Different microbatch models in the same `dbt run` could end up with different `current_time`. This could cause a situation where two microbatch models operating on the same inputs could end up with more/less data if one microbatch model was executed significantly later than the other.

### Solution

Make it so each microbatch model in an invocation is using the same `current_time`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
