### PR TITLE
Revert "Fix circular import (#11137)"

### DIFF
--- a/.changes/unreleased/Fixes-20241211-132203.yaml
+++ b/.changes/unreleased/Fixes-20241211-132203.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Fix circular dependency
-time: 2024-12-11T13:22:03.637443979-08:00
-custom:
-    Author: dradetsky
-    Issue: 11142

--- a/core/dbt/cli/__init__.py
+++ b/core/dbt/cli/__init__.py
@@ -1,0 +1,1 @@
+from .main import cli as dbt_cli  # noqa

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
 
 from dbt.adapters.contracts.connection import Credentials, HasCredentials
-from dbt.cli.resolvers import default_profiles_dir
 from dbt.clients.yaml_helper import load_yaml_text
 from dbt.contracts.project import ProfileConfig
 from dbt.events.types import MissingProfileTarget
@@ -165,6 +164,15 @@ class Profile(HasCredentials):
         args_profile_name: Optional[str],
         project_profile_name: Optional[str] = None,
     ) -> str:
+        # TODO: Duplicating this method as direct copy of the implementation in dbt.cli.resolvers
+        # dbt.cli.resolvers implementation can't be used because it causes a circular dependency.
+        # This should be removed and use a safe default access on the Flags module when
+        # https://github.com/dbt-labs/dbt-core/issues/6259 is closed.
+        def default_profiles_dir():
+            from pathlib import Path
+
+            return Path.cwd() if (Path.cwd() / "profiles.yml").exists() else Path.home() / ".dbt"
+
         profile_name = project_profile_name
         if args_profile_name is not None:
             profile_name = args_profile_name


### PR DESCRIPTION
This reverts commit 95c090bed0b745c272a977d11fc248168e94bb25 from PR #11137 

### Problem

This introduced a circular import in dbt-postgres 

https://github.com/dbt-labs/dbt-postgres/actions/runs/12421973228/job/34729594861

<details><summary>CI log</summary>
<p>

```Run hatch run integration-tests
Creating environment: default
Installing project in development mode
Checking dependencies
Syncing dependencies
ImportError while loading conftest '/home/runner/work/dbt-postgres/dbt-postgres/tests/conftest.py'.
tests/conftest.py:6: in <module>
    set_from_args(Namespace(), None)
../../../.local/share/hatch/env/virtual/dbt-postgres/ogKa4-GM/dbt-postgres/lib/python3.9/site-packages/dbt/flags.py:[22](https://github.com/dbt-labs/dbt-postgres/actions/runs/12421973228/job/34729594861#step:8:23): in set_from_args
    from dbt.cli.flags import Flags, convert_config
../../../.local/share/hatch/env/virtual/dbt-postgres/ogKa4-GM/dbt-postgres/lib/python3.9/site-packages/dbt/cli/flags.py:15: in <module>
    from dbt.cli.resolvers import default_log_path, default_project_dir
../../../.local/share/hatch/env/virtual/dbt-postgres/ogKa4-GM/dbt-postgres/lib/python3.9/site-packages/dbt/cli/resolvers.py:3: in <module>
    from dbt.config.project import PartialProject
../../../.local/share/hatch/env/virtual/dbt-postgres/ogKa4-GM/dbt-postgres/lib/python3.9/site-packages/dbt/config/__init__.py:2: in <module>
    from .profile import Profile  # noqa
../../../.local/share/hatch/env/virtual/dbt-postgres/ogKa4-GM/dbt-postgres/lib/python3.9/site-packages/dbt/config/profile.py:6: in <module>
    from dbt.cli.resolvers import default_profiles_dir
E   ImportError: cannot import name 'default_profiles_dir' from partially initialized module 'dbt.cli.resolvers' (most likely due to a circular import) (/home/runner/.local/share/hatch/env/virtual/dbt-postgres/ogKa4-GM/dbt-postgres/lib/python3.9/site-packages/dbt/cli/resolvers.py)
```

</p>
</details> 

### Solution

Revery and revisit later

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
