### PR TITLE
Flip behavior flag to disallow spaces in resource names

### DIFF
--- a/.changes/unreleased/Breaking Changes-20250520-131830.yaml
+++ b/.changes/unreleased/Breaking Changes-20250520-131830.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Flip behavior flag to disallow spaces in resource names
+time: 2025-05-20T13:18:30.352998-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11610"

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -351,7 +351,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     # legacy behaviors - https://github.com/dbt-labs/dbt-core/blob/main/docs/guides/behavior-change-flags.md
     require_batched_execution_for_custom_microbatch_strategy: bool = False
     require_explicit_package_overrides_for_builtin_materializations: bool = True
-    require_resource_names_without_spaces: bool = False
+    require_resource_names_without_spaces: bool = True
     source_freshness_run_project_hooks: bool = True
     skip_nodes_if_on_run_start_fails: bool = False
     state_modified_compare_more_unrendered_values: bool = False

--- a/tests/functional/manifest_validations/test_check_for_spaces_in_model_names.py
+++ b/tests/functional/manifest_validations/test_check_for_spaces_in_model_names.py
@@ -29,6 +29,8 @@ class TestSpacesInModelNamesSadPath:
         }
 
     def tests_warning_when_spaces_in_name(self, project) -> None:
+        config_patch = {"flags": {"require_resource_names_without_spaces": False}}
+        update_config_file(config_patch, project.project_root, "dbt_project.yml")
         event_catcher = EventCatcher(SpacesInResourceNameDeprecation)
         total_catcher = EventCatcher(ResourceNamesWithSpacesDeprecation)
         runner = dbtRunner(callbacks=[event_catcher.catch, total_catcher.catch])
@@ -50,6 +52,8 @@ class TestSpaceInModelNamesWithDebug:
         }
 
     def tests_debug_when_spaces_in_name(self, project) -> None:
+        config_patch = {"flags": {"require_resource_names_without_spaces": False}}
+        update_config_file(config_patch, project.project_root, "dbt_project.yml")
         deprecations.reset_deprecations()
         spaces_check_catcher = EventCatcher(SpacesInResourceNameDeprecation)
         total_catcher = EventCatcher(ResourceNamesWithSpacesDeprecation)
@@ -83,6 +87,8 @@ class TestAllowSpacesInModelNamesFalse:
         }
 
     def test_require_resource_names_without_spaces(self, project):
+        config_patch = {"flags": {"require_resource_names_without_spaces": False}}
+        update_config_file(config_patch, project.project_root, "dbt_project.yml")
         spaces_check_catcher = EventCatcher(SpacesInResourceNameDeprecation)
         runner = dbtRunner(callbacks=[spaces_check_catcher.catch])
         runner.invoke(["parse"])


### PR DESCRIPTION
Resolves #11610
Resolves #9397

### Problem

In 1.10 spaces in resource names should be considered an error

### Solution

Flip behavior flag `require_resource_names_without_spaces` such that spaces in resource names will raise errors.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
