### PR TITLE
Do not check markdown documentation files for stray jinja blocks.

### DIFF
--- a/core/dbt/parser/docs.py
+++ b/core/dbt/parser/docs.py
@@ -45,6 +45,7 @@ class DocumentationParser(Parser[Documentation]):
             source=[file_block],
             allowed_blocks={"docs"},
             source_tag_factory=BlockContents,
+            check_jinja=False,
         )
         for block in searcher:
             for parsed in self.parse_block(block):

--- a/core/dbt/parser/search.py
+++ b/core/dbt/parser/search.py
@@ -111,10 +111,12 @@ class BlockSearcher(Generic[BlockSearchResult], Iterable[BlockSearchResult]):
         source: List[FileBlock],
         allowed_blocks: Set[str],
         source_tag_factory: BlockSearchResultFactory,
+        check_jinja: bool = True,
     ) -> None:
         self.source = source
         self.allowed_blocks = allowed_blocks
         self.source_tag_factory: BlockSearchResultFactory = source_tag_factory
+        self.check_jinja = check_jinja
 
     def extract_blocks(self, source_file: FileBlock) -> Iterable[BlockTag]:
         # This is a bit of a hack to get the file path to the deprecation
@@ -126,7 +128,7 @@ class BlockSearcher(Generic[BlockSearchResult], Iterable[BlockSearchResult]):
                 source_file.contents,
                 allowed_blocks=self.allowed_blocks,
                 collect_raw_data=False,
-                warning_callback=wrap_handle_extract_warning,
+                warning_callback=wrap_handle_extract_warning if self.check_jinja else None,
             )
             # this makes mypy happy, and this is an invariant we really need
             for block in blocks:


### PR DESCRIPTION
Resolves #11603

### Problem

Over-aggressive scanning for jinja issues was causing false deprecation warnings on documentation (markdown) files.

### Solution

Disable jinja deprecation checking in the docs parser.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
