### PR TITLE
Update latest jsonschema for schema files to have 'warn_unsupported' property

### DIFF
--- a/core/dbt/include/jsonschemas/resources/latest.json
+++ b/core/dbt/include/jsonschemas/resources/latest.json
@@ -492,6 +492,12 @@
         },
         "type": {
           "$ref": "#/definitions/ConstraintType"
+        },
+        "warn_unsupported": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Resolves #N/A

### Problem

`warn_unsupported` wasn't a supported property of `constraint` in the jsonschema

### Solution

Add it to the jsonschema

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
