### PR TITLE
add database to ModelNodeArgs in partial parsing test to better reflect prod use cases

### DIFF
--- a/tests/functional/partial_parsing/test_partial_parsing.py
+++ b/tests/functional/partial_parsing/test_partial_parsing.py
@@ -703,6 +703,7 @@ class TestExternalModels:
             package_name="test",
             identifier="test_identifier",
             schema="test_schema",
+            database="dbt",
         )
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
`database` on `ModelNodeArgs` is optional to mirror the manifest schema, but in practice this is rarely the case.