### PR TITLE
Implement partial parsing for singular data tests configs in yaml files

### DIFF
--- a/.changes/unreleased/Fixes-20241205-145307.yaml
+++ b/.changes/unreleased/Fixes-20241205-145307.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Implement partial parsing for singular data test configs in yaml files
+time: 2024-12-05T14:53:07.295536-05:00
+custom:
+  Author: gshank
+  Issue: "10801"

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -725,6 +725,7 @@ class PartialParsing:
         handle_change("semantic_models", self.delete_schema_semantic_model)
         handle_change("unit_tests", self.delete_schema_unit_test)
         handle_change("saved_queries", self.delete_schema_saved_query)
+        handle_change("data_tests", self.delete_schema_data_test_patch)
 
     def _handle_element_change(
         self, schema_file, saved_yaml_dict, new_yaml_dict, env_var_changes, dict_key: str, delete
@@ -918,6 +919,24 @@ class PartialParsing:
             if macro_file_id in self.new_files:
                 self.saved_files[macro_file_id] = deepcopy(self.new_files[macro_file_id])
                 self.add_to_pp_files(self.saved_files[macro_file_id])
+
+    def delete_schema_data_test_patch(self, schema_file, data_test):
+        print(f"--- in delete_schema_data_test_patch")
+        data_test_unique_id = None
+        for unique_id in schema_file.node_patches:
+            if not unique_id.startswith("test"):
+                continue
+            parts = unique_id.split(".")
+            elem_name = parts[2]
+            if elem_name == data_test["name"]:
+                data_test_unique_id = unique_id
+                break
+        if data_test_unique_id and data_test_unique_id in self.saved_manifest.nodes:
+            singular_data_test = self.saved_manifest.nodes.pop(data_test_unique_id)
+            file_id = singular_data_test.file_id
+            if file_id in self.new_files:
+                self.saved_files[file_id] = deepcopy(self.new_files[file_id])
+                self.add_to_pp_files(self.saved_files[file_id])
 
     # exposures are created only from schema files, so just delete
     # the exposure or the disabled exposure.

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -921,7 +921,6 @@ class PartialParsing:
                 self.add_to_pp_files(self.saved_files[macro_file_id])
 
     def delete_schema_data_test_patch(self, schema_file, data_test):
-        print(f"--- in delete_schema_data_test_patch")
         data_test_unique_id = None
         for unique_id in schema_file.node_patches:
             if not unique_id.startswith("test"):

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -1199,8 +1199,6 @@ class SingularTestPatchParser(PatchParser[UnparsedSingularTestUpdate, ParsedSing
         node.patch_path = patch.file_id
         node.description = patch.description
         node.created_at = time.time()
-        node.meta = patch.meta
-        node.docs = patch.docs
 
 
 class MacroPatchParser(PatchParser[UnparsedMacroUpdate, ParsedMacroPatch]):

--- a/tests/functional/data_test_patch/fixtures.py
+++ b/tests/functional/data_test_patch/fixtures.py
@@ -13,8 +13,8 @@ data_tests:
     description: "{{ doc('my_singular_test_documentation') }}"
     config:
       error_if: ">10"
-    meta:
-      some_key: some_val
+      meta:
+        some_key: some_val
 """
 
 tests__schema_2_yml = """
@@ -23,8 +23,8 @@ data_tests:
     description: "My singular test description"
     config:
       error_if: ">10"
-    meta:
-      some_key: another_val
+      meta:
+        some_key: another_val
 """
 
 tests__doc_block_md = """

--- a/tests/functional/data_test_patch/fixtures.py
+++ b/tests/functional/data_test_patch/fixtures.py
@@ -24,7 +24,7 @@ data_tests:
     config:
       error_if: ">10"
     meta:
-      some_key: some_val
+      some_key: another_val
 """
 
 tests__doc_block_md = """

--- a/tests/functional/data_test_patch/fixtures.py
+++ b/tests/functional/data_test_patch/fixtures.py
@@ -17,6 +17,16 @@ data_tests:
       some_key: some_val
 """
 
+tests__schema_2_yml = """
+data_tests:
+  - name: my_singular_test
+    description: "My singular test description"
+    config:
+      error_if: ">10"
+    meta:
+      some_key: some_val
+"""
+
 tests__doc_block_md = """
 {% docs my_singular_test_documentation %}
 

--- a/tests/functional/data_test_patch/test_singular_test_patch.py
+++ b/tests/functional/data_test_patch/test_singular_test_patch.py
@@ -38,8 +38,8 @@ class TestPatchSingularTest:
         manifest = run_dbt(["parse"])
         test_node = manifest.nodes["test.test.my_singular_test"]
         assert test_node.description == "My singular test description"
-        print(f"--- config.meta: {test_node.config.meta}")
-        print(f"--- node.meta: {test_node.meta}")
+        assert test_node.config.meta == {"some_key": "another_val"}
+        assert test_node.meta == {"some_key": "another_val"}
 
 
 class TestPatchSingularTestInvalidName:

--- a/tests/functional/data_test_patch/test_singular_test_patch.py
+++ b/tests/functional/data_test_patch/test_singular_test_patch.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from dbt.tests.util import get_artifact, run_dbt, run_dbt_and_capture, write_file
+from dbt.tests.util import get_manifest, run_dbt, run_dbt_and_capture, write_file
 from tests.functional.data_test_patch.fixtures import (
     tests__doc_block_md,
     tests__invalid_name_schema_yml,
@@ -24,19 +24,22 @@ class TestPatchSingularTest:
 
     def test_compile(self, project):
         run_dbt(["compile"])
-        manifest = get_artifact(project.project_root, "target", "manifest.json")
-        assert len(manifest["nodes"]) == 1
+        manifest = get_manifest(project.project_root)
+        assert len(manifest.nodes) == 1
 
-        my_singular_test_node = manifest["nodes"]["test.test.my_singular_test"]
-        assert my_singular_test_node["description"] == "Some docs from a doc block"
-        assert my_singular_test_node["config"]["error_if"] == ">10"
-        assert my_singular_test_node["config"]["meta"] == {"some_key": "some_val"}
+        my_singular_test_node = manifest.nodes["test.test.my_singular_test"]
+        assert my_singular_test_node.description == "Some docs from a doc block"
+        assert my_singular_test_node.config.error_if == ">10"
+        assert my_singular_test_node.config.meta == {"some_key": "some_val"}
+        assert my_singular_test_node.meta == {"some_key": "some_val"}
 
         # partial parsing test
         write_file(tests__schema_2_yml, project.project_root, "tests", "schema.yml")
         manifest = run_dbt(["parse"])
         test_node = manifest.nodes["test.test.my_singular_test"]
         assert test_node.description == "My singular test description"
+        print(f"--- config.meta: {test_node.config.meta}")
+        print(f"--- node.meta: {test_node.meta}")
 
 
 class TestPatchSingularTestInvalidName:

--- a/tests/functional/data_test_patch/test_singular_test_patch.py
+++ b/tests/functional/data_test_patch/test_singular_test_patch.py
@@ -2,12 +2,13 @@ from pathlib import Path
 
 import pytest
 
-from dbt.tests.util import get_artifact, run_dbt, run_dbt_and_capture
+from dbt.tests.util import get_artifact, run_dbt, run_dbt_and_capture, write_file
 from tests.functional.data_test_patch.fixtures import (
     tests__doc_block_md,
     tests__invalid_name_schema_yml,
     tests__malformed_schema_yml,
     tests__my_singular_test_sql,
+    tests__schema_2_yml,
     tests__schema_yml,
 )
 
@@ -30,6 +31,12 @@ class TestPatchSingularTest:
         assert my_singular_test_node["description"] == "Some docs from a doc block"
         assert my_singular_test_node["config"]["error_if"] == ">10"
         assert my_singular_test_node["config"]["meta"] == {"some_key": "some_val"}
+
+        # partial parsing test
+        write_file(tests__schema_2_yml, project.project_root, "tests", "schema.yml")
+        manifest = run_dbt(["parse"])
+        test_node = manifest.nodes["test.test.my_singular_test"]
+        assert test_node.description == "My singular test description"
 
 
 class TestPatchSingularTestInvalidName:


### PR DESCRIPTION
Resolves #10801


### Problem

Changes to singular data test configs in yaml files were not causing the singular data test nodes to be updated.

### Solution

Add partial parsing code to handle data_tests sections in schema source files.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
