### PR TITLE
Improve performance of select_children() and select_parents()

### DIFF
--- a/.changes/unreleased/Under the Hood-20241205-143144.yaml
+++ b/.changes/unreleased/Under the Hood-20241205-143144.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Improve selection peformance by optimizing the select_children() and select_parents()
+  functions.
+time: 2024-12-05T14:31:44.584216-05:00
+custom:
+  Author: peterallenwebb
+  Issue: "11099"

--- a/core/dbt/graph/graph.py
+++ b/core/dbt/graph/graph.py
@@ -67,8 +67,14 @@ class Graph:
         while len(selected) > 0 and (max_depth is None or i < max_depth):
             next_layer: Set[UniqueId] = set()
             for node in selected:
-                next_layer.update(self.descendants(node, 1))
-            next_layer = next_layer - children  # Avoid re-searching
+                next_layer.update(
+                    iter(
+                        e[1]
+                        for e in self.graph.out_edges(node)
+                        if e[1] not in children
+                        and self.filter_edges_by_type(e[0], e[1], "parent_test")
+                    )
+                )
             children.update(next_layer)
             selected = next_layer
             i += 1
@@ -86,8 +92,14 @@ class Graph:
         while len(selected) > 0 and (max_depth is None or i < max_depth):
             next_layer: Set[UniqueId] = set()
             for node in selected:
-                next_layer.update(self.ancestors(node, 1))
-            next_layer = next_layer - parents  # Avoid re-searching
+                next_layer.update(
+                    iter(
+                        e[0]
+                        for e in self.graph.in_edges(node)
+                        if e[0] not in parents
+                        and self.filter_edges_by_type(e[0], e[1], "parent_test")
+                    )
+                )
             parents.update(next_layer)
             selected = next_layer
             i += 1


### PR DESCRIPTION
### Problem

The select_children() and select_parents() functions have been identified as performance bottlenecks, particularly as they are used via semantic layer code.

We've received reports of projects spending over 15 minutes waiting for these operations.

### Solution

The present changes are behavior-neutral, but they avoid the repeated application of networkx graph views, which are slow. We already have some unit tests covering these functions, but went further and tested that the new functions gave the same results as the old on a large set of real-world graphs, choosing sets of "selected" nodes at random at a variety of sizes. I observed a reliable speedup of 60-100x for select_children() and 20-30x for select_parents().

This should reduce the project time mentioned above from 15 minutes to less than 15 seconds.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
