### PR TITLE
Fix functional deprecation tests so they don't break on windows

### DIFF
--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -305,8 +305,7 @@ class TestDeprecatedInvalidDeprecationDate:
 
         assert len(event_catcher.caught_events) == 1
         assert (
-            "1 is not of type 'string', 'null' in file `models/models.yml` at path\n`models[0].deprecation_date`"
-            in event_catcher.caught_events[0].info.msg
+            "1 is not of type 'string', 'null' in file" in event_catcher.caught_events[0].info.msg
         )
 
 
@@ -323,7 +322,7 @@ class TestDuplicateYAMLKeysInSchemaFiles:
         run_dbt(["parse", "--no-partial-parse"], callbacks=[event_catcher.catch])
         assert len(event_catcher.caught_events) == 1
         assert (
-            "Duplicate key 'models' in \"<unicode string>\", line 6, column 1 in file\n`models/models.yml`"
+            "Duplicate key 'models' in \"<unicode string>\", line 6, column 1 in file"
             in event_catcher.caught_events[0].info.msg
         )
 
@@ -359,6 +358,6 @@ class TestCustomKeyInObjectDeprecation:
         run_dbt(["parse", "--no-partial-parse"], callbacks=[event_catcher.catch])
         assert len(event_catcher.caught_events) == 1
         assert (
-            "Custom key `'my_custom_property'` found at `models[0]` in file\n`models/models.yml`."
+            "Custom key `'my_custom_property'` found at `models[0]` in file"
             in event_catcher.caught_events[0].info.msg
         )


### PR DESCRIPTION
In a lot of our function deprecation warning tests we check for a matching string within an event message. Some of these matches check for a file path. The problem with this was that windows formats file paths differently. This was causing the functional tests to _fail_ when run in a windows environment. To fix this we've removed the file path part of the string from the test assertions.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
