### PR TITLE
Combine `--sample` and `--sample-window` into one CLI param

### DIFF
--- a/.changes/unreleased/Features-20250212-155658.yaml
+++ b/.changes/unreleased/Features-20250212-155658.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Combine `--sample` and `--sample-window` CLI params
+time: 2025-02-12T15:56:58.546879-06:00
+custom:
+  Author: QMalcolm
+  Issue: "11299"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -556,7 +556,6 @@ def parse(ctx, **kwargs):
 @p.event_time_start
 @p.event_time_end
 @p.sample
-@p.sample_window
 @p.select
 @p.selector
 @p.target_path

--- a/core/dbt/cli/option_types.py
+++ b/core/dbt/cli/option_types.py
@@ -94,8 +94,8 @@ class ChoiceTuple(Choice):
         return value
 
 
-class SampleWindowType(ParamType):
-    name = "SAMPLE_WINDOW"
+class SampleType(ParamType):
+    name = "SAMPLE"
 
     def convert(
         self, value, param: Optional[Parameter], ctx: Optional[Context]

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -6,7 +6,7 @@ from dbt.cli.option_types import (
     YAML,
     ChoiceTuple,
     Package,
-    SampleWindowType,
+    SampleType,
     WarnErrorOptionsType,
 )
 from dbt.cli.options import MultiOption
@@ -525,20 +525,11 @@ resource_type = click.option(
 )
 
 sample = click.option(
-    "--sample/--no-sample",
+    "--sample",
     envvar="DBT_SAMPLE",
-    help="Run in sample mode, creating only samples of models where possible",
-    default=False,
-    is_flag=True,
-    hidden=True,  # TODO: Unhide
-)
-
-sample_window = click.option(
-    "--sample-window",
-    envvar="DBT_SAMPLE_WINDOW",
-    help="The time window to use with sample mode. Example: '3 days'.",
+    help="Run in sample mode with given SAMPLE_WINDOW spec, such that ref/source calls are sampled by the sample window.",
     default=None,
-    type=SampleWindowType(),
+    type=SampleType(),
     hidden=True,  # TODO: Unhide
 )
 

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -239,8 +239,7 @@ class BaseResolver(metaclass=abc.ABCMeta):
         event_time_filter = None
         sample_mode = bool(
             os.environ.get("DBT_EXPERIMENTAL_SAMPLE_MODE")
-            and getattr(self.config.args, "sample", False)
-            and getattr(self.config.args, "sample_window", None)
+            and getattr(self.config.args, "sample", None)
         )
 
         # TODO The number of branches here is getting rough. We should consider ways to simplify
@@ -263,13 +262,13 @@ class BaseResolver(metaclass=abc.ABCMeta):
                 # Sample mode microbatch models
                 if sample_mode:
                     start = (
-                        self.config.args.sample_window.start
-                        if self.config.args.sample_window.start > self.model.batch.event_time_start
+                        self.config.args.sample.start
+                        if self.config.args.sample.start > self.model.batch.event_time_start
                         else self.model.batch.event_time_start
                     )
                     end = (
-                        self.config.args.sample_window.end
-                        if self.config.args.sample_window.end < self.model.batch.event_time_end
+                        self.config.args.sample.end
+                        if self.config.args.sample.end < self.model.batch.event_time_end
                         else self.model.batch.event_time_end
                     )
                     event_time_filter = EventTimeFilter(
@@ -290,8 +289,8 @@ class BaseResolver(metaclass=abc.ABCMeta):
             elif sample_mode:
                 event_time_filter = EventTimeFilter(
                     field_name=target.config.event_time,
-                    start=self.config.args.sample_window.start,
-                    end=self.config.args.sample_window.end,
+                    start=self.config.args.sample.start,
+                    end=self.config.args.sample.end,
                 )
 
         return event_time_filter

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -561,13 +561,11 @@ class MicrobatchModelRunner(ModelRunner):
         event_time_start = getattr(self.config.args, "EVENT_TIME_START", None)
         event_time_end = getattr(self.config.args, "EVENT_TIME_END", None)
 
-        if (
-            os.environ.get("DBT_EXPERIMENTAL_SAMPLE_MODE")
-            and getattr(self.config.args, "SAMPLE", None)
-            and getattr(self.config.args, "SAMPLE_WINDOW", None)
+        if os.environ.get("DBT_EXPERIMENTAL_SAMPLE_MODE") and getattr(
+            self.config.args, "SAMPLE", None
         ):
-            event_time_start = self.config.args.sample_window.start
-            event_time_end = self.config.args.sample_window.end
+            event_time_start = self.config.args.sample.start
+            event_time_end = self.config.args.sample.end
 
         microbatch_builder = MicrobatchBuilder(
             model=model,

--- a/tests/unit/cli/test_option_types.py
+++ b/tests/unit/cli/test_option_types.py
@@ -6,7 +6,7 @@ import pytest
 import pytz
 from click import BadParameter, Option
 
-from dbt.cli.option_types import YAML, SampleWindowType
+from dbt.cli.option_types import YAML, SampleType
 from dbt.event_time.sample_window import SampleWindow
 
 
@@ -32,7 +32,7 @@ class TestYAML:
         assert "--vars" in e.value.format_message()
 
 
-class TestSampleWindowType:
+class TestSampleType:
     @pytest.mark.parametrize(
         "input,expected_result",
         [
@@ -61,7 +61,7 @@ class TestSampleWindowType:
     )
     def test_convert(self, input: str, expected_result: Union[SampleWindow, Exception]):
         try:
-            result = SampleWindowType().convert(input, Option(["--sample-window"]), None)
+            result = SampleType().convert(input, Option(["--sample"]), None)
             assert result == expected_result
         except Exception as e:
             assert str(e) == str(expected_result)
@@ -76,5 +76,5 @@ class TestSampleWindowType:
             start=datetime(2025, 1, 25, 2, 3, 0, 0, pytz.UTC),
             end=datetime(2025, 1, 28, 2, 3, 0, 0, pytz.UTC),
         )
-        result = SampleWindowType().convert(input, Option(["--sample-window"]), None)
+        result = SampleType().convert(input, Option(["--sample"]), None)
         assert result == expected_result

--- a/tests/unit/context/test_providers.py
+++ b/tests/unit/context/test_providers.py
@@ -46,7 +46,7 @@ class TestBaseResolver:
         assert resolver.resolve_limit == expected_resolve_limit
 
     @pytest.mark.parametrize(
-        "use_microbatch_batches,materialized,incremental_strategy,sample_mode_available,run_sample_mode,sample_window,resolver_model_node,expect_filter",
+        "use_microbatch_batches,materialized,incremental_strategy,sample_mode_available,sample,resolver_model_node,expect_filter",
         [
             # Microbatch model without sample
             (
@@ -54,7 +54,6 @@ class TestBaseResolver:
                 "incremental",
                 "microbatch",
                 True,
-                False,
                 None,
                 True,
                 True,
@@ -64,7 +63,6 @@ class TestBaseResolver:
                 True,
                 "incremental",
                 "microbatch",
-                True,
                 True,
                 SampleWindow(
                     start=datetime(2024, 1, 1, tzinfo=pytz.UTC),
@@ -79,7 +77,6 @@ class TestBaseResolver:
                 "table",
                 None,
                 True,
-                True,
                 SampleWindow(
                     start=datetime(2024, 1, 1, tzinfo=pytz.UTC),
                     end=datetime(2025, 1, 1, tzinfo=pytz.UTC),
@@ -92,7 +89,6 @@ class TestBaseResolver:
                 True,
                 "incremental",
                 "merge",
-                True,
                 True,
                 SampleWindow(
                     start=datetime(2024, 1, 1, tzinfo=pytz.UTC),
@@ -107,7 +103,6 @@ class TestBaseResolver:
                 "table",
                 None,
                 False,
-                True,
                 SampleWindow(
                     start=datetime(2024, 1, 1, tzinfo=pytz.UTC),
                     end=datetime(2025, 1, 1, tzinfo=pytz.UTC),
@@ -120,7 +115,6 @@ class TestBaseResolver:
                 False,
                 "table",
                 None,
-                True,
                 True,
                 SampleWindow(
                     start=datetime(2024, 1, 1, tzinfo=pytz.UTC),
@@ -135,7 +129,6 @@ class TestBaseResolver:
                 "incremental",
                 "microbatch",
                 False,
-                False,
                 None,
                 False,
                 False,
@@ -145,7 +138,6 @@ class TestBaseResolver:
                 False,
                 "incremental",
                 "microbatch",
-                False,
                 False,
                 None,
                 True,
@@ -157,13 +149,12 @@ class TestBaseResolver:
                 "table",
                 "microbatch",
                 False,
-                False,
                 None,
                 True,
                 False,
             ),
             # Incremental merge
-            (True, "incremental", "merge", False, False, None, True, False),
+            (True, "incremental", "merge", False, None, True, False),
         ],
     )
     def test_resolve_event_time_filter(
@@ -174,8 +165,7 @@ class TestBaseResolver:
         materialized: str,
         incremental_strategy: Optional[str],
         sample_mode_available: bool,
-        run_sample_mode: bool,
-        sample_window: Optional[SampleWindow],
+        sample: Optional[SampleWindow],
         resolver_model_node: bool,
         expect_filter: bool,
     ) -> None:
@@ -191,8 +181,7 @@ class TestBaseResolver:
         # Resolver mocking
         resolver.config.args.EVENT_TIME_END = None
         resolver.config.args.EVENT_TIME_START = None
-        resolver.config.args.sample = run_sample_mode
-        resolver.config.args.sample_window = sample_window
+        resolver.config.args.sample = sample
         if resolver_model_node:
             resolver.model = mock.MagicMock(spec=ModelNode)
         resolver.model.batch = BatchContext(


### PR DESCRIPTION
Resolves #11299

### Problem

We had two CLI params from sample mode `--sample` and `--sample-window`. These were fairly duplicative. Although there was some benefit to having the separated, it created an undesirable experience

### Solution

Collapse `--sample-window` into `--sample`.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
