### PR TITLE
ADAP-1183: Use the new location for dbt-postgres

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,7 +32,7 @@ This is the docs website code. It comes from the dbt-docs repository, and is gen
 ## Adapters
 
 dbt uses an adapter-plugin pattern to extend support to different databases, warehouses, query engines, etc. 
-Note: dbt-postgres used to exist in dbt-core but is now in [its own repo](https://github.com/dbt-labs/dbt-postgres) 
+Note: dbt-postgres used to exist in dbt-core but is now in [a separate repo](https://github.com/dbt-labs/dbt-adapters/dbt-postgres) 
 
 Each adapter is a mix of python, Jinja2, and SQL. The adapter code also makes heavy use of Jinja2 to wrap modular chunks of SQL functionality, define default implementations, and allow plugins to override it.
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/dbt-labs/dbt-adapters.git@main
 git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git@main
-git+https://github.com/dbt-labs/dbt-postgres.git@main
+git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-postgres
 # black must match what's in .pre-commit-config.yaml to be sure local env matches CI
 black==24.3.0
 bumpversion

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,7 +7,7 @@ This Dockerfile can create images for the following targets, each named after th
 * `dbt-core` _(no db-adapter support)_
 * `dbt-third-party` _(requires additional build-arg)_
 
-For platform-specific images, please refer to that platform's repository (eg. `dbt-labs/dbt-postgres`)
+For platform-specific images, please refer to that platform's repository (eg. `dbt-labs/dbt-adapters/dbt-postgres`)
 
 In order to build a new image, run the following docker command.
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,7 +7,7 @@ This Dockerfile can create images for the following targets, each named after th
 * `dbt-core` _(no db-adapter support)_
 * `dbt-third-party` _(requires additional build-arg)_
 
-For platform-specific images, please refer to that platform's repository (eg. `dbt-labs/dbt-adapters/dbt-postgres`)
+For platform-specific images, please refer to that platform's repository (eg. [dbt-postgres](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-postgres/docker/README.md))
 
 In order to build a new image, run the following docker command.
 ```


### PR DESCRIPTION
### Problem

dbt-postgres is moving to dbt-adapters.  

### Solution

Change links.

blocked on https://github.com/dbt-labs/dbt-adapters/pull/615

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
