### PR TITLE
fire GenericExceptionOnRun for batch-level exception

### DIFF
--- a/.changes/unreleased/Fixes-20241114-112535.yaml
+++ b/.changes/unreleased/Fixes-20241114-112535.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Emit batch-level exception with node_info on microbatch batch run failure
+time: 2024-11-14T11:25:35.050914-05:00
+custom:
+  Author: michelleark
+  Issue: "10840"

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -27,11 +27,11 @@ from dbt.context.providers import generate_runtime_model_context
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.nodes import HookNode, ModelNode, ResultNode
 from dbt.events.types import (
+    GenericExceptionOnRun,
     LogHookEndLine,
     LogHookStartLine,
     LogModelResult,
     LogStartLine,
-    RunningOperationCaughtError,
 )
 from dbt.exceptions import CompilationError, DbtInternalError, DbtRuntimeError
 from dbt.graph import ResourceTypeSelector
@@ -275,7 +275,13 @@ class ModelRunner(CompileRunner):
             level=level,
         )
         if exception:
-            fire_event(RunningOperationCaughtError(exc=str(exception)))
+            fire_event(
+                GenericExceptionOnRun(
+                    unique_id=self.node.unique_id,
+                    exc=f"Exception on worker thread. {str(exception)}",
+                    node_info=self.node.node_info,
+                )
+            )
 
     def print_batch_start_line(
         self, batch_start: Optional[datetime], batch_idx: int, batch_total: int


### PR DESCRIPTION
Resolves #10840

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
When executing microbatch models, batch-level exceptions are not being associated to their base model in the fired RunningOperationError event because that event does not include a `node_info`.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
* Switch to using `GenericExceptionOnRun`

🎩 
```sh
Invoking dbt with ['run']
16:31:02  Running with dbt=1.9.0-b4
16:31:02  Registered adapter: postgres=1.9.0-b1
16:31:02  Unable to do partial parsing because saved manifest not found. Starting full parse.
16:31:03  Found 3 models, 429 macros
16:31:03  
16:31:03  Concurrency: 4 threads (target='default')
16:31:03  
16:31:04  1 of 3 START sql table model test17316018506385627244_test_microbatch.input_model  [RUN]
16:31:04  1 of 3 OK created sql table model test17316018506385627244_test_microbatch.input_model  [SELECT 3 in 0.09s]
16:31:04  2 of 3 START sql microbatch model test17316018506385627244_test_microbatch.microbatch_model  [RUN]
16:31:04  1 of 3 START batch 2020-01-01 of test17316018506385627244_test_microbatch.microbatch_model  [RUN]
16:31:04  1 of 3 OK created batch 2020-01-01 of test17316018506385627244_test_microbatch.microbatch_model  [SELECT 1 in 0.04s]
16:31:04  2 of 3 START batch 2020-01-02 of test17316018506385627244_test_microbatch.microbatch_model  [RUN]
16:31:04  2 of 3 ERROR creating batch 2020-01-02 of test17316018506385627244_test_microbatch.microbatch_model  [ERROR in 0.01s]
16:31:04  Unhandled error while executing 
Exception on worker thread. Database Error
  syntax error at or near "invalid_sql"
  LINE 15:  invalid_sql
            ^
16:31:04  3 of 3 START batch 2020-01-03 of test17316018506385627244_test_microbatch.microbatch_model  [RUN]
16:31:04  3 of 3 OK created batch 2020-01-03 of test17316018506385627244_test_microbatch.microbatch_model  [MERGE 1 in 0.07s]
16:31:04  2 of 3 PARTIALLY created sql microbatch model test17316018506385627244_test_microbatch.microbatch_model  [PARTIAL SUCCESS (2/3) in 0.13s]
16:31:04  3 of 3 SKIP relation test17316018506385627244_test_microbatch.downstream_model . [SKIP]
16:31:04  
16:31:04  Finished running 1 incremental model, 1 table model, 1 view model in 0 hours 0 minutes and 0.97 seconds (0.97s).
16:31:04  
16:31:04  Completed with 1 partial success and 0 warnings
16:31:04  
16:31:04  Done. PASS=1 WARN=0 ERROR=1 SKIP=1 TOTAL=3
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
