### PR TITLE
[Backport 1.6.latest] upgrade macos version (#10974)

### DIFF
--- a/.github/actions/setup-postgres-macos/action.yml
+++ b/.github/actions/setup-postgres-macos/action.yml
@@ -5,7 +5,9 @@ runs:
   steps:
     - shell: bash
       run: |
-        brew services start postgresql
+        brew install postgresql@16
+        brew link postgresql@16 --force
+        brew services start postgresql@16
         echo "Check PostgreSQL service is running"
         i=10
         COMMAND='pg_isready'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,7 +139,7 @@ jobs:
       - name: generate include
         id: generate-include
         run: |
-          INCLUDE=('"python-version":"3.9","os":"windows-latest"' '"python-version":"3.9","os":"macos-12"' )
+          INCLUDE=('"python-version":"3.9","os":"windows-latest"' '"python-version":"3.9","os":"macos-14"' )
           INCLUDE_GROUPS="["
           for include in ${INCLUDE[@]}; do
               for group in $(seq 1 ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }}); do

--- a/.github/workflows/test-repeater.yml
+++ b/.github/workflows/test-repeater.yml
@@ -35,7 +35,7 @@ on:
         type: choice
         options:
           - 'ubuntu-latest'
-          - 'macos-12'
+          - 'macos-14'
           - 'windows-latest'
       num_runs_per_batch:
         description: 'Max number of times to run the test per batch.  We always run 10 batches.'
@@ -100,7 +100,7 @@ jobs:
 
         # mac and windows don't use make due to limitations with docker with those runners in GitHub
       - name: "Set up postgres (macos)"
-        if: inputs.os == 'macos-12'
+        if: inputs.os == 'macos-14'
         uses: ./.github/actions/setup-postgres-macos
 
       - name: "Set up postgres (windows)"


### PR DESCRIPTION
backport https://github.com/dbt-labs/dbt-core/pull/10974

CI only, no release needed