### PR TITLE
Ensure `KeyboardInterrupt` halts microbatch model execution

### DIFF
--- a/.changes/unreleased/Fixes-20241017-153022.yaml
+++ b/.changes/unreleased/Fixes-20241017-153022.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Ensure KeyboardInterrupt/SystemExit halts microbatch model execution
+time: 2024-10-17T15:30:22.781854-07:00
+custom:
+  Author: QMalcolm
+  Issue: "10862"

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -568,6 +568,9 @@ class ModelRunner(CompileRunner):
                 # At least one batch has been inserted successfully!
                 incremental_batch = True
 
+            except (KeyboardInterrupt, SystemExit):
+                # reraise it for GraphRunnableTask.execute_nodes to handle
+                raise
             except Exception as e:
                 exception = e
                 batch_run_result = self._build_failed_run_batch_result(


### PR DESCRIPTION
Resolves #10862 

### Problem

A `KeyboardInterrupt` during the execution of microbatches would only cause the currently executing batch to stop, and then the rest of the batches (and job) would continue.

### Solution

Make `KeyboardInterrupt`s halt batch execution.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
