### PR TITLE
Update ShowTaskDirect to correctly handle --limit -1

### DIFF
--- a/.changes/unreleased/Fixes-20250207-131424.yaml
+++ b/.changes/unreleased/Fixes-20250207-131424.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Handle `--limit -1` properly in `ShowTaskDirect` so that it propagates None instead of a negative int
+time: 2025-02-07T13:14:24.725503-05:00
+custom:
+    Author: WilliamDee
+    Issue: None

--- a/core/dbt/task/show.py
+++ b/core/dbt/task/show.py
@@ -128,9 +128,8 @@ class ShowTaskDirect(ConfiguredTask):
     def run(self):
         adapter = get_adapter(self.config)
         with adapter.connection_named("show", should_release_connection=False):
-            response, table = adapter.execute(
-                self.args.inline_direct, fetch=True, limit=self.args.limit
-            )
+            limit = None if self.args.limit < 0 else self.args.limit
+            response, table = adapter.execute(self.args.inline_direct, fetch=True, limit=limit)
 
             output = io.StringIO()
             if self.args.output == "json":

--- a/tests/functional/show/test_show.py
+++ b/tests/functional/show/test_show.py
@@ -181,6 +181,16 @@ class TestShowInlineDirect(ShowBase):
         # See prior test for explanation of why this is here
         run_dbt(["seed"])
 
+    def test_inline_direct_pass_no_limit(self, project):
+        query = f"select * from {project.test_schema}.sample_seed"
+        (_, log_output) = run_dbt_and_capture(["show", "--inline-direct", query, "--limit", -1])
+        assert "Previewing inline node" in log_output
+        assert "sample_num" in log_output
+        assert "sample_bool" in log_output
+
+        # See prior test for explanation of why this is here
+        run_dbt(["seed"])
+
 
 class TestShowInlineDirectFail(ShowBase):
 


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem
In dbt show, if we don't pass --limit it defaults to 5 and renders LIMIT 5 at the end of the SQL. You can get around it by adding --limit -1 so that it doesn't render the LIMIT. However, it seems like that only works for --inline and if you try doing dbt show --inline-direct <> --limit -1 it errors with an adapter error showing cannot limit by a negative row number for certain adapters. In the `ShowRunner` we handle this case by `limit = None if self.config.args.limit < 0 else self.config.args.limit`, but this isn't the case for `ShowTaskDirect`.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
update `ShowTaskDirect` so that the limit gets set to `None` if it's a negative int when passed to the adapter.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
