### PR TITLE
Always emit warning when microbatch models lack any filtered input node

### DIFF
--- a/.changes/unreleased/Fixes-20250107-173719.yaml
+++ b/.changes/unreleased/Fixes-20250107-173719.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Ensure warning about microbatch lacking filter inputs is always fired
+time: 2025-01-07T17:37:19.373261-06:00
+custom:
+  Author: QMalcolm
+  Issue: "11159"

--- a/tests/functional/microbatch/test_microbatch.py
+++ b/tests/functional/microbatch/test_microbatch.py
@@ -464,9 +464,11 @@ class TestMicrobatchWithInputWithoutEventTime(BaseMicrobatchTest):
         assert len(catcher.caught_events) == 1
 
         # our partition grain is "day" so running the same day without new data should produce the same results
+        catcher.caught_events = []
         with patch_microbatch_end_time("2020-01-03 14:57:00"):
-            run_dbt(["run"])
+            run_dbt(["run"], callbacks=[catcher.catch])
         self.assert_row_count(project, "microbatch_model", 3)
+        assert len(catcher.caught_events) == 1
 
         # add next two days of data
         test_schema_relation = project.adapter.Relation.create(


### PR DESCRIPTION
Resolves #11159 

### Problem
When doing partial parsing, no warning about microbatch models missing inputs with event time configs are ever fired.

### Solution
Ensure we always validate the inputs for microbatch models

### Demo

Demo can be found [here](https://dbtlabs.zoom.us/clips/share/A2F3MRZETmloM2txZ1R0RzRPX1RkTlhOblpBAQ), or click on the gif.
[![pf400IOVQRSoGBjUsl61Aw](https://github.com/user-attachments/assets/cec2bdbc-b946-4807-8b5f-072f3cbc899a)](https://dbtlabs.zoom.us/clips/share/A2F3MRZETmloM2txZ1R0RzRPX1RkTlhOblpBAQ)


### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
