### PR TITLE
Access DEBUG flag though get_flags()

### DIFF
--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -626,10 +626,11 @@ class ManifestLoader:
             if self.root_project.args.REQUIRE_RESOURCE_NAMES_WITHOUT_SPACES
             else EventLevel.WARN
         )
+        flags = get_flags()
 
         for node in self.manifest.nodes.values():
             if " " in node.name:
-                if improper_resource_names == 0 or self.root_project.args.DEBUG:
+                if improper_resource_names == 0 or flags.DEBUG:
                     fire_event(
                         SpacesInResourceNameDeprecation(
                             unique_id=node.unique_id,
@@ -641,7 +642,6 @@ class ManifestLoader:
 
         if improper_resource_names > 0:
             if level == EventLevel.WARN:
-                flags = get_flags()
                 dbt.deprecations.warn(
                     "resource-names-with-spaces",
                     count_invalid_names=improper_resource_names,


### PR DESCRIPTION
Resolves #11068

### Problem
`ManifestLoader.check_for_spaces_in_resource_names()` causes an `AttributeError` in certain cases, for instance when used with SQLFluff dbt templater.
`AttributeError: 'DbtConfigArgs' object has no attribute 'DEBUG'` 

### Solution
Access the `DEBUG` flag through the `get_flags()`method as done everywhere else in the codebase.

### Checklist

- [ x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ x] I have run this code in development, and it appears to resolve the stated issue.
- [x ] This PR includes tests, or tests are not required or relevant for this PR.
- [ x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
