### PR TITLE
Fix: Source quoting ignores global configuration

### DIFF
--- a/.changes/unreleased/Fixes-20241023-152054.yaml
+++ b/.changes/unreleased/Fixes-20241023-152054.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Restore source quoting behaviour when quoting config provided in dbt_project.yml
+time: 2024-10-23T15:20:54.766893-04:00
+custom:
+  Author: michelleark
+  Issue: "10892"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -684,12 +684,18 @@ class RuntimeSourceResolver(BaseSourceResolver):
                 target_kind="source",
                 disabled=(isinstance(target_source, Disabled)),
             )
-        return self.Relation.create_from(
-            self.config,
+
+        class SourceQuotingConfig:
+            quoting: Dict[str, Any] = {"database": False, "schema": False, "identifier": False}
+
+        relation = self.Relation.create_from(
+            SourceQuotingConfig(),
             target_source,
             limit=self.resolve_limit,
             event_time_filter=self.resolve_event_time_filter(target_source),
         )
+
+        return relation
 
 
 class RuntimeUnitTestSourceResolver(BaseSourceResolver):

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -688,11 +688,11 @@ class RuntimeSourceResolver(BaseSourceResolver):
         # Source quoting does _not_ respect global configs in dbt_project.yml, as documented here:
         # https://docs.getdbt.com/reference/project-configs/quoting
         # Use an object with an empty quoting field to bypass any settings in self.
-        class SourceQuotingConfig:
+        class SourceQuotingBaseConfig:
             quoting: Dict[str, Any] = {}
 
         return self.Relation.create_from(
-            SourceQuotingConfig(),
+            SourceQuotingBaseConfig(),
             target_source,
             limit=self.resolve_limit,
             event_time_filter=self.resolve_event_time_filter(target_source),

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -688,8 +688,15 @@ class RuntimeSourceResolver(BaseSourceResolver):
         class SourceQuotingConfig:
             quoting: Dict[str, Any] = {"database": False, "schema": False, "identifier": False}
 
+        # Preserve legacy behaviour where sources do not consider quoting configuration from dbt_project.yml
+        base_quoting_config = (
+            self.config
+            if self.config.args.source_quoting_respects_project_config
+            else SourceQuotingConfig()
+        )
+
         relation = self.Relation.create_from(
-            SourceQuotingConfig(),
+            base_quoting_config,
             target_source,
             limit=self.resolve_limit,
             event_time_filter=self.resolve_event_time_filter(target_source),

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -688,15 +688,8 @@ class RuntimeSourceResolver(BaseSourceResolver):
         class SourceQuotingConfig:
             quoting: Dict[str, Any] = {}
 
-        # Preserve legacy behaviour where sources do not consider quoting configuration from dbt_project.yml
-        base_quoting_config = (
-            self.config
-            if self.config.args.source_quoting_respects_project_config
-            else SourceQuotingConfig()
-        )
-
         relation = self.Relation.create_from(
-            base_quoting_config,
+            SourceQuotingConfig(),
             target_source,
             limit=self.resolve_limit,
             event_time_filter=self.resolve_event_time_filter(target_source),

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -685,6 +685,9 @@ class RuntimeSourceResolver(BaseSourceResolver):
                 disabled=(isinstance(target_source, Disabled)),
             )
 
+        # Source quoting does _not_ respect global configs in dbt_project.yml, as documented here:
+        # https://docs.getdbt.com/reference/project-configs/quoting
+        # Use an object with an empty quoting field to bypass any settings in self.
         class SourceQuotingConfig:
             quoting: Dict[str, Any] = {}
 

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -691,14 +691,12 @@ class RuntimeSourceResolver(BaseSourceResolver):
         class SourceQuotingConfig:
             quoting: Dict[str, Any] = {}
 
-        relation = self.Relation.create_from(
+        return self.Relation.create_from(
             SourceQuotingConfig(),
             target_source,
             limit=self.resolve_limit,
             event_time_filter=self.resolve_event_time_filter(target_source),
         )
-
-        return relation
 
 
 class RuntimeUnitTestSourceResolver(BaseSourceResolver):

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -686,7 +686,7 @@ class RuntimeSourceResolver(BaseSourceResolver):
             )
 
         class SourceQuotingConfig:
-            quoting: Dict[str, Any] = {"database": False, "schema": False, "identifier": False}
+            quoting: Dict[str, Any] = {}
 
         # Preserve legacy behaviour where sources do not consider quoting configuration from dbt_project.yml
         base_quoting_config = (

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -341,7 +341,6 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     require_explicit_package_overrides_for_builtin_materializations: bool = True
     require_resource_names_without_spaces: bool = False
     source_freshness_run_project_hooks: bool = False
-    source_quoting_respects_project_config: bool = False
     skip_nodes_if_on_run_start_fails: bool = False
     state_modified_compare_more_unrendered_values: bool = False
     state_modified_compare_vars: bool = False
@@ -352,7 +351,6 @@ class ProjectFlags(ExtensibleDbtClassMixin):
             "require_explicit_package_overrides_for_builtin_materializations": self.require_explicit_package_overrides_for_builtin_materializations,
             "require_resource_names_without_spaces": self.require_resource_names_without_spaces,
             "source_freshness_run_project_hooks": self.source_freshness_run_project_hooks,
-            "source_quoting_respects_project_config": self.source_quoting_respects_project_config,
             "skip_nodes_if_on_run_start_fails": self.skip_nodes_if_on_run_start_fails,
             "state_modified_compare_more_unrendered_values": self.state_modified_compare_more_unrendered_values,
             "state_modified_compare_vars": self.state_modified_compare_vars,

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -341,6 +341,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     require_explicit_package_overrides_for_builtin_materializations: bool = True
     require_resource_names_without_spaces: bool = False
     source_freshness_run_project_hooks: bool = False
+    source_quoting_respects_project_config: bool = False
     skip_nodes_if_on_run_start_fails: bool = False
     state_modified_compare_more_unrendered_values: bool = False
     state_modified_compare_vars: bool = False
@@ -351,6 +352,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
             "require_explicit_package_overrides_for_builtin_materializations": self.require_explicit_package_overrides_for_builtin_materializations,
             "require_resource_names_without_spaces": self.require_resource_names_without_spaces,
             "source_freshness_run_project_hooks": self.source_freshness_run_project_hooks,
+            "source_quoting_respects_project_config": self.source_quoting_respects_project_config,
             "skip_nodes_if_on_run_start_fails": self.skip_nodes_if_on_run_start_fails,
             "state_modified_compare_more_unrendered_values": self.state_modified_compare_more_unrendered_values,
             "state_modified_compare_vars": self.state_modified_compare_vars,

--- a/tests/functional/relation_quoting/test_relation_quoting.py
+++ b/tests/functional/relation_quoting/test_relation_quoting.py
@@ -1,0 +1,37 @@
+import pytest
+
+from dbt.tests.util import read_file, run_dbt
+
+_SOURCES_YML = """
+sources:
+  - name: source_name
+    database: source_database
+    schema: source_schema
+    tables:
+      - name: customers
+"""
+
+
+class TestSourceQuotingLegacy:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "quoting": {
+                "database": True,
+                "schema": True,
+                "database": True,
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "sources.yml": _SOURCES_YML,
+            "model.sql": "select * from {{ source('source_name', 'customers') }}",
+        }
+
+    def test_sources_ignore_global_quoting_configs(self, project):
+        run_dbt(["compile"])
+
+        generated_sql = read_file("target", "compiled", "test", "models", "model.sql")
+        assert generated_sql == "select * from source_database.source_schema.customers"

--- a/tests/functional/relation_quoting/test_relation_quoting.py
+++ b/tests/functional/relation_quoting/test_relation_quoting.py
@@ -15,11 +15,12 @@ sources:
 class TestSourceQuotingLegacy:
     @pytest.fixture(scope="class")
     def project_config_update(self):
+        # Postgres quoting configs are True by default -- turn them all to False to show they are not respected during source rendering
         return {
             "quoting": {
-                "database": True,
-                "schema": True,
-                "database": True,
+                "database": False,
+                "schema": False,
+                "database": False,
             },
         }
 
@@ -34,4 +35,4 @@ class TestSourceQuotingLegacy:
         run_dbt(["compile"])
 
         generated_sql = read_file("target", "compiled", "test", "models", "model.sql")
-        assert generated_sql == "select * from source_database.source_schema.customers"
+        assert generated_sql == 'select * from "source_database"."source_schema"."customers"'

--- a/tests/functional/relation_quoting/test_relation_quoting.py
+++ b/tests/functional/relation_quoting/test_relation_quoting.py
@@ -57,7 +57,7 @@ class TestModelQuoting:
             "model_downstream.sql": "select * from {{ ref('model') }}",
         }
 
-    def test_sources_ignore_global_quoting_configs(self, project):
+    def test_models_respect_global_quoting_configs(self, project):
         run_dbt(["compile"])
 
         generated_sql = read_file("target", "compiled", "test", "models", "model_downstream.sql")

--- a/tests/functional/relation_quoting/test_relation_quoting.py
+++ b/tests/functional/relation_quoting/test_relation_quoting.py
@@ -12,7 +12,7 @@ sources:
 """
 
 
-class TestSourceQuotingLegacy:
+class TestSourceQuotingGlobalConfigsLegacy:
     @pytest.fixture(scope="class")
     def project_config_update(self):
         # Postgres quoting configs are True by default -- turn them all to False to show they are not respected during source rendering
@@ -20,7 +20,7 @@ class TestSourceQuotingLegacy:
             "quoting": {
                 "database": False,
                 "schema": False,
-                "database": False,
+                "identifier": False,
             },
         }
 
@@ -36,3 +36,58 @@ class TestSourceQuotingLegacy:
 
         generated_sql = read_file("target", "compiled", "test", "models", "model.sql")
         assert generated_sql == 'select * from "source_database"."source_schema"."customers"'
+
+
+class TestSourceQuotingGlobalConfigs:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        # Postgres quoting configs are True by default -- turn them all to False to show they are respected during source rendering
+        return {
+            "quoting": {
+                "database": False,
+                "schema": False,
+                "identifier": False,
+            },
+            "flags": {
+                "source_quoting_respects_project_config": True,
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "sources.yml": _SOURCES_YML,
+            "model.sql": "select * from {{ source('source_name', 'customers') }}",
+        }
+
+    def test_sources_ignore_global_quoting_configs(self, project):
+        run_dbt(["compile"])
+
+        generated_sql = read_file("target", "compiled", "test", "models", "model.sql")
+        assert generated_sql == "select * from source_database.source_schema.customers"
+
+
+class TestModelQuoting:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        # Postgres quoting configs are True by default -- turn them all to False to show they are respected during model rendering
+        return {
+            "quoting": {
+                "database": False,
+                "schema": False,
+                "identifier": False,
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model.sql": "select 1 as id",
+            "model_downstream.sql": "select * from {{ ref('model') }}",
+        }
+
+    def test_sources_ignore_global_quoting_configs(self, project):
+        run_dbt(["compile"])
+
+        generated_sql = read_file("target", "compiled", "test", "models", "model_downstream.sql")
+        assert generated_sql == f"select * from dbt.{project.test_schema}.model"

--- a/tests/functional/relation_quoting/test_relation_quoting.py
+++ b/tests/functional/relation_quoting/test_relation_quoting.py
@@ -12,7 +12,7 @@ sources:
 """
 
 
-class TestSourceQuotingGlobalConfigsLegacy:
+class TestSourceQuotingGlobalConfigs:
     @pytest.fixture(scope="class")
     def project_config_update(self):
         # Postgres quoting configs are True by default -- turn them all to False to show they are not respected during source rendering
@@ -36,35 +36,6 @@ class TestSourceQuotingGlobalConfigsLegacy:
 
         generated_sql = read_file("target", "compiled", "test", "models", "model.sql")
         assert generated_sql == 'select * from "source_database"."source_schema"."customers"'
-
-
-class TestSourceQuotingGlobalConfigs:
-    @pytest.fixture(scope="class")
-    def project_config_update(self):
-        # Postgres quoting configs are True by default -- turn them all to False to show they are respected during source rendering
-        return {
-            "quoting": {
-                "database": False,
-                "schema": False,
-                "identifier": False,
-            },
-            "flags": {
-                "source_quoting_respects_project_config": True,
-            },
-        }
-
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "sources.yml": _SOURCES_YML,
-            "model.sql": "select * from {{ source('source_name', 'customers') }}",
-        }
-
-    def test_sources_ignore_global_quoting_configs(self, project):
-        run_dbt(["compile"])
-
-        generated_sql = read_file("target", "compiled", "test", "models", "model.sql")
-        assert generated_sql == "select * from source_database.source_schema.customers"
 
 
 class TestModelQuoting:


### PR DESCRIPTION
Resolves #10892 (regression)

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

In dbt-core 1.7 and earlier, quoting behavior for sources was not controlled by the quoting configuration in dbt_project.yml, but newer versions of dbt also apply those settings to sources.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
For sources, pass along an 'empty' quoting config as the base config, ignoring anything that's in self.config.quoting (ie dbt_project.yml). This was effectively the case in versions <1.7, which used [create_from_source](https://github.com/dbt-labs/dbt-core/blob/1.7.latest/core/dbt/adapters/base/relation.py#L207-L211) which did not incorporate the config quoting like [create_from_node](https://github.com/dbt-labs/dbt-core/blob/1.7.latest/core/dbt/adapters/base/relation.py#L241) did.

⚠️ Note: 
We are not putting this behind a behaviour flag because: 
* This behaviour was previously intentional and documented ([here](https://docs.getdbt.com/reference/project-configs/quoting) and [here](https://docs.getdbt.com/reference/resource-properties/quoting)). The quoting: config in the dbt_project.yml file is just for creating relations / resolving a ref, and this is truly addressing a regression
* It is highly unlikely that restoring the previous behaviour will cause any issues in existing projects that may be depending on the quoting config being ignored. [By default and in most adapters other than snowflake, quoting is True by default](https://docs.getdbt.com/reference/project-configs/quoting), so sources getting opted into quoting has not been problematic. It's only on snowflake that the regression has been raised because it is `False` by default, and adding quotes has been unsafe to do by default for sources when they otherwise wouldn't have been.
   * In either case, the current behaviour goes counter to our documentation and would not have been safe to rely on.
* We don't want to phase in the new behaviour / deprecate the old behavior. From @jtcohen6: 
  * people should be specifically configuring sources with nonstandard quoting, so for those people this should be no change (and the previous behavior is more desirable)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
