### PR TITLE
update adapter version messages

### DIFF
--- a/.changes/unreleased/Fixes-20241025-104339.yaml
+++ b/.changes/unreleased/Fixes-20241025-104339.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: update adapter version messages
+time: 2024-10-25T10:43:39.274723-05:00
+custom:
+  Author: dave-connors-3
+  Issue: "10230"

--- a/core/dbt/version.py
+++ b/core/dbt/version.py
@@ -130,7 +130,11 @@ def _get_plugin_msg_info(
 
     needs_update = False
 
-    if plugin.major != core.major or plugin.minor != core.minor:
+    assert plugin.major is not None
+    assert plugin.minor is not None
+    assert core.major is not None
+    assert core.minor is not None
+    if plugin.major != core.major or plugin.minor < core.minor:
         compatibility_msg = red("Not compatible!")
         needs_update = True
         return (compatibility_msg, needs_update)

--- a/core/dbt/version.py
+++ b/core/dbt/version.py
@@ -8,7 +8,7 @@ from typing import Iterator, List, Optional, Tuple
 import requests
 
 import dbt_common.semver as semver
-from dbt_common.ui import green, red, yellow
+from dbt_common.ui import green, yellow
 
 PYPI_VERSION_URL = "https://pypi.org/pypi/dbt-core/json"
 
@@ -19,7 +19,7 @@ def get_version_information() -> str:
 
     core_msg_lines, core_info_msg = _get_core_msg_lines(installed, latest)
     core_msg = _format_core_msg(core_msg_lines)
-    plugin_version_msg = _get_plugins_msg(installed)
+    plugin_version_msg = _get_plugins_msg()
 
     msg_lines = [core_msg]
 
@@ -97,7 +97,7 @@ def _format_core_msg(lines: List[List[str]]) -> str:
     return msg + "\n".join(msg_lines)
 
 
-def _get_plugins_msg(installed: semver.VersionSpecifier) -> str:
+def _get_plugins_msg() -> str:
     msg_lines = ["Plugins:"]
 
     plugins = []
@@ -113,7 +113,7 @@ def _get_plugins_msg(installed: semver.VersionSpecifier) -> str:
 
     if display_update_msg:
         update_msg = (
-            "  At least one plugin is out of date or incompatible with dbt-core.\n"
+            "  At least one plugin is out of date with dbt-core.\n"
             "  You can find instructions for upgrading here:\n"
             "  https://docs.getdbt.com/docs/installation"
         )
@@ -129,15 +129,6 @@ def _get_plugin_msg_info(
     latest_plugin = get_latest_version(version_url=get_package_pypi_url(name))
 
     needs_update = False
-
-    assert plugin.major is not None
-    assert plugin.minor is not None
-    assert core.major is not None
-    assert core.minor is not None
-    if plugin.major != core.major or plugin.minor < core.minor:
-        compatibility_msg = red("Not compatible!")
-        needs_update = True
-        return (compatibility_msg, needs_update)
 
     if not latest_plugin:
         compatibility_msg = yellow("Could not determine latest version")

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -489,6 +489,68 @@ class TestGetVersionInformation:
 
         assert expected == actual
 
+    def test_plugin_diff_plugin_minor_ahead_latest(self, mocker):
+        """
+        Now that adapters are decoupled from core, a higher minor version of a plugin
+        is compatible with a lower minor version of core.
+        """
+
+        mock_versions(
+            mocker,
+            installed="1.8.0",
+            latest="1.8.0",
+            plugins={
+                "foobar": ("1.9.0", "1.9.0"),
+            },
+        )
+
+        actual = dbt.version.get_version_information()
+        expected = "\n".join(
+            [
+                "Core:",
+                "  - installed: 1.8.0",
+                f"  - latest:    1.8.0 - {green('Up to date!')}",
+                "",
+                "Plugins:",
+                f"  - foobar: 1.9.0 - {green('Up to date!')}",
+                "",
+                "",
+            ]
+        )
+
+        assert expected == actual
+
+    def test_plugin_diff_plugin_minor_ahead_no_latest(self, mocker):
+        """
+        Now that adapters are decoupled from core, a higher minor version of a plugin
+        is compatible with a lower minor version of core.
+        """
+
+        mock_versions(
+            mocker,
+            installed="1.8.0",
+            latest="1.8.0",
+            plugins={
+                "foobar": ("1.9.0", None),
+            },
+        )
+
+        actual = dbt.version.get_version_information()
+        expected = "\n".join(
+            [
+                "Core:",
+                "  - installed: 1.8.0",
+                f"  - latest:    1.8.0 - {green('Up to date!')}",
+                "",
+                "Plugins:",
+                f"  - foobar: 1.9.0 - {yellow('Could not determine latest version')}",
+                "",
+                "",
+            ]
+        )
+
+        assert expected == actual
+
     def test_plugin_diff_core_minor_behind_latest(self, mocker):
         mock_versions(
             mocker,

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -520,6 +520,37 @@ class TestGetVersionInformation:
 
         assert expected == actual
 
+    def test_plugin_diff_plugin_patch_ahead_latest(self, mocker):
+        """
+        Now that adapters are decoupled from core, a higher minor version of a plugin
+        is compatible with a lower minor version of core.
+        """
+
+        mock_versions(
+            mocker,
+            installed="1.8.0",
+            latest="1.8.0",
+            plugins={
+                "foobar": ("1.8.4", "1.8.4"),
+            },
+        )
+
+        actual = dbt.version.get_version_information()
+        expected = "\n".join(
+            [
+                "Core:",
+                "  - installed: 1.8.0",
+                f"  - latest:    1.8.0 - {green('Up to date!')}",
+                "",
+                "Plugins:",
+                f"  - foobar: 1.8.4 - {green('Up to date!')}",
+                "",
+                "",
+            ]
+        )
+
+        assert expected == actual
+
     def test_plugin_diff_plugin_minor_ahead_no_latest(self, mocker):
         """
         Now that adapters are decoupled from core, a higher minor version of a plugin

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,5 +1,5 @@
 import dbt.version
-from dbt_common.ui import green, red, yellow
+from dbt_common.ui import green, yellow
 
 
 class TestGetVersionInformation:
@@ -239,7 +239,7 @@ class TestGetVersionInformation:
                 "Plugins:",
                 f"  - foobar: 1.0.0 - {yellow('Update available!')}",
                 "",
-                "  At least one plugin is out of date or incompatible with dbt-core.",
+                "  At least one plugin is out of date with dbt-core.",
                 "  You can find instructions for upgrading here:",
                 "  https://docs.getdbt.com/docs/installation",
                 "",
@@ -269,127 +269,7 @@ class TestGetVersionInformation:
                 "Plugins:",
                 f"  - foobar: 1.0.0 - {yellow('Update available!')}",
                 "",
-                "  At least one plugin is out of date or incompatible with dbt-core.",
-                "  You can find instructions for upgrading here:",
-                "  https://docs.getdbt.com/docs/installation",
-                "",
-                "",
-            ]
-        )
-
-        assert expected == actual
-
-    def test_plugin_diff_core_major_match_latest(self, mocker):
-        mock_versions(
-            mocker,
-            installed="2.0.0",
-            latest="2.0.0",
-            plugins={
-                "foobar": ("1.0.0", "1.0.0"),
-            },
-        )
-
-        actual = dbt.version.get_version_information()
-        expected = "\n".join(
-            [
-                "Core:",
-                "  - installed: 2.0.0",
-                f"  - latest:    2.0.0 - {green('Up to date!')}",
-                "",
-                "Plugins:",
-                f"  - foobar: 1.0.0 - {red('Not compatible!')}",
-                "",
-                "  At least one plugin is out of date or incompatible with dbt-core.",
-                "  You can find instructions for upgrading here:",
-                "  https://docs.getdbt.com/docs/installation",
-                "",
-                "",
-            ]
-        )
-
-        assert expected == actual
-
-    def test_plugin_diff_core_major_no_latest(self, mocker):
-        mock_versions(
-            mocker,
-            installed="2.0.0",
-            latest="2.0.0",
-            plugins={
-                "foobar": ("1.0.0", None),
-            },
-        )
-
-        actual = dbt.version.get_version_information()
-        expected = "\n".join(
-            [
-                "Core:",
-                "  - installed: 2.0.0",
-                f"  - latest:    2.0.0 - {green('Up to date!')}",
-                "",
-                "Plugins:",
-                f"  - foobar: 1.0.0 - {red('Not compatible!')}",
-                "",
-                "  At least one plugin is out of date or incompatible with dbt-core.",
-                "  You can find instructions for upgrading here:",
-                "  https://docs.getdbt.com/docs/installation",
-                "",
-                "",
-            ]
-        )
-
-        assert expected == actual
-
-    def test_plugin_diff_core_major_ahead_latest(self, mocker):
-        mock_versions(
-            mocker,
-            installed="2.0.0",
-            latest="2.0.0",
-            plugins={
-                "foobar": ("1.0.0", "0.0.1"),
-            },
-        )
-
-        actual = dbt.version.get_version_information()
-        expected = "\n".join(
-            [
-                "Core:",
-                "  - installed: 2.0.0",
-                f"  - latest:    2.0.0 - {green('Up to date!')}",
-                "",
-                "Plugins:",
-                f"  - foobar: 1.0.0 - {red('Not compatible!')}",
-                "",
-                "  At least one plugin is out of date or incompatible with dbt-core.",
-                "  You can find instructions for upgrading here:",
-                "  https://docs.getdbt.com/docs/installation",
-                "",
-                "",
-            ]
-        )
-
-        assert expected == actual
-
-    def test_plugin_diff_core_major_behind_latest(self, mocker):
-        mock_versions(
-            mocker,
-            installed="2.0.0",
-            latest="2.0.0",
-            plugins={
-                "foobar": ("1.0.0", "1.1.0"),
-            },
-        )
-
-        actual = dbt.version.get_version_information()
-        expected = "\n".join(
-            [
-                "Core:",
-                "  - installed: 2.0.0",
-                f"  - latest:    2.0.0 - {green('Up to date!')}",
-                "",
-                "Plugins:",
-                f"  - foobar: 1.0.0 - {red('Not compatible!')}",
-                "",
-                "  At least one plugin is out of date or incompatible with dbt-core.",
+                "  At least one plugin is out of date with dbt-core.",
                 "  You can find instructions for upgrading here:",
                 "  https://docs.getdbt.com/docs/installation",
                 "",
@@ -417,11 +297,7 @@ class TestGetVersionInformation:
                 f"  - latest:    1.1.0 - {green('Up to date!')}",
                 "",
                 "Plugins:",
-                f"  - foobar: 1.0.0 - {red('Not compatible!')}",
-                "",
-                "  At least one plugin is out of date or incompatible with dbt-core.",
-                "  You can find instructions for upgrading here:",
-                "  https://docs.getdbt.com/docs/installation",
+                f"  - foobar: 1.0.0 - {green('Up to date!')}",
                 "",
                 "",
             ]
@@ -447,11 +323,7 @@ class TestGetVersionInformation:
                 f"  - latest:    1.1.0 - {green('Up to date!')}",
                 "",
                 "Plugins:",
-                f"  - foobar: 1.0.0 - {red('Not compatible!')}",
-                "",
-                "  At least one plugin is out of date or incompatible with dbt-core.",
-                "  You can find instructions for upgrading here:",
-                "  https://docs.getdbt.com/docs/installation",
+                f"  - foobar: 1.0.0 - {yellow('Could not determine latest version')}",
                 "",
                 "",
             ]
@@ -477,11 +349,7 @@ class TestGetVersionInformation:
                 f"  - latest:    1.1.0 - {green('Up to date!')}",
                 "",
                 "Plugins:",
-                f"  - foobar: 1.0.0 - {red('Not compatible!')}",
-                "",
-                "  At least one plugin is out of date or incompatible with dbt-core.",
-                "  You can find instructions for upgrading here:",
-                "  https://docs.getdbt.com/docs/installation",
+                f"  - foobar: 1.0.0 - {yellow('Ahead of latest version!')}",
                 "",
                 "",
             ]
@@ -582,6 +450,37 @@ class TestGetVersionInformation:
 
         assert expected == actual
 
+    def test_plugin_diff_plugin_minor_behind_core_no_latest(self, mocker):
+        """
+        Now that adapters are decoupled from core, a lower minor version of a plugin (1.8)
+        is compatible with a higher minor version of core. (1.9)
+        """
+
+        mock_versions(
+            mocker,
+            installed="1.9.0",
+            latest="1.9.0",
+            plugins={
+                "foobar": ("1.8.0", "1.8.0"),
+            },
+        )
+
+        actual = dbt.version.get_version_information()
+        expected = "\n".join(
+            [
+                "Core:",
+                "  - installed: 1.9.0",
+                f"  - latest:    1.9.0 - {green('Up to date!')}",
+                "",
+                "Plugins:",
+                f"  - foobar: 1.8.0 - {green('Up to date!')}",
+                "",
+                "",
+            ]
+        )
+
+        assert expected == actual
+
     def test_plugin_diff_core_minor_behind_latest(self, mocker):
         mock_versions(
             mocker,
@@ -600,9 +499,9 @@ class TestGetVersionInformation:
                 f"  - latest:    1.1.0 - {green('Up to date!')}",
                 "",
                 "Plugins:",
-                f"  - foobar: 1.0.0 - {red('Not compatible!')}",
+                f"  - foobar: 1.0.0 - {yellow('Update available!')}",
                 "",
-                "  At least one plugin is out of date or incompatible with dbt-core.",
+                "  At least one plugin is out of date with dbt-core.",
                 "  You can find instructions for upgrading here:",
                 "  https://docs.getdbt.com/docs/installation",
                 "",
@@ -621,7 +520,6 @@ class TestGetVersionInformation:
                 "foobar": ("2.1.0", "2.1.0"),
                 "bazqux": ("2.1.0", None),
                 "quuux": ("2.1.0", "2.1.0"),
-                "corge": ("22.21.20", "22.21.21"),
                 "grault": ("2.1.0", "2.1.1"),
                 "garply": ("2.1.0-b1", None),
             },
@@ -638,11 +536,10 @@ class TestGetVersionInformation:
                 f"  - foobar: 2.1.0    - {green('Up to date!')}",
                 f"  - bazqux: 2.1.0    - {yellow('Could not determine latest version')}",
                 f"  - quuux:  2.1.0    - {green('Up to date!')}",
-                f"  - corge:  22.21.20 - {red('Not compatible!')}",
                 f"  - grault: 2.1.0    - {yellow('Update available!')}",
                 f"  - garply: 2.1.0-b1 - {yellow('Could not determine latest version')}",
                 "",
-                "  At least one plugin is out of date or incompatible with dbt-core.",
+                "  At least one plugin is out of date with dbt-core.",
                 "  You can find instructions for upgrading here:",
                 "  https://docs.getdbt.com/docs/installation",
                 "",


### PR DESCRIPTION
Resolves #10230 

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

The messages in `dbt --version` don't reflect the fact that the minor version of an adapter could be ahead of the minor version of dbt core 

### Solution

update the semver check in `version.py`!

I added the assertions for mypy's sake, but can be convinced to do that a different way

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
