### PR TITLE
Add object to context with compiled code for full refresh

### DIFF
--- a/.changes/unreleased/Features-20260803-113650.yaml
+++ b/.changes/unreleased/Features-20260803-113650.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: "Add `sql_full_refresh` context variable exposing the full-refresh compiled SQL for incremental models with `on_schema_change: full_refresh`"
+time: 2026-08-03T11:36:50.002721+02:00
+custom:
+    Author: b-per
+    Issue: "11383"

--- a/core/dbt/artifacts/resources/v1/components.py
+++ b/core/dbt/artifacts/resources/v1/components.py
@@ -288,6 +288,7 @@ class CompiledResource(ParsedResource):
     compiled_path: Optional[str] = None
     compiled: bool = False
     compiled_code: Optional[str] = None
+    compiled_code_full_refresh: Optional[str] = None
     extra_ctes_injected: bool = False
     extra_ctes: List[InjectedCTE] = field(default_factory=list)
     _pre_injected_sql: Optional[str] = None

--- a/core/dbt/artifacts/resources/v1/components.py
+++ b/core/dbt/artifacts/resources/v1/components.py
@@ -298,6 +298,11 @@ class CompiledResource(ParsedResource):
         dct = super().__post_serialize__(dct, context)
         if "_pre_injected_sql" in dct:
             del dct["_pre_injected_sql"]
+        # compiled_code_full_refresh is only needed at runtime for the
+        # `sql_full_refresh` Jinja context variable; it isn't part of the
+        # manifest/run-results JSON schemas.
+        if "compiled_code_full_refresh" in dct:
+            del dct["compiled_code_full_refresh"]
         # Remove compiled attributes
         if "compiled" in dct and dct["compiled"] is False:
             del dct["compiled"]

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -681,6 +681,15 @@ class Compiler:
                             node,
                         )
 
+            # we update the model context to run in full refresh mode to get the full refresh sql
+            # this is required when on_schema_change is set to full_refresh
+            context["flags"].FULL_REFRESH = True
+            node.compiled_code_full_refresh = jinja.get_rendered(
+                node.raw_code,
+                context,
+                node,
+            )
+
         node.compiled = True
 
         # relation_name is set at parse time, except for tests without store_failures,

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -647,6 +647,32 @@ class Compiler:
         # if model.extra_ctes is not set to prepended ctes, something went wrong
         return model, model.extra_ctes
 
+    def _compile_full_refresh_variant(
+        self, node: ManifestSQLNode, context: Dict[str, Any]
+    ) -> None:
+        """Set compiled_code_full_refresh for models that need it.
+
+        Only compiles the full-refresh variant of the SQL for models with
+        on_schema_change=full_refresh, to avoid doubling compile cost/memory
+        for every other model.
+        """
+        if getattr(node.config, "on_schema_change", "ignore") != "full_refresh":
+            return
+
+        if context["flags"].FULL_REFRESH:
+            # The run is already executing with --full-refresh, so the
+            # compiled_code rendered above is already the full-refresh variant.
+            node.compiled_code_full_refresh = node.compiled_code
+        else:
+            # we update the model context to run in full refresh mode to get the full refresh sql
+            # this is required when on_schema_change is set to full_refresh
+            context["flags"].FULL_REFRESH = True
+            node.compiled_code_full_refresh = jinja.get_rendered(
+                node.raw_code,
+                context,
+                node,
+            )
+
     # Sets compiled_code and compiled flag in the ManifestSQLNode passed in,
     # creates a "context" dictionary for jinja rendering,
     # and then renders the "compiled_code" using the node, the
@@ -689,23 +715,7 @@ class Compiler:
                             node,
                         )
 
-            # Only compile the full-refresh variant of the SQL for models that
-            # actually need it, to avoid doubling compile cost/memory for every
-            # other model.
-            if getattr(node.config, "on_schema_change", "ignore") == "full_refresh":
-                if context["flags"].FULL_REFRESH:
-                    # The run is already executing with --full-refresh, so the
-                    # compiled_code above is already the full-refresh variant.
-                    node.compiled_code_full_refresh = node.compiled_code
-                else:
-                    # we update the model context to run in full refresh mode to get the full refresh sql
-                    # this is required when on_schema_change is set to full_refresh
-                    context["flags"].FULL_REFRESH = True
-                    node.compiled_code_full_refresh = jinja.get_rendered(
-                        node.raw_code,
-                        context,
-                        node,
-                    )
+            self._compile_full_refresh_variant(node, context)
 
         node.compiled = True
 

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -635,6 +635,14 @@ class Compiler:
                 model._pre_injected_sql = model.compiled_code
                 model.compiled_code = injected_sql
                 model.extra_ctes = prepended_ctes
+                # compiled_code_full_refresh needs the same ephemeral CTEs injected as
+                # compiled_code, otherwise models that `ref()` ephemeral models would
+                # produce full-refresh SQL missing the CTE definitions it depends on.
+                if model.compiled_code_full_refresh:
+                    model.compiled_code_full_refresh = inject_ctes_into_sql(
+                        model.compiled_code_full_refresh,
+                        prepended_ctes,
+                    )
 
         # if model.extra_ctes is not set to prepended ctes, something went wrong
         return model, model.extra_ctes
@@ -681,14 +689,23 @@ class Compiler:
                             node,
                         )
 
-            # we update the model context to run in full refresh mode to get the full refresh sql
-            # this is required when on_schema_change is set to full_refresh
-            context["flags"].FULL_REFRESH = True
-            node.compiled_code_full_refresh = jinja.get_rendered(
-                node.raw_code,
-                context,
-                node,
-            )
+            # Only compile the full-refresh variant of the SQL for models that
+            # actually need it, to avoid doubling compile cost/memory for every
+            # other model.
+            if getattr(node.config, "on_schema_change", "ignore") == "full_refresh":
+                if context["flags"].FULL_REFRESH:
+                    # The run is already executing with --full-refresh, so the
+                    # compiled_code above is already the full-refresh variant.
+                    node.compiled_code_full_refresh = node.compiled_code
+                else:
+                    # we update the model context to run in full refresh mode to get the full refresh sql
+                    # this is required when on_schema_change is set to full_refresh
+                    context["flags"].FULL_REFRESH = True
+                    node.compiled_code_full_refresh = jinja.get_rendered(
+                        node.raw_code,
+                        context,
+                        node,
+                    )
 
         node.compiled = True
 

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1895,6 +1895,13 @@ class ModelContext(ProviderContext):
             return None
 
     @contextproperty()
+    def sql_full_refresh(self) -> Optional[str]:
+        if self.model.language == ModelLanguage.sql:  # type: ignore[union-attr]
+            return self.model.compiled_code_full_refresh
+        else:
+            return None
+
+    @contextproperty()
     def database(self) -> str:
         return getattr(self.model, "database", self.config.credentials.database)
 

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1895,9 +1895,22 @@ class ModelContext(ProviderContext):
             return None
 
     @contextproperty()
+    def compiled_code_full_refresh(self) -> Optional[str]:
+        # TODO: avoid routing on args.which if possible
+        if getattr(self.model, "defer_relation", None) and self.config.args.which == "clone":
+            # TODO https://github.com/dbt-labs/dbt-core/issues/7976
+            return f"select * from {self.model.defer_relation.relation_name or str(self.defer_relation)}"  # type: ignore[union-attr]
+        elif getattr(self.model, "extra_ctes_injected", None):
+            # TODO CT-211
+            return self.model.compiled_code_full_refresh  # type: ignore[union-attr]
+        else:
+            return None
+
+    @contextproperty()
     def sql_full_refresh(self) -> Optional[str]:
+        # only set this for sql models, for backward compatibility
         if self.model.language == ModelLanguage.sql:  # type: ignore[union-attr]
-            return self.model.compiled_code_full_refresh
+            return self.compiled_code_full_refresh
         else:
             return None
 

--- a/tests/unit/context/test_context.py
+++ b/tests/unit/context/test_context.py
@@ -250,7 +250,12 @@ REQUIRED_MACRO_KEYS = REQUIRED_QUERY_HEADER_KEYS | {
     "dbt_metadata_envs",
     "function",
 }
-REQUIRED_MODEL_KEYS = REQUIRED_MACRO_KEYS | {"this", "compiled_code"}
+REQUIRED_MODEL_KEYS = REQUIRED_MACRO_KEYS | {
+    "this",
+    "compiled_code",
+    "sql_full_refresh",
+    "compiled_code_full_refresh",
+}
 MAYBE_KEYS = frozenset({"debug", "defer_relation"})
 
 


### PR DESCRIPTION
Part of the solution to resolve https://github.com/dbt-labs/dbt-adapters/issues/154

Needs to be released along with https://github.com/dbt-labs/dbt-adapters/pull/900 for the materialization code.

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
Today it is not possible to set `on_schema_change = full_refresh` for incremental models.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

To make it possible to add the feature, this implementation adds an object called `sql_full_refresh` to the context so that the materialization macros in `dbt-adapters` can use this variable.

This prevents having to re-compile the model if we realize that a model should run as a full refresh when its schema changes.

There is no test for now, but I am happy to add some if the approach in this PR along with the dbt-adapters one is OK to be merged. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
