### PR TITLE
Fix exception type of run operation macro not found

### DIFF
--- a/.changes/unreleased/Under the Hood-20250107-123955.yaml
+++ b/.changes/unreleased/Under the Hood-20250107-123955.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Change exception type from DbtInternalException to UndefinedMacroError when
+  macro not found in 'run operation' command
+time: 2025-01-07T12:39:55.234321-05:00
+custom:
+  Author: michelleark
+  Issue: "11192"

--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -85,7 +85,7 @@ class RunOperationTask(ConfiguredTask):
             unique_id = macro.unique_id
             fqn = unique_id.split(".")
         else:
-            raise dbt_common.exceptions.macros.UndefinedMacroError(
+            raise dbt_common.exceptions.UndefinedMacroError(
                 f"dbt could not find a macro with the name '{macro_name}' in any package"
             )
 

--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -19,7 +19,6 @@ from dbt.events.types import (
 from dbt.node_types import NodeType
 from dbt.task.base import ConfiguredTask
 from dbt_common.events.functions import fire_event
-from dbt_common.exceptions import DbtInternalError
 
 RESULT_FILE_NAME = "run_results.json"
 
@@ -86,7 +85,7 @@ class RunOperationTask(ConfiguredTask):
             unique_id = macro.unique_id
             fqn = unique_id.split(".")
         else:
-            raise DbtInternalError(
+            raise dbt_common.exceptions.macros.UndefinedMacroError(
                 f"dbt could not find a macro with the name '{macro_name}' in any package"
             )
 

--- a/tests/functional/run_operations/test_run_operations.py
+++ b/tests/functional/run_operations/test_run_operations.py
@@ -13,7 +13,7 @@ from dbt.tests.util import (
     run_dbt_and_capture,
     write_file,
 )
-from dbt_common.exceptions import DbtInternalError
+from dbt_common.exceptions.macros import UndefinedMacroError
 from tests.functional.run_operations.fixtures import (
     happy_macros_sql,
     model_sql,
@@ -81,7 +81,7 @@ class TestOperations:
 
     def test_macro_missing(self, project):
         with pytest.raises(
-            DbtInternalError,
+            UndefinedMacroError,
             match="dbt could not find a macro with the name 'this_macro_does_not_exist' in any package",
         ):
             self.run_operation("this_macro_does_not_exist", False)

--- a/tests/functional/run_operations/test_run_operations.py
+++ b/tests/functional/run_operations/test_run_operations.py
@@ -13,7 +13,7 @@ from dbt.tests.util import (
     run_dbt_and_capture,
     write_file,
 )
-from dbt_common.exceptions.macros import UndefinedMacroError
+from dbt_common.exceptions import UndefinedMacroError
 from tests.functional.run_operations.fixtures import (
     happy_macros_sql,
     model_sql,


### PR DESCRIPTION
Resolves #11192 

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
Missing macro in run operation should raise user exception (UndefinedMacroError)

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Raise UndefinedMacroError, same as is done during `dbt compile` when a model references a non-existent macro here: https://github.com/dbt-labs/dbt-common/blob/2253401254d0ef6b819415b6a2546de3e16e5d95/dbt_common/clients/jinja.py#L600

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
