### PR TITLE
Bump libpq-dev to 13.18-0+deb11u1 in docker/Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
     build-essential=12.9 \
     ca-certificates=20210119 \
     git=1:2.30.2-1+deb11u2 \
-    libpq-dev=13.16-0+deb11u1 \
+    libpq-dev=13.18-0+deb11u1 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \


### PR DESCRIPTION
Fix error in docker build:

```
#5 10.70 The following packages have unmet dependencies:
#5 10.75  libpq-dev : Depends: libpq5 (= 13.16-0+deb11u1) but 13.18-0+deb11u1 is to be installed
#5 10.75 E: Unable to correct problems, you have held broken packages.
```