### PR TITLE
Move initialization of keyword_args up

### DIFF
--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -769,6 +769,7 @@ class StateSelectorMethod(SelectorMethod):
 
         manifest: Manifest = self.previous_state.manifest
 
+        keyword_args = {}  # initialize here to handle disabled node check below
         for unique_id, node in self.all_nodes(included_nodes):
             previous_node: Optional[SelectorTarget] = None
 
@@ -787,7 +788,6 @@ class StateSelectorMethod(SelectorMethod):
             elif unique_id in manifest.saved_queries:
                 previous_node = SavedQuery.from_resource(manifest.saved_queries[unique_id])
 
-            keyword_args = {}
             if checker.__name__ in [
                 "same_contract",
                 "check_modified_content",


### PR DESCRIPTION
Resolves #

### Problem

```
    checker(removed_node, None, **keyword_args)  # type: ignore
                                  ^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'keyword_args' where it is not associated with a value
```

### Solution

Move up initialization of keyword_args

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
