### PR TITLE
Fix #10988: Validate manifest has group_map during group_lookup init

### DIFF
--- a/.changes/unreleased/Fixes-20241113-171516.yaml
+++ b/.changes/unreleased/Fixes-20241113-171516.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Validate manifest has group_map during group_lookup init
+time: 2024-11-13T17:15:16.176082Z
+custom:
+    Author: aranke
+    Issue: "10988"

--- a/core/dbt/task/group_lookup.py
+++ b/core/dbt/task/group_lookup.py
@@ -14,6 +14,9 @@ def init(manifest: Optional[Manifest], selected_ids: AbstractSet[str]) -> None:
     if not manifest.groups:
         return
 
+    if not hasattr(manifest, "group_map"):
+        manifest.build_group_map()
+
     _every_group_name_to_group_map = {v.name: v for v in manifest.groups.values()}
 
     for group_name, node_ids in manifest.group_map.items():

--- a/core/dbt/task/group_lookup.py
+++ b/core/dbt/task/group_lookup.py
@@ -11,6 +11,9 @@ def init(manifest: Optional[Manifest], selected_ids: AbstractSet[str]) -> None:
     if not manifest:
         return
 
+    if not manifest.groups:
+        return
+
     _every_group_name_to_group_map = {v.name: v for v in manifest.groups.values()}
 
     for group_name, node_ids in manifest.group_map.items():

--- a/tests/functional/logging/test_logging.py
+++ b/tests/functional/logging/test_logging.py
@@ -277,3 +277,15 @@ class TestRunResultWarningGroup:
                 run_result_warning_count += 1
 
         assert run_result_warning_count == 1
+
+
+class TestRunResultNoGroup:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": "select 1 as id",
+        }
+
+    def test_node_info_on_results(self, project, logs_dir):
+        results = run_dbt(["--no-write-json", "run"])
+        assert len(results) == 1


### PR DESCRIPTION
Resolves #10988 

### Problem

`dbt build --no-write-json` was failing if there was no group map.

### Solution

Validate `manifest.group_map` exists and add a test for the same.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
