### PR TITLE
Fix jsonschema validation that fires `CustomKeyInConfigDeprecation`

### DIFF
--- a/.changes/unreleased/Fixes-20250502-131822.yaml
+++ b/.changes/unreleased/Fixes-20250502-131822.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Ensure the right key is associatd with the `CustomKeyInConfigDeprecation` deprecation
+time: 2025-05-02T13:18:22.940373-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11576"

--- a/core/dbt/jsonschemas.py
+++ b/core/dbt/jsonschemas.py
@@ -91,13 +91,7 @@ def jsonschema_validate(schema: Dict[str, Any], json: Dict[str, Any], file_path:
                         file=file_path,
                         key_path=key_path,
                     )
-        elif (
-            error.validator == "anyOf"
-            and len(error_path) > 0
-            and error_path[-1] == "config"
-            and isinstance(error.instance, dict)
-            and len(error.instance.keys()) > 0
-        ):
+        elif error.validator == "anyOf" and len(error_path) > 0 and error_path[-1] == "config":
             for sub_error in error.context or []:
                 if (
                     isinstance(sub_error, ValidationError)

--- a/core/dbt/jsonschemas.py
+++ b/core/dbt/jsonschemas.py
@@ -90,12 +90,18 @@ def jsonschema_validate(schema: Dict[str, Any], json: Dict[str, Any], file_path:
             and isinstance(error.instance, dict)
             and len(error.instance.keys()) > 0
         ):
-            deprecations.warn(
-                "custom-key-in-config-deprecation",
-                key=(list(error.instance.keys()))[0],
-                file=file_path,
-                key_path=error_path_to_string(error),
-            )
+            for sub_error in error.context or []:
+                if (
+                    isinstance(sub_error, ValidationError)
+                    and sub_error.validator == "additionalProperties"
+                ):
+                    key = re.search(r"'\S+'", sub_error.message)
+                    deprecations.warn(
+                        "custom-key-in-config-deprecation",
+                        key=key.group().strip("'") if key else "",
+                        file=file_path,
+                        key_path=error_path_to_string(error),
+                    )
         else:
             deprecations.warn(
                 "generic-json-schema-validation-deprecation",

--- a/tests/functional/deprecations/fixtures.py
+++ b/tests/functional/deprecations/fixtures.py
@@ -168,6 +168,16 @@ models:
       my_custom_key: "my_custom_value"
 """
 
+multiple_custom_keys_in_config_yaml = """
+models:
+  - name: models_trivial
+    description: "This is a test model"
+    deprecation_date: 1999-01-01 00:00:00.00+00:00
+    config:
+      my_custom_key: "my_custom_value"
+      my_custom_key2: "my_custom_value2"
+"""
+
 custom_key_in_object_yaml = """
 models:
   - name: models_trivial

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -363,7 +363,7 @@ class TestCustomKeyInObjectDeprecation:
         run_dbt(["parse", "--no-partial-parse"], callbacks=[event_catcher.catch])
         assert len(event_catcher.caught_events) == 1
         assert (
-            "Custom key `'my_custom_property'` found at `models[0]` in file"
+            "Custom key `my_custom_property` found at `models[0]` in file"
             in event_catcher.caught_events[0].info.msg
         )
 

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -26,6 +26,7 @@ from tests.functional.deprecations.fixtures import (
     duplicate_keys_yaml,
     invalid_deprecation_date_yaml,
     models_trivial__model_sql,
+    multiple_custom_keys_in_config_yaml,
 )
 from tests.utils import EventCatcher
 
@@ -341,11 +342,40 @@ class TestCustomKeyInConfigDeprecation:
     @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
     def test_duplicate_yaml_keys_in_schema_files(self, project):
         event_catcher = EventCatcher(CustomKeyInConfigDeprecation)
-        run_dbt(["parse", "--no-partial-parse"], callbacks=[event_catcher.catch])
+        run_dbt(
+            ["parse", "--no-partial-parse", "--show-all-deprecations"],
+            callbacks=[event_catcher.catch],
+        )
         assert len(event_catcher.caught_events) == 1
         assert (
             "Custom key `my_custom_key` found in `config` at path `models[0].config`"
             in event_catcher.caught_events[0].info.msg
+        )
+
+
+class TestMultipleCustomKeysInConfigDeprecation:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "models_trivial.sql": models_trivial__model_sql,
+            "models.yml": multiple_custom_keys_in_config_yaml,
+        }
+
+    @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
+    def test_duplicate_yaml_keys_in_schema_files(self, project):
+        event_catcher = EventCatcher(CustomKeyInConfigDeprecation)
+        run_dbt(
+            ["parse", "--no-partial-parse", "--show-all-deprecations"],
+            callbacks=[event_catcher.catch],
+        )
+        assert len(event_catcher.caught_events) == 2
+        assert (
+            "Custom key `my_custom_key` found in `config` at path `models[0].config`"
+            in event_catcher.caught_events[0].info.msg
+        )
+        assert (
+            "Custom key `my_custom_key2` found in `config` at path `models[0].config`"
+            in event_catcher.caught_events[1].info.msg
         )
 
 


### PR DESCRIPTION
Resolves #11576

### Problem

The firing logic was taking the first key present in the `ValidationError.instance.keys()`. However, that contained all keys present in the object, so we were just returning the first key whether it was valid or not

### Solution

Dive further into the validation error to find the `additionalProperties` violation, and get the keys from that sub violation.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
