### PR TITLE
Update `dir` to look

### DIFF
--- a/.changes/unreleased/Fixes-20250326-194259.yaml
+++ b/.changes/unreleased/Fixes-20250326-194259.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Update ConfigFolderDirectory dir to use str.
+time: 2025-03-26T19:42:59.335179-07:00
+custom:
+    Author: thorn14 dbeatty10
+    Issue: 9768 11305

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -65,7 +65,7 @@ class InitTask(BaseTask):
         """Create the user's profiles directory if it doesn't already exist."""
         profiles_path = Path(profiles_dir)
         if not profiles_path.exists():
-            fire_event(ConfigFolderDirectory(dir=str(profiles_dir))) 
+            fire_event(ConfigFolderDirectory(dir=str(profiles_dir)))
             dbt_common.clients.system.make_directory(profiles_dir)
             return True
         return False

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -65,7 +65,7 @@ class InitTask(BaseTask):
         """Create the user's profiles directory if it doesn't already exist."""
         profiles_path = Path(profiles_dir)
         if not profiles_path.exists():
-            fire_event(ConfigFolderDirectory(dir=profiles_dir))
+            fire_event(ConfigFolderDirectory(dir=str(profiles_dir))) 
             dbt_common.clients.system.make_directory(profiles_dir)
             return True
         return False


### PR DESCRIPTION
Resolves #11305 & resolves #9768

### Problem
This resolves an open issue where initialization fails. 

### Solution
This implements a fix mentioned [here](https://github.com/dbt-labs/dbt-core/issues/9768#issuecomment-2005253192).

The `dir` is expecting a string in two places ([1](https://github.com/dbt-labs/dbt-core/blob/29395ac6170f4068a622802f87852b3566415997/core/dbt/events/types.py#L130-L135), [2](https://github.com/dbt-labs/dbt-core/blob/29395ac6170f4068a622802f87852b3566415997/core/dbt/events/core_types.proto#L185-L188)), which this corrects.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
