### PR TITLE
[QOL] add index.html to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ test.env
 makefile.test.env
 *.pytest_cache/
 
+# Unit test artifacts
+index.html
+
 
 # Translations
 *.mo


### PR DESCRIPTION
Resolves #N/A

Running unit tests currently leaves an `index.html` artifact that you need to be mindful of checking in. Let's .gitignore it!
