### PR TITLE
Fix plural of "partial success"

### DIFF
--- a/.changes/unreleased/Fixes-20241114-170328.yaml
+++ b/.changes/unreleased/Fixes-20241114-170328.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix plural of 'partial success' in log message
+time: 2024-11-14T17:03:28.888232+01:00
+custom:
+    Author: jtcohen6
+    Issue: "10999"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1927,17 +1927,9 @@ class EndOfRunSummary(InfoLevel):
         return "Z030"
 
     def message(self) -> str:
-
-        class PartialSuccess:
-            def __str__(self) -> str:
-                return "partial success"
-
-            def pluralize(self) -> str:
-                return f"{self}es"
-
         error_plural = pluralize(self.num_errors, "error")
         warn_plural = pluralize(self.num_warnings, "warning")
-        partial_success_plural = pluralize(self.num_partial_success, PartialSuccess())
+        partial_success_plural = f"""{self.num_partial_success} partial {"success" if self.num_partial_success == 1 else "successes"}"""
 
         if self.keyboard_interrupt:
             message = yellow("Exited because of keyboard interrupt")

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1927,9 +1927,17 @@ class EndOfRunSummary(InfoLevel):
         return "Z030"
 
     def message(self) -> str:
+
+        class PartialSuccess:
+            def __str__(self) -> str:
+                return "partial success"
+
+            def pluralize(self) -> str:
+                return f"{self}es"
+
         error_plural = pluralize(self.num_errors, "error")
         warn_plural = pluralize(self.num_warnings, "warning")
-        partial_success_plural = pluralize(self.num_partial_success, "partial success")
+        partial_success_plural = pluralize(self.num_partial_success, PartialSuccess())
 
         if self.keyboard_interrupt:
             message = yellow("Exited because of keyboard interrupt")

--- a/tests/functional/microbatch/test_microbatch.py
+++ b/tests/functional/microbatch/test_microbatch.py
@@ -603,7 +603,7 @@ class TestMicrobatchMultipleRetries(BaseMicrobatchTest):
 
         assert "PARTIAL SUCCESS" not in console_output
         assert "ERROR" in console_output
-        assert "Completed with 1 error, 0 partial successs, and 0 warnings" in console_output
+        assert "Completed with 1 error, 0 partial successes, and 0 warnings" in console_output
 
         self.assert_row_count(project, "microbatch_model", 2)
 
@@ -612,7 +612,7 @@ class TestMicrobatchMultipleRetries(BaseMicrobatchTest):
 
         assert "PARTIAL SUCCESS" not in console_output
         assert "ERROR" in console_output
-        assert "Completed with 1 error, 0 partial successs, and 0 warnings" in console_output
+        assert "Completed with 1 error, 0 partial successes, and 0 warnings" in console_output
 
         self.assert_row_count(project, "microbatch_model", 2)
 

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -569,7 +569,6 @@ def test_single_run_error():
         )
         results = [error_result]
         print_run_end_messages(results)
-        events = [e for e in event_mgr.event_history]
 
         summary_event = [
             e for e in event_mgr.event_history if isinstance(e[0], core_types.EndOfRunSummary)

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -18,8 +18,7 @@ from dbt.events.base_types import (
     TestLevel,
     WarnLevel,
 )
-from dbt.events.types import RunResultError
-from dbt.task.printer import print_run_result_error
+from dbt.task.printer import print_run_end_messages
 from dbt_common.events import types
 from dbt_common.events.base_types import msg_from_base_event
 from dbt_common.events.event_manager import EventManager, TestEventManager
@@ -553,23 +552,38 @@ def test_single_run_error():
         event_mgr = TestEventManager()
         ctx_set_event_manager(event_mgr)
 
+        class MockNode:
+            unique_id: str = ""
+            node_info = None
+
         error_result = RunResult(
             status=RunStatus.Error,
             timing=[],
             thread_id="",
             execution_time=0.0,
-            node=None,
+            node=MockNode(),
             adapter_response=dict(),
             message="oh no!",
             failures=1,
             batch_results=None,
         )
+        results = [error_result]
+        print_run_end_messages(results)
+        events = [e for e in event_mgr.event_history]
 
-        print_run_result_error(error_result)
-        events = [e for e in event_mgr.event_history if isinstance(e[0], RunResultError)]
+        summary_event = [
+            e for e in event_mgr.event_history if isinstance(e[0], core_types.EndOfRunSummary)
+        ]
+        run_result_error_events = [
+            e for e in event_mgr.event_history if isinstance(e[0], core_types.RunResultError)
+        ]
 
-        assert len(events) == 1
-        assert events[0][0].msg == "oh no!"
+        # expect correct plural
+        assert "partial successes" in summary_event[0][0].message()
+
+        # expect one error to show up
+        assert len(run_result_error_events) == 1
+        assert run_result_error_events[0][0].msg == "oh no!"
 
     finally:
         # Set an empty event manager unconditionally on exit. This is an early


### PR DESCRIPTION
Resolves #10999

### Problem

The plural of `partial success`

### Solution

Implement `PartialSuccess.pluralize()` (sort of)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
