### PR TITLE
Add indenting to toyaml & tojson context methods

### DIFF
--- a/.changes/unreleased/Features-20250113-223828.yaml
+++ b/.changes/unreleased/Features-20250113-223828.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add indent parameter to tojson and toyaml context methods
+time: 2025-01-13T22:38:28.480988715Z
+custom:
+    Author: mjsqu
+    Issue: None

--- a/.changes/unreleased/Features-20250113-223828.yaml
+++ b/.changes/unreleased/Features-20250113-223828.yaml
@@ -3,4 +3,4 @@ body: Add indent parameter to tojson and toyaml context methods
 time: 2025-01-13T22:38:28.480988715Z
 custom:
     Author: mjsqu
-    Issue: None
+    Issue: 11210

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -393,7 +393,9 @@ class BaseContext(metaclass=ContextMeta):
 
     @contextmember()
     @staticmethod
-    def tojson(value: Any, default: Any = None, sort_keys: bool = False) -> Any:
+    def tojson(
+        value: Any, default: Any = None, sort_keys: bool = False, indent: int | str | None = None
+    ) -> Any:
         """The `tojson` context method can be used to serialize a Python
         object primitive, eg. a `dict` or `list` to a json string.
 
@@ -401,6 +403,9 @@ class BaseContext(metaclass=ContextMeta):
         :param default: A default value to return if the `value` argument
             cannot be serialized
         :param sort_keys: If True, sort the keys.
+        :param indent: If indent is a non-negative integer, then nested
+            structures will be serialized indented by that value. An indent
+            value of 0 will insert newlines with no indenting.
 
 
         Usage:
@@ -410,7 +415,7 @@ class BaseContext(metaclass=ContextMeta):
             {% do log(my_json_string) %}
         """
         try:
-            return json.dumps(value, sort_keys=sort_keys)
+            return json.dumps(value, sort_keys=sort_keys, indent=indent)
         except ValueError:
             return default
 
@@ -448,15 +453,21 @@ class BaseContext(metaclass=ContextMeta):
     @contextmember()
     @staticmethod
     def toyaml(
-        value: Any, default: Optional[str] = None, sort_keys: bool = False
+        value: Any,
+        default: Optional[str] = None,
+        sort_keys: bool = False,
+        indent: int | None = None,
     ) -> Optional[str]:
-        """The `tojson` context method can be used to serialize a Python
+        """The `toyaml` context method can be used to serialize a Python
         object primitive, eg. a `dict` or `list` to a yaml string.
 
         :param value: The value serialize to yaml
         :param default: A default value to return if the `value` argument
             cannot be serialized
         :param sort_keys: If True, sort the keys.
+        :param indent: If indent is a non-negative integer, the number of
+            spaces by which to indent nested structures (Default for YAML
+            is indenting by 2 spaces)
 
 
         Usage:
@@ -466,7 +477,7 @@ class BaseContext(metaclass=ContextMeta):
             {% do log(my_yaml_string) %}
         """
         try:
-            return yaml.safe_dump(data=value, sort_keys=sort_keys)
+            return yaml.safe_dump(data=value, sort_keys=sort_keys, indent=indent)
         except (ValueError, yaml.YAMLError):
             return default
 

--- a/tests/functional/context_methods/test_json_yaml_functions.py
+++ b/tests/functional/context_methods/test_json_yaml_functions.py
@@ -24,6 +24,8 @@ tests__to_yaml_sql = """
 {% set default_sort = (toyaml({'b': 2, 'a': 1}) == 'b: 2\\na: 1\\n') %}
 {% set unsorted = (toyaml({'b': 2, 'a': 1}, sort_keys=False) == 'b: 2\\na: 1\\n') %}
 {% set sorted = (toyaml({'b': 2, 'a': 1}, sort_keys=True) == 'a: 1\\nb: 2\\n') %}
+{% set yaml_indented = (toyaml({'a': {'ab': 1}, 'b': {'ba':2}}, indent=8) == 'a:\\n        ab: 1\\nb:\\n        ba: 2\\n') %}
+{% set json_indented = (tojson({'a': {'ab': 1}, 'b': {'ba':2}}, indent=4) == '{\\n    "a": {\\n        "ab": 1\\n    },\\n    "b": {\\n        "ba": 2\\n    }\\n}') %}
 {% set default_results = (toyaml({'a': adapter}, 'failed') == 'failed') %}
 
 (select 'simplest' as name {% if simplest %}limit 0{% endif %})


### PR DESCRIPTION
Resolves #11210

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

Printing of large JSON objects for debugging can be difficult when using the inbuilt context method `tojson()` rather than the Jinja filter, which allows indenting `| tojson(indent=4)`. The underlying methods used, `json.dumps` and `yaml.safe_dump`, have ready-made `indent` parameters which can be leveraged.

### Solution

Adds `indent` parameter to `tojson` and `toyaml` context methods, passing the value directly to `json.dumps` and `yaml.safe_dump` respectively. The change mirrors the functionality of `sort_keys`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
