### PR TITLE
Use xdg

### DIFF
--- a/.changes/unreleased/Fixes-20241207-155958.yaml
+++ b/.changes/unreleased/Fixes-20241207-155958.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Use xdg and also fix circular dep
+time: 2024-12-07T15:59:58.137140008-08:00
+custom:
+    Author: dradetsky
+    Issue: "2515"

--- a/core/dbt/cli/__init__.py
+++ b/core/dbt/cli/__init__.py
@@ -1,1 +1,0 @@
-from .main import cli as dbt_cli  # noqa

--- a/core/dbt/cli/resolvers.py
+++ b/core/dbt/cli/resolvers.py
@@ -16,7 +16,7 @@ def default_profiles_dir() -> Path:
     if (Path.cwd() / "profiles.yml").exists():
         return Path.cwd()
     else:
-        return user_config_dir() / Path("dbt")
+        return user_config_dir(appname="dbt", appauthor="dbt-labs")
 
 
 def default_log_path(project_dir: Path, verify_version: bool = False) -> Path:

--- a/core/dbt/cli/resolvers.py
+++ b/core/dbt/cli/resolvers.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from dbt.config.project import PartialProject
 from dbt.exceptions import DbtProjectError
 
+from appdirs import user_config_dir
+
 
 def default_project_dir() -> Path:
     paths = list(Path.cwd().parents)
@@ -11,7 +13,10 @@ def default_project_dir() -> Path:
 
 
 def default_profiles_dir() -> Path:
-    return Path.cwd() if (Path.cwd() / "profiles.yml").exists() else Path.home() / ".dbt"
+    if (Path.cwd() / "profiles.yml").exists():
+        return Path.cwd()
+    else:
+        return user_config_dir() / Path("dbt")
 
 
 def default_log_path(project_dir: Path, verify_version: bool = False) -> Path:

--- a/core/dbt/cli/resolvers.py
+++ b/core/dbt/cli/resolvers.py
@@ -16,7 +16,7 @@ def default_profiles_dir() -> Path:
     if (Path.cwd() / "profiles.yml").exists():
         return Path.cwd()
     else:
-        return user_config_dir(appname="dbt", appauthor="dbt-labs")
+        return Path(user_config_dir(appname="dbt", appauthor="dbt-labs"))
 
 
 def default_log_path(project_dir: Path, verify_version: bool = False) -> Path:

--- a/core/dbt/cli/resolvers.py
+++ b/core/dbt/cli/resolvers.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
+from appdirs import user_config_dir
+
 from dbt.config.project import PartialProject
 from dbt.exceptions import DbtProjectError
-
-from appdirs import user_config_dir
 
 
 def default_project_dir() -> Path:

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
 
 from dbt.adapters.contracts.connection import Credentials, HasCredentials
+from dbt.cli.resolvers import default_profiles_dir
 from dbt.clients.yaml_helper import load_yaml_text
 from dbt.contracts.project import ProfileConfig
 from dbt.events.types import MissingProfileTarget
@@ -164,15 +165,6 @@ class Profile(HasCredentials):
         args_profile_name: Optional[str],
         project_profile_name: Optional[str] = None,
     ) -> str:
-        # TODO: Duplicating this method as direct copy of the implementation in dbt.cli.resolvers
-        # dbt.cli.resolvers implementation can't be used because it causes a circular dependency.
-        # This should be removed and use a safe default access on the Flags module when
-        # https://github.com/dbt-labs/dbt-core/issues/6259 is closed.
-        def default_profiles_dir():
-            from pathlib import Path
-
-            return Path.cwd() if (Path.cwd() / "profiles.yml").exists() else Path.home() / ".dbt"
-
         profile_name = project_profile_name
         if args_profile_name is not None:
             profile_name = args_profile_name

--- a/core/setup.py
+++ b/core/setup.py
@@ -46,6 +46,7 @@ setup(
         "console_scripts": ["dbt = dbt.cli.main:cli"],
     },
     install_requires=[
+        "appdirs>=1.4.4",
         # ----
         # dbt-core uses these packages deeply, throughout the codebase, and there have been breaking changes in past patch releases (even though these are major-version-one).
         # Pin to the patch or minor version, and bump in each new minor version of dbt-core.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ git+https://github.com/dbt-labs/dbt-adapters.git@main
 git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git@main
 git+https://github.com/dbt-labs/dbt-postgres.git@main
+appdirs
 # black must match what's in .pre-commit-config.yaml to be sure local env matches CI
 black==24.3.0
 bumpversion
@@ -29,6 +30,7 @@ pytest-split
 pytest-xdist
 sphinx
 tox>=3.13
+types-appdirs
 types-docutils
 types-PyYAML
 types-Jinja2


### PR DESCRIPTION
Resolves #2515 

### Problem

We hardcode the profile dir to `~/.dbt` instead of using xdg.

On a related note, there was a circular dep issue that caused us to have to copypaste `default_profiles_dir()` instead of just importing it (which is annoying if we want to add more complexity to it), so we have to fix that.

### Solution

Import & use appdirs.

### Considerations

Per #2515, this has different effects on different platforms. I'm only thinking about it in terms of Linux, but maybe we don't want to use this on win/macos. Somebody else more familiar with those should comment.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
