### PR TITLE
Flip behavior flag `source-freshness-run-proejct-hooks` to true

### DIFF
--- a/.changes/unreleased/Breaking Changes-20250512-150436.yaml
+++ b/.changes/unreleased/Breaking Changes-20250512-150436.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Flip beahvior flag `source-freshness-run-project-hooks` to true
+time: 2025-05-12T15:04:36.70678-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11609"

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -352,7 +352,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     require_batched_execution_for_custom_microbatch_strategy: bool = False
     require_explicit_package_overrides_for_builtin_materializations: bool = True
     require_resource_names_without_spaces: bool = False
-    source_freshness_run_project_hooks: bool = False
+    source_freshness_run_project_hooks: bool = True
     skip_nodes_if_on_run_start_fails: bool = False
     state_modified_compare_more_unrendered_values: bool = False
     state_modified_compare_vars: bool = False

--- a/tests/functional/sources/test_source_freshness.py
+++ b/tests/functional/sources/test_source_freshness.py
@@ -577,8 +577,8 @@ class TestHooksInSourceFreshnessDefault(SuccessfulSourceFreshnessTest):
             ],
             expect_pass=False,
         )
-        # default behaviour - no hooks run in source freshness
-        self._assert_project_hooks_not_called(log_output)
+        # default behaviour - hooks are run in source freshness
+        self._assert_project_hooks_called(log_output)
 
 
 class TestSourceFreshnessCustomSQL(SuccessfulSourceFreshnessTest):


### PR DESCRIPTION
Resolves #11609

### Problem

We need to flip this behavior flag for 1.10

### Solution

Flip the behavior flag

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
