### PR TITLE
Add `batch` context object to microbatch jinja context

### DIFF
--- a/.changes/unreleased/Features-20241121-125630.yaml
+++ b/.changes/unreleased/Features-20241121-125630.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Add `batch_id` to model context
+body: Add `batch` context object to model jinja context
 time: 2024-11-21T12:56:30.715473-06:00
 custom:
   Author: QMalcolm

--- a/.changes/unreleased/Features-20241121-125630.yaml
+++ b/.changes/unreleased/Features-20241121-125630.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add `batch_id` to model context
+time: 2024-11-21T12:56:30.715473-06:00
+custom:
+  Author: QMalcolm
+  Issue: "11025"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -244,10 +244,10 @@ class BaseResolver(metaclass=abc.ABCMeta):
             and self.model.config.materialized == "incremental"
             and self.model.config.incremental_strategy == "microbatch"
             and self.manifest.use_microbatch_batches(project_name=self.config.project_name)
-            and self.model.batch_context is not None
+            and self.model.batch is not None
         ):
-            start = self.model.batch_context.event_time_start
-            end = self.model.batch_context.event_time_end
+            start = self.model.batch.event_time_start
+            end = self.model.batch.event_time_end
 
             if start is not None or end is not None:
                 event_time_filter = EventTimeFilter(

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -244,9 +244,10 @@ class BaseResolver(metaclass=abc.ABCMeta):
             and self.model.config.materialized == "incremental"
             and self.model.config.incremental_strategy == "microbatch"
             and self.manifest.use_microbatch_batches(project_name=self.config.project_name)
+            and self.model.batch_context is not None
         ):
-            start = self.model.config.get("__dbt_internal_microbatch_event_time_start")
-            end = self.model.config.get("__dbt_internal_microbatch_event_time_end")
+            start = self.model.batch_context.event_time_start
+            end = self.model.batch_context.event_time_end
 
             if start is not None or end is not None:
                 event_time_filter = EventTimeFilter(

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -466,7 +466,7 @@ class BatchContext(dbtClassMixin):
 @dataclass
 class ModelNode(ModelResource, CompiledNode):
     previous_batch_results: Optional[BatchResults] = None
-    batch_context: Optional[BatchContext] = None
+    batch: Optional[BatchContext] = None
     _has_this: Optional[bool] = None
 
     def __post_serialize__(self, dct: Dict, context: Optional[Dict] = None):

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -81,6 +81,7 @@ from dbt.events.types import (
 )
 from dbt.exceptions import ContractBreakingChangeError, ParsingError, ValidationError
 from dbt.flags import get_flags
+from dbt.materializations.incremental.microbatch import BatchContext
 from dbt.node_types import (
     REFABLE_NODE_TYPES,
     VERSIONED_NODE_TYPES,
@@ -445,6 +446,7 @@ class HookNode(HookNodeResource, CompiledNode):
 @dataclass
 class ModelNode(ModelResource, CompiledNode):
     previous_batch_results: Optional[BatchResults] = None
+    batch_context: Optional[BatchContext] = None
     _has_this: Optional[bool] = None
 
     def __post_serialize__(self, dct: Dict, context: Optional[Dict] = None):

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -93,6 +93,7 @@ from dbt_common.contracts.constraints import (
     ConstraintType,
     ModelLevelConstraint,
 )
+from dbt_common.dataclass_schema import dbtClassMixin
 from dbt_common.events.contextvars import set_log_contextvars
 from dbt_common.events.functions import warn_or_error
 
@@ -443,10 +444,23 @@ class HookNode(HookNodeResource, CompiledNode):
 
 
 @dataclass
-class BatchContext:
+class BatchContext(dbtClassMixin):
     id: str
     event_time_start: datetime
     event_time_end: datetime
+
+    def __post_serialize__(self, data, context):
+        # This is insane, but necessary, I apologize. Mashumaro handles the
+        # dictification of this class via a compile time generated `to_dict`
+        # method based off of the _typing_ of th class. By default `datetime`
+        # types are converted to strings. We don't want that, we want them to
+        # stay datetimes.
+        # Note: This is safe because the `BatchContext` isn't part of the artifact
+        # and thus doesn't get written out.
+        new_data = super().__post_serialize__(data, context)
+        new_data["event_time_start"] = self.event_time_start
+        new_data["event_time_end"] = self.event_time_end
+        return new_data
 
 
 @dataclass

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -81,7 +81,6 @@ from dbt.events.types import (
 )
 from dbt.exceptions import ContractBreakingChangeError, ParsingError, ValidationError
 from dbt.flags import get_flags
-from dbt.materializations.incremental.microbatch import BatchContext
 from dbt.node_types import (
     REFABLE_NODE_TYPES,
     VERSIONED_NODE_TYPES,
@@ -441,6 +440,13 @@ class HookNode(HookNodeResource, CompiledNode):
     @classmethod
     def resource_class(cls) -> Type[HookNodeResource]:
         return HookNodeResource
+
+
+@dataclass
+class BatchContext:
+    id: str
+    event_time_start: datetime
+    event_time_end: datetime
 
 
 @dataclass

--- a/core/dbt/materializations/incremental/microbatch.py
+++ b/core/dbt/materializations/incremental/microbatch.py
@@ -120,7 +120,6 @@ class MicrobatchBuilder:
         batch_context["model"] = self.model.to_dict()
         batch_context["sql"] = self.model.compiled_code
         batch_context["compiled_code"] = self.model.compiled_code
-        batch_context["batch_id"] = self.batch_id(start_time=start_time)
 
         # Add incremental context variables for batches running incrementally
         if incremental_batch:
@@ -202,8 +201,8 @@ class MicrobatchBuilder:
         return truncated
 
     @staticmethod
-    def batch_id(start_time: datetime) -> str:
-        return start_time.strftime("%Y%M%d%H")
+    def batch_id(start_time: datetime, batch_size: BatchSize) -> str:
+        return MicrobatchBuilder.format_batch_start(start_time, batch_size).replace("_", "")
 
     @staticmethod
     def format_batch_start(batch_start: datetime, batch_size: BatchSize) -> str:

--- a/core/dbt/materializations/incremental/microbatch.py
+++ b/core/dbt/materializations/incremental/microbatch.py
@@ -100,25 +100,25 @@ class MicrobatchBuilder:
 
         return batches
 
-    def build_batch_context(self, incremental_batch: bool) -> Dict[str, Any]:
+    def build_jinja_context_for_batch(self, incremental_batch: bool) -> Dict[str, Any]:
         """
         Create context with entries that reflect microbatch model + incremental execution state
 
         Assumes self.model has been (re)-compiled with necessary batch filters applied.
         """
-        batch_context: Dict[str, Any] = {}
+        jinja_context: Dict[str, Any] = {}
 
         # Microbatch model properties
-        batch_context["model"] = self.model.to_dict()
-        batch_context["sql"] = self.model.compiled_code
-        batch_context["compiled_code"] = self.model.compiled_code
+        jinja_context["model"] = self.model.to_dict()
+        jinja_context["sql"] = self.model.compiled_code
+        jinja_context["compiled_code"] = self.model.compiled_code
 
         # Add incremental context variables for batches running incrementally
         if incremental_batch:
-            batch_context["is_incremental"] = lambda: True
-            batch_context["should_full_refresh"] = lambda: False
+            jinja_context["is_incremental"] = lambda: True
+            jinja_context["should_full_refresh"] = lambda: False
 
-        return batch_context
+        return jinja_context
 
     @staticmethod
     def offset_timestamp(timestamp: datetime, batch_size: BatchSize, offset: int) -> datetime:

--- a/core/dbt/materializations/incremental/microbatch.py
+++ b/core/dbt/materializations/incremental/microbatch.py
@@ -100,7 +100,7 @@ class MicrobatchBuilder:
 
         return batches
 
-    def build_batch_context(self, incremental_batch: bool) -> Dict[str, Any]:
+    def build_batch_context(self, incremental_batch: bool, start_time: datetime) -> Dict[str, Any]:
         """
         Create context with entries that reflect microbatch model + incremental execution state
 
@@ -112,6 +112,7 @@ class MicrobatchBuilder:
         batch_context["model"] = self.model.to_dict()
         batch_context["sql"] = self.model.compiled_code
         batch_context["compiled_code"] = self.model.compiled_code
+        batch_context["batch_id"] = self.batch_id(start_time=start_time)
 
         # Add incremental context variables for batches running incrementally
         if incremental_batch:
@@ -191,6 +192,10 @@ class MicrobatchBuilder:
             truncated = datetime(timestamp.year, 1, 1, 0, 0, 0, 0, pytz.utc)
 
         return truncated
+
+    @staticmethod
+    def batch_id(start_time: datetime) -> str:
+        return start_time.strftime("%Y%M%d%H")
 
     @staticmethod
     def format_batch_start(

--- a/core/dbt/materializations/incremental/microbatch.py
+++ b/core/dbt/materializations/incremental/microbatch.py
@@ -198,12 +198,7 @@ class MicrobatchBuilder:
         return start_time.strftime("%Y%M%d%H")
 
     @staticmethod
-    def format_batch_start(
-        batch_start: Optional[datetime], batch_size: BatchSize
-    ) -> Optional[str]:
-        if batch_start is None:
-            return batch_start
-
+    def format_batch_start(batch_start: datetime, batch_size: BatchSize) -> str:
         return str(
             batch_start.date() if (batch_start and batch_size != BatchSize.hour) else batch_start
         )

--- a/core/dbt/materializations/incremental/microbatch.py
+++ b/core/dbt/materializations/incremental/microbatch.py
@@ -2,11 +2,19 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 import pytz
+from attr import dataclass
 
 from dbt.artifacts.resources.types import BatchSize
 from dbt.artifacts.schemas.batch_results import BatchType
 from dbt.contracts.graph.nodes import ModelNode, NodeConfig
 from dbt.exceptions import DbtInternalError, DbtRuntimeError
+
+
+@dataclass
+class BatchContext:
+    id: str
+    event_time_start: datetime
+    event_time_end: datetime
 
 
 class MicrobatchBuilder:

--- a/core/dbt/materializations/incremental/microbatch.py
+++ b/core/dbt/materializations/incremental/microbatch.py
@@ -194,7 +194,7 @@ class MicrobatchBuilder:
 
     @staticmethod
     def batch_id(start_time: datetime, batch_size: BatchSize) -> str:
-        return MicrobatchBuilder.format_batch_start(start_time, batch_size).replace("_", "")
+        return MicrobatchBuilder.format_batch_start(start_time, batch_size).replace("-", "")
 
     @staticmethod
     def format_batch_start(batch_start: datetime, batch_size: BatchSize) -> str:

--- a/core/dbt/materializations/incremental/microbatch.py
+++ b/core/dbt/materializations/incremental/microbatch.py
@@ -2,19 +2,11 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 import pytz
-from attr import dataclass
 
 from dbt.artifacts.resources.types import BatchSize
 from dbt.artifacts.schemas.batch_results import BatchType
 from dbt.contracts.graph.nodes import ModelNode, NodeConfig
 from dbt.exceptions import DbtInternalError, DbtRuntimeError
-
-
-@dataclass
-class BatchContext:
-    id: str
-    event_time_start: datetime
-    event_time_end: datetime
 
 
 class MicrobatchBuilder:
@@ -108,7 +100,7 @@ class MicrobatchBuilder:
 
         return batches
 
-    def build_batch_context(self, incremental_batch: bool, start_time: datetime) -> Dict[str, Any]:
+    def build_batch_context(self, incremental_batch: bool) -> Dict[str, Any]:
         """
         Create context with entries that reflect microbatch model + incremental execution state
 

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -545,7 +545,8 @@ class MicrobatchModelRunner(ModelRunner):
                 )
                 # Update jinja context with batch context members
                 batch_context = microbatch_builder.build_batch_context(
-                    incremental_batch=self.relation_exists
+                    incremental_batch=self.relation_exists,
+                    start_time=batch[0],
                 )
                 context.update(batch_context)
 

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -557,10 +557,10 @@ class MicrobatchModelRunner(ModelRunner):
                     ),
                 )
                 # Update jinja context with batch context members
-                batch_context = microbatch_builder.build_batch_context(
+                jinja_context = microbatch_builder.build_jinja_context_for_batch(
                     incremental_batch=self.relation_exists
                 )
-                context.update(batch_context)
+                context.update(jinja_context)
 
                 # Materialize batch and cache any materialized relations
                 result = MacroGenerator(

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -27,7 +27,7 @@ from dbt.clients.jinja import MacroGenerator
 from dbt.config import RuntimeConfig
 from dbt.context.providers import generate_runtime_model_context
 from dbt.contracts.graph.manifest import Manifest
-from dbt.contracts.graph.nodes import HookNode, ModelNode, ResultNode
+from dbt.contracts.graph.nodes import BatchContext, HookNode, ModelNode, ResultNode
 from dbt.events.types import (
     GenericExceptionOnRun,
     LogHookEndLine,
@@ -39,7 +39,7 @@ from dbt.events.types import (
 from dbt.exceptions import CompilationError, DbtInternalError, DbtRuntimeError
 from dbt.graph import ResourceTypeSelector
 from dbt.hooks import get_hook_dict
-from dbt.materializations.incremental.microbatch import BatchContext, MicrobatchBuilder
+from dbt.materializations.incremental.microbatch import MicrobatchBuilder
 from dbt.node_types import NodeType, RunHookType
 from dbt.task import group_lookup
 from dbt.task.base import BaseRunner
@@ -551,8 +551,7 @@ class MicrobatchModelRunner(ModelRunner):
                 )
                 # Update jinja context with batch context members
                 batch_context = microbatch_builder.build_batch_context(
-                    incremental_batch=self.relation_exists,
-                    start_time=batch[0],
+                    incremental_batch=self.relation_exists
                 )
                 context.update(batch_context)
 

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -341,6 +341,13 @@ class MicrobatchModelRunner(ModelRunner):
         self.batches: Dict[int, BatchType] = {}
         self.relation_exists: bool = False
 
+    def compile(self, manifest: Manifest):
+        # The default compile function is _always_ called. However, we do our
+        # compilation _later_ in `_execute_microbatch_materialization`. This
+        # meant the node was being compiled _twice_ for each batch. To get around
+        # this, we've overriden the default compile method to do nothing
+        return self.node
+
     def set_batch_idx(self, batch_idx: int) -> None:
         self.batch_idx = batch_idx
 

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -542,7 +542,7 @@ class MicrobatchModelRunner(ModelRunner):
                 model.config["__dbt_internal_microbatch_event_time_start"] = batch[0]
                 model.config["__dbt_internal_microbatch_event_time_end"] = batch[1]
                 # Create batch context on model node prior to re-compiling
-                model.batch_context = BatchContext(
+                model.batch = BatchContext(
                     id=MicrobatchBuilder.batch_id(batch[0], model.config.batch_size),
                     event_time_start=batch[0],
                     event_time_end=batch[1],

--- a/tests/functional/microbatch/test_microbatch.py
+++ b/tests/functional/microbatch/test_microbatch.py
@@ -498,6 +498,13 @@ microbatch_model_context_vars = """
 {{ config(materialized='incremental', incremental_strategy='microbatch', unique_key='id', event_time='event_time', batch_size='day', begin=modules.datetime.datetime(2020, 1, 1, 0, 0, 0)) }}
 {{ log("start: "~ model.config.__dbt_internal_microbatch_event_time_start, info=True)}}
 {{ log("end: "~ model.config.__dbt_internal_microbatch_event_time_end, info=True)}}
+{% if model.batch_context %}
+{{ log("batch_context.event_time_start: "~ model.batch_context.event_time_start, info=True)}}
+{{ log("batch_context.event_time_end: "~ model.batch_context.event_time_end, info=True)}}
+{{ log("batch_context.id: "~ model.batch_context.id, info=True)}}
+{{ log("start timezone: "~ model.batch_context.event_time_start.tzinfo, info=True)}}
+{{ log("end timezone: "~ model.batch_context.event_time_end.tzinfo, info=True)}}
+{% endif %}
 select * from {{ ref('input_model') }}
 """
 
@@ -516,12 +523,23 @@ class TestMicrobatchJinjaContextVarsAvailable(BaseMicrobatchTest):
 
         assert "start: 2020-01-01 00:00:00+00:00" in logs
         assert "end: 2020-01-02 00:00:00+00:00" in logs
+        assert "batch_context.event_time_start: 2020-01-01 00:00:00+00:00" in logs
+        assert "batch_context.event_time_end: 2020-01-02 00:00:00+00:00" in logs
+        assert "batch_context.id: 20200101" in logs
+        assert "start timezone: UTC" in logs
+        assert "end timezone: UTC" in logs
 
         assert "start: 2020-01-02 00:00:00+00:00" in logs
         assert "end: 2020-01-03 00:00:00+00:00" in logs
+        assert "batch_context.event_time_start: 2020-01-02 00:00:00+00:00" in logs
+        assert "batch_context.event_time_end: 2020-01-03 00:00:00+00:00" in logs
+        assert "batch_context.id: 20200102" in logs
 
         assert "start: 2020-01-03 00:00:00+00:00" in logs
         assert "end: 2020-01-03 13:57:00+00:00" in logs
+        assert "batch_context.event_time_start: 2020-01-03 00:00:00+00:00" in logs
+        assert "batch_context.event_time_end: 2020-01-03 13:57:00+00:00" in logs
+        assert "batch_context.id: 20200103" in logs
 
 
 microbatch_model_failing_incremental_partition_sql = """

--- a/tests/functional/microbatch/test_microbatch.py
+++ b/tests/functional/microbatch/test_microbatch.py
@@ -498,12 +498,12 @@ microbatch_model_context_vars = """
 {{ config(materialized='incremental', incremental_strategy='microbatch', unique_key='id', event_time='event_time', batch_size='day', begin=modules.datetime.datetime(2020, 1, 1, 0, 0, 0)) }}
 {{ log("start: "~ model.config.__dbt_internal_microbatch_event_time_start, info=True)}}
 {{ log("end: "~ model.config.__dbt_internal_microbatch_event_time_end, info=True)}}
-{% if model.batch_context %}
-{{ log("batch_context.event_time_start: "~ model.batch_context.event_time_start, info=True)}}
-{{ log("batch_context.event_time_end: "~ model.batch_context.event_time_end, info=True)}}
-{{ log("batch_context.id: "~ model.batch_context.id, info=True)}}
-{{ log("start timezone: "~ model.batch_context.event_time_start.tzinfo, info=True)}}
-{{ log("end timezone: "~ model.batch_context.event_time_end.tzinfo, info=True)}}
+{% if model.batch %}
+{{ log("batch.event_time_start: "~ model.batch.event_time_start, info=True)}}
+{{ log("batch.event_time_end: "~ model.batch.event_time_end, info=True)}}
+{{ log("batch.id: "~ model.batch.id, info=True)}}
+{{ log("start timezone: "~ model.batch.event_time_start.tzinfo, info=True)}}
+{{ log("end timezone: "~ model.batch.event_time_end.tzinfo, info=True)}}
 {% endif %}
 select * from {{ ref('input_model') }}
 """
@@ -523,23 +523,23 @@ class TestMicrobatchJinjaContextVarsAvailable(BaseMicrobatchTest):
 
         assert "start: 2020-01-01 00:00:00+00:00" in logs
         assert "end: 2020-01-02 00:00:00+00:00" in logs
-        assert "batch_context.event_time_start: 2020-01-01 00:00:00+00:00" in logs
-        assert "batch_context.event_time_end: 2020-01-02 00:00:00+00:00" in logs
-        assert "batch_context.id: 20200101" in logs
+        assert "batch.event_time_start: 2020-01-01 00:00:00+00:00" in logs
+        assert "batch.event_time_end: 2020-01-02 00:00:00+00:00" in logs
+        assert "batch.id: 20200101" in logs
         assert "start timezone: UTC" in logs
         assert "end timezone: UTC" in logs
 
         assert "start: 2020-01-02 00:00:00+00:00" in logs
         assert "end: 2020-01-03 00:00:00+00:00" in logs
-        assert "batch_context.event_time_start: 2020-01-02 00:00:00+00:00" in logs
-        assert "batch_context.event_time_end: 2020-01-03 00:00:00+00:00" in logs
-        assert "batch_context.id: 20200102" in logs
+        assert "batch.event_time_start: 2020-01-02 00:00:00+00:00" in logs
+        assert "batch.event_time_end: 2020-01-03 00:00:00+00:00" in logs
+        assert "batch.id: 20200102" in logs
 
         assert "start: 2020-01-03 00:00:00+00:00" in logs
         assert "end: 2020-01-03 13:57:00+00:00" in logs
-        assert "batch_context.event_time_start: 2020-01-03 00:00:00+00:00" in logs
-        assert "batch_context.event_time_end: 2020-01-03 13:57:00+00:00" in logs
-        assert "batch_context.id: 20200103" in logs
+        assert "batch.event_time_start: 2020-01-03 00:00:00+00:00" in logs
+        assert "batch.event_time_end: 2020-01-03 13:57:00+00:00" in logs
+        assert "batch.id: 20200103" in logs
 
 
 microbatch_model_failing_incremental_partition_sql = """

--- a/tests/functional/microbatch/test_microbatch.py
+++ b/tests/functional/microbatch/test_microbatch.py
@@ -64,8 +64,8 @@ microbatch_yearly_model_downstream_sql = """
 select * from {{ ref('microbatch_model') }}
 """
 
-invalid_batch_context_macro_sql = """
-{% macro check_invalid_batch_context() %}
+invalid_batch_jinja_context_macro_sql = """
+{% macro check_invalid_batch_jinja_context() %}
 
 {% if model is not mapping %}
     {{ exceptions.raise_compiler_error("`model` is invalid: expected mapping type") }}
@@ -83,9 +83,9 @@ invalid_batch_context_macro_sql = """
 """
 
 microbatch_model_with_context_checks_sql = """
-{{ config(pre_hook="{{ check_invalid_batch_context() }}", materialized='incremental', incremental_strategy='microbatch', unique_key='id', event_time='event_time', batch_size='day', begin=modules.datetime.datetime(2020, 1, 1, 0, 0, 0)) }}
+{{ config(pre_hook="{{ check_invalid_batch_jinja_context() }}", materialized='incremental', incremental_strategy='microbatch', unique_key='id', event_time='event_time', batch_size='day', begin=modules.datetime.datetime(2020, 1, 1, 0, 0, 0)) }}
 
-{{ check_invalid_batch_context() }}
+{{ check_invalid_batch_jinja_context() }}
 select * from {{ ref('input_model') }}
 """
 
@@ -404,7 +404,7 @@ class TestMicrobatchJinjaContext(BaseMicrobatchTest):
 
     @pytest.fixture(scope="class")
     def macros(self):
-        return {"check_batch_context.sql": invalid_batch_context_macro_sql}
+        return {"check_batch_jinja_context.sql": invalid_batch_jinja_context_macro_sql}
 
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/functional/microbatch/test_microbatch.py
+++ b/tests/functional/microbatch/test_microbatch.py
@@ -693,16 +693,6 @@ class TestMicrobatchCompiledRunPaths(BaseMicrobatchTest):
         with patch_microbatch_end_time("2020-01-03 13:57:00"):
             run_dbt(["run"])
 
-        # Compiled paths - compiled model without filter only
-        assert read_file(
-            project.project_root,
-            "target",
-            "compiled",
-            "test",
-            "models",
-            "microbatch_model.sql",
-        )
-
         # Compiled paths - batch compilations
         assert read_file(
             project.project_root,

--- a/tests/unit/contracts/graph/test_manifest.py
+++ b/tests/unit/contracts/graph/test_manifest.py
@@ -96,7 +96,7 @@ REQUIRED_PARSED_NODE_KEYS = frozenset(
         "deprecation_date",
         "defer_relation",
         "time_spine",
-        "batch_context",
+        "batch",
     }
 )
 

--- a/tests/unit/contracts/graph/test_manifest.py
+++ b/tests/unit/contracts/graph/test_manifest.py
@@ -96,6 +96,7 @@ REQUIRED_PARSED_NODE_KEYS = frozenset(
         "deprecation_date",
         "defer_relation",
         "time_spine",
+        "batch_context",
     }
 )
 

--- a/tests/unit/materializations/incremental/test_microbatch.py
+++ b/tests/unit/materializations/incremental/test_microbatch.py
@@ -489,11 +489,11 @@ class TestMicrobatchBuilder:
         assert len(actual_batches) == len(expected_batches)
         assert actual_batches == expected_batches
 
-    def test_build_batch_context_incremental_batch(self, microbatch_model):
+    def test_build_jinja_context_for_incremental_batch(self, microbatch_model):
         microbatch_builder = MicrobatchBuilder(
             model=microbatch_model, is_incremental=True, event_time_start=None, event_time_end=None
         )
-        context = microbatch_builder.build_batch_context(incremental_batch=True)
+        context = microbatch_builder.build_jinja_context_for_batch(incremental_batch=True)
 
         assert context["model"] == microbatch_model.to_dict()
         assert context["sql"] == microbatch_model.compiled_code
@@ -502,11 +502,11 @@ class TestMicrobatchBuilder:
         assert context["is_incremental"]() is True
         assert context["should_full_refresh"]() is False
 
-    def test_build_batch_context_incremental_batch_false(self, microbatch_model):
+    def test_build_jinja_context_for_incremental_batch_false(self, microbatch_model):
         microbatch_builder = MicrobatchBuilder(
             model=microbatch_model, is_incremental=True, event_time_start=None, event_time_end=None
         )
-        context = microbatch_builder.build_batch_context(incremental_batch=False)
+        context = microbatch_builder.build_jinja_context_for_batch(incremental_batch=False)
 
         assert context["model"] == microbatch_model.to_dict()
         assert context["sql"] == microbatch_model.compiled_code

--- a/tests/unit/materializations/incremental/test_microbatch.py
+++ b/tests/unit/materializations/incremental/test_microbatch.py
@@ -605,7 +605,6 @@ class TestMicrobatchBuilder:
     @pytest.mark.parametrize(
         "batch_size,batch_start,expected_formatted_batch_start",
         [
-            (None, None, None),
             (BatchSize.year, datetime(2020, 1, 1, 1), "2020-01-01"),
             (BatchSize.month, datetime(2020, 1, 1, 1), "2020-01-01"),
             (BatchSize.day, datetime(2020, 1, 1, 1), "2020-01-01"),


### PR DESCRIPTION
Resolves #11025

### Problem

We need to get an `id` for a batch into the jinja context for batches of models

### Solution

Add a `BatchContext` object under the `batch` key for a `ModelNodel`. The `BatchContext` contains an `id`, `event_time_start`, and `event_time_end`. The `id` field sets out the original problem we set out to solve. The `event_time_start` and `event_time_end`, formalize and supercede what we previously used `__dbt_internal_event_time_start` and `__dbt_internal_event_time_end`

As part of this work, we also _stopped_ double compiling each batch. Previously we were
(1) Compiling for the batch prior to instantiating the jinja context for the batch
(2) Compiling for the batch after instantiating the jinja context for the batch

We have stopped doing (1). As a side effect of this, the compiled `.sql` file for the microbatch model that had no event time filtering will no longer be outputted. Each batch specific compiled `.sql` file will still be produced. This _should_ be safe as `microbatch` is a new kind of model node being added in 1.9 and 1.9 GA has not been released yet. As such, nobody should be depending on its existence. If it does prove to be problematic, we've already spiked out some work on how to bring it back.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
