### PR TITLE
Deprecate usage of `include` and `exclude` for `--warn-error-options`

### DIFF
--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -15,6 +15,7 @@ from dbt.cli.exceptions import DbtUsageException
 from dbt.cli.resolvers import default_log_path, default_project_dir
 from dbt.cli.types import Command as CliCommand
 from dbt.config.project import read_project_flags
+from dbt.config.utils import normalize_warn_error_options
 from dbt.contracts.project import ProjectFlags
 from dbt.deprecations import fire_buffered_deprecations, renamed_env_var
 from dbt.events import ALL_EVENT_NAMES
@@ -22,7 +23,7 @@ from dbt_common import ui
 from dbt_common.clients import jinja
 from dbt_common.events import functions
 from dbt_common.exceptions import DbtInternalError
-from dbt_common.helper_types import WarnErrorOptions
+from dbt_common.helper_types import WarnErrorOptionsV2
 
 if os.name != "nt":
     # https://bugs.python.org/issue41567
@@ -56,9 +57,10 @@ def convert_config(config_name, config_value):
     """Convert the values from config and original set_from_args to the correct type."""
     ret = config_value
     if config_name.lower() == "warn_error_options" and type(config_value) == dict:
-        ret = WarnErrorOptions(
-            include=config_value.get("include", []),
-            exclude=config_value.get("exclude", []),
+        normalize_warn_error_options(ret)
+        ret = WarnErrorOptionsV2(
+            error=config_value.get("error", []),
+            warn=config_value.get("warn", []),
             silence=config_value.get("silence", []),
             valid_error_names=ALL_EVENT_NAMES,
         )

--- a/core/dbt/cli/option_types.py
+++ b/core/dbt/cli/option_types.py
@@ -8,7 +8,7 @@ from dbt.event_time.sample_window import SampleWindow
 from dbt.events import ALL_EVENT_NAMES
 from dbt.exceptions import OptionNotYamlDictError, ValidationError
 from dbt_common.exceptions import DbtValidationError
-from dbt_common.helper_types import WarnErrorOptions
+from dbt_common.helper_types import WarnErrorOptionsV2
 
 
 class YAML(ParamType):
@@ -54,13 +54,13 @@ class WarnErrorOptionsType(YAML):
 
     def convert(self, value, param, ctx):
         # this function is being used by param in click
-        include_exclude = super().convert(value, param, ctx)
-        normalize_warn_error_options(include_exclude)
+        warn_error_options = super().convert(value, param, ctx)
+        normalize_warn_error_options(warn_error_options)
 
-        return WarnErrorOptions(
-            include=include_exclude.get("include", []),
-            exclude=include_exclude.get("exclude", []),
-            silence=include_exclude.get("silence", []),
+        return WarnErrorOptionsV2(
+            error=warn_error_options.get("error", []),
+            warn=warn_error_options.get("warn", []),
+            silence=warn_error_options.get("silence", []),
             valid_error_names=ALL_EVENT_NAMES,
         )
 

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -758,8 +758,8 @@ warn_error_options = click.option(
     "--warn-error-options",
     envvar="DBT_WARN_ERROR_OPTIONS",
     default="{}",
-    help="""If dbt would normally warn, instead raise an exception based on include/exclude configuration. Examples include --select that selects nothing, deprecations, configurations with no associated models, invalid test configurations,
-    and missing sources/refs in tests. This argument should be a YAML string, with keys 'include' or 'exclude'. eg. '{"include": "all", "exclude": ["NoNodesForSelectionCriteria"]}'""",
+    help="""If dbt would normally warn, instead raise an exception based on error/warn configuration. Examples include --select that selects nothing, deprecations, configurations with no associated models, invalid test configurations,
+    and missing sources/refs in tests. This argument should be a YAML string, with keys 'error' or 'warn'. eg. '{"error": "all", "warn": ["NoNodesForSelectionCriteria"]}'""",
     type=WarnErrorOptionsType(),
 )
 

--- a/core/dbt/config/utils.py
+++ b/core/dbt/config/utils.py
@@ -56,11 +56,11 @@ def exclusive_primary_alt_value_setting(
 
 def normalize_warn_error_options(warn_error_options: Dict[str, Any]) -> None:
     exclusive_primary_alt_value_setting(
-        warn_error_options, "include", "error", "warn_error_options"
+        warn_error_options, "error", "include", "warn_error_options"
     )
     exclusive_primary_alt_value_setting(
-        warn_error_options, "exclude", "warn", "warn_error_options"
+        warn_error_options, "warn", "exclude", "warn_error_options"
     )
-    for key in ("include", "exclude", "silence"):
+    for key in ("error", "warn", "silence"):
         if key in warn_error_options and warn_error_options[key] is None:
             warn_error_options[key] = []

--- a/core/dbt/task/retry.py
+++ b/core/dbt/task/retry.py
@@ -93,7 +93,7 @@ class RetryTask(ConfiguredTask):
         args_to_remove = {
             "show": lambda x: True,
             "resource_types": lambda x: x == [],
-            "warn_error_options": lambda x: x == {"exclude": [], "include": []},
+            "warn_error_options": lambda x: x == {"warn": [], "error": [], "silence": []},
         }
         for k, v in args_to_remove.items():
             if k in self.previous_args and v(self.previous_args[k]):

--- a/core/dbt/utils/utils.py
+++ b/core/dbt/utils/utils.py
@@ -28,7 +28,7 @@ import jinja2
 from dbt import flags
 from dbt.exceptions import DuplicateAliasError
 from dbt_common.exceptions import RecursionError
-from dbt_common.helper_types import WarnErrorOptions
+from dbt_common.helper_types import WarnErrorOptionsV2
 from dbt_common.utils import md5
 
 DECIMALS: Tuple[Type[Any], ...]
@@ -364,7 +364,7 @@ def args_to_dict(args):
         # this was required for a test case
         if isinstance(var_args[key], PosixPath) or isinstance(var_args[key], WindowsPath):
             var_args[key] = str(var_args[key])
-        if isinstance(var_args[key], WarnErrorOptions):
+        if isinstance(var_args[key], WarnErrorOptionsV2):
             var_args[key] = var_args[key].to_dict()
 
         dict_args[key] = var_args[key]

--- a/core/setup.py
+++ b/core/setup.py
@@ -71,7 +71,7 @@ setup(
         "dbt-extractor>=0.5.0,<=0.6",
         "dbt-semantic-interfaces>=0.8.3,<0.9",
         # Minor versions for these are expected to be backwards-compatible
-        "dbt-common>=1.22.0,<2.0",
+        "dbt-common>=1.25.0,<2.0",
         "dbt-adapters>=1.13.0,<2.0",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.

--- a/tests/functional/configs/test_warn_error_options.py
+++ b/tests/functional/configs/test_warn_error_options.py
@@ -108,7 +108,7 @@ class TestWarnErrorOptionsFromCLI:
         )
         assert not result.success
         assert result.exception is not None
-        assert "Only `error` or `include` can be specified" in str(result.exception)
+        assert "Only `include` or `error` can be specified" in str(result.exception)
 
     def test_cant_set_both_exclude_and_warn(self, project, runner: dbtRunner) -> None:
         result = runner.invoke(
@@ -120,7 +120,7 @@ class TestWarnErrorOptionsFromCLI:
         )
         assert not result.success
         assert result.exception is not None
-        assert "Only `warn` or `exclude` can be specified" in str(result.exception)
+        assert "Only `exclude` or `warn` can be specified" in str(result.exception)
 
 
 class TestWarnErrorOptionsFromProject:
@@ -188,7 +188,7 @@ class TestWarnErrorOptionsFromProject:
         result = runner.invoke(["run"])
         assert not result.success
         assert result.exception is not None
-        assert "Only `error` or `include` can be specified" in str(result.exception)
+        assert "Only `include` or `error` can be specified" in str(result.exception)
 
     def test_cant_set_both_exclude_and_warn(
         self, project, clear_project_flags, project_root, runner: dbtRunner
@@ -206,7 +206,7 @@ class TestWarnErrorOptionsFromProject:
         result = runner.invoke(["run"])
         assert not result.success
         assert result.exception is not None
-        assert "Only `warn` or `exclude` can be specified" in str(result.exception)
+        assert "Only `exclude` or `warn` can be specified" in str(result.exception)
 
 
 class TestEmptyWarnError:

--- a/tests/functional/dbt_runner/test_dbt_runner.py
+++ b/tests/functional/dbt_runner/test_dbt_runner.py
@@ -32,9 +32,9 @@ class TestDbtRunner:
         assert type(res.exception) == DbtUsageException
 
     def test_command_mutually_exclusive_option(self, dbt: dbtRunner) -> None:
-        res = dbt.invoke(["--warn-error", "--warn-error-options", '{"include": "all"}', "deps"])
+        res = dbt.invoke(["--warn-error", "--warn-error-options", '{"error": "all"}', "deps"])
         assert type(res.exception) == DbtUsageException
-        res = dbt.invoke(["deps", "--warn-error", "--warn-error-options", '{"include": "all"}'])
+        res = dbt.invoke(["deps", "--warn-error", "--warn-error-options", '{"error": "all"}'])
         assert type(res.exception) == DbtUsageException
 
         res = dbt.invoke(["compile", "--select", "models", "--inline", "select 1 as id"])

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -203,11 +203,11 @@ class TestProjectFlagsMovedDeprecationWarnErrorOptions(TestProjectFlagsMovedDepr
     def test_profile_config_deprecation(self, project):
         deprecations.reset_deprecations()
         with pytest.raises(EventCompilationError):
-            run_dbt(["--warn-error-options", "{'include': 'all'}", "parse"])
+            run_dbt(["--warn-error-options", "{'error': 'all'}", "parse"])
 
         with pytest.raises(EventCompilationError):
             run_dbt(
-                ["--warn-error-options", "{'include': ['ProjectFlagsMovedDeprecation']}", "parse"]
+                ["--warn-error-options", "{'error': ['ProjectFlagsMovedDeprecation']}", "parse"]
             )
 
         _, logs = run_dbt_and_capture(

--- a/tests/functional/deprecations/test_model_deprecations.py
+++ b/tests/functional/deprecations/test_model_deprecations.py
@@ -49,7 +49,7 @@ class TestModelDeprecationWarning:
 
     def test_deprecation_warning_error_options(self, project):
         with pytest.raises(EventCompilationError):
-            run_dbt(["--warn-error-options", '{"include": ["DeprecatedModel"]}', "parse"])
+            run_dbt(["--warn-error-options", '{"error": ["DeprecatedModel"]}', "parse"])
 
 
 class TestUpcomingReferenceDeprecationWarning:
@@ -76,7 +76,7 @@ class TestUpcomingReferenceDeprecationWarning:
     def test_deprecation_warning_error_options(self, project):
         with pytest.raises(EventCompilationError):
             run_dbt(
-                ["--warn-error-options", '{"include": ["UpcomingReferenceDeprecation"]}', "parse"]
+                ["--warn-error-options", '{"error": ["UpcomingReferenceDeprecation"]}', "parse"]
             )
 
 
@@ -103,4 +103,4 @@ class TestDeprecatedReferenceWarning:
 
     def test_deprecation_warning_error_options(self, project):
         with pytest.raises(EventCompilationError):
-            run_dbt(["--warn-error-options", '{"include": ["DeprecatedReference"]}', "parse"])
+            run_dbt(["--warn-error-options", '{"error": ["DeprecatedReference"]}', "parse"])

--- a/tests/unit/cli/test_flags.py
+++ b/tests/unit/cli/test_flags.py
@@ -158,14 +158,14 @@ class TestFlags:
         assert flags.WARN_ERROR
 
         warn_error_options_context = self.make_dbt_context(
-            "run", ["--warn-error-options", '{"include": "all"}', "run"]
+            "run", ["--warn-error-options", '{"error": "all"}', "run"]
         )
         flags = Flags(warn_error_options_context)
         assert flags.WARN_ERROR_OPTIONS == WarnErrorOptionsV2(error="all")
 
     def test_mutually_exclusive_options_from_cli(self):
         context = self.make_dbt_context(
-            "run", ["--warn-error", "--warn-error-options", '{"include": "all"}', "run"]
+            "run", ["--warn-error", "--warn-error-options", '{"error": "all"}', "run"]
         )
 
         with pytest.raises(DbtUsageException):
@@ -174,9 +174,7 @@ class TestFlags:
     @pytest.mark.parametrize("warn_error", [True, False])
     def test_mutually_exclusive_options_from_project_flags(self, warn_error, project_flags):
         project_flags.warn_error = warn_error
-        context = self.make_dbt_context(
-            "run", ["--warn-error-options", '{"include": "all"}', "run"]
-        )
+        context = self.make_dbt_context("run", ["--warn-error-options", '{"error": "all"}', "run"])
 
         with pytest.raises(DbtUsageException):
             Flags(context, project_flags)
@@ -184,7 +182,7 @@ class TestFlags:
     @pytest.mark.parametrize("warn_error", ["True", "False"])
     def test_mutually_exclusive_options_from_envvar(self, warn_error, monkeypatch):
         monkeypatch.setenv("DBT_WARN_ERROR", warn_error)
-        monkeypatch.setenv("DBT_WARN_ERROR_OPTIONS", '{"include":"all"}')
+        monkeypatch.setenv("DBT_WARN_ERROR_OPTIONS", '{"error":"all"}')
         context = self.make_dbt_context("run", ["run"])
 
         with pytest.raises(DbtUsageException):
@@ -195,9 +193,7 @@ class TestFlags:
         self, warn_error, project_flags
     ):
         project_flags.warn_error = warn_error
-        context = self.make_dbt_context(
-            "run", ["--warn-error-options", '{"include": "all"}', "run"]
-        )
+        context = self.make_dbt_context("run", ["--warn-error-options", '{"error": "all"}', "run"])
 
         with pytest.raises(DbtUsageException):
             Flags(context, project_flags)
@@ -205,9 +201,7 @@ class TestFlags:
     @pytest.mark.parametrize("warn_error", ["True", "False"])
     def test_mutually_exclusive_options_from_cli_and_envvar(self, warn_error, monkeypatch):
         monkeypatch.setenv("DBT_WARN_ERROR", warn_error)
-        context = self.make_dbt_context(
-            "run", ["--warn-error-options", '{"include": "all"}', "run"]
-        )
+        context = self.make_dbt_context("run", ["--warn-error-options", '{"error": "all"}', "run"])
 
         with pytest.raises(DbtUsageException):
             Flags(context)
@@ -217,7 +211,7 @@ class TestFlags:
         self, project_flags, warn_error, monkeypatch
     ):
         project_flags.warn_error = warn_error
-        monkeypatch.setenv("DBT_WARN_ERROR_OPTIONS", '{"include": "all"}')
+        monkeypatch.setenv("DBT_WARN_ERROR_OPTIONS", '{"error": "all"}')
         context = self.make_dbt_context("run", ["run"])
 
         with pytest.raises(DbtUsageException):

--- a/tests/unit/cli/test_flags.py
+++ b/tests/unit/cli/test_flags.py
@@ -11,7 +11,7 @@ from dbt.cli.types import Command
 from dbt.contracts.project import ProjectFlags
 from dbt.tests.util import rm_file, write_file
 from dbt_common.exceptions import DbtInternalError
-from dbt_common.helper_types import WarnErrorOptions
+from dbt_common.helper_types import WarnErrorOptionsV2
 
 
 class TestFlags:
@@ -161,7 +161,7 @@ class TestFlags:
             "run", ["--warn-error-options", '{"include": "all"}', "run"]
         )
         flags = Flags(warn_error_options_context)
-        assert flags.WARN_ERROR_OPTIONS == WarnErrorOptions(include="all")
+        assert flags.WARN_ERROR_OPTIONS == WarnErrorOptionsV2(error="all")
 
     def test_mutually_exclusive_options_from_cli(self):
         context = self.make_dbt_context(

--- a/tests/unit/config/test_utils.py
+++ b/tests/unit/config/test_utils.py
@@ -46,17 +46,17 @@ class TestExclusivePrimaryAltValueSetting:
 class TestNormalizeWarnErrorOptions:
     def test_primary_set(self):
         test_dict = {
-            "error": ["SomeWarning"],
+            "include": ["SomeWarning"],
         }
         normalize_warn_error_options(test_dict)
         assert len(test_dict) == 1
-        assert test_dict["include"] == ["SomeWarning"]
+        assert test_dict["error"] == ["SomeWarning"]
 
     def test_convert(self):
-        test_dict = {"warn": None, "silence": None, "include": ["SomeWarning"]}
+        test_dict = {"exclude": None, "silence": None, "error": ["SomeWarning"]}
         normalize_warn_error_options(test_dict)
-        assert test_dict["exclude"] == []
-        assert test_dict["include"] == ["SomeWarning"]
+        assert test_dict["warn"] == []
+        assert test_dict["error"] == ["SomeWarning"]
         assert test_dict["silence"] == []
 
     def test_both_keys_set(self):
@@ -70,5 +70,5 @@ class TestNormalizeWarnErrorOptions:
     def test_empty_dict(self):
         test_dict = {}
         normalize_warn_error_options(test_dict)
-        assert test_dict.get("include") is None
-        assert test_dict.get("exclude") is None
+        assert test_dict.get("error") is None
+        assert test_dict.get("warn") is None

--- a/tests/unit/context/test_context.py
+++ b/tests/unit/context/test_context.py
@@ -465,7 +465,11 @@ def test_invocation_args_to_dict_in_macro_runtime_context(
     assert ctx["invocation_args_dict"]["profile_dir"] == "/dev/null"
 
     assert isinstance(ctx["invocation_args_dict"]["warn_error_options"], Dict)
-    assert ctx["invocation_args_dict"]["warn_error_options"] == {"include": [], "exclude": []}
+    assert ctx["invocation_args_dict"]["warn_error_options"] == {
+        "error": [],
+        "warn": [],
+        "silence": [],
+    }
 
 
 def test_model_parse_context(config_postgres, manifest_fx, get_adapter, get_include_paths):

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -13,12 +13,12 @@ from dbt_common.exceptions import EventCompilationError
 @pytest.mark.parametrize(
     "warn_error_options,expect_compilation_exception",
     [
-        ({"include": "all"}, True),
-        ({"include": ["NoNodesForSelectionCriteria"]}, True),
-        ({"include": []}, False),
+        ({"error": "all"}, True),
+        ({"error": ["NoNodesForSelectionCriteria"]}, True),
+        ({"error": []}, False),
         ({}, False),
-        ({"include": ["MainTrackingUserState"]}, False),
-        ({"include": "all", "exclude": ["NoNodesForSelectionCriteria"]}, False),
+        ({"error": ["MainTrackingUserState"]}, False),
+        ({"error": "all", "warn": ["NoNodesForSelectionCriteria"]}, False),
     ],
 )
 def test_warn_or_error_warn_error_options(warn_error_options, expect_compilation_exception):
@@ -40,12 +40,12 @@ def test_warn_or_error_warn_error_options(warn_error_options, expect_compilation
     ],
 )
 def test_warn_error_options_captures_all_events(error_cls):
-    args = Namespace(warn_error_options={"include": [error_cls.__name__]})
+    args = Namespace(warn_error_options={"error": [error_cls.__name__]})
     flags.set_from_args(args, {})
     with pytest.raises(EventCompilationError):
         warn_or_error(error_cls())
 
-    args = Namespace(warn_error_options={"include": "*", "exclude": [error_cls.__name__]})
+    args = Namespace(warn_error_options={"error": "*", "warn": [error_cls.__name__]})
     flags.set_from_args(args, {})
     warn_or_error(error_cls())
 


### PR DESCRIPTION
Resolves #11557 

### Problem

We are going to stop deprecating the `include` and `exclude` terminology for `WarnErrorOptions`

### Solution

Begin emitting a deprecation warning about usages of `include` and `exclude` with `WarnErrrorOptions`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
