### PR TITLE
Fix microbatch model edge case of having only one batch (that failed) but counting as success

### DIFF
--- a/.changes/unreleased/Fixes-20250328-170142.yaml
+++ b/.changes/unreleased/Fixes-20250328-170142.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix microbatch models couting as success when only having one batch (and that
+  batch failing)
+time: 2025-03-28T17:01:42.342741-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11390"

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -429,6 +429,20 @@ class MicrobatchBatchRunner(ModelRunner):
         self.print_result_line(result=result)
         return result
 
+    def error_result(self, node, message, start_time, timing_info):
+        """Necessary to return a result with a batch result
+
+        Called by `BaseRunner.safe_run` when an error occurs
+        """
+        return self._build_run_result(
+            node=node,
+            start_time=start_time,
+            status=RunStatus.Error,
+            timing_info=timing_info,
+            message=message,
+            batch_results=BatchResults(failed=[self.batches[self.batch_idx]]),
+        )
+
     def compile(self, manifest: Manifest):
         batch = self.batches[self.batch_idx]
 

--- a/tests/functional/microbatch/test_microbatch.py
+++ b/tests/functional/microbatch/test_microbatch.py
@@ -1282,5 +1282,5 @@ class TestCompilationErrorOnSingleBatchRun(BaseMicrobatchTest):
         }
 
     def test_microbatch(self, project) -> None:
-        _, console_output = run_dbt_and_capture(["run"], expect_pass=True)
+        _, console_output = run_dbt_and_capture(["run"], expect_pass=False)
         assert "Completed with 1 error, 0 partial successes, and 0 warnings" in console_output

--- a/tests/functional/microbatch/test_microbatch.py
+++ b/tests/functional/microbatch/test_microbatch.py
@@ -1,4 +1,5 @@
 import json
+from typing import Dict
 from unittest import mock
 
 import pytest
@@ -1231,3 +1232,55 @@ class TestCanSilenceInvalidConcurrentBatchesConfigWarning(BaseMicrobatchTest):
             )
         # Because we silenced the warning, it shouldn't get fired
         assert len(event_catcher.caught_events) == 0
+
+
+single_batch_microbatch_model_sql = """
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='microbatch',
+        unique_key='tmp',
+        event_time='tmp',
+        begin=modules.datetime.datetime.now(),
+        lookback=0,
+        batch_size='day',
+        meta={'param': 'invalid_param'},
+        pre_hook=[
+            validate_param('param1')
+        ]
+    )
+}}
+
+SELECT current_date as tmp
+"""
+
+validate_param_macro_sql = """
+{% macro validate_param(valid_param) %}
+    {% set current_param = config.get('meta')['param'] %}
+
+    {% if execute %}
+        {% if current_param != valid_param %}
+            {% set exceptions_message = "Invalid param: " ~ current_param ~ ", valid param: " ~ valid_param %}
+            {% do exceptions.raise_compiler_error(exceptions_message) %}
+        {% endif %}
+    {% endif %}
+{% endmacro %}
+"""
+
+
+class TestCompilationErrorOnSingleBatchRun(BaseMicrobatchTest):
+    @pytest.fixture(scope="class")
+    def models(self) -> Dict[str, str]:
+        return {
+            "microbatch_model.sql": single_batch_microbatch_model_sql,
+        }
+
+    @pytest.fixture(scope="class")
+    def macros(self) -> Dict[str, str]:
+        return {
+            "validate_param.sql": validate_param_macro_sql,
+        }
+
+    def test_microbatch(self, project) -> None:
+        _, console_output = run_dbt_and_capture(["run"], expect_pass=True)
+        assert "Completed with 1 error, 0 partial successes, and 0 warnings" in console_output


### PR DESCRIPTION
Resolves #11390 

### Problem
An error can get raised raised [here during compilation](https://github.com/dbt-labs/dbt-core/blob/729caf0d5ec8017b8aa22b8f88db3076cf0bc9e3/core/dbt/compilation.py#L611). This eventually produces a run result for the batch [here](https://github.com/dbt-labs/dbt-core/blob/729caf0d5ec8017b8aa22b8f88db3076cf0bc9e3/core/dbt/task/base.py#L379). Unfortunately, the produced run result doesn't include the batch results. And since there is only one batch being run, this results in the batch results for the microbatch model having no failures, which we count as a success [here](https://github.com/dbt-labs/dbt-core/blob/729caf0d5ec8017b8aa22b8f88db3076cf0bc9e3/core/dbt/task/run.py#L651).

### Solution

Created an override method `MicrobatchBatchRunner.error_result` which ensures the batch information is included in the run result.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
