### PR TITLE
update analyses configs + happy path fixture

### DIFF
--- a/core/dbt/include/jsonschemas/resources/latest.json
+++ b/core/dbt/include/jsonschemas/resources/latest.json
@@ -186,9 +186,25 @@
     "AnalysesConfig": {
       "type": "object",
       "properties": {
+        "docs": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DocsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "enabled": {
           "type": [
             "boolean",
+            "null"
+          ]
+        },
+        "group": {
+          "type": [
+            "string",
             "null"
           ]
         },
@@ -238,22 +254,6 @@
           ]
         },
         "description": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "docs": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DocsConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "group": {
           "type": [
             "string",
             "null"

--- a/tests/functional/fixtures/happy_path_project/analyses/a.yml
+++ b/tests/functional/fixtures/happy_path_project/analyses/a.yml
@@ -1,15 +1,15 @@
 analyses:
   - name: a
     description: description
-    docs:
-      show: true
-      node_color: purple
     config:
       tags: ["tag"]
       enabled: true
       meta: {
         "test": 1
       }
+      docs:
+        show: true
+        node_color: purple
     columns:
       - name: id
         description: id description


### PR DESCRIPTION
🎩 
```

Invoking dbt with ['parse', '--no-partial-parse', '--show-all-deprecations']
14:57:29  Running with dbt=1.10.0-b3
14:57:30  Registered adapter: postgres=1.9.1-a0
14:57:30  [WARNING]: Deprecated functionality
Custom key `warn_unsupported` found at `models[3].constraints[0]` in file
`models/schema.yml`. This may mean the key is a typo, or is simply not a key
supported by the object.
14:57:30  [WARNING]: Deprecated functionality
'is_partition' is a required property in file `models/sm.yml` at path
`semantic_models[0].dimensions[0]`
14:57:30  [WARNING]: Deprecated functionality
Custom key `description` found at `metrics[0]` in file `models/m.yml`. This may
mean the key is a typo, or is simply not a key supported by the object.
14:57:30  [WARNING]: Deprecated functionality
Custom key `label` found at `metrics[0]` in file `models/m.yml`. This may mean
the key is a typo, or is simply not a key supported by the object.
14:57:30  [WARNING]: Deprecated functionality
Custom key `name` found at `metrics[0]` in file `models/m.yml`. This may mean
the key is a typo, or is simply not a key supported by the object.
14:57:30  [WARNING]: Deprecated functionality
Custom key `type` found at `metrics[0]` in file `models/m.yml`. This may mean
the key is a typo, or is simply not a key supported by the object.
14:57:30  [WARNING]: Deprecated functionality
Custom key `type_params` found at `metrics[0]` in file `models/m.yml`. This may
mean the key is a typo, or is simply not a key supported by the object.
14:57:31  Performance info: /private/var/folders/k6/gtt07v8j2vn51m_z05xk_fjc0000gp/T/pytest-of-michelleark/pytest-362/project0/target/perf_info.json
14:57:31  [WARNING]: Deprecated functionality
Summary of encountered deprecations:
- CustomKeyInObjectDeprecation: 6 occurrences
- GenericJSONSchemaValidationDeprecation: 1 occurrence
```

Confirmed no new warnings from analyses changes.