### PR TITLE
Fix regression when an exposure references a deprecated model

### DIFF
--- a/.changes/unreleased/Fixes-20241024-104938.yaml
+++ b/.changes/unreleased/Fixes-20241024-104938.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix bug when referencing deprecated models
+time: 2024-10-24T10:49:38.352328-06:00
+custom:
+  Author: dbeatty10 danlsn
+  Issue: "10915"

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -590,7 +590,7 @@ class ManifestLoader:
                 # Get the child_nodes and check for deprecations.
                 child_nodes = self.manifest.child_map[node.unique_id]
                 for child_unique_id in child_nodes:
-                    child_node = self.manifest.nodes[child_unique_id]
+                    child_node = self.manifest.nodes.get(child_unique_id)
                     if not isinstance(child_node, ModelNode):
                         continue
                     if node.is_past_deprecation_date:

--- a/tests/functional/deprecations/fixtures.py
+++ b/tests/functional/deprecations/fixtures.py
@@ -30,6 +30,23 @@ exposures:
       email: something@example.com
 """
 
+
+deprecated_model_exposure_yaml = """
+version: 2
+
+models:
+  - name: model
+    deprecation_date: 1999-01-01 00:00:00.00+00:00
+
+exposures:
+  - name: simple_exposure
+    type: dashboard
+    depends_on:
+      - ref('model')
+    owner:
+      email: something@example.com
+"""
+
 # deprecated test config fixtures
 data_tests_yaml = """
 models:

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -7,6 +7,7 @@ from dbt.tests.util import run_dbt, run_dbt_and_capture, write_file
 from dbt_common.exceptions import EventCompilationError
 from tests.functional.deprecations.fixtures import (
     bad_name_yaml,
+    deprecated_model_exposure_yaml,
     models_trivial__model_sql,
 )
 
@@ -97,6 +98,18 @@ class TestPackageRedirectDeprecation:
         exc_str = " ".join(str(exc.value).split())  # flatten all whitespace
         expected_msg = "The `fishtown-analytics/dbt_utils` package is deprecated in favor of `dbt-labs/dbt_utils`"
         assert expected_msg in exc_str
+
+
+class TestDeprecatedModelExposure:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model.sql": models_trivial__model_sql,
+            "exposure.yml": deprecated_model_exposure_yaml,
+        }
+
+    def test_exposure_with_deprecated_model(self, project):
+        run_dbt(["parse"])
 
 
 class TestExposureNameDeprecation:


### PR DESCRIPTION
Resolves #10911

### Problem

Our current code looks like this:
```python
child_node = self.manifest.nodes[child_unique_id]
```

This will raise a `KeyError` if `child_unique_id` is not found in the dictionary.

We'd want to use this if we're **certain** that the key will always exist, and we want an error to be raised if it doesn't. But an error is exactly opposite of what we want. Rather, we want to get `None` instead of an error.

### Solution

Change to this code:
```python
child_node = self.manifest.nodes.get(child_unique_id)
```

This will return `None` if `child_unique_id` is not found in the dictionary. Since the key might not exist, this allows us to  gracefully handle it without raising an exception (i.e. checking if `isinstance(child_node, ModelNode)` or not).

### Testing

Manually confirmed that the new test class failed without the code change ❌  and passes with the code change ✅ .

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
