### PR TITLE
fix: unit tests with versioned refs

### DIFF
--- a/.changes/unreleased/Fixes-20241021-093047.yaml
+++ b/.changes/unreleased/Fixes-20241021-093047.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: unit tests with versioned refs
+time: 2024-10-21T09:30:47.949023898-03:00
+custom:
+    Author: devmessias
+    Issue: 10880 10528 10623

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -110,7 +110,6 @@ class UnitTestManifestLoader:
         # unit_test_node now has a populated refs/sources
 
         self.unit_test_manifest.nodes[unit_test_node.unique_id] = unit_test_node
-
         # Now create input_nodes for the test inputs
         """
         given:
@@ -132,7 +131,6 @@ class UnitTestManifestLoader:
                 given.input, tested_node, test_case.name
             )
             input_name = original_input_node.name
-
             common_fields = {
                 "resource_type": NodeType.Model,
                 # root directory for input and output fixtures
@@ -149,21 +147,25 @@ class UnitTestManifestLoader:
                 "name": input_name,
                 "path": f"{input_name}.sql",
             }
+            resource_type = original_input_node.resource_type
 
-            if original_input_node.resource_type in (
+            if resource_type in (
                 NodeType.Model,
                 NodeType.Seed,
                 NodeType.Snapshot,
             ):
+
                 input_node = ModelNode(
                     **common_fields,
                     defer_relation=original_input_node.defer_relation,
                 )
-                if (
-                    original_input_node.resource_type == NodeType.Model
-                    and original_input_node.version
-                ):
+
+                if not resource_type == NodeType.Model:
+                    continue
+                if original_input_node.version:
                     input_node.version = original_input_node.version
+                if original_input_node.latest_version:
+                    input_node.latest_version = original_input_node.latest_version
 
             elif original_input_node.resource_type == NodeType.Source:
                 # We are reusing the database/schema/identifier from the original source,

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -159,16 +159,11 @@ class UnitTestManifestLoader:
                     **common_fields,
                     defer_relation=original_input_node.defer_relation,
                 )
-
-                if original_input_node.version:
-                    input_node.version = original_input_node.version
-                if original_input_node.latest_version:
-                    input_node.latest_version = original_input_node.latest_version
-            elif resource_type in (NodeType.Seed, NodeType.Snapshot):
-                input_node = ModelNode(
-                    **common_fields,
-                    defer_relation=original_input_node.defer_relation,
-                )
+                if resource_type == NodeType.Model:
+                    if original_input_node.version:
+                        input_node.version = original_input_node.version
+                    if original_input_node.latest_version:
+                        input_node.latest_version = original_input_node.latest_version
 
             elif resource_type == NodeType.Source:
                 # We are reusing the database/schema/identifier from the original source,

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -160,12 +160,15 @@ class UnitTestManifestLoader:
                     defer_relation=original_input_node.defer_relation,
                 )
 
-                if not resource_type == NodeType.Model:
-                    continue
                 if original_input_node.version:
                     input_node.version = original_input_node.version
                 if original_input_node.latest_version:
                     input_node.latest_version = original_input_node.latest_version
+            elif resource_type in (NodeType.Seed, NodeType.Snapshot):
+                input_node = ModelNode(
+                    **common_fields,
+                    defer_relation=original_input_node.defer_relation,
+                )
 
             elif resource_type == NodeType.Source:
                 # We are reusing the database/schema/identifier from the original source,

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -167,7 +167,7 @@ class UnitTestManifestLoader:
                 if original_input_node.latest_version:
                     input_node.latest_version = original_input_node.latest_version
 
-            elif original_input_node.resource_type == NodeType.Source:
+            elif resource_type == NodeType.Source:
                 # We are reusing the database/schema/identifier from the original source,
                 # but that shouldn't matter since this acts as an ephemeral model which just
                 # wraps a CTE around the unit test node.

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -291,6 +291,24 @@ class TestUnitTestIncrementalModelWithAlias:
         assert len(results) == 2
 
 
+class TestUnitTestIncrementalModelWithVersion:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_incremental_model.sql": my_incremental_model_sql,
+            "events.sql": event_sql,
+            "schema.yml": my_incremental_model_versioned_yml + test_my_model_incremental_yml_basic,
+        }
+
+    def test_basic(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 2
+
+        # Select by model name
+        results = run_dbt(["test", "--select", "my_incremental_model"], expect_pass=True)
+        assert len(results) == 2
+
+
 schema_ref_with_version = """
 models:
   - name: source

--- a/tests/functional/unit_testing/test_unit_testing.py
+++ b/tests/functional/unit_testing/test_unit_testing.py
@@ -291,22 +291,139 @@ class TestUnitTestIncrementalModelWithAlias:
         assert len(results) == 2
 
 
-class TestUnitTestIncrementalModelWithVersion:
+schema_ref_with_version = """
+models:
+  - name: source
+    latest_version: {latest_version}
+    versions:
+        - v: 1
+        - v: 2
+  - name: model_to_test
+unit_tests:
+  - name: ref_versioned
+    model: 'model_to_test'
+    given:
+    - input: {input}
+      rows:
+        - {{result: 3}}
+    expect:
+      rows:
+        - {{result: 3}}
+
+"""
+
+
+class TestUnitTestRefWithVersion:
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "my_incremental_model.sql": my_incremental_model_sql,
-            "events.sql": event_sql,
-            "schema.yml": my_incremental_model_versioned_yml + test_my_model_incremental_yml_basic,
+            "model_to_test.sql": "select result from {{ ref('source')}}",
+            "source.sql": "select 2 as result",
+            "source_v2.sql": "select 2 as result",
+            "schema.yml": schema_ref_with_version.format(
+                **{"latest_version": 1, "input": "ref('source')"}
+            ),
         }
 
     def test_basic(self, project):
         results = run_dbt(["run"])
-        assert len(results) == 2
 
-        # Select by model name
-        results = run_dbt(["test", "--select", "my_incremental_model"], expect_pass=True)
-        assert len(results) == 2
+        results = run_dbt(["test", "--select", "model_to_test"], expect_pass=True)
+        assert len(results) == 1
+
+
+class TestUnitTestRefMissingVersionModel:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_to_test.sql": "select result from {{ ref('source')}}",
+            "source_v1.sql": "select 2 as result",
+            "source_v2.sql": "select 2 as result",
+            "schema.yml": schema_ref_with_version.format(
+                **{"latest_version": 1, "input": "ref('source', v=1)"}
+            ),
+        }
+
+    def test_basic(self, project):
+        results = run_dbt(["run"])
+
+        results = run_dbt(["test", "--select", "model_to_test"], expect_pass=True)
+        assert len(results) == 1
+
+
+class TestUnitTestRefWithMissingVersionRef:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_to_test.sql": "select result from {{ ref('source', v=1)}}",
+            "source_v1.sql": "select 2 as result",
+            "source_v2.sql": "select 2 as result",
+            "schema.yml": schema_ref_with_version.format(
+                **{"latest_version": 1, "input": "ref('source')"}
+            ),
+        }
+
+    def test_basic(self, project):
+        results = run_dbt(["run"])
+
+        results = run_dbt(["test", "--select", "model_to_test"], expect_pass=True)
+        assert len(results) == 1
+
+
+class TestUnitTestRefWithVersionLatestSecond:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_to_test.sql": "select result from {{ ref('source')}}",
+            "source_v1.sql": "select 2 as result",
+            "source_v2.sql": "select 2 as result",
+            "schema.yml": schema_ref_with_version.format(
+                **{"latest_version": 2, "input": "ref('source')"}
+            ),
+        }
+
+    def test_basic(self, project):
+        results = run_dbt(["run"])
+
+        results = run_dbt(["test", "--select", "model_to_test"], expect_pass=True)
+        assert len(results) == 1
+
+
+class TestUnitTestRefWithVersionMissingRefTest:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_to_test.sql": "select result from {{ ref('source', v=2)}}",
+            "source_v1.sql": "select 2 as result",
+            "source_v2.sql": "select 2 as result",
+            "schema.yml": schema_ref_with_version.format(
+                **{"latest_version": 1, "input": "ref('source')"}
+            ),
+        }
+
+    def test_basic(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 3
+        # TODO: How to capture an compilation Error? pytest.raises(CompilationError) not working
+        run_dbt(["test", "--select", "model_to_test"], expect_pass=False)
+
+
+class TestUnitTestRefWithVersionDiffLatest:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_to_test.sql": "select result from {{ ref('source', v=2)}}",
+            "source_v1.sql": "select 2 as result",
+            "source_v2.sql": "select 2 as result",
+            "schema.yml": schema_ref_with_version.format(
+                **{"latest_version": 1, "input": "ref('source', v=2)"}
+            ),
+        }
+
+    def test_basic(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 3
+        run_dbt(["test", "--select", "model_to_test"], expect_pass=True)
 
 
 class TestUnitTestExplicitSeed:


### PR DESCRIPTION
Resolves #10880; Resolves #10528; Resolves #10623 



### Problem
The error raises due the method `RefableLookup.find` at  dbt-my/core/dbt/contracts/graph/manifest.py: 

Tracking the storage object, without specifying a version in the model we will obtain something like that for the Unit Test Node running phase 

 
```python
{'upstream_model_versioned': {}, 'upstream_model_versioned.v<LATEST>': {'demo_dbt_py': 'model.demo_dbt_py.upstream_model_versioned'}} 
```
 

Which it seems to me that is not right, because if I specified the `latest_version` for my model, I should get   a Storage like this 
```python
{
    'upstream_model_versioned': {'demo_dbt_py': 'model.demo_dbt_py.upstream_model_versioned'}, 
    'upstream_model_versioned.v <LATEST> ': {'demo_dbt_py': 'model.demo_dbt_py.upstream_model_versioned'} 
} 
```

I run some different cases and obtain the following table 

| Status | Model Ref | Model Latest | Test Ref | Test Latest | Expectation | v on find | Compilation Message | 
|--------|-----------|--------------|----------|-------------|-------------|---------------|---------------------| 
| ❌     | true      | true         | true     | false       | fail        | 1             | depends on a node named 'upstream_model_versioned' with version '1' which was not found | 
| ❌     | true      | false        | false    | None        | fail        | 2             | depends on a node named 'upstream_model_versioned' with version '2' which was not found | 
| ❌     | false     | None         | false    | false       | success     | None          | depends on a node named 'upstream_model_versioned' which was not found | 
| ❌     | false     | None         | true     | true        | success     | None          | depends on a node named 'upstream_model_versioned' which was not found | 
| ✅     | true      | true         | false    | None        | success     | 1             | model.demo_dbt_py.upstream_model_versioned | 
| ✅     | true      | true         | true     | true        | success     | 1             | model.demo_dbt_py.upstream_model_versioned | 
| ✅     | true      | false        | true     | false       | success     | 2             | model.demo_dbt_py.upstream_model_versioned | 



However, even in cases where the tests were successful, the storage objects it seems that not properly constructed. For example, when using `ref('upstream_model_versioned', v=1)` I got this:

```python
{'upstream_model_versioned': {}, 
 'upstream_model_versioned.v1': {'demo_dbt_py': 'model.demo_dbt_py.upstream_model_versioned'}}
```

This worked not because the storage structure was correct, but because there was a key named `upstream_model_versioned.v1`.


### Solution

The only problem that I found is that the Node object for the UnitTest was not copying the value from latest_version prop if it was available

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
