### PR TITLE
Move upper bounds back to 2.0

### DIFF
--- a/.changes/unreleased/Under the Hood-20241121-105350.yaml
+++ b/.changes/unreleased/Under the Hood-20241121-105350.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Pin dbt-common and dbt-adapters with upper bound of 2.0.
+time: 2024-11-21T10:53:50.051757-06:00
+custom:
+  Author: emmyoop
+  Issue: "1"

--- a/.changes/unreleased/Under the Hood-20241121-105350.yaml
+++ b/.changes/unreleased/Under the Hood-20241121-105350.yaml
@@ -3,4 +3,4 @@ body: Pin dbt-common and dbt-adapters with upper bound of 2.0.
 time: 2024-11-21T10:53:50.051757-06:00
 custom:
   Author: emmyoop
-  Issue: "1"
+  Issue: "11024"

--- a/core/setup.py
+++ b/core/setup.py
@@ -61,7 +61,7 @@ setup(
         # with major versions in each new minor version of dbt-core.
         "click>=8.0.2,<9.0",
         "networkx>=2.3,<4.0",
-        "protobuf>=4.0.0,<5",
+        "protobuf>=5.0,<6.0",
         "requests<3.0.0",  # should match dbt-common
         # ----
         # These packages are major-version-0. Keep upper bounds on upcoming minor versions (which could have breaking changes)

--- a/core/setup.py
+++ b/core/setup.py
@@ -75,8 +75,8 @@ setup(
         "minimal-snowplow-tracker>=0.0.2,<0.1",
         "dbt-semantic-interfaces>=0.5.1,<0.6",
         # Minor versions for these are expected to be backwards-compatible
-        "dbt-common>=1.0.4,<1.11.0",
-        "dbt-adapters>=1.1.1,<1.7.1",
+        "dbt-common>=1.0.4,<2.0",
+        "dbt-adapters>=1.1.1,<2.0",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
         "packaging>20.9",

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,8 @@
-# We hardcode these two dependencies to ensure that we are testing against the correct versions of
-# released code to ensure we don't introduce any breaking changes
-dbt-tests-adapter<=1.10.2
-dbt-postgres<=1.9.0
+# These point to main to catch any regressions before they are released to OSS
+git+https://github.com/dbt-labs/dbt-adapters.git@main
+git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-tests-adapter
+git+https://github.com/dbt-labs/dbt-common.git@main
+git+https://github.com/dbt-labs/dbt-postgres.git@main
 #
 black>=24.3.0,<25.0
 bumpversion


### PR DESCRIPTION
### Problem

The upper bound pin of dbt-common and dbt-adapters is causing adapters to pick up the wrong, older version, of dbt-core.

### Solution

Open the pin of dbt-common and dbt-adapters back up to 2.0 on 1.8.latest.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
