### PR TITLE
Cleaner call of DBT CLI as Python Module

### DIFF
--- a/core/dbt/cli/__main__.py
+++ b/core/dbt/cli/__main__.py
@@ -1,0 +1,8 @@
+
+from __future__ import annotations
+
+from dbt.cli.main import cli
+
+
+if __name__ == '__main__':
+    raise SystemExit(cli())


### PR DESCRIPTION
Resolves #

Calling `dbt.cli` module without specifying `main` module.

### Problem

Call DBT cli as module as `dbt.cli.main`

### Solution

Create a `__main__.py` at the root of `core/dbt/cli` calling `cli()` from `main.py`. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
