### PR TITLE
Fix #11275: `_get_doc_blocks` is crashing parsing if `.format` is called

### DIFF
--- a/.changes/unreleased/Fixes-20250218-134745.yaml
+++ b/.changes/unreleased/Fixes-20250218-134745.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: _get_doc_blocks is crashing parsing if .format is called
+time: 2025-02-18T13:47:45.659731Z
+custom:
+    Author: aranke
+    Issue: "11310"

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1672,6 +1672,7 @@ def _get_doc_blocks(description: str, manifest: Manifest, node_package: str) -> 
                 isinstance(node, Call)
                 and hasattr(node, "node")
                 and hasattr(node, "args")
+                and hasattr(node.node, "name")
                 and node.node.name == "doc"
             ):
                 doc_args = [arg.value for arg in node.args]

--- a/tests/functional/docs/test_doc_blocks_formatting.py
+++ b/tests/functional/docs/test_doc_blocks_formatting.py
@@ -42,3 +42,4 @@ class TestDocBlocksBackCompat:
 
         for column_name, column in model_data["columns"].items():
             assert column["description"] == f"This is a test for column {column_name}"
+            assert column["doc_blocks"] == []

--- a/tests/functional/docs/test_doc_blocks_formatting.py
+++ b/tests/functional/docs/test_doc_blocks_formatting.py
@@ -1,0 +1,44 @@
+import json
+import os
+
+import pytest
+
+from dbt.tests.util import run_dbt
+
+docs_md = """{% docs test_doc %}
+This is a test for column {test_name}
+{% enddocs %}
+"""
+
+schema_yml = """
+models:
+  - name: my_colors
+    columns:
+      - name: id
+        description: "{{ doc('test_doc').format(test_name = 'id') }}"
+      - name: color
+        description: "{{ 'This is a test for column {test_name}'.format(test_name = 'color') }}"
+"""
+
+
+class TestDocBlocksBackCompat:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_colors.sql": "select 1 as id, 'blue' as color",
+            "schema.yml": schema_yml,
+            "docs.md": docs_md,
+        }
+
+    def test_doc_blocks_back_compat(self, project):
+        run_dbt(["parse"])
+
+        assert os.path.exists("./target/manifest.json")
+
+        with open("./target/manifest.json") as fp:
+            manifest = json.load(fp)
+
+        model_data = manifest["nodes"]["model.test.my_colors"]
+
+        for column_name, column in model_data["columns"].items():
+            assert column["description"] == f"This is a test for column {column_name}"


### PR DESCRIPTION
Resolves #11275 

### Problem

`_get_doc_blocks` was crashing if we used `.format` on a string or doc block.

### Solution

Add an additional check in `_get_doc_blocks` and a couple tests.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
