### PR TITLE
[1.8.latest] Pin dbt-common to <1.11.0

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -75,7 +75,7 @@ setup(
         "minimal-snowplow-tracker>=0.0.2,<0.1",
         "dbt-semantic-interfaces>=0.5.1,<0.6",
         # Minor versions for these are expected to be backwards-compatible
-        "dbt-common>=1.0.4,<2.0",
+        "dbt-common>=1.0.4,<1.11.0",
         "dbt-adapters>=1.1.1,<2.0",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/dbt-labs/dbt-adapters.git@main
 git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-tests-adapter
-git+https://github.com/dbt-labs/dbt-common.git@main
+git+https://github.com/dbt-labs/dbt-common.git@1.10.latest
 git+https://github.com/dbt-labs/dbt-postgres.git@main
 black>=24.3.0,<25.0
 bumpversion


### PR DESCRIPTION

### Problem

In 1.8 we need to pin dbt-common because of incompatibility with new features

### Solution

Pin dbt-common to < 1.11.0

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
