### PR TITLE
Bump dbt adapters minior minimum to 1.8.0

### DIFF
--- a/.changes/unreleased/Dependencies-20241030-134526.yaml
+++ b/.changes/unreleased/Dependencies-20241030-134526.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump minimnum allowed dbt-adapters version to 1.8.0
+time: 2024-10-30T13:45:26.144328-05:00
+custom:
+  Author: QMalcolm
+  Issue: N/A

--- a/core/setup.py
+++ b/core/setup.py
@@ -72,7 +72,7 @@ setup(
         "dbt-semantic-interfaces>=0.7.3,<0.8",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.11.0,<2.0",
-        "dbt-adapters>=1.7.0,<2.0",
+        "dbt-adapters>=1.8.0,<2.0",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
         "packaging>20.9",


### PR DESCRIPTION
Resolves N/A

### Problem

In https://github.com/dbt-labs/dbt-core/pull/10859 we started using the `get_adapter_run_info` method provided by `dbt-adapters`. However, that function is only available in dbt-adapters >= 1.8.0. Thus, 1.8.0 is our new minimum for dbt-adapters.

### Solution

Raise the minimum allowed dbt-adapters version to `1.8.0`.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
