### PR TITLE
Support python3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
     env:
       TOXENV: "unit"
@@ -162,7 +162,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         os: [ubuntu-20.04]
         split-group: ${{ fromJson(needs.integration-metadata.outputs.split-groups) }}
         include: ${{ fromJson(needs.integration-metadata.outputs.include) }}

--- a/core/dbt/artifacts/schemas/base.py
+++ b/core/dbt/artifacts/schemas/base.py
@@ -2,6 +2,7 @@ import dataclasses
 import functools
 from datetime import datetime
 from typing import Any, ClassVar, Dict, Optional, Type, TypeVar
+from zoneinfo import ZoneInfo
 
 from mashumaro.jsonschema import build_json_schema
 from mashumaro.jsonschema.dialects import DRAFT_2020_12
@@ -55,7 +56,7 @@ class Readable:
 class BaseArtifactMetadata(dbtClassMixin):
     dbt_schema_version: str
     dbt_version: str = __version__
-    generated_at: datetime = dataclasses.field(default_factory=datetime.utcnow)
+    generated_at: datetime = dataclasses.field(default_factory=(lambda: datetime.now(ZoneInfo("UTC"))))
     invocation_id: Optional[str] = dataclasses.field(default_factory=get_invocation_id)
     invocation_started_at: Optional[datetime] = dataclasses.field(
         default_factory=get_invocation_started_at

--- a/core/dbt/artifacts/schemas/base.py
+++ b/core/dbt/artifacts/schemas/base.py
@@ -56,7 +56,9 @@ class Readable:
 class BaseArtifactMetadata(dbtClassMixin):
     dbt_schema_version: str
     dbt_version: str = __version__
-    generated_at: datetime = dataclasses.field(default_factory=(lambda: datetime.now(ZoneInfo("UTC"))))
+    generated_at: datetime = dataclasses.field(
+        default_factory=(lambda: datetime.now(ZoneInfo("UTC")))
+    )
     invocation_id: Optional[str] = dataclasses.field(default_factory=get_invocation_id)
     invocation_started_at: Optional[datetime] = dataclasses.field(
         default_factory=get_invocation_started_at

--- a/core/dbt/artifacts/schemas/results.py
+++ b/core/dbt/artifacts/schemas/results.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from zoneinfo import ZoneInfo
 
 from dbt.contracts.graph.nodes import ResultNode
 from dbt_common.dataclass_schema import StrEnum, dbtClassMixin
@@ -21,10 +22,10 @@ class TimingInfo(dbtClassMixin):
     completed_at: Optional[datetime] = None
 
     def begin(self):
-        self.started_at = datetime.utcnow()
+        self.started_at = datetime.now(ZoneInfo("UTC"))
 
     def end(self):
-        self.completed_at = datetime.utcnow()
+        self.completed_at = datetime.now(ZoneInfo("UTC"))
 
     def to_msg_dict(self):
         msg_dict = {"name": str(self.name)}

--- a/core/dbt/artifacts/schemas/run/v5/run.py
+++ b/core/dbt/artifacts/schemas/run/v5/run.py
@@ -5,6 +5,7 @@ import threading
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, Iterable, Optional, Sequence, Tuple
+from zoneinfo import ZoneInfo
 
 # https://github.com/dbt-labs/dbt-core/issues/10098
 # Needed for Mashumaro serialization of RunResult below
@@ -101,7 +102,7 @@ class RunExecutionResult(
 ):
     results: Sequence[RunResult]
     args: Dict[str, Any] = field(default_factory=dict)
-    generated_at: datetime = field(default_factory=datetime.utcnow)
+    generated_at: datetime = field(default_factory=(lambda: datetime.now(ZoneInfo("UTC"))))
 
     def write(self, path: str):
         writable = RunResultsArtifact.from_execution_results(

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -206,7 +206,7 @@ def load_raw_project(project_root: str) -> Dict[str, Any]:
 
 
 def _query_comment_from_cfg(
-    cfg_query_comment: Union[QueryComment, NoValue, str, None]
+    cfg_query_comment: Union[QueryComment, NoValue, str, None],
 ) -> QueryComment:
     if not cfg_query_comment:
         return QueryComment(comment="")

--- a/core/dbt/contracts/graph/node_args.py
+++ b/core/dbt/contracts/graph/node_args.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import List, Optional
+from zoneinfo import ZoneInfo
 
 from dbt.artifacts.resources import NodeVersion
 from dbt.node_types import AccessType, NodeType
@@ -18,7 +19,7 @@ class ModelNodeArgs:
     latest_version: Optional[NodeVersion] = None
     deprecation_date: Optional[datetime] = None
     access: Optional[str] = AccessType.Protected.value
-    generated_at: datetime = field(default_factory=datetime.utcnow)
+    generated_at: datetime = field(default_factory=(lambda: datetime.now(ZoneInfo("UTC"))))
     depends_on_nodes: List[str] = field(default_factory=list)
     enabled: bool = True
 

--- a/core/dbt/contracts/sql.py
+++ b/core/dbt/contracts/sql.py
@@ -2,6 +2,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Sequence
+from zoneinfo import ZoneInfo
 
 from dbt.artifacts.schemas.base import VersionedSchema, schema_version
 from dbt.artifacts.schemas.results import ExecutionResult, TimingInfo
@@ -28,7 +29,7 @@ class RemoteCompileResultMixin(VersionedSchema):
 @dataclass
 @schema_version("remote-compile-result", 1)
 class RemoteCompileResult(RemoteCompileResultMixin):
-    generated_at: datetime = field(default_factory=datetime.utcnow)
+    generated_at: datetime = field(default_factory=(lambda: datetime.now(ZoneInfo("UTC"))))
 
     @property
     def error(self) -> None:
@@ -41,7 +42,7 @@ class RemoteCompileResult(RemoteCompileResultMixin):
 class RemoteExecutionResult(ExecutionResult):
     results: Sequence[RunResult]
     args: Dict[str, Any] = field(default_factory=dict)
-    generated_at: datetime = field(default_factory=datetime.utcnow)
+    generated_at: datetime = field(default_factory=(lambda: datetime.now(ZoneInfo("UTC"))))
 
     def write(self, path: str) -> None:
         writable = RunResultsArtifact.from_execution_results(
@@ -76,4 +77,4 @@ class ResultTable(dbtClassMixin):
 @schema_version("remote-run-result", 1)
 class RemoteRunResult(RemoteCompileResultMixin):
     table: ResultTable
-    generated_at: datetime = field(default_factory=datetime.utcnow)
+    generated_at: datetime = field(default_factory=(lambda: datetime.now(ZoneInfo("UTC"))))

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -951,7 +951,7 @@ class ManifestLoader:
                 is_partial_parsable, reparse_reason = self.is_partial_parsable(manifest)
                 if is_partial_parsable:
                     # We don't want to have stale generated_at dates
-                    manifest.metadata.generated_at = datetime.datetime.utcnow()
+                    manifest.metadata.generated_at = datetime.datetime.now(datetime.UTC)
                     # or invocation_ids
                     manifest.metadata.invocation_id = get_invocation_id()
                     return manifest

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -72,7 +72,7 @@ from dbt_semantic_interfaces.type_enums import (
 
 
 def parse_where_filter(
-    where: Optional[Union[List[str], str]]
+    where: Optional[Union[List[str], str]],
 ) -> Optional[WhereFilterIntersection]:
     if where is None:
         return None

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -211,8 +211,7 @@ class BaseRunner(metaclass=ABCMeta):
 
         result = self.safe_run(manifest)
         self.node.update_event_status(
-            node_status=result.status,
-            finished_at=datetime.now(ZoneInfo("UTC")).isoformat()
+            node_status=result.status, finished_at=datetime.now(ZoneInfo("UTC")).isoformat()
         )
 
         if not self.node.is_ephemeral_model:

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -7,6 +7,7 @@ from contextlib import nullcontext
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
+from zoneinfo import ZoneInfo
 
 import dbt.exceptions
 import dbt_common.exceptions.base
@@ -210,7 +211,8 @@ class BaseRunner(metaclass=ABCMeta):
 
         result = self.safe_run(manifest)
         self.node.update_event_status(
-            node_status=result.status, finished_at=datetime.utcnow().isoformat()
+            node_status=result.status,
+            finished_at=datetime.now(ZoneInfo("UTC")).isoformat()
         )
 
         if not self.node.is_ephemeral_model:

--- a/core/dbt/task/docs/generate.py
+++ b/core/dbt/task/docs/generate.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 from datetime import datetime
 from itertools import chain
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+from zoneinfo import ZoneInfo
 
 import agate
 
@@ -223,7 +224,7 @@ class GenerateTask(CompileTask):
                 return CatalogArtifact.from_results(
                     nodes={},
                     sources={},
-                    generated_at=datetime.utcnow(),
+                    generated_at=datetime.now(ZoneInfo("UTC")),
                     errors=None,
                     compile_results=compile_results,
                 )
@@ -303,7 +304,7 @@ class GenerateTask(CompileTask):
         results = self.get_catalog_results(
             nodes=nodes,
             sources=sources,
-            generated_at=datetime.utcnow(),
+            generated_at=datetime.now(ZoneInfo("UTC")),
             compile_results=compile_results,
             errors=errors,
         )

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -7,6 +7,7 @@ from dataclasses import asdict
 from datetime import datetime
 from multiprocessing.pool import ThreadPool
 from typing import AbstractSet, Any, Dict, Iterable, List, Optional, Set, Tuple, Type
+from zoneinfo import ZoneInfo
 
 from dbt import tracking, utils
 from dbt.adapters.base import BaseAdapter, BaseRelation
@@ -913,7 +914,7 @@ class RunTask(CompileTask):
                             adapter, hook, hook.index, num_hooks, extra_context
                         )
 
-                    started_at = timing[0].started_at or datetime.utcnow()
+                    started_at = timing[0].started_at or datetime.now(ZoneInfo("UTC"))
                     hook.update_event_status(
                         started_at=started_at.isoformat(), node_status=RunningStatus.Started
                     )
@@ -930,7 +931,7 @@ class RunTask(CompileTask):
                     with collect_timing_info("execute", timing.append):
                         status, message = get_execution_status(sql, adapter)
 
-                    finished_at = timing[1].completed_at or datetime.utcnow()
+                    finished_at = timing[1].completed_at or datetime.now(ZoneInfo("UTC"))
                     hook.update_event_status(finished_at=finished_at.isoformat())
                     execution_time = (finished_at - started_at).total_seconds()
                     failures = 0 if status == RunStatus.Success else 1
@@ -1038,7 +1039,7 @@ class RunTask(CompileTask):
             run_result = self.get_result(
                 results=self.node_results,
                 elapsed_time=time.time() - self.started_at,
-                generated_at=datetime.utcnow(),
+                generated_at=datetime.now(ZoneInfo("UTC")),
             )
 
             if self.args.write_json and hasattr(run_result, "write"):

--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -3,6 +3,7 @@ import threading
 import traceback
 from datetime import datetime
 from typing import TYPE_CHECKING, List
+from zoneinfo import ZoneInfo
 
 import dbt_common.exceptions
 from dbt.adapters.factory import get_adapter
@@ -116,7 +117,7 @@ class RunOperationTask(ConfiguredTask):
         )
 
         results = RunResultsArtifact.from_execution_results(
-            generated_at=end or datetime.utcnow(),
+            generated_at=end or datetime.now(ZoneInfo("UTC")),
             elapsed_time=execution_time,
             args={
                 k: v

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from multiprocessing.dummy import Pool as ThreadPool
 from pathlib import Path
 from typing import AbstractSet, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
+from zoneinfo import ZoneInfo
 
 import dbt.exceptions
 import dbt.tracking
@@ -225,7 +226,7 @@ class GraphRunnableTask(ConfiguredTask):
     def call_runner(self, runner: BaseRunner) -> RunResult:
         with log_contextvars(node_info=runner.node.node_info):
             runner.node.update_event_status(
-                started_at=datetime.utcnow().isoformat(), node_status=RunningStatus.Started
+                started_at=datetime.now(ZoneInfo("UTC")).isoformat(), node_status=RunningStatus.Started
             )
             fire_event(
                 NodeStart(
@@ -430,7 +431,7 @@ class GraphRunnableTask(ConfiguredTask):
             run_result = self.get_result(
                 results=self.node_results,
                 elapsed_time=time.time() - self.started_at,
-                generated_at=datetime.utcnow(),
+                generated_at=datetime.now(ZoneInfo("UTC")),
             )
 
             if self.args.write_json and hasattr(run_result, "write"):
@@ -562,7 +563,7 @@ class GraphRunnableTask(ConfiguredTask):
             elapsed = time.time() - self.started_at
             self.print_results_line(self.node_results, elapsed)
             result = self.get_result(
-                results=self.node_results, elapsed_time=elapsed, generated_at=datetime.utcnow()
+                results=self.node_results, elapsed_time=elapsed, generated_at=datetime.now(ZoneInfo("UTC"))
             )
 
         return result
@@ -585,7 +586,7 @@ class GraphRunnableTask(ConfiguredTask):
                 warn_or_error(NothingToDo())
                 result = self.get_result(
                     results=[],
-                    generated_at=datetime.utcnow(),
+                    generated_at=datetime.now(ZoneInfo("UTC")),
                     elapsed_time=0.0,
                 )
             else:

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -226,7 +226,8 @@ class GraphRunnableTask(ConfiguredTask):
     def call_runner(self, runner: BaseRunner) -> RunResult:
         with log_contextvars(node_info=runner.node.node_info):
             runner.node.update_event_status(
-                started_at=datetime.now(ZoneInfo("UTC")).isoformat(), node_status=RunningStatus.Started
+                started_at=datetime.now(ZoneInfo("UTC")).isoformat(),
+                node_status=RunningStatus.Started,
             )
             fire_event(
                 NodeStart(
@@ -563,7 +564,9 @@ class GraphRunnableTask(ConfiguredTask):
             elapsed = time.time() - self.started_at
             self.print_results_line(self.node_results, elapsed)
             result = self.get_result(
-                results=self.node_results, elapsed_time=elapsed, generated_at=datetime.now(ZoneInfo("UTC"))
+                results=self.node_results,
+                elapsed_time=elapsed,
+                generated_at=datetime.now(ZoneInfo("UTC")),
             )
 
         return result

--- a/core/dbt/task/sql.py
+++ b/core/dbt/task/sql.py
@@ -2,6 +2,7 @@ import traceback
 from abc import abstractmethod
 from datetime import datetime
 from typing import Generic, TypeVar
+from zoneinfo import ZoneInfo
 
 import dbt.exceptions
 import dbt_common.exceptions.base
@@ -68,7 +69,7 @@ class SqlCompileRunner(GenericSqlRunner[RemoteCompileResult]):
             compiled_code=compiled_node.compiled_code,
             node=compiled_node,
             timing=[],  # this will get added later
-            generated_at=datetime.utcnow(),
+            generated_at=datetime.now(ZoneInfo("UTC")),
         )
 
     def from_run_result(self, result, start_time, timing_info) -> RemoteCompileResult:
@@ -77,7 +78,7 @@ class SqlCompileRunner(GenericSqlRunner[RemoteCompileResult]):
             compiled_code=result.compiled_code,
             node=result.node,
             timing=timing_info,
-            generated_at=datetime.utcnow(),
+            generated_at=datetime.now(ZoneInfo("UTC")),
         )
 
 
@@ -96,7 +97,7 @@ class SqlExecuteRunner(GenericSqlRunner[RemoteRunResult]):
             node=compiled_node,
             table=table,
             timing=[],
-            generated_at=datetime.utcnow(),
+            generated_at=datetime.now(ZoneInfo("UTC")),
         )
 
     def from_run_result(self, result, start_time, timing_info) -> RemoteRunResult:
@@ -106,5 +107,5 @@ class SqlExecuteRunner(GenericSqlRunner[RemoteRunResult]):
             node=result.node,
             table=result.table,
             timing=timing_info,
-            generated_at=datetime.utcnow(),
+            generated_at=datetime.now(ZoneInfo("UTC")),
         )

--- a/core/dbt/tests/fixtures/project.py
+++ b/core/dbt/tests/fixtures/project.py
@@ -4,6 +4,7 @@ from argparse import Namespace
 from datetime import datetime
 from pathlib import Path
 from typing import Mapping
+from zoneinfo import ZoneInfo
 
 import pytest  # type: ignore
 import yaml
@@ -75,7 +76,7 @@ from dbt_common.tests import enable_test_caching
 def prefix():
     # create a directory name that will be unique per test session
     _randint = random.randint(0, 9999)
-    _runtime_timedelta = datetime.utcnow() - datetime(1970, 1, 1, 0, 0, 0)
+    _runtime_timedelta = datetime.now(ZoneInfo("UTC")) - datetime(1970, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))
     _runtime = (int(_runtime_timedelta.total_seconds() * 1e6)) + _runtime_timedelta.microseconds
     prefix = f"test{_runtime}{_randint:04}"
     return prefix

--- a/core/dbt/tests/fixtures/project.py
+++ b/core/dbt/tests/fixtures/project.py
@@ -76,7 +76,9 @@ from dbt_common.tests import enable_test_caching
 def prefix():
     # create a directory name that will be unique per test session
     _randint = random.randint(0, 9999)
-    _runtime_timedelta = datetime.now(ZoneInfo("UTC")) - datetime(1970, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))
+    _runtime_timedelta = datetime.now(ZoneInfo("UTC")) - datetime(
+        1970, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC")
+    )
     _runtime = (int(_runtime_timedelta.total_seconds() * 1e6)) + _runtime_timedelta.microseconds
     prefix = f"test{_runtime}{_randint:04}"
     return prefix

--- a/core/dbt/tests/util.py
+++ b/core/dbt/tests/util.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from io import StringIO
 from typing import Any, Callable, Dict, List, Optional
 from unittest import mock
+from zoneinfo import ZoneInfo
 
 import pytz
 import yaml
@@ -284,7 +285,7 @@ def check_result_nodes_by_unique_id(results, unique_ids):
 def check_datetime_between(timestr, start, end=None):
     datefmt = "%Y-%m-%dT%H:%M:%S.%fZ"
     if end is None:
-        end = datetime.utcnow()
+        end = datetime.now(ZoneInfo("UTC"))
     parsed = datetime.strptime(timestr, datefmt)
     assert start <= parsed
     assert end >= parsed

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -144,7 +144,7 @@ def add_ephemeral_model_prefix(s: str) -> str:
 def timestring() -> str:
     """Get the current datetime as an RFC 3339-compliant string"""
     # isoformat doesn't include the mandatory trailing 'Z' for UTC.
-    return datetime.datetime.utcnow().isoformat() + "Z"
+    return datetime.datetime.now(datetime.UTC).isoformat() + "Z"
 
 
 def humanize_execution_time(execution_time: int) -> str:

--- a/core/setup.py
+++ b/core/setup.py
@@ -89,10 +89,12 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     python_requires=">=3.9",
 )

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,7 @@ docutils
 # flake8 must match what's in .pre-commit-config.yaml to be sure local env matches CI
 flake8==4.0.1
 flaky
-freezegun>=1.4.0,<1.5
+freezegun>=1.5.1,<1.6
 hypothesis
 ipdb
 # isort must match what's in .pre-commit-config.yaml to be sure local env matches CI

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-postgres
 # black must match what's in .pre-commit-config.yaml to be sure local env matches CI
 black==24.3.0
 bumpversion
-ddtrace==2.3.0
+ddtrace==2.21.2
 docutils
 # flake8 must match what's in .pre-commit-config.yaml to be sure local env matches CI
 flake8==4.0.1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,4 +56,4 @@ RUN if [ "$dbt_third_party" ]; then \
         python -m pip install --no-cache-dir "${dbt_third_party}"; \
     else \
         echo "No third party adapter provided"; \
-    fi \
+    fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,17 @@
 ARG py_version=3.11.2
 
-FROM python:$py_version-slim-bullseye as base
+FROM python:$py_version-slim-bookworm as base
 
 RUN apt-get update \
   && apt-get dist-upgrade -y \
   && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
-    ca-certificates=20210119 \
-    git=1:2.30.2-1+deb11u2 \
-    libpq-dev=13.18-0+deb11u1 \
+    ca-certificates=20230311 \
+    git=1:2.39.5-0+deb12u2 \
+    libpq-dev=15.10-0+deb12u1 \
     make=4.3-4.1 \
-    openssh-client=1:8.4p1-5+deb11u3 \
-    software-properties-common=0.96.20.2-2.1 \
+    openssh-client=1:9.2p1-2+deb12u5 \
+    software-properties-common=0.99.30-4.1~deb12u1 \
   && apt-get clean \
   && rm -rf \
     /var/lib/apt/lists/* \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG py_version=3.11.2
+ARG py_version=3.12.9
 
 FROM python:$py_version-slim-bookworm as base
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,18 +1,22 @@
 # Docker for dbt
+
 This docker file is suitable for building dbt Docker images locally or using with CI/CD to automate populating a container registry.
 
+## Building an image
 
-## Building an image:
 This Dockerfile can create images for the following targets, each named after the database they support:
+
 * `dbt-core` _(no db-adapter support)_
 * `dbt-third-party` _(requires additional build-arg)_
 
 For platform-specific images, please refer to that platform's repository (eg. [dbt-postgres](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-postgres/docker/README.md))
 
 In order to build a new image, run the following docker command.
-```
+
+```sh
 docker build --tag <your_image_name> --target <target_name> <path/to/dockerfile>
 ```
+
 ---
 > **Note:**  Docker must be configured to use [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/) in order for images to build properly!
 
@@ -20,7 +24,8 @@ docker build --tag <your_image_name> --target <target_name> <path/to/dockerfile>
 
 By default the images will be populated with `dbt-core` on `main`.
 If you need to use a different version you can specify it by git ref (tag, branch, sha) using the `--build-arg` flag:
-```
+
+```sh
 docker build --tag <your_image_name> \
   --target <target_name> \
   --build-arg commit_ref=<git_ref> \
@@ -29,17 +34,21 @@ docker build --tag <your_image_name> \
 
 If you wish to build an image with a third-party adapter you can use the `dbt-third-party` target.
 This target requires you provide a path to the adapter that can be processed by `pip` by using the `dbt_third_party` build arg:
-```
+
+```sh
 docker build --tag <your_image_name> \
   --target dbt-third-party \
   --build-arg dbt_third_party=<pip_parsable_install_string> \
   <path/to/dockerfile>
 ```
+
 This can also be combined with the `commit_ref` build arg to specify a version of `dbt-core`.
 
-### Examples:
+### Examples
+
 To build an image named "my-third-party-dbt" that uses the latest release of [Materialize third party adapter](https://github.com/MaterializeInc/materialize/tree/main/misc/dbt-materialize) and the latest dev version of `dbt-core`:
-```
+
+```sh
 cd dbt-core/docker
 docker build --tag my-third-party-dbt \
   --target dbt-third-party \
@@ -47,10 +56,11 @@ docker build --tag my-third-party-dbt \
   .
 ```
 
+## Running an image in a container
 
-## Running an image in a container:
 The `ENTRYPOINT` for this Dockerfile is the command `dbt` so you can bind-mount your project to `/usr/app` and use dbt as normal:
-```
+
+```sh
 docker run \
   --network=host \
   --mount type=bind,source=path/to/project,target=/usr/app \
@@ -58,8 +68,10 @@ docker run \
   my-dbt \
   ls
 ```
+
 ---
 **Notes:**
+
 * Bind-mount sources _must_ be an absolute path
 * You may need to make adjustments to the docker networking setting depending on the specifics of your data warehouse/database host.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,4 @@ namespace_packages = true
 
 [tool.black]
 line-length = 99
-target-version = ['py38']
+target-version = ['py39']

--- a/tests/functional/adapter/basic/test_docs_generate.py
+++ b/tests/functional/adapter/basic/test_docs_generate.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -354,7 +355,7 @@ def run_and_generate(project, args=None):
     rm_file(project.project_root, "target", "manifest.json")
     rm_file(project.project_root, "target", "run_results.json")
 
-    start_time = datetime.utcnow()
+    start_time = datetime.now(ZoneInfo("UTC"))
     run_args = ["docs", "generate"]
     if args:
         run_args.extend(args)

--- a/tests/functional/adapter/utils/test_current_timestamp.py
+++ b/tests/functional/adapter/utils/test_current_timestamp.py
@@ -46,7 +46,12 @@ class BaseCurrentTimestamp:
         """
         Current UTC datetime with the same timezone-awareness (or naiveness) as the input.
         """
-        return datetime.now(timezone.utc) if is_aware(dt) else datetime.utcnow()
+        utc_clock = datetime.now(timezone.utc)
+        if is_aware(dt):
+            return utc_clock
+        else:
+            utc_clock(tzinfo=None)
+            return utc_clock
 
 
 class BaseCurrentTimestampAware(BaseCurrentTimestamp):

--- a/tests/functional/artifacts/test_artifacts.py
+++ b/tests/functional/artifacts/test_artifacts.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import jsonschema
 import pytest
@@ -620,7 +621,7 @@ class TestVerifyArtifacts(BaseVerifyProject):
     # Test generic "docs generate" command
     def test_run_and_generate(self, project, manifest_schema_path, run_results_schema_path):
         catcher = EventCatcher(ArtifactWritten)
-        start_time = datetime.utcnow()
+        start_time = datetime.now(ZoneInfo("UTC"))
         results = run_dbt(args=["compile"], callbacks=[catcher.catch])
         assert len(results) == 7
         verify_manifest(
@@ -692,7 +693,7 @@ class TestVerifyArtifactsReferences(BaseVerifyProject):
         }
 
     def test_references(self, project, manifest_schema_path, run_results_schema_path):
-        start_time = datetime.utcnow()
+        start_time = datetime.now(ZoneInfo("UTC"))
         results = run_dbt(["compile"])
         assert len(results) == 4
         verify_manifest(
@@ -722,7 +723,7 @@ class TestVerifyArtifactsVersions(BaseVerifyProject):
         return {}
 
     def test_versions(self, project, manifest_schema_path, run_results_schema_path):
-        start_time = datetime.utcnow()
+        start_time = datetime.now(ZoneInfo("UTC"))
         results = run_dbt(["compile"])
         assert len(results) == 6
         verify_manifest(

--- a/tests/functional/configs/test_configs.py
+++ b/tests/functional/configs/test_configs.py
@@ -57,7 +57,7 @@ class TestTargetConfigs(BaseConfigProject):
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
-            "target-path": "target_{{ modules.datetime.datetime.utcnow().strftime('%Y%m%dT%H%M%S') }}",
+            "target-path": "target_{{ modules.datetime.datetime.now(datetime.UTC).strftime('%Y%m%dT%H%M%S') }}",
             "seeds": {
                 "quote_columns": False,
             },

--- a/tests/functional/source_overrides/test_simple_source_override.py
+++ b/tests/functional/source_overrides/test_simple_source_override.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -62,7 +63,7 @@ class TestSourceOverride:
         }
 
     def _set_updated_at_to(self, insert_id, delta, project):
-        insert_time = datetime.utcnow() + delta
+        insert_time = datetime.now(ZoneInfo("UTC")) + delta
         timestr = insert_time.strftime("%Y-%m-%d %H:%M:%S")
         # favorite_color,id,first_name,email,ip_address,updated_at
 

--- a/tests/functional/sources/test_source_fresher_state.py
+++ b/tests/functional/sources/test_source_fresher_state.py
@@ -2,6 +2,7 @@ import json
 import os
 import shutil
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -28,7 +29,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
     def setUp(self, project):
         self.run_dbt_with_vars(project, ["seed"])
         pytest._id = 101
-        pytest.freshness_start_time = datetime.utcnow()
+        pytest.freshness_start_time = datetime.now(ZoneInfo("UTC"))
         # this is the db initial value
         pytest.last_inserted_time = "2016-09-19T14:45:51+00:00"
 
@@ -39,7 +40,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
         del os.environ["DBT_ENV_CUSTOM_ENV_key"]
 
     def _set_updated_at_to(self, project, delta):
-        insert_time = datetime.utcnow() + delta
+        insert_time = datetime.now(ZoneInfo("UTC")) + delta
         timestr = insert_time.strftime("%Y-%m-%d %H:%M:%S")
         # favorite_color,id,first_name,email,ip_address,updated_at
         insert_id = pytest._id
@@ -68,7 +69,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
     def assertBetween(self, timestr, start, end=None):
         datefmt = "%Y-%m-%dT%H:%M:%S.%fZ"
         if end is None:
-            end = datetime.utcnow()
+            end = datetime.now(ZoneInfo("UTC"))
 
         parsed = datetime.strptime(timestr, datefmt)
 

--- a/tests/functional/sources/test_source_freshness.py
+++ b/tests/functional/sources/test_source_freshness.py
@@ -1,6 +1,7 @@
 import json
 import os
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 import yaml
@@ -28,7 +29,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
     def setUp(self, project):
         self.run_dbt_with_vars(project, ["seed"])
         pytest._id = 101
-        pytest.freshness_start_time = datetime.utcnow()
+        pytest.freshness_start_time = datetime.now(ZoneInfo("UTC"))
         # this is the db initial value
         pytest.last_inserted_time = "2016-09-19T14:45:51+00:00"
 
@@ -39,7 +40,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
         del os.environ["DBT_ENV_CUSTOM_ENV_key"]
 
     def _set_updated_at_to(self, project, delta):
-        insert_time = datetime.utcnow() + delta
+        insert_time = datetime.now(ZoneInfo("UTC")) + delta
         timestr = insert_time.strftime("%Y-%m-%d %H:%M:%S")
         # favorite_color,id,first_name,email,ip_address,updated_at
         insert_id = pytest._id
@@ -68,7 +69,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
     def assertBetween(self, timestr, start, end=None):
         datefmt = "%Y-%m-%dT%H:%M:%S.%fZ"
         if end is None:
-            end = datetime.utcnow()
+            end = datetime.now(ZoneInfo("UTC"))
 
         parsed = datetime.strptime(timestr, datefmt)
 

--- a/tests/unit/contracts/graph/test_manifest.py
+++ b/tests/unit/contracts/graph/test_manifest.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from datetime import datetime
 from itertools import product
 from unittest import mock
+from zoneinfo import ZoneInfo
 
 import freezegun
 import pytest
@@ -377,7 +378,7 @@ class ManifestTest(unittest.TestCase):
             exposures={},
             metrics={},
             selectors={},
-            metadata=ManifestMetadata(generated_at=datetime.utcnow()),
+            metadata=ManifestMetadata(generated_at=datetime.now(ZoneInfo("UTC"))),
             semantic_models={},
             saved_queries={},
         )
@@ -400,7 +401,7 @@ class ManifestTest(unittest.TestCase):
                 "child_map": {},
                 "group_map": {},
                 "metadata": {
-                    "generated_at": "2018-02-14T09:15:13Z",
+                    "generated_at": "2018-02-14T09:15:13+00:00Z",
                     "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
                     "dbt_version": dbt.version.__version__,
                     "env": {ENV_KEY_NAME: "value"},
@@ -433,10 +434,10 @@ class ManifestTest(unittest.TestCase):
             exposures={},
             metrics={},
             selectors={},
-            metadata=ManifestMetadata(generated_at=datetime.utcnow()),
+            metadata=ManifestMetadata(generated_at=datetime.now(ZoneInfo("UTC"))),
         )
         serialized = manifest.writable_manifest().to_dict(omit_none=True)
-        self.assertEqual(serialized["metadata"]["generated_at"], "2018-02-14T09:15:13Z")
+        self.assertEqual(serialized["metadata"]["generated_at"], "2018-02-14T09:15:13+00:00Z")
         self.assertEqual(serialized["metadata"]["user_id"], mock_user.id)
         self.assertFalse(serialized["metadata"]["send_anonymous_usage_stats"])
         self.assertEqual(serialized["docs"], {})
@@ -533,12 +534,12 @@ class ManifestTest(unittest.TestCase):
     def test_no_nodes_with_metadata(self, mock_user):
         mock_user.id = "cfc9500f-dc7f-4c83-9ea7-2c581c1b38cf"
         dbt_common.invocation._INVOCATION_ID = "01234567-0123-0123-0123-0123456789ab"
-        dbt_common.invocation._INVOCATION_STARTED_AT = datetime.utcnow()
+        dbt_common.invocation._INVOCATION_STARTED_AT = datetime.now(ZoneInfo("UTC"))
         set_from_args(Namespace(SEND_ANONYMOUS_USAGE_STATS=False), None)
         metadata = ManifestMetadata(
             project_id="098f6bcd4621d373cade4e832627b4f6",
             adapter_type="postgres",
-            generated_at=datetime.utcnow(),
+            generated_at=datetime.now(ZoneInfo("UTC")),
             invocation_started_at=dbt_common.invocation._INVOCATION_STARTED_AT,
             user_id="cfc9500f-dc7f-4c83-9ea7-2c581c1b38cf",
             send_anonymous_usage_stats=False,
@@ -575,7 +576,7 @@ class ManifestTest(unittest.TestCase):
                 "group_map": {},
                 "docs": {},
                 "metadata": {
-                    "generated_at": "2018-02-14T09:15:13Z",
+                    "generated_at": "2018-02-14T09:15:13+00:00Z",
                     "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
                     "dbt_version": dbt.version.__version__,
                     "project_id": "098f6bcd4621d373cade4e832627b4f6",
@@ -892,9 +893,10 @@ class MixedManifestTest(unittest.TestCase):
     def test_no_nodes(self, mock_user):
         mock_user.id = "cfc9500f-dc7f-4c83-9ea7-2c581c1b38cf"
         set_from_args(Namespace(SEND_ANONYMOUS_USAGE_STATS=False), None)
-        invocation_started_at = datetime.utcnow()
+        invocation_started_at = datetime.now(ZoneInfo("UTC"))
+        generated_at = datetime.now(ZoneInfo("UTC"))
         metadata = ManifestMetadata(
-            generated_at=datetime.utcnow(),
+            generated_at=generated_at,
             invocation_id="01234567-0123-0123-0123-0123456789ab",
             invocation_started_at=invocation_started_at,
         )
@@ -925,7 +927,7 @@ class MixedManifestTest(unittest.TestCase):
                 "child_map": {},
                 "group_map": {},
                 "metadata": {
-                    "generated_at": "2018-02-14T09:15:13Z",
+                    "generated_at": "2018-02-14T09:15:13+00:00Z",
                     "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
                     "dbt_version": dbt.version.__version__,
                     "invocation_id": "01234567-0123-0123-0123-0123456789ab",
@@ -952,12 +954,12 @@ class MixedManifestTest(unittest.TestCase):
             docs={},
             disabled={},
             selectors={},
-            metadata=ManifestMetadata(generated_at=datetime.utcnow()),
+            metadata=ManifestMetadata(generated_at=datetime.now(ZoneInfo("UTC"))),
             files={},
             exposures={},
         )
         serialized = manifest.writable_manifest().to_dict(omit_none=True)
-        self.assertEqual(serialized["metadata"]["generated_at"], "2018-02-14T09:15:13Z")
+        self.assertEqual(serialized["metadata"]["generated_at"], "2018-02-14T09:15:13+00:00Z")
         self.assertEqual(serialized["disabled"], {})
         parent_map = serialized["parent_map"]
         child_map = serialized["child_map"]

--- a/tests/unit/contracts/graph/test_semantic_manifest.py
+++ b/tests/unit/contracts/graph/test_semantic_manifest.py
@@ -46,9 +46,10 @@ class TestSemanticManifest:
     def test_require_yaml_configuration_for_mf_time_spines(
         self, manifest: Manifest, metricflow_time_spine_model: ModelNode
     ):
-        with patch("dbt.contracts.graph.semantic_manifest.get_flags") as patched_get_flags, patch(
-            "dbt.contracts.graph.semantic_manifest.deprecations"
-        ) as patched_deprecations:
+        with (
+            patch("dbt.contracts.graph.semantic_manifest.get_flags") as patched_get_flags,
+            patch("dbt.contracts.graph.semantic_manifest.deprecations") as patched_deprecations,
+        ):
             patched_get_flags.return_value.require_yaml_configuration_for_mf_time_spines = False
             manifest.nodes[metricflow_time_spine_model.unique_id] = metricflow_time_spine_model
             sm_manifest = SemanticManifest(manifest)
@@ -136,9 +137,10 @@ class TestSemanticManifest:
         should_error: bool,
         flag_value: bool,
     ):
-        with patch("dbt.contracts.graph.semantic_manifest.get_flags") as patched_get_flags, patch(
-            "dbt.contracts.graph.semantic_manifest.deprecations"
-        ) as patched_deprecations:
+        with (
+            patch("dbt.contracts.graph.semantic_manifest.get_flags") as patched_get_flags,
+            patch("dbt.contracts.graph.semantic_manifest.deprecations") as patched_deprecations,
+        ):
             patched_get_flags.return_value.require_nested_cumulative_type_params = flag_value
             manifest.metrics["metric.test.my_metric"] = Metric(
                 name="my_metric",

--- a/tests/unit/task/test_clone.py
+++ b/tests/unit/task/test_clone.py
@@ -7,9 +7,10 @@ from dbt.task.clone import CloneTask
 def test_clone_task_not_preserve_edges():
     mock_node_selector = MagicMock()
     mock_spec = MagicMock()
-    with patch.object(
-        CloneTask, "get_node_selector", return_value=mock_node_selector
-    ), patch.object(CloneTask, "get_selection_spec", return_value=mock_spec):
+    with (
+        patch.object(CloneTask, "get_node_selector", return_value=mock_node_selector),
+        patch.object(CloneTask, "get_selection_spec", return_value=mock_spec),
+    ):
         task = CloneTask(get_flags(), None, None)
         task.get_graph_queue()
         # when we get the graph queue, preserve_edges is False

--- a/tests/unit/task/test_run.py
+++ b/tests/unit/task/test_run.py
@@ -47,9 +47,10 @@ def test_run_task_cancel_connections(
     def mock_run_queue(*args, **kwargs):
         raise exception_to_raise("Test exception")
 
-    with patch.object(RunTask, "run_queue", mock_run_queue), patch.object(
-        RunTask, "_cancel_connections"
-    ) as mock_cancel_connections:
+    with (
+        patch.object(RunTask, "run_queue", mock_run_queue),
+        patch.object(RunTask, "_cancel_connections") as mock_cancel_connections,
+    ):
 
         set_from_args(Namespace(write_json=False), None)
         task = RunTask(
@@ -65,8 +66,9 @@ def test_run_task_cancel_connections(
 def test_run_task_preserve_edges():
     mock_node_selector = MagicMock()
     mock_spec = MagicMock()
-    with patch.object(RunTask, "get_node_selector", return_value=mock_node_selector), patch.object(
-        RunTask, "get_selection_spec", return_value=mock_spec
+    with (
+        patch.object(RunTask, "get_node_selector", return_value=mock_node_selector),
+        patch.object(RunTask, "get_selection_spec", return_value=mock_spec),
     ):
         task = RunTask(get_flags(), None, None)
         task.get_graph_queue()

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 envlist = unit,integration
 
-[testenv:{unit,py38,py39,py310,py311,py}]
+[testenv:{unit,py39,py310,py311,py312,py313,py}]
 description = unit testing
 download = true
 skip_install = true


### PR DESCRIPTION
Resolves #11106 

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

Support for Python 3.13 is required. Also, there are some problems , so that need to be fixed.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

- For `DeprecationWarning` of `datetime.datetime.utcnow`, replace it with `datetime.datetime.now(ZoneInfo("UTC"))`
- For EOL of Debian 11 Bullseye, replace it with Debian 12 bookworm
- For Python 3.13 compatibility, update `freezegun` and `ddtrace`

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
