### PR TITLE
exclude hook results from results in on-run-end context

### DIFF
--- a/.changes/unreleased/Fixes-20241018-135810.yaml
+++ b/.changes/unreleased/Fixes-20241018-135810.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Exclude hook result from results in on-run-end context
+time: 2024-10-18T13:58:10.396884-07:00
+custom:
+  Author: ChenyuLInx
+  Issue: "7387"

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -774,7 +774,9 @@ class RunTask(CompileTask):
 
         extras = {
             "schemas": list({s for _, s in database_schema_set}),
-            "results": results,
+            "results": [
+                r for r in results if r.thread_id != "main"
+            ],  # exclude hooks to preserve backwards compatibility
             "database_schemas": list(database_schema_set),
         }
         with adapter.connection_named("master"):

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -775,8 +775,8 @@ class RunTask(CompileTask):
         extras = {
             "schemas": list({s for _, s in database_schema_set}),
             "results": [
-                r for r in results if r.thread_id != "main"
-            ],  # exclude hooks to preserve backwards compatibility
+                r for r in results if r.thread_id != "main" or r.status == RunStatus.Error
+            ],  # exclude that didn't fail to preserve backwards compatibility
             "database_schemas": list(database_schema_set),
         }
         with adapter.connection_named("master"):

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -512,7 +512,6 @@ class GraphRunnableTask(ConfiguredTask):
         self.started_at = time.time()
         try:
             before_run_status = self.before_run(adapter, selected_uids)
-
             if before_run_status == RunStatus.Success or (
                 not get_flags().skip_nodes_if_on_run_start_fails
             ):

--- a/tests/functional/adapter/hooks/test_on_run_hooks.py
+++ b/tests/functional/adapter/hooks/test_on_run_hooks.py
@@ -168,3 +168,41 @@ class Test__SelectorEmpty__NoHooksRan:
 
         run_results = get_artifact(project.project_root, "target", "run_results.json")
         assert run_results["results"] == []
+
+
+class Test__HookContext:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "on-run-start": [
+                "select 1 as id",  # success
+                "select 1 as id",  # success
+            ],
+            "on-run-end": [
+                '{{ log("Num Results in context: " ~ results|length)}}'
+                "{{ output_thread_ids(results) }}",
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "log.sql": """
+{% macro output_thread_ids(results) %}
+    {% for result in results %}
+        {{ log("Thread ID: " ~ result.thread_id) }}
+    {% endfor %}
+{% endmacro %}
+"""
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_model.sql": "select 1"}
+
+    def test_results_in_context(self, project):
+        results, log_output = run_dbt_and_capture(["--debug", "run"])
+        assert "Thread ID: " in log_output
+        assert "Thread ID: main" not in log_output
+        assert results[0].thread_id == "main"
+        assert "Num Results in context: 1" in log_output

--- a/tests/functional/adapter/hooks/test_on_run_hooks.py
+++ b/tests/functional/adapter/hooks/test_on_run_hooks.py
@@ -170,7 +170,7 @@ class Test__SelectorEmpty__NoHooksRan:
         assert run_results["results"] == []
 
 
-class Test__HookContext:
+class Test__HookContext__HookSuccess:
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
@@ -200,9 +200,45 @@ class Test__HookContext:
     def models(self):
         return {"my_model.sql": "select 1"}
 
-    def test_results_in_context(self, project):
+    def test_results_in_context_success(self, project):
         results, log_output = run_dbt_and_capture(["--debug", "run"])
         assert "Thread ID: " in log_output
         assert "Thread ID: main" not in log_output
+        assert results[0].thread_id == "main"  # hook still exists in run results
+        assert "Num Results in context: 1" in log_output  # only model given hook was successful
+
+
+class Test__HookContext__HookFail:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "on-run-start": [
+                "select a as id",  # fail
+            ],
+            "on-run-end": [
+                '{{ log("Num Results in context: " ~ results|length)}}'
+                "{{ output_thread_ids(results) }}",
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "log.sql": """
+{% macro output_thread_ids(results) %}
+    {% for result in results %}
+        {{ log("Thread ID: " ~ result.thread_id) }}
+    {% endfor %}
+{% endmacro %}
+"""
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_model.sql": "select 1"}
+
+    def test_results_in_context_hook_fail(self, project):
+        results, log_output = run_dbt_and_capture(["--debug", "run"], expect_pass=False)
+        assert "Thread ID: main" in log_output
         assert results[0].thread_id == "main"
-        assert "Num Results in context: 1" in log_output
+        assert "Num Results in context: 2" in log_output  # failed hook and model


### PR DESCRIPTION
This brings the results in on-run-end back to before https://github.com/dbt-labs/dbt-core/pull/10699/files was introduced.
We can introduce this behind a behavior flag as needed later on.

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
