### PR TITLE
Behavior flag to handle all warnings with warn_error logic

### DIFF
--- a/.changes/unreleased/Features-20250410-111023.yaml
+++ b/.changes/unreleased/Features-20250410-111023.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add behavior flag for handling all warnings via warn_error logic
+time: 2025-04-10T11:10:23.344469-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11116"

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -41,6 +41,7 @@ from dbt.version import installed as installed_version
 from dbt_common.clients.system import get_env
 from dbt_common.context import get_invocation_context, set_invocation_context
 from dbt_common.events.base_types import EventLevel
+from dbt_common.events.event_manager_client import get_event_manager
 from dbt_common.events.functions import LOG_VERSION, fire_event
 from dbt_common.events.helpers import get_json_string_utcnow
 from dbt_common.exceptions import DbtBaseException as DbtException
@@ -74,6 +75,9 @@ def preflight(func):
         flags = Flags(ctx)
         ctx.obj["flags"] = flags
         set_flags(flags)
+        get_event_manager().require_warn_or_error_handling = (
+            flags.require_all_warnings_handled_by_warn_error
+        )
 
         # Reset invocation_id for each 'invocation' of a dbt command (can happen multiple times in a single process)
         reset_invocation_id()

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -348,6 +348,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     require_yaml_configuration_for_mf_time_spines: bool = False
     require_nested_cumulative_type_params: bool = False
     validate_macro_args: bool = False
+    require_all_warnings_handled_by_warn_error: bool = False
 
     @property
     def project_only_flags(self) -> Dict[str, Any]:
@@ -362,6 +363,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
             "require_yaml_configuration_for_mf_time_spines": self.require_yaml_configuration_for_mf_time_spines,
             "require_nested_cumulative_type_params": self.require_nested_cumulative_type_params,
             "validate_macro_args": self.validate_macro_args,
+            "require_all_warnings_handled_by_warn_error": self.require_all_warnings_handled_by_warn_error,
         }
 
 


### PR DESCRIPTION
Resolves #11116 

### Problem

Not all warnings are currently handled by `warn_error`. This is problematic, as our docs lead one to believe if they have `--warn-error` or `--warn-error-options={'error': 'all'}` that all warnings will become errors ([docs](https://docs.getdbt.com/reference/global-configs/warnings)). Unfortunately, we can't just make it such that all warnings are handled by the `warn_error` logic, as that means currently working projects which are using either of the flags I previously described would begin to fail.

### Solution
Add a behavior flag `require_all_warnings_handled_by_warn_error` which, if set to `True`, will make it so all warnings are handled by `warn_error` logic. This is possible because of the work done in https://github.com/dbt-labs/dbt-common/pull/259.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
