### PR TITLE
[Fix] assert resolver.model is ModelNode prior to resolving event_time_filter

### DIFF
--- a/.changes/unreleased/Fixes-20241105-151459.yaml
+++ b/.changes/unreleased/Fixes-20241105-151459.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix 'no attribute .config' error when ref-ing a microbatch model from non-Model
+  context
+time: 2024-11-05T15:14:59.002236-05:00
+custom:
+  Author: michelleark
+  Issue: "10928"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -241,6 +241,7 @@ class BaseResolver(metaclass=abc.ABCMeta):
             os.environ.get("DBT_EXPERIMENTAL_MICROBATCH")
             and (isinstance(target.config, NodeConfig) or isinstance(target.config, SourceConfig))
             and target.config.event_time
+            and isinstance(self.model, ModelNode)
             and self.model.config.materialized == "incremental"
             and self.model.config.incremental_strategy == "microbatch"
         ):


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/10928

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

From the issue:
> When running a macro that executes ref() with a microbatch model name, an error occurs: 'Macro' object has no attribute 'config'

This error could surface from any resolver context that has a non-model node, since event_time_filters should only be resolved for microbatch incremental model nodes.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
add an additional isinstance check on resolver.model to ensure it's actually a model prior to trying to resolve an event time fitler.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
