### PR TITLE
Bump minimum dbt-adapters requirement to 1.9.0

### DIFF
--- a/.changes/unreleased/Dependencies-20241113-112043.yaml
+++ b/.changes/unreleased/Dependencies-20241113-112043.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump minimum dbt-adapters version to 1.9.0
+time: 2024-11-13T11:20:43.25658-06:00
+custom:
+  Author: QMalcolm
+  Issue: "10996"

--- a/core/setup.py
+++ b/core/setup.py
@@ -72,7 +72,7 @@ setup(
         "dbt-semantic-interfaces>=0.7.4,<0.8",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.11.0,<2.0",
-        "dbt-adapters>=1.8.0,<2.0",
+        "dbt-adapters>=1.9.0,<2.0",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
         "packaging>20.9",


### PR DESCRIPTION
Resolves #10996 

### Problem

In dbt-core we've made a switch from an environment variable for gating microbatch functionality to a project flag (https://github.com/dbt-labs/dbt-core/pull/10799). In dbt-adapters we've done likewise (https://github.com/dbt-labs/dbt-adapters/pull/323). For everything to work properly, we need depend on those changes in dbt-adapters, which will go out in 1.12.0

### Solution

bump dbt-core's requirement spec for dbt-adapters to have a minimum of 1.12.0

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
