### PR TITLE
Rename internal `batch_info` variable to `previous_batch_results`

### DIFF
--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -444,7 +444,7 @@ class HookNode(HookNodeResource, CompiledNode):
 
 @dataclass
 class ModelNode(ModelResource, CompiledNode):
-    batch_info: Optional[BatchResults] = None
+    previous_batch_results: Optional[BatchResults] = None
     _has_this: Optional[bool] = None
 
     def __post_serialize__(self, dct: Dict, context: Optional[Dict] = None):

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -451,6 +451,8 @@ class ModelNode(ModelResource, CompiledNode):
         dct = super().__post_serialize__(dct, context)
         if "_has_this" in dct:
             del dct["_has_this"]
+        if "previous_batch_results" in dct:
+            del dct["previous_batch_results"]
         return dct
 
     @classmethod

--- a/core/dbt/task/retry.py
+++ b/core/dbt/task/retry.py
@@ -136,7 +136,7 @@ class RetryTask(ConfiguredTask):
         # batch info if there were _no_ successful batches previously. This is
         # because passing the batch info _forces_ the microbatch process into
         # _incremental_ model, and it may be that we need to be in full refresh
-        # mode which is only handled if batch_info _isn't_ passed for a node
+        # mode which is only handled if previous_batch_results _isn't_ passed for a node
         batch_map = {
             result.unique_id: result.batch_results
             for result in self.previous_results.results

--- a/tests/unit/contracts/graph/test_manifest.py
+++ b/tests/unit/contracts/graph/test_manifest.py
@@ -96,7 +96,7 @@ REQUIRED_PARSED_NODE_KEYS = frozenset(
         "deprecation_date",
         "defer_relation",
         "time_spine",
-        "batch_info",
+        "previous_batch_results",
     }
 )
 

--- a/tests/unit/contracts/graph/test_manifest.py
+++ b/tests/unit/contracts/graph/test_manifest.py
@@ -96,7 +96,6 @@ REQUIRED_PARSED_NODE_KEYS = frozenset(
         "deprecation_date",
         "defer_relation",
         "time_spine",
-        "previous_batch_results",
     }
 )
 


### PR DESCRIPTION
### Problem / Solution

We were using `batch_info` to store the information on previous batch execution (if available) at runtime. However this name is confusing. Thus, we're renaming it to something more applicable, `previous_batch_results`. This is a non-dangerous change because `batch_info` wasn't written out as part of any artifacts.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
