### PR TITLE
Add Support for Python 3.13

### DIFF
--- a/.changes/unreleased/Features-20250319-153356.yaml
+++ b/.changes/unreleased/Features-20250319-153356.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add support for Python 3.13!
+time: 2025-03-19T15:33:56.641753-04:00
+custom:
+    Author: peterallenwebb
+    Issue: "11401"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
     env:
       TOXENV: "unit"
@@ -162,7 +162,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         os: [ubuntu-latest]
         split-group: ${{ fromJson(needs.integration-metadata.outputs.split-groups) }}
     env:

--- a/core/setup.py
+++ b/core/setup.py
@@ -93,6 +93,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     python_requires=">=3.9",
 )

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,7 @@ docutils
 # flake8 must match what's in .pre-commit-config.yaml to be sure local env matches CI
 flake8==4.0.1
 flaky
-freezegun>=1.4.0,<1.5
+freezegun>=1.5.1
 hypothesis
 ipdb
 # isort must match what's in .pre-commit-config.yaml to be sure local env matches CI

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-postgres
 # black must match what's in .pre-commit-config.yaml to be sure local env matches CI
 black==24.3.0
 bumpversion
-ddtrace==2.3.0
+ddtrace==2.21.3
 docutils
 # flake8 must match what's in .pre-commit-config.yaml to be sure local env matches CI
 flake8==4.0.1


### PR DESCRIPTION
### Problem

dbt-core does not currently work on Python 3.13

### Solution

Update dependencies and integration tests to support Python 3.13

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
