### PR TITLE
Fix erroneous additional batch execution

### DIFF
--- a/.changes/unreleased/Fixes-20241209-133317.yaml
+++ b/.changes/unreleased/Fixes-20241209-133317.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix running of extra "last" batch when there is only one batch
+time: 2024-12-09T13:33:17.253326-06:00
+custom:
+  Author: QMalcolm
+  Issue: "11112"

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -768,18 +768,21 @@ class RunTask(CompileTask):
         # Wait until all submitted batches have completed
         while len(batch_results) != batch_idx:
             pass
-        # Final batch runs once all others complete to ensure post_hook runs at the end
-        self._submit_batch(
-            node=node,
-            adapter=runner.adapter,
-            relation_exists=relation_exists,
-            batches=batches,
-            batch_idx=batch_idx,
-            batch_results=batch_results,
-            pool=pool,
-            force_sequential_run=True,
-            skip=skip_batches,
-        )
+
+        # Only run "last" batch if there is more than one batch
+        if len(batches) != 1:
+            # Final batch runs once all others complete to ensure post_hook runs at the end
+            self._submit_batch(
+                node=node,
+                adapter=runner.adapter,
+                relation_exists=relation_exists,
+                batches=batches,
+                batch_idx=batch_idx,
+                batch_results=batch_results,
+                pool=pool,
+                force_sequential_run=True,
+                skip=skip_batches,
+            )
 
         # Finalize run: merge results, track model run, and print final result line
         runner.merge_batch_results(result, batch_results)


### PR DESCRIPTION
Resolves #11112

### Problem

Microbatch models that only ran on batch (either due to `lookback=0` or setting `--event-time-start` + `--event-time-end`) would raise an `Unhandled exception` like the following:
<img width="1107" alt="Screenshot 2024-12-09 at 12 43 50" src="https://github.com/user-attachments/assets/dec8c7e6-cd59-4b47-b1c1-123ad67988e1">

### Solution

Ensure we skip the last batch execution path when only one batch needs to be run in total for a microbatch model
<img width="1106" alt="Screenshot 2024-12-09 at 13 50 14" src="https://github.com/user-attachments/assets/d7debd20-b038-4cd5-a939-91090aa8f500">

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
