### PR TITLE
Update latest jsonschema

### DIFF
--- a/core/dbt/include/jsonschemas/resources/latest.json
+++ b/core/dbt/include/jsonschemas/resources/latest.json
@@ -152,6 +152,14 @@
       },
       "additionalProperties": false
     },
+    "Access": {
+      "type": "string",
+      "enum": [
+        "private",
+        "protected",
+        "public"
+      ]
+    },
     "AggregationTypeParams": {
       "type": "object",
       "properties": {
@@ -1735,12 +1743,6 @@
         "name"
       ],
       "properties": {
-        "access": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "columns": {
           "type": [
             "array",
@@ -1788,16 +1790,6 @@
           "type": [
             "string",
             "null"
-          ]
-        },
-        "docs": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DocsConfig"
-            },
-            {
-              "type": "null"
-            }
           ]
         },
         "freshness": {
@@ -1864,6 +1856,16 @@
     "ModelPropertiesConfigs": {
       "type": "object",
       "properties": {
+        "access": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Access"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "alias": {
           "type": [
             "string",
@@ -1942,6 +1944,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "freshness": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelFreshness"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "full_refresh": {
@@ -2410,16 +2422,6 @@
             "null"
           ]
         },
-        "docs": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DocsConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "name": {
           "type": "string"
         },
@@ -2444,7 +2446,13 @@
             "null"
           ]
         },
-        "column_types": true,
+        "column_types": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false
+        },
         "copy_grants": {
           "type": [
             "boolean",
@@ -2461,6 +2469,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "docs": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DocsConfig"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "enabled": {

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -432,9 +432,9 @@ class TestCustomOutputPathInSourceFreshnessDeprecation:
         assert len(event_catcher.caught_events) == 1
 
 
-# @pytest.mark.skip(
-#     reason="Skip until we have have regenerated the json schemas to account for all happy path failures"
-# )
+@pytest.mark.skip(
+    reason="Skip until we have have regenerated the json schemas to account for all happy path failures"
+)
 class TestHappyPathProjectHasNoDeprecations:
     @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
     def test_happy_path_project_has_no_deprecations(self, happy_path_project):

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -432,9 +432,9 @@ class TestCustomOutputPathInSourceFreshnessDeprecation:
         assert len(event_catcher.caught_events) == 1
 
 
-@pytest.mark.skip(
-    reason="Skip until we have have regenerated the json schemas to account for all happy path failures"
-)
+# @pytest.mark.skip(
+#     reason="Skip until we have have regenerated the json schemas to account for all happy path failures"
+# )
 class TestHappyPathProjectHasNoDeprecations:
     @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
     def test_happy_path_project_has_no_deprecations(self, happy_path_project):

--- a/tests/functional/fixtures/happy_path_project/models/schema.yml
+++ b/tests/functional/fixtures/happy_path_project/models/schema.yml
@@ -33,7 +33,6 @@ models:
       - name: ts_second
         granularity: second
   - name: model_with_lots_of_schema_configs
-    access: public
     columns:
       - name: id
         data_tests:
@@ -41,6 +40,7 @@ models:
           - not_null
         description: The id value
     config:
+      access: public
       alias: "outer_alias"
       batch_size: day
       begin: "2020-01-01"
@@ -48,6 +48,9 @@ models:
       contract:
         alias_types: true
         enforce: true
+      docs:
+        node_color: purple
+        show: true
       database: "dbt"
       enabled: true
       full_refresh: false
@@ -81,9 +84,6 @@ models:
         name: "Check that id is greater than 0"
     deprecation_date: "2052-05-01"
     description: A model with lots of configs
-    docs:
-      node_color: purple
-      show: true
 
 sources:
   - name: my_source

--- a/tests/functional/fixtures/happy_path_project/seeds/s.yml
+++ b/tests/functional/fixtures/happy_path_project/seeds/s.yml
@@ -1,9 +1,6 @@
 seeds:
   - name: seed
     description: 'test_description'
-    docs:
-      show: true
-      node_color: purple
     data_tests:
       - expression_is_true:
           expression: "b = 2"
@@ -25,6 +22,9 @@ seeds:
           meta: {}
           tags: ["tag"]
     config:
+      docs:
+        show: true
+        node_color: purple
       quote_columns: false
       column_types:
         a: BIGINT


### PR DESCRIPTION
Resolves # NA

We're down to a few remaining deprecation warnings on this happy path project: 
```
Invoking dbt with ['parse', '--no-partial-parse', '--show-all-deprecations']
19:32:34  Running with dbt=1.10.0-b3
19:32:34  Registered adapter: postgres=1.9.1-a0
19:32:34  [WARNING][CustomKeyInConfigDeprecation]: Deprecated functionality
Custom key `a` found in `config` at path `seeds[0].config` in file
`seeds/s.yml`. Custom config keys should move into the `config.meta`.
19:32:34  [WARNING][CustomKeyInObjectDeprecation]: Deprecated functionality
Custom key `warn_unsupported` found at `models[3].constraints[0]` in file
`models/schema.yml`. This may mean the key is a typo, or is simply not a key
supported by the object.
19:32:34  [WARNING][GenericJSONSchemaValidationDeprecation]: Deprecated
functionality
'is_partition' is a required property in file `models/sm.yml` at path
`semantic_models[0].dimensions[0]`
19:32:35  Performance info: /private/var/folders/k6/gtt07v8j2vn51m_z05xk_fjc0000gp/T/pytest-of-michelleark/pytest-475/project0/target/perf_info.json
19:32:35  [WARNING][DeprecationsSummary]: Deprecated functionality
Summary of encountered deprecations:
- CustomKeyInConfigDeprecation: 1 occurrence
- CustomKeyInObjectDeprecation: 1 occurrence
- GenericJSONSchemaValidationDeprecation: 1 occurrence
```