### PR TITLE
[Issue 11312] Data test run results always show failures

### DIFF
--- a/.changes/unreleased/Fixes-20250508-134002.yaml
+++ b/.changes/unreleased/Fixes-20250508-134002.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Data test run results always report 0 failures on a pass even if number is higher.
+time: 2025-05-08T13:40:02.000000+02:00
+custom:
+    Author: vglocus tbog357
+    Issue: "11312"

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -294,13 +294,12 @@ class TestRunner(CompileRunner):  # type: ignore[type-arg]
         severity = test.config.severity.upper()
         thread_id = threading.current_thread().name
         num_errors = pluralize(result.failures, "result")
-        status = None
+        failures = result.failures
+        status = TestStatus.Pass
         message = None
-        failures = 0
         if severity == "ERROR" and result.should_error:
             status = TestStatus.Fail
             message = f"Got {num_errors}, configured to fail if {test.config.error_if}"
-            failures = result.failures
         elif result.should_warn:
             if get_flags().WARN_ERROR or get_flags().WARN_ERROR_OPTIONS.includes(
                 LogTestResult.__name__
@@ -310,9 +309,6 @@ class TestRunner(CompileRunner):  # type: ignore[type-arg]
             else:
                 status = TestStatus.Warn
                 message = f"Got {num_errors}, configured to warn if {test.config.warn_if}"
-            failures = result.failures
-        else:
-            status = TestStatus.Pass
 
         run_result = RunResult(
             node=test,

--- a/tests/functional/schema_tests/test_schema_v2_tests.py
+++ b/tests/functional/schema_tests/test_schema_v2_tests.py
@@ -129,7 +129,7 @@ class TestSchemaTests:
     def assertTestPassed(self, result):
         assert result.status == "pass"
         assert not result.skipped
-        assert result.failures == 0, "test {} failed".format(result.node.name)
+        assert result.failures is not None and result.failures >= 0, "test {} failed".format(result.node.name)
 
     def test_schema_tests(
         self,
@@ -216,7 +216,7 @@ class TestLimitedSchemaTests:
     def assertTestPassed(self, result):
         assert result.status == "pass"
         assert not result.skipped
-        assert result.failures == 0, "test {} failed".format(result.node.name)
+        assert result.failures is not None and result.failures >= 0, "test {} failed".format(result.node.name)
 
     def test_limit_schema_tests(
         self,
@@ -238,7 +238,7 @@ class TestLimitedSchemaTests:
             else:
                 self.assertTestPassed(result)
         # warnings are also marked as failures
-        assert sum(x.failures for x in test_results) == 3
+        assert sum(x.failures for x in test_results) == 4
 
 
 class TestDefaultBoolType:
@@ -267,7 +267,7 @@ class TestDefaultBoolType:
     def assertTestPassed(self, result):
         assert result.status == "pass"
         assert not result.skipped
-        assert result.failures == 0, "test {} failed".format(result.node.name)
+        assert result.failures is not None and result.failures >= 0, "test {} failed".format(result.node.name)
 
     def test_limit_schema_tests(
         self,
@@ -289,7 +289,7 @@ class TestDefaultBoolType:
             else:
                 self.assertTestPassed(result)
         # warnings are also marked as failures
-        assert sum(x.failures for x in test_results) == 3
+        assert sum(x.failures for x in test_results) == 4
 
 
 class TestOtherBoolType:
@@ -334,7 +334,7 @@ class TestOtherBoolType:
     def assertTestPassed(self, result):
         assert result.status == "pass"
         assert not result.skipped
-        assert result.failures == 0, "test {} failed".format(result.node.name)
+        assert result.failures is not None and result.failures >= 0, "test {} failed".format(result.node.name)
 
     def test_limit_schema_tests(
         self,
@@ -356,7 +356,7 @@ class TestOtherBoolType:
             else:
                 self.assertTestPassed(result)
         # warnings are also marked as failures
-        assert sum(x.failures for x in test_results) == 3
+        assert sum(x.failures for x in test_results) == 4
 
 
 class TestNonBoolType:
@@ -481,7 +481,7 @@ class TestHooksInTests:
         for result in results:
             assert result.status in ("pass", "success")
             assert not result.skipped
-            assert result.failures == 0, "test {} failed".format(result.node.name)
+            assert result.failures is not None and result.failures >= 0, "test {} failed".format(result.node.name)
 
 
 class TestHooksForWhich:
@@ -514,7 +514,7 @@ class TestHooksForWhich:
         for result in results:
             assert result.status in ("pass", "success")
             assert not result.skipped
-            assert result.failures == 0, "test {} failed".format(result.node.name)
+            assert result.failures is not None and result.failures >= 0, "test {} failed".format(result.node.name)
 
 
 class TestCustomSchemaTests:

--- a/tests/unit/task/test_test.py
+++ b/tests/unit/task/test_test.py
@@ -89,61 +89,66 @@ def _make_runner():
 
 class TestBuildTestRunResult:
     @pytest.mark.parametrize(
-        "failures,should_error,should_warn,severity,expected_status,expected_failures",
+        "failures,should_error,should_warn,expected_status",
         [
-            # The bug fix: passing test with failures > 0 must preserve the count
-            (4, False, False, "ERROR", TestStatus.Pass, 4),
-            # Simple pass with 0 failures
-            (0, False, False, "ERROR", TestStatus.Pass, 0),
-            # Error path
-            (3, True, False, "ERROR", TestStatus.Fail, 3),
-            # Warn path (severity ERROR but should_warn triggers)
-            (2, False, True, "ERROR", TestStatus.Warn, 2),
-            # Warn severity
-            (5, False, True, "WARN", TestStatus.Warn, 5),
+            (4, False, False, TestStatus.Pass),
+            (0, False, False, TestStatus.Pass),
+            (3, True, False, TestStatus.Fail),
+            (2, False, True, TestStatus.Warn),
         ],
     )
-    @patch("dbt.task.test.get_flags")
     def test_failures_always_preserved(
-        self,
-        mock_get_flags,
-        failures,
-        should_error,
-        should_warn,
-        severity,
-        expected_status,
-        expected_failures,
+        self, failures, should_error, should_warn, expected_status
     ):
-        mock_get_flags.return_value.WARN_ERROR = False
-        mock_get_flags.return_value.WARN_ERROR_OPTIONS.includes.return_value = False
+        with patch("dbt.task.test.get_flags") as mock_get_flags:
+            mock_get_flags.return_value.WARN_ERROR = False
+            mock_get_flags.return_value.WARN_ERROR_OPTIONS.includes.return_value = False
 
-        node = _make_test_node(severity=severity)
-        result = TestResultData(
-            failures=failures,
-            should_error=should_error,
-            should_warn=should_warn,
-            adapter_response={},
-        )
+            node = _make_test_node()
+            result = TestResultData(
+                failures=failures,
+                should_error=should_error,
+                should_warn=should_warn,
+                adapter_response={},
+            )
 
-        run_result = _make_runner().build_test_run_result(node, result)
+            run_result = _make_runner().build_test_run_result(node, result)
 
-        assert run_result.status == expected_status
-        assert run_result.failures == expected_failures
+            assert run_result.status == expected_status
+            assert run_result.failures == failures
 
-    @patch("dbt.task.test.get_flags")
-    def test_warn_escalated_to_fail_with_warn_error(self, mock_get_flags):
-        mock_get_flags.return_value.WARN_ERROR = True
-        mock_get_flags.return_value.WARN_ERROR_OPTIONS.includes.return_value = False
+    def test_failures_preserved_with_warn_severity(self):
+        with patch("dbt.task.test.get_flags") as mock_get_flags:
+            mock_get_flags.return_value.WARN_ERROR = False
+            mock_get_flags.return_value.WARN_ERROR_OPTIONS.includes.return_value = False
 
-        node = _make_test_node(severity="ERROR")
-        result = TestResultData(
-            failures=7,
-            should_error=False,
-            should_warn=True,
-            adapter_response={},
-        )
+            node = _make_test_node(severity="WARN")
+            result = TestResultData(
+                failures=5,
+                should_error=False,
+                should_warn=True,
+                adapter_response={},
+            )
 
-        run_result = _make_runner().build_test_run_result(node, result)
+            run_result = _make_runner().build_test_run_result(node, result)
 
-        assert run_result.status == TestStatus.Fail
-        assert run_result.failures == 7
+            assert run_result.status == TestStatus.Warn
+            assert run_result.failures == 5
+
+    def test_warn_escalated_to_fail_with_warn_error(self):
+        with patch("dbt.task.test.get_flags") as mock_get_flags:
+            mock_get_flags.return_value.WARN_ERROR = True
+            mock_get_flags.return_value.WARN_ERROR_OPTIONS.includes.return_value = False
+
+            node = _make_test_node()
+            result = TestResultData(
+                failures=7,
+                should_error=False,
+                should_warn=True,
+                adapter_response={},
+            )
+
+            run_result = _make_runner().build_test_run_result(node, result)
+
+            assert run_result.status == TestStatus.Fail
+            assert run_result.failures == 7

--- a/tests/unit/task/test_test.py
+++ b/tests/unit/task/test_test.py
@@ -87,6 +87,21 @@ def _make_runner():
     return runner
 
 
+def _run_build_test(failures, should_error, should_warn, severity="ERROR", warn_error=False):
+    with patch("dbt.task.test.get_flags") as mock_get_flags:
+        mock_get_flags.return_value.WARN_ERROR = warn_error
+        mock_get_flags.return_value.WARN_ERROR_OPTIONS.includes.return_value = False
+
+        node = _make_test_node(severity=severity)
+        result = TestResultData(
+            failures=failures,
+            should_error=should_error,
+            should_warn=should_warn,
+            adapter_response={},
+        )
+        return _make_runner().build_test_run_result(node, result)
+
+
 class TestBuildTestRunResult:
     @pytest.mark.parametrize(
         "failures,should_error,should_warn,expected_status",
@@ -100,55 +115,16 @@ class TestBuildTestRunResult:
     def test_failures_always_preserved(
         self, failures, should_error, should_warn, expected_status
     ):
-        with patch("dbt.task.test.get_flags") as mock_get_flags:
-            mock_get_flags.return_value.WARN_ERROR = False
-            mock_get_flags.return_value.WARN_ERROR_OPTIONS.includes.return_value = False
-
-            node = _make_test_node()
-            result = TestResultData(
-                failures=failures,
-                should_error=should_error,
-                should_warn=should_warn,
-                adapter_response={},
-            )
-
-            run_result = _make_runner().build_test_run_result(node, result)
-
-            assert run_result.status == expected_status
-            assert run_result.failures == failures
+        run_result = _run_build_test(failures, should_error, should_warn)
+        assert run_result.status == expected_status
+        assert run_result.failures == failures
 
     def test_failures_preserved_with_warn_severity(self):
-        with patch("dbt.task.test.get_flags") as mock_get_flags:
-            mock_get_flags.return_value.WARN_ERROR = False
-            mock_get_flags.return_value.WARN_ERROR_OPTIONS.includes.return_value = False
-
-            node = _make_test_node(severity="WARN")
-            result = TestResultData(
-                failures=5,
-                should_error=False,
-                should_warn=True,
-                adapter_response={},
-            )
-
-            run_result = _make_runner().build_test_run_result(node, result)
-
-            assert run_result.status == TestStatus.Warn
-            assert run_result.failures == 5
+        run_result = _run_build_test(5, False, True, severity="WARN")
+        assert run_result.status == TestStatus.Warn
+        assert run_result.failures == 5
 
     def test_warn_escalated_to_fail_with_warn_error(self):
-        with patch("dbt.task.test.get_flags") as mock_get_flags:
-            mock_get_flags.return_value.WARN_ERROR = True
-            mock_get_flags.return_value.WARN_ERROR_OPTIONS.includes.return_value = False
-
-            node = _make_test_node()
-            result = TestResultData(
-                failures=7,
-                should_error=False,
-                should_warn=True,
-                adapter_response={},
-            )
-
-            run_result = _make_runner().build_test_run_result(node, result)
-
-            assert run_result.status == TestStatus.Fail
-            assert run_result.failures == 7
+        run_result = _run_build_test(7, False, True, warn_error=True)
+        assert run_result.status == TestStatus.Fail
+        assert run_result.failures == 7

--- a/tests/unit/task/test_test.py
+++ b/tests/unit/task/test_test.py
@@ -1,7 +1,10 @@
+from unittest.mock import MagicMock, patch
+
 import agate
 import pytest
 
-from dbt.task.test import list_rows_from_table
+from dbt.artifacts.schemas.results import TestStatus
+from dbt.task.test import TestResultData, TestRunner, list_rows_from_table
 
 
 class TestListRowsFromTable:
@@ -69,3 +72,78 @@ class TestListRowsFromTable:
 
         list_rows = list_rows_from_table(table, sort=True)
         assert list_rows == expected_list_rows
+
+
+def _make_test_node(severity="ERROR", error_if="!= 0", warn_if="!= 0"):
+    node = MagicMock()
+    node.config.severity = severity
+    node.config.error_if = error_if
+    node.config.warn_if = warn_if
+    return node
+
+
+def _make_runner():
+    runner = TestRunner.__new__(TestRunner)
+    return runner
+
+
+class TestBuildTestRunResult:
+    @pytest.mark.parametrize(
+        "failures,should_error,should_warn,severity,expected_status,expected_failures",
+        [
+            # The bug fix: passing test with failures > 0 must preserve the count
+            (4, False, False, "ERROR", TestStatus.Pass, 4),
+            # Simple pass with 0 failures
+            (0, False, False, "ERROR", TestStatus.Pass, 0),
+            # Error path
+            (3, True, False, "ERROR", TestStatus.Fail, 3),
+            # Warn path (severity ERROR but should_warn triggers)
+            (2, False, True, "ERROR", TestStatus.Warn, 2),
+            # Warn severity
+            (5, False, True, "WARN", TestStatus.Warn, 5),
+        ],
+    )
+    @patch("dbt.task.test.get_flags")
+    def test_failures_always_preserved(
+        self,
+        mock_get_flags,
+        failures,
+        should_error,
+        should_warn,
+        severity,
+        expected_status,
+        expected_failures,
+    ):
+        mock_get_flags.return_value.WARN_ERROR = False
+        mock_get_flags.return_value.WARN_ERROR_OPTIONS.includes.return_value = False
+
+        node = _make_test_node(severity=severity)
+        result = TestResultData(
+            failures=failures,
+            should_error=should_error,
+            should_warn=should_warn,
+            adapter_response={},
+        )
+
+        run_result = _make_runner().build_test_run_result(node, result)
+
+        assert run_result.status == expected_status
+        assert run_result.failures == expected_failures
+
+    @patch("dbt.task.test.get_flags")
+    def test_warn_escalated_to_fail_with_warn_error(self, mock_get_flags):
+        mock_get_flags.return_value.WARN_ERROR = True
+        mock_get_flags.return_value.WARN_ERROR_OPTIONS.includes.return_value = False
+
+        node = _make_test_node(severity="ERROR")
+        result = TestResultData(
+            failures=7,
+            should_error=False,
+            should_warn=True,
+            adapter_response={},
+        )
+
+        run_result = _make_runner().build_test_run_result(node, result)
+
+        assert run_result.status == TestStatus.Fail
+        assert run_result.failures == 7

--- a/tests/unit/task/test_test.py
+++ b/tests/unit/task/test_test.py
@@ -87,19 +87,20 @@ def _make_runner():
     return runner
 
 
-def _run_build_test(failures, should_error, should_warn, severity="ERROR", warn_error=False):
+def _run_build_test(result, node=None, warn_error=False):
     with patch("dbt.task.test.get_flags") as mock_get_flags:
         mock_get_flags.return_value.WARN_ERROR = warn_error
         mock_get_flags.return_value.WARN_ERROR_OPTIONS.includes.return_value = False
+        return _make_runner().build_test_run_result(node or _make_test_node(), result)
 
-        node = _make_test_node(severity=severity)
-        result = TestResultData(
-            failures=failures,
-            should_error=should_error,
-            should_warn=should_warn,
-            adapter_response={},
-        )
-        return _make_runner().build_test_run_result(node, result)
+
+def _make_result(failures, should_error, should_warn):
+    return TestResultData(
+        failures=failures,
+        should_error=should_error,
+        should_warn=should_warn,
+        adapter_response={},
+    )
 
 
 class TestBuildTestRunResult:
@@ -115,16 +116,18 @@ class TestBuildTestRunResult:
     def test_failures_always_preserved(
         self, failures, should_error, should_warn, expected_status
     ):
-        run_result = _run_build_test(failures, should_error, should_warn)
+        run_result = _run_build_test(_make_result(failures, should_error, should_warn))
         assert run_result.status == expected_status
         assert run_result.failures == failures
 
     def test_failures_preserved_with_warn_severity(self):
-        run_result = _run_build_test(5, False, True, severity="WARN")
+        run_result = _run_build_test(
+            _make_result(5, False, True), node=_make_test_node(severity="WARN")
+        )
         assert run_result.status == TestStatus.Warn
         assert run_result.failures == 5
 
     def test_warn_escalated_to_fail_with_warn_error(self):
-        run_result = _run_build_test(7, False, True, warn_error=True)
+        run_result = _run_build_test(_make_result(7, False, True), warn_error=True)
         assert run_result.status == TestStatus.Fail
         assert run_result.failures == 7


### PR DESCRIPTION
Resolves #11312 

### Problem

Previously, a RunResult for a data test always showed 0 failures for a passing test, no matter what the DataTestResult returned. For example a test that will error or warn if '> 10' and the result is 4 failures, the RunResult returns 0 failures, because it is passing.

### Solution

For data tests, always set failures to the actual failure count, even if technically not a failure.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
