### PR TITLE
Support disabling unit tests

### DIFF
--- a/.changes/unreleased/Fixes-20241007-121402.yaml
+++ b/.changes/unreleased/Fixes-20241007-121402.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Support disabling unit tests via config.
+time: 2024-10-07T12:14:02.252744-07:00
+custom:
+    Author: tsturge
+    Issue: 9109 10540

--- a/core/dbt/artifacts/resources/v1/unit_test_definition.py
+++ b/core/dbt/artifacts/resources/v1/unit_test_definition.py
@@ -20,6 +20,7 @@ class UnitTestConfig(BaseConfig):
         default_factory=dict,
         metadata=MergeBehavior.Update.meta(),
     )
+    enabled: bool = True
 
 
 class UnitTestFormat(StrEnum):

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1655,6 +1655,8 @@ class Manifest(MacroMethods, dbtClassMixin):
                 source_file.semantic_models.append(node.unique_id)
             if isinstance(node, Exposure):
                 source_file.exposures.append(node.unique_id)
+            if isinstance(node, UnitTestDefinition):
+                source_file.unit_tests.append(node.unique_id)
         elif isinstance(source_file, FixtureSourceFile):
             pass
         else:

--- a/core/dbt/graph/selector.py
+++ b/core/dbt/graph/selector.py
@@ -173,7 +173,8 @@ class NodeSelector(MethodManager):
             semantic_model = self.manifest.semantic_models[unique_id]
             return semantic_model.config.enabled
         elif unique_id in self.manifest.unit_tests:
-            return True
+            unit_test = self.manifest.unit_tests[unique_id]
+            return unit_test.config.enabled
         elif unique_id in self.manifest.saved_queries:
             saved_query = self.manifest.saved_queries[unique_id]
             return saved_query.config.enabled

--- a/schemas/dbt/manifest/v12.json
+++ b/schemas/dbt/manifest/v12.json
@@ -20935,6 +20935,10 @@
                           "propertyNames": {
                             "type": "string"
                           }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
                         }
                       },
                       "additionalProperties": true
@@ -22500,6 +22504,10 @@
                 "propertyNames": {
                   "type": "string"
                 }
+              },
+              "enabled": {
+                "type": "boolean",
+                "default": true
               }
             },
             "additionalProperties": true

--- a/tests/functional/unit_testing/fixtures.py
+++ b/tests/functional/unit_testing/fixtures.py
@@ -145,6 +145,24 @@ unit_tests:
         - {c: 3}
 """
 
+test_disabled_my_model_yml = """
+unit_tests:
+  - name: test_disabled_my_model
+    model: my_model
+    config:
+      enabled: false
+    given:
+      - input: ref('my_model_a')
+        rows:
+          - {id: 1, a: 1}
+      - input: ref('my_model_b')
+        rows:
+          - {id: 1, b: 2}
+          - {id: 2, b: 2}
+    expect:
+      rows:
+        - {c: 3}
+"""
 
 test_my_model_simple_fixture_yml = """
 unit_tests:

--- a/tests/functional/unit_testing/test_ut_list.py
+++ b/tests/functional/unit_testing/test_ut_list.py
@@ -22,7 +22,7 @@ class TestUnitTestList:
             "my_model_a.sql": my_model_a_sql,
             "my_model_b.sql": my_model_b_sql,
             "test_my_model.yml": test_my_model_yml + datetime_test,
-            "test_disabled_my_model.yml": test_disabled_my_model_yml
+            "test_disabled_my_model.yml": test_disabled_my_model_yml,
         }
 
     @pytest.fixture(scope="class")

--- a/tests/functional/unit_testing/test_ut_list.py
+++ b/tests/functional/unit_testing/test_ut_list.py
@@ -7,6 +7,7 @@ from fixtures import (  # noqa: F401
     my_model_a_sql,
     my_model_b_sql,
     my_model_vars_sql,
+    test_disabled_my_model_yml,
     test_my_model_yml,
 )
 
@@ -21,6 +22,7 @@ class TestUnitTestList:
             "my_model_a.sql": my_model_a_sql,
             "my_model_b.sql": my_model_b_sql,
             "test_my_model.yml": test_my_model_yml + datetime_test,
+            "test_disabled_my_model.yml": test_disabled_my_model_yml
         }
 
     @pytest.fixture(scope="class")

--- a/tests/functional/unit_testing/test_ut_list.py
+++ b/tests/functional/unit_testing/test_ut_list.py
@@ -59,7 +59,7 @@ class TestUnitTestList:
             "original_file_path": os.path.join("models", "test_my_model.yml"),
             "unique_id": "unit_test.test.my_model.test_my_model",
             "depends_on": {"macros": [], "nodes": ["model.test.my_model"]},
-            "config": {"tags": [], "meta": {}},
+            "config": {"tags": [], "meta": {}, "enabled": True},
         }
         for result in results:
             json_result = json.loads(result)


### PR DESCRIPTION
Support config: disabled for unit tests. (#9109)

Also, when a model is disabled, disable the corresponding unit tests automatically. (#10540)

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

config:
   enabled: false

### Solution

Check for the config: enabled variable while parsing the unit test. If it is set to false, mark the unit test as disabled.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
