### PR TITLE
pin internal dependencies with upper bounds

### DIFF
--- a/.changes/unreleased/Dependencies-20241021-131923.yaml
+++ b/.changes/unreleased/Dependencies-20241021-131923.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Pin dbt-common and dbt-adapters with upper bound.
+time: 2024-10-21T13:19:23.137466-05:00
+custom:
+  Author: emmyoop
+  Issue: "10895"

--- a/core/setup.py
+++ b/core/setup.py
@@ -75,8 +75,8 @@ setup(
         "minimal-snowplow-tracker>=0.0.2,<0.1",
         "dbt-semantic-interfaces>=0.5.1,<0.6",
         # Minor versions for these are expected to be backwards-compatible
-        "dbt-common>=1.0.4,<2.0",
-        "dbt-adapters>=1.1.1,<2.0",
+        "dbt-common>=1.0.4,<1.11.0",
+        "dbt-adapters>=1.1.1,<1.7.1",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
         "packaging>20.9",

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,8 @@
-git+https://github.com/dbt-labs/dbt-adapters.git@main
-git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-tests-adapter
-git+https://github.com/dbt-labs/dbt-common.git@main
-git+https://github.com/dbt-labs/dbt-postgres.git@main
+# We hardcode these two dependencies to ensure that we are testing against the correct versions of
+# released code to ensure we don't introduce any breaking changes
+dbt-tests-adapter<=1.10.2
+dbt-postgres<=1.9.0
+#
 black>=24.3.0,<25.0
 bumpversion
 ddtrace==2.3.0


### PR DESCRIPTION
Resolves #10895 

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

We introduce some dev thrash with some changes to dbt-common.  Most recently we updated an error message that caused tests in 1.8 to break.

### Solution

Give dbt-common and dbt-adapters an upper bound pin.  Stop point dev-dependencies to main.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
