### PR TITLE
do not have DbtProject unit tests rely on default QueryCommment settings

### DIFF
--- a/tests/unit/config/test_project.py
+++ b/tests/unit/config/test_project.py
@@ -402,7 +402,7 @@ class TestProjectInitialization(BaseConfigTest):
         )
         self.assertEqual(project.query_comment.comment, "run by user test")
         self.assertEqual(project.query_comment.append, True)
-    
+
     def test_default_query_comment_append_False(self):
         self.default_project_data.update(
             {

--- a/tests/unit/config/test_project.py
+++ b/tests/unit/config/test_project.py
@@ -350,7 +350,7 @@ class TestProjectInitialization(BaseConfigTest):
 
         assert "Cycle detected" in str(exc.exception)
 
-    def test_query_comment_disabled(self):
+    def test_query_comment_empty(self):
         self.default_project_data.update(
             {
                 "query-comment": None,
@@ -360,7 +360,7 @@ class TestProjectInitialization(BaseConfigTest):
             self.default_project_data, project_root=self.project_dir
         )
         self.assertEqual(project.query_comment.comment, "")
-        self.assertEqual(project.query_comment.append, None)
+        self.assertEqual(project.query_comment.append, QueryComment().append)
 
         self.default_project_data.update(
             {
@@ -371,7 +371,7 @@ class TestProjectInitialization(BaseConfigTest):
             self.default_project_data, project_root=self.project_dir
         )
         self.assertEqual(project.query_comment.comment, "")
-        self.assertEqual(project.query_comment.append, None)
+        self.assertEqual(project.query_comment.append, QueryComment().append)
 
     def test_default_query_comment(self):
         project = project_from_config_norender(
@@ -402,6 +402,30 @@ class TestProjectInitialization(BaseConfigTest):
         )
         self.assertEqual(project.query_comment.comment, "run by user test")
         self.assertEqual(project.query_comment.append, True)
+    
+    def test_default_query_comment_append_False(self):
+        self.default_project_data.update(
+            {
+                "query-comment": {"append": False},
+            }
+        )
+        project = project_from_config_norender(
+            self.default_project_data, project_root=self.project_dir
+        )
+        self.assertEqual(project.query_comment.comment, DEFAULT_QUERY_COMMENT)
+        self.assertEqual(project.query_comment.append, False)
+
+    def test_custom_query_comment_append_false(self):
+        self.default_project_data.update(
+            {
+                "query-comment": {"comment": "run by user test", "append": False},
+            }
+        )
+        project = project_from_config_norender(
+            self.default_project_data, project_root=self.project_dir
+        )
+        self.assertEqual(project.query_comment.comment, "run by user test")
+        self.assertEqual(project.query_comment.append, False)
 
     def test_packages_from_dependencies(self):
         packages = {

--- a/tests/unit/utils/project.py
+++ b/tests/unit/utils/project.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from dbt.adapters.contracts.connection import QueryComment
+from dbt.adapters.contracts.connection import QueryComment, DEFAULT_QUERY_COMMENT
 from dbt.config import RuntimeConfig
 from dbt.config.project import Project, RenderComponents, VarProvider
 from dbt.config.selectors import SelectorConfig
@@ -64,7 +64,8 @@ def project(selector_config: SelectorConfig) -> Project:
         packages=PackageConfig([]),
         manifest_selectors={},
         selectors=selector_config,
-        query_comment=QueryComment(),
+        # QueryComment contract defaults are defined by dbt-adapters, so not hard-coding this fixture to rely on particular settings of their defaults.
+        query_comment=QueryComment(comment=DEFAULT_QUERY_COMMENT, append=None, job_label=False),
         config_version=1,
         unrendered=RenderComponents({}, {}, {}),
         project_env_vars={},

--- a/tests/unit/utils/project.py
+++ b/tests/unit/utils/project.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from dbt.adapters.contracts.connection import QueryComment, DEFAULT_QUERY_COMMENT
+from dbt.adapters.contracts.connection import DEFAULT_QUERY_COMMENT, QueryComment
 from dbt.config import RuntimeConfig
 from dbt.config.project import Project, RenderComponents, VarProvider
 from dbt.config.selectors import SelectorConfig


### PR DESCRIPTION
Resolves # N/A

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

[#1064](https://github.com/dbt-labs/dbt-adapters/pull/1064) caused dbt-core to start failing some tests because it tests off dbt-adapters which were subsequently fixed in [#11596](https://github.com/dbt-labs/dbt-core/pull/11596). However, these test fixes rely on a dbt-adapters bump for changes that should ideally be decoupled.
### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Fixing the tests such that they do not depend on particular settings of QueryComment attribute defaults.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
