### PR TITLE
Loosen Type in TimingInfo

### DIFF
--- a/core/dbt/artifacts/schemas/results.py
+++ b/core/dbt/artifacts/schemas/results.py
@@ -16,7 +16,7 @@ class TimingInfo(dbtClassMixin):
     Do not call directly, use `collect_timing_info` instead.
     """
 
-    name: Literal["compile", "execute", "other"]
+    name: str
     started_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
 

--- a/core/dbt/artifacts/schemas/results.py
+++ b/core/dbt/artifacts/schemas/results.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from dbt.contracts.graph.nodes import ResultNode
 from dbt_common.dataclass_schema import StrEnum, dbtClassMixin
@@ -37,9 +37,7 @@ class TimingInfo(dbtClassMixin):
 
 # This is a context manager
 class collect_timing_info:
-    def __init__(
-        self, name: Literal["compile", "execute", "other"], callback: Callable[[TimingInfo], None]
-    ) -> None:
+    def __init__(self, name: str, callback: Callable[[TimingInfo], None]) -> None:
         self.timing_info = TimingInfo(name=name)
         self.callback = callback
 

--- a/schemas/dbt/run-results/v6.json
+++ b/schemas/dbt/run-results/v6.json
@@ -84,11 +84,7 @@
               "title": "TimingInfo",
               "properties": {
                 "name": {
-                  "enum": [
-                    "compile",
-                    "execute",
-                    "other"
-                  ]
+                  "type": "string"
                 },
                 "started_at": {
                   "anyOf": [

--- a/schemas/dbt/sources/v3.json
+++ b/schemas/dbt/sources/v3.json
@@ -211,11 +211,7 @@
                   "title": "TimingInfo",
                   "properties": {
                     "name": {
-                      "enum": [
-                        "compile",
-                        "execute",
-                        "other"
-                      ]
+                      "type": "string"
                     },
                     "started_at": {
                       "anyOf": [


### PR DESCRIPTION

### Problem

An overly restrictive type annotation caused problems deserializing previously stored run results.

### Solution

Loosen the annotation back to its original type.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
