### PR TITLE
Fix #11660: Prevent overcounting PropertyMovedToConfigDeprecation for source freshness

### DIFF
--- a/.changes/unreleased/Under the Hood-20250527-162136.yaml
+++ b/.changes/unreleased/Under the Hood-20250527-162136.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Prevent overcounting PropertyMovedToConfigDeprecation for source freshness
+time: 2025-05-27T16:21:36.551426+01:00
+custom:
+    Author: aranke
+    Issue: "11660"

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -54,6 +54,7 @@ class SourcePatcher:
         self.generic_test_parsers: Dict[str, SchemaGenericTestParser] = {}
         self.patches_used: Dict[SourceKey, Set[str]] = {}
         self.sources: Dict[str, SourceDefinition] = {}
+        self._deprecations: Set[Any] = set()
 
     # This method calls the 'parse_source' method which takes
     # the UnpatchedSourceDefinitions in the manifest and combines them
@@ -169,24 +170,26 @@ class SourcePatcher:
             project_freshness = None
 
         source_freshness = source.freshness
-        if source_freshness:
+        if source_freshness and (target.path, source.name) not in self._deprecations:
             deprecations.warn(
                 "property-moved-to-config-deprecation",
                 key="freshness",
                 file=target.path,
                 key_path=source.name,
             )
+            self._deprecations.add((target.path, source.name))
 
         source_config_freshness = FreshnessThreshold.from_dict(source.config.get("freshness", {}))
 
         table_freshness = table.freshness
-        if table_freshness:
+        if table_freshness and (target.path, table.name) not in self._deprecations:
             deprecations.warn(
                 "property-moved-to-config-deprecation",
                 key="freshness",
                 file=target.path,
                 key_path=table.name,
             )
+            self._deprecations.add((target.path, table.name))
 
         table_config_freshness = FreshnessThreshold.from_dict(table.config.get("freshness", {}))
         freshness = merge_source_freshness(


### PR DESCRIPTION
Resolves #11660 

### Problem

Log output is noisy because of multiple freshness warnings in the same file.

### Solution

Dedupe by file + key instead.

🎩 example:

```
❯ dbt parse --no-partial-parse --show-all-deprecations                                                    
15:58:27  Running with dbt=1.10.0-b3
15:58:28  Registered adapter: snowflake=1.9.4
15:58:28  [WARNING][PropertyMovedToConfigDeprecation]: Deprecated functionality
Found `freshness` as a top-level property of `raw` in file `models/sources.yml`.
The `freshness` top-level property should be moved into the `config` of `raw`.
15:58:28  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- data_tests.my_dir
15:58:28  Performance info: /Users/karanke/workspace/jaffle_shop_duckdb/target/perf_info.json
15:58:28  [WARNING][DeprecationsSummary]: Deprecated functionality
Summary of encountered deprecations:
- PropertyMovedToConfigDeprecation: 1 occurrence
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
