### PR TITLE
Auto-response for bug reports during holiday break

### DIFF
--- a/.github/workflows/auto-respond-bug-reports.yml
+++ b/.github/workflows/auto-respond-bug-reports.yml
@@ -1,0 +1,50 @@
+# **what?**
+# Check if the an issue is opened near or during an extended holiday period.
+# If so, post an automatically-generated comment about the holiday for bug reports.
+# Also provide specific information to customers of dbt Cloud.
+
+# **why?**
+# Explain why responses will be delayed during our holiday period.
+
+# **when?**
+# This will run when new issues are opened.
+
+name: Auto-Respond to Bug Reports During Holiday Period
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  auto-response:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if current date is within holiday period
+        id: date-check
+        run: |
+          current_date=$(date -u +"%Y-%m-%d")
+          start_date="2024-12-23"
+          end_date="2025-01-05"
+
+          if [[ "$current_date" < "$start_date" || "$current_date" > "$end_date" ]]; then
+            echo "outside_holiday=true" >> $GITHUB_ENV
+          else
+            echo "outside_holiday=false" >> $GITHUB_ENV
+          fi
+
+      - name: Post comment
+        if: ${{ env.outside_holiday == 'false' && contains(github.event.issue.labels.*.name, 'bug') }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body "Thank you for your bug report! Our team is will be out of the office for [Christmas and our Global Week of Rest](https://handbook.getdbt.com/docs/time_off#2024-us-holidays), from December 25, 2024, through January 3, 2025.
+
+          We will review your issue as soon as possible after returning.
+          Thank you for your understanding, and happy holidays! 🎄🎉
+
+          If you are a customer of dbt Cloud, please contact our Customer Support team via the dbt Cloud web interface or email **support@dbtlabs.com**."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Problem

The team that maintains `dbt-core` will be out of the office for [Christmas and our Global Week of Rest](https://handbook.getdbt.com/docs/time_off#2024-us-holidays), from December 25, 2024, through January 3, 2025.

Any bugs opened during this time will not get an immediate response.

### Solution

During the company holiday, generate an automatic comment for new issues that are labeled with the `bug` label upon opening. Also include this auto-response for the two days leading up to Christmas as well as the weekend following the Global Week of Rest:

<img width="897" alt="image" src="https://github.com/user-attachments/assets/9355abee-1bf8-4f1f-8c1f-651f9a221b9b" />

### 🎩 

Testing was done in this private repo:

Examples for testing start and end dates was in issues like these:
- https://github.com/dbt-labs/tmp-test-github-autoresponder/issues/19
- https://github.com/dbt-labs/tmp-test-github-autoresponder/issues/20

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] ~This PR includes tests, or~ tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [N/A] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
