### PR TITLE
Add tags to SavedQueries

### DIFF
--- a/.changes/unreleased/Features-20241216-095435.yaml
+++ b/.changes/unreleased/Features-20241216-095435.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support "tags" in Saved Queries
+time: 2024-12-16T09:54:35.327675-08:00
+custom:
+    Author: theyostalservice
+    Issue: "11155"

--- a/core/dbt/artifacts/resources/v1/saved_query.py
+++ b/core/dbt/artifacts/resources/v1/saved_query.py
@@ -2,16 +2,18 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from dbt.artifacts.resources.base import GraphResource
 from dbt.artifacts.resources.types import NodeType
 from dbt.artifacts.resources.v1.components import DependsOn, RefArgs
+from dbt.artifacts.resources.v1.config import list_str, metas
 from dbt.artifacts.resources.v1.semantic_layer_components import (
     SourceFileMetadata,
     WhereFilterIntersection,
 )
 from dbt_common.contracts.config.base import BaseConfig, CompareBehavior, MergeBehavior
+from dbt_common.contracts.config.metadata import ShowBehavior
 from dbt_common.dataclass_schema import dbtClassMixin
 from dbt_semantic_interfaces.type_enums.export_destination_type import (
     ExportDestinationType,
@@ -95,6 +97,10 @@ class SavedQuery(SavedQueryMandatory):
     depends_on: DependsOn = field(default_factory=DependsOn)
     created_at: float = field(default_factory=lambda: time.time())
     refs: List[RefArgs] = field(default_factory=list)
+    tags: Union[List[str], str] = field(
+        default_factory=list_str,
+        metadata=metas(ShowBehavior.Hide, MergeBehavior.Append, CompareBehavior.Exclude),
+    )
 
     @property
     def metrics(self) -> List[str]:

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1647,6 +1647,9 @@ class SavedQuery(NodeInfoMixin, GraphNode, SavedQueryResource):
 
         return True
 
+    def same_tags(self, old: "SavedQuery") -> bool:
+        return self.tags == old.tags
+
     def same_contents(self, old: Optional["SavedQuery"]) -> bool:
         # existing when it didn't before is a change!
         # metadata/tags changes are not "changes"
@@ -1662,6 +1665,7 @@ class SavedQuery(NodeInfoMixin, GraphNode, SavedQueryResource):
             and self.same_config(old)
             and self.same_group(old)
             and self.same_exports(old)
+            and self.same_tags(old)
             and True
         )
 

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -27,8 +27,11 @@ from dbt.artifacts.resources import (
     UnitTestOutputFixture,
     UnitTestOverrides,
 )
+from dbt.artifacts.resources.v1.config import list_str, metas
 from dbt.exceptions import ParsingError
 from dbt.node_types import NodeType
+from dbt_common.contracts.config.base import CompareBehavior, MergeBehavior
+from dbt_common.contracts.config.metadata import ShowBehavior
 from dbt_common.contracts.config.properties import AdditionalPropertiesMixin
 from dbt_common.contracts.util import Mergeable
 from dbt_common.dataclass_schema import (
@@ -740,6 +743,12 @@ class UnparsedSavedQuery(dbtClassMixin):
     label: Optional[str] = None
     exports: List[UnparsedExport] = field(default_factory=list)
     config: Dict[str, Any] = field(default_factory=dict)
+    # Note: the order of the types is critical; it's the order that they will be checked against inputs.
+    #       if reversed, a single-string tag like `tag: "good"` becomes ['g','o','o','d']
+    tags: Union[str, List[str]] = field(
+        default_factory=list_str,
+        metadata=metas(ShowBehavior.Hide, MergeBehavior.Append, CompareBehavior.Exclude),
+    )
 
 
 def normalize_date(d: Optional[datetime.date]) -> Optional[datetime.datetime]:

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -799,6 +799,18 @@ class SavedQueryParser(YamlReader):
             rendered=False,
         )
 
+        # The parser handles plain strings just fine, but we need to be able
+        # to join two lists, remove duplicates, and sort, so we have to wrap things here.
+        def wrap_tags(s: Union[List[str], str]) -> List[str]:
+            if s is None:
+                return []
+            return [s] if isinstance(s, str) else s
+
+        config_tags = wrap_tags(config.get("tags"))
+        unparsed_tags = wrap_tags(unparsed.tags)
+        tags = list(set([*unparsed_tags, *config_tags]))
+        tags.sort()
+
         parsed = SavedQuery(
             description=unparsed.description,
             label=unparsed.label,
@@ -814,6 +826,7 @@ class SavedQueryParser(YamlReader):
             config=config,
             unrendered_config=unrendered_config,
             group=config.group,
+            tags=tags,
         )
 
         for export in parsed.exports:

--- a/editable-requirements.txt
+++ b/editable-requirements.txt
@@ -1,1 +1,2 @@
 -e ./core
+-e /Users/patricky/git/dbt-semantic-interfaces

--- a/editable-requirements.txt
+++ b/editable-requirements.txt
@@ -1,2 +1,1 @@
 -e ./core
--e /Users/patricky/git/dbt-semantic-interfaces

--- a/schemas/dbt/catalog/v1.json
+++ b/schemas/dbt/catalog/v1.json
@@ -12,7 +12,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.9.0b2"
+          "default": "1.9.0b4"
         },
         "generated_at": {
           "type": "string"

--- a/schemas/dbt/catalog/v1.json
+++ b/schemas/dbt/catalog/v1.json
@@ -12,7 +12,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.9.0b4"
+          "default": "1.10.0a1"
         },
         "generated_at": {
           "type": "string"

--- a/schemas/dbt/manifest/v12.json
+++ b/schemas/dbt/manifest/v12.json
@@ -19781,6 +19781,19 @@
                           "name"
                         ]
                       }
+                    },
+                    "tags": {
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
                     }
                   },
                   "additionalProperties": false,
@@ -21399,6 +21412,19 @@
                 "name"
               ]
             }
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string"
+              }
+            ]
           }
         },
         "additionalProperties": false,

--- a/schemas/dbt/run-results/v6.json
+++ b/schemas/dbt/run-results/v6.json
@@ -12,7 +12,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.9.0b2"
+          "default": "1.9.0b4"
         },
         "generated_at": {
           "type": "string"

--- a/schemas/dbt/run-results/v6.json
+++ b/schemas/dbt/run-results/v6.json
@@ -12,7 +12,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.9.0b4"
+          "default": "1.10.0a1"
         },
         "generated_at": {
           "type": "string"
@@ -55,7 +55,8 @@
                   "success",
                   "error",
                   "skipped",
-                  "partial success"
+                  "partial success",
+                  "no-op"
                 ]
               },
               {

--- a/schemas/dbt/sources/v3.json
+++ b/schemas/dbt/sources/v3.json
@@ -12,7 +12,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.9.0b2"
+          "default": "1.9.0b4"
         },
         "generated_at": {
           "type": "string"

--- a/schemas/dbt/sources/v3.json
+++ b/schemas/dbt/sources/v3.json
@@ -12,7 +12,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.9.0b4"
+          "default": "1.10.0a1"
         },
         "generated_at": {
           "type": "string"

--- a/tests/functional/saved_queries/fixtures.py
+++ b/tests/functional/saved_queries/fixtures.py
@@ -164,3 +164,27 @@ saved_queries:
             export_as: table
             schema: my_export_schema_name
 """
+
+saved_query_with_tags_defined_yml = """
+saved_queries:
+  - name: test_saved_query
+    description: "{{ doc('saved_query_description') }}"
+    label: Test Saved Query
+    tags:
+        - tag_a
+        - tag_c
+    query_params:
+        metrics:
+            - simple_metric
+        group_by:
+            - "Dimension('id__ds')"
+        where:
+            - "{{ TimeDimension('id__ds', 'DAY') }} <= now()"
+            - "{{ TimeDimension('id__ds', 'DAY') }} >= '2023-01-01'"
+    exports:
+        - name: my_export
+          config:
+            alias: my_export_alias
+            export_as: table
+            schema: my_export_schema_name
+"""


### PR DESCRIPTION
Resolves #11155

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

Folks would like to be able to execute exports based on tags.  We can't easily support individual exports in the dbt dag right now because the exports aren't proper nodes in the dbt graph, but we can provide similar functionality by allowing them to tag the saved queries that declare those exports.

This provides several types of related functionality -
* Add tags directly to the saved query in the way described [in our docs](https://docs.getdbt.com/reference/resource-configs/tags) for non-config objects.  These can be arranged in several different forms - 
    * `tags: ["my_tag_1", "my_tag_2"]`
    * `tags: "my_tag"`
    * ```
      tags:
         - "my_tag_1"
         - "my_tag_2"
         ```
* Add tags may also be set and inherited from config objects

### Solution

To do this, updates were made to the schemas and pydantic class for saved queries in dsi in a preceding PR.  In this PR, we update how the saved queries are parsed in dbt-core (for the manifest, not the semantic-manifest).  We add a little special logic to handle the case where the tags argument is just a single string and to sort and de-duplicate tags because that's just nicer.

(Linked [PR](https://github.com/dbt-labs/schemas.getdbt.com/pull/75) in schemas.dbt.com)

### Manual Testing

To test this locally, I ran `make dev` and then used the local version of dbt-core to parse a test project we have.

I added this to the dbt_project.yml:
```
saved-queries:
  +cache:
    enabled: true
  +tags: 
    - tag_config_1
  enabled: false
```
(only the tags lines were new)

And I added this line to a yml file's saved query :
`tags: ['tag_b', 'tag_d', 'tag_a']`

I ran `~/git/dbt-core/venv/bin/dbt parse` (i had some weirdness when i didn't point at my venv), and checked the manifest file and semantic manifest.  they both had sections like this for the saved query:
`"tags": ["tag_a", "tag_b", "tag_config_1", "tag_d"]}]}`

I tried it again with lists of tags in my saved queries structured like
* ```
  tags: 
      - "tag_A"
      - "tag_2"
  ```
  resulting in `"tags": ["tag_2", "tag_A", "tag_config_1"]}]}`

* and 
  ```
    tags: "tag_A"
  ```
  resulting in `"tags": ["tag_A", "tag_config_1"]}]}`

**Running with these tags selected**
The difference in dbt_core is actually minimal.

If I run this with a selector on tags that doesn't exist, I see:
> ─ ~/git/dbt-core/venv/bin/dbt build --select tag:tag_45
╰─ ~/git/dbt-core/venv/bin/dbt build --select tag:tag_45
16:35:49  Running with dbt=1.10.0-a1
16:35:49  Registered adapter: snowflake=1.8.4
16:35:50  Found 10 models, 6 seeds, 18 data tests, 15 sources, 18 metrics, 683 macros, 1 group, 5 semantic models, 1 saved query
16:35:50  The selection criterion 'tag:tag_45' does not match any enabled nodes
16:35:50  The selection criterion 'tag:tag_45' does not match any enabled nodes
16:35:50  The selection criterion 'tag:tag_45' does not match any enabled nodes
16:35:50  Nothing to do. Try checking your model configs and model specification args

Whereas with a real tag, we build as expected:
> ~/git/dbt-core/venv/bin/dbt build --select tag:tag_a       
16:35:55  Running with dbt=1.10.0-a1
16:35:55  Registered adapter: snowflake=1.8.4
16:35:55  Found 10 models, 6 seeds, 18 data tests, 15 sources, 18 metrics, 683 macros, 1 group, 5 semantic models, 1 saved query
16:35:55  
16:35:55  Concurrency: 8 threads (target='dev')
16:35:55  
16:35:57  1 of 1 NO-OP saved query with_list_tags_v2 ..................................... [NO-OP in 0.00s]
16:35:57  
16:35:57  Finished running 1 saved query in 0 hours 0 minutes and 1.42 seconds (1.42s).
16:35:57  
16:35:57  Completed successfully
16:35:57  
16:35:57  Done. PASS=0 WARN=0 ERROR=0 SKIP=0 NO-OP=1 TOTAL=1

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
