### PR TITLE
`normalize` expected file path of functional test to ensure windows testing doesn't break

### DIFF
--- a/tests/functional/list/test_list.py
+++ b/tests/functional/list/test_list.py
@@ -401,7 +401,9 @@ class TestList:
                     "name": "model_with_lots_of_schema_configs",
                     "resource_type": "model",
                     "package_name": "test",
-                    "original_file_path": "models/model_with_lots_of_schema_configs.sql",
+                    "original_file_path": normalize(
+                        "models/model_with_lots_of_schema_configs.sql"
+                    ),
                     "unique_id": "model.test.model_with_lots_of_schema_configs",
                     "alias": "outer_alias",
                     "config": {


### PR DESCRIPTION
Resolves #N/A

### Problem

A functional test was failing in CI on Windows due to a file path not being normalized

### Solution

Normalize the file path

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
