### PR TITLE
Fix for dbt_project.yml "tests" config resulting in incorrect state:modified

### DIFF
--- a/.changes/unreleased/Fixes-20241218-112640.yaml
+++ b/.changes/unreleased/Fixes-20241218-112640.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix unrendered_config for tests from dbt_project.yml
+time: 2024-12-18T11:26:40.270022-05:00
+custom:
+  Author: gshank
+  Issue: "11146"

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -195,11 +195,12 @@ def load_raw_project(project_root: str) -> Dict[str, Any]:
         )
 
     project_dict = _load_yaml(project_yaml_filepath)
-    if "tests" in project_dict:
-        project_dict["data_tests"] = project_dict.pop("tests")
 
     if not isinstance(project_dict, dict):
         raise DbtProjectError(f"{DBT_PROJECT_FILE_NAME} does not parse to a dictionary")
+
+    if "tests" in project_dict:
+        project_dict["data_tests"] = project_dict.pop("tests")
 
     return project_dict
 

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -195,6 +195,8 @@ def load_raw_project(project_root: str) -> Dict[str, Any]:
         )
 
     project_dict = _load_yaml(project_yaml_filepath)
+    if "tests" in project_dict:
+        project_dict["data_tests"] = project_dict.pop("tests")
 
     if not isinstance(project_dict, dict):
         raise DbtProjectError(f"{DBT_PROJECT_FILE_NAME} does not parse to a dictionary")

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -199,7 +199,7 @@ def load_raw_project(project_root: str) -> Dict[str, Any]:
     if not isinstance(project_dict, dict):
         raise DbtProjectError(f"{DBT_PROJECT_FILE_NAME} does not parse to a dictionary")
 
-    if "tests" in project_dict:
+    if "tests" in project_dict and "data_tests" not in project_dict:
         project_dict["data_tests"] = project_dict.pop("tests")
 
     return project_dict

--- a/core/dbt/context/context_config.py
+++ b/core/dbt/context/context_config.py
@@ -46,7 +46,7 @@ class UnrenderedConfig(ConfigSource):
         elif resource_type == NodeType.Source:
             model_configs = unrendered.get("sources")
         elif resource_type == NodeType.Test:
-            model_configs = unrendered.get("data_tests")
+            model_configs = unrendered.get("data_tests") or unrendered.get("tests")
         elif resource_type == NodeType.Metric:
             model_configs = unrendered.get("metrics")
         elif resource_type == NodeType.SemanticModel:

--- a/core/dbt/context/context_config.py
+++ b/core/dbt/context/context_config.py
@@ -46,7 +46,7 @@ class UnrenderedConfig(ConfigSource):
         elif resource_type == NodeType.Source:
             model_configs = unrendered.get("sources")
         elif resource_type == NodeType.Test:
-            model_configs = unrendered.get("data_tests") or unrendered.get("tests")
+            model_configs = unrendered.get("data_tests")
         elif resource_type == NodeType.Metric:
             model_configs = unrendered.get("metrics")
         elif resource_type == NodeType.SemanticModel:

--- a/tests/functional/defer_state/test_unrendered_config.py
+++ b/tests/functional/defer_state/test_unrendered_config.py
@@ -40,7 +40,6 @@ class TestGenericTestUnrenderedConfig:
     def test_unrendered_config(self, project):
         manifest = run_dbt(["parse"])
         assert manifest
-        print(f"--- nodes: {manifest.nodes.keys()}")
         test_node_id = "test.test.unique_foo_id.fa8c520a2e"
         test_node = manifest.nodes[test_node_id]
         assert test_node.unrendered_config == {"store_failures": True}

--- a/tests/functional/defer_state/test_unrendered_config.py
+++ b/tests/functional/defer_state/test_unrendered_config.py
@@ -1,0 +1,46 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+
+dbt_project_update = """
+models:
+  my_dbt_project:
+    +materialized: table
+
+tests:
+  +store_failures: true
+"""
+
+foo_sql = """
+select 1 as id
+"""
+
+schema_yml = """
+models:
+  - name: foo
+    columns:
+      - name: id
+        tests:
+          - unique
+"""
+
+class TestGenericTestUnrenderedConfig():
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return dbt_project_update
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "foo.sql": foo_sql,
+            "schema.yml": schema_yml,
+        }
+
+    def test_unrendered_config(self, project):
+        manifest = run_dbt(["parse"])
+        assert manifest
+        print(f"--- nodes: {manifest.nodes.keys()}")
+        test_node_id = 'test.test.unique_foo_id.fa8c520a2e'
+        test_node = manifest.nodes[test_node_id]
+        assert test_node.unrendered_config == {"store_failures": True}

--- a/tests/functional/defer_state/test_unrendered_config.py
+++ b/tests/functional/defer_state/test_unrendered_config.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt.tests.util import run_dbt
 
-
 dbt_project_update = """
 models:
   my_dbt_project:
@@ -25,7 +24,8 @@ models:
           - unique
 """
 
-class TestGenericTestUnrenderedConfig():
+
+class TestGenericTestUnrenderedConfig:
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return dbt_project_update
@@ -41,6 +41,6 @@ class TestGenericTestUnrenderedConfig():
         manifest = run_dbt(["parse"])
         assert manifest
         print(f"--- nodes: {manifest.nodes.keys()}")
-        test_node_id = 'test.test.unique_foo_id.fa8c520a2e'
+        test_node_id = "test.test.unique_foo_id.fa8c520a2e"
         test_node = manifest.nodes[test_node_id]
         assert test_node.unrendered_config == {"store_failures": True}


### PR DESCRIPTION
Resolves #11146

### Problem

If the data_tests config in dbt_project.yml is named "tests", the unrendered_config for data tests is incorrect, resulting in incorrect state:modified results.

### Solution

Rename the "tests" dictionary to "data_tests", so unrendered config is correctly generated.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
