### PR TITLE
fix: python version up to 3.12 from 3.11 in Dockerfile #9654

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG py_version=3.11.2
+ARG py_version=3.12.8
 
 FROM python:$py_version-slim-bullseye as base
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
 ENV PYTHONIOENCODING=utf-8
 ENV LANG=C.UTF-8
 
-RUN python -m pip install --upgrade "pip==24.0" "setuptools==69.2.0" "wheel==0.43.0" --no-cache-dir
+RUN python -m pip install --upgrade "pip==24.3" "setuptools==75.6.0" "wheel==0.45.1" --no-cache-dir
 
 
 FROM base as dbt-core


### PR DESCRIPTION
### Problem

By the time Python 3.13 is released ([October 2024](https://devguide.python.org/versions/)), we'll want to upgrade it to use Python 3.12 so that users are getting an up-to-date Python version that is a stable release still receiving bug fixes (and not merely security fixes).

### Solution

This pull request includes updates to the `docker/Dockerfile` to upgrade the Python version and several Python packages.

* Updated Python version from `3.11.2` to `3.12.8` (`docker/Dockerfile`)
* Upgraded `pip`, `setuptools`, and `wheel` to newer versions in the `RUN apt-get update` section (`docker/Dockerfile`)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
