### PR TITLE
Add secondary_profiles to `profile.py`

### DIFF
--- a/.changes/unreleased/Under the Hood-20250214-123853.yaml
+++ b/.changes/unreleased/Under the Hood-20250214-123853.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add secondary profiles to profile.py
+time: 2025-02-14T12:38:53.964266Z
+custom:
+    Author: aranke
+    Issue: XPLAT-241

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -1,6 +1,8 @@
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Self, Tuple
+from typing import Any, Dict, Optional, Tuple
+
+from typing_extensions import Self
 
 from dbt.adapters.contracts.connection import Credentials, HasCredentials
 from dbt.clients.yaml_helper import load_yaml_text

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -324,11 +324,10 @@ defined in your profiles.yml file. You can find profiles.yml here:
             raw_profile, profile_name, target_override, renderer, is_secondary=is_secondary
         )
 
-        if is_secondary:
-            if "secondary_profiles" in profile_data:
-                raise DbtProfileError(
-                    f"Secondary profile '{profile_name}' cannot have nested secondary profiles"
-                )
+        if is_secondary and "secondary_profiles" in profile_data:
+            raise DbtProfileError(
+                f"Secondary profile '{profile_name}' cannot have nested secondary profiles"
+            )
 
         # valid connections never include the number of threads, but it's
         # stored on a per-connection level in the raw configs

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -2,8 +2,6 @@ import os
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
 
-from typing_extensions import Self
-
 from dbt.adapters.contracts.connection import Credentials, HasCredentials
 from dbt.clients.yaml_helper import load_yaml_text
 from dbt.contracts.project import ProfileConfig
@@ -62,7 +60,7 @@ class Profile(HasCredentials):
     credentials: Credentials
     profile_env_vars: Dict[str, Any]
     log_cache_events: bool
-    secondary_profiles: Dict[str, Self]
+    secondary_profiles: Dict[str, "Profile"]
 
     def __init__(
         self,
@@ -233,7 +231,7 @@ defined in your profiles.yml file. You can find profiles.yml here:
         threads: int,
         profile_name: str,
         target_name: str,
-    ) -> Self:
+    ) -> "Profile":
         """Create a profile from an existing set of Credentials and the
         remaining information.
 
@@ -304,7 +302,7 @@ defined in your profiles.yml file. You can find profiles.yml here:
         target_override: Optional[str] = None,
         threads_override: Optional[int] = None,
         is_secondary: bool = False,
-    ) -> Self:
+    ) -> "Profile":
         """Create a profile from its raw profile information.
 
          (this is an intermediate step, mostly useful for unit testing)
@@ -374,7 +372,7 @@ defined in your profiles.yml file. You can find profiles.yml here:
         renderer: ProfileRenderer,
         target_override: Optional[str] = None,
         threads_override: Optional[int] = None,
-    ) -> Self:
+    ) -> "Profile":
         """
         :param raw_profiles: The profile data, from disk as yaml.
         :param profile_name: The profile name to use.
@@ -415,7 +413,7 @@ defined in your profiles.yml file. You can find profiles.yml here:
         profile_name_override: Optional[str] = None,
         target_override: Optional[str] = None,
         threads_override: Optional[int] = None,
-    ) -> Self:
+    ) -> "Profile":
         """Given the raw profiles as read from disk and the name of the desired
         profile if specified, return the profile component of the runtime
         config.

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -259,6 +259,7 @@ defined in your profiles.yml file. You can find profiles.yml here:
         profile_name: str,
         target_override: Optional[str],
         renderer: ProfileRenderer,
+        infer_target_name: bool = False,
     ) -> Tuple[str, Dict[str, Any]]:
         """This is a containment zone for the hateful way we're rendering
         profiles.
@@ -275,6 +276,9 @@ defined in your profiles.yml file. You can find profiles.yml here:
         elif "target" in raw_profile:
             # render the target if it was parsed from yaml
             target_name = renderer.render_value(raw_profile["target"])
+        elif infer_target_name and len(raw_profile["outputs"]) == 1:
+            target_name = next(iter(raw_profile["outputs"]))
+            fire_event(MissingProfileTarget(profile_name=profile_name, target_name=target_name))
         else:
             target_name = "default"
             fire_event(MissingProfileTarget(profile_name=profile_name, target_name=target_name))
@@ -345,7 +349,11 @@ defined in your profiles.yml file. You can find profiles.yml here:
                         )
 
                     secondary_target_name, secondary_profile_data = cls.render_profile(
-                        secondary_raw_profile, secondary_profile_name, target_override, renderer
+                        secondary_raw_profile,
+                        secondary_profile_name,
+                        target_override,
+                        renderer,
+                        infer_target_name=True,
                     )
 
                     if secondary_profile_data.get("secondary_profiles"):

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -276,10 +276,11 @@ defined in your profiles.yml file. You can find profiles.yml here:
         elif "target" in raw_profile:
             # render the target if it was parsed from yaml
             target_name = renderer.render_value(raw_profile["target"])
-        elif is_secondary and len(raw_profile["outputs"]) == 1:
+        elif is_secondary and len(raw_profile.get("outputs", [])) == 1:
             # if we only have one target, we can infer the target name
             # currently, this is only used for secondary profiles
             target_name = next(iter(raw_profile["outputs"]))
+            # the event name is slightly misleading, but the message indicates that we inferred the target name for a profile
             fire_event(MissingProfileTarget(profile_name=profile_name, target_name=target_name))
         else:
             target_name = "default"

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -188,6 +188,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
             project_env_vars=project.project_env_vars,
             restrict_access=project.restrict_access,
             profile_env_vars=profile.profile_env_vars,
+            secondary_profiles=profile.secondary_profiles,
             profile_name=profile.profile_name,
             target_name=profile.target_name,
             threads=profile.threads,

--- a/tests/unit/config/test_profile.py
+++ b/tests/unit/config/test_profile.py
@@ -292,3 +292,170 @@ class TestProfileFile(BaseConfigTest):
                 self.default_profile_data, "empty_profile_data", renderer
             )
         self.assertIn("Profile empty_profile_data in profiles.yml is empty", str(exc.exception))
+
+
+class TestSecondaryProfiles(BaseConfigTest):
+    def test_secondary_profiles_basic(self):
+        profile_data_with_secondary = deepcopy(self.default_profile_data)
+        profile_data_with_secondary["default"]["outputs"]["postgres"]["secondary_profiles"] = [
+            {
+                "secondary_profile_1": {
+                    "target": "secondary_target_1",
+                    "outputs": {
+                        "secondary_target_1": {
+                            "type": "postgres",
+                            "host": "secondary-host",
+                            "port": 1234,
+                            "user": "secondary_user",
+                            "password": "secondary_password",
+                            "schema": "secondary_schema",
+                            "database": "secondary_db",
+                        }
+                    },
+                }
+            }
+        ]
+        renderer = empty_profile_renderer()
+        profile = dbt.config.Profile.from_raw_profiles(
+            profile_data_with_secondary, "default", renderer
+        )
+
+        self.assertIn("secondary_profile_1", profile.secondary_profiles)
+        secondary_profile = profile.secondary_profiles["secondary_profile_1"]
+        self.assertEqual(secondary_profile.profile_name, "secondary_profile_1")
+        self.assertEqual(secondary_profile.target_name, "secondary_target_1")
+        self.assertTrue(isinstance(secondary_profile.credentials, PostgresCredentials))
+        self.assertEqual(secondary_profile.credentials.host, "secondary-host")
+        self.assertEqual(secondary_profile.credentials.port, 1234)
+        self.assertEqual(secondary_profile.credentials.database, "secondary_db")
+
+    def test_secondary_profiles_override_threads(self):
+        profile_data_with_secondary = deepcopy(self.default_profile_data)
+        profile_data_with_secondary["default"]["outputs"]["postgres"]["secondary_profiles"] = [
+            {
+                "secondary_profile_1": {
+                    "target": "secondary_target_1",
+                    "outputs": {
+                        "secondary_target_1": {
+                            "type": "postgres",
+                            "host": "secondary-host",
+                            "port": 1234,
+                            "user": "secondary_user",
+                            "password": "secondary_password",
+                            "schema": "secondary_schema",
+                            "database": "secondary_db",
+                            "threads": 5,  # threads defined in secondary profile
+                        }
+                    },
+                }
+            }
+        ]
+        renderer = empty_profile_renderer()
+        profile = dbt.config.Profile.from_raw_profiles(
+            profile_data_with_secondary, "default", renderer, threads_override=10
+        )  # override threads to 10
+
+        self.assertIn("secondary_profile_1", profile.secondary_profiles)
+        secondary_profile = profile.secondary_profiles["secondary_profile_1"]
+        # threads_override should take precedence over threads defined in secondary profile
+        self.assertEqual(secondary_profile.threads, 10)
+        self.assertEqual(
+            profile.threads, 10
+        )  # primary profile should also have overridden threads
+
+    def test_secondary_profiles_duplicate_names(self):
+        profile_data_with_duplicate_secondary = deepcopy(self.default_profile_data)
+        profile_data_with_duplicate_secondary["default"]["outputs"]["postgres"][
+            "secondary_profiles"
+        ] = [
+            {
+                "secondary_profile_1": {
+                    "target": "secondary_target_1",
+                    "outputs": {
+                        "secondary_target_1": {
+                            "type": "postgres",
+                            "host": "secondary-host",
+                            "port": 1234,
+                            "user": "secondary_user",
+                            "password": "secondary_password",
+                            "schema": "secondary_schema",
+                            "database": "secondary_db",
+                        }
+                    },
+                }
+            },
+            {
+                "secondary_profile_1": {  # Duplicate name
+                    "target": "secondary_target_2",
+                    "outputs": {
+                        "secondary_target_2": {
+                            "type": "postgres",
+                            "host": "another-secondary-host",
+                            "port": 5678,
+                            "user": "another_secondary_user",
+                            "password": "another_secondary_password",
+                            "schema": "another_secondary_schema",
+                            "database": "another_secondary_db",
+                        }
+                    },
+                }
+            },
+        ]
+        renderer = empty_profile_renderer()
+        with self.assertRaises(dbt.exceptions.DbtProfileError) as exc:
+            dbt.config.Profile.from_raw_profiles(
+                profile_data_with_duplicate_secondary, "default", renderer
+            )
+        self.assertIn(
+            "Secondary profile 'secondary_profile_1' is already defined", str(exc.exception)
+        )
+
+    def test_secondary_profiles_nested_secondary(self):
+        profile_data_with_nested_secondary = deepcopy(self.default_profile_data)
+        profile_data_with_nested_secondary["default"]["outputs"]["postgres"][
+            "secondary_profiles"
+        ] = [
+            {
+                "secondary_profile_1": {
+                    "target": "secondary_target_1",
+                    "outputs": {
+                        "secondary_target_1": {
+                            "type": "postgres",
+                            "host": "secondary-host",
+                            "port": 1234,
+                            "user": "secondary_user",
+                            "password": "secondary_password",
+                            "schema": "secondary_schema",
+                            "database": "secondary_db",
+                            "secondary_profiles": [  # Nested secondary profiles - should be disallowed
+                                {
+                                    "nested_secondary_profile": {
+                                        "target": "nested_target",
+                                        "outputs": {
+                                            "nested_target": {
+                                                "type": "postgres",
+                                                "host": "nested-host",
+                                                "port": 9012,
+                                                "user": "nested_user",
+                                                "password": "nested_password",
+                                                "schema": "nested_schema",
+                                                "database": "nested_db",
+                                            }
+                                        },
+                                    }
+                                }
+                            ],
+                        }
+                    },
+                }
+            }
+        ]
+        renderer = empty_profile_renderer()
+        with self.assertRaises(dbt.exceptions.DbtProfileError) as exc:
+            dbt.config.Profile.from_raw_profiles(
+                profile_data_with_nested_secondary, "default", renderer
+            )
+        self.assertIn(
+            "Secondary profile 'secondary_profile_1' cannot have nested secondary profiles",
+            str(exc.exception),
+        )


### PR DESCRIPTION
Resolves [XPLAT-241](https://dbtlabs.atlassian.net/browse/XPLAT-241).

### Problem

We need to parse `secondary_profiles` associated with a given profile.

### Solution

- Create a new `secondary_profiles` dict on the `Profile` class.
- Validate and load each secondary profile as if they were primary profiles.
- Allow `target_name` to be optional iff a secondary profile has a single target.
- Add tests.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.


[XPLAT-241]: https://dbtlabs.atlassian.net/browse/XPLAT-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ