### PR TITLE
Update artifact triggers and concurrency rules

### DIFF
--- a/.github/workflows/artifact-reviews.yml
+++ b/.github/workflows/artifact-reviews.yml
@@ -20,8 +20,8 @@ on:
 
 # only run this once per PR at a time
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false  # wait for in-progress runs to complete to prevent race condition
 
 env:
     required_approvals: 2

--- a/.github/workflows/artifact-reviews.yml
+++ b/.github/workflows/artifact-reviews.yml
@@ -16,7 +16,7 @@ on:
     types: [opened, synchronize, reopened, edited]
   # retrigger check on review events
   pull_request_review:
-    types: [submitted, dismissed]
+    types: [submitted, edited, dismissed]
 
 # only run this once per PR at a time
 concurrency:
@@ -38,11 +38,13 @@ jobs:
       - name: "Dismiss previous workflow runs"
         run: |
           # Get all check runs for this PR's SHA
-          checks=$(gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/check-runs \
+          cleanup_checks=$(gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/check-runs \
+            --jq '.check_runs[] | select(.name == "Cleanup Previous Runs")')
+          review_checks=$(gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/check-runs \
             --jq '.check_runs[] | select(.name == "Validate Additional Reviews")')
 
           # For each check run from this workflow (except current), dismiss it
-          echo "$checks" | jq -r '. | select(.id != ${{ github.run_id }}) | .id' | \
+          { echo "$cleanup_checks"; echo "$review_checks"; } | jq -r '. | select(.id != ${{ github.run_id }}) | .id' | \
           while read -r check_id; do
             echo "Dismissing check $check_id"
             gh api repos/${{ github.repository }}/check-runs/$check_id \

--- a/.github/workflows/artifact-reviews.yml
+++ b/.github/workflows/artifact-reviews.yml
@@ -111,14 +111,17 @@ jobs:
 
             # Get all reviews
             REVIEWS=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews)
-
-            # Count approved reviews from core team members
+            # Count approved reviews from core team members (only most recent review per user)
             CORE_APPROVALS=0
             while IFS= read -r member; do
-              echo "$member"
-              echo "$user"
-              APPROVED=$(echo "$REVIEWS" | jq --arg user "$member" \
-                '.[] | select(.user.login == $user and .state == "APPROVED") | .user.login' | wc -l)
+              echo "member: $member"
+              APPROVED=$(echo "$REVIEWS" | jq --arg user "$member" '
+                group_by(.user.login) |
+                map(select(.[0].user.login == $user) |
+                    sort_by(.submitted_at) |
+                    last) |
+                map(select(.state == "APPROVED")) |
+                length')
               CORE_APPROVALS=$((CORE_APPROVALS + APPROVED))
             done <<< "${{ steps.core_members.outputs.membership }}"
 
@@ -128,7 +131,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Notify and fail if not enough approvals"
-        if: ${{ steps.artifact_files_changed.outputs.artifact_changes == 'true' && steps.check_approvals.outputs.CORE_APPROVALS != env.required_approvals }}
+        if: ${{ steps.artifact_files_changed.outputs.artifact_changes == 'true' && steps.check_approvals.outputs.CORE_APPROVALS < fromJSON(env.required_approvals) }}
         run: |
           title="PR Approval Requirements Not Met"
           message="Changes to artifact directory files requires at least ${{ env.required_approvals }} approvals from core team members. Current number of core team approvals: ${{ steps.check_approvals.outputs.CORE_APPROVALS }} "
@@ -136,7 +139,7 @@ jobs:
           exit 1
 
       - name: "Notify of sufficient approvals"
-        if: ${{ steps.artifact_files_changed.outputs.artifact_changes == 'true' && steps.check_approvals.outputs.CORE_APPROVALS >= env.required_approvals }}
+        if: ${{ steps.artifact_files_changed.outputs.artifact_changes == 'true' && steps.check_approvals.outputs.CORE_APPROVALS >= fromJSON(env.required_approvals) }}
         run: |
           title="Extra requirements met"
           message="Changes to artifact directory files requires at least ${{ env.required_approvals }} approvals from core team members. Current number of core team approvals: ${{ steps.check_approvals.outputs.CORE_APPROVALS }} "


### PR DESCRIPTION
### Problem

Artifact checks were not returning the correct results

### Solution

Retrigger on any review edits.
Instead of cancelling in progress runs, wait for them to complete
Since this is only triggered on pull-requests we can just use the PR number to ensure the concurrency group is always the same

Validated on internal testing repo PR: https://github.com/dbt-labs/core-action-testing/pull/12

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
