### PR TITLE
Remove Python 3.8 for dbt 1.6

### DIFF
--- a/.changes/unreleased/Under the Hood-20241016-144056.yaml
+++ b/.changes/unreleased/Under the Hood-20241016-144056.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove support and testing for Python 3.8, which is now EOL.
+time: 2024-10-16T14:40:56.451972-04:00
+custom:
+  Author: gshank peterallenwebb
+  Issue: "10861"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install python dependencies
         run: |
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: [ "3.9", "3.10", "3.11" ]
 
     env:
       TOXENV: "unit"
@@ -139,7 +139,7 @@ jobs:
       - name: generate include
         id: generate-include
         run: |
-          INCLUDE=('"python-version":"3.8","os":"windows-latest"' '"python-version":"3.8","os":"macos-12"' )
+          INCLUDE=('"python-version":"3.9","os":"windows-latest"' '"python-version":"3.9","os":"macos-12"' )
           INCLUDE_GROUPS="["
           for include in ${INCLUDE[@]}; do
               for group in $(seq 1 ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }}); do
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: [ "3.9", "3.10", "3.11" ]
         os: [ubuntu-20.04]
         split-group: ${{ fromJson(needs.integration-metadata.outputs.split-groups) }}
         include: ${{ fromJson(needs.integration-metadata.outputs.include) }}
@@ -263,7 +263,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/model_performance.yml
+++ b/.github/workflows/model_performance.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Install dbt
         run: pip install dbt-postgres==${{ needs.set-variables.outputs.release_id }}

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Checkout dbt repo
         uses: actions/checkout@v4

--- a/.github/workflows/structured-logging-schema-check.yml
+++ b/.github/workflows/structured-logging-schema-check.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/test-repeater.yml
+++ b/.github/workflows/test-repeater.yml
@@ -27,7 +27,6 @@ on:
         description: 'Version of Python to Test Against'
         type: choice
         options:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 exclude: ^(core/dbt/docs/build/|core/dbt/events/types_pb2.py)
 
-# Force all unspecified python hooks to run python 3.8
+# Force all unspecified python hooks to run python 3.9
 default_language_version:
   python: python3
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -33,9 +33,6 @@ RUN apt-get update \
     python-is-python3 \
     python-dev-is-python3 \
     python3-pip \
-    python3.8 \
-    python3.8-dev \
-    python3.8-venv \
     python3.9 \
     python3.9-dev \
     python3.9-venv \

--- a/core/setup.py
+++ b/core/setup.py
@@ -2,9 +2,9 @@
 import os
 import sys
 
-if sys.version_info < (3, 8):
+if sys.version_info < (3, 9):
     print("Error: dbt does not support this version of Python.")
-    print("Please upgrade to Python 3.8 or higher.")
+    print("Please upgrade to Python 3.9 or higher.")
     sys.exit(1)
 
 
@@ -98,10 +98,9 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
 )


### PR DESCRIPTION
### Problem

Python 3.8 is EOL and no longer supported by some of dbt's upstream dependencies.

### Solution

We are ending support for 3.8 in all future releases, and will no longer test against it.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
