### PR TITLE
fix: change target path for nodes defined in yml

### DIFF
--- a/.changes/unreleased/Fixes-20250219-224310.yaml
+++ b/.changes/unreleased/Fixes-20250219-224310.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Models defined in .yml files have weird paths
+time: 2025-02-19T22:43:10.5172941+10:30
+custom:
+    Author: joshuanits
+    Issue: "11321"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -255,6 +255,11 @@ class ParsedNode(ParsedResource, NodeInfoMixin, ParsedNodeMandatory, Serializabl
         if os.path.basename(self.path) == os.path.basename(self.original_file_path):
             # One-to-one relationship of nodes to files.
             path = self.original_file_path
+        elif os.path.dirname(self.path) == os.path.basename(self.original_file_path):
+            parent_dirname = os.path.dirname(self.original_file_path)
+            dirname = os.path.dirname(self.path).replace(".", "_")
+            basename = os.path.basename(self.path)
+            path = os.path.join(parent_dirname, dirname, basename)
         else:
             #  Many-to-one relationship of nodes to files.
             path = os.path.join(self.original_file_path, self.path)

--- a/tests/unit/graph/test_nodes.py
+++ b/tests/unit/graph/test_nodes.py
@@ -410,6 +410,22 @@ class TestParsedNode:
             database=None,
         )
 
+    @pytest.fixture(scope="class")
+    def parsed_yml_node(self) -> ParsedNode:
+        return ParsedNode(
+            resource_type=NodeType.Model,
+            unique_id="model.test_package.test_name",
+            name="test_name",
+            package_name="test_package",
+            schema="test_schema",
+            alias="test_alias",
+            fqn=["models", "test_name"],
+            original_file_path="folder/test_original_file_path.yml",
+            checksum=FileHash.from_contents("checksum"),
+            path="test_original_file_path.yml/test_path.sql",
+            database=None,
+        )
+
     def test_get_target_write_path(self, parsed_node):
         write_path = parsed_node.get_target_write_path("target_path", "subdirectory")
         assert (
@@ -422,4 +438,11 @@ class TestParsedNode:
         assert (
             write_path
             == "target_path/subdirectory/test_package/test_original_file_path/test_path/test_path_split.sql"
+        )
+
+    def test_get_target_write_path_for_yml_node(self, parsed_yml_node):
+        write_path = parsed_yml_node.get_target_write_path("target_path", "subdirectory")
+        assert (
+            write_path
+            == "target_path/subdirectory/test_package/folder/test_original_file_path_yml/test_path.sql"
         )


### PR DESCRIPTION
Resolves #11321

### Problem

Models defined in yaml files (such as the new snapshots) are built to a file path such as `target/run/models/schema.yml/schema.yml/snapshot.sql`.

This is both unclear and introduces possible collisions if `target/run/models/schema.yml` is a file.

This path is made from joining the file path `models/schema.yml` with the 'logical' path `schema.yml/snapshot.sql`.

### Solution

If the basename of the file path matches the dirname of the logical path, construct a new path from:
- dirname of the file path `models/`
- dirname of the logical path, replacing `.` with `_`: `schema_yml/`
- basename of the logical path: `snapshot.sql`

Joined result being `models/schema_yml/snapshot.sql`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
