### PR TITLE
Fix circular import

### DIFF
--- a/.changes/unreleased/Fixes-20241211-132203.yaml
+++ b/.changes/unreleased/Fixes-20241211-132203.yaml
@@ -3,4 +3,4 @@ body: Fix circular dependency
 time: 2024-12-11T13:22:03.637443979-08:00
 custom:
     Author: dradetsky
-    Issue: none
+    Issue: 11142

--- a/.changes/unreleased/Fixes-20241211-132203.yaml
+++ b/.changes/unreleased/Fixes-20241211-132203.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix circular dependency
+time: 2024-12-11T13:22:03.637443979-08:00
+custom:
+    Author: dradetsky
+    Issue: none

--- a/core/dbt/cli/__init__.py
+++ b/core/dbt/cli/__init__.py
@@ -1,1 +1,0 @@
-from .main import cli as dbt_cli  # noqa

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
 
 from dbt.adapters.contracts.connection import Credentials, HasCredentials
+from dbt.cli.resolvers import default_profiles_dir
 from dbt.clients.yaml_helper import load_yaml_text
 from dbt.contracts.project import ProfileConfig
 from dbt.events.types import MissingProfileTarget
@@ -164,15 +165,6 @@ class Profile(HasCredentials):
         args_profile_name: Optional[str],
         project_profile_name: Optional[str] = None,
     ) -> str:
-        # TODO: Duplicating this method as direct copy of the implementation in dbt.cli.resolvers
-        # dbt.cli.resolvers implementation can't be used because it causes a circular dependency.
-        # This should be removed and use a safe default access on the Flags module when
-        # https://github.com/dbt-labs/dbt-core/issues/6259 is closed.
-        def default_profiles_dir():
-            from pathlib import Path
-
-            return Path.cwd() if (Path.cwd() / "profiles.yml").exists() else Path.home() / ".dbt"
-
         profile_name = project_profile_name
         if args_profile_name is not None:
             profile_name = args_profile_name


### PR DESCRIPTION
resolves #11142

### Problem

There was a circular import which required duplicating a method in `core/dbt/config/profile.py`. This was both ugly and an impediment to improving that method if required (as in #11108).

### Solution

Fix the circular import and remove the duplication

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
