### PR TITLE
Begin showing event name in msg of deprecation events

### DIFF
--- a/.changes/unreleased/Features-20250526-100955.yaml
+++ b/.changes/unreleased/Features-20250526-100955.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Include event names in deprecation warning messages
+time: 2025-05-26T10:09:55.012225-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11471"

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -350,6 +350,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
 
     # legacy behaviors - https://github.com/dbt-labs/dbt-core/blob/main/docs/guides/behavior-change-flags.md
     require_batched_execution_for_custom_microbatch_strategy: bool = False
+    require_event_names_in_deprecations: bool = False
     require_explicit_package_overrides_for_builtin_materializations: bool = True
     require_resource_names_without_spaces: bool = True
     source_freshness_run_project_hooks: bool = True

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -518,7 +518,7 @@ class GenericJSONSchemaValidationDeprecation(WarnLevel):
         else:
             description = f"{self.violation} in file `{self.file}` at path `{self.key_path}`"
 
-        return line_wrap_message(deprecation_tag(description))
+        return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 
 
 class UnexpectedJinjaBlockDeprecation(WarnLevel):
@@ -527,7 +527,7 @@ class UnexpectedJinjaBlockDeprecation(WarnLevel):
 
     def message(self) -> str:
         description = f"{self.msg} in file `{self.file}`"
-        return line_wrap_message(deprecation_tag(description))
+        return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 
 
 class DuplicateYAMLKeysDeprecation(WarnLevel):
@@ -536,7 +536,7 @@ class DuplicateYAMLKeysDeprecation(WarnLevel):
 
     def message(self) -> str:
         description = f"{self.duplicate_description} in file `{self.file}`"
-        return line_wrap_message(deprecation_tag(description))
+        return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 
 
 class CustomTopLevelKeyDeprecation(WarnLevel):
@@ -545,7 +545,7 @@ class CustomTopLevelKeyDeprecation(WarnLevel):
 
     def message(self) -> str:
         description = f"{self.msg} in file `{self.file}`"
-        return line_wrap_message(deprecation_tag(description))
+        return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 
 
 class CustomKeyInConfigDeprecation(WarnLevel):
@@ -554,7 +554,7 @@ class CustomKeyInConfigDeprecation(WarnLevel):
 
     def message(self) -> str:
         description = f"Custom key `{self.key}` found in `config` at path `{self.key_path}` in file `{self.file}`. Custom config keys should move into the `config.meta`."
-        return line_wrap_message(deprecation_tag(description))
+        return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 
 
 class CustomKeyInObjectDeprecation(WarnLevel):
@@ -563,7 +563,7 @@ class CustomKeyInObjectDeprecation(WarnLevel):
 
     def message(self) -> str:
         description = f"Custom key `{self.key}` found at `{self.key_path}` in file `{self.file}`. This may mean the key is a typo, or is simply not a key supported by the object."
-        return line_wrap_message(deprecation_tag(description))
+        return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 
 
 class DeprecationsSummary(WarnLevel):
@@ -580,7 +580,7 @@ class DeprecationsSummary(WarnLevel):
         if self.show_all_hint:
             description += "\n\nTo see all deprecation instances instead of just the first occurrence of each, run command again with the `--show-all-deprecations` flag. You may also need to run with `--no-partial-parse` as some deprecations are only encountered during parsing."
 
-        return line_wrap_message(deprecation_tag(description))
+        return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 
 
 class CustomOutputPathInSourceFreshnessDeprecation(WarnLevel):
@@ -589,7 +589,7 @@ class CustomOutputPathInSourceFreshnessDeprecation(WarnLevel):
 
     def message(self) -> str:
         description = f"Custom output path usage `--output {self.path}` usage detected in `dbt source freshness` command."
-        return line_wrap_message(deprecation_tag(description))
+        return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 
 
 class PropertyMovedToConfigDeprecation(WarnLevel):
@@ -598,7 +598,7 @@ class PropertyMovedToConfigDeprecation(WarnLevel):
 
     def message(self) -> str:
         description = f"Found `{self.key}` as a top-level property of `{self.key_path}` in file `{self.file}`. The `{self.key}` top-level property should be moved into the `config` of `{self.key_path}`."
-        return line_wrap_message(deprecation_tag(description))
+        return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 
 
 class WEOIncludeExcludeDeprecation(WarnLevel):

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -9,6 +9,7 @@ from dbt.events.base_types import (
     InfoLevel,
     WarnLevel,
 )
+from dbt.flags import get_flags
 from dbt_common.events.base_types import EventLevel
 from dbt_common.events.format import (
     format_fancy_output_line,
@@ -240,6 +241,13 @@ Happy modeling!
 # =======================================================
 
 
+def require_event_names_in_deprecations():
+    # The require_event_names_in_deprecations flag isn't guaranteed to be set by the
+    # time some deprecations are fired. We could have done the following ever single deprecation
+    # that needs it, but this makes it simpler to flip the flag later.
+    return getattr(get_flags(), "require_event_names_in_deprecations", False)
+
+
 class DeprecatedModel(WarnLevel):
     def code(self) -> str:
         return "I065"
@@ -250,7 +258,11 @@ class DeprecatedModel(WarnLevel):
             f"Model {self.model_name}{version} has passed its deprecation date of {self.deprecation_date}. "
             "This model should be disabled or removed."
         )
-        return warning_tag(msg)
+
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(msg, self.__class__.__name__))
+        else:
+            return warning_tag(msg)
 
 
 class PackageRedirectDeprecation(WarnLevel):
@@ -262,7 +274,11 @@ class PackageRedirectDeprecation(WarnLevel):
             f"The `{self.old_name}` package is deprecated in favor of `{self.new_name}`. Please "
             f"update your `packages.yml` configuration to use `{self.new_name}` instead."
         )
-        return line_wrap_message(deprecation_tag(description))
+
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(deprecation_tag(description))
 
 
 class PackageInstallPathDeprecation(WarnLevel):
@@ -275,7 +291,11 @@ class PackageInstallPathDeprecation(WarnLevel):
         Please update `clean-targets` in `dbt_project.yml` and check `.gitignore` as well.
         Or, set `packages-install-path: dbt_modules` if you'd like to keep the current value.
         """
-        return line_wrap_message(deprecation_tag(description))
+
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(deprecation_tag(description))
 
 
 class ConfigSourcePathDeprecation(WarnLevel):
@@ -287,7 +307,11 @@ class ConfigSourcePathDeprecation(WarnLevel):
             f"The `{self.deprecated_path}` config has been renamed to `{self.exp_path}`. "
             "Please update your `dbt_project.yml` configuration to reflect this change."
         )
-        return line_wrap_message(deprecation_tag(description))
+
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(deprecation_tag(description))
 
 
 class ConfigDataPathDeprecation(WarnLevel):
@@ -299,7 +323,11 @@ class ConfigDataPathDeprecation(WarnLevel):
             f"The `{self.deprecated_path}` config has been renamed to `{self.exp_path}`. "
             "Please update your `dbt_project.yml` configuration to reflect this change."
         )
-        return line_wrap_message(deprecation_tag(description))
+
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(deprecation_tag(description))
 
 
 class MetricAttributesRenamed(WarnLevel):
@@ -316,7 +344,10 @@ class MetricAttributesRenamed(WarnLevel):
             "\nRelevant issue here: https://github.com/dbt-labs/dbt-core/issues/5849"
         )
 
-        return deprecation_tag(description)
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return deprecation_tag(description)
 
 
 class ExposureNameDeprecation(WarnLevel):
@@ -331,7 +362,11 @@ class ExposureNameDeprecation(WarnLevel):
             "follow this pattern. Please update the 'name', and use the 'label' property for a "
             "human-friendly title. This will raise an error in a future version of dbt-core."
         )
-        return line_wrap_message(deprecation_tag(description))
+
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(deprecation_tag(description))
 
 
 class InternalDeprecation(WarnLevel):
@@ -346,7 +381,11 @@ class InternalDeprecation(WarnLevel):
             f"`{self.name}` is deprecated and will be removed in dbt-core version {self.version}\n\n"
             f"Adapter maintainers can resolve this deprecation by {self.suggested_action}. {extra_reason}"
         )
-        return warning_tag(msg)
+
+        if require_event_names_in_deprecations():
+            return deprecation_tag(msg, self.__class__.__name__)
+        else:
+            return warning_tag(msg)
 
 
 class EnvironmentVariableRenamed(WarnLevel):
@@ -360,7 +399,11 @@ class EnvironmentVariableRenamed(WarnLevel):
             f"Set `{self.new_name}` and unset `{self.old_name}` to avoid this deprecation warning and "
             "ensure it works properly in a future release."
         )
-        return line_wrap_message(deprecation_tag(description))
+
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(deprecation_tag(description))
 
 
 class ConfigLogPathDeprecation(WarnLevel):
@@ -377,7 +420,11 @@ class ConfigLogPathDeprecation(WarnLevel):
             f"If you wish to write dbt {output} to a custom directory, please use "
             f"the {cli_flag} CLI flag or {env_var} env var instead."
         )
-        return line_wrap_message(deprecation_tag(description))
+
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(deprecation_tag(description))
 
 
 class ConfigTargetPathDeprecation(WarnLevel):
@@ -394,7 +441,11 @@ class ConfigTargetPathDeprecation(WarnLevel):
             f"If you wish to write dbt {output} to a custom directory, please use "
             f"the {cli_flag} CLI flag or {env_var} env var instead."
         )
-        return line_wrap_message(deprecation_tag(description))
+
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(deprecation_tag(description))
 
 
 # Note: this deprecation has been removed, but we are leaving
@@ -409,7 +460,11 @@ class TestsConfigDeprecation(WarnLevel):
             f"The `{self.deprecated_path}` config has been renamed to `{self.exp_path}`. "
             "Please see https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax for more information."
         )
-        return line_wrap_message(deprecation_tag(description))
+
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(deprecation_tag(description))
 
 
 class ProjectFlagsMovedDeprecation(WarnLevel):
@@ -422,7 +477,10 @@ class ProjectFlagsMovedDeprecation(WarnLevel):
             "key in dbt_project.yml."
         )
         # Can't use line_wrap_message here because flags.printer_width isn't available yet
-        return deprecation_tag(description)
+        if require_event_names_in_deprecations():
+            return deprecation_tag(description, self.__class__.__name__)
+        else:
+            return deprecation_tag(description)
 
 
 class SpacesInResourceNameDeprecation(DynamicLevel):
@@ -437,7 +495,10 @@ class SpacesInResourceNameDeprecation(DynamicLevel):
         elif self.level == EventLevel.WARN.value:
             description = warning_tag(description)
 
-        return line_wrap_message(description)
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(description)
 
 
 class ResourceNamesWithSpacesDeprecation(WarnLevel):
@@ -452,7 +513,10 @@ class ResourceNamesWithSpacesDeprecation(WarnLevel):
 
         description += " For more information: https://docs.getdbt.com/reference/global-configs/legacy-behaviors"
 
-        return line_wrap_message(warning_tag(description))
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(warning_tag(description))
 
 
 class PackageMaterializationOverrideDeprecation(WarnLevel):
@@ -462,7 +526,10 @@ class PackageMaterializationOverrideDeprecation(WarnLevel):
     def message(self) -> str:
         description = f"Installed package '{self.package_name}' is overriding the built-in materialization '{self.materialization_name}'. Overrides of built-in materializations from installed packages will be deprecated in future versions of dbt. For more information: https://docs.getdbt.com/reference/global-configs/legacy-behaviors"
 
-        return line_wrap_message(warning_tag(description))
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(warning_tag(description))
 
 
 class SourceFreshnessProjectHooksNotRun(WarnLevel):
@@ -472,7 +539,10 @@ class SourceFreshnessProjectHooksNotRun(WarnLevel):
     def message(self) -> str:
         description = "In a future version of dbt, the `source freshness` command will start running `on-run-start` and `on-run-end` hooks by default. For more information: https://docs.getdbt.com/reference/global-configs/legacy-behaviors"
 
-        return line_wrap_message(warning_tag(description))
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(warning_tag(description))
 
 
 class MFTimespineWithoutYamlConfigurationDeprecation(WarnLevel):
@@ -482,7 +552,10 @@ class MFTimespineWithoutYamlConfigurationDeprecation(WarnLevel):
     def message(self) -> str:
         description = "Time spines without YAML configuration are in the process of deprecation. Please add YAML configuration for your 'metricflow_time_spine' model. See documentation on MetricFlow time spines: https://docs.getdbt.com/docs/build/metricflow-time-spine and behavior change documentation: https://docs.getdbt.com/reference/global-configs/behavior-changes."
 
-        return line_wrap_message(warning_tag(description))
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(warning_tag(description))
 
 
 class MFCumulativeTypeParamsDeprecation(WarnLevel):
@@ -492,7 +565,10 @@ class MFCumulativeTypeParamsDeprecation(WarnLevel):
     def message(self) -> str:
         description = "Cumulative fields `type_params.window` and `type_params.grain_to_date` have been moved and will soon be deprecated. Please nest those values under `type_params.cumulative_type_params.window` and `type_params.cumulative_type_params.grain_to_date`. See documentation on behavior changes: https://docs.getdbt.com/reference/global-configs/behavior-changes."
 
-        return line_wrap_message(warning_tag(description))
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(warning_tag(description))
 
 
 class MicrobatchMacroOutsideOfBatchesDeprecation(WarnLevel):
@@ -502,7 +578,10 @@ class MicrobatchMacroOutsideOfBatchesDeprecation(WarnLevel):
     def message(self) -> str:
         description = "The use of a custom microbatch macro outside of batched execution is deprecated. To use it with batched execution, set `flags.require_batched_execution_for_custom_microbatch_strategy` to `True` in `dbt_project.yml`. In the future this will be the default behavior."
 
-        return line_wrap_message(warning_tag(description))
+        if require_event_names_in_deprecations():
+            return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+        else:
+            return line_wrap_message(warning_tag(description))
 
 
 # Skipping D021. It belonged to the now deleted PackageRedirectDeprecationSummary event.


### PR DESCRIPTION
Resolves #11471 

### Problem

In the stdout of events, the event name isn't included. This makes it harder to debug deprecations in one's project, especially since we now have a docs page dedicated to deprecation that lists the event names.

### Solution

For recently added deprecation warnings, begin including the event name in the deprecation tag. For older deprecation warnings, show the event name depending on the state of behavior flag `require_event_names_in_deprecations`, which currently defaults to `False`.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
