### PR TITLE
Update changelog to point to 1.8 and 1.9

### DIFF
--- a/.changes/0.0.0.md
+++ b/.changes/0.0.0.md
@@ -3,6 +3,8 @@
 For information on prior major and minor releases, see their changelogs:
 
 
+* [1.9](https://github.com/dbt-labs/dbt-core/blob/1.9.latest/CHANGELOG.md)
+* [1.8](https://github.com/dbt-labs/dbt-core/blob/1.8.latest/CHANGELOG.md)
 * [1.7](https://github.com/dbt-labs/dbt-core/blob/1.7.latest/CHANGELOG.md)
 * [1.6](https://github.com/dbt-labs/dbt-core/blob/1.6.latest/CHANGELOG.md)
 * [1.5](https://github.com/dbt-labs/dbt-core/blob/1.5.latest/CHANGELOG.md)


### PR DESCRIPTION
Minor docs/DX update to point to all previous changelogs in the latest one