### PR TITLE
update latest.json with metrics objects

### DIFF
--- a/core/dbt/include/jsonschemas/resources/latest.json
+++ b/core/dbt/include/jsonschemas/resources/latest.json
@@ -12,6 +12,15 @@
         "$ref": "#/definitions/AnalysesProperties"
       }
     },
+    "data_tests": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/TestProperties"
+      }
+    },
     "exposures": {
       "type": [
         "array",
@@ -100,6 +109,15 @@
       ],
       "items": {
         "$ref": "#/definitions/SourceProperties"
+      }
+    },
+    "tests": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/TestProperties"
       }
     },
     "unit_tests": {
@@ -403,6 +421,22 @@
         "year"
       ]
     },
+    "ConstantPropertyInput": {
+      "type": "object",
+      "required": [
+        "base_property",
+        "conversion_property"
+      ],
+      "properties": {
+        "base_property": {
+          "type": "string"
+        },
+        "conversion_property": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "Constraint": {
       "description": "Constraints (model level or column level)",
       "type": "object",
@@ -464,6 +498,84 @@
         "check",
         "custom"
       ]
+    },
+    "ConversionCalculationType": {
+      "type": "string",
+      "enum": [
+        "conversions",
+        "conversion_rate"
+      ]
+    },
+    "ConversionTypeParams": {
+      "type": "object",
+      "required": [
+        "base_measure",
+        "calculation",
+        "conversion_measure",
+        "entity"
+      ],
+      "properties": {
+        "base_measure": {
+          "$ref": "#/definitions/MetricInputMeasure"
+        },
+        "calculation": {
+          "$ref": "#/definitions/ConversionCalculationType"
+        },
+        "constant_properties": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ConstantPropertyInput"
+          }
+        },
+        "conversion_measure": {
+          "$ref": "#/definitions/MetricInputMeasure"
+        },
+        "entity": {
+          "type": "string"
+        },
+        "window": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MetricTimeWindow"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "CumulativeTypeParams": {
+      "type": "object",
+      "required": [
+        "period_agg"
+      ],
+      "properties": {
+        "grain_to_date": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "period_agg": {
+          "$ref": "#/definitions/PeriodAggregationType"
+        },
+        "window": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MetricTimeWindow"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "CustomGranularity": {
       "type": "object",
@@ -812,7 +924,23 @@
             "null"
           ]
         },
-        "meta": true
+        "meta": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
       },
       "additionalProperties": false
     },
@@ -879,22 +1007,11 @@
             "null"
           ]
         },
-        "meta": true,
         "name": {
           "type": "string"
         },
         "owner": {
           "$ref": "#/definitions/ExposuresOwner"
-        },
-        "tags": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/StringOrArrayOfStrings"
-            },
-            {
-              "type": "null"
-            }
-          ]
         },
         "type": {
           "type": "string"
@@ -1305,8 +1422,295 @@
         "median"
       ]
     },
+    "MetricInput": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WhereFilterIntersection"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "offset_to_grain": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "offset_window": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MetricTimeWindow"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "MetricInputMeasure": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "fill_nulls_with": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WhereFilterIntersection"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "join_to_timepine": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "MetricTimeWindow": {
+      "type": "object",
+      "required": [
+        "count",
+        "granularity"
+      ],
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "granularity": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "MetricType": {
+      "type": "string",
+      "enum": [
+        "simple",
+        "ratio",
+        "cumulative",
+        "derived",
+        "conversion"
+      ]
+    },
+    "MetricTypeParams": {
+      "type": "object",
+      "properties": {
+        "conversion_type_params": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConversionTypeParams"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cumulative_type_params": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CumulativeTypeParams"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "denominator": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MetricInput"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "expr": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "input_measures": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MetricInputMeasure"
+          }
+        },
+        "measure": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrMetricInputMeasure"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "metrics": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/MetricInput"
+          }
+        },
+        "numerator": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MetricInput"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "window": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MetricTimeWindow"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "MetricsProperties": {
       "type": "object",
+      "required": [
+        "label",
+        "name",
+        "type",
+        "type_params"
+      ],
+      "properties": {
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MetricsPropertiesConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "filter": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "time_granularity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TimeGranularity"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/MetricType"
+        },
+        "type_params": {
+          "$ref": "#/definitions/MetricTypeParams"
+        }
+      },
+      "additionalProperties": false
+    },
+    "MetricsPropertiesConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "group": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "meta": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
       "additionalProperties": false
     },
     "ModelFreshness": {
@@ -1792,6 +2196,14 @@
         }
       ]
     },
+    "PeriodAggregationType": {
+      "type": "string",
+      "enum": [
+        "first",
+        "last",
+        "average"
+      ]
+    },
     "PersistDocsConfig": {
       "type": "object",
       "properties": {
@@ -2271,17 +2683,6 @@
             "null"
           ]
         },
-        "docs": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DocsConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "meta": true,
         "name": {
           "type": "string"
         },
@@ -2636,6 +3037,16 @@
         }
       ]
     },
+    "StringOrMetricInputMeasure": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/MetricInputMeasure"
+        }
+      ]
+    },
     "Tables": {
       "type": "object",
       "required": [
@@ -2771,6 +3182,144 @@
       },
       "additionalProperties": false
     },
+    "TestProperties": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TestPropertiesConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "TestPropertiesConfig": {
+      "type": "object",
+      "properties": {
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "database": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "error_if": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "fail_calc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "group": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "meta": true,
+        "quoting": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DbtQuoting"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "severity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "store_failures": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "warn_if": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TimeGranularity": {
+      "type": "string",
+      "enum": [
+        "nanosecond",
+        "microsecond",
+        "millisecond",
+        "second",
+        "minute",
+        "hour",
+        "day",
+        "week",
+        "month",
+        "quarter",
+        "year"
+      ]
+    },
     "UniqueTest": {
       "type": "object",
       "required": [
@@ -2886,6 +3435,33 @@
           ]
         },
         "v": true
+      },
+      "additionalProperties": false
+    },
+    "WhereFilter": {
+      "type": "object",
+      "required": [
+        "where_sql_template"
+      ],
+      "properties": {
+        "where_sql_template": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "WhereFilterIntersection": {
+      "type": "object",
+      "required": [
+        "where_filters"
+      ],
+      "properties": {
+        "where_filters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WhereFilter"
+          }
+        }
       },
       "additionalProperties": false
     },


### PR DESCRIPTION
Resolves #N/A

Updating latest.json jsonschema with metrics objects

🎩 
```
Invoking dbt with ['parse', '--no-partial-parse', '--show-all-deprecations']
23:28:35  Running with dbt=1.10.0-b3
23:28:35  Registered adapter: postgres=1.9.1-a0
23:28:35  [WARNING]: Deprecated functionality
Custom key `warn_unsupported` found at `models[3].constraints[0]` in file
`models/schema.yml`. This may mean the key is a typo, or is simply not a key
supported by the object.
23:28:35  [WARNING]: Deprecated functionality
Custom key `meta` found at `exposures[0]` in file `models/e.yml`. This may mean
the key is a typo, or is simply not a key supported by the object.
23:28:35  [WARNING]: Deprecated functionality
Custom key `tags` found at `exposures[0]` in file `models/e.yml`. This may mean
the key is a typo, or is simply not a key supported by the object.
23:28:35  [WARNING]: Deprecated functionality
'is_partition' is a required property in file `models/sm.yml` at path
`semantic_models[0].dimensions[0]`
23:28:37  Performance info: /private/var/folders/k6/gtt07v8j2vn51m_z05xk_fjc0000gp/T/pytest-of-michelleark/pytest-437/project0/target/perf_info.json
23:28:37  [WARNING]: Deprecated functionality
Summary of encountered deprecations:
- CustomKeyInObjectDeprecation: 3 occurrences
- GenericJSONSchemaValidationDeprecation: 1 occurrence
```

^ note no issues with m.yml

e.yml issues are unrelated and resolved by https://github.com/dbt-labs/dbt-core/pull/11663