### PR TITLE
Fix #11012: Catch DbtRuntimeError for hooks

### DIFF
--- a/.changes/unreleased/Fixes-20241121-181739.yaml
+++ b/.changes/unreleased/Fixes-20241121-181739.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Catch DbtRuntimeError for hooks
+time: 2024-11-21T18:17:39.753235Z
+custom:
+    Author: aranke
+    Issue: "11012"

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -922,7 +922,7 @@ class RunTask(CompileTask):
         try:
             with adapter.connection_named("master"):
                 self.safe_run_hooks(adapter, RunHookType.End, extras)
-        except (KeyboardInterrupt, SystemExit):
+        except (KeyboardInterrupt, SystemExit, DbtRuntimeError):
             run_result = self.get_result(
                 results=self.node_results,
                 elapsed_time=time.time() - self.started_at,


### PR DESCRIPTION
Resolves #11012

### Problem

`DbtRuntimeError` was not caught for hooks, which resulted in `run_results.json` not being written.

### Solution

Explicitly catch `DbtRuntimeError`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
