### PR TITLE
add more seed configs to happy_path_project

### DIFF
--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -40,7 +40,6 @@ class DBTDeprecation:
         raise NotImplementedError("event not implemented for {}".format(self._event))
 
     def preview(self, base_event: abc.ABCMeta) -> None:
-        # breakpoint()
         note_event = Note(msg=base_event.message())  # type: ignore
         fire_event(note_event)
 

--- a/core/dbt/include/jsonschemas/resources/latest.json
+++ b/core/dbt/include/jsonschemas/resources/latest.json
@@ -1,2766 +1,2815 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "DbtPropertiesFile",
-    "type": "object",
-    "properties": {
-      "analyses": {
-        "type": [
-          "array",
-          "null"
-        ],
-        "items": {
-          "$ref": "#/definitions/AnalysesProperties"
-        }
-      },
-      "exposures": {
-        "type": [
-          "array",
-          "null"
-        ],
-        "items": {
-          "$ref": "#/definitions/ExposuresProperties"
-        }
-      },
-      "groups": {
-        "type": [
-          "array",
-          "null"
-        ],
-        "items": {
-          "$ref": "#/definitions/GroupsProperties"
-        }
-      },
-      "macros": {
-        "type": [
-          "array",
-          "null"
-        ],
-        "items": {
-          "$ref": "#/definitions/MacrosProperties"
-        }
-      },
-      "metrics": {
-        "type": [
-          "array",
-          "null"
-        ],
-        "items": {
-          "$ref": "#/definitions/MetricsProperties"
-        }
-      },
-      "models": {
-        "type": [
-          "array",
-          "null"
-        ],
-        "items": {
-          "$ref": "#/definitions/ModelProperties"
-        }
-      },
-      "saved_queries": {
-        "type": [
-          "array",
-          "null"
-        ],
-        "items": {
-          "$ref": "#/definitions/SavedQueriesProperties"
-        }
-      },
-      "seeds": {
-        "type": [
-          "array",
-          "null"
-        ],
-        "items": {
-          "$ref": "#/definitions/SeedProperties"
-        }
-      },
-      "semantic_models": {
-        "type": [
-          "array",
-          "null"
-        ],
-        "items": {
-          "$ref": "#/definitions/SemanticModelsProperties"
-        }
-      },
-      "snapshots": {
-        "type": [
-          "array",
-          "null"
-        ],
-        "items": {
-          "$ref": "#/definitions/SnapshotProperties"
-        }
-      },
-      "sources": {
-        "type": [
-          "array",
-          "null"
-        ],
-        "items": {
-          "$ref": "#/definitions/SourceProperties"
-        }
-      },
-      "unit_tests": {
-        "type": [
-          "array",
-          "null"
-        ],
-        "items": {
-          "$ref": "#/definitions/UnitTestProperties"
-        }
-      },
-      "version": {
-        "anyOf": [
-          {
-            "$ref": "#/definitions/FloatOrString"
-          },
-          {
-            "type": "null"
-          }
-        ]
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DbtPropertiesFile",
+  "type": "object",
+  "properties": {
+    "analyses": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/AnalysesProperties"
       }
     },
-    "additionalProperties": false,
-    "definitions": {
-      "AcceptedValuesTest": {
-        "type": "object",
-        "required": [
-          "accepted_values"
-        ],
-        "properties": {
-          "accepted_values": true
+    "exposures": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/ExposuresProperties"
+      }
+    },
+    "groups": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/GroupsProperties"
+      }
+    },
+    "macros": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/MacrosProperties"
+      }
+    },
+    "metrics": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/MetricsProperties"
+      }
+    },
+    "models": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/ModelProperties"
+      }
+    },
+    "saved_queries": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/SavedQueriesProperties"
+      }
+    },
+    "seeds": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/SeedProperties"
+      }
+    },
+    "semantic_models": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/SemanticModelsProperties"
+      }
+    },
+    "snapshots": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/SnapshotProperties"
+      }
+    },
+    "sources": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/SourceProperties"
+      }
+    },
+    "unit_tests": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/UnitTestProperties"
+      }
+    },
+    "version": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FloatOrString"
         },
-        "additionalProperties": false
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "AcceptedValuesTest": {
+      "type": "object",
+      "required": [
+        "accepted_values"
+      ],
+      "properties": {
+        "accepted_values": true
       },
-      "AggregationTypeParams": {
-        "type": "object",
-        "properties": {
-          "percentile": {
-            "type": [
-              "number",
-              "null"
-            ],
-            "format": "float"
-          },
-          "use_approximate_percentile": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "use_discrete_percentile": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          }
+      "additionalProperties": false
+    },
+    "AggregationTypeParams": {
+      "type": "object",
+      "properties": {
+        "percentile": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "float"
         },
-        "additionalProperties": false
-      },
-      "AnalysesColumns": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "data_type": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "name": {
-            "type": "string"
-          }
+        "use_approximate_percentile": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
-        "additionalProperties": false
+        "use_discrete_percentile": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
       },
-      "AnalysesConfig": {
-        "type": "object",
-        "properties": {
-          "tags": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/StringOrArrayOfStrings"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
+      "additionalProperties": false
+    },
+    "AnalysesColumns": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "data_type": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
-        "additionalProperties": false
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        }
       },
-      "AnalysesProperties": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "columns": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/AnalysesColumns"
+      "additionalProperties": false
+    },
+    "AnalysesConfig": {
+      "type": "object",
+      "properties": {
+        "tags": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
             }
-          },
-          "config": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/AnalysesConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "docs": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/DocsConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "group": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "name": {
-            "type": "string"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "AnalysesProperties": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "columns": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/AnalysesColumns"
           }
         },
-        "additionalProperties": false
-      },
-      "AnyValue": true,
-      "BooleanOrJinjaString": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "boolean"
-          }
-        ]
-      },
-      "ColumnProperties": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "constraints": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": true
-          },
-          "data_tests": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/DataTests"
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnalysesConfig"
+            },
+            {
+              "type": "null"
             }
-          },
-          "data_type": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "granularity": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ColumnPropertiesGranularity"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "meta": true,
-          "name": {
-            "type": "string"
-          },
-          "policy_tags": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "docs": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DocsConfig"
+            },
+            {
+              "type": "null"
             }
-          },
-          "quote": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/BooleanOrJinjaString"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "tags": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/StringOrArrayOfStrings"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "tests": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/DataTests"
+          ]
+        },
+        "group": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "AnyValue": true,
+    "BooleanOrJinjaString": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "ColumnProperties": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "constraints": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": true
+        },
+        "data_tests": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataTests"
+          }
+        },
+        "data_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "granularity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ColumnPropertiesGranularity"
+            },
+            {
+              "type": "null"
             }
+          ]
+        },
+        "meta": true,
+        "name": {
+          "type": "string"
+        },
+        "policy_tags": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
           }
         },
-        "additionalProperties": false
-      },
-      "ColumnPropertiesGranularity": {
-        "type": "string",
-        "enum": [
-          "nanosecond",
-          "microsecond",
-          "millisecond",
-          "second",
-          "minute",
-          "hour",
-          "day",
-          "week",
-          "month",
-          "quarter",
-          "year"
-        ]
-      },
-      "Constraint": {
-        "description": "Constraints (model level or column level)",
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "columns": {
-            "description": "model-level only",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
+        "quote": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BooleanOrJinjaString"
+            },
+            {
+              "type": "null"
             }
-          },
-          "expression": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "name": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "to": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "to_columns": {
-            "description": "Only ForeignKey constraints accept: a list columns in that table containing the corresponding primary or unique key.",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
+          ]
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
             }
-          },
-          "type": {
-            "$ref": "#/definitions/ConstraintType"
-          }
+          ]
         },
-        "additionalProperties": false
+        "tests": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataTests"
+          }
+        }
       },
-      "ConstraintType": {
-        "type": "string",
-        "enum": [
-          "not_null",
-          "unique",
-          "primary_key",
-          "foreign_key",
-          "check",
-          "custom"
-        ]
-      },
-      "CustomGranularity": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "column_name": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "name": {
+      "additionalProperties": false
+    },
+    "ColumnPropertiesGranularity": {
+      "type": "string",
+      "enum": [
+        "nanosecond",
+        "microsecond",
+        "millisecond",
+        "second",
+        "minute",
+        "hour",
+        "day",
+        "week",
+        "month",
+        "quarter",
+        "year"
+      ]
+    },
+    "Constraint": {
+      "description": "Constraints (model level or column level)",
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "columns": {
+          "description": "model-level only",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
             "type": "string"
           }
         },
-        "additionalProperties": false
-      },
-      "DataTests": {
-        "anyOf": [
-          {
+        "expression": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "to": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "to_columns": {
+          "description": "Only ForeignKey constraints accept: a list columns in that table containing the corresponding primary or unique key.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
             "type": "string"
-          },
-          {
-            "$ref": "#/definitions/UniqueTest"
-          },
-          {
-            "$ref": "#/definitions/NotNullTest"
-          },
-          {
-            "$ref": "#/definitions/RelationshipsTest"
-          },
-          {
-            "$ref": "#/definitions/AcceptedValuesTest"
-          },
-          true
-        ]
-      },
-      "DbtContract": {
-        "type": "object",
-        "properties": {
-          "alias_types": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "checksum": true,
-          "enforced": {
-            "type": [
-              "boolean",
-              "null"
-            ]
           }
         },
-        "additionalProperties": false
+        "type": {
+          "$ref": "#/definitions/ConstraintType"
+        }
       },
-      "DbtQuoting": {
-        "type": "object",
-        "properties": {
-          "database": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "identifier": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "schema": {
-            "type": [
-              "boolean",
-              "null"
-            ]
+      "additionalProperties": false
+    },
+    "ConstraintType": {
+      "type": "string",
+      "enum": [
+        "not_null",
+        "unique",
+        "primary_key",
+        "foreign_key",
+        "check",
+        "custom"
+      ]
+    },
+    "CustomGranularity": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "column_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DataTests": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/UniqueTest"
+        },
+        {
+          "$ref": "#/definitions/NotNullTest"
+        },
+        {
+          "$ref": "#/definitions/RelationshipsTest"
+        },
+        {
+          "$ref": "#/definitions/AcceptedValuesTest"
+        },
+        true
+      ]
+    },
+    "DbtContract": {
+      "type": "object",
+      "properties": {
+        "alias_types": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "checksum": true,
+        "enforced": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "DbtQuoting": {
+      "type": "object",
+      "properties": {
+        "database": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "identifier": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "schema": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Dimension": {
+      "type": "object",
+      "required": [
+        "is_partition",
+        "name",
+        "type"
+      ],
+      "properties": {
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DimensionConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expr": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "is_partition": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "metadata": true,
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "type_params": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DimensionTypeParams"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "DimensionConfig": {
+      "type": "object",
+      "required": [
+        "meta"
+      ],
+      "properties": {
+        "meta": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "DimensionTypeParams": {
+      "type": "object",
+      "properties": {
+        "time_granularity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "validity_params": true
+      },
+      "additionalProperties": false
+    },
+    "DocsConfig": {
+      "type": "object",
+      "properties": {
+        "node_color": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "show": {
+          "default": true,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Entity": {
+      "type": "object",
+      "required": [
+        "name",
+        "type"
+      ],
+      "properties": {
+        "config": true,
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "entity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expr": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/EntityExpr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/EntityType"
+        }
+      },
+      "additionalProperties": false
+    },
+    "EntityExpr": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "EntityType": {
+      "type": "string",
+      "enum": [
+        "PRIMARY",
+        "UNIQUE",
+        "FOREIGN",
+        "NATURAL",
+        "primary",
+        "unique",
+        "foreign",
+        "natural"
+      ]
+    },
+    "Expect": {
+      "type": "object",
+      "properties": {
+        "fixture": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "default": "dict",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Formats"
+            }
+          ]
+        },
+        "rows": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Rows"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Export": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ExportConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExportConfig": {
+      "type": "object",
+      "properties": {
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "export_as": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ExportConfigExportAs"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExportConfigExportAs": {
+      "type": "string",
+      "enum": [
+        "table",
+        "view",
+        "cache"
+      ]
+    },
+    "ExposurePropertiesConfigs": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "meta": true
+      },
+      "additionalProperties": false
+    },
+    "ExposuresOwner": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExposuresProperties": {
+      "type": "object",
+      "required": [
+        "name",
+        "owner",
+        "type"
+      ],
+      "properties": {
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ExposurePropertiesConfigs"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "depends_on": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
           }
         },
-        "additionalProperties": false
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "maturity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "meta": true,
+        "name": {
+          "type": "string"
+        },
+        "owner": {
+          "$ref": "#/definitions/ExposuresOwner"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "type": "string"
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
       },
-      "Dimension": {
-        "type": "object",
-        "required": [
-          "is_partition",
-          "name",
-          "type"
-        ],
-        "properties": {
-          "config": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/DimensionConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "expr": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "is_partition": {
-            "type": "boolean"
-          },
-          "label": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "metadata": true,
-          "name": {
+      "additionalProperties": false
+    },
+    "FloatOrString": {
+      "anyOf": [
+        {
+          "type": "number",
+          "format": "float"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "Formats": {
+      "type": "string",
+      "enum": [
+        "dict",
+        "csv",
+        "sql"
+      ]
+    },
+    "FreshnessDefinition": {
+      "type": "object",
+      "properties": {
+        "error_after": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FreshnessRules"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "filter": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "warn_after": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FreshnessRules"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "FreshnessPeriod": {
+      "type": "string",
+      "enum": [
+        "minute",
+        "hour",
+        "day"
+      ]
+    },
+    "FreshnessRules": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NumberOrJinjaString"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "period": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FreshnessPeriod"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Given": {
+      "type": "object",
+      "required": [
+        "input"
+      ],
+      "properties": {
+        "fixture": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "default": "dict",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Formats"
+            }
+          ]
+        },
+        "input": {
+          "type": "string"
+        },
+        "rows": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Rows"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "GrantAccessToTarget": {
+      "type": "object",
+      "properties": {
+        "dataset": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "project": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "GroupsOwner": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "GroupsProperties": {
+      "type": "object",
+      "required": [
+        "name",
+        "owner"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "owner": {
+          "$ref": "#/definitions/GroupsOwner"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HookConfig": {
+      "type": "object",
+      "properties": {
+        "sql": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "transaction": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Hooks": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "type_params": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/DimensionTypeParams"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
-        "additionalProperties": false
+        {
+          "$ref": "#/definitions/HookConfig"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/HookConfig"
+          }
+        }
+      ]
+    },
+    "MacrosArguments": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
       },
-      "DimensionConfig": {
-        "type": "object",
-        "required": [
-          "meta"
-        ],
-        "properties": {
-          "meta": {
+      "additionalProperties": false
+    },
+    "MacrosProperties": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "arguments": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/MacrosArguments"
+          }
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "docs": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DocsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Measure": {
+      "type": "object",
+      "required": [
+        "agg",
+        "name"
+      ],
+      "properties": {
+        "agg": {
+          "$ref": "#/definitions/MeasureAgg"
+        },
+        "agg_params": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AggregationTypeParams"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "agg_time_dimension": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "config": true,
+        "create_metric": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "create_metric_display_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expr": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/_MeasureExpr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "non_additive_dimension": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NonAdditiveDimension"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "MeasureAgg": {
+      "type": "string",
+      "enum": [
+        "SUM",
+        "MIN",
+        "MAX",
+        "AVERAGE",
+        "COUNT_DISTINCT",
+        "SUM_BOOLEAN",
+        "COUNT",
+        "PERCENTILE",
+        "MEDIAN",
+        "sum",
+        "min",
+        "max",
+        "average",
+        "count_distinct",
+        "sum_boolean",
+        "count",
+        "percentile",
+        "median"
+      ]
+    },
+    "MetricsProperties": {
+      "type": "object",
+      "additionalProperties": false
+    },
+    "ModelFreshness": {
+      "type": "object",
+      "properties": {
+        "build_after": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FreshnessRules"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ModelProperties": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "access": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "columns": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ColumnProperties"
+          }
+        },
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelPropertiesConfigs"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "constraints": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Constraint"
+          }
+        },
+        "data_tests": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataTests"
+          }
+        },
+        "deprecation_date": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "docs": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DocsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "freshness": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelFreshness"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "group": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "identifier": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "latest_version": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FloatOrString"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "meta": true,
+        "name": {
+          "type": "string"
+        },
+        "tests": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataTests"
+          }
+        },
+        "time_spine": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelsTimeSpine"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "versions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Versions"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ModelPropertiesConfigs": {
+      "type": "object",
+      "properties": {
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "auto_refresh": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "backup": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "batch_size": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "begin": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "concurrent_batches": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "contract": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DbtContract"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "database": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "docs": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DocsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "event_time": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "file_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "full_refresh": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "grant_access_to": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/GrantAccessToTarget"
+          }
+        },
+        "grants": true,
+        "group": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "hours_to_expiration": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "float"
+        },
+        "include_full_name_in_path": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "incremental_strategy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "kms_key_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labels": true,
+        "location": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "location_root": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lookback": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "float"
+        },
+        "materialized": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "meta": true,
+        "on_configuration_change": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "on_schema_change": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "persist_docs": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PersistDocsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "post_hook": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Hooks"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pre_hook": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Hooks"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "snowflake_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sql_header": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "table_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "target_lag": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tblproperties": true,
+        "unique_key": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ModelsTimeSpine": {
+      "type": "object",
+      "required": [
+        "standard_granularity_column"
+      ],
+      "properties": {
+        "custom_granularities": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/CustomGranularity"
+          }
+        },
+        "standard_granularity_column": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "NonAdditiveDimension": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "window_choice": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NonAdditiveDimensionWindowChoice"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "window_groupings": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "NonAdditiveDimensionWindowChoice": {
+      "type": "string",
+      "enum": [
+        "MIN",
+        "MAX",
+        "min",
+        "max"
+      ]
+    },
+    "NotNullTest": {
+      "type": "object",
+      "required": [
+        "not_null"
+      ],
+      "properties": {
+        "not_null": true
+      },
+      "additionalProperties": false
+    },
+    "NumberOrJinjaString": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer",
+          "format": "int32"
+        }
+      ]
+    },
+    "PersistDocsConfig": {
+      "type": "object",
+      "properties": {
+        "columns": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "relation": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "RelationshipsTest": {
+      "type": "object",
+      "required": [
+        "relationships"
+      ],
+      "properties": {
+        "relationships": true
+      },
+      "additionalProperties": false
+    },
+    "Rows": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
             "type": "object",
             "additionalProperties": true
           }
+        }
+      ]
+    },
+    "SavedQueriesConfig": {
+      "type": "object",
+      "properties": {
+        "cache": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SavedQueriesConfigCache"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
-        "additionalProperties": false
-      },
-      "DimensionTypeParams": {
-        "type": "object",
-        "properties": {
-          "time_granularity": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "validity_params": true
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
-        "additionalProperties": false
+        "meta": true
       },
-      "DocsConfig": {
-        "type": "object",
-        "properties": {
-          "node_color": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "show": {
-            "default": true,
-            "type": "boolean"
+      "additionalProperties": false
+    },
+    "SavedQueriesConfigCache": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SavedQueriesProperties": {
+      "type": "object",
+      "required": [
+        "name",
+        "query_params"
+      ],
+      "properties": {
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SavedQueriesConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "exports": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Export"
           }
         },
-        "additionalProperties": false
-      },
-      "Entity": {
-        "type": "object",
-        "required": [
-          "name",
-          "type"
-        ],
-        "properties": {
-          "config": true,
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "entity": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "expr": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/EntityExpr"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "label": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "$ref": "#/definitions/EntityType"
-          }
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
-        "additionalProperties": false
-      },
-      "EntityExpr": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "boolean"
-          }
-        ]
-      },
-      "EntityType": {
-        "type": "string",
-        "enum": [
-          "PRIMARY",
-          "UNIQUE",
-          "FOREIGN",
-          "NATURAL",
-          "primary",
-          "unique",
-          "foreign",
-          "natural"
-        ]
-      },
-      "Expect": {
-        "type": "object",
-        "properties": {
-          "fixture": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "format": {
-            "default": "dict",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Formats"
-              }
-            ]
-          },
-          "rows": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Rows"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
+        "name": {
+          "type": "string"
         },
-        "additionalProperties": false
+        "query_params": {
+          "$ref": "#/definitions/SavedQueriesQueryParams"
+        }
       },
-      "Export": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "config": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ExportConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "name": {
+      "additionalProperties": false
+    },
+    "SavedQueriesQueryParams": {
+      "type": "object",
+      "properties": {
+        "dimensions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
             "type": "string"
           }
         },
-        "additionalProperties": false
-      },
-      "ExportConfig": {
-        "type": "object",
-        "properties": {
-          "alias": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "export_as": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ExportConfigExportAs"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "schema": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "ExportConfigExportAs": {
-        "type": "string",
-        "enum": [
-          "table",
-          "view",
-          "cache"
-        ]
-      },
-      "ExposurePropertiesConfigs": {
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "meta": true
-        },
-        "additionalProperties": false
-      },
-      "ExposuresOwner": {
-        "type": "object",
-        "properties": {
-          "email": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "name": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "ExposuresProperties": {
-        "type": "object",
-        "required": [
-          "name",
-          "owner",
-          "type"
-        ],
-        "properties": {
-          "config": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ExposurePropertiesConfigs"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "depends_on": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
-            }
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "label": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "maturity": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "meta": true,
-          "name": {
-            "type": "string"
-          },
-          "owner": {
-            "$ref": "#/definitions/ExposuresOwner"
-          },
-          "tags": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/StringOrArrayOfStrings"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string"
-          },
-          "url": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "FloatOrString": {
-        "anyOf": [
-          {
-            "type": "number",
-            "format": "float"
-          },
-          {
-            "type": "string"
-          }
-        ]
-      },
-      "Formats": {
-        "type": "string",
-        "enum": [
-          "dict",
-          "csv",
-          "sql"
-        ]
-      },
-      "FreshnessDefinition": {
-        "type": "object",
-        "properties": {
-          "error_after": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/FreshnessRules"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "filter": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "warn_after": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/FreshnessRules"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "FreshnessPeriod": {
-        "type": "string",
-        "enum": [
-          "minute",
-          "hour",
-          "day"
-        ]
-      },
-      "FreshnessRules": {
-        "type": "object",
-        "properties": {
-          "count": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/NumberOrJinjaString"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "period": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/FreshnessPeriod"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "Given": {
-        "type": "object",
-        "required": [
-          "input"
-        ],
-        "properties": {
-          "fixture": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "format": {
-            "default": "dict",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Formats"
-              }
-            ]
-          },
-          "input": {
-            "type": "string"
-          },
-          "rows": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Rows"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "GrantAccessToTarget": {
-        "type": "object",
-        "properties": {
-          "dataset": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "project": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "GroupsOwner": {
-        "type": "object",
-        "properties": {
-          "email": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "name": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "GroupsProperties": {
-        "type": "object",
-        "required": [
-          "name",
-          "owner"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "owner": {
-            "$ref": "#/definitions/GroupsOwner"
-          }
-        },
-        "additionalProperties": false
-      },
-      "HookConfig": {
-        "type": "object",
-        "properties": {
-          "sql": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "transaction": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "Hooks": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          {
-            "$ref": "#/definitions/HookConfig"
-          },
-          {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/HookConfig"
-            }
-          }
-        ]
-      },
-      "MacrosArguments": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "MacrosProperties": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "arguments": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/MacrosArguments"
-            }
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "docs": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/DocsConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "name": {
+        "group_by": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
             "type": "string"
           }
         },
-        "additionalProperties": false
-      },
-      "Measure": {
-        "type": "object",
-        "required": [
-          "agg",
-          "name"
-        ],
-        "properties": {
-          "agg": {
-            "$ref": "#/definitions/MeasureAgg"
-          },
-          "agg_params": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/AggregationTypeParams"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "agg_time_dimension": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "config": true,
-          "create_metric": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "create_metric_display_name": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "expr": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/_MeasureExpr"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "label": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "name": {
-            "type": "string"
-          },
-          "non_additive_dimension": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/NonAdditiveDimension"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "MeasureAgg": {
-        "type": "string",
-        "enum": [
-          "SUM",
-          "MIN",
-          "MAX",
-          "AVERAGE",
-          "COUNT_DISTINCT",
-          "SUM_BOOLEAN",
-          "COUNT",
-          "PERCENTILE",
-          "MEDIAN",
-          "sum",
-          "min",
-          "max",
-          "average",
-          "count_distinct",
-          "sum_boolean",
-          "count",
-          "percentile",
-          "median"
-        ]
-      },
-      "MetricsProperties": {
-        "type": "object",
-        "additionalProperties": false
-      },
-      "ModelFreshness": {
-        "type": "object",
-        "properties": {
-          "build_after": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/FreshnessRules"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "ModelProperties": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "access": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "columns": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/ColumnProperties"
-            }
-          },
-          "config": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ModelPropertiesConfigs"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "constraints": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Constraint"
-            }
-          },
-          "data_tests": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/DataTests"
-            }
-          },
-          "deprecation_date": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "docs": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/DocsConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "freshness": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ModelFreshness"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "group": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "identifier": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "latest_version": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/FloatOrString"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "meta": true,
-          "name": {
-            "type": "string"
-          },
-          "tests": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/DataTests"
-            }
-          },
-          "time_spine": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ModelsTimeSpine"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "versions": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Versions"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "ModelPropertiesConfigs": {
-        "type": "object",
-        "properties": {
-          "alias": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "auto_refresh": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "backup": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "batch_size": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "begin": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "concurrent_batches": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "contract": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/DbtContract"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "database": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "docs": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/DocsConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "enabled": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "event_time": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "file_format": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "full_refresh": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "grant_access_to": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/GrantAccessToTarget"
-            }
-          },
-          "grants": true,
-          "group": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "hours_to_expiration": {
-            "type": [
-              "number",
-              "null"
-            ],
-            "format": "float"
-          },
-          "include_full_name_in_path": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "incremental_strategy": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "kms_key_name": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "labels": true,
-          "location": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "location_root": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "lookback": {
-            "type": [
-              "number",
-              "null"
-            ],
-            "format": "float"
-          },
-          "materialized": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "meta": true,
-          "on_configuration_change": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "on_schema_change": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "persist_docs": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/PersistDocsConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "post_hook": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Hooks"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "pre_hook": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Hooks"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "schema": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "snowflake_warehouse": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "sql_header": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "table_format": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "tags": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/StringOrArrayOfStrings"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "target_lag": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "tblproperties": true,
-          "unique_key": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/StringOrArrayOfStrings"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "ModelsTimeSpine": {
-        "type": "object",
-        "required": [
-          "standard_granularity_column"
-        ],
-        "properties": {
-          "custom_granularities": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/CustomGranularity"
-            }
-          },
-          "standard_granularity_column": {
+        "metrics": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
             "type": "string"
           }
         },
-        "additionalProperties": false
-      },
-      "NonAdditiveDimension": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "window_choice": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/NonAdditiveDimensionWindowChoice"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "window_groupings": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "NonAdditiveDimensionWindowChoice": {
-        "type": "string",
-        "enum": [
-          "MIN",
-          "MAX",
-          "min",
-          "max"
-        ]
-      },
-      "NotNullTest": {
-        "type": "object",
-        "required": [
-          "not_null"
-        ],
-        "properties": {
-          "not_null": true
-        },
-        "additionalProperties": false
-      },
-      "NumberOrJinjaString": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "integer",
-            "format": "int32"
-          }
-        ]
-      },
-      "PersistDocsConfig": {
-        "type": "object",
-        "properties": {
-          "columns": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "relation": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "RelationshipsTest": {
-        "type": "object",
-        "required": [
-          "relationships"
-        ],
-        "properties": {
-          "relationships": true
-        },
-        "additionalProperties": false
-      },
-      "Rows": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "additionalProperties": true
-            }
-          }
-        ]
-      },
-      "SavedQueriesConfig": {
-        "type": "object",
-        "properties": {
-          "cache": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/SavedQueriesConfigCache"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "enabled": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "meta": true
-        },
-        "additionalProperties": false
-      },
-      "SavedQueriesConfigCache": {
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "SavedQueriesProperties": {
-        "type": "object",
-        "required": [
-          "name",
-          "query_params"
-        ],
-        "properties": {
-          "config": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/SavedQueriesConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "exports": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Export"
-            }
-          },
-          "label": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "name": {
-            "type": "string"
-          },
-          "query_params": {
-            "$ref": "#/definitions/SavedQueriesQueryParams"
-          }
-        },
-        "additionalProperties": false
-      },
-      "SavedQueriesQueryParams": {
-        "type": "object",
-        "properties": {
-          "dimensions": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
-            }
-          },
-          "group_by": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
-            }
-          },
-          "metrics": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
-            }
-          },
-          "where": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "SeedProperties": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "columns": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/ColumnProperties"
-            }
-          },
-          "config": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/SeedsConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "data_tests": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/DataTests"
-            }
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "docs": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/DocsConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "group": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "name": {
-            "type": "string"
-          },
-          "tests": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/DataTests"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "SeedsConfig": {
-        "type": "object",
-        "properties": {
-          "alias": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "column_types": true,
-          "copy_grants": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "database": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "enabled": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "grants": true,
-          "persist_docs": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/PersistDocsConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "quote_columns": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "schema": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "tags": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/StringOrArrayOfStrings"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "SemanticModelsDefaults": {
-        "type": "object",
-        "properties": {
-          "agg_time_dimension": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "SemanticModelsProperties": {
-        "type": "object",
-        "required": [
-          "model",
-          "name"
-        ],
-        "properties": {
-          "config": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/DimensionConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "defaults": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/SemanticModelsDefaults"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "dimensions": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Dimension"
-            }
-          },
-          "entities": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Entity"
-            }
-          },
-          "label": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "measures": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Measure"
-            }
-          },
-          "model": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "primary_entity": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "SnapshotProperties": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "columns": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/ColumnProperties"
-            }
-          },
-          "config": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/SnapshotsConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "data_tests": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/DataTests"
-            }
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "docs": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/DocsConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "group": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "meta": true,
-          "name": {
-            "type": "string"
-          },
-          "relation": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "tests": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/DataTests"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "SnapshotsConfig": {
-        "type": "object",
-        "properties": {
-          "alias": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "check_cols": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/StringOrArrayOfStrings"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "dbt_valid_to_current": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "enabled": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "grants": true,
-          "meta": true,
-          "persist_docs": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/PersistDocsConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "post-hook": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Hooks"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "pre-hook": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Hooks"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "quote_columns": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "snapshot_meta_column_names": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/SnapshotsConfigSnapshotMetaColumnNames"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "strategy": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "tags": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/StringOrArrayOfStrings"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "target_database": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "target_schema": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "unique_key": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/StringOrArrayOfStrings"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "updated_at": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "SnapshotsConfigSnapshotMetaColumnNames": {
-        "type": "object",
-        "properties": {
-          "dbt_scd_id": {
-            "default": "DBT_SCD_ID",
-            "type": "string"
-          },
-          "dbt_updated_at": {
-            "default": "DBT_UPDATED_AT",
-            "type": "string"
-          },
-          "dbt_valid_from": {
-            "default": "DBT_VALID_FROM",
-            "type": "string"
-          },
-          "dbt_valid_to": {
-            "default": "DBT_VALID_TO",
+        "where": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
             "type": "string"
           }
-        },
-        "additionalProperties": false
+        }
       },
-      "SourceProperties": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "config": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/SourcePropertiesConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "database": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "freshness": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/FreshnessDefinition"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "loaded_at_field": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "loaded_at_query": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "loader": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "meta": {
-            "type": [
-              "object",
-              "null"
-            ],
-            "additionalProperties": true
-          },
-          "name": {
-            "type": "string"
-          },
-          "overrides": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "quoting": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/DbtQuoting"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "schema": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "tables": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Tables"
+      "additionalProperties": false
+    },
+    "SeedProperties": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "columns": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ColumnProperties"
+          }
+        },
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SeedsConfig"
+            },
+            {
+              "type": "null"
             }
-          },
-          "tags": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/StringOrArrayOfStrings"
-              },
-              {
-                "type": "null"
-              }
-            ]
+          ]
+        },
+        "data_tests": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataTests"
           }
         },
-        "additionalProperties": false
-      },
-      "SourcePropertiesConfig": {
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "event_time": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
-        "additionalProperties": false
-      },
-      "StringOrArrayOfStrings": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "array",
-            "items": {
-              "type": "string"
+        "docs": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DocsConfig"
+            },
+            {
+              "type": "null"
             }
+          ]
+        },
+        "group": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "tests": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataTests"
           }
-        ]
+        }
       },
-      "Tables": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "columns": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/ColumnProperties"
+      "additionalProperties": false
+    },
+    "SeedsConfig": {
+      "type": "object",
+      "properties": {
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "column_types": true,
+        "copy_grants": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "database": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "delimiter": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "event_time": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "full_refresh": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "grants": true,
+        "meta": true,
+        "persist_docs": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PersistDocsConfig"
+            },
+            {
+              "type": "null"
             }
-          },
-          "config": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/TablesConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "data_tests": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/DataTests"
+          ]
+        },
+        "post_hook": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Hooks"
+            },
+            {
+              "type": "null"
             }
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "external": true,
-          "freshness": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/FreshnessDefinition"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "identifier": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "loaded_at_field": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "loaded_at_query": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "loader": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "meta": {
-            "type": [
-              "object",
-              "null"
-            ],
-            "additionalProperties": true
-          },
-          "name": {
-            "type": "string"
-          },
-          "quoting": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/DbtQuoting"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "tags": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/StringOrArrayOfStrings"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "tests": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/DataTests"
+          ]
+        },
+        "pre_hook": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Hooks"
+            },
+            {
+              "type": "null"
             }
-          }
+          ]
         },
-        "additionalProperties": false
-      },
-      "TablesConfig": {
-        "type": "object",
-        "properties": {
-          "event_time": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
+        "quote_columns": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
-        "additionalProperties": false
-      },
-      "UniqueTest": {
-        "type": "object",
-        "required": [
-          "unique"
-        ],
-        "properties": {
-          "unique": true
+        "schema": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
-        "additionalProperties": false
-      },
-      "UnitTestOverrides": {
-        "type": "object",
-        "properties": {
-          "env_vars": true,
-          "macros": true,
-          "vars": true
-        },
-        "additionalProperties": false
-      },
-      "UnitTestProperties": {
-        "type": "object",
-        "required": [
-          "expect",
-          "model",
-          "name"
-        ],
-        "properties": {
-          "config": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/UnitTestPropertiesConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "expect": {
-            "$ref": "#/definitions/Expect"
-          },
-          "given": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Given"
+        "tags": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
             }
-          },
-          "model": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "overrides": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/UnitTestOverrides"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "versions": true
-        },
-        "additionalProperties": false
+          ]
+        }
       },
-      "UnitTestPropertiesConfig": {
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "meta": true,
-          "tags": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/StringOrArrayOfStrings"
-              },
-              {
-                "type": "null"
-              }
-            ]
+      "additionalProperties": false
+    },
+    "SemanticModelsDefaults": {
+      "type": "object",
+      "properties": {
+        "agg_time_dimension": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SemanticModelsProperties": {
+      "type": "object",
+      "required": [
+        "model",
+        "name"
+      ],
+      "properties": {
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DimensionConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "defaults": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SemanticModelsDefaults"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "dimensions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Dimension"
           }
         },
-        "additionalProperties": false
-      },
-      "Versions": {
-        "type": "object",
-        "required": [
-          "v"
-        ],
-        "properties": {
-          "config": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/AnyValue"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "v": true
-        },
-        "additionalProperties": false
-      },
-      "_MeasureExpr": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "integer",
-            "format": "int32"
-          },
-          {
-            "type": "boolean"
+        "entities": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Entity"
           }
-        ]
-      }
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "measures": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Measure"
+          }
+        },
+        "model": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "primary_entity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SnapshotProperties": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "columns": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ColumnProperties"
+          }
+        },
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SnapshotsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "data_tests": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataTests"
+          }
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "docs": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DocsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "group": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "meta": true,
+        "name": {
+          "type": "string"
+        },
+        "relation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tests": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataTests"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "SnapshotsConfig": {
+      "type": "object",
+      "properties": {
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "check_cols": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dbt_valid_to_current": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "grants": true,
+        "hard_deletes": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "meta": true,
+        "persist_docs": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PersistDocsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "post-hook": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Hooks"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pre-hook": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Hooks"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "quote_columns": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "snapshot_meta_column_names": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SnapshotsConfigSnapshotMetaColumnNames"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strategy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "target_database": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "target_schema": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "unique_key": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "updated_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SnapshotsConfigSnapshotMetaColumnNames": {
+      "type": "object",
+      "properties": {
+        "dbt_is_deleted": {
+          "default": "DBT_IS_DELETED",
+          "type": "string"
+        },
+        "dbt_scd_id": {
+          "default": "DBT_SCD_ID",
+          "type": "string"
+        },
+        "dbt_updated_at": {
+          "default": "DBT_UPDATED_AT",
+          "type": "string"
+        },
+        "dbt_valid_from": {
+          "default": "DBT_VALID_FROM",
+          "type": "string"
+        },
+        "dbt_valid_to": {
+          "default": "DBT_VALID_TO",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SourceProperties": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SourcePropertiesConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "database": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "freshness": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FreshnessDefinition"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "loaded_at_field": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "loaded_at_query": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "loader": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "meta": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
+        "name": {
+          "type": "string"
+        },
+        "overrides": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quoting": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DbtQuoting"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tables": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Tables"
+          }
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SourcePropertiesConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "event_time": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "StringOrArrayOfStrings": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "Tables": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "columns": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ColumnProperties"
+          }
+        },
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TablesConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "data_tests": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataTests"
+          }
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "external": true,
+        "freshness": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FreshnessDefinition"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "identifier": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "loaded_at_field": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "loaded_at_query": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "loader": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "meta": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
+        "name": {
+          "type": "string"
+        },
+        "quoting": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DbtQuoting"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tests": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataTests"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "TablesConfig": {
+      "type": "object",
+      "properties": {
+        "event_time": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "UniqueTest": {
+      "type": "object",
+      "required": [
+        "unique"
+      ],
+      "properties": {
+        "unique": true
+      },
+      "additionalProperties": false
+    },
+    "UnitTestOverrides": {
+      "type": "object",
+      "properties": {
+        "env_vars": true,
+        "macros": true,
+        "vars": true
+      },
+      "additionalProperties": false
+    },
+    "UnitTestProperties": {
+      "type": "object",
+      "required": [
+        "expect",
+        "model",
+        "name"
+      ],
+      "properties": {
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/UnitTestPropertiesConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expect": {
+          "$ref": "#/definitions/Expect"
+        },
+        "given": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Given"
+          }
+        },
+        "model": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "overrides": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/UnitTestOverrides"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "versions": true
+      },
+      "additionalProperties": false
+    },
+    "UnitTestPropertiesConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "meta": true,
+        "tags": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Versions": {
+      "type": "object",
+      "required": [
+        "v"
+      ],
+      "properties": {
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "v": true
+      },
+      "additionalProperties": false
+    },
+    "_MeasureExpr": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer",
+          "format": "int32"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     }
   }
+}

--- a/tests/functional/artifacts/data/state/v1/manifest.json
+++ b/tests/functional/artifacts/data/state/v1/manifest.json
@@ -1,1 +1,3331 @@
-{"metadata": {"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v1.json", "dbt_version": "0.19.2", "generated_at": "2022-06-08T05:12:57.550908Z", "invocation_id": "57566e21-fbd4-4848-87ca-d05ddbd9012e", "env": {}, "project_id": "098f6bcd4621d373cade4e832627b4f6", "user_id": null, "send_anonymous_usage_stats": false, "adapter_type": "postgres"}, "nodes": {"model.test.my_model": {"raw_sql": "select 1 as id", "resource_type": "model", "depends_on": {"macros": [], "nodes": []}, "config": {"enabled": true, "materialized": "view", "persist_docs": {}, "vars": {}, "quoting": {}, "column_types": {}, "alias": null, "schema": null, "database": null, "tags": [], "full_refresh": null, "post-hook": [], "pre-hook": []}, "database": "jerco", "schema": "dbt_jcohen", "fqn": ["test", "my_model"], "unique_id": "model.test.my_model", "package_name": "test", "root_path": "/Users/jerco/dev/scratch/testy", "path": "my_model.sql", "original_file_path": "models/my_model.sql", "name": "my_model", "alias": "my_model", "checksum": {"name": "sha256", "checksum": "479636cb85ce8d3b0f8db5ff13cf338b61254ad98d905630eac61f963e719e9d"}, "tags": [], "refs": [], "sources": [], "description": "", "columns": {}, "meta": {}, "docs": {"show": true}, "patch_path": null, "build_path": null, "deferred": false, "unrendered_config": {}}}, "sources": {}, "macros": {"macro.test.drop_relation": {"unique_id": "macro.test.drop_relation", "package_name": "test", "root_path": "/Users/jerco/dev/scratch/testy", "path": "macros/whatever.sql", "original_file_path": "macros/whatever.sql", "name": "drop_relation", "macro_sql": "{% macro drop_relation(relation) -%}\n  {{ return(dbt_labs_materialized_views.drop_relation(relation)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.test.drop_relation"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.test.postgres__list_relations_without_caching": {"unique_id": "macro.test.postgres__list_relations_without_caching", "package_name": "test", "root_path": "/Users/jerco/dev/scratch/testy", "path": "macros/whatever.sql", "original_file_path": "macros/whatever.sql", "name": "postgres__list_relations_without_caching", "macro_sql": "{% macro postgres__list_relations_without_caching(schema_relation) %}\n  {{ return(dbt_labs_materialized_views.postgres__list_relations_without_caching(schema_relation)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.test.postgres__list_relations_without_caching"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.test.postgres_get_relations": {"unique_id": "macro.test.postgres_get_relations", "package_name": "test", "root_path": "/Users/jerco/dev/scratch/testy", "path": "macros/whatever.sql", "original_file_path": "macros/whatever.sql", "name": "postgres_get_relations", "macro_sql": "{% macro postgres_get_relations() %}\n  {{ return(dbt_labs_materialized_views.postgres_get_relations()) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.test.postgres_get_relations"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.test.redshift__list_relations_without_caching": {"unique_id": "macro.test.redshift__list_relations_without_caching", "package_name": "test", "root_path": "/Users/jerco/dev/scratch/testy", "path": "macros/whatever.sql", "original_file_path": "macros/whatever.sql", "name": "redshift__list_relations_without_caching", "macro_sql": "{% macro redshift__list_relations_without_caching(schema_relation) %}\n  {{ return(dbt_labs_materialized_views.redshift__list_relations_without_caching(schema_relation)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.test.redshift__list_relations_without_caching"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.test.load_relation": {"unique_id": "macro.test.load_relation", "package_name": "test", "root_path": "/Users/jerco/dev/scratch/testy", "path": "macros/whatever.sql", "original_file_path": "macros/whatever.sql", "name": "load_relation", "macro_sql": "{% macro load_relation(relation) %}\n  {{ return(dbt_labs_materialized_views.redshift_load_relation_or_mv(relation)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__get_catalog": {"unique_id": "macro.dbt_postgres.postgres__get_catalog", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/catalog.sql", "original_file_path": "macros/catalog.sql", "name": "postgres__get_catalog", "macro_sql": "{% macro postgres__get_catalog(information_schema, schemas) -%}\n\n  {%- call statement('catalog', fetch_result=True) -%}\n    {#\n      If the user has multiple databases set and the first one is wrong, this will fail.\n      But we won't fail in the case where there are multiple quoting-difference-only dbs, which is better.\n    #}\n    {% set database = information_schema.database %}\n    {{ adapter.verify_database(database) }}\n\n    select\n        '{{ database }}' as table_database,\n        sch.nspname as table_schema,\n        tbl.relname as table_name,\n        case tbl.relkind\n            when 'v' then 'VIEW'\n            else 'BASE TABLE'\n        end as table_type,\n        tbl_desc.description as table_comment,\n        col.attname as column_name,\n        col.attnum as column_index,\n        pg_catalog.format_type(col.atttypid, col.atttypmod) as column_type,\n        col_desc.description as column_comment,\n        pg_get_userbyid(tbl.relowner) as table_owner\n\n    from pg_catalog.pg_namespace sch\n    join pg_catalog.pg_class tbl on tbl.relnamespace = sch.oid\n    join pg_catalog.pg_attribute col on col.attrelid = tbl.oid\n    left outer join pg_catalog.pg_description tbl_desc on (tbl_desc.objoid = tbl.oid and tbl_desc.objsubid = 0)\n    left outer join pg_catalog.pg_description col_desc on (col_desc.objoid = tbl.oid and col_desc.objsubid = col.attnum)\n\n    where (\n        {%- for schema in schemas -%}\n          upper(sch.nspname) = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}\n        {%- endfor -%}\n      )\n      and not pg_is_other_temp_schema(sch.oid) -- not a temporary schema belonging to another session\n      and tbl.relpersistence = 'p' -- [p]ermanent table. Other values are [u]nlogged table, [t]emporary table\n      and tbl.relkind in ('r', 'v', 'f', 'p') -- o[r]dinary table, [v]iew, [f]oreign table, [p]artitioned table. Other values are [i]ndex, [S]equence, [c]omposite type, [t]OAST table, [m]aterialized view\n      and col.attnum > 0 -- negative numbers are used for system columns such as oid\n      and not col.attisdropped -- column as not been dropped\n\n    order by\n        sch.nspname,\n        tbl.relname,\n        col.attnum\n\n  {%- endcall -%}\n\n  {{ return(load_result('catalog').table) }}\n\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres_get_relations": {"unique_id": "macro.dbt_postgres.postgres_get_relations", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/relations.sql", "original_file_path": "macros/relations.sql", "name": "postgres_get_relations", "macro_sql": "{% macro postgres_get_relations () -%}\n\n  {#\n      -- in pg_depend, objid is the dependent, refobjid is the referenced object\n      --  > a pg_depend entry indicates that the referenced object cannot be\n      --  > dropped without also dropping the dependent object.\n  #}\n\n  {%- call statement('relations', fetch_result=True) -%}\n    with relation as (\n        select\n            pg_rewrite.ev_class as class,\n            pg_rewrite.oid as id\n        from pg_rewrite\n    ),\n    class as (\n        select\n            oid as id,\n            relname as name,\n            relnamespace as schema,\n            relkind as kind\n        from pg_class\n    ),\n    dependency as (\n        select\n            pg_depend.objid as id,\n            pg_depend.refobjid as ref\n        from pg_depend\n    ),\n    schema as (\n        select\n            pg_namespace.oid as id,\n            pg_namespace.nspname as name\n        from pg_namespace\n        where nspname != 'information_schema' and nspname not like 'pg\\_%'\n    ),\n    referenced as (\n        select\n            relation.id AS id,\n            referenced_class.name ,\n            referenced_class.schema ,\n            referenced_class.kind\n        from relation\n        join class as referenced_class on relation.class=referenced_class.id\n        where referenced_class.kind in ('r', 'v')\n    ),\n    relationships as (\n        select\n            referenced.name as referenced_name,\n            referenced.schema as referenced_schema_id,\n            dependent_class.name as dependent_name,\n            dependent_class.schema as dependent_schema_id,\n            referenced.kind as kind\n        from referenced\n        join dependency on referenced.id=dependency.id\n        join class as dependent_class on dependency.ref=dependent_class.id\n        where\n            (referenced.name != dependent_class.name or\n             referenced.schema != dependent_class.schema)\n    )\n\n    select\n        referenced_schema.name as referenced_schema,\n        relationships.referenced_name as referenced_name,\n        dependent_schema.name as dependent_schema,\n        relationships.dependent_name as dependent_name\n    from relationships\n    join schema as dependent_schema on relationships.dependent_schema_id=dependent_schema.id\n    join schema as referenced_schema on relationships.referenced_schema_id=referenced_schema.id\n    group by referenced_schema, referenced_name, dependent_schema, dependent_name\n    order by referenced_schema, referenced_name, dependent_schema, dependent_name;\n\n  {%- endcall -%}\n\n  {{ return(load_result('relations').table) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__create_table_as": {"unique_id": "macro.dbt_postgres.postgres__create_table_as", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/adapters.sql", "original_file_path": "macros/adapters.sql", "name": "postgres__create_table_as", "macro_sql": "{% macro postgres__create_table_as(temporary, relation, sql) -%}\n  {%- set unlogged = config.get('unlogged', default=false) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n\n  create {% if temporary -%}\n    temporary\n  {%- elif unlogged -%}\n    unlogged\n  {%- endif %} table {{ relation }}\n  as (\n    {{ sql }}\n  );\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__create_schema": {"unique_id": "macro.dbt_postgres.postgres__create_schema", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/adapters.sql", "original_file_path": "macros/adapters.sql", "name": "postgres__create_schema", "macro_sql": "{% macro postgres__create_schema(relation) -%}\n  {% if relation.database -%}\n    {{ adapter.verify_database(relation.database) }}\n  {%- endif -%}\n  {%- call statement('create_schema') -%}\n    create schema if not exists {{ relation.without_identifier().include(database=False) }}\n  {%- endcall -%}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__drop_schema": {"unique_id": "macro.dbt_postgres.postgres__drop_schema", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/adapters.sql", "original_file_path": "macros/adapters.sql", "name": "postgres__drop_schema", "macro_sql": "{% macro postgres__drop_schema(relation) -%}\n  {% if relation.database -%}\n    {{ adapter.verify_database(relation.database) }}\n  {%- endif -%}\n  {%- call statement('drop_schema') -%}\n    drop schema if exists {{ relation.without_identifier().include(database=False) }} cascade\n  {%- endcall -%}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__get_columns_in_relation": {"unique_id": "macro.dbt_postgres.postgres__get_columns_in_relation", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/adapters.sql", "original_file_path": "macros/adapters.sql", "name": "postgres__get_columns_in_relation", "macro_sql": "{% macro postgres__get_columns_in_relation(relation) -%}\n  {% call statement('get_columns_in_relation', fetch_result=True) %}\n      select\n          column_name,\n          data_type,\n          character_maximum_length,\n          numeric_precision,\n          numeric_scale\n\n      from {{ relation.information_schema('columns') }}\n      where table_name = '{{ relation.identifier }}'\n        {% if relation.schema %}\n        and table_schema = '{{ relation.schema }}'\n        {% endif %}\n      order by ordinal_position\n\n  {% endcall %}\n  {% set table = load_result('get_columns_in_relation').table %}\n  {{ return(sql_convert_columns_in_relation(table)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement", "macro.dbt.sql_convert_columns_in_relation"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__list_relations_without_caching": {"unique_id": "macro.dbt_postgres.postgres__list_relations_without_caching", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/adapters.sql", "original_file_path": "macros/adapters.sql", "name": "postgres__list_relations_without_caching", "macro_sql": "{% macro postgres__list_relations_without_caching(schema_relation) %}\n  {% call statement('list_relations_without_caching', fetch_result=True) -%}\n    select\n      '{{ schema_relation.database }}' as database,\n      tablename as name,\n      schemaname as schema,\n      'table' as type\n    from pg_tables\n    where schemaname ilike '{{ schema_relation.schema }}'\n    union all\n    select\n      '{{ schema_relation.database }}' as database,\n      viewname as name,\n      schemaname as schema,\n      'view' as type\n    from pg_views\n    where schemaname ilike '{{ schema_relation.schema }}'\n  {% endcall %}\n  {{ return(load_result('list_relations_without_caching').table) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__information_schema_name": {"unique_id": "macro.dbt_postgres.postgres__information_schema_name", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/adapters.sql", "original_file_path": "macros/adapters.sql", "name": "postgres__information_schema_name", "macro_sql": "{% macro postgres__information_schema_name(database) -%}\n  {% if database_name -%}\n    {{ adapter.verify_database(database_name) }}\n  {%- endif -%}\n  information_schema\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__list_schemas": {"unique_id": "macro.dbt_postgres.postgres__list_schemas", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/adapters.sql", "original_file_path": "macros/adapters.sql", "name": "postgres__list_schemas", "macro_sql": "{% macro postgres__list_schemas(database) %}\n  {% if database -%}\n    {{ adapter.verify_database(database) }}\n  {%- endif -%}\n  {% call statement('list_schemas', fetch_result=True, auto_begin=False) %}\n    select distinct nspname from pg_namespace\n  {% endcall %}\n  {{ return(load_result('list_schemas').table) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__check_schema_exists": {"unique_id": "macro.dbt_postgres.postgres__check_schema_exists", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/adapters.sql", "original_file_path": "macros/adapters.sql", "name": "postgres__check_schema_exists", "macro_sql": "{% macro postgres__check_schema_exists(information_schema, schema) -%}\n  {% if information_schema.database -%}\n    {{ adapter.verify_database(information_schema.database) }}\n  {%- endif -%}\n  {% call statement('check_schema_exists', fetch_result=True, auto_begin=False) %}\n    select count(*) from pg_namespace where nspname = '{{ schema }}'\n  {% endcall %}\n  {{ return(load_result('check_schema_exists').table) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__current_timestamp": {"unique_id": "macro.dbt_postgres.postgres__current_timestamp", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/adapters.sql", "original_file_path": "macros/adapters.sql", "name": "postgres__current_timestamp", "macro_sql": "{% macro postgres__current_timestamp() -%}\n  now()\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__snapshot_string_as_time": {"unique_id": "macro.dbt_postgres.postgres__snapshot_string_as_time", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/adapters.sql", "original_file_path": "macros/adapters.sql", "name": "postgres__snapshot_string_as_time", "macro_sql": "{% macro postgres__snapshot_string_as_time(timestamp) -%}\n    {%- set result = \"'\" ~ timestamp ~ \"'::timestamp without time zone\" -%}\n    {{ return(result) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__snapshot_get_time": {"unique_id": "macro.dbt_postgres.postgres__snapshot_get_time", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/adapters.sql", "original_file_path": "macros/adapters.sql", "name": "postgres__snapshot_get_time", "macro_sql": "{% macro postgres__snapshot_get_time() -%}\n  {{ current_timestamp() }}::timestamp without time zone\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.current_timestamp"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__make_temp_relation": {"unique_id": "macro.dbt_postgres.postgres__make_temp_relation", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/adapters.sql", "original_file_path": "macros/adapters.sql", "name": "postgres__make_temp_relation", "macro_sql": "{% macro postgres__make_temp_relation(base_relation, suffix) %}\n    {% set dt = modules.datetime.datetime.now() %}\n    {% set dtstring = dt.strftime(\"%H%M%S%f\") %}\n    {% set suffix_length = suffix|length + dtstring|length %}\n    {% set relation_max_name_length = 63 %}\n    {% if suffix_length > relation_max_name_length %}\n        {% do exceptions.raise_compiler_error('Temp relation suffix is too long (' ~ suffix|length ~ ' characters). Maximum length is ' ~ (relation_max_name_length - dtstring|length) ~ ' characters.') %}\n    {% endif %}\n    {% set tmp_identifier = base_relation.identifier[:relation_max_name_length - suffix_length] ~ suffix ~ dtstring %}\n    {% do return(base_relation.incorporate(\n                                  path={\n                                    \"identifier\": tmp_identifier,\n                                    \"schema\": none,\n                                    \"database\": none\n                                  })) -%}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres_escape_comment": {"unique_id": "macro.dbt_postgres.postgres_escape_comment", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/adapters.sql", "original_file_path": "macros/adapters.sql", "name": "postgres_escape_comment", "macro_sql": "{% macro postgres_escape_comment(comment) -%}\n  {% if comment is not string %}\n    {% do exceptions.raise_compiler_error('cannot escape a non-string: ' ~ comment) %}\n  {% endif %}\n  {%- set magic = '$dbt_comment_literal_block$' -%}\n  {%- if magic in comment -%}\n    {%- do exceptions.raise_compiler_error('The string ' ~ magic ~ ' is not allowed in comments.') -%}\n  {%- endif -%}\n  {{ magic }}{{ comment }}{{ magic }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__alter_relation_comment": {"unique_id": "macro.dbt_postgres.postgres__alter_relation_comment", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/adapters.sql", "original_file_path": "macros/adapters.sql", "name": "postgres__alter_relation_comment", "macro_sql": "{% macro postgres__alter_relation_comment(relation, comment) %}\n  {% set escaped_comment = postgres_escape_comment(comment) %}\n  comment on {{ relation.type }} {{ relation }} is {{ escaped_comment }};\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres_escape_comment"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__alter_column_comment": {"unique_id": "macro.dbt_postgres.postgres__alter_column_comment", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/adapters.sql", "original_file_path": "macros/adapters.sql", "name": "postgres__alter_column_comment", "macro_sql": "{% macro postgres__alter_column_comment(relation, column_dict) %}\n  {% for column_name in column_dict %}\n    {% set comment = column_dict[column_name]['description'] %}\n    {% set escaped_comment = postgres_escape_comment(comment) %}\n    comment on column {{ relation }}.{{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }} is {{ escaped_comment }};\n  {% endfor %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres_escape_comment"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt_postgres.postgres__snapshot_merge_sql": {"unique_id": "macro.dbt_postgres.postgres__snapshot_merge_sql", "package_name": "dbt_postgres", "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres", "path": "macros/materializations/snapshot_merge.sql", "original_file_path": "macros/materializations/snapshot_merge.sql", "name": "postgres__snapshot_merge_sql", "macro_sql": "{% macro postgres__snapshot_merge_sql(target, source, insert_cols) -%}\n    {%- set insert_cols_csv = insert_cols | join(', ') -%}\n\n    update {{ target }}\n    set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to\n    from {{ source }} as DBT_INTERNAL_SOURCE\n    where DBT_INTERNAL_SOURCE.dbt_scd_id::text = {{ target }}.dbt_scd_id::text\n      and DBT_INTERNAL_SOURCE.dbt_change_type::text in ('update'::text, 'delete'::text)\n      and {{ target }}.dbt_valid_to is null;\n\n    insert into {{ target }} ({{ insert_cols_csv }})\n    select {% for column in insert_cols -%}\n        DBT_INTERNAL_SOURCE.{{ column }} {%- if not loop.last %}, {%- endif %}\n    {%- endfor %}\n    from {{ source }} as DBT_INTERNAL_SOURCE\n    where DBT_INTERNAL_SOURCE.dbt_change_type::text = 'insert'::text;\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.statement": {"unique_id": "macro.dbt.statement", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/core.sql", "original_file_path": "macros/core.sql", "name": "statement", "macro_sql": "{% macro statement(name=None, fetch_result=False, auto_begin=True) -%}\n  {%- if execute: -%}\n    {%- set sql = caller() -%}\n\n    {%- if name == 'main' -%}\n      {{ log('Writing runtime SQL for node \"{}\"'.format(model['unique_id'])) }}\n      {{ write(sql) }}\n    {%- endif -%}\n\n    {%- set res, table = adapter.execute(sql, auto_begin=auto_begin, fetch=fetch_result) -%}\n    {%- if name is not none -%}\n      {{ store_result(name, response=res, agate_table=table) }}\n    {%- endif -%}\n\n  {%- endif -%}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.noop_statement": {"unique_id": "macro.dbt.noop_statement", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/core.sql", "original_file_path": "macros/core.sql", "name": "noop_statement", "macro_sql": "{% macro noop_statement(name=None, message=None, code=None, rows_affected=None, res=None) -%}\n  {%- set sql = caller() -%}\n\n  {%- if name == 'main' -%}\n    {{ log('Writing runtime SQL for node \"{}\"'.format(model['unique_id'])) }}\n    {{ write(sql) }}\n  {%- endif -%}\n\n  {%- if name is not none -%}\n    {{ store_raw_result(name, message=message, code=code, rows_affected=rows_affected, agate_table=res) }}\n  {%- endif -%}\n\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.run_hooks": {"unique_id": "macro.dbt.run_hooks", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/helpers.sql", "original_file_path": "macros/materializations/helpers.sql", "name": "run_hooks", "macro_sql": "{% macro run_hooks(hooks, inside_transaction=True) %}\n  {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction)  %}\n    {% if not inside_transaction and loop.first %}\n      {% call statement(auto_begin=inside_transaction) %}\n        commit;\n      {% endcall %}\n    {% endif %}\n    {% set rendered = render(hook.get('sql')) | trim %}\n    {% if (rendered | length) > 0 %}\n      {% call statement(auto_begin=inside_transaction) %}\n        {{ rendered }}\n      {% endcall %}\n    {% endif %}\n  {% endfor %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.column_list": {"unique_id": "macro.dbt.column_list", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/helpers.sql", "original_file_path": "macros/materializations/helpers.sql", "name": "column_list", "macro_sql": "{% macro column_list(columns) %}\n  {%- for col in columns %}\n    {{ col.name }} {% if not loop.last %},{% endif %}\n  {% endfor -%}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.column_list_for_create_table": {"unique_id": "macro.dbt.column_list_for_create_table", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/helpers.sql", "original_file_path": "macros/materializations/helpers.sql", "name": "column_list_for_create_table", "macro_sql": "{% macro column_list_for_create_table(columns) %}\n  {%- for col in columns %}\n    {{ col.name }} {{ col.data_type }} {%- if not loop.last %},{% endif %}\n  {% endfor -%}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.make_hook_config": {"unique_id": "macro.dbt.make_hook_config", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/helpers.sql", "original_file_path": "macros/materializations/helpers.sql", "name": "make_hook_config", "macro_sql": "{% macro make_hook_config(sql, inside_transaction) %}\n    {{ tojson({\"sql\": sql, \"transaction\": inside_transaction}) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.before_begin": {"unique_id": "macro.dbt.before_begin", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/helpers.sql", "original_file_path": "macros/materializations/helpers.sql", "name": "before_begin", "macro_sql": "{% macro before_begin(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.make_hook_config"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.in_transaction": {"unique_id": "macro.dbt.in_transaction", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/helpers.sql", "original_file_path": "macros/materializations/helpers.sql", "name": "in_transaction", "macro_sql": "{% macro in_transaction(sql) %}\n    {{ make_hook_config(sql, inside_transaction=True) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.make_hook_config"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.after_commit": {"unique_id": "macro.dbt.after_commit", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/helpers.sql", "original_file_path": "macros/materializations/helpers.sql", "name": "after_commit", "macro_sql": "{% macro after_commit(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.make_hook_config"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.drop_relation_if_exists": {"unique_id": "macro.dbt.drop_relation_if_exists", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/helpers.sql", "original_file_path": "macros/materializations/helpers.sql", "name": "drop_relation_if_exists", "macro_sql": "{% macro drop_relation_if_exists(relation) %}\n  {% if relation is not none %}\n    {{ adapter.drop_relation(relation) }}\n  {% endif %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.load_relation": {"unique_id": "macro.dbt.load_relation", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/helpers.sql", "original_file_path": "macros/materializations/helpers.sql", "name": "load_relation", "macro_sql": "{% macro load_relation(relation) %}\n  {% do return(adapter.get_relation(\n    database=relation.database,\n    schema=relation.schema,\n    identifier=relation.identifier\n  )) -%}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.should_full_refresh": {"unique_id": "macro.dbt.should_full_refresh", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/helpers.sql", "original_file_path": "macros/materializations/helpers.sql", "name": "should_full_refresh", "macro_sql": "{% macro should_full_refresh() %}\n  {% set config_full_refresh = config.get('full_refresh') %}\n  {% if config_full_refresh is none %}\n    {% set config_full_refresh = flags.FULL_REFRESH %}\n  {% endif %}\n  {% do return(config_full_refresh) %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.snapshot_merge_sql": {"unique_id": "macro.dbt.snapshot_merge_sql", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/snapshot_merge.sql", "original_file_path": "macros/materializations/snapshot/snapshot_merge.sql", "name": "snapshot_merge_sql", "macro_sql": "{% macro snapshot_merge_sql(target, source, insert_cols) -%}\n  {{ adapter.dispatch('snapshot_merge_sql')(target, source, insert_cols) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres__snapshot_merge_sql"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__snapshot_merge_sql": {"unique_id": "macro.dbt.default__snapshot_merge_sql", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/snapshot_merge.sql", "original_file_path": "macros/materializations/snapshot/snapshot_merge.sql", "name": "default__snapshot_merge_sql", "macro_sql": "{% macro default__snapshot_merge_sql(target, source, insert_cols) -%}\n    {%- set insert_cols_csv = insert_cols | join(', ') -%}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n    using {{ source }} as DBT_INTERNAL_SOURCE\n    on DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id\n\n    when matched\n     and DBT_INTERNAL_DEST.dbt_valid_to is null\n     and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')\n        then update\n        set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to\n\n    when not matched\n     and DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'\n        then insert ({{ insert_cols_csv }})\n        values ({{ insert_cols_csv }})\n    ;\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.strategy_dispatch": {"unique_id": "macro.dbt.strategy_dispatch", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/strategies.sql", "original_file_path": "macros/materializations/snapshot/strategies.sql", "name": "strategy_dispatch", "macro_sql": "{% macro strategy_dispatch(name) -%}\n{% set original_name = name %}\n  {% if '.' in name %}\n    {% set package_name, name = name.split(\".\", 1) %}\n  {% else %}\n    {% set package_name = none %}\n  {% endif %}\n\n  {% if package_name is none %}\n    {% set package_context = context %}\n  {% elif package_name in context %}\n    {% set package_context = context[package_name] %}\n  {% else %}\n    {% set error_msg %}\n        Could not find package '{{package_name}}', called with '{{original_name}}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n\n  {%- set search_name = 'snapshot_' ~ name ~ '_strategy' -%}\n\n  {% if search_name not in package_context %}\n    {% set error_msg %}\n        The specified strategy macro '{{name}}' was not found in package '{{ package_name }}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n  {{ return(package_context[search_name]) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.snapshot_hash_arguments": {"unique_id": "macro.dbt.snapshot_hash_arguments", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/strategies.sql", "original_file_path": "macros/materializations/snapshot/strategies.sql", "name": "snapshot_hash_arguments", "macro_sql": "{% macro snapshot_hash_arguments(args) -%}\n  {{ adapter.dispatch('snapshot_hash_arguments')(args) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__snapshot_hash_arguments"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__snapshot_hash_arguments": {"unique_id": "macro.dbt.default__snapshot_hash_arguments", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/strategies.sql", "original_file_path": "macros/materializations/snapshot/strategies.sql", "name": "default__snapshot_hash_arguments", "macro_sql": "{% macro default__snapshot_hash_arguments(args) -%}\n    md5({%- for arg in args -%}\n        coalesce(cast({{ arg }} as varchar ), '')\n        {% if not loop.last %} || '|' || {% endif %}\n    {%- endfor -%})\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.snapshot_get_time": {"unique_id": "macro.dbt.snapshot_get_time", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/strategies.sql", "original_file_path": "macros/materializations/snapshot/strategies.sql", "name": "snapshot_get_time", "macro_sql": "{% macro snapshot_get_time() -%}\n  {{ adapter.dispatch('snapshot_get_time')() }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres__snapshot_get_time"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__snapshot_get_time": {"unique_id": "macro.dbt.default__snapshot_get_time", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/strategies.sql", "original_file_path": "macros/materializations/snapshot/strategies.sql", "name": "default__snapshot_get_time", "macro_sql": "{% macro default__snapshot_get_time() -%}\n  {{ current_timestamp() }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.current_timestamp"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.snapshot_timestamp_strategy": {"unique_id": "macro.dbt.snapshot_timestamp_strategy", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/strategies.sql", "original_file_path": "macros/materializations/snapshot/strategies.sql", "name": "snapshot_timestamp_strategy", "macro_sql": "{% macro snapshot_timestamp_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set primary_key = config['unique_key'] %}\n    {% set updated_at = config['updated_at'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n\n    {#/*\n        The snapshot relation might not have an {{ updated_at }} value if the\n        snapshot strategy is changed from `check` to `timestamp`. We\n        should use a dbt-created column for the comparison in the snapshot\n        table instead of assuming that the user-supplied {{ updated_at }}\n        will be present in the historical data.\n\n        See https://github.com/fishtown-analytics/dbt/issues/2350\n    */ #}\n    {% set row_changed_expr -%}\n        ({{ snapshotted_rel }}.dbt_valid_from < {{ current_rel }}.{{ updated_at }})\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.snapshot_hash_arguments"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.snapshot_string_as_time": {"unique_id": "macro.dbt.snapshot_string_as_time", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/strategies.sql", "original_file_path": "macros/materializations/snapshot/strategies.sql", "name": "snapshot_string_as_time", "macro_sql": "{% macro snapshot_string_as_time(timestamp) -%}\n    {{ adapter.dispatch('snapshot_string_as_time')(timestamp) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres__snapshot_string_as_time"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__snapshot_string_as_time": {"unique_id": "macro.dbt.default__snapshot_string_as_time", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/strategies.sql", "original_file_path": "macros/materializations/snapshot/strategies.sql", "name": "default__snapshot_string_as_time", "macro_sql": "{% macro default__snapshot_string_as_time(timestamp) %}\n    {% do exceptions.raise_not_implemented(\n        'snapshot_string_as_time macro not implemented for adapter '+adapter.type()\n    ) %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.snapshot_check_all_get_existing_columns": {"unique_id": "macro.dbt.snapshot_check_all_get_existing_columns", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/strategies.sql", "original_file_path": "macros/materializations/snapshot/strategies.sql", "name": "snapshot_check_all_get_existing_columns", "macro_sql": "{% macro snapshot_check_all_get_existing_columns(node, target_exists) -%}\n    {%- set query_columns = get_columns_in_query(node['compiled_sql']) -%}\n    {%- if not target_exists -%}\n        {# no table yet -> return whatever the query does #}\n        {{ return([false, query_columns]) }}\n    {%- endif -%}\n    {# handle any schema changes #}\n    {%- set target_table = node.get('alias', node.get('name')) -%}\n    {%- set target_relation = adapter.get_relation(database=node.database, schema=node.schema, identifier=target_table) -%}\n    {%- set existing_cols = get_columns_in_query('select * from ' ~ target_relation) -%}\n    {%- set ns = namespace() -%} {# handle for-loop scoping with a namespace #}\n    {%- set ns.column_added = false -%}\n\n    {%- set intersection = [] -%}\n    {%- for col in query_columns -%}\n        {%- if col in existing_cols -%}\n            {%- do intersection.append(col) -%}\n        {%- else -%}\n            {% set ns.column_added = true %}\n        {%- endif -%}\n    {%- endfor -%}\n    {{ return([ns.column_added, intersection]) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.get_columns_in_query"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.snapshot_check_strategy": {"unique_id": "macro.dbt.snapshot_check_strategy", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/strategies.sql", "original_file_path": "macros/materializations/snapshot/strategies.sql", "name": "snapshot_check_strategy", "macro_sql": "{% macro snapshot_check_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set check_cols_config = config['check_cols'] %}\n    {% set primary_key = config['unique_key'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n    \n    {% set select_current_time -%}\n        select {{ snapshot_get_time() }} as snapshot_start\n    {%- endset %}\n\n    {#-- don't access the column by name, to avoid dealing with casing issues on snowflake #}\n    {%- set now = run_query(select_current_time)[0][0] -%}\n    {% if now is none or now is undefined -%}\n        {%- do exceptions.raise_compiler_error('Could not get a snapshot start time from the database') -%}\n    {%- endif %}\n    {% set updated_at = snapshot_string_as_time(now) %}\n\n    {% set column_added = false %}\n\n    {% if check_cols_config == 'all' %}\n        {% set column_added, check_cols = snapshot_check_all_get_existing_columns(node, target_exists) %}\n    {% elif check_cols_config is iterable and (check_cols_config | length) > 0 %}\n        {% set check_cols = check_cols_config %}\n    {% else %}\n        {% do exceptions.raise_compiler_error(\"Invalid value for 'check_cols': \" ~ check_cols_config) %}\n    {% endif %}\n\n    {%- set row_changed_expr -%}\n    (\n    {%- if column_added -%}\n        TRUE\n    {%- else -%}\n    {%- for col in check_cols -%}\n        {{ snapshotted_rel }}.{{ col }} != {{ current_rel }}.{{ col }}\n        or\n        (\n            (({{ snapshotted_rel }}.{{ col }} is null) and not ({{ current_rel }}.{{ col }} is null))\n            or\n            ((not {{ snapshotted_rel }}.{{ col }} is null) and ({{ current_rel }}.{{ col }} is null))\n        )\n        {%- if not loop.last %} or {% endif -%}\n    {%- endfor -%}\n    {%- endif -%}\n    )\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.snapshot_get_time", "macro.dbt.run_query", "macro.dbt.snapshot_string_as_time", "macro.dbt.snapshot_check_all_get_existing_columns", "macro.dbt.snapshot_hash_arguments"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.create_columns": {"unique_id": "macro.dbt.create_columns", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/snapshot.sql", "original_file_path": "macros/materializations/snapshot/snapshot.sql", "name": "create_columns", "macro_sql": "{% macro create_columns(relation, columns) %}\n  {{ adapter.dispatch('create_columns')(relation, columns) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__create_columns"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__create_columns": {"unique_id": "macro.dbt.default__create_columns", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/snapshot.sql", "original_file_path": "macros/materializations/snapshot/snapshot.sql", "name": "default__create_columns", "macro_sql": "{% macro default__create_columns(relation, columns) %}\n  {% for column in columns %}\n    {% call statement() %}\n      alter table {{ relation }} add column \"{{ column.name }}\" {{ column.data_type }};\n    {% endcall %}\n  {% endfor %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.post_snapshot": {"unique_id": "macro.dbt.post_snapshot", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/snapshot.sql", "original_file_path": "macros/materializations/snapshot/snapshot.sql", "name": "post_snapshot", "macro_sql": "{% macro post_snapshot(staging_relation) %}\n  {{ adapter.dispatch('post_snapshot')(staging_relation) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__post_snapshot"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__post_snapshot": {"unique_id": "macro.dbt.default__post_snapshot", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/snapshot.sql", "original_file_path": "macros/materializations/snapshot/snapshot.sql", "name": "default__post_snapshot", "macro_sql": "{% macro default__post_snapshot(staging_relation) %}\n    {# no-op #}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.snapshot_staging_table": {"unique_id": "macro.dbt.snapshot_staging_table", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/snapshot.sql", "original_file_path": "macros/materializations/snapshot/snapshot.sql", "name": "snapshot_staging_table", "macro_sql": "{% macro snapshot_staging_table(strategy, source_sql, target_relation) -%}\n\n    with snapshot_query as (\n\n        {{ source_sql }}\n\n    ),\n\n    snapshotted_data as (\n\n        select *,\n            {{ strategy.unique_key }} as dbt_unique_key\n\n        from {{ target_relation }}\n        where dbt_valid_to is null\n\n    ),\n\n    insertions_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to,\n            {{ strategy.scd_id }} as dbt_scd_id\n\n        from snapshot_query\n    ),\n\n    updates_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            {{ strategy.updated_at }} as dbt_valid_to\n\n        from snapshot_query\n    ),\n\n    {%- if strategy.invalidate_hard_deletes %}\n\n    deletes_source_data as (\n\n        select \n            *,\n            {{ strategy.unique_key }} as dbt_unique_key\n        from snapshot_query\n    ),\n    {% endif %}\n\n    insertions as (\n\n        select\n            'insert' as dbt_change_type,\n            source_data.*\n\n        from insertions_source_data as source_data\n        left outer join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where snapshotted_data.dbt_unique_key is null\n           or (\n                snapshotted_data.dbt_unique_key is not null\n            and (\n                {{ strategy.row_changed }}\n            )\n        )\n\n    ),\n\n    updates as (\n\n        select\n            'update' as dbt_change_type,\n            source_data.*,\n            snapshotted_data.dbt_scd_id\n\n        from updates_source_data as source_data\n        join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where (\n            {{ strategy.row_changed }}\n        )\n    )\n\n    {%- if strategy.invalidate_hard_deletes -%}\n    ,\n\n    deletes as (\n    \n        select\n            'delete' as dbt_change_type,\n            source_data.*,\n            {{ snapshot_get_time() }} as dbt_valid_from,\n            {{ snapshot_get_time() }} as dbt_updated_at,\n            {{ snapshot_get_time() }} as dbt_valid_to,\n            snapshotted_data.dbt_scd_id\n    \n        from snapshotted_data\n        left join deletes_source_data as source_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where source_data.dbt_unique_key is null\n    )\n    {%- endif %}\n\n    select * from insertions\n    union all\n    select * from updates\n    {%- if strategy.invalidate_hard_deletes %}\n    union all\n    select * from deletes\n    {%- endif %}\n\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.snapshot_get_time"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.build_snapshot_table": {"unique_id": "macro.dbt.build_snapshot_table", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/snapshot.sql", "original_file_path": "macros/materializations/snapshot/snapshot.sql", "name": "build_snapshot_table", "macro_sql": "{% macro build_snapshot_table(strategy, sql) %}\n\n    select *,\n        {{ strategy.scd_id }} as dbt_scd_id,\n        {{ strategy.updated_at }} as dbt_updated_at,\n        {{ strategy.updated_at }} as dbt_valid_from,\n        nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to\n    from (\n        {{ sql }}\n    ) sbq\n\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.get_or_create_relation": {"unique_id": "macro.dbt.get_or_create_relation", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/snapshot.sql", "original_file_path": "macros/materializations/snapshot/snapshot.sql", "name": "get_or_create_relation", "macro_sql": "{% macro get_or_create_relation(database, schema, identifier, type) %}\n  {%- set target_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}\n\n  {% if target_relation %}\n    {% do return([true, target_relation]) %}\n  {% endif %}\n\n  {%- set new_relation = api.Relation.create(\n      database=database,\n      schema=schema,\n      identifier=identifier,\n      type=type\n  ) -%}\n  {% do return([false, new_relation]) %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.build_snapshot_staging_table": {"unique_id": "macro.dbt.build_snapshot_staging_table", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/snapshot.sql", "original_file_path": "macros/materializations/snapshot/snapshot.sql", "name": "build_snapshot_staging_table", "macro_sql": "{% macro build_snapshot_staging_table(strategy, sql, target_relation) %}\n    {% set tmp_relation = make_temp_relation(target_relation) %}\n\n    {% set select = snapshot_staging_table(strategy, sql, target_relation) %}\n\n    {% call statement('build_snapshot_staging_relation') %}\n        {{ create_table_as(True, tmp_relation, select) }}\n    {% endcall %}\n\n    {% do return(tmp_relation) %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.make_temp_relation", "macro.dbt.snapshot_staging_table", "macro.dbt.statement", "macro.dbt.create_table_as"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.materialization_snapshot_default": {"unique_id": "macro.dbt.materialization_snapshot_default", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/snapshot/snapshot.sql", "original_file_path": "macros/materializations/snapshot/snapshot.sql", "name": "materialization_snapshot_default", "macro_sql": "{% materialization snapshot, default %}\n  {%- set config = model['config'] -%}\n\n  {%- set target_table = model.get('alias', model.get('name')) -%}\n\n  {%- set strategy_name = config.get('strategy') -%}\n  {%- set unique_key = config.get('unique_key') %}\n\n  {% if not adapter.check_schema_exists(model.database, model.schema) %}\n    {% do create_schema(model.database, model.schema) %}\n  {% endif %}\n\n  {% set target_relation_exists, target_relation = get_or_create_relation(\n          database=model.database,\n          schema=model.schema,\n          identifier=target_table,\n          type='table') -%}\n\n  {%- if not target_relation.is_table -%}\n    {% do exceptions.relation_wrong_type(target_relation, 'table') %}\n  {%- endif -%}\n\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set strategy_macro = strategy_dispatch(strategy_name) %}\n  {% set strategy = strategy_macro(model, \"snapshotted_data\", \"source_data\", config, target_relation_exists) %}\n\n  {% if not target_relation_exists %}\n\n      {% set build_sql = build_snapshot_table(strategy, model['compiled_sql']) %}\n      {% set final_sql = create_table_as(False, target_relation, build_sql) %}\n\n  {% else %}\n\n      {{ adapter.valid_snapshot_target(target_relation) }}\n\n      {% set staging_table = build_snapshot_staging_table(strategy, sql, target_relation) %}\n\n      -- this may no-op if the database does not require column expansion\n      {% do adapter.expand_target_column_types(from_relation=staging_table,\n                                               to_relation=target_relation) %}\n\n      {% set missing_columns = adapter.get_missing_columns(staging_table, target_relation)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% do create_columns(target_relation, missing_columns) %}\n\n      {% set source_columns = adapter.get_columns_in_relation(staging_table)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% set quoted_source_columns = [] %}\n      {% for column in source_columns %}\n        {% do quoted_source_columns.append(adapter.quote(column.name)) %}\n      {% endfor %}\n\n      {% set final_sql = snapshot_merge_sql(\n            target = target_relation,\n            source = staging_table,\n            insert_cols = quoted_source_columns\n         )\n      %}\n\n  {% endif %}\n\n  {% call statement('main') %}\n      {{ final_sql }}\n  {% endcall %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {% if staging_table is defined %}\n      {% do post_snapshot(staging_table) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.create_schema", "macro.dbt.get_or_create_relation", "macro.dbt.run_hooks", "macro.dbt.strategy_dispatch", "macro.dbt.build_snapshot_table", "macro.dbt.create_table_as", "macro.dbt.build_snapshot_staging_table", "macro.dbt.create_columns", "macro.dbt.snapshot_merge_sql", "macro.dbt.statement", "macro.dbt.persist_docs", "macro.dbt.post_snapshot"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.create_csv_table": {"unique_id": "macro.dbt.create_csv_table", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/seed/seed.sql", "original_file_path": "macros/materializations/seed/seed.sql", "name": "create_csv_table", "macro_sql": "{% macro create_csv_table(model, agate_table) -%}\n  {{ adapter.dispatch('create_csv_table')(model, agate_table) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__create_csv_table"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.reset_csv_table": {"unique_id": "macro.dbt.reset_csv_table", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/seed/seed.sql", "original_file_path": "macros/materializations/seed/seed.sql", "name": "reset_csv_table", "macro_sql": "{% macro reset_csv_table(model, full_refresh, old_relation, agate_table) -%}\n  {{ adapter.dispatch('reset_csv_table')(model, full_refresh, old_relation, agate_table) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__reset_csv_table"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.load_csv_rows": {"unique_id": "macro.dbt.load_csv_rows", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/seed/seed.sql", "original_file_path": "macros/materializations/seed/seed.sql", "name": "load_csv_rows", "macro_sql": "{% macro load_csv_rows(model, agate_table) -%}\n  {{ adapter.dispatch('load_csv_rows')(model, agate_table) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__load_csv_rows"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__create_csv_table": {"unique_id": "macro.dbt.default__create_csv_table", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/seed/seed.sql", "original_file_path": "macros/materializations/seed/seed.sql", "name": "default__create_csv_table", "macro_sql": "{% macro default__create_csv_table(model, agate_table) %}\n  {%- set column_override = model['config'].get('column_types', {}) -%}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n\n  {% set sql %}\n    create table {{ this.render() }} (\n        {%- for col_name in agate_table.column_names -%}\n            {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}\n            {%- set type = column_override.get(col_name, inferred_type) -%}\n            {%- set column_name = (col_name | string) -%}\n            {{ adapter.quote_seed_column(column_name, quote_seed_column) }} {{ type }} {%- if not loop.last -%}, {%- endif -%}\n        {%- endfor -%}\n    )\n  {% endset %}\n\n  {% call statement('_') -%}\n    {{ sql }}\n  {%- endcall %}\n\n  {{ return(sql) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__reset_csv_table": {"unique_id": "macro.dbt.default__reset_csv_table", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/seed/seed.sql", "original_file_path": "macros/materializations/seed/seed.sql", "name": "default__reset_csv_table", "macro_sql": "{% macro default__reset_csv_table(model, full_refresh, old_relation, agate_table) %}\n    {% set sql = \"\" %}\n    {% if full_refresh %}\n        {{ adapter.drop_relation(old_relation) }}\n        {% set sql = create_csv_table(model, agate_table) %}\n    {% else %}\n        {{ adapter.truncate_relation(old_relation) }}\n        {% set sql = \"truncate table \" ~ old_relation %}\n    {% endif %}\n\n    {{ return(sql) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.create_csv_table"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.get_seed_column_quoted_csv": {"unique_id": "macro.dbt.get_seed_column_quoted_csv", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/seed/seed.sql", "original_file_path": "macros/materializations/seed/seed.sql", "name": "get_seed_column_quoted_csv", "macro_sql": "{% macro get_seed_column_quoted_csv(model, column_names) %}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote_seed_column(col, quote_seed_column)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.basic_load_csv_rows": {"unique_id": "macro.dbt.basic_load_csv_rows", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/seed/seed.sql", "original_file_path": "macros/materializations/seed/seed.sql", "name": "basic_load_csv_rows", "macro_sql": "{% macro basic_load_csv_rows(model, batch_size, agate_table) %}\n    {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}\n    {% set bindings = [] %}\n\n    {% set statements = [] %}\n\n    {% for chunk in agate_table.rows | batch(batch_size) %}\n        {% set bindings = [] %}\n\n        {% for row in chunk %}\n            {% do bindings.extend(row) %}\n        {% endfor %}\n\n        {% set sql %}\n            insert into {{ this.render() }} ({{ cols_sql }}) values\n            {% for row in chunk -%}\n                ({%- for column in agate_table.column_names -%}\n                    %s\n                    {%- if not loop.last%},{%- endif %}\n                {%- endfor -%})\n                {%- if not loop.last%},{%- endif %}\n            {%- endfor %}\n        {% endset %}\n\n        {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}\n\n        {% if loop.index0 == 0 %}\n            {% do statements.append(sql) %}\n        {% endif %}\n    {% endfor %}\n\n    {# Return SQL so we can render it out into the compiled files #}\n    {{ return(statements[0]) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.get_seed_column_quoted_csv"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__load_csv_rows": {"unique_id": "macro.dbt.default__load_csv_rows", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/seed/seed.sql", "original_file_path": "macros/materializations/seed/seed.sql", "name": "default__load_csv_rows", "macro_sql": "{% macro default__load_csv_rows(model, agate_table) %}\n  {{ return(basic_load_csv_rows(model, 10000, agate_table) )}}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.basic_load_csv_rows"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.materialization_seed_default": {"unique_id": "macro.dbt.materialization_seed_default", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/seed/seed.sql", "original_file_path": "macros/materializations/seed/seed.sql", "name": "materialization_seed_default", "macro_sql": "{% materialization seed, default %}\n\n  {%- set identifier = model['alias'] -%}\n  {%- set full_refresh_mode = (should_full_refresh()) -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n\n  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set agate_table = load_agate_table() -%}\n  {%- do store_result('agate_table', response='OK', agate_table=agate_table) -%}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% set create_table_sql = \"\" %}\n  {% if exists_as_view %}\n    {{ exceptions.raise_compiler_error(\"Cannot seed to '{}', it is a view\".format(old_relation)) }}\n  {% elif exists_as_table %}\n    {% set create_table_sql = reset_csv_table(model, full_refresh_mode, old_relation, agate_table) %}\n  {% else %}\n    {% set create_table_sql = create_csv_table(model, agate_table) %}\n  {% endif %}\n\n  {% set code = 'CREATE' if full_refresh_mode else 'INSERT' %}\n  {% set rows_affected = (agate_table.rows | length) %}\n  {% set sql = load_csv_rows(model, agate_table) %}\n\n  {% call noop_statement('main', code ~ ' ' ~ rows_affected, code, rows_affected) %}\n    {{ create_table_sql }};\n    -- dbt seed --\n    {{ sql }}\n  {% endcall %}\n\n  {% set target_relation = this.incorporate(type='table') %}\n  {% do persist_docs(target_relation, model) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.should_full_refresh", "macro.dbt.run_hooks", "macro.dbt.reset_csv_table", "macro.dbt.create_csv_table", "macro.dbt.load_csv_rows", "macro.dbt.noop_statement", "macro.dbt.persist_docs"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.incremental_upsert": {"unique_id": "macro.dbt.incremental_upsert", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/incremental/helpers.sql", "original_file_path": "macros/materializations/incremental/helpers.sql", "name": "incremental_upsert", "macro_sql": "{% macro incremental_upsert(tmp_relation, target_relation, unique_key=none, statement_name=\"main\") %}\n    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}\n    {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}\n\n    {%- if unique_key is not none -%}\n    delete\n    from {{ target_relation }}\n    where ({{ unique_key }}) in (\n        select ({{ unique_key }})\n        from {{ tmp_relation }}\n    );\n    {%- endif %}\n\n    insert into {{ target_relation }} ({{ dest_cols_csv }})\n    (\n       select {{ dest_cols_csv }}\n       from {{ tmp_relation }}\n    );\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.materialization_incremental_default": {"unique_id": "macro.dbt.materialization_incremental_default", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/incremental/incremental.sql", "original_file_path": "macros/materializations/incremental/incremental.sql", "name": "materialization_incremental_default", "macro_sql": "{% materialization incremental, default -%}\n\n  {% set unique_key = config.get('unique_key') %}\n\n  {% set target_relation = this.incorporate(type='table') %}\n  {% set existing_relation = load_relation(this) %}\n  {% set tmp_relation = make_temp_relation(this) %}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set to_drop = [] %}\n  {% if existing_relation is none %}\n      {% set build_sql = create_table_as(False, target_relation, sql) %}\n  {% elif existing_relation.is_view or should_full_refresh() %}\n      {#-- Make sure the backup doesn't exist so we don't encounter issues with the rename below #}\n      {% set backup_identifier = existing_relation.identifier ~ \"__dbt_backup\" %}\n      {% set backup_relation = existing_relation.incorporate(path={\"identifier\": backup_identifier}) %}\n      {% do adapter.drop_relation(backup_relation) %}\n\n      {% do adapter.rename_relation(target_relation, backup_relation) %}\n      {% set build_sql = create_table_as(False, target_relation, sql) %}\n      {% do to_drop.append(backup_relation) %}\n  {% else %}\n      {% set tmp_relation = make_temp_relation(target_relation) %}\n      {% do run_query(create_table_as(True, tmp_relation, sql)) %}\n      {% do adapter.expand_target_column_types(\n             from_relation=tmp_relation,\n             to_relation=target_relation) %}\n      {% set build_sql = incremental_upsert(tmp_relation, target_relation, unique_key=unique_key) %}\n  {% endif %}\n\n  {% call statement(\"main\") %}\n      {{ build_sql }}\n  {% endcall %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {% do adapter.commit() %}\n\n  {% for rel in to_drop %}\n      {% do adapter.drop_relation(rel) %}\n  {% endfor %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.test.load_relation", "macro.dbt.make_temp_relation", "macro.dbt.run_hooks", "macro.dbt.create_table_as", "macro.dbt.should_full_refresh", "macro.dbt.run_query", "macro.dbt.incremental_upsert", "macro.dbt.statement", "macro.dbt.persist_docs"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.get_merge_sql": {"unique_id": "macro.dbt.get_merge_sql", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/common/merge.sql", "original_file_path": "macros/materializations/common/merge.sql", "name": "get_merge_sql", "macro_sql": "{% macro get_merge_sql(target, source, unique_key, dest_columns, predicates=none) -%}\n  {{ adapter.dispatch('get_merge_sql')(target, source, unique_key, dest_columns, predicates) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__get_merge_sql"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.get_delete_insert_merge_sql": {"unique_id": "macro.dbt.get_delete_insert_merge_sql", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/common/merge.sql", "original_file_path": "macros/materializations/common/merge.sql", "name": "get_delete_insert_merge_sql", "macro_sql": "{% macro get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}\n  {{ adapter.dispatch('get_delete_insert_merge_sql')(target, source, unique_key, dest_columns) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__get_delete_insert_merge_sql"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.get_insert_overwrite_merge_sql": {"unique_id": "macro.dbt.get_insert_overwrite_merge_sql", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/common/merge.sql", "original_file_path": "macros/materializations/common/merge.sql", "name": "get_insert_overwrite_merge_sql", "macro_sql": "{% macro get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header=false) -%}\n  {{ adapter.dispatch('get_insert_overwrite_merge_sql')(target, source, dest_columns, predicates, include_sql_header) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__get_insert_overwrite_merge_sql"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__get_merge_sql": {"unique_id": "macro.dbt.default__get_merge_sql", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/common/merge.sql", "original_file_path": "macros/materializations/common/merge.sql", "name": "default__get_merge_sql", "macro_sql": "{% macro default__get_merge_sql(target, source, unique_key, dest_columns, predicates) -%}\n    {%- set predicates = [] if predicates is none else [] + predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {% if unique_key %}\n        {% set unique_key_match %}\n            DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}\n        {% endset %}\n        {% do predicates.append(unique_key_match) %}\n    {% else %}\n        {% do predicates.append('FALSE') %}\n    {% endif %}\n\n    {{ sql_header if sql_header is not none }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on {{ predicates | join(' and ') }}\n\n    {% if unique_key %}\n    when matched then update set\n        {% for column in dest_columns -%}\n            {{ adapter.quote(column.name) }} = DBT_INTERNAL_SOURCE.{{ adapter.quote(column.name) }}\n            {%- if not loop.last %}, {%- endif %}\n        {%- endfor %}\n    {% endif %}\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.get_quoted_csv"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.get_quoted_csv": {"unique_id": "macro.dbt.get_quoted_csv", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/common/merge.sql", "original_file_path": "macros/materializations/common/merge.sql", "name": "get_quoted_csv", "macro_sql": "{% macro get_quoted_csv(column_names) %}\n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote(col)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.common_get_delete_insert_merge_sql": {"unique_id": "macro.dbt.common_get_delete_insert_merge_sql", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/common/merge.sql", "original_file_path": "macros/materializations/common/merge.sql", "name": "common_get_delete_insert_merge_sql", "macro_sql": "{% macro common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}\n\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n\n    {% if unique_key is not none %}\n    delete from {{ target }}\n    where ({{ unique_key }}) in (\n        select ({{ unique_key }})\n        from {{ source }}\n    );\n    {% endif %}\n\n    insert into {{ target }} ({{ dest_cols_csv }})\n    (\n        select {{ dest_cols_csv }}\n        from {{ source }}\n    );\n\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.get_quoted_csv"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__get_delete_insert_merge_sql": {"unique_id": "macro.dbt.default__get_delete_insert_merge_sql", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/common/merge.sql", "original_file_path": "macros/materializations/common/merge.sql", "name": "default__get_delete_insert_merge_sql", "macro_sql": "{% macro default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}\n    {{ common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.common_get_delete_insert_merge_sql"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__get_insert_overwrite_merge_sql": {"unique_id": "macro.dbt.default__get_insert_overwrite_merge_sql", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/common/merge.sql", "original_file_path": "macros/materializations/common/merge.sql", "name": "default__get_insert_overwrite_merge_sql", "macro_sql": "{% macro default__get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header) -%}\n    {%- set predicates = [] if predicates is none else [] + predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {{ sql_header if sql_header is not none and include_sql_header }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on FALSE\n\n    when not matched by source\n        {% if predicates %} and {{ predicates | join(' and ') }} {% endif %}\n        then delete\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.get_quoted_csv"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.materialization_table_default": {"unique_id": "macro.dbt.materialization_table_default", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/table/table.sql", "original_file_path": "macros/materializations/table/table.sql", "name": "materialization_table_default", "macro_sql": "{% materialization table, default %}\n  {%- set identifier = model['alias'] -%}\n  {%- set tmp_identifier = model['name'] + '__dbt_tmp' -%}\n  {%- set backup_identifier = model['name'] + '__dbt_backup' -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n  {%- set target_relation = api.Relation.create(identifier=identifier,\n                                                schema=schema,\n                                                database=database,\n                                                type='table') -%}\n  {%- set intermediate_relation = api.Relation.create(identifier=tmp_identifier,\n                                                      schema=schema,\n                                                      database=database,\n                                                      type='table') -%}\n\n  /*\n      See ../view/view.sql for more information about this relation.\n  */\n  {%- set backup_relation_type = 'table' if old_relation is none else old_relation.type -%}\n  {%- set backup_relation = api.Relation.create(identifier=backup_identifier,\n                                                schema=schema,\n                                                database=database,\n                                                type=backup_relation_type) -%}\n\n  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n\n  -- drop the temp relations if they exists for some reason\n  {{ adapter.drop_relation(intermediate_relation) }}\n  {{ adapter.drop_relation(backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ create_table_as(False, intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  {% if old_relation is not none %}\n      {{ adapter.rename_relation(target_relation, backup_relation) }}\n  {% endif %}\n\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {% do persist_docs(target_relation, model) %}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  -- finally, drop the existing/backup relation after the commit\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n{% endmaterialization %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.run_hooks", "macro.dbt.statement", "macro.dbt.create_table_as", "macro.dbt.persist_docs", "macro.dbt.drop_relation_if_exists"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.materialization_view_default": {"unique_id": "macro.dbt.materialization_view_default", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/view/view.sql", "original_file_path": "macros/materializations/view/view.sql", "name": "materialization_view_default", "macro_sql": "{%- materialization view, default -%}\n\n  {%- set identifier = model['alias'] -%}\n  {%- set tmp_identifier = model['name'] + '__dbt_tmp' -%}\n  {%- set backup_identifier = model['name'] + '__dbt_backup' -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n  {%- set target_relation = api.Relation.create(identifier=identifier, schema=schema, database=database,\n                                                type='view') -%}\n  {%- set intermediate_relation = api.Relation.create(identifier=tmp_identifier,\n                                                      schema=schema, database=database, type='view') -%}\n\n  /*\n     This relation (probably) doesn't exist yet. If it does exist, it's a leftover from\n     a previous run, and we're going to try to drop it immediately. At the end of this\n     materialization, we're going to rename the \"old_relation\" to this identifier,\n     and then we're going to drop it. In order to make sure we run the correct one of:\n       - drop view ...\n       - drop table ...\n\n     We need to set the type of this relation to be the type of the old_relation, if it exists,\n     or else \"view\" as a sane default if it does not. Note that if the old_relation does not\n     exist, then there is nothing to move out of the way and subsequentally drop. In that case,\n     this relation will be effectively unused.\n  */\n  {%- set backup_relation_type = 'view' if old_relation is none else old_relation.type -%}\n  {%- set backup_relation = api.Relation.create(identifier=backup_identifier,\n                                                schema=schema, database=database,\n                                                type=backup_relation_type) -%}\n\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- drop the temp relations if they exists for some reason\n  {{ adapter.drop_relation(intermediate_relation) }}\n  {{ adapter.drop_relation(backup_relation) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ create_view_as(intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  -- move the existing view out of the way\n  {% if old_relation is not none %}\n    {{ adapter.rename_relation(target_relation, backup_relation) }}\n  {% endif %}\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization -%}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.run_hooks", "macro.dbt.statement", "macro.dbt.create_view_as", "macro.dbt.persist_docs", "macro.dbt.drop_relation_if_exists"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.handle_existing_table": {"unique_id": "macro.dbt.handle_existing_table", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/view/create_or_replace_view.sql", "original_file_path": "macros/materializations/view/create_or_replace_view.sql", "name": "handle_existing_table", "macro_sql": "{% macro handle_existing_table(full_refresh, old_relation) %}\n    {{ adapter.dispatch(\"handle_existing_table\", packages=['dbt'])(full_refresh, old_relation) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__handle_existing_table"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__handle_existing_table": {"unique_id": "macro.dbt.default__handle_existing_table", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/view/create_or_replace_view.sql", "original_file_path": "macros/materializations/view/create_or_replace_view.sql", "name": "default__handle_existing_table", "macro_sql": "{% macro default__handle_existing_table(full_refresh, old_relation) %}\n    {{ adapter.drop_relation(old_relation) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.create_or_replace_view": {"unique_id": "macro.dbt.create_or_replace_view", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/materializations/view/create_or_replace_view.sql", "original_file_path": "macros/materializations/view/create_or_replace_view.sql", "name": "create_or_replace_view", "macro_sql": "{% macro create_or_replace_view(run_outside_transaction_hooks=True) %}\n  {%- set identifier = model['alias'] -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set target_relation = api.Relation.create(\n      identifier=identifier, schema=schema, database=database,\n      type='view') -%}\n\n  {% if run_outside_transaction_hooks %}\n      -- no transactions on BigQuery\n      {{ run_hooks(pre_hooks, inside_transaction=False) }}\n  {% endif %}\n\n  -- `BEGIN` happens here on Snowflake\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- If there's a table with the same name and we weren't told to full refresh,\n  -- that's an error. If we were told to full refresh, drop it. This behavior differs\n  -- for Snowflake and BigQuery, so multiple dispatch is used.\n  {%- if old_relation is not none and old_relation.is_table -%}\n    {{ handle_existing_table(should_full_refresh(), old_relation) }}\n  {%- endif -%}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ create_view_as(target_relation, sql) }}\n  {%- endcall %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {% if run_outside_transaction_hooks %}\n      -- No transactions on BigQuery\n      {{ run_hooks(post_hooks, inside_transaction=False) }}\n  {% endif %}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.run_hooks", "macro.dbt.handle_existing_table", "macro.dbt.should_full_refresh", "macro.dbt.statement", "macro.dbt.create_view_as"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.generate_alias_name": {"unique_id": "macro.dbt.generate_alias_name", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/etc/get_custom_alias.sql", "original_file_path": "macros/etc/get_custom_alias.sql", "name": "generate_alias_name", "macro_sql": "{% macro generate_alias_name(custom_alias_name=none, node=none) -%}\n\n    {%- if custom_alias_name is none -%}\n\n        {{ node.name }}\n\n    {%- else -%}\n\n        {{ custom_alias_name | trim }}\n\n    {%- endif -%}\n\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.run_query": {"unique_id": "macro.dbt.run_query", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/etc/query.sql", "original_file_path": "macros/etc/query.sql", "name": "run_query", "macro_sql": "{% macro run_query(sql) %}\n  {% call statement(\"run_query_statement\", fetch_result=true, auto_begin=false) %}\n    {{ sql }}\n  {% endcall %}\n\n  {% do return(load_result(\"run_query_statement\").table) %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.is_incremental": {"unique_id": "macro.dbt.is_incremental", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/etc/is_incremental.sql", "original_file_path": "macros/etc/is_incremental.sql", "name": "is_incremental", "macro_sql": "{% macro is_incremental() %}\n    {#-- do not run introspective queries in parsing #}\n    {% if not execute %}\n        {{ return(False) }}\n    {% else %}\n        {% set relation = adapter.get_relation(this.database, this.schema, this.table) %}\n        {{ return(relation is not none\n                  and relation.type == 'table'\n                  and model.config.materialized == 'incremental'\n                  and not should_full_refresh()) }}\n    {% endif %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.should_full_refresh"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.convert_datetime": {"unique_id": "macro.dbt.convert_datetime", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/etc/datetime.sql", "original_file_path": "macros/etc/datetime.sql", "name": "convert_datetime", "macro_sql": "{% macro convert_datetime(date_str, date_fmt) %}\n\n  {% set error_msg -%}\n      The provided partition date '{{ date_str }}' does not match the expected format '{{ date_fmt }}'\n  {%- endset %}\n\n  {% set res = try_or_compiler_error(error_msg, modules.datetime.datetime.strptime, date_str.strip(), date_fmt) %}\n  {{ return(res) }}\n\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.dates_in_range": {"unique_id": "macro.dbt.dates_in_range", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/etc/datetime.sql", "original_file_path": "macros/etc/datetime.sql", "name": "dates_in_range", "macro_sql": "{% macro dates_in_range(start_date_str, end_date_str=none, in_fmt=\"%Y%m%d\", out_fmt=\"%Y%m%d\") %}\n    {% set end_date_str = start_date_str if end_date_str is none else end_date_str %}\n\n    {% set start_date = convert_datetime(start_date_str, in_fmt) %}\n    {% set end_date = convert_datetime(end_date_str, in_fmt) %}\n\n    {% set day_count = (end_date - start_date).days %}\n    {% if day_count < 0 %}\n        {% set msg -%}\n            Partition start date is after the end date ({{ start_date }}, {{ end_date }})\n        {%- endset %}\n\n        {{ exceptions.raise_compiler_error(msg, model) }}\n    {% endif %}\n\n    {% set date_list = [] %}\n    {% for i in range(0, day_count + 1) %}\n        {% set the_date = (modules.datetime.timedelta(days=i) + start_date) %}\n        {% if not out_fmt %}\n            {% set _ = date_list.append(the_date) %}\n        {% else %}\n            {% set _ = date_list.append(the_date.strftime(out_fmt)) %}\n        {% endif %}\n    {% endfor %}\n\n    {{ return(date_list) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.convert_datetime"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.partition_range": {"unique_id": "macro.dbt.partition_range", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/etc/datetime.sql", "original_file_path": "macros/etc/datetime.sql", "name": "partition_range", "macro_sql": "{% macro partition_range(raw_partition_date, date_fmt='%Y%m%d') %}\n    {% set partition_range = (raw_partition_date | string).split(\",\") %}\n\n    {% if (partition_range | length) == 1 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = none %}\n    {% elif (partition_range | length) == 2 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = partition_range[1] %}\n    {% else %}\n      {{ exceptions.raise_compiler_error(\"Invalid partition time. Expected format: {Start Date}[,{End Date}]. Got: \" ~ raw_partition_date) }}\n    {% endif %}\n\n    {{ return(dates_in_range(start_date, end_date, in_fmt=date_fmt)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.dates_in_range"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.py_current_timestring": {"unique_id": "macro.dbt.py_current_timestring", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/etc/datetime.sql", "original_file_path": "macros/etc/datetime.sql", "name": "py_current_timestring", "macro_sql": "{% macro py_current_timestring() %}\n    {% set dt = modules.datetime.datetime.now() %}\n    {% do return(dt.strftime(\"%Y%m%d%H%M%S%f\")) %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.generate_schema_name": {"unique_id": "macro.dbt.generate_schema_name", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/etc/get_custom_schema.sql", "original_file_path": "macros/etc/get_custom_schema.sql", "name": "generate_schema_name", "macro_sql": "{% macro generate_schema_name(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if custom_schema_name is none -%}\n\n        {{ default_schema }}\n\n    {%- else -%}\n\n        {{ default_schema }}_{{ custom_schema_name | trim }}\n\n    {%- endif -%}\n\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.generate_schema_name_for_env": {"unique_id": "macro.dbt.generate_schema_name_for_env", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/etc/get_custom_schema.sql", "original_file_path": "macros/etc/get_custom_schema.sql", "name": "generate_schema_name_for_env", "macro_sql": "{% macro generate_schema_name_for_env(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if target.name == 'prod' and custom_schema_name is not none -%}\n\n        {{ custom_schema_name | trim }}\n\n    {%- else -%}\n\n        {{ default_schema }}\n\n    {%- endif -%}\n\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.generate_database_name": {"unique_id": "macro.dbt.generate_database_name", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/etc/get_custom_database.sql", "original_file_path": "macros/etc/get_custom_database.sql", "name": "generate_database_name", "macro_sql": "{% macro generate_database_name(custom_database_name=none, node=none) -%}\n    {% do return(adapter.dispatch('generate_database_name')(custom_database_name, node)) %}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__generate_database_name"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__generate_database_name": {"unique_id": "macro.dbt.default__generate_database_name", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/etc/get_custom_database.sql", "original_file_path": "macros/etc/get_custom_database.sql", "name": "default__generate_database_name", "macro_sql": "{% macro default__generate_database_name(custom_database_name=none, node=none) -%}\n    {%- set default_database = target.database -%}\n    {%- if custom_database_name is none -%}\n\n        {{ default_database }}\n\n    {%- else -%}\n\n        {{ custom_database_name }}\n\n    {%- endif -%}\n\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.get_columns_in_query": {"unique_id": "macro.dbt.get_columns_in_query", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "get_columns_in_query", "macro_sql": "{% macro get_columns_in_query(select_sql) -%}\n  {{ return(adapter.dispatch('get_columns_in_query')(select_sql)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__get_columns_in_query"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__get_columns_in_query": {"unique_id": "macro.dbt.default__get_columns_in_query", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__get_columns_in_query", "macro_sql": "{% macro default__get_columns_in_query(select_sql) %}\n    {% call statement('get_columns_in_query', fetch_result=True, auto_begin=False) -%}\n        select * from (\n            {{ select_sql }}\n        ) as __dbt_sbq\n        where false\n        limit 0\n    {% endcall %}\n\n    {{ return(load_result('get_columns_in_query').table.columns | map(attribute='name') | list) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.create_schema": {"unique_id": "macro.dbt.create_schema", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "create_schema", "macro_sql": "{% macro create_schema(relation) -%}\n  {{ adapter.dispatch('create_schema')(relation) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres__create_schema"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__create_schema": {"unique_id": "macro.dbt.default__create_schema", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__create_schema", "macro_sql": "{% macro default__create_schema(relation) -%}\n  {%- call statement('create_schema') -%}\n    create schema if not exists {{ relation.without_identifier() }}\n  {% endcall %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.drop_schema": {"unique_id": "macro.dbt.drop_schema", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "drop_schema", "macro_sql": "{% macro drop_schema(relation) -%}\n  {{ adapter.dispatch('drop_schema')(relation) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres__drop_schema"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__drop_schema": {"unique_id": "macro.dbt.default__drop_schema", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__drop_schema", "macro_sql": "{% macro default__drop_schema(relation) -%}\n  {%- call statement('drop_schema') -%}\n    drop schema if exists {{ relation.without_identifier() }} cascade\n  {% endcall %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.create_table_as": {"unique_id": "macro.dbt.create_table_as", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "create_table_as", "macro_sql": "{% macro create_table_as(temporary, relation, sql) -%}\n  {{ adapter.dispatch('create_table_as')(temporary, relation, sql) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres__create_table_as"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__create_table_as": {"unique_id": "macro.dbt.default__create_table_as", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__create_table_as", "macro_sql": "{% macro default__create_table_as(temporary, relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n\n  create {% if temporary: -%}temporary{%- endif %} table\n    {{ relation.include(database=(not temporary), schema=(not temporary)) }}\n  as (\n    {{ sql }}\n  );\n\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.create_view_as": {"unique_id": "macro.dbt.create_view_as", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "create_view_as", "macro_sql": "{% macro create_view_as(relation, sql) -%}\n  {{ adapter.dispatch('create_view_as')(relation, sql) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__create_view_as"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__create_view_as": {"unique_id": "macro.dbt.default__create_view_as", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__create_view_as", "macro_sql": "{% macro default__create_view_as(relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n  create view {{ relation }} as (\n    {{ sql }}\n  );\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.get_catalog": {"unique_id": "macro.dbt.get_catalog", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "get_catalog", "macro_sql": "{% macro get_catalog(information_schema, schemas) -%}\n  {{ return(adapter.dispatch('get_catalog')(information_schema, schemas)) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres__get_catalog"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__get_catalog": {"unique_id": "macro.dbt.default__get_catalog", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__get_catalog", "macro_sql": "{% macro default__get_catalog(information_schema, schemas) -%}\n\n  {% set typename = adapter.type() %}\n  {% set msg -%}\n    get_catalog not implemented for {{ typename }}\n  {%- endset %}\n\n  {{ exceptions.raise_compiler_error(msg) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.get_columns_in_relation": {"unique_id": "macro.dbt.get_columns_in_relation", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "get_columns_in_relation", "macro_sql": "{% macro get_columns_in_relation(relation) -%}\n  {{ return(adapter.dispatch('get_columns_in_relation')(relation)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres__get_columns_in_relation"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.sql_convert_columns_in_relation": {"unique_id": "macro.dbt.sql_convert_columns_in_relation", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "sql_convert_columns_in_relation", "macro_sql": "{% macro sql_convert_columns_in_relation(table) -%}\n  {% set columns = [] %}\n  {% for row in table %}\n    {% do columns.append(api.Column(*row)) %}\n  {% endfor %}\n  {{ return(columns) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__get_columns_in_relation": {"unique_id": "macro.dbt.default__get_columns_in_relation", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__get_columns_in_relation", "macro_sql": "{% macro default__get_columns_in_relation(relation) -%}\n  {{ exceptions.raise_not_implemented(\n    'get_columns_in_relation macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.alter_column_type": {"unique_id": "macro.dbt.alter_column_type", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "alter_column_type", "macro_sql": "{% macro alter_column_type(relation, column_name, new_column_type) -%}\n  {{ return(adapter.dispatch('alter_column_type')(relation, column_name, new_column_type)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__alter_column_type"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.alter_column_comment": {"unique_id": "macro.dbt.alter_column_comment", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "alter_column_comment", "macro_sql": "{% macro alter_column_comment(relation, column_dict) -%}\n  {{ return(adapter.dispatch('alter_column_comment')(relation, column_dict)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres__alter_column_comment"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__alter_column_comment": {"unique_id": "macro.dbt.default__alter_column_comment", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__alter_column_comment", "macro_sql": "{% macro default__alter_column_comment(relation, column_dict) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_column_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.alter_relation_comment": {"unique_id": "macro.dbt.alter_relation_comment", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "alter_relation_comment", "macro_sql": "{% macro alter_relation_comment(relation, relation_comment) -%}\n  {{ return(adapter.dispatch('alter_relation_comment')(relation, relation_comment)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres__alter_relation_comment"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__alter_relation_comment": {"unique_id": "macro.dbt.default__alter_relation_comment", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__alter_relation_comment", "macro_sql": "{% macro default__alter_relation_comment(relation, relation_comment) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_relation_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.persist_docs": {"unique_id": "macro.dbt.persist_docs", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "persist_docs", "macro_sql": "{% macro persist_docs(relation, model, for_relation=true, for_columns=true) -%}\n  {{ return(adapter.dispatch('persist_docs')(relation, model, for_relation, for_columns)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__persist_docs"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__persist_docs": {"unique_id": "macro.dbt.default__persist_docs", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__persist_docs", "macro_sql": "{% macro default__persist_docs(relation, model, for_relation, for_columns) -%}\n  {% if for_relation and config.persist_relation_docs() and model.description %}\n    {% do run_query(alter_relation_comment(relation, model.description)) %}\n  {% endif %}\n\n  {% if for_columns and config.persist_column_docs() and model.columns %}\n    {% do run_query(alter_column_comment(relation, model.columns)) %}\n  {% endif %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.run_query", "macro.dbt.alter_relation_comment", "macro.dbt.alter_column_comment"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__alter_column_type": {"unique_id": "macro.dbt.default__alter_column_type", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__alter_column_type", "macro_sql": "{% macro default__alter_column_type(relation, column_name, new_column_type) -%}\n  {#\n    1. Create a new column (w/ temp name and correct type)\n    2. Copy data over to it\n    3. Drop the existing column (cascade!)\n    4. Rename the new column to existing column\n  #}\n  {%- set tmp_column = column_name + \"__dbt_alter\" -%}\n\n  {% call statement('alter_column_type') %}\n    alter table {{ relation }} add column {{ adapter.quote(tmp_column) }} {{ new_column_type }};\n    update {{ relation }} set {{ adapter.quote(tmp_column) }} = {{ adapter.quote(column_name) }};\n    alter table {{ relation }} drop column {{ adapter.quote(column_name) }} cascade;\n    alter table {{ relation }} rename column {{ adapter.quote(tmp_column) }} to {{ adapter.quote(column_name) }}\n  {% endcall %}\n\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.drop_relation": {"unique_id": "macro.dbt.drop_relation", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "drop_relation", "macro_sql": "{% macro drop_relation(relation) -%}\n  {{ return(adapter.dispatch('drop_relation')(relation)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__drop_relation"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__drop_relation": {"unique_id": "macro.dbt.default__drop_relation", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__drop_relation", "macro_sql": "{% macro default__drop_relation(relation) -%}\n  {% call statement('drop_relation', auto_begin=False) -%}\n    drop {{ relation.type }} if exists {{ relation }} cascade\n  {%- endcall %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.truncate_relation": {"unique_id": "macro.dbt.truncate_relation", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "truncate_relation", "macro_sql": "{% macro truncate_relation(relation) -%}\n  {{ return(adapter.dispatch('truncate_relation')(relation)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__truncate_relation"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__truncate_relation": {"unique_id": "macro.dbt.default__truncate_relation", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__truncate_relation", "macro_sql": "{% macro default__truncate_relation(relation) -%}\n  {% call statement('truncate_relation') -%}\n    truncate table {{ relation }}\n  {%- endcall %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.rename_relation": {"unique_id": "macro.dbt.rename_relation", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "rename_relation", "macro_sql": "{% macro rename_relation(from_relation, to_relation) -%}\n  {{ return(adapter.dispatch('rename_relation')(from_relation, to_relation)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__rename_relation"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__rename_relation": {"unique_id": "macro.dbt.default__rename_relation", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__rename_relation", "macro_sql": "{% macro default__rename_relation(from_relation, to_relation) -%}\n  {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}\n  {% call statement('rename_relation') -%}\n    alter table {{ from_relation }} rename to {{ target_name }}\n  {%- endcall %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.information_schema_name": {"unique_id": "macro.dbt.information_schema_name", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "information_schema_name", "macro_sql": "{% macro information_schema_name(database) %}\n  {{ return(adapter.dispatch('information_schema_name')(database)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres__information_schema_name"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__information_schema_name": {"unique_id": "macro.dbt.default__information_schema_name", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__information_schema_name", "macro_sql": "{% macro default__information_schema_name(database) -%}\n  {%- if database -%}\n    {{ database }}.INFORMATION_SCHEMA\n  {%- else -%}\n    INFORMATION_SCHEMA\n  {%- endif -%}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.list_schemas": {"unique_id": "macro.dbt.list_schemas", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "list_schemas", "macro_sql": "{% macro list_schemas(database) -%}\n  {{ return(adapter.dispatch('list_schemas')(database)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres__list_schemas"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__list_schemas": {"unique_id": "macro.dbt.default__list_schemas", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__list_schemas", "macro_sql": "{% macro default__list_schemas(database) -%}\n  {% set sql %}\n    select distinct schema_name\n    from {{ information_schema_name(database) }}.SCHEMATA\n    where catalog_name ilike '{{ database }}'\n  {% endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.information_schema_name", "macro.dbt.run_query"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.check_schema_exists": {"unique_id": "macro.dbt.check_schema_exists", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "check_schema_exists", "macro_sql": "{% macro check_schema_exists(information_schema, schema) -%}\n  {{ return(adapter.dispatch('check_schema_exists')(information_schema, schema)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres__check_schema_exists"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__check_schema_exists": {"unique_id": "macro.dbt.default__check_schema_exists", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__check_schema_exists", "macro_sql": "{% macro default__check_schema_exists(information_schema, schema) -%}\n  {% set sql -%}\n        select count(*)\n        from {{ information_schema.replace(information_schema_view='SCHEMATA') }}\n        where catalog_name='{{ information_schema.database }}'\n          and schema_name='{{ schema }}'\n  {%- endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.run_query"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.list_relations_without_caching": {"unique_id": "macro.dbt.list_relations_without_caching", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "list_relations_without_caching", "macro_sql": "{% macro list_relations_without_caching(schema_relation) %}\n  {{ return(adapter.dispatch('list_relations_without_caching')(schema_relation)) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.test.postgres__list_relations_without_caching"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__list_relations_without_caching": {"unique_id": "macro.dbt.default__list_relations_without_caching", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__list_relations_without_caching", "macro_sql": "{% macro default__list_relations_without_caching(schema_relation) %}\n  {{ exceptions.raise_not_implemented(\n    'list_relations_without_caching macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.current_timestamp": {"unique_id": "macro.dbt.current_timestamp", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "current_timestamp", "macro_sql": "{% macro current_timestamp() -%}\n  {{ adapter.dispatch('current_timestamp')() }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres__current_timestamp"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__current_timestamp": {"unique_id": "macro.dbt.default__current_timestamp", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__current_timestamp", "macro_sql": "{% macro default__current_timestamp() -%}\n  {{ exceptions.raise_not_implemented(\n    'current_timestamp macro not implemented for adapter '+adapter.type()) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.collect_freshness": {"unique_id": "macro.dbt.collect_freshness", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "collect_freshness", "macro_sql": "{% macro collect_freshness(source, loaded_at_field, filter) %}\n  {{ return(adapter.dispatch('collect_freshness')(source, loaded_at_field, filter))}}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__collect_freshness"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__collect_freshness": {"unique_id": "macro.dbt.default__collect_freshness", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__collect_freshness", "macro_sql": "{% macro default__collect_freshness(source, loaded_at_field, filter) %}\n  {% call statement('collect_freshness', fetch_result=True, auto_begin=False) -%}\n    select\n      max({{ loaded_at_field }}) as max_loaded_at,\n      {{ current_timestamp() }} as snapshotted_at\n    from {{ source }}\n    {% if filter %}\n    where {{ filter }}\n    {% endif %}\n  {% endcall %}\n  {{ return(load_result('collect_freshness').table) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.statement", "macro.dbt.current_timestamp"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.make_temp_relation": {"unique_id": "macro.dbt.make_temp_relation", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "make_temp_relation", "macro_sql": "{% macro make_temp_relation(base_relation, suffix='__dbt_tmp') %}\n  {{ return(adapter.dispatch('make_temp_relation')(base_relation, suffix))}}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt_postgres.postgres__make_temp_relation"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__make_temp_relation": {"unique_id": "macro.dbt.default__make_temp_relation", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "default__make_temp_relation", "macro_sql": "{% macro default__make_temp_relation(base_relation, suffix) %}\n    {% set tmp_identifier = base_relation.identifier ~ suffix %}\n    {% set tmp_relation = base_relation.incorporate(\n                                path={\"identifier\": tmp_identifier}) -%}\n\n    {% do return(tmp_relation) %}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.set_sql_header": {"unique_id": "macro.dbt.set_sql_header", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/adapters/common.sql", "original_file_path": "macros/adapters/common.sql", "name": "set_sql_header", "macro_sql": "{% macro set_sql_header(config) -%}\n  {{ config.set('sql_header', caller()) }}\n{%- endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__test_relationships": {"unique_id": "macro.dbt.default__test_relationships", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/schema_tests/relationships.sql", "original_file_path": "macros/schema_tests/relationships.sql", "name": "default__test_relationships", "macro_sql": "{% macro default__test_relationships(model, to, field) %}\n\n{% set column_name = kwargs.get('column_name', kwargs.get('from')) %}\n\n\nselect count(*) as validation_errors\nfrom (\n    select {{ column_name }} as id from {{ model }}\n) as child\nleft join (\n    select {{ field }} as id from {{ to }}\n) as parent on parent.id = child.id\nwhere child.id is not null\n  and parent.id is null\n\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.test_relationships": {"unique_id": "macro.dbt.test_relationships", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/schema_tests/relationships.sql", "original_file_path": "macros/schema_tests/relationships.sql", "name": "test_relationships", "macro_sql": "{% macro test_relationships(model, to, field) %}\n    {% set macro = adapter.dispatch('test_relationships') %}\n    {{ macro(model, to, field, **kwargs) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__test_relationships"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__test_not_null": {"unique_id": "macro.dbt.default__test_not_null", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/schema_tests/not_null.sql", "original_file_path": "macros/schema_tests/not_null.sql", "name": "default__test_not_null", "macro_sql": "{% macro default__test_not_null(model) %}\n\n{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}\n\nselect count(*) as validation_errors\nfrom {{ model }}\nwhere {{ column_name }} is null\n\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.test_not_null": {"unique_id": "macro.dbt.test_not_null", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/schema_tests/not_null.sql", "original_file_path": "macros/schema_tests/not_null.sql", "name": "test_not_null", "macro_sql": "{% macro test_not_null(model) %}\n    {% set macro = adapter.dispatch('test_not_null') %}\n    {{ macro(model, **kwargs) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__test_not_null"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__test_unique": {"unique_id": "macro.dbt.default__test_unique", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/schema_tests/unique.sql", "original_file_path": "macros/schema_tests/unique.sql", "name": "default__test_unique", "macro_sql": "{% macro default__test_unique(model) %}\n\n{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}\n\nselect count(*) as validation_errors\nfrom (\n\n    select\n        {{ column_name }}\n\n    from {{ model }}\n    where {{ column_name }} is not null\n    group by {{ column_name }}\n    having count(*) > 1\n\n) validation_errors\n\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.test_unique": {"unique_id": "macro.dbt.test_unique", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/schema_tests/unique.sql", "original_file_path": "macros/schema_tests/unique.sql", "name": "test_unique", "macro_sql": "{% macro test_unique(model) %}\n    {% set macro = adapter.dispatch('test_unique') %}\n    {{ macro(model, **kwargs) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__test_unique"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.default__test_accepted_values": {"unique_id": "macro.dbt.default__test_accepted_values", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/schema_tests/accepted_values.sql", "original_file_path": "macros/schema_tests/accepted_values.sql", "name": "default__test_accepted_values", "macro_sql": "{% macro default__test_accepted_values(model, values) %}\n\n{% set column_name = kwargs.get('column_name', kwargs.get('field')) %}\n{% set quote_values = kwargs.get('quote', True) %}\n\nwith all_values as (\n\n    select distinct\n        {{ column_name }} as value_field\n\n    from {{ model }}\n\n),\n\nvalidation_errors as (\n\n    select\n        value_field\n\n    from all_values\n    where value_field not in (\n        {% for value in values -%}\n            {% if quote_values -%}\n            '{{ value }}'\n            {%- else -%}\n            {{ value }}\n            {%- endif -%}\n            {%- if not loop.last -%},{%- endif %}\n        {%- endfor %}\n    )\n)\n\nselect count(*) as validation_errors\nfrom validation_errors\n\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": []}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}, "macro.dbt.test_accepted_values": {"unique_id": "macro.dbt.test_accepted_values", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "macros/schema_tests/accepted_values.sql", "original_file_path": "macros/schema_tests/accepted_values.sql", "name": "test_accepted_values", "macro_sql": "{% macro test_accepted_values(model, values) %}\n    {% set macro = adapter.dispatch('test_accepted_values') %}\n    {{ macro(model, values, **kwargs) }}\n{% endmacro %}", "resource_type": "macro", "tags": [], "depends_on": {"macros": ["macro.dbt.default__test_accepted_values"]}, "description": "", "meta": {}, "docs": {"show": true}, "patch_path": null, "arguments": []}}, "docs": {"dbt.__overview__": {"unique_id": "dbt.__overview__", "package_name": "dbt", "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project", "path": "overview.md", "original_file_path": "docs/overview.md", "name": "__overview__", "block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--models` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/overview)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [chat](https://community.getdbt.com/) on Slack for live questions and support."}}, "exposures": {}, "selectors": {}, "disabled": [], "parent_map": {"model.test.my_model": []}, "child_map": {"model.test.my_model": []}}
+{
+    "metadata": {
+        "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+        "dbt_version": "0.19.2",
+        "generated_at": "2022-06-08T05:12:57.550908Z",
+        "invocation_id": "57566e21-fbd4-4848-87ca-d05ddbd9012e",
+        "env": {},
+        "project_id": "098f6bcd4621d373cade4e832627b4f6",
+        "user_id": null,
+        "send_anonymous_usage_stats": false,
+        "adapter_type": "postgres"
+    },
+    "nodes": {
+        "model.test.my_model": {
+            "raw_sql": "select 1 as id",
+            "resource_type": "model",
+            "depends_on": {
+                "macros": [],
+                "nodes": []
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "view",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "jerco",
+            "schema": "dbt_jcohen",
+            "fqn": [
+                "test",
+                "my_model"
+            ],
+            "unique_id": "model.test.my_model",
+            "package_name": "test",
+            "root_path": "/Users/jerco/dev/scratch/testy",
+            "path": "my_model.sql",
+            "original_file_path": "models/my_model.sql",
+            "name": "my_model",
+            "alias": "my_model",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "479636cb85ce8d3b0f8db5ff13cf338b61254ad98d905630eac61f963e719e9d"
+            },
+            "tags": [],
+            "refs": [],
+            "sources": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {}
+        }
+    },
+    "sources": {},
+    "macros": {
+        "macro.test.drop_relation": {
+            "unique_id": "macro.test.drop_relation",
+            "package_name": "test",
+            "root_path": "/Users/jerco/dev/scratch/testy",
+            "path": "macros/whatever.sql",
+            "original_file_path": "macros/whatever.sql",
+            "name": "drop_relation",
+            "macro_sql": "{% macro drop_relation(relation) -%}\n  {{ return(dbt_labs_materialized_views.drop_relation(relation)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.test.drop_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.test.postgres__list_relations_without_caching": {
+            "unique_id": "macro.test.postgres__list_relations_without_caching",
+            "package_name": "test",
+            "root_path": "/Users/jerco/dev/scratch/testy",
+            "path": "macros/whatever.sql",
+            "original_file_path": "macros/whatever.sql",
+            "name": "postgres__list_relations_without_caching",
+            "macro_sql": "{% macro postgres__list_relations_without_caching(schema_relation) %}\n  {{ return(dbt_labs_materialized_views.postgres__list_relations_without_caching(schema_relation)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.test.postgres__list_relations_without_caching"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.test.postgres_get_relations": {
+            "unique_id": "macro.test.postgres_get_relations",
+            "package_name": "test",
+            "root_path": "/Users/jerco/dev/scratch/testy",
+            "path": "macros/whatever.sql",
+            "original_file_path": "macros/whatever.sql",
+            "name": "postgres_get_relations",
+            "macro_sql": "{% macro postgres_get_relations() %}\n  {{ return(dbt_labs_materialized_views.postgres_get_relations()) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.test.postgres_get_relations"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.test.redshift__list_relations_without_caching": {
+            "unique_id": "macro.test.redshift__list_relations_without_caching",
+            "package_name": "test",
+            "root_path": "/Users/jerco/dev/scratch/testy",
+            "path": "macros/whatever.sql",
+            "original_file_path": "macros/whatever.sql",
+            "name": "redshift__list_relations_without_caching",
+            "macro_sql": "{% macro redshift__list_relations_without_caching(schema_relation) %}\n  {{ return(dbt_labs_materialized_views.redshift__list_relations_without_caching(schema_relation)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.test.redshift__list_relations_without_caching"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.test.load_relation": {
+            "unique_id": "macro.test.load_relation",
+            "package_name": "test",
+            "root_path": "/Users/jerco/dev/scratch/testy",
+            "path": "macros/whatever.sql",
+            "original_file_path": "macros/whatever.sql",
+            "name": "load_relation",
+            "macro_sql": "{% macro load_relation(relation) %}\n  {{ return(dbt_labs_materialized_views.redshift_load_relation_or_mv(relation)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__get_catalog": {
+            "unique_id": "macro.dbt_postgres.postgres__get_catalog",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/catalog.sql",
+            "original_file_path": "macros/catalog.sql",
+            "name": "postgres__get_catalog",
+            "macro_sql": "{% macro postgres__get_catalog(information_schema, schemas) -%}\n\n  {%- call statement('catalog', fetch_result=True) -%}\n    {#\n      If the user has multiple databases set and the first one is wrong, this will fail.\n      But we won't fail in the case where there are multiple quoting-difference-only dbs, which is better.\n    #}\n    {% set database = information_schema.database %}\n    {{ adapter.verify_database(database) }}\n\n    select\n        '{{ database }}' as table_database,\n        sch.nspname as table_schema,\n        tbl.relname as table_name,\n        case tbl.relkind\n            when 'v' then 'VIEW'\n            else 'BASE TABLE'\n        end as table_type,\n        tbl_desc.description as table_comment,\n        col.attname as column_name,\n        col.attnum as column_index,\n        pg_catalog.format_type(col.atttypid, col.atttypmod) as column_type,\n        col_desc.description as column_comment,\n        pg_get_userbyid(tbl.relowner) as table_owner\n\n    from pg_catalog.pg_namespace sch\n    join pg_catalog.pg_class tbl on tbl.relnamespace = sch.oid\n    join pg_catalog.pg_attribute col on col.attrelid = tbl.oid\n    left outer join pg_catalog.pg_description tbl_desc on (tbl_desc.objoid = tbl.oid and tbl_desc.objsubid = 0)\n    left outer join pg_catalog.pg_description col_desc on (col_desc.objoid = tbl.oid and col_desc.objsubid = col.attnum)\n\n    where (\n        {%- for schema in schemas -%}\n          upper(sch.nspname) = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}\n        {%- endfor -%}\n      )\n      and not pg_is_other_temp_schema(sch.oid) -- not a temporary schema belonging to another session\n      and tbl.relpersistence = 'p' -- [p]ermanent table. Other values are [u]nlogged table, [t]emporary table\n      and tbl.relkind in ('r', 'v', 'f', 'p') -- o[r]dinary table, [v]iew, [f]oreign table, [p]artitioned table. Other values are [i]ndex, [S]equence, [c]omposite type, [t]OAST table, [m]aterialized view\n      and col.attnum > 0 -- negative numbers are used for system columns such as oid\n      and not col.attisdropped -- column as not been dropped\n\n    order by\n        sch.nspname,\n        tbl.relname,\n        col.attnum\n\n  {%- endcall -%}\n\n  {{ return(load_result('catalog').table) }}\n\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres_get_relations": {
+            "unique_id": "macro.dbt_postgres.postgres_get_relations",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/relations.sql",
+            "original_file_path": "macros/relations.sql",
+            "name": "postgres_get_relations",
+            "macro_sql": "{% macro postgres_get_relations () -%}\n\n  {#\n      -- in pg_depend, objid is the dependent, refobjid is the referenced object\n      --  > a pg_depend entry indicates that the referenced object cannot be\n      --  > dropped without also dropping the dependent object.\n  #}\n\n  {%- call statement('relations', fetch_result=True) -%}\n    with relation as (\n        select\n            pg_rewrite.ev_class as class,\n            pg_rewrite.oid as id\n        from pg_rewrite\n    ),\n    class as (\n        select\n            oid as id,\n            relname as name,\n            relnamespace as schema,\n            relkind as kind\n        from pg_class\n    ),\n    dependency as (\n        select\n            pg_depend.objid as id,\n            pg_depend.refobjid as ref\n        from pg_depend\n    ),\n    schema as (\n        select\n            pg_namespace.oid as id,\n            pg_namespace.nspname as name\n        from pg_namespace\n        where nspname != 'information_schema' and nspname not like 'pg\\_%'\n    ),\n    referenced as (\n        select\n            relation.id AS id,\n            referenced_class.name ,\n            referenced_class.schema ,\n            referenced_class.kind\n        from relation\n        join class as referenced_class on relation.class=referenced_class.id\n        where referenced_class.kind in ('r', 'v')\n    ),\n    relationships as (\n        select\n            referenced.name as referenced_name,\n            referenced.schema as referenced_schema_id,\n            dependent_class.name as dependent_name,\n            dependent_class.schema as dependent_schema_id,\n            referenced.kind as kind\n        from referenced\n        join dependency on referenced.id=dependency.id\n        join class as dependent_class on dependency.ref=dependent_class.id\n        where\n            (referenced.name != dependent_class.name or\n             referenced.schema != dependent_class.schema)\n    )\n\n    select\n        referenced_schema.name as referenced_schema,\n        relationships.referenced_name as referenced_name,\n        dependent_schema.name as dependent_schema,\n        relationships.dependent_name as dependent_name\n    from relationships\n    join schema as dependent_schema on relationships.dependent_schema_id=dependent_schema.id\n    join schema as referenced_schema on relationships.referenced_schema_id=referenced_schema.id\n    group by referenced_schema, referenced_name, dependent_schema, dependent_name\n    order by referenced_schema, referenced_name, dependent_schema, dependent_name;\n\n  {%- endcall -%}\n\n  {{ return(load_result('relations').table) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__create_table_as": {
+            "unique_id": "macro.dbt_postgres.postgres__create_table_as",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "name": "postgres__create_table_as",
+            "macro_sql": "{% macro postgres__create_table_as(temporary, relation, sql) -%}\n  {%- set unlogged = config.get('unlogged', default=false) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n\n  create {% if temporary -%}\n    temporary\n  {%- elif unlogged -%}\n    unlogged\n  {%- endif %} table {{ relation }}\n  as (\n    {{ sql }}\n  );\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__create_schema": {
+            "unique_id": "macro.dbt_postgres.postgres__create_schema",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "name": "postgres__create_schema",
+            "macro_sql": "{% macro postgres__create_schema(relation) -%}\n  {% if relation.database -%}\n    {{ adapter.verify_database(relation.database) }}\n  {%- endif -%}\n  {%- call statement('create_schema') -%}\n    create schema if not exists {{ relation.without_identifier().include(database=False) }}\n  {%- endcall -%}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__drop_schema": {
+            "unique_id": "macro.dbt_postgres.postgres__drop_schema",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "name": "postgres__drop_schema",
+            "macro_sql": "{% macro postgres__drop_schema(relation) -%}\n  {% if relation.database -%}\n    {{ adapter.verify_database(relation.database) }}\n  {%- endif -%}\n  {%- call statement('drop_schema') -%}\n    drop schema if exists {{ relation.without_identifier().include(database=False) }} cascade\n  {%- endcall -%}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__get_columns_in_relation": {
+            "unique_id": "macro.dbt_postgres.postgres__get_columns_in_relation",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "name": "postgres__get_columns_in_relation",
+            "macro_sql": "{% macro postgres__get_columns_in_relation(relation) -%}\n  {% call statement('get_columns_in_relation', fetch_result=True) %}\n      select\n          column_name,\n          data_type,\n          character_maximum_length,\n          numeric_precision,\n          numeric_scale\n\n      from {{ relation.information_schema('columns') }}\n      where table_name = '{{ relation.identifier }}'\n        {% if relation.schema %}\n        and table_schema = '{{ relation.schema }}'\n        {% endif %}\n      order by ordinal_position\n\n  {% endcall %}\n  {% set table = load_result('get_columns_in_relation').table %}\n  {{ return(sql_convert_columns_in_relation(table)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement",
+                    "macro.dbt.sql_convert_columns_in_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__list_relations_without_caching": {
+            "unique_id": "macro.dbt_postgres.postgres__list_relations_without_caching",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "name": "postgres__list_relations_without_caching",
+            "macro_sql": "{% macro postgres__list_relations_without_caching(schema_relation) %}\n  {% call statement('list_relations_without_caching', fetch_result=True) -%}\n    select\n      '{{ schema_relation.database }}' as database,\n      tablename as name,\n      schemaname as schema,\n      'table' as type\n    from pg_tables\n    where schemaname ilike '{{ schema_relation.schema }}'\n    union all\n    select\n      '{{ schema_relation.database }}' as database,\n      viewname as name,\n      schemaname as schema,\n      'view' as type\n    from pg_views\n    where schemaname ilike '{{ schema_relation.schema }}'\n  {% endcall %}\n  {{ return(load_result('list_relations_without_caching').table) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__information_schema_name": {
+            "unique_id": "macro.dbt_postgres.postgres__information_schema_name",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "name": "postgres__information_schema_name",
+            "macro_sql": "{% macro postgres__information_schema_name(database) -%}\n  {% if database_name -%}\n    {{ adapter.verify_database(database_name) }}\n  {%- endif -%}\n  information_schema\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__list_schemas": {
+            "unique_id": "macro.dbt_postgres.postgres__list_schemas",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "name": "postgres__list_schemas",
+            "macro_sql": "{% macro postgres__list_schemas(database) %}\n  {% if database -%}\n    {{ adapter.verify_database(database) }}\n  {%- endif -%}\n  {% call statement('list_schemas', fetch_result=True, auto_begin=False) %}\n    select distinct nspname from pg_namespace\n  {% endcall %}\n  {{ return(load_result('list_schemas').table) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__check_schema_exists": {
+            "unique_id": "macro.dbt_postgres.postgres__check_schema_exists",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "name": "postgres__check_schema_exists",
+            "macro_sql": "{% macro postgres__check_schema_exists(information_schema, schema) -%}\n  {% if information_schema.database -%}\n    {{ adapter.verify_database(information_schema.database) }}\n  {%- endif -%}\n  {% call statement('check_schema_exists', fetch_result=True, auto_begin=False) %}\n    select count(*) from pg_namespace where nspname = '{{ schema }}'\n  {% endcall %}\n  {{ return(load_result('check_schema_exists').table) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__current_timestamp": {
+            "unique_id": "macro.dbt_postgres.postgres__current_timestamp",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "name": "postgres__current_timestamp",
+            "macro_sql": "{% macro postgres__current_timestamp() -%}\n  now()\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__snapshot_string_as_time": {
+            "unique_id": "macro.dbt_postgres.postgres__snapshot_string_as_time",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "name": "postgres__snapshot_string_as_time",
+            "macro_sql": "{% macro postgres__snapshot_string_as_time(timestamp) -%}\n    {%- set result = \"'\" ~ timestamp ~ \"'::timestamp without time zone\" -%}\n    {{ return(result) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__snapshot_get_time": {
+            "unique_id": "macro.dbt_postgres.postgres__snapshot_get_time",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "name": "postgres__snapshot_get_time",
+            "macro_sql": "{% macro postgres__snapshot_get_time() -%}\n  {{ current_timestamp() }}::timestamp without time zone\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.current_timestamp"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__make_temp_relation": {
+            "unique_id": "macro.dbt_postgres.postgres__make_temp_relation",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "name": "postgres__make_temp_relation",
+            "macro_sql": "{% macro postgres__make_temp_relation(base_relation, suffix) %}\n    {% set dt = modules.datetime.datetime.now() %}\n    {% set dtstring = dt.strftime(\"%H%M%S%f\") %}\n    {% set suffix_length = suffix|length + dtstring|length %}\n    {% set relation_max_name_length = 63 %}\n    {% if suffix_length > relation_max_name_length %}\n        {% do exceptions.raise_compiler_error('Temp relation suffix is too long (' ~ suffix|length ~ ' characters). Maximum length is ' ~ (relation_max_name_length - dtstring|length) ~ ' characters.') %}\n    {% endif %}\n    {% set tmp_identifier = base_relation.identifier[:relation_max_name_length - suffix_length] ~ suffix ~ dtstring %}\n    {% do return(base_relation.incorporate(\n                                  path={\n                                    \"identifier\": tmp_identifier,\n                                    \"schema\": none,\n                                    \"database\": none\n                                  })) -%}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres_escape_comment": {
+            "unique_id": "macro.dbt_postgres.postgres_escape_comment",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "name": "postgres_escape_comment",
+            "macro_sql": "{% macro postgres_escape_comment(comment) -%}\n  {% if comment is not string %}\n    {% do exceptions.raise_compiler_error('cannot escape a non-string: ' ~ comment) %}\n  {% endif %}\n  {%- set magic = '$dbt_comment_literal_block$' -%}\n  {%- if magic in comment -%}\n    {%- do exceptions.raise_compiler_error('The string ' ~ magic ~ ' is not allowed in comments.') -%}\n  {%- endif -%}\n  {{ magic }}{{ comment }}{{ magic }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__alter_relation_comment": {
+            "unique_id": "macro.dbt_postgres.postgres__alter_relation_comment",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "name": "postgres__alter_relation_comment",
+            "macro_sql": "{% macro postgres__alter_relation_comment(relation, comment) %}\n  {% set escaped_comment = postgres_escape_comment(comment) %}\n  comment on {{ relation.type }} {{ relation }} is {{ escaped_comment }};\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres_escape_comment"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__alter_column_comment": {
+            "unique_id": "macro.dbt_postgres.postgres__alter_column_comment",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "name": "postgres__alter_column_comment",
+            "macro_sql": "{% macro postgres__alter_column_comment(relation, column_dict) %}\n  {% for column_name in column_dict %}\n    {% set comment = column_dict[column_name]['description'] %}\n    {% set escaped_comment = postgres_escape_comment(comment) %}\n    comment on column {{ relation }}.{{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }} is {{ escaped_comment }};\n  {% endfor %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres_escape_comment"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt_postgres.postgres__snapshot_merge_sql": {
+            "unique_id": "macro.dbt_postgres.postgres__snapshot_merge_sql",
+            "package_name": "dbt_postgres",
+            "root_path": "/Users/jerco/dev/product/dbt-core/plugins/postgres/dbt/include/postgres",
+            "path": "macros/materializations/snapshot_merge.sql",
+            "original_file_path": "macros/materializations/snapshot_merge.sql",
+            "name": "postgres__snapshot_merge_sql",
+            "macro_sql": "{% macro postgres__snapshot_merge_sql(target, source, insert_cols) -%}\n    {%- set insert_cols_csv = insert_cols | join(', ') -%}\n\n    update {{ target }}\n    set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to\n    from {{ source }} as DBT_INTERNAL_SOURCE\n    where DBT_INTERNAL_SOURCE.dbt_scd_id::text = {{ target }}.dbt_scd_id::text\n      and DBT_INTERNAL_SOURCE.dbt_change_type::text in ('update'::text, 'delete'::text)\n      and {{ target }}.dbt_valid_to is null;\n\n    insert into {{ target }} ({{ insert_cols_csv }})\n    select {% for column in insert_cols -%}\n        DBT_INTERNAL_SOURCE.{{ column }} {%- if not loop.last %}, {%- endif %}\n    {%- endfor %}\n    from {{ source }} as DBT_INTERNAL_SOURCE\n    where DBT_INTERNAL_SOURCE.dbt_change_type::text = 'insert'::text;\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.statement": {
+            "unique_id": "macro.dbt.statement",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/core.sql",
+            "original_file_path": "macros/core.sql",
+            "name": "statement",
+            "macro_sql": "{% macro statement(name=None, fetch_result=False, auto_begin=True) -%}\n  {%- if execute: -%}\n    {%- set sql = caller() -%}\n\n    {%- if name == 'main' -%}\n      {{ log('Writing runtime SQL for node \"{}\"'.format(model['unique_id'])) }}\n      {{ write(sql) }}\n    {%- endif -%}\n\n    {%- set res, table = adapter.execute(sql, auto_begin=auto_begin, fetch=fetch_result) -%}\n    {%- if name is not none -%}\n      {{ store_result(name, response=res, agate_table=table) }}\n    {%- endif -%}\n\n  {%- endif -%}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.noop_statement": {
+            "unique_id": "macro.dbt.noop_statement",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/core.sql",
+            "original_file_path": "macros/core.sql",
+            "name": "noop_statement",
+            "macro_sql": "{% macro noop_statement(name=None, message=None, code=None, rows_affected=None, res=None) -%}\n  {%- set sql = caller() -%}\n\n  {%- if name == 'main' -%}\n    {{ log('Writing runtime SQL for node \"{}\"'.format(model['unique_id'])) }}\n    {{ write(sql) }}\n  {%- endif -%}\n\n  {%- if name is not none -%}\n    {{ store_raw_result(name, message=message, code=code, rows_affected=rows_affected, agate_table=res) }}\n  {%- endif -%}\n\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.run_hooks": {
+            "unique_id": "macro.dbt.run_hooks",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/helpers.sql",
+            "original_file_path": "macros/materializations/helpers.sql",
+            "name": "run_hooks",
+            "macro_sql": "{% macro run_hooks(hooks, inside_transaction=True) %}\n  {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction)  %}\n    {% if not inside_transaction and loop.first %}\n      {% call statement(auto_begin=inside_transaction) %}\n        commit;\n      {% endcall %}\n    {% endif %}\n    {% set rendered = render(hook.get('sql')) | trim %}\n    {% if (rendered | length) > 0 %}\n      {% call statement(auto_begin=inside_transaction) %}\n        {{ rendered }}\n      {% endcall %}\n    {% endif %}\n  {% endfor %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.column_list": {
+            "unique_id": "macro.dbt.column_list",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/helpers.sql",
+            "original_file_path": "macros/materializations/helpers.sql",
+            "name": "column_list",
+            "macro_sql": "{% macro column_list(columns) %}\n  {%- for col in columns %}\n    {{ col.name }} {% if not loop.last %},{% endif %}\n  {% endfor -%}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.column_list_for_create_table": {
+            "unique_id": "macro.dbt.column_list_for_create_table",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/helpers.sql",
+            "original_file_path": "macros/materializations/helpers.sql",
+            "name": "column_list_for_create_table",
+            "macro_sql": "{% macro column_list_for_create_table(columns) %}\n  {%- for col in columns %}\n    {{ col.name }} {{ col.data_type }} {%- if not loop.last %},{% endif %}\n  {% endfor -%}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.make_hook_config": {
+            "unique_id": "macro.dbt.make_hook_config",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/helpers.sql",
+            "original_file_path": "macros/materializations/helpers.sql",
+            "name": "make_hook_config",
+            "macro_sql": "{% macro make_hook_config(sql, inside_transaction) %}\n    {{ tojson({\"sql\": sql, \"transaction\": inside_transaction}) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.before_begin": {
+            "unique_id": "macro.dbt.before_begin",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/helpers.sql",
+            "original_file_path": "macros/materializations/helpers.sql",
+            "name": "before_begin",
+            "macro_sql": "{% macro before_begin(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.make_hook_config"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.in_transaction": {
+            "unique_id": "macro.dbt.in_transaction",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/helpers.sql",
+            "original_file_path": "macros/materializations/helpers.sql",
+            "name": "in_transaction",
+            "macro_sql": "{% macro in_transaction(sql) %}\n    {{ make_hook_config(sql, inside_transaction=True) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.make_hook_config"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.after_commit": {
+            "unique_id": "macro.dbt.after_commit",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/helpers.sql",
+            "original_file_path": "macros/materializations/helpers.sql",
+            "name": "after_commit",
+            "macro_sql": "{% macro after_commit(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.make_hook_config"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.drop_relation_if_exists": {
+            "unique_id": "macro.dbt.drop_relation_if_exists",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/helpers.sql",
+            "original_file_path": "macros/materializations/helpers.sql",
+            "name": "drop_relation_if_exists",
+            "macro_sql": "{% macro drop_relation_if_exists(relation) %}\n  {% if relation is not none %}\n    {{ adapter.drop_relation(relation) }}\n  {% endif %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.load_relation": {
+            "unique_id": "macro.dbt.load_relation",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/helpers.sql",
+            "original_file_path": "macros/materializations/helpers.sql",
+            "name": "load_relation",
+            "macro_sql": "{% macro load_relation(relation) %}\n  {% do return(adapter.get_relation(\n    database=relation.database,\n    schema=relation.schema,\n    identifier=relation.identifier\n  )) -%}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.should_full_refresh": {
+            "unique_id": "macro.dbt.should_full_refresh",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/helpers.sql",
+            "original_file_path": "macros/materializations/helpers.sql",
+            "name": "should_full_refresh",
+            "macro_sql": "{% macro should_full_refresh() %}\n  {% set config_full_refresh = config.get('full_refresh') %}\n  {% if config_full_refresh is none %}\n    {% set config_full_refresh = flags.FULL_REFRESH %}\n  {% endif %}\n  {% do return(config_full_refresh) %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.snapshot_merge_sql": {
+            "unique_id": "macro.dbt.snapshot_merge_sql",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/snapshot_merge.sql",
+            "original_file_path": "macros/materializations/snapshot/snapshot_merge.sql",
+            "name": "snapshot_merge_sql",
+            "macro_sql": "{% macro snapshot_merge_sql(target, source, insert_cols) -%}\n  {{ adapter.dispatch('snapshot_merge_sql')(target, source, insert_cols) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres__snapshot_merge_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__snapshot_merge_sql": {
+            "unique_id": "macro.dbt.default__snapshot_merge_sql",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/snapshot_merge.sql",
+            "original_file_path": "macros/materializations/snapshot/snapshot_merge.sql",
+            "name": "default__snapshot_merge_sql",
+            "macro_sql": "{% macro default__snapshot_merge_sql(target, source, insert_cols) -%}\n    {%- set insert_cols_csv = insert_cols | join(', ') -%}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n    using {{ source }} as DBT_INTERNAL_SOURCE\n    on DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id\n\n    when matched\n     and DBT_INTERNAL_DEST.dbt_valid_to is null\n     and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')\n        then update\n        set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to\n\n    when not matched\n     and DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'\n        then insert ({{ insert_cols_csv }})\n        values ({{ insert_cols_csv }})\n    ;\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.strategy_dispatch": {
+            "unique_id": "macro.dbt.strategy_dispatch",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/strategies.sql",
+            "original_file_path": "macros/materializations/snapshot/strategies.sql",
+            "name": "strategy_dispatch",
+            "macro_sql": "{% macro strategy_dispatch(name) -%}\n{% set original_name = name %}\n  {% if '.' in name %}\n    {% set package_name, name = name.split(\".\", 1) %}\n  {% else %}\n    {% set package_name = none %}\n  {% endif %}\n\n  {% if package_name is none %}\n    {% set package_context = context %}\n  {% elif package_name in context %}\n    {% set package_context = context[package_name] %}\n  {% else %}\n    {% set error_msg %}\n        Could not find package '{{package_name}}', called with '{{original_name}}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n\n  {%- set search_name = 'snapshot_' ~ name ~ '_strategy' -%}\n\n  {% if search_name not in package_context %}\n    {% set error_msg %}\n        The specified strategy macro '{{name}}' was not found in package '{{ package_name }}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n  {{ return(package_context[search_name]) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.snapshot_hash_arguments": {
+            "unique_id": "macro.dbt.snapshot_hash_arguments",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/strategies.sql",
+            "original_file_path": "macros/materializations/snapshot/strategies.sql",
+            "name": "snapshot_hash_arguments",
+            "macro_sql": "{% macro snapshot_hash_arguments(args) -%}\n  {{ adapter.dispatch('snapshot_hash_arguments')(args) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__snapshot_hash_arguments"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__snapshot_hash_arguments": {
+            "unique_id": "macro.dbt.default__snapshot_hash_arguments",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/strategies.sql",
+            "original_file_path": "macros/materializations/snapshot/strategies.sql",
+            "name": "default__snapshot_hash_arguments",
+            "macro_sql": "{% macro default__snapshot_hash_arguments(args) -%}\n    md5({%- for arg in args -%}\n        coalesce(cast({{ arg }} as varchar ), '')\n        {% if not loop.last %} || '|' || {% endif %}\n    {%- endfor -%})\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.snapshot_get_time": {
+            "unique_id": "macro.dbt.snapshot_get_time",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/strategies.sql",
+            "original_file_path": "macros/materializations/snapshot/strategies.sql",
+            "name": "snapshot_get_time",
+            "macro_sql": "{% macro snapshot_get_time() -%}\n  {{ adapter.dispatch('snapshot_get_time')() }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres__snapshot_get_time"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__snapshot_get_time": {
+            "unique_id": "macro.dbt.default__snapshot_get_time",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/strategies.sql",
+            "original_file_path": "macros/materializations/snapshot/strategies.sql",
+            "name": "default__snapshot_get_time",
+            "macro_sql": "{% macro default__snapshot_get_time() -%}\n  {{ current_timestamp() }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.current_timestamp"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.snapshot_timestamp_strategy": {
+            "unique_id": "macro.dbt.snapshot_timestamp_strategy",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/strategies.sql",
+            "original_file_path": "macros/materializations/snapshot/strategies.sql",
+            "name": "snapshot_timestamp_strategy",
+            "macro_sql": "{% macro snapshot_timestamp_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set primary_key = config['unique_key'] %}\n    {% set updated_at = config['updated_at'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n\n    {#/*\n        The snapshot relation might not have an {{ updated_at }} value if the\n        snapshot strategy is changed from `check` to `timestamp`. We\n        should use a dbt-created column for the comparison in the snapshot\n        table instead of assuming that the user-supplied {{ updated_at }}\n        will be present in the historical data.\n\n        See https://github.com/fishtown-analytics/dbt/issues/2350\n    */ #}\n    {% set row_changed_expr -%}\n        ({{ snapshotted_rel }}.dbt_valid_from < {{ current_rel }}.{{ updated_at }})\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.snapshot_hash_arguments"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.snapshot_string_as_time": {
+            "unique_id": "macro.dbt.snapshot_string_as_time",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/strategies.sql",
+            "original_file_path": "macros/materializations/snapshot/strategies.sql",
+            "name": "snapshot_string_as_time",
+            "macro_sql": "{% macro snapshot_string_as_time(timestamp) -%}\n    {{ adapter.dispatch('snapshot_string_as_time')(timestamp) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres__snapshot_string_as_time"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__snapshot_string_as_time": {
+            "unique_id": "macro.dbt.default__snapshot_string_as_time",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/strategies.sql",
+            "original_file_path": "macros/materializations/snapshot/strategies.sql",
+            "name": "default__snapshot_string_as_time",
+            "macro_sql": "{% macro default__snapshot_string_as_time(timestamp) %}\n    {% do exceptions.raise_not_implemented(\n        'snapshot_string_as_time macro not implemented for adapter '+adapter.type()\n    ) %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.snapshot_check_all_get_existing_columns": {
+            "unique_id": "macro.dbt.snapshot_check_all_get_existing_columns",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/strategies.sql",
+            "original_file_path": "macros/materializations/snapshot/strategies.sql",
+            "name": "snapshot_check_all_get_existing_columns",
+            "macro_sql": "{% macro snapshot_check_all_get_existing_columns(node, target_exists) -%}\n    {%- set query_columns = get_columns_in_query(node['compiled_sql']) -%}\n    {%- if not target_exists -%}\n        {# no table yet -> return whatever the query does #}\n        {{ return([false, query_columns]) }}\n    {%- endif -%}\n    {# handle any schema changes #}\n    {%- set target_table = node.get('alias', node.get('name')) -%}\n    {%- set target_relation = adapter.get_relation(database=node.database, schema=node.schema, identifier=target_table) -%}\n    {%- set existing_cols = get_columns_in_query('select * from ' ~ target_relation) -%}\n    {%- set ns = namespace() -%} {# handle for-loop scoping with a namespace #}\n    {%- set ns.column_added = false -%}\n\n    {%- set intersection = [] -%}\n    {%- for col in query_columns -%}\n        {%- if col in existing_cols -%}\n            {%- do intersection.append(col) -%}\n        {%- else -%}\n            {% set ns.column_added = true %}\n        {%- endif -%}\n    {%- endfor -%}\n    {{ return([ns.column_added, intersection]) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_columns_in_query"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.snapshot_check_strategy": {
+            "unique_id": "macro.dbt.snapshot_check_strategy",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/strategies.sql",
+            "original_file_path": "macros/materializations/snapshot/strategies.sql",
+            "name": "snapshot_check_strategy",
+            "macro_sql": "{% macro snapshot_check_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set check_cols_config = config['check_cols'] %}\n    {% set primary_key = config['unique_key'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n    \n    {% set select_current_time -%}\n        select {{ snapshot_get_time() }} as snapshot_start\n    {%- endset %}\n\n    {#-- don't access the column by name, to avoid dealing with casing issues on snowflake #}\n    {%- set now = run_query(select_current_time)[0][0] -%}\n    {% if now is none or now is undefined -%}\n        {%- do exceptions.raise_compiler_error('Could not get a snapshot start time from the database') -%}\n    {%- endif %}\n    {% set updated_at = snapshot_string_as_time(now) %}\n\n    {% set column_added = false %}\n\n    {% if check_cols_config == 'all' %}\n        {% set column_added, check_cols = snapshot_check_all_get_existing_columns(node, target_exists) %}\n    {% elif check_cols_config is iterable and (check_cols_config | length) > 0 %}\n        {% set check_cols = check_cols_config %}\n    {% else %}\n        {% do exceptions.raise_compiler_error(\"Invalid value for 'check_cols': \" ~ check_cols_config) %}\n    {% endif %}\n\n    {%- set row_changed_expr -%}\n    (\n    {%- if column_added -%}\n        TRUE\n    {%- else -%}\n    {%- for col in check_cols -%}\n        {{ snapshotted_rel }}.{{ col }} != {{ current_rel }}.{{ col }}\n        or\n        (\n            (({{ snapshotted_rel }}.{{ col }} is null) and not ({{ current_rel }}.{{ col }} is null))\n            or\n            ((not {{ snapshotted_rel }}.{{ col }} is null) and ({{ current_rel }}.{{ col }} is null))\n        )\n        {%- if not loop.last %} or {% endif -%}\n    {%- endfor -%}\n    {%- endif -%}\n    )\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.snapshot_get_time",
+                    "macro.dbt.run_query",
+                    "macro.dbt.snapshot_string_as_time",
+                    "macro.dbt.snapshot_check_all_get_existing_columns",
+                    "macro.dbt.snapshot_hash_arguments"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.create_columns": {
+            "unique_id": "macro.dbt.create_columns",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/snapshot.sql",
+            "original_file_path": "macros/materializations/snapshot/snapshot.sql",
+            "name": "create_columns",
+            "macro_sql": "{% macro create_columns(relation, columns) %}\n  {{ adapter.dispatch('create_columns')(relation, columns) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__create_columns"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__create_columns": {
+            "unique_id": "macro.dbt.default__create_columns",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/snapshot.sql",
+            "original_file_path": "macros/materializations/snapshot/snapshot.sql",
+            "name": "default__create_columns",
+            "macro_sql": "{% macro default__create_columns(relation, columns) %}\n  {% for column in columns %}\n    {% call statement() %}\n      alter table {{ relation }} add column \"{{ column.name }}\" {{ column.data_type }};\n    {% endcall %}\n  {% endfor %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.post_snapshot": {
+            "unique_id": "macro.dbt.post_snapshot",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/snapshot.sql",
+            "original_file_path": "macros/materializations/snapshot/snapshot.sql",
+            "name": "post_snapshot",
+            "macro_sql": "{% macro post_snapshot(staging_relation) %}\n  {{ adapter.dispatch('post_snapshot')(staging_relation) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__post_snapshot"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__post_snapshot": {
+            "unique_id": "macro.dbt.default__post_snapshot",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/snapshot.sql",
+            "original_file_path": "macros/materializations/snapshot/snapshot.sql",
+            "name": "default__post_snapshot",
+            "macro_sql": "{% macro default__post_snapshot(staging_relation) %}\n    {# no-op #}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.snapshot_staging_table": {
+            "unique_id": "macro.dbt.snapshot_staging_table",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/snapshot.sql",
+            "original_file_path": "macros/materializations/snapshot/snapshot.sql",
+            "name": "snapshot_staging_table",
+            "macro_sql": "{% macro snapshot_staging_table(strategy, source_sql, target_relation) -%}\n\n    with snapshot_query as (\n\n        {{ source_sql }}\n\n    ),\n\n    snapshotted_data as (\n\n        select *,\n            {{ strategy.unique_key }} as dbt_unique_key\n\n        from {{ target_relation }}\n        where dbt_valid_to is null\n\n    ),\n\n    insertions_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to,\n            {{ strategy.scd_id }} as dbt_scd_id\n\n        from snapshot_query\n    ),\n\n    updates_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            {{ strategy.updated_at }} as dbt_valid_to\n\n        from snapshot_query\n    ),\n\n    {%- if strategy.invalidate_hard_deletes %}\n\n    deletes_source_data as (\n\n        select \n            *,\n            {{ strategy.unique_key }} as dbt_unique_key\n        from snapshot_query\n    ),\n    {% endif %}\n\n    insertions as (\n\n        select\n            'insert' as dbt_change_type,\n            source_data.*\n\n        from insertions_source_data as source_data\n        left outer join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where snapshotted_data.dbt_unique_key is null\n           or (\n                snapshotted_data.dbt_unique_key is not null\n            and (\n                {{ strategy.row_changed }}\n            )\n        )\n\n    ),\n\n    updates as (\n\n        select\n            'update' as dbt_change_type,\n            source_data.*,\n            snapshotted_data.dbt_scd_id\n\n        from updates_source_data as source_data\n        join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where (\n            {{ strategy.row_changed }}\n        )\n    )\n\n    {%- if strategy.invalidate_hard_deletes -%}\n    ,\n\n    deletes as (\n    \n        select\n            'delete' as dbt_change_type,\n            source_data.*,\n            {{ snapshot_get_time() }} as dbt_valid_from,\n            {{ snapshot_get_time() }} as dbt_updated_at,\n            {{ snapshot_get_time() }} as dbt_valid_to,\n            snapshotted_data.dbt_scd_id\n    \n        from snapshotted_data\n        left join deletes_source_data as source_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where source_data.dbt_unique_key is null\n    )\n    {%- endif %}\n\n    select * from insertions\n    union all\n    select * from updates\n    {%- if strategy.invalidate_hard_deletes %}\n    union all\n    select * from deletes\n    {%- endif %}\n\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.snapshot_get_time"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.build_snapshot_table": {
+            "unique_id": "macro.dbt.build_snapshot_table",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/snapshot.sql",
+            "original_file_path": "macros/materializations/snapshot/snapshot.sql",
+            "name": "build_snapshot_table",
+            "macro_sql": "{% macro build_snapshot_table(strategy, sql) %}\n\n    select *,\n        {{ strategy.scd_id }} as dbt_scd_id,\n        {{ strategy.updated_at }} as dbt_updated_at,\n        {{ strategy.updated_at }} as dbt_valid_from,\n        nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to\n    from (\n        {{ sql }}\n    ) sbq\n\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.get_or_create_relation": {
+            "unique_id": "macro.dbt.get_or_create_relation",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/snapshot.sql",
+            "original_file_path": "macros/materializations/snapshot/snapshot.sql",
+            "name": "get_or_create_relation",
+            "macro_sql": "{% macro get_or_create_relation(database, schema, identifier, type) %}\n  {%- set target_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}\n\n  {% if target_relation %}\n    {% do return([true, target_relation]) %}\n  {% endif %}\n\n  {%- set new_relation = api.Relation.create(\n      database=database,\n      schema=schema,\n      identifier=identifier,\n      type=type\n  ) -%}\n  {% do return([false, new_relation]) %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.build_snapshot_staging_table": {
+            "unique_id": "macro.dbt.build_snapshot_staging_table",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/snapshot.sql",
+            "original_file_path": "macros/materializations/snapshot/snapshot.sql",
+            "name": "build_snapshot_staging_table",
+            "macro_sql": "{% macro build_snapshot_staging_table(strategy, sql, target_relation) %}\n    {% set tmp_relation = make_temp_relation(target_relation) %}\n\n    {% set select = snapshot_staging_table(strategy, sql, target_relation) %}\n\n    {% call statement('build_snapshot_staging_relation') %}\n        {{ create_table_as(True, tmp_relation, select) }}\n    {% endcall %}\n\n    {% do return(tmp_relation) %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.make_temp_relation",
+                    "macro.dbt.snapshot_staging_table",
+                    "macro.dbt.statement",
+                    "macro.dbt.create_table_as"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.materialization_snapshot_default": {
+            "unique_id": "macro.dbt.materialization_snapshot_default",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/snapshot/snapshot.sql",
+            "original_file_path": "macros/materializations/snapshot/snapshot.sql",
+            "name": "materialization_snapshot_default",
+            "macro_sql": "{% materialization snapshot, default %}\n  {%- set config = model['config'] -%}\n\n  {%- set target_table = model.get('alias', model.get('name')) -%}\n\n  {%- set strategy_name = config.get('strategy') -%}\n  {%- set unique_key = config.get('unique_key') %}\n\n  {% if not adapter.check_schema_exists(model.database, model.schema) %}\n    {% do create_schema(model.database, model.schema) %}\n  {% endif %}\n\n  {% set target_relation_exists, target_relation = get_or_create_relation(\n          database=model.database,\n          schema=model.schema,\n          identifier=target_table,\n          type='table') -%}\n\n  {%- if not target_relation.is_table -%}\n    {% do exceptions.relation_wrong_type(target_relation, 'table') %}\n  {%- endif -%}\n\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set strategy_macro = strategy_dispatch(strategy_name) %}\n  {% set strategy = strategy_macro(model, \"snapshotted_data\", \"source_data\", config, target_relation_exists) %}\n\n  {% if not target_relation_exists %}\n\n      {% set build_sql = build_snapshot_table(strategy, model['compiled_sql']) %}\n      {% set final_sql = create_table_as(False, target_relation, build_sql) %}\n\n  {% else %}\n\n      {{ adapter.valid_snapshot_target(target_relation) }}\n\n      {% set staging_table = build_snapshot_staging_table(strategy, sql, target_relation) %}\n\n      -- this may no-op if the database does not require column expansion\n      {% do adapter.expand_target_column_types(from_relation=staging_table,\n                                               to_relation=target_relation) %}\n\n      {% set missing_columns = adapter.get_missing_columns(staging_table, target_relation)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% do create_columns(target_relation, missing_columns) %}\n\n      {% set source_columns = adapter.get_columns_in_relation(staging_table)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% set quoted_source_columns = [] %}\n      {% for column in source_columns %}\n        {% do quoted_source_columns.append(adapter.quote(column.name)) %}\n      {% endfor %}\n\n      {% set final_sql = snapshot_merge_sql(\n            target = target_relation,\n            source = staging_table,\n            insert_cols = quoted_source_columns\n         )\n      %}\n\n  {% endif %}\n\n  {% call statement('main') %}\n      {{ final_sql }}\n  {% endcall %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {% if staging_table is defined %}\n      {% do post_snapshot(staging_table) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.create_schema",
+                    "macro.dbt.get_or_create_relation",
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.strategy_dispatch",
+                    "macro.dbt.build_snapshot_table",
+                    "macro.dbt.create_table_as",
+                    "macro.dbt.build_snapshot_staging_table",
+                    "macro.dbt.create_columns",
+                    "macro.dbt.snapshot_merge_sql",
+                    "macro.dbt.statement",
+                    "macro.dbt.persist_docs",
+                    "macro.dbt.post_snapshot"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.create_csv_table": {
+            "unique_id": "macro.dbt.create_csv_table",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/seed/seed.sql",
+            "original_file_path": "macros/materializations/seed/seed.sql",
+            "name": "create_csv_table",
+            "macro_sql": "{% macro create_csv_table(model, agate_table) -%}\n  {{ adapter.dispatch('create_csv_table')(model, agate_table) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__create_csv_table"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.reset_csv_table": {
+            "unique_id": "macro.dbt.reset_csv_table",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/seed/seed.sql",
+            "original_file_path": "macros/materializations/seed/seed.sql",
+            "name": "reset_csv_table",
+            "macro_sql": "{% macro reset_csv_table(model, full_refresh, old_relation, agate_table) -%}\n  {{ adapter.dispatch('reset_csv_table')(model, full_refresh, old_relation, agate_table) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__reset_csv_table"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.load_csv_rows": {
+            "unique_id": "macro.dbt.load_csv_rows",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/seed/seed.sql",
+            "original_file_path": "macros/materializations/seed/seed.sql",
+            "name": "load_csv_rows",
+            "macro_sql": "{% macro load_csv_rows(model, agate_table) -%}\n  {{ adapter.dispatch('load_csv_rows')(model, agate_table) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__load_csv_rows"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__create_csv_table": {
+            "unique_id": "macro.dbt.default__create_csv_table",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/seed/seed.sql",
+            "original_file_path": "macros/materializations/seed/seed.sql",
+            "name": "default__create_csv_table",
+            "macro_sql": "{% macro default__create_csv_table(model, agate_table) %}\n  {%- set column_override = model['config'].get('column_types', {}) -%}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n\n  {% set sql %}\n    create table {{ this.render() }} (\n        {%- for col_name in agate_table.column_names -%}\n            {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}\n            {%- set type = column_override.get(col_name, inferred_type) -%}\n            {%- set column_name = (col_name | string) -%}\n            {{ adapter.quote_seed_column(column_name, quote_seed_column) }} {{ type }} {%- if not loop.last -%}, {%- endif -%}\n        {%- endfor -%}\n    )\n  {% endset %}\n\n  {% call statement('_') -%}\n    {{ sql }}\n  {%- endcall %}\n\n  {{ return(sql) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__reset_csv_table": {
+            "unique_id": "macro.dbt.default__reset_csv_table",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/seed/seed.sql",
+            "original_file_path": "macros/materializations/seed/seed.sql",
+            "name": "default__reset_csv_table",
+            "macro_sql": "{% macro default__reset_csv_table(model, full_refresh, old_relation, agate_table) %}\n    {% set sql = \"\" %}\n    {% if full_refresh %}\n        {{ adapter.drop_relation(old_relation) }}\n        {% set sql = create_csv_table(model, agate_table) %}\n    {% else %}\n        {{ adapter.truncate_relation(old_relation) }}\n        {% set sql = \"truncate table \" ~ old_relation %}\n    {% endif %}\n\n    {{ return(sql) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.create_csv_table"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.get_seed_column_quoted_csv": {
+            "unique_id": "macro.dbt.get_seed_column_quoted_csv",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/seed/seed.sql",
+            "original_file_path": "macros/materializations/seed/seed.sql",
+            "name": "get_seed_column_quoted_csv",
+            "macro_sql": "{% macro get_seed_column_quoted_csv(model, column_names) %}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote_seed_column(col, quote_seed_column)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.basic_load_csv_rows": {
+            "unique_id": "macro.dbt.basic_load_csv_rows",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/seed/seed.sql",
+            "original_file_path": "macros/materializations/seed/seed.sql",
+            "name": "basic_load_csv_rows",
+            "macro_sql": "{% macro basic_load_csv_rows(model, batch_size, agate_table) %}\n    {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}\n    {% set bindings = [] %}\n\n    {% set statements = [] %}\n\n    {% for chunk in agate_table.rows | batch(batch_size) %}\n        {% set bindings = [] %}\n\n        {% for row in chunk %}\n            {% do bindings.extend(row) %}\n        {% endfor %}\n\n        {% set sql %}\n            insert into {{ this.render() }} ({{ cols_sql }}) values\n            {% for row in chunk -%}\n                ({%- for column in agate_table.column_names -%}\n                    %s\n                    {%- if not loop.last%},{%- endif %}\n                {%- endfor -%})\n                {%- if not loop.last%},{%- endif %}\n            {%- endfor %}\n        {% endset %}\n\n        {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}\n\n        {% if loop.index0 == 0 %}\n            {% do statements.append(sql) %}\n        {% endif %}\n    {% endfor %}\n\n    {# Return SQL so we can render it out into the compiled files #}\n    {{ return(statements[0]) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_seed_column_quoted_csv"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__load_csv_rows": {
+            "unique_id": "macro.dbt.default__load_csv_rows",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/seed/seed.sql",
+            "original_file_path": "macros/materializations/seed/seed.sql",
+            "name": "default__load_csv_rows",
+            "macro_sql": "{% macro default__load_csv_rows(model, agate_table) %}\n  {{ return(basic_load_csv_rows(model, 10000, agate_table) )}}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.basic_load_csv_rows"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.materialization_seed_default": {
+            "unique_id": "macro.dbt.materialization_seed_default",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/seed/seed.sql",
+            "original_file_path": "macros/materializations/seed/seed.sql",
+            "name": "materialization_seed_default",
+            "macro_sql": "{% materialization seed, default %}\n\n  {%- set identifier = model['alias'] -%}\n  {%- set full_refresh_mode = (should_full_refresh()) -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n\n  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set agate_table = load_agate_table() -%}\n  {%- do store_result('agate_table', response='OK', agate_table=agate_table) -%}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% set create_table_sql = \"\" %}\n  {% if exists_as_view %}\n    {{ exceptions.raise_compiler_error(\"Cannot seed to '{}', it is a view\".format(old_relation)) }}\n  {% elif exists_as_table %}\n    {% set create_table_sql = reset_csv_table(model, full_refresh_mode, old_relation, agate_table) %}\n  {% else %}\n    {% set create_table_sql = create_csv_table(model, agate_table) %}\n  {% endif %}\n\n  {% set code = 'CREATE' if full_refresh_mode else 'INSERT' %}\n  {% set rows_affected = (agate_table.rows | length) %}\n  {% set sql = load_csv_rows(model, agate_table) %}\n\n  {% call noop_statement('main', code ~ ' ' ~ rows_affected, code, rows_affected) %}\n    {{ create_table_sql }};\n    -- dbt seed --\n    {{ sql }}\n  {% endcall %}\n\n  {% set target_relation = this.incorporate(type='table') %}\n  {% do persist_docs(target_relation, model) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.should_full_refresh",
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.reset_csv_table",
+                    "macro.dbt.create_csv_table",
+                    "macro.dbt.load_csv_rows",
+                    "macro.dbt.noop_statement",
+                    "macro.dbt.persist_docs"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.incremental_upsert": {
+            "unique_id": "macro.dbt.incremental_upsert",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/incremental/helpers.sql",
+            "original_file_path": "macros/materializations/incremental/helpers.sql",
+            "name": "incremental_upsert",
+            "macro_sql": "{% macro incremental_upsert(tmp_relation, target_relation, unique_key=none, statement_name=\"main\") %}\n    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}\n    {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}\n\n    {%- if unique_key is not none -%}\n    delete\n    from {{ target_relation }}\n    where ({{ unique_key }}) in (\n        select ({{ unique_key }})\n        from {{ tmp_relation }}\n    );\n    {%- endif %}\n\n    insert into {{ target_relation }} ({{ dest_cols_csv }})\n    (\n       select {{ dest_cols_csv }}\n       from {{ tmp_relation }}\n    );\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.materialization_incremental_default": {
+            "unique_id": "macro.dbt.materialization_incremental_default",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/incremental/incremental.sql",
+            "original_file_path": "macros/materializations/incremental/incremental.sql",
+            "name": "materialization_incremental_default",
+            "macro_sql": "{% materialization incremental, default -%}\n\n  {% set unique_key = config.get('unique_key') %}\n\n  {% set target_relation = this.incorporate(type='table') %}\n  {% set existing_relation = load_relation(this) %}\n  {% set tmp_relation = make_temp_relation(this) %}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set to_drop = [] %}\n  {% if existing_relation is none %}\n      {% set build_sql = create_table_as(False, target_relation, sql) %}\n  {% elif existing_relation.is_view or should_full_refresh() %}\n      {#-- Make sure the backup doesn't exist so we don't encounter issues with the rename below #}\n      {% set backup_identifier = existing_relation.identifier ~ \"__dbt_backup\" %}\n      {% set backup_relation = existing_relation.incorporate(path={\"identifier\": backup_identifier}) %}\n      {% do adapter.drop_relation(backup_relation) %}\n\n      {% do adapter.rename_relation(target_relation, backup_relation) %}\n      {% set build_sql = create_table_as(False, target_relation, sql) %}\n      {% do to_drop.append(backup_relation) %}\n  {% else %}\n      {% set tmp_relation = make_temp_relation(target_relation) %}\n      {% do run_query(create_table_as(True, tmp_relation, sql)) %}\n      {% do adapter.expand_target_column_types(\n             from_relation=tmp_relation,\n             to_relation=target_relation) %}\n      {% set build_sql = incremental_upsert(tmp_relation, target_relation, unique_key=unique_key) %}\n  {% endif %}\n\n  {% call statement(\"main\") %}\n      {{ build_sql }}\n  {% endcall %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {% do adapter.commit() %}\n\n  {% for rel in to_drop %}\n      {% do adapter.drop_relation(rel) %}\n  {% endfor %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.test.load_relation",
+                    "macro.dbt.make_temp_relation",
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.create_table_as",
+                    "macro.dbt.should_full_refresh",
+                    "macro.dbt.run_query",
+                    "macro.dbt.incremental_upsert",
+                    "macro.dbt.statement",
+                    "macro.dbt.persist_docs"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.get_merge_sql": {
+            "unique_id": "macro.dbt.get_merge_sql",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/common/merge.sql",
+            "original_file_path": "macros/materializations/common/merge.sql",
+            "name": "get_merge_sql",
+            "macro_sql": "{% macro get_merge_sql(target, source, unique_key, dest_columns, predicates=none) -%}\n  {{ adapter.dispatch('get_merge_sql')(target, source, unique_key, dest_columns, predicates) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_merge_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.get_delete_insert_merge_sql": {
+            "unique_id": "macro.dbt.get_delete_insert_merge_sql",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/common/merge.sql",
+            "original_file_path": "macros/materializations/common/merge.sql",
+            "name": "get_delete_insert_merge_sql",
+            "macro_sql": "{% macro get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}\n  {{ adapter.dispatch('get_delete_insert_merge_sql')(target, source, unique_key, dest_columns) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_delete_insert_merge_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.get_insert_overwrite_merge_sql": {
+            "unique_id": "macro.dbt.get_insert_overwrite_merge_sql",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/common/merge.sql",
+            "original_file_path": "macros/materializations/common/merge.sql",
+            "name": "get_insert_overwrite_merge_sql",
+            "macro_sql": "{% macro get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header=false) -%}\n  {{ adapter.dispatch('get_insert_overwrite_merge_sql')(target, source, dest_columns, predicates, include_sql_header) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_insert_overwrite_merge_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__get_merge_sql": {
+            "unique_id": "macro.dbt.default__get_merge_sql",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/common/merge.sql",
+            "original_file_path": "macros/materializations/common/merge.sql",
+            "name": "default__get_merge_sql",
+            "macro_sql": "{% macro default__get_merge_sql(target, source, unique_key, dest_columns, predicates) -%}\n    {%- set predicates = [] if predicates is none else [] + predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {% if unique_key %}\n        {% set unique_key_match %}\n            DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}\n        {% endset %}\n        {% do predicates.append(unique_key_match) %}\n    {% else %}\n        {% do predicates.append('FALSE') %}\n    {% endif %}\n\n    {{ sql_header if sql_header is not none }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on {{ predicates | join(' and ') }}\n\n    {% if unique_key %}\n    when matched then update set\n        {% for column in dest_columns -%}\n            {{ adapter.quote(column.name) }} = DBT_INTERNAL_SOURCE.{{ adapter.quote(column.name) }}\n            {%- if not loop.last %}, {%- endif %}\n        {%- endfor %}\n    {% endif %}\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_quoted_csv"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.get_quoted_csv": {
+            "unique_id": "macro.dbt.get_quoted_csv",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/common/merge.sql",
+            "original_file_path": "macros/materializations/common/merge.sql",
+            "name": "get_quoted_csv",
+            "macro_sql": "{% macro get_quoted_csv(column_names) %}\n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote(col)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.common_get_delete_insert_merge_sql": {
+            "unique_id": "macro.dbt.common_get_delete_insert_merge_sql",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/common/merge.sql",
+            "original_file_path": "macros/materializations/common/merge.sql",
+            "name": "common_get_delete_insert_merge_sql",
+            "macro_sql": "{% macro common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}\n\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n\n    {% if unique_key is not none %}\n    delete from {{ target }}\n    where ({{ unique_key }}) in (\n        select ({{ unique_key }})\n        from {{ source }}\n    );\n    {% endif %}\n\n    insert into {{ target }} ({{ dest_cols_csv }})\n    (\n        select {{ dest_cols_csv }}\n        from {{ source }}\n    );\n\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_quoted_csv"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__get_delete_insert_merge_sql": {
+            "unique_id": "macro.dbt.default__get_delete_insert_merge_sql",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/common/merge.sql",
+            "original_file_path": "macros/materializations/common/merge.sql",
+            "name": "default__get_delete_insert_merge_sql",
+            "macro_sql": "{% macro default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}\n    {{ common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.common_get_delete_insert_merge_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__get_insert_overwrite_merge_sql": {
+            "unique_id": "macro.dbt.default__get_insert_overwrite_merge_sql",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/common/merge.sql",
+            "original_file_path": "macros/materializations/common/merge.sql",
+            "name": "default__get_insert_overwrite_merge_sql",
+            "macro_sql": "{% macro default__get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header) -%}\n    {%- set predicates = [] if predicates is none else [] + predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {{ sql_header if sql_header is not none and include_sql_header }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on FALSE\n\n    when not matched by source\n        {% if predicates %} and {{ predicates | join(' and ') }} {% endif %}\n        then delete\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_quoted_csv"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.materialization_table_default": {
+            "unique_id": "macro.dbt.materialization_table_default",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/table/table.sql",
+            "original_file_path": "macros/materializations/table/table.sql",
+            "name": "materialization_table_default",
+            "macro_sql": "{% materialization table, default %}\n  {%- set identifier = model['alias'] -%}\n  {%- set tmp_identifier = model['name'] + '__dbt_tmp' -%}\n  {%- set backup_identifier = model['name'] + '__dbt_backup' -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n  {%- set target_relation = api.Relation.create(identifier=identifier,\n                                                schema=schema,\n                                                database=database,\n                                                type='table') -%}\n  {%- set intermediate_relation = api.Relation.create(identifier=tmp_identifier,\n                                                      schema=schema,\n                                                      database=database,\n                                                      type='table') -%}\n\n  /*\n      See ../view/view.sql for more information about this relation.\n  */\n  {%- set backup_relation_type = 'table' if old_relation is none else old_relation.type -%}\n  {%- set backup_relation = api.Relation.create(identifier=backup_identifier,\n                                                schema=schema,\n                                                database=database,\n                                                type=backup_relation_type) -%}\n\n  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n\n  -- drop the temp relations if they exists for some reason\n  {{ adapter.drop_relation(intermediate_relation) }}\n  {{ adapter.drop_relation(backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ create_table_as(False, intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  {% if old_relation is not none %}\n      {{ adapter.rename_relation(target_relation, backup_relation) }}\n  {% endif %}\n\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {% do persist_docs(target_relation, model) %}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  -- finally, drop the existing/backup relation after the commit\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n{% endmaterialization %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.statement",
+                    "macro.dbt.create_table_as",
+                    "macro.dbt.persist_docs",
+                    "macro.dbt.drop_relation_if_exists"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.materialization_view_default": {
+            "unique_id": "macro.dbt.materialization_view_default",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/view/view.sql",
+            "original_file_path": "macros/materializations/view/view.sql",
+            "name": "materialization_view_default",
+            "macro_sql": "{%- materialization view, default -%}\n\n  {%- set identifier = model['alias'] -%}\n  {%- set tmp_identifier = model['name'] + '__dbt_tmp' -%}\n  {%- set backup_identifier = model['name'] + '__dbt_backup' -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n  {%- set target_relation = api.Relation.create(identifier=identifier, schema=schema, database=database,\n                                                type='view') -%}\n  {%- set intermediate_relation = api.Relation.create(identifier=tmp_identifier,\n                                                      schema=schema, database=database, type='view') -%}\n\n  /*\n     This relation (probably) doesn't exist yet. If it does exist, it's a leftover from\n     a previous run, and we're going to try to drop it immediately. At the end of this\n     materialization, we're going to rename the \"old_relation\" to this identifier,\n     and then we're going to drop it. In order to make sure we run the correct one of:\n       - drop view ...\n       - drop table ...\n\n     We need to set the type of this relation to be the type of the old_relation, if it exists,\n     or else \"view\" as a sane default if it does not. Note that if the old_relation does not\n     exist, then there is nothing to move out of the way and subsequentally drop. In that case,\n     this relation will be effectively unused.\n  */\n  {%- set backup_relation_type = 'view' if old_relation is none else old_relation.type -%}\n  {%- set backup_relation = api.Relation.create(identifier=backup_identifier,\n                                                schema=schema, database=database,\n                                                type=backup_relation_type) -%}\n\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- drop the temp relations if they exists for some reason\n  {{ adapter.drop_relation(intermediate_relation) }}\n  {{ adapter.drop_relation(backup_relation) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ create_view_as(intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  -- move the existing view out of the way\n  {% if old_relation is not none %}\n    {{ adapter.rename_relation(target_relation, backup_relation) }}\n  {% endif %}\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization -%}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.statement",
+                    "macro.dbt.create_view_as",
+                    "macro.dbt.persist_docs",
+                    "macro.dbt.drop_relation_if_exists"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.handle_existing_table": {
+            "unique_id": "macro.dbt.handle_existing_table",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/view/create_or_replace_view.sql",
+            "original_file_path": "macros/materializations/view/create_or_replace_view.sql",
+            "name": "handle_existing_table",
+            "macro_sql": "{% macro handle_existing_table(full_refresh, old_relation) %}\n    {{ adapter.dispatch(\"handle_existing_table\", packages=['dbt'])(full_refresh, old_relation) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__handle_existing_table"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__handle_existing_table": {
+            "unique_id": "macro.dbt.default__handle_existing_table",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/view/create_or_replace_view.sql",
+            "original_file_path": "macros/materializations/view/create_or_replace_view.sql",
+            "name": "default__handle_existing_table",
+            "macro_sql": "{% macro default__handle_existing_table(full_refresh, old_relation) %}\n    {{ adapter.drop_relation(old_relation) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.create_or_replace_view": {
+            "unique_id": "macro.dbt.create_or_replace_view",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/materializations/view/create_or_replace_view.sql",
+            "original_file_path": "macros/materializations/view/create_or_replace_view.sql",
+            "name": "create_or_replace_view",
+            "macro_sql": "{% macro create_or_replace_view(run_outside_transaction_hooks=True) %}\n  {%- set identifier = model['alias'] -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set target_relation = api.Relation.create(\n      identifier=identifier, schema=schema, database=database,\n      type='view') -%}\n\n  {% if run_outside_transaction_hooks %}\n      -- no transactions on BigQuery\n      {{ run_hooks(pre_hooks, inside_transaction=False) }}\n  {% endif %}\n\n  -- `BEGIN` happens here on Snowflake\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- If there's a table with the same name and we weren't told to full refresh,\n  -- that's an error. If we were told to full refresh, drop it. This behavior differs\n  -- for Snowflake and BigQuery, so multiple dispatch is used.\n  {%- if old_relation is not none and old_relation.is_table -%}\n    {{ handle_existing_table(should_full_refresh(), old_relation) }}\n  {%- endif -%}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ create_view_as(target_relation, sql) }}\n  {%- endcall %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {% if run_outside_transaction_hooks %}\n      -- No transactions on BigQuery\n      {{ run_hooks(post_hooks, inside_transaction=False) }}\n  {% endif %}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.handle_existing_table",
+                    "macro.dbt.should_full_refresh",
+                    "macro.dbt.statement",
+                    "macro.dbt.create_view_as"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.generate_alias_name": {
+            "unique_id": "macro.dbt.generate_alias_name",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/etc/get_custom_alias.sql",
+            "original_file_path": "macros/etc/get_custom_alias.sql",
+            "name": "generate_alias_name",
+            "macro_sql": "{% macro generate_alias_name(custom_alias_name=none, node=none) -%}\n\n    {%- if custom_alias_name is none -%}\n\n        {{ node.name }}\n\n    {%- else -%}\n\n        {{ custom_alias_name | trim }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.run_query": {
+            "unique_id": "macro.dbt.run_query",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/etc/query.sql",
+            "original_file_path": "macros/etc/query.sql",
+            "name": "run_query",
+            "macro_sql": "{% macro run_query(sql) %}\n  {% call statement(\"run_query_statement\", fetch_result=true, auto_begin=false) %}\n    {{ sql }}\n  {% endcall %}\n\n  {% do return(load_result(\"run_query_statement\").table) %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.is_incremental": {
+            "unique_id": "macro.dbt.is_incremental",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/etc/is_incremental.sql",
+            "original_file_path": "macros/etc/is_incremental.sql",
+            "name": "is_incremental",
+            "macro_sql": "{% macro is_incremental() %}\n    {#-- do not run introspective queries in parsing #}\n    {% if not execute %}\n        {{ return(False) }}\n    {% else %}\n        {% set relation = adapter.get_relation(this.database, this.schema, this.table) %}\n        {{ return(relation is not none\n                  and relation.type == 'table'\n                  and model.config.materialized == 'incremental'\n                  and not should_full_refresh()) }}\n    {% endif %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.should_full_refresh"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.convert_datetime": {
+            "unique_id": "macro.dbt.convert_datetime",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/etc/datetime.sql",
+            "original_file_path": "macros/etc/datetime.sql",
+            "name": "convert_datetime",
+            "macro_sql": "{% macro convert_datetime(date_str, date_fmt) %}\n\n  {% set error_msg -%}\n      The provided partition date '{{ date_str }}' does not match the expected format '{{ date_fmt }}'\n  {%- endset %}\n\n  {% set res = try_or_compiler_error(error_msg, modules.datetime.datetime.strptime, date_str.strip(), date_fmt) %}\n  {{ return(res) }}\n\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.dates_in_range": {
+            "unique_id": "macro.dbt.dates_in_range",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/etc/datetime.sql",
+            "original_file_path": "macros/etc/datetime.sql",
+            "name": "dates_in_range",
+            "macro_sql": "{% macro dates_in_range(start_date_str, end_date_str=none, in_fmt=\"%Y%m%d\", out_fmt=\"%Y%m%d\") %}\n    {% set end_date_str = start_date_str if end_date_str is none else end_date_str %}\n\n    {% set start_date = convert_datetime(start_date_str, in_fmt) %}\n    {% set end_date = convert_datetime(end_date_str, in_fmt) %}\n\n    {% set day_count = (end_date - start_date).days %}\n    {% if day_count < 0 %}\n        {% set msg -%}\n            Partition start date is after the end date ({{ start_date }}, {{ end_date }})\n        {%- endset %}\n\n        {{ exceptions.raise_compiler_error(msg, model) }}\n    {% endif %}\n\n    {% set date_list = [] %}\n    {% for i in range(0, day_count + 1) %}\n        {% set the_date = (modules.datetime.timedelta(days=i) + start_date) %}\n        {% if not out_fmt %}\n            {% set _ = date_list.append(the_date) %}\n        {% else %}\n            {% set _ = date_list.append(the_date.strftime(out_fmt)) %}\n        {% endif %}\n    {% endfor %}\n\n    {{ return(date_list) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.convert_datetime"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.partition_range": {
+            "unique_id": "macro.dbt.partition_range",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/etc/datetime.sql",
+            "original_file_path": "macros/etc/datetime.sql",
+            "name": "partition_range",
+            "macro_sql": "{% macro partition_range(raw_partition_date, date_fmt='%Y%m%d') %}\n    {% set partition_range = (raw_partition_date | string).split(\",\") %}\n\n    {% if (partition_range | length) == 1 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = none %}\n    {% elif (partition_range | length) == 2 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = partition_range[1] %}\n    {% else %}\n      {{ exceptions.raise_compiler_error(\"Invalid partition time. Expected format: {Start Date}[,{End Date}]. Got: \" ~ raw_partition_date) }}\n    {% endif %}\n\n    {{ return(dates_in_range(start_date, end_date, in_fmt=date_fmt)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.dates_in_range"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.py_current_timestring": {
+            "unique_id": "macro.dbt.py_current_timestring",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/etc/datetime.sql",
+            "original_file_path": "macros/etc/datetime.sql",
+            "name": "py_current_timestring",
+            "macro_sql": "{% macro py_current_timestring() %}\n    {% set dt = modules.datetime.datetime.now() %}\n    {% do return(dt.strftime(\"%Y%m%d%H%M%S%f\")) %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.generate_schema_name": {
+            "unique_id": "macro.dbt.generate_schema_name",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/etc/get_custom_schema.sql",
+            "original_file_path": "macros/etc/get_custom_schema.sql",
+            "name": "generate_schema_name",
+            "macro_sql": "{% macro generate_schema_name(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if custom_schema_name is none -%}\n\n        {{ default_schema }}\n\n    {%- else -%}\n\n        {{ default_schema }}_{{ custom_schema_name | trim }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.generate_schema_name_for_env": {
+            "unique_id": "macro.dbt.generate_schema_name_for_env",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/etc/get_custom_schema.sql",
+            "original_file_path": "macros/etc/get_custom_schema.sql",
+            "name": "generate_schema_name_for_env",
+            "macro_sql": "{% macro generate_schema_name_for_env(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if target.name == 'prod' and custom_schema_name is not none -%}\n\n        {{ custom_schema_name | trim }}\n\n    {%- else -%}\n\n        {{ default_schema }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.generate_database_name": {
+            "unique_id": "macro.dbt.generate_database_name",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/etc/get_custom_database.sql",
+            "original_file_path": "macros/etc/get_custom_database.sql",
+            "name": "generate_database_name",
+            "macro_sql": "{% macro generate_database_name(custom_database_name=none, node=none) -%}\n    {% do return(adapter.dispatch('generate_database_name')(custom_database_name, node)) %}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__generate_database_name"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__generate_database_name": {
+            "unique_id": "macro.dbt.default__generate_database_name",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/etc/get_custom_database.sql",
+            "original_file_path": "macros/etc/get_custom_database.sql",
+            "name": "default__generate_database_name",
+            "macro_sql": "{% macro default__generate_database_name(custom_database_name=none, node=none) -%}\n    {%- set default_database = target.database -%}\n    {%- if custom_database_name is none -%}\n\n        {{ default_database }}\n\n    {%- else -%}\n\n        {{ custom_database_name }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.get_columns_in_query": {
+            "unique_id": "macro.dbt.get_columns_in_query",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "get_columns_in_query",
+            "macro_sql": "{% macro get_columns_in_query(select_sql) -%}\n  {{ return(adapter.dispatch('get_columns_in_query')(select_sql)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_columns_in_query"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__get_columns_in_query": {
+            "unique_id": "macro.dbt.default__get_columns_in_query",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__get_columns_in_query",
+            "macro_sql": "{% macro default__get_columns_in_query(select_sql) %}\n    {% call statement('get_columns_in_query', fetch_result=True, auto_begin=False) -%}\n        select * from (\n            {{ select_sql }}\n        ) as __dbt_sbq\n        where false\n        limit 0\n    {% endcall %}\n\n    {{ return(load_result('get_columns_in_query').table.columns | map(attribute='name') | list) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.create_schema": {
+            "unique_id": "macro.dbt.create_schema",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "create_schema",
+            "macro_sql": "{% macro create_schema(relation) -%}\n  {{ adapter.dispatch('create_schema')(relation) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres__create_schema"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__create_schema": {
+            "unique_id": "macro.dbt.default__create_schema",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__create_schema",
+            "macro_sql": "{% macro default__create_schema(relation) -%}\n  {%- call statement('create_schema') -%}\n    create schema if not exists {{ relation.without_identifier() }}\n  {% endcall %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.drop_schema": {
+            "unique_id": "macro.dbt.drop_schema",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "drop_schema",
+            "macro_sql": "{% macro drop_schema(relation) -%}\n  {{ adapter.dispatch('drop_schema')(relation) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres__drop_schema"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__drop_schema": {
+            "unique_id": "macro.dbt.default__drop_schema",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__drop_schema",
+            "macro_sql": "{% macro default__drop_schema(relation) -%}\n  {%- call statement('drop_schema') -%}\n    drop schema if exists {{ relation.without_identifier() }} cascade\n  {% endcall %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.create_table_as": {
+            "unique_id": "macro.dbt.create_table_as",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "create_table_as",
+            "macro_sql": "{% macro create_table_as(temporary, relation, sql) -%}\n  {{ adapter.dispatch('create_table_as')(temporary, relation, sql) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres__create_table_as"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__create_table_as": {
+            "unique_id": "macro.dbt.default__create_table_as",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__create_table_as",
+            "macro_sql": "{% macro default__create_table_as(temporary, relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n\n  create {% if temporary: -%}temporary{%- endif %} table\n    {{ relation.include(database=(not temporary), schema=(not temporary)) }}\n  as (\n    {{ sql }}\n  );\n\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.create_view_as": {
+            "unique_id": "macro.dbt.create_view_as",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "create_view_as",
+            "macro_sql": "{% macro create_view_as(relation, sql) -%}\n  {{ adapter.dispatch('create_view_as')(relation, sql) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__create_view_as"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__create_view_as": {
+            "unique_id": "macro.dbt.default__create_view_as",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__create_view_as",
+            "macro_sql": "{% macro default__create_view_as(relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n  create view {{ relation }} as (\n    {{ sql }}\n  );\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.get_catalog": {
+            "unique_id": "macro.dbt.get_catalog",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "get_catalog",
+            "macro_sql": "{% macro get_catalog(information_schema, schemas) -%}\n  {{ return(adapter.dispatch('get_catalog')(information_schema, schemas)) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres__get_catalog"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__get_catalog": {
+            "unique_id": "macro.dbt.default__get_catalog",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__get_catalog",
+            "macro_sql": "{% macro default__get_catalog(information_schema, schemas) -%}\n\n  {% set typename = adapter.type() %}\n  {% set msg -%}\n    get_catalog not implemented for {{ typename }}\n  {%- endset %}\n\n  {{ exceptions.raise_compiler_error(msg) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.get_columns_in_relation": {
+            "unique_id": "macro.dbt.get_columns_in_relation",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "get_columns_in_relation",
+            "macro_sql": "{% macro get_columns_in_relation(relation) -%}\n  {{ return(adapter.dispatch('get_columns_in_relation')(relation)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres__get_columns_in_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.sql_convert_columns_in_relation": {
+            "unique_id": "macro.dbt.sql_convert_columns_in_relation",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "sql_convert_columns_in_relation",
+            "macro_sql": "{% macro sql_convert_columns_in_relation(table) -%}\n  {% set columns = [] %}\n  {% for row in table %}\n    {% do columns.append(api.Column(*row)) %}\n  {% endfor %}\n  {{ return(columns) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__get_columns_in_relation": {
+            "unique_id": "macro.dbt.default__get_columns_in_relation",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__get_columns_in_relation",
+            "macro_sql": "{% macro default__get_columns_in_relation(relation) -%}\n  {{ exceptions.raise_not_implemented(\n    'get_columns_in_relation macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.alter_column_type": {
+            "unique_id": "macro.dbt.alter_column_type",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "alter_column_type",
+            "macro_sql": "{% macro alter_column_type(relation, column_name, new_column_type) -%}\n  {{ return(adapter.dispatch('alter_column_type')(relation, column_name, new_column_type)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__alter_column_type"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.alter_column_comment": {
+            "unique_id": "macro.dbt.alter_column_comment",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "alter_column_comment",
+            "macro_sql": "{% macro alter_column_comment(relation, column_dict) -%}\n  {{ return(adapter.dispatch('alter_column_comment')(relation, column_dict)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres__alter_column_comment"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__alter_column_comment": {
+            "unique_id": "macro.dbt.default__alter_column_comment",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__alter_column_comment",
+            "macro_sql": "{% macro default__alter_column_comment(relation, column_dict) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_column_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.alter_relation_comment": {
+            "unique_id": "macro.dbt.alter_relation_comment",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "alter_relation_comment",
+            "macro_sql": "{% macro alter_relation_comment(relation, relation_comment) -%}\n  {{ return(adapter.dispatch('alter_relation_comment')(relation, relation_comment)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres__alter_relation_comment"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__alter_relation_comment": {
+            "unique_id": "macro.dbt.default__alter_relation_comment",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__alter_relation_comment",
+            "macro_sql": "{% macro default__alter_relation_comment(relation, relation_comment) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_relation_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.persist_docs": {
+            "unique_id": "macro.dbt.persist_docs",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "persist_docs",
+            "macro_sql": "{% macro persist_docs(relation, model, for_relation=true, for_columns=true) -%}\n  {{ return(adapter.dispatch('persist_docs')(relation, model, for_relation, for_columns)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__persist_docs"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__persist_docs": {
+            "unique_id": "macro.dbt.default__persist_docs",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__persist_docs",
+            "macro_sql": "{% macro default__persist_docs(relation, model, for_relation, for_columns) -%}\n  {% if for_relation and config.persist_relation_docs() and model.description %}\n    {% do run_query(alter_relation_comment(relation, model.description)) %}\n  {% endif %}\n\n  {% if for_columns and config.persist_column_docs() and model.columns %}\n    {% do run_query(alter_column_comment(relation, model.columns)) %}\n  {% endif %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.run_query",
+                    "macro.dbt.alter_relation_comment",
+                    "macro.dbt.alter_column_comment"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__alter_column_type": {
+            "unique_id": "macro.dbt.default__alter_column_type",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__alter_column_type",
+            "macro_sql": "{% macro default__alter_column_type(relation, column_name, new_column_type) -%}\n  {#\n    1. Create a new column (w/ temp name and correct type)\n    2. Copy data over to it\n    3. Drop the existing column (cascade!)\n    4. Rename the new column to existing column\n  #}\n  {%- set tmp_column = column_name + \"__dbt_alter\" -%}\n\n  {% call statement('alter_column_type') %}\n    alter table {{ relation }} add column {{ adapter.quote(tmp_column) }} {{ new_column_type }};\n    update {{ relation }} set {{ adapter.quote(tmp_column) }} = {{ adapter.quote(column_name) }};\n    alter table {{ relation }} drop column {{ adapter.quote(column_name) }} cascade;\n    alter table {{ relation }} rename column {{ adapter.quote(tmp_column) }} to {{ adapter.quote(column_name) }}\n  {% endcall %}\n\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.drop_relation": {
+            "unique_id": "macro.dbt.drop_relation",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "drop_relation",
+            "macro_sql": "{% macro drop_relation(relation) -%}\n  {{ return(adapter.dispatch('drop_relation')(relation)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__drop_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__drop_relation": {
+            "unique_id": "macro.dbt.default__drop_relation",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__drop_relation",
+            "macro_sql": "{% macro default__drop_relation(relation) -%}\n  {% call statement('drop_relation', auto_begin=False) -%}\n    drop {{ relation.type }} if exists {{ relation }} cascade\n  {%- endcall %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.truncate_relation": {
+            "unique_id": "macro.dbt.truncate_relation",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "truncate_relation",
+            "macro_sql": "{% macro truncate_relation(relation) -%}\n  {{ return(adapter.dispatch('truncate_relation')(relation)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__truncate_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__truncate_relation": {
+            "unique_id": "macro.dbt.default__truncate_relation",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__truncate_relation",
+            "macro_sql": "{% macro default__truncate_relation(relation) -%}\n  {% call statement('truncate_relation') -%}\n    truncate table {{ relation }}\n  {%- endcall %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.rename_relation": {
+            "unique_id": "macro.dbt.rename_relation",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "rename_relation",
+            "macro_sql": "{% macro rename_relation(from_relation, to_relation) -%}\n  {{ return(adapter.dispatch('rename_relation')(from_relation, to_relation)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__rename_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__rename_relation": {
+            "unique_id": "macro.dbt.default__rename_relation",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__rename_relation",
+            "macro_sql": "{% macro default__rename_relation(from_relation, to_relation) -%}\n  {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}\n  {% call statement('rename_relation') -%}\n    alter table {{ from_relation }} rename to {{ target_name }}\n  {%- endcall %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.information_schema_name": {
+            "unique_id": "macro.dbt.information_schema_name",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "information_schema_name",
+            "macro_sql": "{% macro information_schema_name(database) %}\n  {{ return(adapter.dispatch('information_schema_name')(database)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres__information_schema_name"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__information_schema_name": {
+            "unique_id": "macro.dbt.default__information_schema_name",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__information_schema_name",
+            "macro_sql": "{% macro default__information_schema_name(database) -%}\n  {%- if database -%}\n    {{ database }}.INFORMATION_SCHEMA\n  {%- else -%}\n    INFORMATION_SCHEMA\n  {%- endif -%}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.list_schemas": {
+            "unique_id": "macro.dbt.list_schemas",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "list_schemas",
+            "macro_sql": "{% macro list_schemas(database) -%}\n  {{ return(adapter.dispatch('list_schemas')(database)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres__list_schemas"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__list_schemas": {
+            "unique_id": "macro.dbt.default__list_schemas",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__list_schemas",
+            "macro_sql": "{% macro default__list_schemas(database) -%}\n  {% set sql %}\n    select distinct schema_name\n    from {{ information_schema_name(database) }}.SCHEMATA\n    where catalog_name ilike '{{ database }}'\n  {% endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.information_schema_name",
+                    "macro.dbt.run_query"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.check_schema_exists": {
+            "unique_id": "macro.dbt.check_schema_exists",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "check_schema_exists",
+            "macro_sql": "{% macro check_schema_exists(information_schema, schema) -%}\n  {{ return(adapter.dispatch('check_schema_exists')(information_schema, schema)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres__check_schema_exists"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__check_schema_exists": {
+            "unique_id": "macro.dbt.default__check_schema_exists",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__check_schema_exists",
+            "macro_sql": "{% macro default__check_schema_exists(information_schema, schema) -%}\n  {% set sql -%}\n        select count(*)\n        from {{ information_schema.replace(information_schema_view='SCHEMATA') }}\n        where catalog_name='{{ information_schema.database }}'\n          and schema_name='{{ schema }}'\n  {%- endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.run_query"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.list_relations_without_caching": {
+            "unique_id": "macro.dbt.list_relations_without_caching",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "list_relations_without_caching",
+            "macro_sql": "{% macro list_relations_without_caching(schema_relation) %}\n  {{ return(adapter.dispatch('list_relations_without_caching')(schema_relation)) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.test.postgres__list_relations_without_caching"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__list_relations_without_caching": {
+            "unique_id": "macro.dbt.default__list_relations_without_caching",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__list_relations_without_caching",
+            "macro_sql": "{% macro default__list_relations_without_caching(schema_relation) %}\n  {{ exceptions.raise_not_implemented(\n    'list_relations_without_caching macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.current_timestamp": {
+            "unique_id": "macro.dbt.current_timestamp",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "current_timestamp",
+            "macro_sql": "{% macro current_timestamp() -%}\n  {{ adapter.dispatch('current_timestamp')() }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres__current_timestamp"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__current_timestamp": {
+            "unique_id": "macro.dbt.default__current_timestamp",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__current_timestamp",
+            "macro_sql": "{% macro default__current_timestamp() -%}\n  {{ exceptions.raise_not_implemented(\n    'current_timestamp macro not implemented for adapter '+adapter.type()) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.collect_freshness": {
+            "unique_id": "macro.dbt.collect_freshness",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "collect_freshness",
+            "macro_sql": "{% macro collect_freshness(source, loaded_at_field, filter) %}\n  {{ return(adapter.dispatch('collect_freshness')(source, loaded_at_field, filter))}}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__collect_freshness"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__collect_freshness": {
+            "unique_id": "macro.dbt.default__collect_freshness",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__collect_freshness",
+            "macro_sql": "{% macro default__collect_freshness(source, loaded_at_field, filter) %}\n  {% call statement('collect_freshness', fetch_result=True, auto_begin=False) -%}\n    select\n      max({{ loaded_at_field }}) as max_loaded_at,\n      {{ current_timestamp() }} as snapshotted_at\n    from {{ source }}\n    {% if filter %}\n    where {{ filter }}\n    {% endif %}\n  {% endcall %}\n  {{ return(load_result('collect_freshness').table) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement",
+                    "macro.dbt.current_timestamp"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.make_temp_relation": {
+            "unique_id": "macro.dbt.make_temp_relation",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "make_temp_relation",
+            "macro_sql": "{% macro make_temp_relation(base_relation, suffix='__dbt_tmp') %}\n  {{ return(adapter.dispatch('make_temp_relation')(base_relation, suffix))}}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_postgres.postgres__make_temp_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__make_temp_relation": {
+            "unique_id": "macro.dbt.default__make_temp_relation",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "default__make_temp_relation",
+            "macro_sql": "{% macro default__make_temp_relation(base_relation, suffix) %}\n    {% set tmp_identifier = base_relation.identifier ~ suffix %}\n    {% set tmp_relation = base_relation.incorporate(\n                                path={\"identifier\": tmp_identifier}) -%}\n\n    {% do return(tmp_relation) %}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.set_sql_header": {
+            "unique_id": "macro.dbt.set_sql_header",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/adapters/common.sql",
+            "original_file_path": "macros/adapters/common.sql",
+            "name": "set_sql_header",
+            "macro_sql": "{% macro set_sql_header(config) -%}\n  {{ config.set('sql_header', caller()) }}\n{%- endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__test_relationships": {
+            "unique_id": "macro.dbt.default__test_relationships",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/schema_tests/relationships.sql",
+            "original_file_path": "macros/schema_tests/relationships.sql",
+            "name": "default__test_relationships",
+            "macro_sql": "{% macro default__test_relationships(model, to, field) %}\n\n{% set column_name = kwargs.get('column_name', kwargs.get('from')) %}\n\n\nselect count(*) as validation_errors\nfrom (\n    select {{ column_name }} as id from {{ model }}\n) as child\nleft join (\n    select {{ field }} as id from {{ to }}\n) as parent on parent.id = child.id\nwhere child.id is not null\n  and parent.id is null\n\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.test_relationships": {
+            "unique_id": "macro.dbt.test_relationships",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/schema_tests/relationships.sql",
+            "original_file_path": "macros/schema_tests/relationships.sql",
+            "name": "test_relationships",
+            "macro_sql": "{% macro test_relationships(model, to, field) %}\n    {% set macro = adapter.dispatch('test_relationships') %}\n    {{ macro(model, to, field, **kwargs) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__test_relationships"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__test_not_null": {
+            "unique_id": "macro.dbt.default__test_not_null",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/schema_tests/not_null.sql",
+            "original_file_path": "macros/schema_tests/not_null.sql",
+            "name": "default__test_not_null",
+            "macro_sql": "{% macro default__test_not_null(model) %}\n\n{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}\n\nselect count(*) as validation_errors\nfrom {{ model }}\nwhere {{ column_name }} is null\n\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.test_not_null": {
+            "unique_id": "macro.dbt.test_not_null",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/schema_tests/not_null.sql",
+            "original_file_path": "macros/schema_tests/not_null.sql",
+            "name": "test_not_null",
+            "macro_sql": "{% macro test_not_null(model) %}\n    {% set macro = adapter.dispatch('test_not_null') %}\n    {{ macro(model, **kwargs) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__test_not_null"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__test_unique": {
+            "unique_id": "macro.dbt.default__test_unique",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/schema_tests/unique.sql",
+            "original_file_path": "macros/schema_tests/unique.sql",
+            "name": "default__test_unique",
+            "macro_sql": "{% macro default__test_unique(model) %}\n\n{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}\n\nselect count(*) as validation_errors\nfrom (\n\n    select\n        {{ column_name }}\n\n    from {{ model }}\n    where {{ column_name }} is not null\n    group by {{ column_name }}\n    having count(*) > 1\n\n) validation_errors\n\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.test_unique": {
+            "unique_id": "macro.dbt.test_unique",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/schema_tests/unique.sql",
+            "original_file_path": "macros/schema_tests/unique.sql",
+            "name": "test_unique",
+            "macro_sql": "{% macro test_unique(model) %}\n    {% set macro = adapter.dispatch('test_unique') %}\n    {{ macro(model, **kwargs) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__test_unique"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.default__test_accepted_values": {
+            "unique_id": "macro.dbt.default__test_accepted_values",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/schema_tests/accepted_values.sql",
+            "original_file_path": "macros/schema_tests/accepted_values.sql",
+            "name": "default__test_accepted_values",
+            "macro_sql": "{% macro default__test_accepted_values(model, values) %}\n\n{% set column_name = kwargs.get('column_name', kwargs.get('field')) %}\n{% set quote_values = kwargs.get('quote', True) %}\n\nwith all_values as (\n\n    select distinct\n        {{ column_name }} as value_field\n\n    from {{ model }}\n\n),\n\nvalidation_errors as (\n\n    select\n        value_field\n\n    from all_values\n    where value_field not in (\n        {% for value in values -%}\n            {% if quote_values -%}\n            '{{ value }}'\n            {%- else -%}\n            {{ value }}\n            {%- endif -%}\n            {%- if not loop.last -%},{%- endif %}\n        {%- endfor %}\n    )\n)\n\nselect count(*) as validation_errors\nfrom validation_errors\n\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        },
+        "macro.dbt.test_accepted_values": {
+            "unique_id": "macro.dbt.test_accepted_values",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "macros/schema_tests/accepted_values.sql",
+            "original_file_path": "macros/schema_tests/accepted_values.sql",
+            "name": "test_accepted_values",
+            "macro_sql": "{% macro test_accepted_values(model, values) %}\n    {% set macro = adapter.dispatch('test_accepted_values') %}\n    {{ macro(model, values, **kwargs) }}\n{% endmacro %}",
+            "resource_type": "macro",
+            "tags": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__test_accepted_values"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "arguments": []
+        }
+    },
+    "docs": {
+        "dbt.__overview__": {
+            "unique_id": "dbt.__overview__",
+            "package_name": "dbt",
+            "root_path": "/Users/jerco/dev/product/dbt-core/core/dbt/include/global_project",
+            "path": "overview.md",
+            "original_file_path": "docs/overview.md",
+            "name": "__overview__",
+            "block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--models` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/overview)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [chat](https://community.getdbt.com/) on Slack for live questions and support."
+        }
+    },
+    "exposures": {},
+    "selectors": {},
+    "disabled": [],
+    "parent_map": {
+        "model.test.my_model": []
+    },
+    "child_map": {
+        "model.test.my_model": []
+    }
+}

--- a/tests/functional/fixtures/happy_path_project/macros/expression_is_true.sql
+++ b/tests/functional/fixtures/happy_path_project/macros/expression_is_true.sql
@@ -1,0 +1,14 @@
+{% test expression_is_true(model, expression, column_name=None) %}
+
+{% set column_list = '*' if should_store_failures() else "1" %}
+
+select
+    {{ column_list }}
+from {{ model }}
+{% if column_name is none %}
+where not({{ expression }})
+{%- else %}
+where not({{ column_name }} {{ expression }})
+{%- endif %}
+
+{% endtest %}

--- a/tests/functional/fixtures/happy_path_project/seeds/s.yml
+++ b/tests/functional/fixtures/happy_path_project/seeds/s.yml
@@ -5,11 +5,8 @@ seeds:
       show: true
       node_color: purple
     data_tests:
-      - accepted_values:
-          name: unexpected_a_column
-          values: [1]
-          config:
-            where: "b = 2"
+      - expression_is_true:
+          expression: "b = 2"
     columns:
       - name: a
         description: a description
@@ -34,8 +31,8 @@ seeds:
       tags: "tag"
       pre_hook: "select 1"
       post_hook: "select 1"
-      database: test_database
-      schema: test_schema
+      database: "dbt"
+      schema: "test"
       alias: test_alias
       persist_docs: {}
       full_refresh: true

--- a/tests/functional/fixtures/happy_path_project/seeds/s.yml
+++ b/tests/functional/fixtures/happy_path_project/seeds/s.yml
@@ -1,0 +1,19 @@
+seeds:
+  - name: seed
+    config:
+      quote_columns: false
+      column_types:
+        a: BIGINT
+      delimiter: ","
+      enabled: true
+      tags: "tag"
+      pre_hook: "select 1"
+      post_hook: "select 1"
+      database: test_database
+      schema: test_schema
+      alias: test_alias
+      persist_docs: {}
+      full_refresh: true
+      meta: {'meta_key': 'meta_value'}
+      grants: {}
+      event_time: my_time_field

--- a/tests/functional/fixtures/happy_path_project/seeds/s.yml
+++ b/tests/functional/fixtures/happy_path_project/seeds/s.yml
@@ -1,5 +1,30 @@
 seeds:
   - name: seed
+    description: 'test_description'
+    docs:
+      show: true
+      node_color: purple
+    data_tests:
+      - accepted_values:
+          name: unexpected_a_column
+          values: [1]
+          config:
+            where: "b = 2"
+    columns:
+      - name: a
+        description: a description
+        meta: {}
+        quote: true
+        tags: ["tag"]
+        tests:
+          - not_null
+      - name: b
+        description: b description
+        meta: {}
+        quote: true
+        tags: ["tag"]
+        tests:
+          - not_null
     config:
       quote_columns: false
       column_types:

--- a/tests/functional/list/test_list.py
+++ b/tests/functional/list/test_list.py
@@ -587,33 +587,33 @@ class TestList:
             "json": {
                 "name": "seed",
                 "package_name": "test",
-                "tags": [],
+                "tags": ["tag"],
                 "config": {
                     "enabled": True,
                     "group": None,
                     "materialized": "seed",
-                    "post-hook": [],
-                    "tags": [],
-                    "pre-hook": [],
+                    "post-hook": [{"sql": "select 1", "transaction": True, "index": None}],
+                    "tags": ["tag"],
+                    "pre-hook": [{"sql": "select 1", "transaction": True, "index": None}],
                     "quoting": {},
-                    "column_types": {},
+                    "column_types": {"a": "BIGINT"},
                     "delimiter": ",",
                     "persist_docs": {},
                     "quote_columns": False,
-                    "full_refresh": None,
+                    "full_refresh": True,
                     "unique_key": None,
                     "on_schema_change": "ignore",
                     "on_configuration_change": "apply",
-                    "database": None,
-                    "schema": None,
-                    "alias": None,
-                    "meta": {},
+                    "database": "dbt",
+                    "schema": "test",
+                    "alias": "test_alias",
+                    "meta": {"meta_key": "meta_value"},
                     "grants": {},
                     "packages": [],
                     "incremental_strategy": None,
-                    "docs": {"node_color": None, "show": True},
+                    "docs": {"node_color": "purple", "show": True},
                     "contract": {"enforced": False, "alias_types": True},
-                    "event_time": None,
+                    "event_time": "my_time_field",
                     "lookback": 1,
                     "batch_size": None,
                     "begin": None,
@@ -622,7 +622,7 @@ class TestList:
                 "depends_on": {"macros": []},
                 "unique_id": "seed.test.seed",
                 "original_file_path": normalize("seeds/seed.csv"),
-                "alias": "seed",
+                "alias": "test_alias",
                 "resource_type": "seed",
             },
             "path": self.dir("seeds/seed.csv"),
@@ -1076,17 +1076,17 @@ class TestList:
             self.assert_json_equal(got, expected)
 
     def test_ls(self, happy_path_project):  # noqa: F811
-        self.expect_snapshot_output(happy_path_project)
-        self.expect_analyses_output()
-        self.expect_model_output()
-        self.expect_source_output()
+        # self.expect_snapshot_output(happy_path_project)
+        # self.expect_analyses_output()
+        # self.expect_model_output()
+        # self.expect_source_output()
         self.expect_seed_output()
-        self.expect_test_output()
-        self.expect_select()
-        self.expect_resource_type_multiple()
-        self.expect_resource_type_env_var()
-        self.expect_all_output()
-        self.expect_selected_keys(happy_path_project)
+        # self.expect_test_output()
+        # self.expect_select()
+        # self.expect_resource_type_multiple()
+        # self.expect_resource_type_env_var()
+        # self.expect_all_output()
+        # self.expect_selected_keys(happy_path_project)
 
 
 def normalize(path):

--- a/tests/functional/list/test_list.py
+++ b/tests/functional/list/test_list.py
@@ -1076,17 +1076,17 @@ class TestList:
             self.assert_json_equal(got, expected)
 
     def test_ls(self, happy_path_project):  # noqa: F811
-        # self.expect_snapshot_output(happy_path_project)
-        # self.expect_analyses_output()
-        # self.expect_model_output()
-        # self.expect_source_output()
+        self.expect_snapshot_output(happy_path_project)
+        self.expect_analyses_output()
+        self.expect_model_output()
+        self.expect_source_output()
         self.expect_seed_output()
-        # self.expect_test_output()
-        # self.expect_select()
-        # self.expect_resource_type_multiple()
-        # self.expect_resource_type_env_var()
-        # self.expect_all_output()
-        # self.expect_selected_keys(happy_path_project)
+        self.expect_test_output()
+        self.expect_select()
+        self.expect_resource_type_multiple()
+        self.expect_resource_type_env_var()
+        self.expect_all_output()
+        self.expect_selected_keys(happy_path_project)
 
 
 def normalize(path):

--- a/tests/functional/list/test_list.py
+++ b/tests/functional/list/test_list.py
@@ -630,22 +630,63 @@ class TestList:
         self.expect_given_output(["--resource-type", "seed"], expectations)
 
     def expect_test_output(self):
+        # This is order sensitive :grimace:
         expectations = {
             "name": (
+                "expression_is_true_seed_b_2",
                 "not_null_model_with_lots_of_schema_configs_id",
                 "not_null_outer_id",
+                "not_null_seed__a_",
+                "not_null_seed__b_",
                 "t",
                 "unique_model_with_lots_of_schema_configs_id",
                 "unique_outer_id",
             ),
             "selector": (
+                "test.expression_is_true_seed_b_2",
                 "test.not_null_model_with_lots_of_schema_configs_id",
                 "test.not_null_outer_id",
+                "test.not_null_seed__a_",
+                "test.not_null_seed__b_",
                 "test.t",
                 "test.unique_model_with_lots_of_schema_configs_id",
                 "test.unique_outer_id",
             ),
             "json": (
+                {
+                    "alias": "expression_is_true_seed_b_2",
+                    "config": {
+                        "alias": None,
+                        "database": None,
+                        "enabled": True,
+                        "error_if": "!= 0",
+                        "fail_calc": "count(*)",
+                        "group": None,
+                        "limit": None,
+                        "materialized": "test",
+                        "meta": {},
+                        "schema": "dbt_test__audit",
+                        "severity": "ERROR",
+                        "store_failures": None,
+                        "store_failures_as": None,
+                        "tags": [],
+                        "warn_if": "!= 0",
+                        "where": None,
+                    },
+                    "depends_on": {
+                        "macros": [
+                            "macro.test.test_expression_is_true",
+                            "macro.dbt.get_where_subquery",
+                        ],
+                        "nodes": ["seed.test.seed"],
+                    },
+                    "name": "expression_is_true_seed_b_2",
+                    "original_file_path": normalize("seeds/s.yml"),
+                    "package_name": "test",
+                    "resource_type": "test",
+                    "tags": [],
+                    "unique_id": "test.test.expression_is_true_seed_b_2.4e0babbea4",
+                },
                 {
                     "alias": "not_null_model_with_lots_of_schema_configs_id",
                     "config": {
@@ -707,6 +748,68 @@ class TestList:
                     "original_file_path": normalize("models/schema.yml"),
                     "alias": "not_null_outer_id",
                     "resource_type": "test",
+                },
+                {
+                    "alias": "not_null_seed__a_",
+                    "config": {
+                        "alias": None,
+                        "database": None,
+                        "enabled": True,
+                        "error_if": "!= 0",
+                        "fail_calc": "count(*)",
+                        "group": None,
+                        "limit": None,
+                        "materialized": "test",
+                        "meta": {},
+                        "schema": "dbt_test__audit",
+                        "severity": "ERROR",
+                        "store_failures": None,
+                        "store_failures_as": None,
+                        "tags": [],
+                        "warn_if": "!= 0",
+                        "where": None,
+                    },
+                    "depends_on": {
+                        "macros": ["macro.dbt.test_not_null"],
+                        "nodes": ["seed.test.seed"],
+                    },
+                    "name": "not_null_seed__a_",
+                    "original_file_path": normalize("seeds/s.yml"),
+                    "package_name": "test",
+                    "resource_type": "test",
+                    "tags": ["tag"],
+                    "unique_id": "test.test.not_null_seed__a_.6b59640cde",
+                },
+                {
+                    "alias": "not_null_seed__b_",
+                    "config": {
+                        "alias": None,
+                        "database": None,
+                        "enabled": True,
+                        "error_if": "!= 0",
+                        "fail_calc": "count(*)",
+                        "group": None,
+                        "limit": None,
+                        "materialized": "test",
+                        "meta": {},
+                        "schema": "dbt_test__audit",
+                        "severity": "ERROR",
+                        "store_failures": None,
+                        "store_failures_as": None,
+                        "tags": [],
+                        "warn_if": "!= 0",
+                        "where": None,
+                    },
+                    "depends_on": {
+                        "macros": ["macro.dbt.test_not_null"],
+                        "nodes": ["seed.test.seed"],
+                    },
+                    "name": "not_null_seed__b_",
+                    "original_file_path": normalize("seeds/s.yml"),
+                    "package_name": "test",
+                    "resource_type": "test",
+                    "tags": ["tag"],
+                    "unique_id": "test.test.not_null_seed__b_.a088b263cb",
                 },
                 {
                     "name": "t",
@@ -800,8 +903,11 @@ class TestList:
                 },
             ),
             "path": (
+                self.dir("seeds/s.yml"),
                 self.dir("models/schema.yml"),
                 self.dir("models/schema.yml"),
+                self.dir("seeds/s.yml"),
+                self.dir("seeds/s.yml"),
                 self.dir("tests/t.sql"),
                 self.dir("models/schema.yml"),
                 self.dir("models/schema.yml"),
@@ -832,6 +938,9 @@ class TestList:
             "semantic_model:test.my_sm",
             "metric:test.total_outer",
             "saved_query:test.my_saved_query",
+            "test.expression_is_true_seed_b_2",
+            "test.not_null_seed__a_",
+            "test.not_null_seed__b_",
         }
         # analyses have their type inserted into their fqn like tests
         expected_all = expected_default | {"test.analysis.a"}
@@ -901,6 +1010,9 @@ class TestList:
             "test.t",
             "test.unique_outer_id",
             "test.unique_model_with_lots_of_schema_configs_id",
+            "test.expression_is_true_seed_b_2",
+            "test.not_null_seed__a_",
+            "test.not_null_seed__b_",
         }
 
         results = self.run_dbt_ls(
@@ -925,6 +1037,9 @@ class TestList:
             "test.sub.inner",
             "test.t",
             "test.unique_model_with_lots_of_schema_configs_id",
+            "test.expression_is_true_seed_b_2",
+            "test.not_null_seed__a_",
+            "test.not_null_seed__b_",
         }
 
         results = self.run_dbt_ls(
@@ -964,6 +1079,9 @@ class TestList:
             "test.t",
             "test.unique_outer_id",
             "test.unique_model_with_lots_of_schema_configs_id",
+            "test.expression_is_true_seed_b_2",
+            "test.not_null_seed__a_",
+            "test.not_null_seed__b_",
         }
         del os.environ["DBT_RESOURCE_TYPES"]
         os.environ["DBT_EXCLUDE_RESOURCE_TYPES"] = (
@@ -1032,8 +1150,11 @@ class TestList:
         """Expect selected fields of the test resource types
         """
         expectations = [
+            {"name": "expression_is_true_seed_b_2", "column_name": None},
             {"name": "not_null_model_with_lots_of_schema_configs_id", "column_name": "id"},
             {"name": "not_null_outer_id", "column_name": "id"},
+            {"name": "not_null_seed__a_", "column_name": '"a"'},
+            {"name": "not_null_seed__b_", "column_name": '"b"'},
             {"name": "t"},
             {"name": "unique_model_with_lots_of_schema_configs_id", "column_name": "id"},
             {"name": "unique_outer_id", "column_name": "id"},


### PR DESCRIPTION
Resolves #

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->
Adding seed configs & properties to happy path fixture
* https://docs.getdbt.com/reference/seed-configs
* https://docs.getdbt.com/reference/seed-properties

Since we're skipping the deprecations test in CI for now, here are the log outputs for sanity's sake!
```sh

Invoking dbt with ['parse', '--no-partial-parse', '--show-all-deprecations']
18:06:02  Running with dbt=1.10.0-b3
18:06:02  Registered adapter: postgres=1.9.1-a0
18:06:02  [WARNING]: Deprecated functionality
Custom key `warn_unsupported` found at `models[3].constraints[0]` in file
`models/schema.yml`. This may mean the key is a typo, or is simply not a key
supported by the object.
18:06:02  [WARNING]: Deprecated functionality
'is_partition' is a required property in file `models/sm.yml` at path
`semantic_models[0].dimensions[0]`
18:06:02  [WARNING]: Deprecated functionality
Custom key `description` found at `metrics[0]` in file `models/m.yml`. This may
mean the key is a typo, or is simply not a key supported by the object.
18:06:02  [WARNING]: Deprecated functionality
Custom key `label` found at `metrics[0]` in file `models/m.yml`. This may mean
the key is a typo, or is simply not a key supported by the object.
18:06:02  [WARNING]: Deprecated functionality
Custom key `name` found at `metrics[0]` in file `models/m.yml`. This may mean
the key is a typo, or is simply not a key supported by the object.
18:06:02  [WARNING]: Deprecated functionality
Custom key `type` found at `metrics[0]` in file `models/m.yml`. This may mean
the key is a typo, or is simply not a key supported by the object.
18:06:02  [WARNING]: Deprecated functionality
Custom key `type_params` found at `metrics[0]` in file `models/m.yml`. This may
mean the key is a typo, or is simply not a key supported by the object.
18:06:04  Performance info: /private/var/folders/k6/gtt07v8j2vn51m_z05xk_fjc0000gp/T/pytest-of-michelleark/pytest-215/project0/target/perf_info.json
18:06:04  [WARNING]: Deprecated functionality
Summary of encountered deprecations:
- CustomKeyInObjectDeprecation: 6 occurrences
- GenericJSONSchemaValidationDeprecation: 1 occurrence
```

^ notice there are no warnings relating to s.yml

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
