### PR TITLE
add ephemeral as valid option to is_incremental()

### DIFF
--- a/.changes/unreleased/Features-20250206-152955.yaml
+++ b/.changes/unreleased/Features-20250206-152955.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Allows pass through is is_incremental function to pass through to ephemeral models"
+time: 2025-02-06T15:29:55.182223-06:00
+custom:
+    Author: michael-urrutia
+    Issue: na

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -675,7 +675,7 @@ class MicrobatchModelRunner(ModelRunner):
         if (
             relation is not None
             and relation.type == "table"
-            and model.config.materialized == "incremental"
+            and model.config.materialized in ["incremental","ephemeral"]
         ):
             if model.config.full_refresh is not None:
                 return not model.config.full_refresh


### PR DESCRIPTION
### Resolves
* Efficiently leveraging ephemeral models in build of incremental models

### Problem

When modeling complex data, ephemeral models make it easy to separate chunks of code for ease of maintainability, as well as readability of the downstream production model. If the downstream production model is incremental, it is important to be able to leverage `is_incremental()` in upstream ephemeral models. Currently this is not possible given the model materialization is not being considered

### Solution

Add the materialization type of `ephemeral` to the definition of the `is_incremental()` function

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
