### PR TITLE
[TIDY FIRST] Click option defintiion organization (alphabetization)

### DIFF
--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -7,6 +7,18 @@ from dbt.cli.options import MultiOption
 from dbt.cli.resolvers import default_profiles_dir, default_project_dir
 from dbt.version import get_version_information
 
+# --- shared option specs --- #
+model_decls = ("-m", "--models", "--model")
+select_decls = ("-s", "--select")
+select_attrs = {
+    "envvar": None,
+    "help": "Specify the nodes to include.",
+    "cls": MultiOption,
+    "multiple": True,
+    "type": tuple,
+}
+
+# --- The actual option definitions --- #
 add_package = click.option(
     "--add-package",
     help="Add a package to current package spec, specify it as package-name@version. Change the source with --source flag.",
@@ -341,6 +353,8 @@ macro_debugging = click.option(
     hidden=True,
 )
 
+models = click.option(*model_decls, **select_attrs)  # type: ignore[arg-type]
+
 # This less standard usage of --output where output_path below is more standard
 output = click.option(
     "--output",
@@ -466,6 +480,8 @@ quiet = click.option(
     help="Suppress all non-error logging to stdout. Does not affect {{ print() }} macro calls.",
 )
 
+raw_select = click.option(*select_decls, **select_attrs)  # type: ignore[arg-type]
+
 record_timing_info = click.option(
     "--record-timing-info",
     "-r",
@@ -502,22 +518,10 @@ resource_type = click.option(
     default=(),
 )
 
-model_decls = ("-m", "--models", "--model")
-select_decls = ("-s", "--select")
-select_attrs = {
-    "envvar": None,
-    "help": "Specify the nodes to include.",
-    "cls": MultiOption,
-    "multiple": True,
-    "type": tuple,
-}
-
 # `--select` and `--models` are analogous for most commands except `dbt list` for legacy reasons.
 # Most CLI arguments should use the combined `select` option that aliases `--models` to `--select`.
 # However, if you need to split out these separators (like `dbt ls`), use the `models` and `raw_select` options instead.
 # See https://github.com/dbt-labs/dbt-core/pull/6774#issuecomment-1408476095 for more info.
-models = click.option(*model_decls, **select_attrs)  # type: ignore[arg-type]
-raw_select = click.option(*select_decls, **select_attrs)  # type: ignore[arg-type]
 select = click.option(*select_decls, *model_decls, **select_attrs)  # type: ignore[arg-type]
 
 selector = click.option(


### PR DESCRIPTION
Resolves #N/A because it's a tidy first

### Problem

The organization of click option definitions in `cli/params.py` was a weird mixture of some alphabetization, new options getting added to the EOF, and grouping by feature. This mean the only way to find an option was to do a text search which was annoying. It also made it confusing as to where a _new_ option should get added. Alphabetically? To the end of the file? Was there some similar option that the new option should be "near"?

### Solution

Alphabetize the click option definitions.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
