### PR TITLE
Add `doc_blocks` to manifest for nodes and columns

### DIFF
--- a/.changes/unreleased/Features-20250122-170328.yaml
+++ b/.changes/unreleased/Features-20250122-170328.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add doc_blocks to manifest for nodes and columns
+time: 2025-01-22T17:03:28.866522Z
+custom:
+    Author: aranke
+    Issue: 11000 11001

--- a/core/dbt/artifacts/resources/v1/components.py
+++ b/core/dbt/artifacts/resources/v1/components.py
@@ -68,6 +68,7 @@ class ColumnInfo(AdditionalPropertiesMixin, ExtensibleDbtClassMixin):
     tags: List[str] = field(default_factory=list)
     _extra: Dict[str, Any] = field(default_factory=dict)
     granularity: Optional[TimeGranularity] = None
+    doc_blocks: List[List[str]] = field(default_factory=list)
 
 
 @dataclass
@@ -197,6 +198,7 @@ class ParsedResource(ParsedResourceMandatory):
     unrendered_config_call_dict: Dict[str, Any] = field(default_factory=dict)
     relation_name: Optional[str] = None
     raw_code: str = ""
+    doc_blocks: List[List[str]] = field(default_factory=list)
 
     def __post_serialize__(self, dct: Dict, context: Optional[Dict] = None):
         dct = super().__post_serialize__(dct, context)

--- a/core/dbt/artifacts/resources/v1/components.py
+++ b/core/dbt/artifacts/resources/v1/components.py
@@ -68,7 +68,7 @@ class ColumnInfo(AdditionalPropertiesMixin, ExtensibleDbtClassMixin):
     tags: List[str] = field(default_factory=list)
     _extra: Dict[str, Any] = field(default_factory=dict)
     granularity: Optional[TimeGranularity] = None
-    doc_blocks: List[List[str]] = field(default_factory=list)
+    doc_blocks: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -198,7 +198,7 @@ class ParsedResource(ParsedResourceMandatory):
     unrendered_config_call_dict: Dict[str, Any] = field(default_factory=dict)
     relation_name: Optional[str] = None
     raw_code: str = ""
-    doc_blocks: List[List[str]] = field(default_factory=list)
+    doc_blocks: List[str] = field(default_factory=list)
 
     def __post_serialize__(self, dct: Dict, context: Optional[Dict] = None):
         dct = super().__post_serialize__(dct, context)

--- a/core/dbt/artifacts/resources/v1/source_definition.py
+++ b/core/dbt/artifacts/resources/v1/source_definition.py
@@ -74,3 +74,4 @@ class SourceDefinition(ParsedSourceMandatory):
     created_at: float = field(default_factory=lambda: time.time())
     unrendered_database: Optional[str] = None
     unrendered_schema: Optional[str] = None
+    doc_blocks: List[List[str]] = field(default_factory=list)

--- a/core/dbt/artifacts/resources/v1/source_definition.py
+++ b/core/dbt/artifacts/resources/v1/source_definition.py
@@ -74,4 +74,4 @@ class SourceDefinition(ParsedSourceMandatory):
     created_at: float = field(default_factory=lambda: time.time())
     unrendered_database: Optional[str] = None
     unrendered_schema: Optional[str] = None
-    doc_blocks: List[List[str]] = field(default_factory=list)
+    doc_blocks: List[str] = field(default_factory=list)

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1714,17 +1714,17 @@ def _process_docs_for_source(
     context: Dict[str, Any],
     source: SourceDefinition,
 ):
-    table_description = source.description
-    source_description = source.source_description
-    table_description = get_rendered(table_description, context)
-    source_description = get_rendered(source_description, context)
-    source.description = table_description
-    source.source_description = source_description
+    source.description, source.doc_blocks = _get_description_and_doc_blocks(
+        source.description, context
+    )
+    source.source_description, source.doc_blocks = _get_description_and_doc_blocks(
+        source.source_description, context
+    )
 
     for column in source.columns.values():
-        column_desc = column.description
-        column_desc = get_rendered(column_desc, context)
-        column.description = column_desc
+        column.description, column.doc_blocks = _get_description_and_doc_blocks(
+            column.description, context
+        )
 
 
 # macro argument descriptions

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1661,8 +1661,8 @@ DocsContextCallback = Callable[[ResultNode], Dict[str, Any]]
 
 def _get_doc_blocks(s: str) -> Tuple[List[List[str]], bool]:
     ast = parse(s)
-    has_doc_blocks = False
     doc_blocks: List[List[str]] = []
+    has_doc_blocks = False
 
     if not hasattr(ast, "body"):
         return doc_blocks, has_doc_blocks

--- a/schemas/dbt/manifest/v12.json
+++ b/schemas/dbt/manifest/v12.json
@@ -626,10 +626,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     }
                   },
@@ -742,10 +739,7 @@
               "doc_blocks": {
                 "type": "array",
                 "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "type": "string"
                 }
               },
               "root_path": {
@@ -1689,10 +1683,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     }
                   },
@@ -1805,10 +1796,7 @@
               "doc_blocks": {
                 "type": "array",
                 "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "type": "string"
                 }
               },
               "language": {
@@ -2361,10 +2349,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     }
                   },
@@ -2477,10 +2462,7 @@
               "doc_blocks": {
                 "type": "array",
                 "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "type": "string"
                 }
               },
               "language": {
@@ -3173,10 +3155,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     }
                   },
@@ -3289,10 +3268,7 @@
               "doc_blocks": {
                 "type": "array",
                 "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "type": "string"
                 }
               },
               "language": {
@@ -4004,10 +3980,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     }
                   },
@@ -4120,10 +4093,7 @@
               "doc_blocks": {
                 "type": "array",
                 "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "type": "string"
                 }
               },
               "language": {
@@ -5430,10 +5400,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     }
                   },
@@ -5546,10 +5513,7 @@
               "doc_blocks": {
                 "type": "array",
                 "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "type": "string"
                 }
               },
               "language": {
@@ -6102,10 +6066,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     }
                   },
@@ -6218,10 +6179,7 @@
               "doc_blocks": {
                 "type": "array",
                 "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "type": "string"
                 }
               },
               "language": {
@@ -7109,10 +7067,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     }
                   },
@@ -7225,10 +7180,7 @@
               "doc_blocks": {
                 "type": "array",
                 "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "type": "string"
                 }
               },
               "language": {
@@ -8320,10 +8272,7 @@
                 "doc_blocks": {
                   "type": "array",
                   "items": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
+                    "type": "string"
                   }
                 }
               },
@@ -8430,10 +8379,7 @@
           "doc_blocks": {
             "type": "array",
             "items": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "type": "string"
             }
           }
         },
@@ -10649,10 +10595,7 @@
                           "doc_blocks": {
                             "type": "array",
                             "items": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
+                              "type": "string"
                             }
                           }
                         },
@@ -10765,10 +10708,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     },
                     "root_path": {
@@ -11712,10 +11652,7 @@
                           "doc_blocks": {
                             "type": "array",
                             "items": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
+                              "type": "string"
                             }
                           }
                         },
@@ -11828,10 +11765,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     },
                     "language": {
@@ -12384,10 +12318,7 @@
                           "doc_blocks": {
                             "type": "array",
                             "items": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
+                              "type": "string"
                             }
                           }
                         },
@@ -12500,10 +12431,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     },
                     "language": {
@@ -13196,10 +13124,7 @@
                           "doc_blocks": {
                             "type": "array",
                             "items": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
+                              "type": "string"
                             }
                           }
                         },
@@ -13312,10 +13237,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     },
                     "language": {
@@ -14027,10 +13949,7 @@
                           "doc_blocks": {
                             "type": "array",
                             "items": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
+                              "type": "string"
                             }
                           }
                         },
@@ -14143,10 +14062,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     },
                     "language": {
@@ -15453,10 +15369,7 @@
                           "doc_blocks": {
                             "type": "array",
                             "items": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
+                              "type": "string"
                             }
                           }
                         },
@@ -15569,10 +15482,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     },
                     "language": {
@@ -16125,10 +16035,7 @@
                           "doc_blocks": {
                             "type": "array",
                             "items": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
+                              "type": "string"
                             }
                           }
                         },
@@ -16241,10 +16148,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     },
                     "language": {
@@ -17132,10 +17036,7 @@
                           "doc_blocks": {
                             "type": "array",
                             "items": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
+                              "type": "string"
                             }
                           }
                         },
@@ -17248,10 +17149,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     },
                     "language": {
@@ -18334,10 +18232,7 @@
                           "doc_blocks": {
                             "type": "array",
                             "items": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
+                              "type": "string"
                             }
                           }
                         },
@@ -18444,10 +18339,7 @@
                     "doc_blocks": {
                       "type": "array",
                       "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                        "type": "string"
                       }
                     }
                   },

--- a/schemas/dbt/manifest/v12.json
+++ b/schemas/dbt/manifest/v12.json
@@ -8426,6 +8426,15 @@
               }
             ],
             "default": null
+          },
+          "doc_blocks": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           }
         },
         "additionalProperties": false,
@@ -18431,6 +18440,15 @@
                         }
                       ],
                       "default": null
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     }
                   },
                   "additionalProperties": false,

--- a/schemas/dbt/manifest/v12.json
+++ b/schemas/dbt/manifest/v12.json
@@ -622,6 +622,15 @@
                         }
                       ],
                       "default": null
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     }
                   },
                   "additionalProperties": true,
@@ -729,6 +738,15 @@
               "raw_code": {
                 "type": "string",
                 "default": ""
+              },
+              "doc_blocks": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               },
               "root_path": {
                 "anyOf": [
@@ -1667,6 +1685,15 @@
                         }
                       ],
                       "default": null
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     }
                   },
                   "additionalProperties": true,
@@ -1774,6 +1801,15 @@
               "raw_code": {
                 "type": "string",
                 "default": ""
+              },
+              "doc_blocks": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               },
               "language": {
                 "type": "string",
@@ -2321,6 +2357,15 @@
                         }
                       ],
                       "default": null
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     }
                   },
                   "additionalProperties": true,
@@ -2428,6 +2473,15 @@
               "raw_code": {
                 "type": "string",
                 "default": ""
+              },
+              "doc_blocks": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               },
               "language": {
                 "type": "string",
@@ -3115,6 +3169,15 @@
                         }
                       ],
                       "default": null
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     }
                   },
                   "additionalProperties": true,
@@ -3222,6 +3285,15 @@
               "raw_code": {
                 "type": "string",
                 "default": ""
+              },
+              "doc_blocks": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               },
               "language": {
                 "type": "string",
@@ -3928,6 +4000,15 @@
                         }
                       ],
                       "default": null
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     }
                   },
                   "additionalProperties": true,
@@ -4035,6 +4116,15 @@
               "raw_code": {
                 "type": "string",
                 "default": ""
+              },
+              "doc_blocks": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               },
               "language": {
                 "type": "string",
@@ -5336,6 +5426,15 @@
                         }
                       ],
                       "default": null
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     }
                   },
                   "additionalProperties": true,
@@ -5443,6 +5542,15 @@
               "raw_code": {
                 "type": "string",
                 "default": ""
+              },
+              "doc_blocks": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               },
               "language": {
                 "type": "string",
@@ -5990,6 +6098,15 @@
                         }
                       ],
                       "default": null
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     }
                   },
                   "additionalProperties": true,
@@ -6097,6 +6214,15 @@
               "raw_code": {
                 "type": "string",
                 "default": ""
+              },
+              "doc_blocks": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               },
               "language": {
                 "type": "string",
@@ -6979,6 +7105,15 @@
                         }
                       ],
                       "default": null
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     }
                   },
                   "additionalProperties": true,
@@ -7086,6 +7221,15 @@
               "raw_code": {
                 "type": "string",
                 "default": ""
+              },
+              "doc_blocks": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               },
               "language": {
                 "type": "string",
@@ -8172,6 +8316,15 @@
                     }
                   ],
                   "default": null
+                },
+                "doc_blocks": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
                 }
               },
               "additionalProperties": true,
@@ -8545,6 +8698,12 @@
                 "anyOf": [
                   {
                     "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   },
                   {
                     "type": "null"
@@ -9904,6 +10063,12 @@
                     "type": "string"
                   },
                   {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  {
                     "type": "null"
                   }
                 ],
@@ -10471,6 +10636,15 @@
                               }
                             ],
                             "default": null
+                          },
+                          "doc_blocks": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
                           }
                         },
                         "additionalProperties": true,
@@ -10578,6 +10752,15 @@
                     "raw_code": {
                       "type": "string",
                       "default": ""
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     },
                     "root_path": {
                       "anyOf": [
@@ -11516,6 +11699,15 @@
                               }
                             ],
                             "default": null
+                          },
+                          "doc_blocks": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
                           }
                         },
                         "additionalProperties": true,
@@ -11623,6 +11815,15 @@
                     "raw_code": {
                       "type": "string",
                       "default": ""
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     },
                     "language": {
                       "type": "string",
@@ -12170,6 +12371,15 @@
                               }
                             ],
                             "default": null
+                          },
+                          "doc_blocks": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
                           }
                         },
                         "additionalProperties": true,
@@ -12277,6 +12487,15 @@
                     "raw_code": {
                       "type": "string",
                       "default": ""
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     },
                     "language": {
                       "type": "string",
@@ -12964,6 +13183,15 @@
                               }
                             ],
                             "default": null
+                          },
+                          "doc_blocks": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
                           }
                         },
                         "additionalProperties": true,
@@ -13071,6 +13299,15 @@
                     "raw_code": {
                       "type": "string",
                       "default": ""
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     },
                     "language": {
                       "type": "string",
@@ -13777,6 +14014,15 @@
                               }
                             ],
                             "default": null
+                          },
+                          "doc_blocks": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
                           }
                         },
                         "additionalProperties": true,
@@ -13884,6 +14130,15 @@
                     "raw_code": {
                       "type": "string",
                       "default": ""
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     },
                     "language": {
                       "type": "string",
@@ -15185,6 +15440,15 @@
                               }
                             ],
                             "default": null
+                          },
+                          "doc_blocks": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
                           }
                         },
                         "additionalProperties": true,
@@ -15292,6 +15556,15 @@
                     "raw_code": {
                       "type": "string",
                       "default": ""
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     },
                     "language": {
                       "type": "string",
@@ -15839,6 +16112,15 @@
                               }
                             ],
                             "default": null
+                          },
+                          "doc_blocks": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
                           }
                         },
                         "additionalProperties": true,
@@ -15946,6 +16228,15 @@
                     "raw_code": {
                       "type": "string",
                       "default": ""
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     },
                     "language": {
                       "type": "string",
@@ -16828,6 +17119,15 @@
                               }
                             ],
                             "default": null
+                          },
+                          "doc_blocks": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
                           }
                         },
                         "additionalProperties": true,
@@ -16935,6 +17235,15 @@
                     "raw_code": {
                       "type": "string",
                       "default": ""
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     },
                     "language": {
                       "type": "string",
@@ -18012,6 +18321,15 @@
                               }
                             ],
                             "default": null
+                          },
+                          "doc_blocks": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
                           }
                         },
                         "additionalProperties": true,
@@ -18183,6 +18501,12 @@
                           "anyOf": [
                             {
                               "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
                             },
                             {
                               "type": "null"

--- a/tests/functional/artifacts/expected_manifest.py
+++ b/tests/functional/artifacts/expected_manifest.py
@@ -316,6 +316,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "first_name": {
                         "name": "first_name",
@@ -326,6 +327,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "email": {
                         "name": "email",
@@ -336,6 +338,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "ip_address": {
                         "name": "ip_address",
@@ -346,6 +349,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "updated_at": {
                         "name": "updated_at",
@@ -356,6 +360,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                 },
                 "contract": {"checksum": None, "enforced": False, "alias_types": True},
@@ -373,6 +378,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                 "latest_version": None,
                 "time_spine": None,
                 "freshness": None,
+                "doc_blocks": [],
             },
             "model.test.second_model": {
                 "compiled_path": os.path.join(compiled_model_path, "second_model.sql"),
@@ -416,6 +422,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "first_name": {
                         "name": "first_name",
@@ -426,6 +433,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "email": {
                         "name": "email",
@@ -436,6 +444,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "ip_address": {
                         "name": "ip_address",
@@ -446,6 +455,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "updated_at": {
                         "name": "updated_at",
@@ -456,6 +466,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                 },
                 "contract": {"checksum": None, "enforced": False, "alias_types": True},
@@ -473,6 +484,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                 "latest_version": None,
                 "time_spine": None,
                 "freshness": None,
+                "doc_blocks": [],
             },
             "seed.test.seed": {
                 "build_path": None,
@@ -506,6 +518,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "first_name": {
                         "name": "first_name",
@@ -516,6 +529,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "email": {
                         "name": "email",
@@ -526,6 +540,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "ip_address": {
                         "name": "ip_address",
@@ -536,6 +551,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "updated_at": {
                         "name": "updated_at",
@@ -546,6 +562,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                 },
                 "docs": {"node_color": None, "show": True},
@@ -554,6 +571,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                 "relation_name": relation_name_node_format.format(
                     project.database, my_schema_name, "seed"
                 ),
+                "doc_blocks": [],
             },
             "test.test.not_null_model_id.d01cc630e6": {
                 "alias": "not_null_model_id",
@@ -607,6 +625,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                 "checksum": {"name": "none", "checksum": ""},
                 "unrendered_config": unrendered_test_config,
                 "contract": {"checksum": None, "enforced": False, "alias_types": True},
+                "doc_blocks": [],
             },
             "snapshot.test.snapshot_seed": {
                 "alias": "snapshot_seed",
@@ -653,6 +672,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                 "tags": [],
                 "unique_id": "snapshot.test.snapshot_seed",
                 "unrendered_config": unrendered_snapshot_config,
+                "doc_blocks": [],
             },
             "test.test.test_nothing_model_.5d38568946": {
                 "alias": "test_nothing_model_",
@@ -705,6 +725,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                 },
                 "checksum": {"name": "none", "checksum": ""},
                 "unrendered_config": unrendered_test_config,
+                "doc_blocks": [],
             },
             "test.test.unique_model_id.67b76558ff": {
                 "alias": "unique_model_id",
@@ -758,6 +779,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                 },
                 "checksum": {"name": "none", "checksum": ""},
                 "unrendered_config": unrendered_test_config,
+                "doc_blocks": [],
             },
         },
         "sources": {
@@ -773,6 +795,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     }
                 },
                 "config": {

--- a/tests/functional/artifacts/expected_manifest.py
+++ b/tests/functional/artifacts/expected_manifest.py
@@ -840,6 +840,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                 "unrendered_config": {},
                 "unrendered_database": None,
                 "unrendered_schema": "{{ var('test_schema') }}",
+                "doc_blocks": [],
             },
         },
         "exposures": {

--- a/tests/functional/artifacts/expected_manifest.py
+++ b/tests/functional/artifacts/expected_manifest.py
@@ -1046,7 +1046,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
-                        "doc_blocks": [["doc", "summary_first_name"]],
+                        "doc_blocks": ["doc.test.summary_first_name"],
                     },
                     "ct": {
                         "description": "The number of instances of the first name",
@@ -1057,7 +1057,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
-                        "doc_blocks": [["doc", "summary_count"]],
+                        "doc_blocks": ["doc.test.summary_count"],
                     },
                 },
                 "config": get_rendered_model_config(materialized="table", group="test_group"),
@@ -1105,7 +1105,7 @@ def expected_references_manifest(project):
                 "constraints": [],
                 "time_spine": None,
                 "freshness": None,
-                "doc_blocks": [["doc", "ephemeral_summary"]],
+                "doc_blocks": ["doc.test.ephemeral_summary"],
             },
             "model.test.view_summary": {
                 "alias": "view_summary",
@@ -1122,7 +1122,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
-                        "doc_blocks": [["doc", "summary_first_name"]],
+                        "doc_blocks": ["doc.test.summary_first_name"],
                     },
                     "ct": {
                         "description": "The number of instances of the first name",
@@ -1133,7 +1133,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
-                        "doc_blocks": [["doc", "summary_count"]],
+                        "doc_blocks": ["doc.test.summary_count"],
                     },
                 },
                 "config": get_rendered_model_config(),
@@ -1177,7 +1177,7 @@ def expected_references_manifest(project):
                 "constraints": [],
                 "time_spine": None,
                 "freshness": None,
-                "doc_blocks": [["doc", "view_summary"]],
+                "doc_blocks": ["doc.test.view_summary"],
             },
             "seed.test.seed": {
                 "alias": "seed",
@@ -1319,7 +1319,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
-                        "doc_blocks": [["doc", "column_info"]],
+                        "doc_blocks": ["doc.test.column_info"],
                     }
                 },
                 "config": {
@@ -1363,6 +1363,7 @@ def expected_references_manifest(project):
                 "unrendered_config": {},
                 "unrendered_database": None,
                 "unrendered_schema": "{{ var('test_schema') }}",
+                "doc_blocks": ["doc.test.table_info"],
             },
         },
         "exposures": {

--- a/tests/functional/artifacts/expected_manifest.py
+++ b/tests/functional/artifacts/expected_manifest.py
@@ -1029,6 +1029,7 @@ def expected_references_manifest(project):
                 "constraints": [],
                 "time_spine": None,
                 "freshness": None,
+                "doc_blocks": [],
             },
             "model.test.ephemeral_summary": {
                 "alias": "ephemeral_summary",
@@ -1045,6 +1046,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [["doc", "summary_first_name"]],
                     },
                     "ct": {
                         "description": "The number of instances of the first name",
@@ -1055,6 +1057,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [["doc", "summary_count"]],
                     },
                 },
                 "config": get_rendered_model_config(materialized="table", group="test_group"),
@@ -1102,6 +1105,7 @@ def expected_references_manifest(project):
                 "constraints": [],
                 "time_spine": None,
                 "freshness": None,
+                "doc_blocks": [["doc", "ephemeral_summary"]],
             },
             "model.test.view_summary": {
                 "alias": "view_summary",
@@ -1118,6 +1122,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [["doc", "summary_first_name"]],
                     },
                     "ct": {
                         "description": "The number of instances of the first name",
@@ -1128,6 +1133,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [["doc", "summary_count"]],
                     },
                 },
                 "config": get_rendered_model_config(),
@@ -1171,6 +1177,7 @@ def expected_references_manifest(project):
                 "constraints": [],
                 "time_spine": None,
                 "freshness": None,
+                "doc_blocks": [["doc", "view_summary"]],
             },
             "seed.test.seed": {
                 "alias": "seed",
@@ -1186,6 +1193,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "first_name": {
                         "name": "first_name",
@@ -1196,6 +1204,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "email": {
                         "name": "email",
@@ -1206,6 +1215,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "ip_address": {
                         "name": "ip_address",
@@ -1216,6 +1226,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "updated_at": {
                         "name": "updated_at",
@@ -1226,6 +1237,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                 },
                 "config": get_rendered_seed_config(),
@@ -1250,6 +1262,7 @@ def expected_references_manifest(project):
                 "checksum": checksum_file(seed_path),
                 "unrendered_config": get_unrendered_seed_config(),
                 "relation_name": '"{0}"."{1}".seed'.format(project.database, my_schema_name),
+                "doc_blocks": [],
             },
             "snapshot.test.snapshot_seed": {
                 "alias": "snapshot_seed",
@@ -1291,6 +1304,7 @@ def expected_references_manifest(project):
                 "unrendered_config": get_unrendered_snapshot_config(
                     target_schema=alternate_schema
                 ),
+                "doc_blocks": [],
             },
         },
         "sources": {
@@ -1305,6 +1319,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     }
                 },
                 "config": {
@@ -1578,6 +1593,7 @@ def expected_versions_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "ct": {
                         "description": "The number of instances of the first name",
@@ -1588,6 +1604,7 @@ def expected_versions_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                 },
                 "config": get_rendered_model_config(
@@ -1638,6 +1655,7 @@ def expected_versions_manifest(project):
                 "latest_version": 2,
                 "time_spine": None,
                 "freshness": None,
+                "doc_blocks": [],
             },
             "model.test.versioned_model.v2": {
                 "alias": "versioned_model_v2",
@@ -1654,6 +1672,7 @@ def expected_versions_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                     "extra": {
                         "description": "",
@@ -1664,6 +1683,7 @@ def expected_versions_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
+                        "doc_blocks": [],
                     },
                 },
                 "config": get_rendered_model_config(
@@ -1710,6 +1730,7 @@ def expected_versions_manifest(project):
                 "latest_version": 2,
                 "time_spine": None,
                 "freshness": None,
+                "doc_blocks": [],
             },
             "model.test.ref_versioned_model": {
                 "alias": "ref_versioned_model",
@@ -1769,6 +1790,7 @@ def expected_versions_manifest(project):
                 "latest_version": None,
                 "time_spine": None,
                 "freshness": None,
+                "doc_blocks": [],
             },
             "test.test.unique_versioned_model_v1_first_name.6138195dec": {
                 "alias": "unique_versioned_model_v1_first_name",
@@ -1822,6 +1844,7 @@ def expected_versions_manifest(project):
                 },
                 "checksum": {"name": "none", "checksum": ""},
                 "unrendered_config": unrendered_test_config,
+                "doc_blocks": [],
             },
             "test.test.unique_versioned_model_v1_count.0b4c0b688a": {
                 "alias": "unique_versioned_model_v1_count",
@@ -1875,6 +1898,7 @@ def expected_versions_manifest(project):
                 },
                 "checksum": {"name": "none", "checksum": ""},
                 "unrendered_config": unrendered_test_config,
+                "doc_blocks": [],
             },
             "test.test.unique_versioned_model_v2_first_name.998430d28e": {
                 "alias": "unique_versioned_model_v2_first_name",
@@ -1928,6 +1952,7 @@ def expected_versions_manifest(project):
                 },
                 "checksum": {"name": "none", "checksum": ""},
                 "unrendered_config": unrendered_test_config,
+                "doc_blocks": [],
             },
         },
         "exposures": {

--- a/tests/functional/artifacts/expected_manifest.py
+++ b/tests/functional/artifacts/expected_manifest.py
@@ -1319,7 +1319,7 @@ def expected_references_manifest(project):
                         "tags": [],
                         "constraints": [],
                         "granularity": None,
-                        "doc_blocks": [],
+                        "doc_blocks": [["doc", "column_info"]],
                     }
                 },
                 "config": {

--- a/tests/functional/configs/test_contract_configs.py
+++ b/tests/functional/configs/test_contract_configs.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from dbt.artifacts.resources.v1.components import ColumnInfo
 from dbt.exceptions import ParsingError, ValidationError
 from dbt.tests.util import (
     get_artifact,
@@ -10,6 +11,7 @@ from dbt.tests.util import (
     run_dbt_and_capture,
     write_file,
 )
+from dbt_common.contracts.constraints import ColumnLevelConstraint, ConstraintType
 
 my_model_sql = """
 {{
@@ -331,9 +333,74 @@ class TestModelLevelContractEnabledConfigs:
 
         assert contract_actual_config.enforced is True
 
-        expected_columns = "{'id': ColumnInfo(name='id', description='hello', meta={}, data_type='integer', constraints=[ColumnLevelConstraint(type=<ConstraintType.not_null: 'not_null'>, name=None, expression=None, warn_unenforced=True, warn_unsupported=True, to=None, to_columns=[]), ColumnLevelConstraint(type=<ConstraintType.primary_key: 'primary_key'>, name=None, expression=None, warn_unenforced=True, warn_unsupported=True, to=None, to_columns=[]), ColumnLevelConstraint(type=<ConstraintType.check: 'check'>, name=None, expression='(id > 0)', warn_unenforced=True, warn_unsupported=True, to=None, to_columns=[])], quote=True, tags=[], _extra={}, granularity=None), 'color': ColumnInfo(name='color', description='', meta={}, data_type='string', constraints=[], quote=None, tags=[], _extra={}, granularity=None), 'date_day': ColumnInfo(name='date_day', description='', meta={}, data_type='date', constraints=[], quote=None, tags=[], _extra={}, granularity=None)}"
+        expected_columns = {
+            "id": ColumnInfo(
+                name="id",
+                description="hello",
+                meta={},
+                data_type="integer",
+                doc_blocks=[],
+                constraints=[
+                    ColumnLevelConstraint(
+                        type=ConstraintType.not_null,
+                        name=None,
+                        expression=None,
+                        warn_unenforced=True,
+                        warn_unsupported=True,
+                        to=None,
+                        to_columns=[],
+                    ),
+                    ColumnLevelConstraint(
+                        type=ConstraintType.primary_key,
+                        name=None,
+                        expression=None,
+                        warn_unenforced=True,
+                        warn_unsupported=True,
+                        to=None,
+                        to_columns=[],
+                    ),
+                    ColumnLevelConstraint(
+                        type=ConstraintType.check,
+                        name=None,
+                        expression="(id > 0)",
+                        warn_unenforced=True,
+                        warn_unsupported=True,
+                        to=None,
+                        to_columns=[],
+                    ),
+                ],
+                quote=True,
+                tags=[],
+                _extra={},
+                granularity=None,
+            ),
+            "color": ColumnInfo(
+                name="color",
+                description="",
+                doc_blocks=[],
+                meta={},
+                data_type="string",
+                constraints=[],
+                quote=None,
+                tags=[],
+                _extra={},
+                granularity=None,
+            ),
+            "date_day": ColumnInfo(
+                name="date_day",
+                description="",
+                doc_blocks=[],
+                meta={},
+                data_type="date",
+                constraints=[],
+                quote=None,
+                tags=[],
+                _extra={},
+                granularity=None,
+            ),
+        }
 
-        assert expected_columns == str(my_model_columns)
+        assert expected_columns == my_model_columns
 
         # compiled fields aren't in the manifest above because it only has parsed fields
         manifest_json = get_artifact(project.project_root, "target", "manifest.json")

--- a/tests/functional/docs/test_good_docs_blocks.py
+++ b/tests/functional/docs/test_good_docs_blocks.py
@@ -84,7 +84,7 @@ class TestGoodDocsBlocks:
         model_data = manifest["nodes"]["model.test.model"]
 
         assert model_data["description"] == "My model is just a copy of the seed"
-        assert model_data["doc_blocks"] == [["doc", "my_model_doc"]]
+        assert model_data["doc_blocks"] == ["doc.test.my_model_doc"]
 
         assert {
             "name": "id",
@@ -95,7 +95,7 @@ class TestGoodDocsBlocks:
             "quote": None,
             "tags": [],
             "granularity": None,
-            "doc_blocks": [["doc", "my_model_doc__id"]],
+            "doc_blocks": ["doc.test.my_model_doc__id"],
         } == model_data["columns"]["id"]
 
         assert {
@@ -119,7 +119,7 @@ class TestGoodDocsBlocks:
             "quote": None,
             "tags": [],
             "granularity": None,
-            "doc_blocks": [["doc", "test", "my_model_doc__last_name"]],
+            "doc_blocks": ["doc.test.my_model_doc__last_name"],
         } == model_data["columns"]["last_name"]
 
         assert {
@@ -132,9 +132,8 @@ class TestGoodDocsBlocks:
             "tags": [],
             "granularity": None,
             "doc_blocks": [
-                ["doc", "my_model_doc__id"],
-                ["str", " The user's first name "],
-                ["doc", "test", "my_model_doc__last_name"],
+                "doc.test.my_model_doc__id",
+                "doc.test.my_model_doc__last_name",
             ],
         } == model_data["columns"]["tricky"]
 
@@ -168,7 +167,7 @@ class TestGoodDocsBlocksAltPath:
         model_data = manifest["nodes"]["model.test.model"]
 
         assert model_data["description"] == "Alt text about the model"
-        assert model_data["doc_blocks"] == [["doc", "my_model_doc"]]
+        assert model_data["doc_blocks"] == ["doc.test.my_model_doc"]
 
         assert {
             "name": "id",
@@ -179,7 +178,7 @@ class TestGoodDocsBlocksAltPath:
             "quote": None,
             "tags": [],
             "granularity": None,
-            "doc_blocks": [["doc", "my_model_doc__id"]],
+            "doc_blocks": ["doc.test.my_model_doc__id"],
         } == model_data["columns"]["id"]
 
         assert {
@@ -203,7 +202,7 @@ class TestGoodDocsBlocksAltPath:
             "quote": None,
             "tags": [],
             "granularity": None,
-            "doc_blocks": [["doc", "test", "my_model_doc__last_name"]],
+            "doc_blocks": ["doc.test.my_model_doc__last_name"],
         } == model_data["columns"]["last_name"]
 
         assert {
@@ -216,9 +215,8 @@ class TestGoodDocsBlocksAltPath:
             "tags": [],
             "granularity": None,
             "doc_blocks": [
-                ["doc", "my_model_doc__id"],
-                ["str", " The user's first name "],
-                ["doc", "test", "my_model_doc__last_name"],
+                "doc.test.my_model_doc__id",
+                "doc.test.my_model_doc__last_name",
             ],
         } == model_data["columns"]["tricky"]
 

--- a/tests/functional/docs/test_good_docs_blocks.py
+++ b/tests/functional/docs/test_good_docs_blocks.py
@@ -58,6 +58,8 @@ models:
         description: The user's first name
       - name: last_name
         description: "{{ doc('test', 'my_model_doc__last_name') }}"
+      - name: tricky
+        description: "{{ doc('my_model_doc__id') }} The user's first name {{ doc('test', 'my_model_doc__last_name') }}"
 """
 
 
@@ -82,6 +84,7 @@ class TestGoodDocsBlocks:
         model_data = manifest["nodes"]["model.test.model"]
 
         assert model_data["description"] == "My model is just a copy of the seed"
+        assert model_data["doc_blocks"] == [["doc", "my_model_doc"]]
 
         assert {
             "name": "id",
@@ -92,6 +95,7 @@ class TestGoodDocsBlocks:
             "quote": None,
             "tags": [],
             "granularity": None,
+            "doc_blocks": [["doc", "my_model_doc__id"]],
         } == model_data["columns"]["id"]
 
         assert {
@@ -103,6 +107,7 @@ class TestGoodDocsBlocks:
             "quote": None,
             "tags": [],
             "granularity": None,
+            "doc_blocks": [],
         } == model_data["columns"]["first_name"]
 
         assert {
@@ -114,9 +119,26 @@ class TestGoodDocsBlocks:
             "quote": None,
             "tags": [],
             "granularity": None,
+            "doc_blocks": [["doc", "test", "my_model_doc__last_name"]],
         } == model_data["columns"]["last_name"]
 
-        assert len(model_data["columns"]) == 3
+        assert {
+            "name": "tricky",
+            "description": "The user ID number The user's first name The user's last name",
+            "data_type": None,
+            "constraints": [],
+            "meta": {},
+            "quote": None,
+            "tags": [],
+            "granularity": None,
+            "doc_blocks": [
+                ["doc", "my_model_doc__id"],
+                ["str", " The user's first name "],
+                ["doc", "test", "my_model_doc__last_name"],
+            ],
+        } == model_data["columns"]["tricky"]
+
+        assert len(model_data["columns"]) == 4
 
 
 class TestGoodDocsBlocksAltPath:
@@ -146,6 +168,7 @@ class TestGoodDocsBlocksAltPath:
         model_data = manifest["nodes"]["model.test.model"]
 
         assert model_data["description"] == "Alt text about the model"
+        assert model_data["doc_blocks"] == [["doc", "my_model_doc"]]
 
         assert {
             "name": "id",
@@ -156,6 +179,7 @@ class TestGoodDocsBlocksAltPath:
             "quote": None,
             "tags": [],
             "granularity": None,
+            "doc_blocks": [["doc", "my_model_doc__id"]],
         } == model_data["columns"]["id"]
 
         assert {
@@ -167,6 +191,7 @@ class TestGoodDocsBlocksAltPath:
             "quote": None,
             "tags": [],
             "granularity": None,
+            "doc_blocks": [],
         } == model_data["columns"]["first_name"]
 
         assert {
@@ -178,6 +203,23 @@ class TestGoodDocsBlocksAltPath:
             "quote": None,
             "tags": [],
             "granularity": None,
+            "doc_blocks": [["doc", "test", "my_model_doc__last_name"]],
         } == model_data["columns"]["last_name"]
 
-        assert len(model_data["columns"]) == 3
+        assert {
+            "name": "tricky",
+            "description": "The user ID number with alternative text The user's first name The user's last name in this other file",
+            "data_type": None,
+            "constraints": [],
+            "meta": {},
+            "quote": None,
+            "tags": [],
+            "granularity": None,
+            "doc_blocks": [
+                ["doc", "my_model_doc__id"],
+                ["str", " The user's first name "],
+                ["doc", "test", "my_model_doc__last_name"],
+            ],
+        } == model_data["columns"]["tricky"]
+
+        assert len(model_data["columns"]) == 4

--- a/tests/unit/contracts/graph/test_manifest.py
+++ b/tests/unit/contracts/graph/test_manifest.py
@@ -82,6 +82,7 @@ REQUIRED_PARSED_NODE_KEYS = frozenset(
         "compiled_path",
         "patch_path",
         "docs",
+        "doc_blocks",
         "checksum",
         "unrendered_config",
         "unrendered_config_call_dict",

--- a/tests/unit/contracts/graph/test_nodes.py
+++ b/tests/unit/contracts/graph/test_nodes.py
@@ -209,6 +209,7 @@ def basic_compiled_dict():
         "config_call_dict": {},
         "access": "protected",
         "constraints": [],
+        "doc_blocks": [],
     }
 
 
@@ -529,6 +530,7 @@ def basic_compiled_schema_test_dict():
         },
         "unrendered_config_call_dict": {},
         "config_call_dict": {},
+        "doc_blocks": [],
     }
 
 

--- a/tests/unit/contracts/graph/test_nodes_parsed.py
+++ b/tests/unit/contracts/graph/test_nodes_parsed.py
@@ -207,6 +207,7 @@ def base_parsed_model_dict():
         "config_call_dict": {},
         "access": AccessType.Protected.value,
         "constraints": [],
+        "doc_blocks": [],
     }
 
 
@@ -315,6 +316,7 @@ def complex_parsed_model_dict():
                 "meta": {},
                 "tags": [],
                 "constraints": [],
+                "doc_blocks": [],
             },
         },
         "checksum": {
@@ -330,6 +332,7 @@ def complex_parsed_model_dict():
         "config_call_dict": {},
         "access": AccessType.Protected.value,
         "constraints": [],
+        "doc_blocks": [],
     }
 
 
@@ -538,6 +541,7 @@ def basic_parsed_seed_dict():
         "unrendered_config": {},
         "unrendered_config_call_dict": {},
         "config_call_dict": {},
+        "doc_blocks": [],
     }
 
 
@@ -632,6 +636,7 @@ def complex_parsed_seed_dict():
                 "meta": {},
                 "tags": [],
                 "constraints": [],
+                "doc_blocks": [],
             }
         },
         "meta": {"foo": 1000},
@@ -644,6 +649,7 @@ def complex_parsed_seed_dict():
         },
         "unrendered_config_call_dict": {},
         "config_call_dict": {},
+        "doc_blocks": [],
     }
 
 
@@ -844,6 +850,7 @@ def base_parsed_hook_dict():
         "unrendered_config": {},
         "unrendered_config_call_dict": {},
         "config_call_dict": {},
+        "doc_blocks": [],
     }
 
 
@@ -925,6 +932,7 @@ def complex_parsed_hook_dict():
                 "meta": {},
                 "tags": [],
                 "constraints": [],
+                "doc_blocks": [],
             },
         },
         "index": 13,
@@ -938,6 +946,7 @@ def complex_parsed_hook_dict():
         },
         "unrendered_config_call_dict": {},
         "config_call_dict": {},
+        "doc_blocks": [],
     }
 
 
@@ -1083,6 +1092,7 @@ def basic_parsed_schema_test_dict():
         "unrendered_config": {},
         "unrendered_config_call_dict": {},
         "config_call_dict": {},
+        "doc_blocks": [],
     }
 
 
@@ -1158,6 +1168,7 @@ def complex_parsed_schema_test_dict():
                 "meta": {},
                 "tags": [],
                 "constraints": [],
+                "doc_blocks": [],
             },
         },
         "column_name": "id",
@@ -1172,6 +1183,7 @@ def complex_parsed_schema_test_dict():
         "unrendered_config": {"materialized": "table", "severity": "WARN"},
         "unrendered_config_call_dict": {},
         "config_call_dict": {},
+        "doc_blocks": [],
     }
 
 
@@ -1567,6 +1579,7 @@ def basic_timestamp_snapshot_dict():
         },
         "unrendered_config_call_dict": {},
         "config_call_dict": {},
+        "doc_blocks": [],
     }
 
 
@@ -1672,6 +1685,7 @@ def basic_check_snapshot_dict():
         },
         "unrendered_config_call_dict": {},
         "config_call_dict": {},
+        "doc_blocks": [],
     }
 
 

--- a/tests/unit/contracts/graph/test_nodes_parsed.py
+++ b/tests/unit/contracts/graph/test_nodes_parsed.py
@@ -1895,6 +1895,7 @@ def basic_parsed_source_definition_dict():
             "enabled": True,
         },
         "unrendered_config": {},
+        "doc_blocks": [],
     }
 
 
@@ -1927,6 +1928,7 @@ def complex_parsed_source_definition_dict():
         "freshness": {"warn_after": {"period": "hour", "count": 1}, "error_after": {}},
         "loaded_at_field": "loaded_at",
         "unrendered_config": {},
+        "doc_blocks": [],
     }
 
 


### PR DESCRIPTION
Resolves #11000 
Resolves #11001 

### Problem

`doc_blocks` are not listed for node/column descriptions, so it's not possible to know if a description was created via literal or via doc block.

### Solution

Add a new field `doc_blocks` for node and column descriptions that is present in the manifest.

`doc_blocks` is a list of unique IDs that can be accessed like so:

```
for uid in doc_blocks:
   doc_block = manifest.docs[uid]
```

I'll also update `schemas.getdbt.com` once this PR is approved to fix schema check errors below.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
