### PR TITLE
Support --empty option for 'snapshot' command

### DIFF
--- a/.changes/unreleased/Features-20241031-163149.yaml
+++ b/.changes/unreleased/Features-20241031-163149.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support --empty for snapshots
+time: 2024-10-31T16:31:49.926164-04:00
+custom:
+  Author: gshank
+  Issue: "10372"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -716,6 +716,7 @@ def seed(ctx, **kwargs):
 @cli.command("snapshot")
 @click.pass_context
 @global_flags
+@p.empty
 @p.exclude
 @p.profiles_dir
 @p.project_dir

--- a/tests/functional/snapshots/test_snapshot_empty.py
+++ b/tests/functional/snapshots/test_snapshot_empty.py
@@ -1,0 +1,40 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+my_model_sql = """
+select 1 as id, {{ dbt.current_timestamp() }} as updated_at
+"""
+
+snapshots_yml = """
+snapshots:
+  - name: my_snapshot
+    relation: "ref('my_model')"
+    config:
+      unique_key: id
+      strategy: check
+      check_cols: all
+      dbt_valid_to_current: "date('9999-12-31')"
+"""
+
+
+class TestSnapshotEmpty:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "snapshots.yml": snapshots_yml,
+        }
+
+    def test_check(self, project):
+        run_dbt(["run"])
+        run_dbt(["snapshot", "--empty"])
+
+        query = "select id, updated_at, dbt_valid_from, dbt_valid_to from {database}.{schema}.my_snapshot order by updated_at asc"
+        snapshot_out1 = project.run_sql(query, fetch="all")
+        assert snapshot_out1 == []
+
+        run_dbt(["run"])
+        run_dbt(["snapshot", "--empty"])
+        snapshot_out2 = project.run_sql(query, fetch="all")
+        assert snapshot_out2 == []


### PR DESCRIPTION
Resolves #10372

### Problem

The empty flag is not allowed for snapshots.

### Solution

Add 'empty' to the permitted option flags.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
