### PR TITLE
Support `project` as alias for `package` selection method

### DIFF
--- a/.changes/unreleased/Features-20250318-163058.yaml
+++ b/.changes/unreleased/Features-20250318-163058.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Supports `project` as alias for `package` selector
+time: 2025-03-18T16:30:58.540200231-04:00
+custom:
+    Author: smeyerre
+    Issue: "8986"

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -15,6 +15,7 @@ from typing import (
     Union,
 )
 
+from dbt.artifacts.resources.types import AccessType
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.nodes import (
     Exposure,
@@ -51,6 +52,7 @@ class MethodName(StrEnum):
     Path = "path"
     File = "file"
     Package = "package"
+    Project = "project"
     Config = "config"
     TestName = "test_name"
     TestType = "test_type"
@@ -497,6 +499,33 @@ class PackageSelectorMethod(SelectorMethod):
                 yield unique_id
 
 
+class ProjectSelectorMethod(SelectorMethod):
+    def search(self, included_nodes: Set[UniqueId], selector: str) -> Iterator[UniqueId]:
+        """Yields nodes from the specified project/package with special handling for dependency type.
+
+        This is an alias for the package selector with the following behavior:
+        - For package-type dependencies: selects all nodes in the package (same as package selector)
+        - For project-type dependencies: selects only public models from the project
+        """
+        # `this` is an alias for the current dbt project name
+        if selector == "this" and self.manifest.metadata.project_name is not None:
+            selector = self.manifest.metadata.project_name
+
+        for unique_id, node in self.all_nodes(included_nodes):
+            if fnmatch(node.package_name, selector):
+                if node.package_name == self.manifest.metadata.project_name:
+                    # Always include nodes from the current project
+                    yield unique_id
+                elif hasattr(node, "resource_type") and node.resource_type == NodeType.Model:
+                    # For models in other projects, only include if they're public
+                    if hasattr(node, "access") and node.access == AccessType.Public:
+                        yield unique_id
+                else:
+                    # For non-model nodes, exclude them since the project selector
+                    # should only select public models from external projects
+                    pass
+
+
 def _getattr_descend(obj: Any, attrs: List[str]) -> Any:
     value = obj
     for attr in attrs:
@@ -927,6 +956,7 @@ class MethodManager:
         MethodName.Path: PathSelectorMethod,
         MethodName.File: FileSelectorMethod,
         MethodName.Package: PackageSelectorMethod,
+        MethodName.Project: ProjectSelectorMethod,
         MethodName.Config: ConfigSelectorMethod,
         MethodName.TestName: TestNameSelectorMethod,
         MethodName.TestType: TestTypeSelectorMethod,


### PR DESCRIPTION
Resolves #8986 

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem
A user needs to run `dbt list -s package:upstream_project+` even if they have intentionally chosen to depend on `upstream_project` as a "project" rather than a "package". This can lead to confusion.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
This PR implements support for the `project:` method as an alias for `package:` in node selection, but with a filter applied to only include public models from the upstream project.

  The implementation:
  1. Adds logic to detect when the `project:` method is used
  2. Applies the existing `package:` selection logic
  3. Adds a filter to only return nodes that are marked with `access='public'`

  This provides a more intuitive experience for users of dbt Mesh who establish project-type dependencies. Now, instead of having to use `package:upstream_project+`, users can use `project:upstream_project+` which matches the dependency type they've defined.

Manual testing confirms the feature correctly filters out protected and private models while allowing public models through.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
