### PR TITLE
Stop dismissing workflow runs

### DIFF
--- a/.github/workflows/artifact-reviews.yml
+++ b/.github/workflows/artifact-reviews.yml
@@ -6,60 +6,27 @@
 # multiple reviews on a single PR based on files changed, so we need to enforce this manually.
 
 # **when?**
-# This will run when PRs are opened, synchronized, reopened, edited, or when reviews
-# are submitted and dismissed.
+# This will run when reviews are submitted and dismissed.
 
 name: "Enforce Additional Reviews on Artifact and Validations Changes"
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened, edited]
-  # retrigger check on review events
+  # trigger check on review events
   pull_request_review:
     types: [submitted, edited, dismissed]
 
 # only run this once per PR at a time
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: false  # wait for in-progress runs to complete to prevent race condition
+  cancel-in-progress: true
 
 env:
     required_approvals: 2
     team: "core-group"
 
 jobs:
-  cleanup-old-runs:
-    # this job is only run once per PR at a time.  Since it uses two types of triggers,
-    # when the pull_request trigger fails, that run stays around when the pull_request_review
-    # triggers a new run.  This job will clean up those old runs so we only end up with a single run.
-    name: "Cleanup Previous Runs"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Dismiss previous workflow runs"
-        run: |
-          # Get all check runs for this PR's SHA
-          cleanup_checks=$(gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/check-runs \
-            --jq '.check_runs[] | select(.name == "Cleanup Previous Runs")')
-          review_checks=$(gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/check-runs \
-            --jq '.check_runs[] | select(.name == "Validate Additional Reviews")')
-
-          # For each check run from this workflow (except current), dismiss it
-          { echo "$cleanup_checks"; echo "$review_checks"; } | jq -r '. | select(.id != ${{ github.run_id }}) | .id' | \
-          while read -r check_id; do
-            echo "Dismissing check $check_id"
-            gh api repos/${{ github.repository }}/check-runs/$check_id \
-              -X PATCH \
-              -F status="completed" \
-              -F conclusion="neutral" \
-              -F "output[title]=Superseded" \
-              -F "output[summary]=This check was superseded by a newer run"
-          done
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   check-reviews:
     name: "Validate Additional Reviews"
-    needs: [cleanup-old-runs]
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
### Problem

Our artifact review check is failing.

https://github.blog/changelog/2025-02-12-notice-of-upcoming-deprecations-and-breaking-changes-for-github-actions/#changes-to-check-run-status-modification

### Solution

Only trigger on PR reviews.  This means it won't fail until there's at least 1 review but will still ensure artifact changes get at least 2 reviews.

Only GH itself can now dismiss workflows.  

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
