### PR TITLE
Fix #11428: Add tags and meta config to exposures

### DIFF
--- a/.changes/unreleased/Fixes-20250508-142542.yaml
+++ b/.changes/unreleased/Fixes-20250508-142542.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add tags and meta config to exposures
+time: 2025-05-08T14:25:42.489888+01:00
+custom:
+    Author: aranke
+    Issue: "11428"

--- a/core/dbt/artifacts/resources/v1/exposure.py
+++ b/core/dbt/artifacts/resources/v1/exposure.py
@@ -27,6 +27,8 @@ class MaturityType(StrEnum):
 @dataclass
 class ExposureConfig(BaseConfig):
     enabled: bool = True
+    tags: List[str] = field(default_factory=list)
+    meta: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -117,8 +117,8 @@ class ExposureParser(YamlReader):
                 f"Calculated a {type(config)} for an exposure, but expected an ExposureConfig"
             )
 
-        tags = sorted(set(self.project.exposures.get("tags", []) + config.tags + unparsed.tags))
-        meta = {**self.project.exposures.get("meta", {}), **config.meta, **unparsed.meta}
+        tags = sorted(set(self.project.exposures.get("tags", []) + unparsed.tags + config.tags))
+        meta = {**self.project.exposures.get("meta", {}), **unparsed.meta, **config.meta}
 
         config.tags = tags
         config.meta = meta

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -117,8 +117,8 @@ class ExposureParser(YamlReader):
                 f"Calculated a {type(config)} for an exposure, but expected an ExposureConfig"
             )
 
-        tags = sorted(set(self.project.exposures.get("tags", []) + config.tags))
-        meta = {**self.project.exposures.get("meta", {}), **config.meta}
+        tags = sorted(set(self.project.exposures.get("tags", []) + config.tags + unparsed.tags))
+        meta = {**self.project.exposures.get("meta", {}), **config.meta, **unparsed.meta}
 
         config.tags = tags
         config.meta = meta

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -117,6 +117,12 @@ class ExposureParser(YamlReader):
                 f"Calculated a {type(config)} for an exposure, but expected an ExposureConfig"
             )
 
+        tags = sorted(set(self.project.exposures.get("tags", []) + config.tags))
+        meta = {**self.project.exposures.get("meta", {}), **config.meta}
+
+        config.tags = tags
+        config.meta = meta
+
         parsed = Exposure(
             resource_type=NodeType.Exposure,
             package_name=package_name,
@@ -127,8 +133,8 @@ class ExposureParser(YamlReader):
             name=unparsed.name,
             type=unparsed.type,
             url=unparsed.url,
-            meta=unparsed.meta,
-            tags=unparsed.tags,
+            meta=meta,
+            tags=tags,
             description=unparsed.description,
             label=unparsed.label,
             owner=unparsed.owner,

--- a/tests/functional/artifacts/expected_manifest.py
+++ b/tests/functional/artifacts/expected_manifest.py
@@ -854,6 +854,8 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                 "label": None,
                 "config": {
                     "enabled": True,
+                    "meta": {"tool": "my_tool", "languages": ["python"]},
+                    "tags": ["my_department"],
                 },
                 "fqn": ["test", "notebook_exposure"],
                 "maturity": "medium",
@@ -886,6 +888,8 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                 "label": None,
                 "config": {
                     "enabled": True,
+                    "meta": {},
+                    "tags": [],
                 },
                 "fqn": ["test", "simple_exposure"],
                 "metrics": [],
@@ -1378,6 +1382,8 @@ def expected_references_manifest(project):
                 "label": None,
                 "config": {
                     "enabled": True,
+                    "meta": {"tool": "my_tool", "languages": ["python"]},
+                    "tags": ["my_department"],
                 },
                 "fqn": ["test", "notebook_exposure"],
                 "maturity": "medium",
@@ -1968,6 +1974,8 @@ def expected_versions_manifest(project):
                 "label": None,
                 "config": {
                     "enabled": True,
+                    "meta": {},
+                    "tags": [],
                 },
                 "fqn": ["test", "notebook_exposure"],
                 "maturity": None,

--- a/tests/functional/exposures/fixtures.py
+++ b/tests/functional/exposures/fixtures.py
@@ -123,6 +123,10 @@ exposures:
     type: dashboard
     config:
       enabled: True
+      tags: ['local_tag', 'common_tag']
+      meta:
+        some_key: 'some_value'
+        type_change: 123
     depends_on:
       - ref('model')
     owner:

--- a/tests/unit/contracts/graph/test_nodes_parsed.py
+++ b/tests/unit/contracts/graph/test_nodes_parsed.py
@@ -2106,6 +2106,8 @@ def basic_parsed_exposure_dict():
         "created_at": 1.0,
         "config": {
             "enabled": True,
+            "tags": [],
+            "meta": {},
         },
         "unrendered_config": {},
     }
@@ -2161,6 +2163,8 @@ def complex_parsed_exposure_dict():
         "original_file_path": "models/something.yml",
         "config": {
             "enabled": True,
+            "tags": [],
+            "meta": {},
         },
         "unrendered_config": {},
     }


### PR DESCRIPTION
Resolves #11428

### Problem

`meta` and `tags` specified in `dbt_project.yml` weren't flowing down to the exposure

### Solution

Combine `meta` and `tags` between global config in `dbt_project.yml` and local config in `properties.yml`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
