### PR TITLE
Fix default_profiles_dir

### DIFF
--- a/.changes/unreleased/Fixes-20250210-000107.yaml
+++ b/.changes/unreleased/Fixes-20250210-000107.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Error occurs if default_profiles_dir does not exist
+time: 2025-02-10T00:01:07.477255+09:00
+custom:
+    Author: tnk-ysk
+    Issue: "11286"

--- a/.changes/unreleased/Fixes-20250210-000107.yaml
+++ b/.changes/unreleased/Fixes-20250210-000107.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: Error occurs if default_profiles_dir does not exist
+body: Fallback to current working directory (CWD) for `profiles_dir` if `profiles.yml` not found in CWD and `$HOME/.dbt`
 time: 2025-02-10T00:01:07.477255+09:00
 custom:
     Author: tnk-ysk

--- a/core/dbt/cli/resolvers.py
+++ b/core/dbt/cli/resolvers.py
@@ -10,7 +10,8 @@ def default_project_dir() -> Path:
 
 
 def default_profiles_dir() -> Path:
-    return Path.cwd() if (Path.cwd() / "profiles.yml").exists() else Path.home() / ".dbt"
+    paths = [Path.cwd(), Path.home() / ".dbt"]
+    return next((x for x in paths if (x / "profiles.yml").exists()), Path.cwd())
 
 
 def default_log_path(project_dir: Path, verify_version: bool = False) -> Path:


### PR DESCRIPTION
Resolves #11286

### Problem
Avoid error if [`default_profiles_dir`](https://github.com/dbt-labs/dbt-core/blob/300aa09fc562fef6dade08cc5cd7297d636efa3f/core/dbt/cli/resolvers.py#L13) does not exist if profiles_dir is specified.

### Solution
Check current directory and home/.dbt and use current directory if profiles.yml was not present in either.
This allows to avoid [`click.Path(exists=True)`](https://github.com/dbt-labs/dbt-core/blob/300aa09fc562fef6dade08cc5cd7297d636efa3f/core/dbt/cli/params.py#L460) in default_profiles_dir if profiles_dir is specified.

This solution is similar to [`default_project_dir`](https://github.com/dbt-labs/dbt-core/blob/300aa09fc562fef6dade08cc5cd7297d636efa3f/core/dbt/cli/resolvers.py#L7).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
