### PR TITLE
add allow additional property for Model and SourceDefinition

### DIFF
--- a/core/dbt/artifacts/schemas/manifest/v12/manifest.py
+++ b/core/dbt/artifacts/schemas/manifest/v12/manifest.py
@@ -180,3 +180,13 @@ class WritableManifest(ArtifactMixin):
         if manifest_schema_version < cls.dbt_schema_version.version:
             data = upgrade_manifest_json(data, manifest_schema_version)
         return cls.from_dict(data)
+
+    @classmethod
+    def validate(cls, _):
+        # When dbt try to load an artifact with additional optional fields
+        # that are not present in the schema, from_dict will work fine.
+        # As long as validate is not called, the schema will not be enforced.
+        # This is intentional, as it allows for safer schema upgrades.
+        raise RuntimeError(
+            "The WritableManifest should never be validated directly to allow for schema upgrades."
+        )

--- a/core/dbt/artifacts/schemas/manifest/v12/manifest.py
+++ b/core/dbt/artifacts/schemas/manifest/v12/manifest.py
@@ -28,6 +28,7 @@ from dbt.artifacts.schemas.base import (
     schema_version,
 )
 from dbt.artifacts.schemas.upgrades import upgrade_manifest_json
+from dbt_common.exceptions import DbtInternalError
 
 NodeEdgeMap = Dict[str, List[str]]
 UniqueID = str
@@ -187,6 +188,6 @@ class WritableManifest(ArtifactMixin):
         # that are not present in the schema, from_dict will work fine.
         # As long as validate is not called, the schema will not be enforced.
         # This is intentional, as it allows for safer schema upgrades.
-        raise RuntimeError(
+        raise DbtInternalError(
             "The WritableManifest should never be validated directly to allow for schema upgrades."
         )

--- a/schemas/dbt/manifest/v12.json
+++ b/schemas/dbt/manifest/v12.json
@@ -13,7 +13,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.9.0b4"
+          "default": "1.10.0a1"
         },
         "generated_at": {
           "type": "string"
@@ -9121,19 +9121,7 @@
                         "type": "integer"
                       },
                       "granularity": {
-                        "enum": [
-                          "nanosecond",
-                          "microsecond",
-                          "millisecond",
-                          "second",
-                          "minute",
-                          "hour",
-                          "day",
-                          "week",
-                          "month",
-                          "quarter",
-                          "year"
-                        ]
+                        "type": "string"
                       }
                     },
                     "additionalProperties": false,
@@ -18712,19 +18700,7 @@
                                   "type": "integer"
                                 },
                                 "granularity": {
-                                  "enum": [
-                                    "nanosecond",
-                                    "microsecond",
-                                    "millisecond",
-                                    "second",
-                                    "minute",
-                                    "hour",
-                                    "day",
-                                    "week",
-                                    "month",
-                                    "quarter",
-                                    "year"
-                                  ]
+                                  "type": "string"
                                 }
                               },
                               "additionalProperties": false,
@@ -20024,6 +20000,27 @@
                               }
                             ],
                             "default": null
+                          },
+                          "config": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "title": "SemanticLayerElementConfig",
+                                "properties": {
+                                  "meta": {
+                                    "type": "object",
+                                    "propertyNames": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
                           }
                         },
                         "additionalProperties": false,
@@ -20172,6 +20169,27 @@
                             "anyOf": [
                               {
                                 "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "config": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "title": "SemanticLayerElementConfig",
+                                "properties": {
+                                  "meta": {
+                                    "type": "object",
+                                    "propertyNames": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
                               },
                               {
                                 "type": "null"
@@ -20335,6 +20353,27 @@
                                   "repo_file_path",
                                   "file_slice"
                                 ]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "config": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "title": "SemanticLayerElementConfig",
+                                "properties": {
+                                  "meta": {
+                                    "type": "object",
+                                    "propertyNames": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
                               },
                               {
                                 "type": "null"
@@ -21586,6 +21625,27 @@
                     }
                   ],
                   "default": null
+                },
+                "config": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "title": "SemanticLayerElementConfig",
+                      "properties": {
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
                 }
               },
               "additionalProperties": false,
@@ -21734,6 +21794,27 @@
                   "anyOf": [
                     {
                       "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "config": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "title": "SemanticLayerElementConfig",
+                      "properties": {
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
                     },
                     {
                       "type": "null"
@@ -21897,6 +21978,27 @@
                         "repo_file_path",
                         "file_slice"
                       ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "config": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "title": "SemanticLayerElementConfig",
+                      "properties": {
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
                     },
                     {
                       "type": "null"

--- a/tests/unit/contracts/graph/test_nodes.py
+++ b/tests/unit/contracts/graph/test_nodes.py
@@ -236,10 +236,12 @@ def test_basic_compiled_model(basic_compiled_dict, basic_compiled_model):
     assert node.is_ephemeral is False
 
 
-def test_invalid_extra_fields_model(minimal_uncompiled_dict):
-    bad_extra = minimal_uncompiled_dict
-    bad_extra["notvalid"] = "nope"
-    assert_fails_validation(bad_extra, ModelNode)
+def test_extra_fields_model_okay(minimal_uncompiled_dict):
+    extra = minimal_uncompiled_dict
+    extra["notvalid"] = "nope"
+    # Model still load fine with extra fields
+    loaded_model = ModelNode.from_dict(extra)
+    assert not hasattr(loaded_model, "notvalid")
 
 
 def test_invalid_bad_type_model(minimal_uncompiled_dict):

--- a/tests/unit/contracts/graph/test_nodes_parsed.py
+++ b/tests/unit/contracts/graph/test_nodes_parsed.py
@@ -1961,6 +1961,14 @@ def test_basic_source_definition(
     pickle.loads(pickle.dumps(node))
 
 
+def test_extra_fields_source_definition_okay(minimum_parsed_source_definition_dict):
+    extra = minimum_parsed_source_definition_dict
+    extra["notvalid"] = "nope"
+    # Model still load fine with extra fields
+    loaded_source = SourceDefinition.from_dict(extra)
+    assert not hasattr(loaded_source, "notvalid")
+
+
 def test_invalid_missing(minimum_parsed_source_definition_dict):
     bad_missing_name = minimum_parsed_source_definition_dict
     del bad_missing_name["name"]


### PR DESCRIPTION
Allowing additional properties on Model and SourceDefinition so we are more forgiving at reading artifacts.
This change doesn't change user contract. User still cannot add additional fields to project freely

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
