### PR TITLE
fix command test

### DIFF
--- a/tests/functional/list/test_commands.py
+++ b/tests/functional/list/test_commands.py
@@ -50,13 +50,12 @@ class TestRunCommands:
 
         shutil.rmtree(f"{project_root}/snapshots")
 
-    @pytest.mark.parametrize("dbt_command", commands)
     def test_run_commmand(
         self,
         happy_path_project,
-        dbt_command,
     ):
-        run_dbt(dbt_command)
+        for command in commands:
+            run_dbt(command)
 
 
 """

--- a/tests/functional/list/test_commands.py
+++ b/tests/functional/list/test_commands.py
@@ -29,10 +29,11 @@ commands_to_skip = {
     "show",
     "snapshot",
     "freshness",
+    "serve",  # this was actually serving up docs and caused issues locally
 }
 
 # Commands to happy path test
-commands = [command.value for command in Command if command.value not in commands_to_skip]
+commands = [command.to_list() for command in Command if command.value not in commands_to_skip]
 
 
 class TestRunCommands:
@@ -49,13 +50,13 @@ class TestRunCommands:
 
         shutil.rmtree(f"{project_root}/snapshots")
 
-    @pytest.mark.parametrize("dbt_command", [(command,) for command in commands])
+    @pytest.mark.parametrize("dbt_command", commands)
     def test_run_commmand(
         self,
         happy_path_project,
         dbt_command,
     ):
-        run_dbt([dbt_command])
+        run_dbt(dbt_command)
 
 
 """


### PR DESCRIPTION
### Problem

Tests were failing with "command not found" errors for commands that definitely exist.

### Solution

Use `to_list()` instead of `value`

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
