### PR TITLE
Make codecov informational-only

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,10 +8,12 @@ coverage:
       default:
         target: auto
         threshold: 0.1% # Reduce noise by ignoring rounding errors in coverage drops
+        informational: true
     patch:
       default:
         target: auto
         threshold: 80%
+        informational: true
 
 comment:
   layout: "header, diff, flags, components"  # show component info in the PR comment


### PR DESCRIPTION
### Problem

It's hard to know if a test failed because Codecov patch often fails.

### Solution

Make Codecov checks informational only.
Codecov docs here: https://docs.codecov.com/docs/quick-start#tips-and-tricks

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
