### PR TITLE
fix: dead link in `ARCHITECTURE.md`

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,7 +32,7 @@ This is the docs website code. It comes from the dbt-docs repository, and is gen
 ## Adapters
 
 dbt uses an adapter-plugin pattern to extend support to different databases, warehouses, query engines, etc. 
-Note: dbt-postgres used to exist in dbt-core but is now in [a dbt-adapters repo](https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-postgres) 
+Note: dbt-postgres used to exist in dbt-core but is now in [the dbt-adapters repo](https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-postgres) 
 
 Each adapter is a mix of python, Jinja2, and SQL. The adapter code also makes heavy use of Jinja2 to wrap modular chunks of SQL functionality, define default implementations, and allow plugins to override it.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,7 +32,7 @@ This is the docs website code. It comes from the dbt-docs repository, and is gen
 ## Adapters
 
 dbt uses an adapter-plugin pattern to extend support to different databases, warehouses, query engines, etc. 
-Note: dbt-postgres used to exist in dbt-core but is now in [a separate repo](https://github.com/dbt-labs/dbt-adapters/dbt-postgres) 
+Note: dbt-postgres used to exist in dbt-core but is now in [a dbt-adapters repo](https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-postgres) 
 
 Each adapter is a mix of python, Jinja2, and SQL. The adapter code also makes heavy use of Jinja2 to wrap modular chunks of SQL functionality, define default implementations, and allow plugins to override it.
 


### PR DESCRIPTION
Resolves #

Hi! I found a broken link in `ARCHITECTURE.md` - the current link to dbt-postgres points to the root of the dbt-adapters repo instead of the specific adapter directory. This could confuse new developers looking for the Postgres adapter source cod

### Problem

...

### Solution

Updated the link to point directly to the dbt-postgres directory within the dbt-adapters repo.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
