### PR TITLE
Upgrade docker file dependancy libpq-dev to 13.19-0+deb11u1 for secur…

### DIFF
--- a/.changes/unreleased/Security-20250215-174553.yaml
+++ b/.changes/unreleased/Security-20250215-174553.yaml
@@ -1,0 +1,6 @@
+kind: Security
+body: upgrade libpq-dev to version 13.19-0+deb11u1 to resolve CVE-2025-1094
+time: 2025-02-15T17:45:53.0371582+03:00
+custom:
+    Author: saudf
+    Issue: "11314"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
     build-essential=12.9 \
     ca-certificates=20210119 \
     git=1:2.30.2-1+deb11u2 \
-    libpq-dev=13.18-0+deb11u1 \
+    libpq-dev=13.19-0+deb11u1 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \


### PR DESCRIPTION
…ity reasons

Resolves #11314

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem
The current Dockerfile installs libpq-dev 13.18-0+deb11u1 which contains the CVE-2025-1094 vulnerability.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
Upgrade libpq-dev to 13.19-0+deb11u1 which is the patched version.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
