### PR TITLE
Add description/columns to ModelNodeArgs so that plugins ingest description/columns to manifest.json

### DIFF
--- a/.changes/unreleased/Under the Hood-20250429-131931.yaml
+++ b/.changes/unreleased/Under the Hood-20250429-131931.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add description/columns to external ExternalNode so that plugins ingest description/columns
+time: 2025-04-29T13:19:31.737607807+09:00
+custom:
+    Author: toukoudo
+    Issue: "11527"

--- a/core/dbt/contracts/graph/node_args.py
+++ b/core/dbt/contracts/graph/node_args.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from dbt.artifacts.resources import NodeVersion
+from dbt.artifacts.resources.v1.components import ColumnInfo
 from dbt.node_types import AccessType, NodeType
 
 
@@ -17,6 +18,8 @@ class ModelNodeArgs:
     version: Optional[NodeVersion] = None
     latest_version: Optional[NodeVersion] = None
     deprecation_date: Optional[datetime] = None
+    description: str = ""
+    columns: Dict[str, ColumnInfo] = field(default_factory=dict)
     access: Optional[str] = AccessType.Protected.value
     generated_at: datetime = field(
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None)

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -507,6 +507,7 @@ class ModelNode(ModelResource, CompiledNode):
             schema=args.schema,
             alias=args.identifier,
             deprecation_date=args.deprecation_date,
+            description=args.description,
             checksum=FileHash.from_contents(f"{unique_id},{args.generated_at}"),
             access=AccessType(args.access),
             original_file_path="",
@@ -514,6 +515,7 @@ class ModelNode(ModelResource, CompiledNode):
             unrendered_config=unrendered_config,
             depends_on=DependsOn(nodes=args.depends_on_nodes),
             config=ModelConfig(enabled=args.enabled),
+            columns=args.columns,
         )
 
     @property


### PR DESCRIPTION
Resolves #11527

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

* As far as I know, currently, plugins cannot ingest document/column information for external nodes, resulting in no descriptions or column details appearing in manifest.json for these nodes 
* I would like to be able to see description and column information for plugin-ingested nodes in the manifest output

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
* Add columns/description fields to ModelNodeArgs so that plugins can ingest them

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
