### PR TITLE
Core 9775/respect sql header in tests

### DIFF
--- a/.changes/unreleased/Fixes-20250327-002711.yaml
+++ b/.changes/unreleased/Fixes-20250327-002711.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: Provide required missing context to resolve sql_header in unit tests and generic tests.
+body: Provide required missing context to resolve sql_header in unit tests.
 time: 2025-03-27T00:27:11.364727+01:00
 custom:
     Author: Kayrnt versusfacit

--- a/.changes/unreleased/Fixes-20250327-002711.yaml
+++ b/.changes/unreleased/Fixes-20250327-002711.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Provide required missing context to resolve sql_header in unit tests
+time: 2025-03-27T00:27:11.364727+01:00
+custom:
+    Author: Kayrnt
+    Issue: "9775"

--- a/.changes/unreleased/Fixes-20250327-002711.yaml
+++ b/.changes/unreleased/Fixes-20250327-002711.yaml
@@ -1,6 +1,6 @@
 kind: Fixes
-body: Provide required missing context to resolve sql_header in unit tests
+body: Provide required missing context to resolve sql_header in unit tests and generic tests.
 time: 2025-03-27T00:27:11.364727+01:00
 custom:
-    Author: Kayrnt
+    Author: Kayrnt versusfacit
     Issue: "9775"

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -103,7 +103,9 @@ class UnitTestManifestLoader:
             tested_node_unique_id=tested_node.unique_id,
             overrides=test_case.overrides,
         )
-        # setting up the execution environment for a dbt unit test by creating a context with all the necessary functions and objects
+
+        # Needed to support macro-based set_sql_header overrides of the sql_header node config
+        # option.
         ctx = generate_runtime_unit_test_context(unit_test_node, self.root_project, self.manifest)
         ctx.update(
             generate_parse_exposure(

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -237,12 +237,6 @@ class TestRunner(CompileRunner):
                 "Invalid materialization context generated, missing config: {}".format(context)
             )
 
-        # allows test code to access the configuration settings of the component it's testing
-        if unit_test_node.tested_node_unique_id:
-            context["tested_node_config"] = manifest.nodes[
-                unit_test_node.tested_node_unique_id
-            ].config
-
         # generate materialization macro
         macro_func = MacroGenerator(materialization_macro, context)
         try:

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -237,6 +237,12 @@ class TestRunner(CompileRunner):
                 "Invalid materialization context generated, missing config: {}".format(context)
             )
 
+        # allows test code to access the configuration settings of the component it's testing
+        if unit_test_node.tested_node_unique_id:
+            context["tested_node_config"] = manifest.nodes[
+                unit_test_node.tested_node_unique_id
+            ].config
+
         # generate materialization macro
         macro_func = MacroGenerator(materialization_macro, context)
         try:

--- a/tests/functional/unit_testing/test_ut_sql_header.py
+++ b/tests/functional/unit_testing/test_ut_sql_header.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+import pytest
+
+from dbt.tests.util import run_dbt
+
+UNITTEST_MODEL_NAME = "unittest_model"
+HEADER_MARKER = "-- SQL_HEADER_INJECTION_TEST_MARKER"
+
+UNITTEST_MODEL_SQL = f"""
+{{{{ config(
+    materialized='table',
+    sql_header='{HEADER_MARKER}'
+)}}}}
+select 1 as id union all select 2 as id
+"""
+
+UNITTEST_MACRO_SQL_HEADER_MODEL_SQL = f"""
+{{{{ config(
+    materialized='table',
+)}}}}
+{{% call set_sql_header(config) %}}
+  {HEADER_MARKER}
+{{% endcall %}}
+
+select 1 as id union all select 2 as id
+"""
+
+UNITTEST_SCHEMA_YML = f"""
+unit_tests:
+  - name: test_sql_macro_header_injection
+    model: {UNITTEST_MODEL_NAME}
+    given: []
+    expect:
+      rows:
+        - {{id: 1}}
+        - {{id: 2}}
+"""
+
+
+class SQLHeaderInjectionBase:
+    def test_sql_header_is_injected(self, project):
+        results = run_dbt(["build"])
+        assert any(r.node.name == UNITTEST_MODEL_NAME for r in results)
+
+        # Compute path to compiled SQL
+        compiled_model_path = (
+            project.project_root
+            / Path("target")
+            / Path("run")
+            / Path(project.project_name)
+            / Path("models")
+            / Path(f"{UNITTEST_MODEL_NAME}.sql")
+        )
+
+        assert compiled_model_path.exists(), f"Compiled SQL not found: {compiled_model_path}"
+        compiled_sql = compiled_model_path.read_text()
+        assert HEADER_MARKER in compiled_sql, "SQL header marker not found in compiled SQL."
+
+
+class TestSQLHeaderConfigInjection(SQLHeaderInjectionBase):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            f"{UNITTEST_MODEL_NAME}.sql": UNITTEST_MODEL_SQL,
+            "schema.yml": UNITTEST_SCHEMA_YML,
+        }
+
+
+class TestSQLHeaderMacroInjection(SQLHeaderInjectionBase):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            f"{UNITTEST_MODEL_NAME}.sql": UNITTEST_MACRO_SQL_HEADER_MODEL_SQL,
+            "schema.yml": UNITTEST_SCHEMA_YML,
+        }

--- a/tests/functional/unit_testing/test_ut_sql_header.py
+++ b/tests/functional/unit_testing/test_ut_sql_header.py
@@ -6,6 +6,9 @@ from dbt.tests.util import run_dbt
 
 PROJECT_NAME = "sql_header_test"
 UNITTEST_MODEL_NAME = "unittest_model"
+# Why this and not some other database functionality?
+# To keep it database agnostic since we support SQL on the
+# the most generic create table macro"
 HEADER_MARKER = "-- SQL_HEADER_INJECTION_TEST_MARKER"
 
 UNITTEST_MODEL_SQL = f"""


### PR DESCRIPTION
Addresses part of #9775 


### Problem

We're not respect sql header.

### Solution

I'm not a core dev so you may have a better solution in mind. I used some free cycles to upcycle some community code and will also do a followon for dbt bigquery of this feature.

Data tests in general will need support that I don't right now have the expertise to do (we can pair up if you like!)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
