### PR TITLE
Install `pre-commit` in Docker container for running tests

### DIFF
--- a/.changes/unreleased/Fixes-20250414-082916.yaml
+++ b/.changes/unreleased/Fixes-20250414-082916.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Install `pre-commit` in Docker container for running tests
+time: 2025-04-14T08:29:16.392175-06:00
+custom:
+    Author: dbeatty10
+    Issue: "11498"

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -50,7 +50,7 @@ RUN curl -LO https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_V
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-RUN pip3 install -U tox wheel six setuptools
+RUN pip3 install -U tox wheel six setuptools pre-commit
 
 # These args are passed in via docker-compose, which reads then from the .env file.
 # On Linux, run `make .env` to create the .env file for the current user.

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ dev_req: ## Installs dbt-* packages in develop mode along with only development 
 .PHONY: dev
 dev: dev_req ## Installs dbt-* packages in develop mode along with development dependencies and pre-commit.
 	@\
-	pre-commit install
+	$(DOCKER_CMD) pre-commit install
 
 .PHONY: dev-uninstall
 dev-uninstall: ## Uninstall all packages in venv except for build tools


### PR DESCRIPTION
Resolves #11498

### Problem

We supply a Docker container (`Dockerfile.test`) specifically for running tests, and our `CONTRIBUTING` file describes how to use it with `make` commands. However, running `make test USE_DOCKER=true` ends with an error message:

```
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "pre-commit": executable file not found in $PATH: unknown
```

Also, running `make dev` does not take the Docker container into account.

### Solution

- pip install pre-commit so that it is available within the Docker container for tests.
- ensure that all instances where `pre-commit` is called are prefixed with `$(DOCKER_CMD) `

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] Tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.).
- [x] This PR doesn't need ant [type annotations](https://docs.python.org/3/library/typing.html) because there are no new or modified functions.