### PR TITLE
Fix duplicate error when multiple macros in one file with macro patches

### DIFF
--- a/.changes/unreleased/Fixes-20250422-122835.yaml
+++ b/.changes/unreleased/Fixes-20250422-122835.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix duplicate macro error message with multiple macros and multiple patches
+time: 2025-04-22T12:28:35.642843-04:00
+custom:
+  Author: gshank
+  Issue: "4233"

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -920,10 +920,14 @@ class PartialParsing:
         if macro["name"] in schema_file.macro_patches:
             macro_unique_id = schema_file.macro_patches[macro["name"]]
             del schema_file.macro_patches[macro["name"]]
+        # Need to delete all macros in the same file
+        # and then reapply all schema file updates for those macros
         if macro_unique_id and macro_unique_id in self.saved_manifest.macros:
             macro = self.saved_manifest.macros.pop(macro_unique_id)
             macro_file_id = macro.file_id
             if macro_file_id in self.new_files:
+                source_file = self.saved_files[macro_file_id]
+                self.delete_macro_file(source_file)
                 self.saved_files[macro_file_id] = deepcopy(self.new_files[macro_file_id])
                 self.add_to_pp_files(self.saved_files[macro_file_id])
 

--- a/tests/functional/partial_parsing/fixtures.py
+++ b/tests/functional/partial_parsing/fixtures.py
@@ -1304,7 +1304,7 @@ macros:
   - name: foo
     description: Lorem.
   - name: bar
-    description: Lorem ipsum.
+    description: Lorem.
 """
 
 macros_schema2_yml = """

--- a/tests/functional/partial_parsing/fixtures.py
+++ b/tests/functional/partial_parsing/fixtures.py
@@ -1288,3 +1288,29 @@ sources_tests1_sql = """
 
 
 """
+
+macros_sql = """
+{% macro foo() %}
+    foo
+{% endmacro %}
+
+{% macro bar() %}
+    bar
+{% endmacro %}
+"""
+
+macros_schema1_yml = """
+macros:
+  - name: foo
+    description: Lorem.
+  - name: bar
+    description: Lorem ipsum.
+"""
+
+macros_schema2_yml = """
+macros:
+  - name: foo
+    description: Lorem.
+  - name: bar
+    description: Lorem ipsum.
+"""


### PR DESCRIPTION
Resolves #4233


### Problem

When multiple macros are in one file with multiple macro "patches" (config in schema files) and one of the schema file configs is updated, we were getting the error: dbt found two macros named "<macros_name>" in the project "<project_name>".

### Solution

Call "delete_macro_file" when processing macro schema file changes.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
