### PR TITLE
Don't warn for `metricflow_time_spine` with non-day grain

### DIFF
--- a/.changes/unreleased/Fixes-20250528-092055.yaml
+++ b/.changes/unreleased/Fixes-20250528-092055.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Don't warn for metricflow_time_spine with non-day grain
+time: 2025-05-28T09:20:55.866514-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "11690"

--- a/core/dbt/contracts/graph/semantic_manifest.py
+++ b/core/dbt/contracts/graph/semantic_manifest.py
@@ -127,6 +127,7 @@ class SemanticManifest:
     def _get_pydantic_semantic_manifest(self) -> PydanticSemanticManifest:
         pydantic_time_spines: List[PydanticTimeSpine] = []
         minimum_time_spine_granularity: Optional[TimeGranularity] = None
+        has_legacy_time_spine_with_config: bool = False
         for node in self.manifest.nodes.values():
             if not (isinstance(node, ModelNode) and node.time_spine):
                 continue
@@ -166,6 +167,8 @@ class SemanticManifest:
                 ],
             )
             pydantic_time_spines.append(pydantic_time_spine)
+            if pydantic_time_spine.node_relation.relation_name == LEGACY_TIME_SPINE_MODEL_NAME:
+                has_legacy_time_spine_with_config = True
             if (
                 not minimum_time_spine_granularity
                 or standard_granularity_column.granularity.to_int()
@@ -194,16 +197,17 @@ class SemanticManifest:
             )
 
         if self.manifest.semantic_models:
-            legacy_time_spine_model = self.manifest.ref_lookup.find(
-                LEGACY_TIME_SPINE_MODEL_NAME, None, None, self.manifest
-            )
-            if legacy_time_spine_model:
-                if (
-                    not minimum_time_spine_granularity
-                    or LEGACY_TIME_SPINE_GRANULARITY.to_int()
-                    < minimum_time_spine_granularity.to_int()
-                ):
-                    minimum_time_spine_granularity = LEGACY_TIME_SPINE_GRANULARITY
+            if not has_legacy_time_spine_with_config:
+                legacy_time_spine_model = self.manifest.ref_lookup.find(
+                    LEGACY_TIME_SPINE_MODEL_NAME, None, None, self.manifest
+                )
+                if legacy_time_spine_model:
+                    if (
+                        not minimum_time_spine_granularity
+                        or LEGACY_TIME_SPINE_GRANULARITY.to_int()
+                        < minimum_time_spine_granularity.to_int()
+                    ):
+                        minimum_time_spine_granularity = LEGACY_TIME_SPINE_GRANULARITY
 
             # If no time spines have been configured at DAY or smaller AND legacy time spine model does not exist, error.
             if (


### PR DESCRIPTION
Resolves #11690


### Problem
A user brought up this issue:
- I had a metricflow_time_spine.sql model
- I configured a metricflow_time_spine.yml file appropriately with time_spine config
- I got expected deprecation warnings
- I just renamed model and configs to all_days and no more deprecation warnings

It turned out the model was defined at hour granularity, which was a scenario we were not accounting for when deciding whether or not to show the warning.


### Solution
Update the warning logic to not warn if the model uses a different granularity than `day`.


### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
