### PR TITLE
Rewrite execution of microbatch models to avoid blocking the main thread

### DIFF
--- a/.changes/unreleased/Fixes-20250303-131440.yaml
+++ b/.changes/unreleased/Fixes-20250303-131440.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix microbatch execution to not block main thread nor hang
+time: 2025-03-03T13:14:40.432874-06:00
+custom:
+  Author: QMalcolm
+  Issue: 11243 11306

--- a/core/dbt/graph/thread_pool.py
+++ b/core/dbt/graph/thread_pool.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from multiprocessing.pool import ThreadPool
+
+
+class DbtThreadPool(ThreadPool):
+    """A ThreadPool that tracks whether or not it's been closed"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+        super().close()
+
+    def is_closed(self):
+        return self.closed

--- a/core/dbt/materializations/incremental/microbatch.py
+++ b/core/dbt/materializations/incremental/microbatch.py
@@ -100,7 +100,8 @@ class MicrobatchBuilder:
 
         return batches
 
-    def build_jinja_context_for_batch(self, incremental_batch: bool) -> Dict[str, Any]:
+    @staticmethod
+    def build_jinja_context_for_batch(model: ModelNode, incremental_batch: bool) -> Dict[str, Any]:
         """
         Create context with entries that reflect microbatch model + incremental execution state
 
@@ -109,9 +110,9 @@ class MicrobatchBuilder:
         jinja_context: Dict[str, Any] = {}
 
         # Microbatch model properties
-        jinja_context["model"] = self.model.to_dict()
-        jinja_context["sql"] = self.model.compiled_code
-        jinja_context["compiled_code"] = self.model.compiled_code
+        jinja_context["model"] = model.to_dict()
+        jinja_context["sql"] = model.compiled_code
+        jinja_context["compiled_code"] = model.compiled_code
 
         # Add incremental context variables for batches running incrementally
         if incremental_batch:

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -131,8 +131,8 @@ class BuildTask(RunTask):
             runner.do_skip(cause=cause)
 
         if isinstance(runner, MicrobatchModelRunner):
-            runner._parent_task = self
-            runner._pool = pool
+            runner.set_parent_task(self)
+            runner.set_pool(pool)
 
         return self.call_runner(runner)
 
@@ -147,8 +147,8 @@ class BuildTask(RunTask):
             runner.do_skip(cause=cause)
 
         if isinstance(runner, MicrobatchModelRunner):
-            runner._parent_task = self
-            runner._pool = pool
+            runner.set_parent_task(self)
+            runner.set_pool(pool)
 
         args = [runner]
         self._submit(pool, args, callback)

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -131,7 +131,8 @@ class BuildTask(RunTask):
             runner.do_skip(cause=cause)
 
         if isinstance(runner, MicrobatchModelRunner):
-            return self.handle_microbatch_model(runner, pool)
+            runner._parent_task = self
+            runner._pool = pool
 
         return self.call_runner(runner)
 
@@ -146,10 +147,11 @@ class BuildTask(RunTask):
             runner.do_skip(cause=cause)
 
         if isinstance(runner, MicrobatchModelRunner):
-            callback(self.handle_microbatch_model(runner, pool))
-        else:
-            args = [runner]
-            self._submit(pool, args, callback)
+            runner._parent_task = self
+            runner._pool = pool
+
+        args = [runner]
+        self._submit(pool, args, callback)
 
     # Make a map of model unique_ids to selected unit test unique_ids,
     # for processing before the model.

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -345,28 +345,6 @@ class MicrobatchModelRunnerOLD(ModelRunner):
         self.batches: Dict[int, BatchType] = {}
         self.relation_exists: bool = False
 
-    def on_skip(self):
-        # TODO: Split into two method
-        # The first part of the if statement should move to the microbatch orchestration runner
-        # The second should move to the batch runner
-        # If node.batch is None, then we're dealing with skipping of the entire node
-        if self.batch_idx is None:
-            return super().on_skip()
-        else:
-            result = RunResult(
-                node=self.node,
-                status=RunStatus.Skipped,
-                timing=[],
-                thread_id=threading.current_thread().name,
-                execution_time=0.0,
-                message="SKIPPED",
-                adapter_response={},
-                failures=1,
-                batch_results=BatchResults(failed=[self.batches[self.batch_idx]]),
-            )
-            self.print_batch_result_line(result=result)
-            return result
-
     def _build_succesful_run_batch_result(
         self,
         model: ModelNode,
@@ -564,6 +542,21 @@ class MicrobatchBatchRunner(ModelRunner):
             run_in_parallel = not self.node.has_this
 
         return run_in_parallel
+
+    def on_skip(self):
+        result = RunResult(
+            node=self.node,
+            status=RunStatus.Skipped,
+            timing=[],
+            thread_id=threading.current_thread().name,
+            execution_time=0.0,
+            message="SKIPPED",
+            adapter_response={},
+            failures=1,
+            batch_results=BatchResults(failed=[self.batches[self.batch_idx]]),
+        )
+        self.print_batch_result_line(result=result)
+        return result
 
     def compile(self, manifest: Manifest):
         batch = self.batches[self.batch_idx]

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -783,11 +783,8 @@ class RunTask(CompileTask):
             cause = self._skipped_children.pop(runner.node.unique_id)
             runner.do_skip(cause=cause)
 
-        if isinstance(runner, MicrobatchModelRunner):
-            callback(self.handle_microbatch_model(runner, pool))
-        else:
-            args = [runner]
-            self._submit(pool, args, callback)
+        args = [runner]
+        self._submit(pool, args, callback)
 
     def handle_microbatch_model(
         self,

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -511,8 +511,9 @@ class MicrobatchBatchRunner(ModelRunner):
         start_time = time.perf_counter()
         try:
             # Update jinja context with batch context members
-            jinja_context = microbatch_builder.build_jinja_context_for_batch(
-                incremental_batch=self.relation_exists
+            jinja_context = MicrobatchBuilder.build_jinja_context_for_batch(
+                model=model,
+                incremental_batch=self.relation_exists,
             )
             context.update(jinja_context)
 

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -728,7 +728,6 @@ class MicrobatchModelRunner(ModelRunner):
         # Execution really means orchestration in this case
 
         batches = self.get_batches(model=model)
-        # TODO: We should de-dupe this call with the call we also do in get_batches
         relation_exists = self._has_relation(model=model)
         result = self._initial_run_microbatch_model_result(model=model)
 

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -732,10 +732,7 @@ class MicrobatchModelRunner(ModelRunner):
         relation_exists = self._has_relation(model=model)
         result = self._initial_run_microbatch_model_result(model=model)
 
-        # TODO: This might not be necessary once we implement do_skip
-        # if result.status == RunStatus.Skipped:
-        #     return result
-
+        # No batches to run, so return initial result
         if len(batches) == 0:
             return result
 

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -562,7 +562,9 @@ class MicrobatchModelRunner(ModelRunner):
     def __init__(self, config, adapter, node, node_index: int, num_nodes: int):
         super().__init__(config, adapter, node, node_index, num_nodes)
 
+        # The parent task is necessary because we need access to the `_submit_batch` and `submit` methods
         self._parent_task: Optional[RunTask] = None
+        # The pool is necessary because we need to batches to be executed within the same thread pool
         self._pool: Optional[DbtThreadPool] = None
 
     def set_parent_task(self, parent_task: RunTask) -> None:

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -565,11 +565,17 @@ class MicrobatchModelRunner(ModelRunner):
         self._parent_task: Optional[RunTask] = None
         self._pool: Optional[DbtThreadPool] = None
 
+    def set_parent_task(self, parent_task: RunTask) -> None:
+        self._parent_task = parent_task
+
+    def set_pool(self, pool: DbtThreadPool) -> None:
+        self._pool = pool
+
     @property
     def parent_task(self) -> RunTask:
         if self._parent_task is None:
             raise DbtInternalError(
-                msg="Tried to access `parent_task` of `MicrobatchModelRunner` before it was available"
+                msg="Tried to access `parent_task` of `MicrobatchModelRunner` before it was set"
             )
 
         return self._parent_task
@@ -578,7 +584,7 @@ class MicrobatchModelRunner(ModelRunner):
     def pool(self) -> DbtThreadPool:
         if self._pool is None:
             raise DbtInternalError(
-                msg="Tried to access `pool` of `MicrobatchModelRunner` before it was available"
+                msg="Tried to access `pool` of `MicrobatchModelRunner` before it was set"
             )
 
         return self._pool
@@ -840,8 +846,8 @@ class RunTask(CompileTask):
             runner.do_skip(cause=cause)
 
         if isinstance(runner, MicrobatchModelRunner):
-            runner._parent_task = self
-            runner._pool = pool
+            runner.set_parent_task(self)
+            runner.set_pool(pool)
 
         args = [runner]
         self._submit(pool, args, callback)

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -576,23 +576,6 @@ class MicrobatchModelRunnerOLD(ModelRunner):
 
         return batch_result
 
-    def should_run_in_parallel(self) -> bool:
-        # TODO: Should move to batch runner
-        if not self.adapter.supports(Capability.MicrobatchConcurrency):
-            run_in_parallel = False
-        elif not self.relation_exists:
-            # If the relation doesn't exist, we can't run in parallel
-            run_in_parallel = False
-        elif self.node.config.concurrent_batches is not None:
-            # If the relation exists and the `concurrent_batches` config isn't None, use the config value
-            run_in_parallel = self.node.config.concurrent_batches
-        else:
-            # If the relation exists, the `concurrent_batches` config is None, check if the model self references `this`.
-            # If the model self references `this` then we assume the model batches _can't_ be run in parallel
-            run_in_parallel = not self.node.has_this
-
-        return run_in_parallel
-
     def _execute_model(
         self,
         hook_ctx: Any,
@@ -631,6 +614,22 @@ class MicrobatchBatchRunner(ModelRunner):
         self.batch_idx = batch_idx
         self.batches = batches
         self.relation_exists = relation_exists
+
+    def should_run_in_parallel(self) -> bool:
+        if not self.adapter.supports(Capability.MicrobatchConcurrency):
+            run_in_parallel = False
+        elif not self.relation_exists:
+            # If the relation doesn't exist, we can't run in parallel
+            run_in_parallel = False
+        elif self.node.config.concurrent_batches is not None:
+            # If the relation exists and the `concurrent_batches` config isn't None, use the config value
+            run_in_parallel = self.node.config.concurrent_batches
+        else:
+            # If the relation exists, the `concurrent_batches` config is None, check if the model self references `this`.
+            # If the model self references `this` then we assume the model batches _can't_ be run in parallel
+            run_in_parallel = not self.node.has_this
+
+        return run_in_parallel
 
 
 class MicrobatchModelRunner(ModelRunner):

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -824,10 +824,6 @@ class MicrobatchModelRunner(ModelRunner):
         # Finalize run: merge results, track model run, and print final result line
         self.merge_batch_results(result, batch_results)
 
-        # TODO: Is it okay that these goes away? (after_execute should handle them)
-        # track_model_run(runner.node_index, runner.num_nodes, result, adapter=runner.adapter)
-        # self.print_result_line(result)
-
         return result
 
 

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -358,11 +358,6 @@ class MicrobatchBatchRunner(ModelRunner):
         self.relation_exists = relation_exists
         self.incremental_batch = incremental_batch
 
-    def describe_node(self) -> str:
-        # TODO: I'm not sure if we actually need this. We should try removing it once everything
-        # is running and seeing if not having it breaks anything
-        return f"{self.node.language} microbatch model {self.get_node_representation()}"
-
     def describe_batch(self) -> str:
         batch_start = self.batches[self.batch_idx][0]
         formatted_batch_start = MicrobatchBuilder.format_batch_start(

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -334,7 +334,7 @@ class ModelRunner(CompileRunner):
         return self._execute_model(hook_ctx, context_config, model, context, materialization_macro)
 
 
-class MicrobatchModelRunner(ModelRunner):
+class MicrobatchModelRunnerOLD(ModelRunner):
     def __init__(self, config, adapter, node, node_index: int, num_nodes: int):
         super().__init__(config, adapter, node, node_index, num_nodes)
 
@@ -735,6 +735,18 @@ class MicrobatchModelRunner(ModelRunner):
             self.adapter.post_model_hook(context_config, hook_ctx)
 
         return batch_result
+
+
+class MicrobatchBatchRunner(ModelRunner):
+    """Handles the running of individual batches"""
+
+    pass
+
+
+class MicrobatchModelRunner(ModelRunner):
+    """Handles the orchestration of batches to run for a given microbatch model"""
+
+    pass
 
 
 class RunTask(CompileTask):

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -378,21 +378,6 @@ class MicrobatchModelRunnerOLD(ModelRunner):
         # TODO: Move to microbatch orchestration runner AND batch runner
         return f"{self.node.language} microbatch model {self.get_node_representation()}"
 
-    def before_execute(self) -> None:
-        # TODO: Split into two method
-        # The first part of the if statement should move to the microbatch orchestration runner
-        # The second should move to the batch runner
-        if self.batch_idx is None:
-            self.print_start_line()
-        else:
-            self.print_batch_start_line()
-
-    def after_execute(self, result) -> None:
-        # TODO move to batch runner
-        # Note: Might need to add empty `after_execute` to microbatch orchestration runner
-        if self.batch_idx is not None:
-            self.print_batch_result_line(result)
-
     def on_skip(self):
         # TODO: Split into two method
         # The first part of the if statement should move to the microbatch orchestration runner
@@ -583,6 +568,14 @@ class MicrobatchBatchRunner(ModelRunner):
                 node_info=self.node.node_info,
             )
         )
+
+    def before_execute(self) -> None:
+        # TODO: if we rename `print_batch_start_line` we can probably remove this function
+        self.print_batch_start_line()
+
+    def after_execute(self, result) -> None:
+        # TODO: if we rename `print_batch_result_line` we can probably remove this function
+        self.print_batch_result_line(result)
 
     def should_run_in_parallel(self) -> bool:
         if not self.adapter.supports(Capability.MicrobatchConcurrency):

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -374,10 +374,6 @@ class MicrobatchModelRunnerOLD(ModelRunner):
         # Skips compilation for non-batch runs
         return self.node
 
-    def describe_node(self) -> str:
-        # TODO: Move to microbatch orchestration runner AND batch runner
-        return f"{self.node.language} microbatch model {self.get_node_representation()}"
-
     def on_skip(self):
         # TODO: Split into two method
         # The first part of the if statement should move to the microbatch orchestration runner
@@ -524,6 +520,11 @@ class MicrobatchBatchRunner(ModelRunner):
         self.batches = batches
         self.relation_exists = relation_exists
 
+    def describe_node(self) -> str:
+        # TODO: I'm not sure if we actually need this. We should try removing it once everything
+        # is running and seeing if not having it breaks anything
+        return f"{self.node.language} microbatch model {self.get_node_representation()}"
+
     def describe_batch(self) -> str:
         batch_start = self.batches[self.batch_idx][0]
         formatted_batch_start = MicrobatchBuilder.format_batch_start(
@@ -663,6 +664,9 @@ class MicrobatchModelRunner(ModelRunner):
             failures=0,
             batch_results=BatchResults(),
         )
+
+    def describe_node(self) -> str:
+        return f"{self.node.language} microbatch model {self.get_node_representation()}"
 
     def merge_batch_results(self, result: RunResult, batch_results: List[RunResult]):
         """merge batch_results into result"""

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -374,29 +374,9 @@ class MicrobatchModelRunnerOLD(ModelRunner):
         # Skips compilation for non-batch runs
         return self.node
 
-    @property
-    def batch_start(self) -> Optional[datetime]:
-        # TODO: This should go away in entirety :thinky:
-        if self.batch_idx is None:
-            return None
-        else:
-            return self.batches[self.batch_idx][0]
-
     def describe_node(self) -> str:
         # TODO: Move to microbatch orchestration runner AND batch runner
         return f"{self.node.language} microbatch model {self.get_node_representation()}"
-
-    def describe_batch(self) -> str:
-        # TODO: Move to batch runner
-        batch_start = self.batch_start
-        if batch_start is None:
-            return ""
-
-        # Only visualize date if batch_start year/month/day
-        formatted_batch_start = MicrobatchBuilder.format_batch_start(
-            batch_start, self.node.config.batch_size
-        )
-        return f"batch {formatted_batch_start} of {self.get_node_representation()}"
 
     def print_batch_result_line(
         self,
@@ -614,6 +594,13 @@ class MicrobatchBatchRunner(ModelRunner):
         self.batch_idx = batch_idx
         self.batches = batches
         self.relation_exists = relation_exists
+
+    def describe_batch(self) -> str:
+        batch_start = self.batches[self.batch_idx][0]
+        formatted_batch_start = MicrobatchBuilder.format_batch_start(
+            batch_start, self.node.config.batch_size
+        )
+        return f"batch {formatted_batch_start} of {self.get_node_representation()}"
 
     def should_run_in_parallel(self) -> bool:
         if not self.adapter.supports(Capability.MicrobatchConcurrency):

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -748,7 +748,8 @@ class MicrobatchModelRunner(ModelRunner):
         # Execution really means orchestration in this case
 
         batches = self.get_batches(model=model)
-        relation_exists = True  # TODO retrieve existance of relation
+        # TODO: We should de-dupe this call with the call we also do in get_batches
+        relation_exists = self._has_relation(model=model)
         result = RunResult()  # TODO add some better details to this
 
         # TODO: This might not be necessary once we implement do_skip

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -3,7 +3,6 @@ import time
 from abc import abstractmethod
 from concurrent.futures import as_completed
 from datetime import datetime
-from multiprocessing.dummy import Pool as ThreadPool
 from pathlib import Path
 from typing import AbstractSet, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
 
@@ -48,6 +47,7 @@ from dbt.graph import (
     UniqueId,
     parse_difference,
 )
+from dbt.graph.thread_pool import DbtThreadPool
 from dbt.parser.manifest import write_manifest
 from dbt.task import group_lookup
 from dbt.task.base import BaseRunner, ConfiguredTask
@@ -408,7 +408,9 @@ class GraphRunnableTask(ConfiguredTask):
     def execute_nodes(self):
         num_threads = self.config.threads
 
-        pool = ThreadPool(num_threads, self._pool_thread_initializer, [get_invocation_context()])
+        pool = DbtThreadPool(
+            num_threads, self._pool_thread_initializer, [get_invocation_context()]
+        )
         try:
             self.run_queue(pool)
         except FailFastError as failure:

--- a/tests/functional/microbatch/test_microbatch.py
+++ b/tests/functional/microbatch/test_microbatch.py
@@ -967,7 +967,7 @@ class TestMicrobatchCanRunParallelOrSequential(BaseMicrobatchTest):
     def test_microbatch(
         self, mocker: MockerFixture, project, batch_exc_catcher: EventCatcher
     ) -> None:
-        mocked_srip = mocker.patch("dbt.task.run.MicrobatchModelRunner.should_run_in_parallel")
+        mocked_srip = mocker.patch("dbt.task.run.MicrobatchBatchRunner.should_run_in_parallel")
 
         # Should be run in parallel
         mocked_srip.return_value = True
@@ -1007,7 +1007,7 @@ class TestFirstAndLastBatchAlwaysSequential(BaseMicrobatchTest):
     def test_microbatch(
         self, mocker: MockerFixture, project, batch_exc_catcher: EventCatcher
     ) -> None:
-        mocked_srip = mocker.patch("dbt.task.run.MicrobatchModelRunner.should_run_in_parallel")
+        mocked_srip = mocker.patch("dbt.task.run.MicrobatchBatchRunner.should_run_in_parallel")
 
         # Should be run in parallel
         mocked_srip.return_value = True

--- a/tests/functional/microbatch/test_microbatch.py
+++ b/tests/functional/microbatch/test_microbatch.py
@@ -5,8 +5,6 @@ import pytest
 from pytest_mock import MockerFixture
 
 from dbt.events.types import (
-    ArtifactWritten,
-    EndOfRunSummary,
     GenericExceptionOnRun,
     InvalidConcurrentBatchesConfig,
     JinjaLogDebug,
@@ -907,38 +905,6 @@ class TestMicrbobatchModelsRunWithSameCurrentTime(BaseMicrobatchTest):
 
         # they should have the same last batch because they are using the _same_ "current_time"
         assert microbatch_model_last_batch == second_microbatch_model_last_batch
-
-
-class TestMicrobatchModelStoppedByKeyboardInterrupt(BaseMicrobatchTest):
-    @pytest.fixture
-    def catch_eors(self) -> EventCatcher:
-        return EventCatcher(EndOfRunSummary)
-
-    @pytest.fixture
-    def catch_aw(self) -> EventCatcher:
-        return EventCatcher(
-            event_to_catch=ArtifactWritten,
-            predicate=lambda event: event.data.artifact_type == "RunExecutionResult",
-        )
-
-    def test_microbatch(
-        self,
-        mocker: MockerFixture,
-        project,
-        catch_eors: EventCatcher,
-        catch_aw: EventCatcher,
-    ) -> None:
-        mocked_fbs = mocker.patch(
-            "dbt.materializations.incremental.microbatch.MicrobatchBuilder.format_batch_start"
-        )
-        mocked_fbs.side_effect = KeyboardInterrupt
-        try:
-            run_dbt(["run"], callbacks=[catch_eors.catch, catch_aw.catch])
-            assert False, "KeyboardInterrupt failed to stop batch execution"
-        except KeyboardInterrupt:
-            assert len(catch_eors.caught_events) == 1
-            assert "Exited because of keyboard interrupt" in catch_eors.caught_events[0].info.msg
-            assert len(catch_aw.caught_events) == 1
 
 
 class TestMicrobatchModelSkipped(BaseMicrobatchTest):

--- a/tests/unit/materializations/incremental/test_microbatch.py
+++ b/tests/unit/materializations/incremental/test_microbatch.py
@@ -490,10 +490,10 @@ class TestMicrobatchBuilder:
         assert actual_batches == expected_batches
 
     def test_build_jinja_context_for_incremental_batch(self, microbatch_model):
-        microbatch_builder = MicrobatchBuilder(
-            model=microbatch_model, is_incremental=True, event_time_start=None, event_time_end=None
+        context = MicrobatchBuilder.build_jinja_context_for_batch(
+            model=microbatch_model,
+            incremental_batch=True,
         )
-        context = microbatch_builder.build_jinja_context_for_batch(incremental_batch=True)
 
         assert context["model"] == microbatch_model.to_dict()
         assert context["sql"] == microbatch_model.compiled_code
@@ -503,10 +503,10 @@ class TestMicrobatchBuilder:
         assert context["should_full_refresh"]() is False
 
     def test_build_jinja_context_for_incremental_batch_false(self, microbatch_model):
-        microbatch_builder = MicrobatchBuilder(
-            model=microbatch_model, is_incremental=True, event_time_start=None, event_time_end=None
+        context = MicrobatchBuilder.build_jinja_context_for_batch(
+            model=microbatch_model,
+            incremental_batch=False,
         )
-        context = microbatch_builder.build_jinja_context_for_batch(incremental_batch=False)
 
         assert context["model"] == microbatch_model.to_dict()
         assert context["sql"] == microbatch_model.compiled_code


### PR DESCRIPTION
Resolves #11243
Resolves #11306

### Problem

There are two problems
1. Executing microbatch model batches concurrently would block the main thread from scheduling other nodes as described in #11243
2. In certain scenarios, a microbatch model would _hang_ indefinitely as described in #11306

### Solution



### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
