### PR TITLE
[Feature] Return `agate_table` in `dbt` `run-operation` result

### DIFF
--- a/.changes/unreleased/Features-20241031-201031.yaml
+++ b/.changes/unreleased/Features-20241031-201031.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Return agate_table in dbt run-operation result
+time: 2024-10-31T20:10:31.10956+08:00
+custom:
+    Author: acjh
+    Issue: "10956"

--- a/core/dbt/artifacts/schemas/run/v5/run.py
+++ b/core/dbt/artifacts/schemas/run/v5/run.py
@@ -132,7 +132,7 @@ class RunResultsArtifact(ExecutionResult, ArtifactMixin):
         args: Dict,
     ):
         processed_results = [
-            process_run_result(result) for result in results if isinstance(result, RunResult)
+            cls._process_run_result(result) for result in results if isinstance(result, RunResult)
         ]
         meta = RunResultsMetadata(
             dbt_schema_version=str(cls.dbt_schema_version),
@@ -181,6 +181,10 @@ class RunResultsArtifact(ExecutionResult, ArtifactMixin):
                 result["compiled_code"] = ""
                 result["relation_name"] = ""
         return cls.from_dict(data)
+
+    @classmethod
+    def _process_run_result(cls, result: RunResult) -> RunResultOutput:
+        return process_run_result(result)
 
     def write(self, path: str):
         write_json(path, self.to_dict(omit_none=False))

--- a/core/dbt/artifacts/schemas/run/v5/run.py
+++ b/core/dbt/artifacts/schemas/run/v5/run.py
@@ -72,6 +72,9 @@ class RunResultOutput(BaseResult):
     compiled: Optional[bool]
     compiled_code: Optional[str]
     relation_name: Optional[str]
+    agate_table: Optional["agate.Table"] = field(
+        default=None, metadata={"serialize": lambda x: None, "deserialize": lambda x: None}
+    )
     batch_results: Optional[BatchResults] = None
 
 
@@ -88,6 +91,7 @@ def process_run_result(result: RunResult) -> RunResultOutput:
         message=result.message,
         adapter_response=result.adapter_response,
         failures=result.failures,
+        agate_table=result.agate_table,
         batch_results=result.batch_results,
         compiled=result.node.compiled if compiled else None,  # type:ignore
         compiled_code=result.node.compiled_code if compiled else None,  # type:ignore

--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -49,6 +49,9 @@ class RunOperationTask(ConfiguredTask):
                 macro_name, project=package_name, kwargs=macro_kwargs, macro_resolver=self.manifest
             )
 
+        if isinstance(res, str):
+            return None
+
         return res
 
     def run(self) -> RunResultsArtifact:
@@ -61,10 +64,11 @@ class RunOperationTask(ConfiguredTask):
 
         success = True
         package_name, macro_name = self._get_macro_parts()
+        execute_macro_result = None
 
         with collect_timing_info("execute", timing.append):
             try:
-                self._run_unsafe(package_name, macro_name)
+                execute_macro_result = self._run_unsafe(package_name, macro_name)
             except dbt_common.exceptions.DbtBaseException as exc:
                 fire_event(RunningOperationCaughtError(exc=str(exc)))
                 fire_event(LogDebugStackTrace(exc_info=traceback.format_exc()))
@@ -113,6 +117,7 @@ class RunOperationTask(ConfiguredTask):
             ),
             thread_id=threading.current_thread().name,
             timing=timing,
+            agate_table=execute_macro_result,
             batch_results=None,
         )
 

--- a/tests/functional/adapter/dbt_run_operations/fixtures.py
+++ b/tests/functional/adapter/dbt_run_operations/fixtures.py
@@ -1,0 +1,16 @@
+happy_macros_sql = """
+{% macro select_something(name) %}
+  {% set query %}
+    select 'hello, {{ name }}' as name
+  {% endset %}
+  {% set table = run_query(query) %}
+{% endmacro %}
+
+{% macro select_something_with_return(name) %}
+  {% set query %}
+    select 'hello, {{ name }}' as name
+  {% endset %}
+  {% set table = run_query(query) %}
+  {% do return(table) %}
+{% endmacro %}
+"""

--- a/tests/functional/adapter/dbt_run_operations/test_dbt_run_operations.py
+++ b/tests/functional/adapter/dbt_run_operations/test_dbt_run_operations.py
@@ -1,0 +1,34 @@
+import pytest
+import yaml
+
+from dbt.tests.util import run_dbt
+from tests.functional.adapter.dbt_run_operations.fixtures import happy_macros_sql
+
+
+# -- Below we define base classes for tests you import based on if your adapter supports dbt run-operation or not --
+class BaseRunOperationResult:
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"happy_macros.sql": happy_macros_sql}
+
+    def run_operation(self, macro, expect_pass=True, extra_args=None, **kwargs):
+        args = ["run-operation", macro]
+        if kwargs:
+            args.extend(("--args", yaml.safe_dump(kwargs)))
+        if extra_args:
+            args.extend(extra_args)
+        return run_dbt(args, expect_pass=expect_pass)
+
+    def test_result_without_return(self, project):
+        results = self.run_operation("select_something", name="world")
+        assert results.results[0].agate_table is None
+
+    @pytest.mark.xfail
+    def test_result_with_return(self, project):
+        results = self.run_operation("select_something_with_return", name="world")
+        assert len(results.results[0].agate_table) == 1
+        assert results.results[0].agate_table.rows[0]["name"] == "hello, world"
+
+
+class TestPostgresRunOperationResult(BaseRunOperationResult):
+    pass

--- a/tests/functional/adapter/dbt_run_operations/test_dbt_run_operations.py
+++ b/tests/functional/adapter/dbt_run_operations/test_dbt_run_operations.py
@@ -23,7 +23,6 @@ class BaseRunOperationResult:
         results = self.run_operation("select_something", name="world")
         assert results.results[0].agate_table is None
 
-    @pytest.mark.xfail
     def test_result_with_return(self, project):
         results = self.run_operation("select_something_with_return", name="world")
         assert len(results.results[0].agate_table) == 1


### PR DESCRIPTION
Resolves #10956 

### Problem

`dbtRunner` does not propagate the return value of `dbt` `run-operation`.

### Solution

Propagate the return value of `dbt` `run-operation` in the result as `agate_table`:

- In the `run` method of `RunOperationTask`, capture the return value of `_run_unsafe()` in a variable `execute_macro_result` and pass it when instantiating `RunResult` with `agate_table=execute_macro_result`.
- Define `agate_table` field in `RunResultOutput`, and propagate `agate_result` from `RunResult` to `RunResultOutput` in the class method `RunResultsArtifact.from_execution_results`.

Sample usage:

```py
>>> from dbt.cli.main import dbtRunner
>>> dbt = dbtRunner()
>>> res = dbt.invoke(['run-operation', 'select_something_with_return', '--args', 'name: world'])
>>> res.result.results[0].agate_table.print_json()
[{"name": "hello, world"}]
```

Also:
- Added **tests/functional/adapter/dbt_run_operations/test_dbt_run_operations.py**.
- Delegated `process_run_result` to a class method of `RunResultsArtifact` to allow overrides if desired.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, ~~or tests are not required or relevant for this PR~~.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) ~~or this PR has already received feedback and approval from Product or DX~~.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
