### PR TITLE
[Backport 1.8.latest] ADAP-1135: Point to the `dbt-adapters` subdirectory for tests post-monorepo migration

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # These point to main to catch any regressions before they are released to OSS
-git+https://github.com/dbt-labs/dbt-adapters.git@main
+git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-adapters
 git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git@main
 git+https://github.com/dbt-labs/dbt-postgres.git@main


### PR DESCRIPTION
Backport 48d9afa677eee6dcc1bbab6b6e9fa654fdf862b6 from #11244.