### PR TITLE
Fix yaml snapshot specification with data tests

### DIFF
--- a/.changes/unreleased/Fixes-20241216-134645.yaml
+++ b/.changes/unreleased/Fixes-20241216-134645.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Error writing generic test at run time
+time: 2024-12-16T13:46:45.936573-05:00
+custom:
+  Author: gshank
+  Issue: "11110"

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -1,4 +1,5 @@
 import datetime
+import pathlib
 import time
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass, field
@@ -289,9 +290,15 @@ class SchemaParser(SimpleParser[YamlBlock, ModelNode]):
                 parser = SnapshotParser(self.project, self.manifest, self.root_project)
                 fqn = parser.get_fqn_prefix(block.path.relative_path)
                 fqn.append(snapshot["name"])
+
+                compiled_path = str(
+                    pathlib.PurePath("").joinpath(
+                        block.path.relative_path, snapshot["name"] + ".sql"
+                    )
+                )
                 snapshot_node = parser._create_parsetime_node(
                     block,
-                    self.get_compiled_path(block),
+                    compiled_path,
                     parser.initial_config(fqn),
                     fqn,
                     snapshot["name"],

--- a/tests/functional/snapshots/fixtures.py
+++ b/tests/functional/snapshots/fixtures.py
@@ -301,6 +301,10 @@ snapshots:
       updated_at: updated_at
       meta:
         owner: 'a_owner'
+    columns:
+      - name: id
+        data_tests:
+          - not_null
 """
 
 snapshots_pg__snapshot_mod_yml = """
@@ -313,6 +317,10 @@ snapshots:
       updated_at: updated_at
       meta:
         owner: 'b_owner'
+    columns:
+      - name: id
+        data_tests:
+          - not_null
 """
 
 snapshots_pg__snapshot_no_target_schema_sql = """


### PR DESCRIPTION
Resolves #11110

### Problem

We were writing the compiled version of the snapshot node to the yaml file name, so that when generic tests were written out the "directory" was a file. In addition multiple snapshots nodes would have been written to the same output file.

### Solution

Construct the yaml snapshot compiled path including the "name" + ".sql" of the snapshot node.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
