### PR TITLE
Fix microbatch dbt list --output JSON

### DIFF
--- a/.changes/unreleased/Fixes-20250109-123309.yaml
+++ b/.changes/unreleased/Fixes-20250109-123309.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix microbatch dbt list --output json
+time: 2025-01-09T12:33:09.958795+01:00
+custom:
+    Author: internetcoffeephone
+    Issue: 10556 11098

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -17,6 +17,7 @@ from dbt.graph import ResourceTypeSelector
 from dbt.node_types import NodeType
 from dbt.task.base import resource_types_from_args
 from dbt.task.runnable import GraphRunnableTask
+from dbt.utils import JSONEncoder
 from dbt_common.events.contextvars import task_contextvars
 from dbt_common.events.functions import fire_event, warn_or_error
 from dbt_common.events.types import PrintEvent
@@ -142,7 +143,8 @@ class ListTask(GraphRunnableTask):
                         if self.args.output_keys
                         else k in self.ALLOWED_KEYS
                     )
-                }
+                },
+                cls=JSONEncoder,
             )
 
     def generate_paths(self) -> Iterator[str]:

--- a/tests/functional/microbatch/test_microbatch.py
+++ b/tests/functional/microbatch/test_microbatch.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import pytest
@@ -15,6 +16,7 @@ from dbt.events.types import (
     MicrobatchMacroOutsideOfBatchesDeprecation,
     MicrobatchModelNoEventTimeInputs,
 )
+from dbt.tests.fixtures.project import TestProjInfo
 from dbt.tests.util import (
     get_artifact,
     patch_microbatch_end_time,
@@ -331,6 +333,19 @@ class TestMicrobatchCLI(BaseMicrobatchTest):
 
 class TestMicrobatchCLIBuild(TestMicrobatchCLI):
     CLI_COMMAND_NAME = "build"
+
+
+class TestMicrobatchCLIRunOutputJSON(BaseMicrobatchTest):
+    def test_list_output_json(self, project: TestProjInfo):
+        """Test whether the command `dbt list --output json` works"""
+        model_catcher = EventCatcher(event_to_catch=LogModelResult)
+        batch_catcher = EventCatcher(event_to_catch=LogBatchResult)
+
+        _, microbatch_json = run_dbt(
+            ["list", "--output", "json"], callbacks=[model_catcher.catch, batch_catcher.catch]
+        )
+        microbatch_dict = json.loads(microbatch_json)
+        assert microbatch_dict["config"]["begin"] == "2020-01-01T00:00:00"
 
 
 class TestMicroBatchBoundsDefault(BaseMicrobatchTest):


### PR DESCRIPTION
Resolves #10556, #11098

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

Currently, running `dbt list --output JSON` on a project containing a microbatch model results in an error, as microbatch models require a datetime value in their config which cannot be serialized by the default JSON serializer.

### Solution

There already exists a custom JSON serializer within the dbt-core project that converts datetime to ISO string format. This change uses the above serializer to resolve the error.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
