### PR TITLE
Allow configuring the format of EventTimeFilter

### DIFF
--- a/.changes/unreleased/Features-20250308-193830.yaml
+++ b/.changes/unreleased/Features-20250308-193830.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Allow configuring the format of EventTimeFilter
+time: 2025-03-08T19:38:30.907199+09:00
+custom:
+    Author: logicoffee
+    Issue: "11331"

--- a/core/dbt/artifacts/resources/v1/config.py
+++ b/core/dbt/artifacts/resources/v1/config.py
@@ -126,6 +126,7 @@ class NodeConfig(NodeAndTestConfig):
         metadata=MergeBehavior.Update.meta(),
     )
     event_time: Any = None
+    event_time_filter_format: Any = None
     concurrent_batches: Any = None
 
     def __post_init__(self):

--- a/core/dbt/artifacts/resources/v1/source_definition.py
+++ b/core/dbt/artifacts/resources/v1/source_definition.py
@@ -20,6 +20,7 @@ from dbt_common.exceptions import CompilationError
 class SourceConfig(BaseConfig):
     enabled: bool = True
     event_time: Any = None
+    event_time_filter_format: Any = None
 
 
 @dataclass

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -258,7 +258,6 @@ class BaseResolver(metaclass=abc.ABCMeta):
             and target.config.event_time
             and isinstance(self.model, (ModelNode, SnapshotNode))
         ):
-
             # Handling of microbatch models
             if (
                 isinstance(self.model, ModelNode)
@@ -281,6 +280,7 @@ class BaseResolver(metaclass=abc.ABCMeta):
                     )
                     event_time_filter = EventTimeFilter(
                         field_name=target.config.event_time,
+                        filter_format=target.config.event_time_filter_format,
                         start=start,
                         end=end,
                     )
@@ -289,6 +289,7 @@ class BaseResolver(metaclass=abc.ABCMeta):
                 else:
                     event_time_filter = EventTimeFilter(
                         field_name=target.config.event_time,
+                        filter_format=target.config.event_time_filter_format,
                         start=self.model.batch.event_time_start,
                         end=self.model.batch.event_time_end,
                     )
@@ -297,6 +298,7 @@ class BaseResolver(metaclass=abc.ABCMeta):
             elif sample_mode:
                 event_time_filter = EventTimeFilter(
                     field_name=target.config.event_time,
+                    filter_format=target.config.event_time_filter_format,
                     start=self.config.args.sample.start,
                     end=self.config.args.sample.end,
                 )


### PR DESCRIPTION
Resolves #11331

### Problem

Currently, EventTimeFilter is formatted as YYYY-MM-DD HH:MM:SS+00:00. However this format is not suitable for the following cases:

referencing tables where event_time isn't of type timestamp (especially in BigQuery).
For BigQuery, it's addressed by https://github.com/dbt-labs/dbt-bigquery/pull/1422.
But casting event_time to timestamp causes a full scan.
When event_time is of type date, it's preferable to filter referenced tables using event_time > 'YYYY-MM-DD'
referencing sharded tables (especially in BigQuery).
Daily sharded tables are usually have a suffix like 'YYYYMMDD'.
It's better to filter referenced tables using _table_suffix > 'YYYY-MM-DD'.

### Solution

Added format configuration to EventTimeFilter.
This PR depends on https://github.com/dbt-labs/dbt-adapters/pull/893.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
