### PR TITLE
add exposure to happy path project

### DIFF
--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -431,9 +431,9 @@ class TestCustomOutputPathInSourceFreshnessDeprecation:
         assert len(event_catcher.caught_events) == 1
 
 
-@pytest.mark.skip(
-    reason="Skip until we have have regenerated the json schemas to account for all happy path failures"
-)
+# @pytest.mark.skip(
+#     reason="Skip until we have have regenerated the json schemas to account for all happy path failures"
+# )
 class TestHappyPathProjectHasNoDeprecations:
     @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
     def test_happy_path_project_has_no_deprecations(self, happy_path_project):

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -431,9 +431,9 @@ class TestCustomOutputPathInSourceFreshnessDeprecation:
         assert len(event_catcher.caught_events) == 1
 
 
-# @pytest.mark.skip(
-#     reason="Skip until we have have regenerated the json schemas to account for all happy path failures"
-# )
+@pytest.mark.skip(
+    reason="Skip until we have have regenerated the json schemas to account for all happy path failures"
+)
 class TestHappyPathProjectHasNoDeprecations:
     @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
     def test_happy_path_project_has_no_deprecations(self, happy_path_project):

--- a/tests/functional/fixtures/happy_path_project/models/e.yml
+++ b/tests/functional/fixtures/happy_path_project/models/e.yml
@@ -1,0 +1,18 @@
+exposures:
+  - name: weekly_jaffle_metrics
+    meta: {}
+    tags: ["tag"]
+    label: Jaffles by the Week
+    type: dashboard
+    maturity: high
+    url: https://bi.tool/dashboards/1
+    description: >
+      Did someone say "exponential growth"?
+    depends_on:
+      - ref('incremental')
+    owner:
+      name: Callum McData
+      email: data@jaffleshop.com
+    config:
+      enabled: true
+      meta: {}

--- a/tests/functional/list/test_list.py
+++ b/tests/functional/list/test_list.py
@@ -814,6 +814,7 @@ class TestList:
         # models are just package, subdirectory path, name
         # sources are like models, ending in source_name.table_name
         expected_default = {
+            "exposure:test.weekly_jaffle_metrics",
             "test.ephemeral",
             "test.incremental",
             "test.snapshot.my_snapshot",
@@ -971,6 +972,7 @@ class TestList:
         )
         results = self.run_dbt_ls()
         assert set(results) == {
+            "exposure:test.weekly_jaffle_metrics",
             "test.ephemeral",
             "test.incremental",
             "test.outer",


### PR DESCRIPTION
Resolves #

Adding missing exposure properties/configs to the happy path project. no latest.json schema updates needed!
<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->
🎩 👀 
No deprecations related to e.yml:
```sh
Invoking dbt with ['parse', '--no-partial-parse', '--show-all-deprecations']
20:14:11  Running with dbt=1.10.0-b3
20:14:11  Registered adapter: postgres=1.9.1-a0
20:14:11  [WARNING]: Deprecated functionality
Custom key `warn_unsupported` found at `models[3].constraints[0]` in file
`models/schema.yml`. This may mean the key is a typo, or is simply not a key
supported by the object.
20:14:11  [WARNING]: Deprecated functionality
'is_partition' is a required property in file `models/sm.yml` at path
`semantic_models[0].dimensions[0]`
20:14:11  [WARNING]: Deprecated functionality
Custom key `description` found at `metrics[0]` in file `models/m.yml`. This may
mean the key is a typo, or is simply not a key supported by the object.
20:14:11  [WARNING]: Deprecated functionality
Custom key `label` found at `metrics[0]` in file `models/m.yml`. This may mean
the key is a typo, or is simply not a key supported by the object.
20:14:11  [WARNING]: Deprecated functionality
Custom key `name` found at `metrics[0]` in file `models/m.yml`. This may mean
the key is a typo, or is simply not a key supported by the object.
20:14:11  [WARNING]: Deprecated functionality
Custom key `type` found at `metrics[0]` in file `models/m.yml`. This may mean
the key is a typo, or is simply not a key supported by the object.
20:14:11  [WARNING]: Deprecated functionality
Custom key `type_params` found at `metrics[0]` in file `models/m.yml`. This may
mean the key is a typo, or is simply not a key supported by the object.
20:14:12  Performance info: /private/var/folders/k6/gtt07v8j2vn51m_z05xk_fjc0000gp/T/pytest-of-michelleark/pytest-265/project0/target/perf_info.json
20:14:13  [WARNING]: Deprecated functionality
Summary of encountered deprecations:
- CustomKeyInObjectDeprecation: 6 occurrences
- GenericJSONSchemaValidationDeprecation: 1 occurrence
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
