### PR TITLE
Allow for deprecation warning previews

### DIFF
--- a/.changes/unreleased/Under the Hood-20250508-162148.yaml
+++ b/.changes/unreleased/Under the Hood-20250508-162148.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Allow for deprecation previews
+time: 2025-05-08T16:21:48.811505-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11597"

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -1,6 +1,10 @@
 import pytest
 
 import dbt.deprecations as deprecations
+from dbt.events.types import ProjectFlagsMovedDeprecation
+from dbt_common.events.event_manager_client import add_callback_to_manager
+from dbt_common.events.types import Note
+from tests.utils import EventCatcher
 
 
 @pytest.fixture(scope="function")
@@ -56,3 +60,38 @@ def test_number_of_occurances_is_tracked():
     deprecations.warn("project-flags-moved")
     assert "project-flags-moved" in deprecations.active_deprecations
     assert deprecations.active_deprecations["project-flags-moved"] == 2
+
+
+class PreviewedDeprecation(deprecations.DBTDeprecation):
+    _name = "previewed-deprecation"
+    _event = "ProjectFlagsMovedDeprecation"
+    _is_preview = True
+
+
+class TestPreviewDeprecation:
+
+    @pytest.fixture(scope="class", autouse=True)
+    def deprecations_list_and_deprecations(self):
+        deprecations.deprecations_list.append(PreviewedDeprecation())
+        deprecations.deprecations["previewed-deprecation"] = PreviewedDeprecation()
+
+        yield
+
+        for dep in deprecations.deprecations_list:
+            if dep._name == "previewed-deprecation":
+                deprecations.deprecations_list.remove(dep)
+                break
+        deprecations.deprecations.pop("previewed-deprecation")
+
+    def test_preview_deprecation(self):
+        pfmd_catcher = EventCatcher(event_to_catch=ProjectFlagsMovedDeprecation)
+        add_callback_to_manager(pfmd_catcher.catch)
+        note_catcher = EventCatcher(event_to_catch=Note)
+        add_callback_to_manager(note_catcher.catch)
+
+        deprecations.warn(
+            "previewed-deprecation",
+        )
+        assert "previewed-deprecation" not in deprecations.active_deprecations
+        assert len(pfmd_catcher.caught_events) == 0
+        assert len(note_catcher.caught_events) == 1


### PR DESCRIPTION
Resolves #11597

### Problem

Sometimes we don't want deprecation warnings to go live immediately in a beta/rc. Instead we want to give it a little time to bake until turning it into a "real deprecation warning" (i.e. raised as a warning + counted in the summary).

### Solution

Raise "preview" deprecation warnings as `Notes` (which are `info` level events)

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
