### PR TITLE
fix changelog for 1.10

### DIFF
--- a/.changes/0.0.0.md
+++ b/.changes/0.0.0.md
@@ -3,6 +3,8 @@
 For information on prior major and minor releases, see their changelogs:
 
 
+* [1.9](https://github.com/dbt-labs/dbt-core/blob/1.9.latest/CHANGELOG.md)
+* [1.8](https://github.com/dbt-labs/dbt-core/blob/1.8.latest/CHANGELOG.md)
 * [1.7](https://github.com/dbt-labs/dbt-core/blob/1.7.latest/CHANGELOG.md)
 * [1.6](https://github.com/dbt-labs/dbt-core/blob/1.6.latest/CHANGELOG.md)
 * [1.5](https://github.com/dbt-labs/dbt-core/blob/1.5.latest/CHANGELOG.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,6 @@
 - [@kato1208](https://github.com/kato1208) ([#11498](https://github.com/dbt-labs/dbt-core/issues/11498), [#11498](https://github.com/dbt-labs/dbt-core/issues/11498))
 - [@slothkong](https://github.com/slothkong) ([#9791](https://github.com/dbt-labs/dbt-core/issues/9791))
 
-
 ## dbt-core 1.10.0-b2 - April 02, 2025
 
 ### Features
@@ -146,6 +145,8 @@
 For information on prior major and minor releases, see their changelogs:
 
 
+* [1.9](https://github.com/dbt-labs/dbt-core/blob/1.9.latest/CHANGELOG.md)
+* [1.8](https://github.com/dbt-labs/dbt-core/blob/1.8.latest/CHANGELOG.md)
 * [1.7](https://github.com/dbt-labs/dbt-core/blob/1.7.latest/CHANGELOG.md)
 * [1.6](https://github.com/dbt-labs/dbt-core/blob/1.6.latest/CHANGELOG.md)
 * [1.5](https://github.com/dbt-labs/dbt-core/blob/1.5.latest/CHANGELOG.md)


### PR DESCRIPTION
### Problem

Changelogs don't auto update old versions

### Solution

Add them in manually

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
