### PR TITLE
make microbatch models skippable

### DIFF
--- a/.changes/unreleased/Fixes-20241121-112638.yaml
+++ b/.changes/unreleased/Fixes-20241121-112638.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Make microbatch models skippable
+time: 2024-11-21T11:26:38.192345-05:00
+custom:
+  Author: michelleark
+  Issue: "11021"

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -334,9 +334,12 @@ class ModelRunner(CompileRunner):
 
 
 class MicrobatchModelRunner(ModelRunner):
-    batch_idx: Optional[int] = None
-    batches: Dict[int, BatchType] = {}
-    relation_exists: bool = False
+    def __init__(self, config, adapter, node, node_index: int, num_nodes: int):
+        super().__init__(config, adapter, node, node_index, num_nodes)
+
+        self.batch_idx: Optional[int] = None
+        self.batches: Dict[int, BatchType] = {}
+        self.relation_exists: bool = False
 
     def set_batch_idx(self, batch_idx: int) -> None:
         self.batch_idx = batch_idx


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/11021

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

1. Skipping microbatch model fails with typeError: object of type 'Field' has no len()
2. That codepath indicates the microbatch model is still running in some capacity

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

1. Stop using `field(default_factory=...)` outside a dataclass (MicrobatchModelRunner)
2. Return results early if initial microbatch run results in a skipped result

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.


🎩 
```sh
Invoking dbt with ['run']
16:21:04  Running with dbt=1.9.0-b4
16:21:04  Registered adapter: postgres=1.9.0-b1
16:21:04  Unable to do partial parsing because saved manifest not found. Starting full parse.
16:21:05  Found 2 models, 429 macros
16:21:05  
16:21:05  Concurrency: 4 threads (target='default')
16:21:05  
16:21:05  1 of 2 START sql table model test17322060642773181458_test_microbatch.input_model  [RUN]
16:21:05  1 of 2 ERROR creating sql table model test17322060642773181458_test_microbatch.input_model  [ERROR in 0.05s]
16:21:05  2 of 2 SKIP relation test17322060642773181458_test_microbatch.microbatch_model . [SKIP]
16:21:05  
16:21:05  Finished running 1 incremental model, 1 table model in 0 hours 0 minutes and 0.55 seconds (0.55s).
16:21:05  
16:21:05  Completed with 1 error, 0 partial successs, and 0 warnings:
16:21:05  
16:21:05    Database Error in model input_model (models/input_model.sql)
  column "invalid" does not exist
  LINE 14: select invalid as event_time
                  ^
  compiled code at target/run/test/models/input_model.sql
16:21:05  
```

(extra '.' in skip result is a general issue, not just for microbatch models)