### PR TITLE
Fix #2578: Allow instances of generic data tests to be documented

### DIFF
--- a/.changes/unreleased/Fixes-20241014-212135.yaml
+++ b/.changes/unreleased/Fixes-20241014-212135.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Allow instances of generic data tests to be documented
+time: 2024-10-14T21:21:35.767115+01:00
+custom:
+    Author: aranke
+    Issue: "2578"

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -136,6 +136,17 @@ class TestBuilder(Generic[Testable]):
         if self.namespace is not None:
             self.package_name = self.namespace
 
+        # If the user has provided a description for this generic test, use it
+        # Then delete the "description" argument to:
+        # 1. Avoid passing it into the test macro
+        # 2. Avoid passing it into the test name synthesis
+        # Otherwise, use an empty string
+        self.description: str = ""
+
+        if "description" in self.args:
+            self.description = self.args["description"]
+            del self.args["description"]
+
         # If the user has provided a custom name for this generic test, use it
         # Then delete the "name" argument to avoid passing it into the test macro
         # Otherwise, use an auto-generated name synthesized from test inputs

--- a/core/dbt/parser/schema_generic_tests.py
+++ b/core/dbt/parser/schema_generic_tests.py
@@ -96,6 +96,7 @@ class SchemaGenericTestParser(SimpleParser):
         test_metadata: Dict[str, Any],
         file_key_name: str,
         column_name: Optional[str],
+        description: str,
     ) -> GenericTestNode:
 
         HASH_LENGTH = 10
@@ -134,6 +135,7 @@ class SchemaGenericTestParser(SimpleParser):
             "column_name": column_name,
             "checksum": FileHash.empty().to_dict(omit_none=True),
             "file_key_name": file_key_name,
+            "description": description,
         }
         try:
             GenericTestNode.validate(dct)
@@ -229,6 +231,7 @@ class SchemaGenericTestParser(SimpleParser):
             column_name=column_name,
             test_metadata=metadata,
             file_key_name=file_key_name,
+            description=builder.description,
         )
         self.render_test_update(node, config, builder, schema_file_id)
 

--- a/tests/functional/generic_test_description/fixtures.py
+++ b/tests/functional/generic_test_description/fixtures.py
@@ -1,0 +1,34 @@
+models__my_model_sql = """
+with my_cte as (
+    select 1 as id, 'blue' as color
+    union all
+    select 2 as id, 'green' as red
+    union all
+    select 3 as id, 'red' as red
+)
+select * from my_cte
+"""
+
+models__schema_yml = """
+models:
+  - name: my_model
+    columns:
+      - name: id
+        tests:
+          - unique:
+              description: "id must be unique"
+          - not_null
+      - name: color
+        tests:
+          - accepted_values:
+              values: ['blue', 'green', 'red']
+              description: "{{ doc('color_accepted_values') }}"
+"""
+
+models__doc_block_md = """
+{% docs color_accepted_values %}
+
+The `color` column must be one of 'blue', 'green', or 'red'.
+
+{% enddocs %}
+"""

--- a/tests/functional/generic_test_description/test_generic_test_description.py
+++ b/tests/functional/generic_test_description/test_generic_test_description.py
@@ -1,0 +1,32 @@
+import pytest
+
+from dbt.tests.util import get_artifact, run_dbt
+from tests.functional.generic_test_description.fixtures import (
+    models__doc_block_md,
+    models__my_model_sql,
+    models__schema_yml,
+)
+
+
+class TestBuiltinGenericTestDescription:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": models__my_model_sql,
+            "schema.yml": models__schema_yml,
+            "doc_block.md": models__doc_block_md,
+        }
+
+    def test_compile(self, project):
+        run_dbt(["compile"])
+        manifest = get_artifact(project.project_root, "target", "manifest.json")
+        assert len(manifest["nodes"]) == 4
+
+        nodes = {node["alias"]: node for node in manifest["nodes"].values()}
+
+        assert nodes["unique_my_model_id"]["description"] == "id must be unique"
+        assert nodes["not_null_my_model_id"]["description"] == ""
+        assert (
+            nodes["accepted_values_my_model_color__blue__green__red"]["description"]
+            == "The `color` column must be one of 'blue', 'green', or 'red'."
+        )

--- a/tests/unit/parser/test_parser.py
+++ b/tests/unit/parser/test_parser.py
@@ -279,6 +279,7 @@ models:
             - not_null:
                 severity: WARN
             - accepted_values:
+                description: Only primary colors are allowed in here
                 values: ['red', 'blue', 'green']
             - foreign_package.test_case:
                 arg: 100
@@ -631,6 +632,7 @@ class SchemaParserModelsTest(SchemaParserTest):
         self.assertEqual(tests[0].tags, [])
         self.assertEqual(tests[0].refs, [RefArgs(name="my_model")])
         self.assertEqual(tests[0].column_name, "color")
+        self.assertEqual(tests[0].description, "Only primary colors are allowed in here")
         self.assertEqual(tests[0].package_name, "snowplow")
         self.assertTrue(tests[0].name.startswith("accepted_values_"))
         self.assertEqual(tests[0].fqn, ["snowplow", tests[0].name])
@@ -654,7 +656,7 @@ class SchemaParserModelsTest(SchemaParserTest):
         self.assertEqual(tests[1].tags, [])
         self.assertEqual(tests[1].refs, [RefArgs(name="my_model")])
         self.assertEqual(tests[1].column_name, "color")
-        self.assertEqual(tests[1].column_name, "color")
+        self.assertEqual(tests[1].description, "")
         self.assertEqual(tests[1].fqn, ["snowplow", tests[1].name])
         self.assertTrue(tests[1].name.startswith("foreign_package_test_case_"))
         self.assertEqual(tests[1].package_name, "snowplow")


### PR DESCRIPTION
Resolves #2578

### Problem

Not being able to document instances of generic data tests has been a longstanding paper cut.

### Solution

Allow documenting instances of generic data tests, e.g.

```
- name: color
  tests:
    - accepted_values:
        values: ['blue', 'green', 'red']
        description: "{{ doc('color_accepted_values') }}"
```

Tests implemented:
- [x] Setting description as a string
- [x] No description set, defaults to `""`
- [x] Description can be set via doc block

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
