### PR TITLE
Ability to sample seeds

### DIFF
--- a/.changes/unreleased/Features-20250212-173743.yaml
+++ b/.changes/unreleased/Features-20250212-173743.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Allow for sampling of ref'd seeds
+time: 2025-02-12T17:37:43.554156-06:00
+custom:
+  Author: QMalcolm
+  Issue: "11300"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -28,7 +28,13 @@ from dbt.adapters.factory import (
     get_adapter_package_names,
     get_adapter_type_names,
 )
-from dbt.artifacts.resources import NodeConfig, NodeVersion, RefArgs, SourceConfig
+from dbt.artifacts.resources import (
+    NodeConfig,
+    NodeVersion,
+    RefArgs,
+    SeedConfig,
+    SourceConfig,
+)
 from dbt.clients.jinja import (
     MacroGenerator,
     MacroStack,
@@ -247,7 +253,11 @@ class BaseResolver(metaclass=abc.ABCMeta):
 
         # Only do event time filtering if the base node has the necessary event time configs
         if (
-            (isinstance(target.config, NodeConfig) or isinstance(target.config, SourceConfig))
+            (
+                isinstance(target.config, NodeConfig)
+                or isinstance(target.config, SourceConfig)
+                or isinstance(target.config, SeedConfig)
+            )
             and target.config.event_time
             and isinstance(self.model, ModelNode)
         ):

--- a/tests/functional/sample_mode/test_sample_mode.py
+++ b/tests/functional/sample_mode/test_sample_mode.py
@@ -49,6 +49,8 @@ seeds:
     - name: input_seed
       config:
         event_time: event_time
+        column_types:
+            event_time: timestamp
 """
 
 sample_mode_model_sql = """

--- a/tests/functional/sample_mode/test_sample_mode.py
+++ b/tests/functional/sample_mode/test_sample_mode.py
@@ -38,6 +38,19 @@ UNION ALL
 select 6 as id, TIMESTAMP '2025-01-06 12:32:00-0' as event_time
 """
 
+input_seed_csv = """id,event_time
+1,'2020-01-01 01:25:00-0'
+2,'2025-01-02 13:47:00-0'
+3,'2025-01-03 01:32:00-0'
+"""
+
+seed_properties_yml = """
+seeds:
+    - name: input_seed
+      config:
+        event_time: event_time
+"""
+
 sample_mode_model_sql = """
 {{ config(materialized='table', event_time='event_time') }}
 
@@ -46,6 +59,12 @@ sample_mode_model_sql = """
 {% endif %}
 
 SELECT * FROM {{ ref("input_model") }}
+"""
+
+sample_input_seed_sql = """
+{{ config(materialized='table') }}
+
+SELECT * FROM {{ ref("input_seed") }}
 """
 
 sample_microbatch_model_sql = """
@@ -367,4 +386,52 @@ class TestIncrementalModelSampleModeSpecific(BaseSampleMode):
             project=project,
             relation_name="sample_incremental_merge",
             expected_row_count=expected_rows,
+        )
+
+
+class TestSampleSeedRefs(BaseSampleMode):
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "input_seed.csv": input_seed_csv,
+            "properties.yml": seed_properties_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "sample_input_seed.sql": sample_input_seed_sql,
+        }
+
+    @pytest.mark.parametrize(
+        "sample_mode_available,run_sample_mode,expected_row_count",
+        [
+            (True, True, 2),
+            (True, False, 3),
+            (False, True, 3),
+            (False, False, 3),
+        ],
+    )
+    @freezegun.freeze_time("2025-01-03T02:03:0Z")
+    def test_sample_mode(
+        self,
+        project,
+        mocker: MockerFixture,
+        sample_mode_available: bool,
+        run_sample_mode: bool,
+        expected_row_count: int,
+    ):
+        run_args = ["run"]
+        if run_sample_mode:
+            run_args.append("--sample=1 day")
+
+        if sample_mode_available:
+            mocker.patch.dict(os.environ, {"DBT_EXPERIMENTAL_SAMPLE_MODE": "1"})
+
+        _ = run_dbt(["seed"])
+        _ = run_dbt(run_args)
+        self.assert_row_count(
+            project=project,
+            relation_name="sample_input_seed",
+            expected_row_count=expected_row_count,
         )


### PR DESCRIPTION
Resolves #11300 

### Problem

Refs of seeds couldn't be sampled

### Solution

Allow for sampling of ref'd seeds

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
