### PR TITLE
Eliminate False-Positive in Check for YAML Anchor Overrides

### DIFF
--- a/core/dbt/clients/checked_load.py
+++ b/core/dbt/clients/checked_load.py
@@ -33,6 +33,11 @@ def checked_load(contents) -> Tuple[Optional[Dict[str, Any]], List[YamlCheckFail
                 raise yaml.constructor.ConstructorError(
                     None, None, "expected a mapping node, but found %s" % node.id, node.start_mark
                 )
+            is_override = (
+                len(node.value) > 0
+                and len(node.value[0]) > 0
+                and getattr(node.value[0][0], "value") == "<<"
+            )
             self.flatten_mapping(node)
             mapping = {}
             for key_node, value_node in node.value:
@@ -46,7 +51,7 @@ def checked_load(contents) -> Tuple[Optional[Dict[str, Any]], List[YamlCheckFail
                     )
                 value = self.construct_object(value_node, deep=deep)
 
-                if key in mapping:
+                if not is_override and key in mapping:
                     start_mark = str(key_node.start_mark)
                     if start_mark.startswith("  in"):  # this means it was at the top level
                         message = f"Duplicate key '{key}' {start_mark.lstrip()}"

--- a/tests/unit/clients/test_yaml_helper.py
+++ b/tests/unit/clients/test_yaml_helper.py
@@ -42,6 +42,53 @@ d:
     f: 5
 """
 
+# Overrides should not cause duplicate key warnings on the data_tests key below.
+override__yml = """
+version: 2
+
+models:
+  - name: my_first_dbt_model
+    description: &description
+      "A starter dbt model"
+    columns:
+      - &copy_me
+        name: id
+        description: The ID.
+        data_tests:
+          - not_null
+
+  - name: my_second_dbt_model
+    description: *description
+    columns:
+      - <<: *copy_me
+        data_tests:
+          - unique
+"""
+
+override_with_issue__yml = """
+version: 2
+
+models:
+  - name: my_first_dbt_model
+    description: &description
+      "A starter dbt model"
+    columns:
+      - &copy_me
+        name: id
+        description: The ID.
+        data_tests:
+          - not_null
+
+  - name: my_second_dbt_model
+    description: *description
+    columns:
+      - <<: *copy_me
+        data_tests:
+          - unique
+        data_tests:
+          - unique
+"""
+
 
 def test_checked_load():
 
@@ -50,7 +97,17 @@ def test_checked_load():
 
     top_level_dupe_issues = checked_load(top_level_dupe__yml)[1]
     assert len(top_level_dupe_issues) == 1
+
     nested_dupe_issues = checked_load(nested_dupe__yml)[1]
     assert len(nested_dupe_issues) == 1
+
     multiple_dupes_issues = checked_load(multiple_dupes__yml)[1]
     assert len(multiple_dupes_issues) == 2
+
+    override_dupes_issues = checked_load(override__yml)[1]
+    assert len(override_dupes_issues) == 0
+
+    # This currently fails. We are not checking for genuine duplicate keys
+    # in override anchors.
+    # real_override_dupes_issues = checked_load(override__yml)[1]
+    # assert len(real_override_dupes_issues) == 1


### PR DESCRIPTION
Resolves #11602

### Problem

YAML anchor overrides were tripping our duplicate-key checker, and therefore generating errant deprecation warnings.

### Solution

For now, simply don't scan anchor overrides for duplicates. Actual cases of duplicates in overrides are likely very rare.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
