### PR TITLE
Remove `DBT_EXPERIMENTAL_SAMPLE_MODE` env var gating for sample mode

### DIFF
--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -244,10 +244,7 @@ class BaseResolver(metaclass=abc.ABCMeta):
 
     def resolve_event_time_filter(self, target: ManifestNode) -> Optional[EventTimeFilter]:
         event_time_filter = None
-        sample_mode = bool(
-            os.environ.get("DBT_EXPERIMENTAL_SAMPLE_MODE")
-            and getattr(self.config.args, "sample", None)
-        )
+        sample_mode = getattr(self.config.args, "sample", None) is not None
 
         # TODO The number of branches here is getting rough. We should consider ways to simplify
         # what is going on to make it easier to maintain

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import os
 import threading
 import time
 from copy import deepcopy
@@ -698,9 +697,7 @@ class MicrobatchModelRunner(ModelRunner):
         event_time_end = getattr(self.config.args, "EVENT_TIME_END", None)
 
         # If we're in sample mode, alter start/end to sample values
-        if os.environ.get("DBT_EXPERIMENTAL_SAMPLE_MODE") and getattr(
-            self.config.args, "SAMPLE", None
-        ):
+        if getattr(self.config.args, "SAMPLE", None) is not None:
             event_time_start = self.config.args.sample.start
             event_time_end = self.config.args.sample.end
 


### PR DESCRIPTION
Resolves #11228 

### Problem

We added an env var `DBT_EXPERIMENTAL_SAMPLE_MODE` early in sample mode development to gate accessing the feature. At this point, we consider sample mode _stable_ (at least how one interacts with it), and thus the extra environment variable gating is no longer necessary

### Solution

Remove the `DBT_EXPERIMENTAL_SAMPLE_MODE` env var gating for sample mode

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
