### PR TITLE
Install `pre-commit` in Docker container for running tests

### DIFF
--- a/.changes/unreleased/Fixes-20250430-084512.yaml
+++ b/.changes/unreleased/Fixes-20250430-084512.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add `pre-commit` installation to Docker container for testing compatibility
+time: 2025-04-30T08:45:12.247827-06:00
+custom:
+    Author: kato1208 dbeatty10
+    Issue: "11498"

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -50,7 +50,7 @@ RUN curl -LO https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_V
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-RUN pip3 install -U tox wheel six setuptools
+RUN pip3 install -U tox wheel six setuptools pre-commit
 
 # These args are passed in via docker-compose, which reads then from the .env file.
 # On Linux, run `make .env` to create the .env file for the current user.

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ dev_req: ## Installs dbt-* packages in develop mode along with only development 
 .PHONY: dev
 dev: dev_req ## Installs dbt-* packages in develop mode along with development dependencies and pre-commit.
 	@\
-	pre-commit install
+	$(DOCKER_CMD) pre-commit install
 
 .PHONY: dev-uninstall
 dev-uninstall: ## Uninstall all packages in venv except for build tools


### PR DESCRIPTION
Resolves #11498

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

We supply a Docker container (`Dockerfile.test`) specifically for running tests, and our `CONTRIBUTING` file describes how to use it with `make` commands. However, running `make test USE_DOCKER=true` ends with an error message:

```
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "pre-commit": executable file not found in $PATH: unknown
```

Also, running `make dev` does not take the Docker container into account.

#### Another problem

[This line](https://github.com/dbt-labs/dbt-core/blob/e920053306b063082822b99bae32f9cca426d851/Dockerfile.test#L53) didn't change when https://github.com/dbt-labs/dbt-core/pull/11499 was merged for some reason, so I'm re-opening this.

The root cause probably had to do with being merged first in https://github.com/dbt-labs/dbt-core/pull/11501 and then subsequently being reverted in https://github.com/dbt-labs/dbt-core/pull/11508.

### Solution

- pip install pre-commit so that it is available within the Docker container for tests.
- ensure that all instances where `pre-commit` is called are prefixed with `$(DOCKER_CMD)`

👉 The changelog entry was already included within https://github.com/dbt-labs/dbt-core/pull/11499, so it does not need to be included again.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] Tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.).
- [x] This PR doesn't need any [type annotations](https://docs.python.org/3/library/typing.html) because there are no new or modified functions.
