### PR TITLE
[Fix] Ensure inferred primary_key is a List[str]

### DIFF
--- a/.changes/unreleased/Fixes-20241106-144656.yaml
+++ b/.changes/unreleased/Fixes-20241106-144656.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: 'Ensure inferred primary_key is a List[str] with no null values '
+time: 2024-11-06T14:46:56.652963-05:00
+custom:
+  Author: michelleark
+  Issue: "10983"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -541,11 +541,20 @@ class ModelNode(ModelResource, CompiledNode):
         columns_with_disabled_unique_tests = set()
         columns_with_not_null_tests = set()
         for test in data_tests:
-            columns = []
-            if "column_name" in test.test_metadata.kwargs:
+            columns: List[str] = []
+            # extract columns from test kwargs, ensuring columns is a List[str] given tests can have custom (user or pacakge-defined) kwarg types
+            if "column_name" in test.test_metadata.kwargs and isinstance(
+                test.test_metadata.kwargs["column_name"], str
+            ):
                 columns = [test.test_metadata.kwargs["column_name"]]
-            elif "combination_of_columns" in test.test_metadata.kwargs:
-                columns = test.test_metadata.kwargs["combination_of_columns"]
+            elif "combination_of_columns" in test.test_metadata.kwargs and isinstance(
+                test.test_metadata.kwargs["combination_of_columns"], list
+            ):
+                columns = [
+                    column
+                    for column in test.test_metadata.kwargs["combination_of_columns"]
+                    if isinstance(column, str)
+                ]
 
             for column in columns:
                 if test.test_metadata.name in ["unique", "unique_combination_of_columns"]:

--- a/tests/functional/primary_keys/fixtures.py
+++ b/tests/functional/primary_keys/fixtures.py
@@ -11,6 +11,16 @@ models:
           - unique
 """
 
+invalid_model_unique_test = """
+models:
+  - name: simple_model
+    data_tests:
+      - unique:
+          column_name: null
+    columns:
+      - name: id
+"""
+
 simple_model_disabled_unique_test = """
 models:
   - name: simple_model
@@ -38,6 +48,16 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns: [id, color]
+"""
+
+invalid_model_unique_combo_of_columns = """
+models:
+  - name: simple_model
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [null]
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: "test"
 """
 
 simple_model_constraints = """

--- a/tests/functional/primary_keys/test_primary_keys.py
+++ b/tests/functional/primary_keys/test_primary_keys.py
@@ -2,6 +2,8 @@ import pytest
 
 from dbt.tests.util import get_manifest, run_dbt
 from tests.functional.primary_keys.fixtures import (
+    invalid_model_unique_combo_of_columns,
+    invalid_model_unique_test,
     simple_model_constraints,
     simple_model_disabled_unique_test,
     simple_model_sql,
@@ -155,3 +157,57 @@ class TestSimpleModelCombinationOfColumns:
         manifest = get_manifest(project.project_root)
         node = manifest.nodes["model.test.simple_model"]
         assert node.primary_key == ["color", "id"]
+
+
+class TestInvalidModelCombinationOfColumns:
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {
+                    "git": "https://github.com/dbt-labs/dbt-utils.git",
+                    "revision": "1.1.0",
+                },
+            ]
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "simple_model.sql": simple_model_sql,
+            "schema.yml": invalid_model_unique_combo_of_columns,
+        }
+
+    def test_invalid_combo_of_columns(self, project):
+        run_dbt(["deps"])
+        run_dbt(["run"])
+        manifest = get_manifest(project.project_root)
+        node = manifest.nodes["model.test.simple_model"]
+        assert node.primary_key == []
+
+
+class TestInvalidModelUniqueTest:
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {
+                    "git": "https://github.com/dbt-labs/dbt-utils.git",
+                    "revision": "1.1.0",
+                },
+            ]
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "simple_model.sql": simple_model_sql,
+            "schema.yml": invalid_model_unique_test,
+        }
+
+    def test_invalid_combo_of_columns(self, project):
+        run_dbt(["deps"])
+        run_dbt(["run"])
+        manifest = get_manifest(project.project_root)
+        node = manifest.nodes["model.test.simple_model"]
+        assert node.primary_key == []


### PR DESCRIPTION
Resolves #10983 

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
Even though our schemas dictate that node.primary_key is a `List[str]`, it is possible for `None` values to creep into the `primary_key` if `unique` or `unique_combination_of_columns` are not specified correctly and contain null values. This is a violation of our published manifest [schema](https://schemas.getdbt.com/dbt/manifest/v12/index.html#nodes_additionalProperties_anyOf_i4_primary_key) and can lead to parsing issues downstream.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Do a better job validating the types of generic test kwargs primary key inference is depending on, especially given they may come from other packages like dbt_utils and not be validated at all (unlike our own constraint structures).

This is not a behaviour change -- no project should have been relying on `null` values in the `primary_key` as they are semantically useless. If anything it was probably breaking parsing / validation on the consumption end if the `unique` or `unique_combination_of_columns`. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
