### PR TITLE
Allow for running `sample mode` with `build` command

### DIFF
--- a/.changes/unreleased/Features-20250213-182932.yaml
+++ b/.changes/unreleased/Features-20250213-182932.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Enable sample mode for 'build' command
+time: 2025-02-13T18:29:32.238857-06:00
+custom:
+  Author: QMalcolm
+  Issue: "11298"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -179,6 +179,7 @@ def cli(ctx, **kwargs):
 @p.project_dir
 @p.resource_type
 @p.exclude_resource_type
+@p.sample
 @p.select
 @p.selector
 @p.show

--- a/tests/functional/sample_mode/test_sample_mode.py
+++ b/tests/functional/sample_mode/test_sample_mode.py
@@ -122,12 +122,14 @@ class TestBasicSampleMode(BaseSampleMode):
         return EventCatcher(event_to_catch=JinjaLogInfo)  # type: ignore
 
     @pytest.mark.parametrize(
-        "sample_mode_available,run_sample_mode,expected_row_count",
+        "dbt_command,sample_mode_available,run_sample_mode,expected_row_count",
         [
-            (True, True, 2),
-            (True, False, 3),
-            (False, True, 3),
-            (False, False, 3),
+            ("run", True, True, 2),
+            ("run", True, False, 3),
+            ("run", False, True, 3),
+            ("run", False, False, 3),
+            ("build", True, True, 2),
+            ("build", False, True, 3),
         ],
     )
     @freezegun.freeze_time("2025-01-03T02:03:0Z")
@@ -136,11 +138,12 @@ class TestBasicSampleMode(BaseSampleMode):
         project,
         mocker: MockerFixture,
         event_catcher: EventCatcher,
+        dbt_command: str,
         sample_mode_available: bool,
         run_sample_mode: bool,
         expected_row_count: int,
     ):
-        run_args = ["run"]
+        run_args = [dbt_command]
         expected_sample = None
         if run_sample_mode:
             run_args.append("--sample=1 day")


### PR DESCRIPTION
Resolves #11298

### Problem

Sample mode could only be run with `run` command, we want to also use it with `build` command

### Solution

Allow for specification of `--sample=SAMPLE_SPEC` on `build` command

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
