### PR TITLE
Check modified contracts when doing state:modified

### DIFF
--- a/.changes/unreleased/Fixes-20241217-154848.yaml
+++ b/.changes/unreleased/Fixes-20241217-154848.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Run check_modified_contract for state:modified
+time: 2024-12-17T15:48:48.053054-05:00
+custom:
+  Author: gshank
+  Issue: "11034"

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -680,17 +680,24 @@ class StateSelectorMethod(SelectorMethod):
     def check_modified_content(
         self, old: Optional[SelectorTarget], new: SelectorTarget, adapter_type: str
     ) -> bool:
+        different_contents = False
         if isinstance(
             new,
             (SourceDefinition, Exposure, Metric, SemanticModel, UnitTestDefinition, SavedQuery),
         ):
             # these all overwrite `same_contents`
             different_contents = not new.same_contents(old)  # type: ignore
-        else:
+        elif new:  # because we also pull in deleted/disabled nodes, this could be None
             different_contents = not new.same_contents(old, adapter_type)  # type: ignore
 
         upstream_macro_change = self.check_macros_modified(new)
-        return different_contents or upstream_macro_change
+
+        check_modified_contract = False
+        if isinstance(old, ModelNode):
+            func = self.check_modified_contract("same_contract", adapter_type)
+            check_modified_contract = func(old, new)
+
+        return different_contents or upstream_macro_change or check_modified_contract
 
     def check_unmodified_content(
         self, old: Optional[SelectorTarget], new: SelectorTarget, adapter_type: str
@@ -792,7 +799,7 @@ class StateSelectorMethod(SelectorMethod):
                 yield unique_id
 
         # checkers that can handle removed nodes
-        if checker.__name__ in ["check_modified_contract"]:
+        if checker.__name__ in ["check_modified_contract", "check_modified_content", "check_unmodified_content"]:
             # ignore included_nodes, since those cannot contain removed nodes
             for previous_unique_id, previous_node in manifest.nodes.items():
                 # detect removed (deleted, renamed, or disabled) nodes

--- a/tests/functional/defer_state/test_modified_state.py
+++ b/tests/functional/defer_state/test_modified_state.py
@@ -676,6 +676,15 @@ class TestDeleteUnversionedContractedModel(BaseModifiedState):
         assert expected_warning in logs
         assert expected_change in logs
 
+        # the same but for general-purpose state:modified
+        _, logs = run_dbt_and_capture(
+            ["run", "--models", "state:modified.contract", "--state", "./state"]
+        )
+        expected_warning = "While comparing to previous project state, dbt detected a breaking change to an unversioned model"
+        expected_change = "Contracted model 'model.test.table_model' was deleted or renamed"
+        assert expected_warning in logs
+        assert expected_change in logs
+
 
 class TestDeleteVersionedContractedModel(BaseModifiedState):
     MODEL_UNIQUE_ID = "model.test.table_model.v1"
@@ -692,6 +701,14 @@ class TestDeleteVersionedContractedModel(BaseModifiedState):
         # since the models are versioned, they raise an error
         with pytest.raises(ContractBreakingChangeError) as e:
             run_dbt(["run", "--models", "state:modified.contract", "--state", "./state"])
+
+        assert "Contracted model 'model.test.table_model.v1' was deleted or renamed." in str(
+            e.value
+        )
+
+        # the same but for general-purpose state:modified
+        with pytest.raises(ContractBreakingChangeError) as e:
+            run_dbt(["run", "--models", "state:modified", "--state", "./state"])
 
         assert "Contracted model 'model.test.table_model.v1' was deleted or renamed." in str(
             e.value


### PR DESCRIPTION
Resolves #11034

### Problem

Checking modified:contract needed to be run separately, which users found unexpected.

### Solution

Call check_modified_contract when running check_modified.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
