### PR TITLE
Support both `yaml` and `yml` file extension for project config files

### DIFF
--- a/.changes/unreleased/Features-20250131-164002.yaml
+++ b/.changes/unreleased/Features-20250131-164002.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support both yaml and yml file extension for project config files
+time: 2025-01-31T16:40:02.049453+11:00
+custom:
+    Author: morgan-dgk
+    Issue: '#5002 #8738'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: ^(core/dbt/docs/build/|core/dbt/common/events/types_pb2.py|core/dbt/eve
 
 # Force all unspecified python hooks to run python 3.9
 default_language_version:
-  python: python3
+  python: python3.9
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/core/dbt/clients/yaml_helper.py
+++ b/core/dbt/clients/yaml_helper.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Dict, Optional
 
 import yaml
@@ -66,3 +67,12 @@ def load_yaml_text(contents, path=None):
             error = str(e)
 
         raise dbt_common.exceptions.base.DbtValidationError(error)
+
+
+def get_yaml_path(path: str) -> str:
+    if os.path.exists("{}.yml".format(path)):
+        return path + ".yml"
+    elif os.path.exists("{}.yaml".format(path)):
+        return path + ".yaml"
+    else:
+        return ""

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
 
 from dbt.adapters.contracts.connection import Credentials, HasCredentials
-from dbt.clients.yaml_helper import load_yaml_text
+from dbt.clients.yaml_helper import get_yaml_path, load_yaml_text
 from dbt.contracts.project import ProfileConfig
 from dbt.events.types import MissingProfileTarget
 from dbt.exceptions import (
@@ -31,7 +31,7 @@ dbt encountered an error while trying to read your profiles.yml file.
 
 
 def read_profile(profiles_dir: str) -> Dict[str, Any]:
-    path = os.path.join(profiles_dir, "profiles.yml")
+    path = get_yaml_path(os.path.join(profiles_dir, "profiles"))
 
     contents = None
     if os.path.isfile(path):

--- a/core/dbt/constants.py
+++ b/core/dbt/constants.py
@@ -11,8 +11,8 @@ PIN_PACKAGE_URL = (
     "https://docs.getdbt.com/docs/package-management#section-specifying-package-versions"
 )
 
-DBT_PROJECT_FILE_NAME = "dbt_project.yml"
-PACKAGES_FILE_NAME = "packages.yml"
+DBT_PROJECT_FILE_NAME = "dbt_project"
+PACKAGES_FILE_NAME = "packages"
 DEPENDENCIES_FILE_NAME = "dependencies.yml"
 PACKAGE_LOCK_FILE_NAME = "package-lock.yml"
 MANIFEST_FILE_NAME = "manifest.json"

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -21,6 +21,7 @@ from dbt.artifacts.schemas.results import (
 )
 from dbt.artifacts.schemas.run import RunResult
 from dbt.cli.flags import Flags
+from dbt.clients.yaml_helper import get_yaml_path
 from dbt.compilation import Compiler
 from dbt.config import RuntimeConfig
 from dbt.config.profile import read_profile
@@ -88,6 +89,7 @@ def get_nearest_project_dir(project_dir: Optional[str]) -> Path:
     if project_dir:
         cur_dir = Path(project_dir)
         project_file = Path(project_dir) / DBT_PROJECT_FILE_NAME
+        project_file = Path(get_yaml_path(str(project_file)))
         if project_file.is_file():
             return cur_dir
         else:


### PR DESCRIPTION
Resolves #5002, #8738
<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

From relevant [faq](https://docs.getdbt.com/faqs/Project/yaml-file-extension):

> At present, dbt will only search for files with a .yml file extension. In a future release of dbt, dbt will also search for files with a .yaml file extension

This behaviour is potentially confusing to new users and runs against the official recommendations in the yaml [faq](https://yaml.org/faq.html). I was certainly confused by this when I first started working with dbt and ran into errors finding dbt project configuration fils such as `profiles.yaml` and `dbt_project.yaml`.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Failing tests are currently due to hardcoded file names in assertions where tests are expected to fail.

This PR introduces a new helper function `get_yaml_path` in the `yaml_helper` module. Given the path to a stem (i.e the path to a yaml file without any extension), this function attempts to finding a matching yaml file ending in either of the accepted extensions, i.e. `.yml` or `.yaml`. If no match is found, an empty string is returned.

So as to minimise the changes required to existing code, I also removed the `.yml` extension from the relevant constants in the `dbt/constants` module. 

I initially considered implementing this somewhere in `dbt_common` following previous guidance provided on #5002 but the structure of the project appears to have changed since those comments were made. Additionally, there is some variance in how paths to config files are resolved.

For example, some project file paths are defined as [constants](https://github.com/dbt-labs/dbt-core/blob/0bf38ce294e21c6e4056ed36ba8f35538c10604a/core/dbt/constants.py#L14-L16) whereas `profiles.yml` is passed directly as a string to `os.path.join` in [`profiles.yml`](https://github.com/dbt-labs/dbt-core/blob/0bf38ce294e21c6e4056ed36ba8f35538c10604a/core/dbt/config/profile.py#L34). In the majority of cases, the path to project files appears to be passed around as a string, but in [`tasks/base.py`](https://github.com/dbt-labs/dbt-core/blob/fdabe9534ca07464243a566ec760668f157a8783/core/dbt/task/base.py#L90C9-L90C65).

Using the new helper function as a wrapper to existing calls to resolve the path for relevant config files seemed the least likely to break existing behaviour. 

See also comments on #5002.

2e938d729d0b7d99cc001f52c36078ef3118779a is an unrelated change, but I could not get pre-commit hooks to work correctly without this change. I believe the underlying issue relates to changes in `metadata` lib in python 3.12 

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ x ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ x ] I have run this code in development, and it appears to resolve the stated issue.
- [    ] This PR includes tests, or tests are not required or relevant for this PR.
- [ x ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ x ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
