### PR TITLE
fix partial parsing behaviour when model name contains dots

### DIFF
--- a/.changes/unreleased/Fixes-20250402-232806.yaml
+++ b/.changes/unreleased/Fixes-20250402-232806.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: fix partial parsing behaviour when model name contains dots
+time: 2025-04-02T23:28:06.077059013+03:00
+custom:
+    Author: yakovlevvs
+    Issue: "11363"

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -829,14 +829,21 @@ class PartialParsing:
     def delete_schema_mssa_links(self, schema_file, dict_key, elem) -> None:
         # find elem node unique_id in node_patches
         prefix = key_to_prefix[dict_key]
+        model_prefix = "{}.{}.".format(prefix, schema_file.project_name)
         elem_unique_ids = []
         for unique_id in schema_file.node_patches:
             if not unique_id.startswith(prefix):
                 continue
-            parts = unique_id.split(".", maxsplit=2)
-            elem_name = parts[2]
-            if elem_name == elem["name"]:
-                elem_unique_ids.append(unique_id)
+            if prefix == "model":
+                if unique_id == model_prefix + elem["name"] or (
+                    "versions" in elem and unique_id.startswith(model_prefix + elem["name"] + ".v")
+                ):
+                    elem_unique_ids.append(unique_id)
+            else:
+                parts = unique_id.split(".")
+                elem_name = parts[2]
+                if elem_name == elem["name"]:
+                    elem_unique_ids.append(unique_id)
 
         # remove elem node and remove unique_id from node_patches
         for elem_unique_id in elem_unique_ids:

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -833,7 +833,7 @@ class PartialParsing:
         for unique_id in schema_file.node_patches:
             if not unique_id.startswith(prefix):
                 continue
-            parts = unique_id.split(".")
+            parts = unique_id.split(".", maxsplit=2)
             elem_name = parts[2]
             if elem_name == elem["name"]:
                 elem_unique_ids.append(unique_id)

--- a/tests/functional/partial_parsing/fixtures.py
+++ b/tests/functional/partial_parsing/fixtures.py
@@ -1288,3 +1288,26 @@ sources_tests1_sql = """
 
 
 """
+
+model_with_dots_sql = """
+select 1 as col1
+
+"""
+
+
+model_with_dots_yml = """
+models:
+  - name: a.b.orders
+    columns:
+      - name: col1
+
+"""
+
+model_with_dots_edited_yml = """
+models:
+  - name: a.b.orders
+    columns:
+      - name: col1
+      - name: col2
+
+"""

--- a/tests/functional/partial_parsing/test_partial_parsing.py
+++ b/tests/functional/partial_parsing/test_partial_parsing.py
@@ -52,6 +52,9 @@ from tests.functional.partial_parsing.fixtures import (
     model_three_sql,
     model_two_disabled_sql,
     model_two_sql,
+    model_with_dots_sql,
+    model_with_dots_edited_yml,
+    model_with_dots_yml,
     models_schema1_yml,
     models_schema2_yml,
     models_schema2b_yml,
@@ -655,6 +658,29 @@ class TestTests:
             "test.test.is_odd_orders_id.82834fdc5b",
         ]
         assert expected_nodes == list(manifest.nodes.keys())
+
+
+class TestModelsWithDots:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "a.b.orders.sql": model_with_dots_sql,
+            "schema.yml": model_with_dots_yml,
+        }
+
+    def test_pp_model_with_dots(self, project):
+        # initial parse
+        manifest = run_dbt(["parse"])
+        expected_nodes = ["model.test.a.b.orders"]
+        assert expected_nodes == list(manifest.nodes.keys())
+
+        # edit YAML in models-path
+        write_file(
+            model_with_dots_edited_yml, project.project_root, "models", "schema.yml"
+        )
+
+        # parse again
+        results = run_dbt(["--partial-parse", "parse"])
 
 
 class TestExternalModels:

--- a/tests/functional/partial_parsing/test_partial_parsing.py
+++ b/tests/functional/partial_parsing/test_partial_parsing.py
@@ -678,7 +678,7 @@ class TestModelsWithDots:
         write_file(model_with_dots_edited_yml, project.project_root, "models", "schema.yml")
 
         # parse again
-        results = run_dbt(["--partial-parse", "parse"])
+        run_dbt(["--partial-parse", "parse"])
 
 
 class TestExternalModels:

--- a/tests/functional/partial_parsing/test_partial_parsing.py
+++ b/tests/functional/partial_parsing/test_partial_parsing.py
@@ -52,8 +52,8 @@ from tests.functional.partial_parsing.fixtures import (
     model_three_sql,
     model_two_disabled_sql,
     model_two_sql,
-    model_with_dots_sql,
     model_with_dots_edited_yml,
+    model_with_dots_sql,
     model_with_dots_yml,
     models_schema1_yml,
     models_schema2_yml,
@@ -675,9 +675,7 @@ class TestModelsWithDots:
         assert expected_nodes == list(manifest.nodes.keys())
 
         # edit YAML in models-path
-        write_file(
-            model_with_dots_edited_yml, project.project_root, "models", "schema.yml"
-        )
+        write_file(model_with_dots_edited_yml, project.project_root, "models", "schema.yml")
 
         # parse again
         results = run_dbt(["--partial-parse", "parse"])


### PR DESCRIPTION
Resolves #11363 

### Problem

When model name contains dots, partial parsing fails with `dbt found two schema.yml entries for the same resource named` error.

### Solution

Fixed a function which causes incorrect manifest parsing for this case.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
