### PR TITLE
Fix parsing error for projects using the new YAML format for snapshots

### DIFF
--- a/.changes/unreleased/Fixes-20250305-110257.yaml
+++ b/.changes/unreleased/Fixes-20250305-110257.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fixes parsing errors when using the new YAML format for snapshots
+time: 2025-03-05T11:02:57.829685Z
+custom:
+    Author: amardatar
+    Issue: "11164"

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -344,7 +344,11 @@ class PartialParsing:
         if node.patch_path:
             file_id = node.patch_path
             # it might be changed...  then what?
-            if file_id not in self.file_diff["deleted"] and file_id in self.saved_files:
+            if (
+                file_id not in self.file_diff["deleted"]
+                and file_id in self.saved_files
+                and source_file.parse_file_type in parse_file_type_to_key
+            ):
                 # Schema files should already be updated if this comes from a node,
                 # but this code is also called when updating groups and exposures.
                 # This might save the old schema file element, so when the schema file
@@ -391,10 +395,10 @@ class PartialParsing:
         self.saved_files[new_source_file.file_id] = deepcopy(new_source_file)
         self.add_to_pp_files(new_source_file)
 
-    def remove_mssat_file(self, source_file):
+    def remove_mssat_file(self, source_file: AnySourceFile):
         # nodes [unique_ids] -- SQL files
         # There should always be a node for a SQL file
-        if not source_file.nodes:
+        if not hasattr(source_file, "nodes") or not source_file.nodes:
             return
         # There is generally only 1 node for SQL files, except for macros and snapshots
         for unique_id in source_file.nodes:

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -7,6 +7,7 @@ from dbt.contracts.files import (
     AnySourceFile,
     ParseFileType,
     SchemaSourceFile,
+    SourceFile,
     parse_file_type_to_parser,
 )
 from dbt.contracts.graph.manifest import Manifest
@@ -398,7 +399,7 @@ class PartialParsing:
     def remove_mssat_file(self, source_file: AnySourceFile):
         # nodes [unique_ids] -- SQL files
         # There should always be a node for a SQL file
-        if not hasattr(source_file, "nodes") or not source_file.nodes:
+        if not isinstance(source_file, SourceFile) or not source_file.nodes:
             return
         # There is generally only 1 node for SQL files, except for macros and snapshots
         for unique_id in source_file.nodes:

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -301,6 +301,11 @@ class SchemaParser(SimpleParser[YamlBlock, ModelNode]):
                         block.path.relative_path, snapshot["name"] + ".sql"
                     )
                 )
+
+                # This is used to initially populate `raw_code`, which must not be empty to pass validation.
+                if block.file.contents is None:
+                    block.file.contents = ""
+
                 snapshot_node = parser._create_parsetime_node(
                     block,
                     compiled_path,

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -301,11 +301,6 @@ class SchemaParser(SimpleParser[YamlBlock, ModelNode]):
                         block.path.relative_path, snapshot["name"] + ".sql"
                     )
                 )
-
-                # This is used to initially populate `raw_code`, which must not be empty to pass validation.
-                if block.file.contents is None:
-                    block.file.contents = ""
-
                 snapshot_node = parser._create_parsetime_node(
                     block,
                     compiled_path,

--- a/tests/functional/snapshots/fixtures.py
+++ b/tests/functional/snapshots/fixtures.py
@@ -307,6 +307,16 @@ snapshots:
           - not_null
 """
 
+snapshots_pg__source_snapshot_yml = """
+snapshots:
+  - name: snapshot_source
+    relation: "source('information_schema', 'tables')"
+    config:
+      unique_key: "table_schema || '-' || table_name"
+      strategy: check
+      check_cols: all
+"""
+
 snapshots_pg__snapshot_mod_yml = """
 snapshots:
   - name: snapshot_actual
@@ -416,4 +426,24 @@ snapshots_check_col_noconfig__snapshot_sql = """
     {{ config(check_cols='all') }}
     select * from {{target.database}}.{{schema}}.seed
 {% endsnapshot %}
+"""
+
+
+sources_pg__source_yml = """
+sources:
+  - name: information_schema
+    database: dbt
+    schema: information_schema
+    tables:
+      - name: tables
+"""
+
+sources_pg__source_mod_yml = """
+sources:
+  - name: information_schema
+    database: dbt
+    schema: information_schema
+    tables:
+      - name: tables
+        description: tables
 """

--- a/tests/unit/utils/manifest.py
+++ b/tests/unit/utils/manifest.py
@@ -531,7 +531,6 @@ def make_source_snapshot(pkg: str, name: str, source: SourceDefinition, path=Non
             nodes=[source.unique_id],
             macros=[],
         ),
-        # relation=f"source('{source.source_name}', '{source.name}')",
         config=SnapshotConfig(
             strategy="check",
             unique_key="'dummy'",

--- a/tests/unit/utils/manifest.py
+++ b/tests/unit/utils/manifest.py
@@ -11,6 +11,7 @@ from dbt.artifacts.resources import (
     Owner,
     QueryParams,
     RefArgs,
+    SnapshotConfig,
     TestConfig,
     TestMetadata,
     WhereFilter,
@@ -37,6 +38,7 @@ from dbt.contracts.graph.nodes import (
     SeedNode,
     SemanticModel,
     SingularTestNode,
+    SnapshotNode,
     SourceDefinition,
     UnitTestDefinition,
 )
@@ -505,6 +507,36 @@ def make_saved_query(pkg: str, name: str, metric: str, path=None):
         unique_id=f"saved_query.{pkg}.{name}",
         original_file_path=path,
         fqn=[pkg, "saved_queries", name],
+    )
+
+
+def make_source_snapshot(pkg: str, name: str, source: SourceDefinition, path=None) -> SnapshotNode:
+    if path is None:
+        path = "schema.yml"
+
+    return SnapshotNode(
+        database=source.database,
+        schema=source.schema,
+        name=name,
+        resource_type=NodeType.Snapshot,
+        package_name=source.package_name,
+        path=path,
+        original_file_path=path,
+        unique_id=f"snapshot.{pkg}.{name}",
+        fqn=[pkg, "snapshot", name],
+        alias=None,
+        checksum="",
+        sources=[[source.source_name, source.name]],
+        depends_on=DependsOn(
+            nodes=[source.unique_id],
+            macros=[],
+        ),
+        # relation=f"source('{source.source_name}', '{source.name}')",
+        config=SnapshotConfig(
+            strategy="check",
+            unique_key="'dummy'",
+            check_cols="all",
+        ),
     )
 
 
@@ -1016,7 +1048,7 @@ def make_manifest(
     groups: List[Group] = [],
     macros: List[Macro] = [],
     metrics: List[Metric] = [],
-    nodes: List[ModelNode] = [],
+    nodes: List[ManifestNode] = [],
     saved_queries: List[SavedQuery] = [],
     selectors: Dict[str, Any] = {},
     semantic_models: List[SemanticModel] = [],


### PR DESCRIPTION
Resolves #11164

### Problem

See #11164 - dbt projects using the new YAML format for Snapshots fail to parse, due to the schema used during parsing having `raw_code = None` while this is required by schema validation to be a string.

### Solution

This manually sets `block.file.contents` to an empty string to allow validation to pass while parsing.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
