### PR TITLE
Fix null handling of source freshness and dbt_project vs schema spec precedence

### DIFF
--- a/.changes/unreleased/Fixes-20250530-005804.yaml
+++ b/.changes/unreleased/Fixes-20250530-005804.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix source freshness set via config to handle explicit nulls
+time: 2025-05-30T00:58:04.94133-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11685"

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -387,7 +387,7 @@ class SourcePatcher:
                         f"  - Source table {patch_name}.{table_name} " f"(in {patch.path})"
                     )
         return unused_tables_formatted
-    
+
     def calculate_freshness_from_raw_target(
         self,
         target: UnpatchedSourceDefinition,

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -487,7 +487,7 @@ def merge_source_freshness(
             merged_freshness_obj.error_after = merged_error_after
             merged_freshness_obj.warn_after = merged_warn_after
             current_merged_value = merged_freshness_obj
-        elif base is None and update is not None:
+        elif base is None and bool(update):
             # If current_merged_value (base) is None, the update becomes the new value
             current_merged_value = update
         else:  # This covers cases where 'update' is None, or both 'base' and 'update' are None.

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -206,7 +206,8 @@ class SourcePatcher:
             loader=source.loader,
             loaded_at_field=loaded_at_field,
             loaded_at_query=loaded_at_query,
-            freshness=config.freshness,
+            # The setting to an empty freshness object is to maintain what we were previously doing if no freshenss was specified
+            freshness=config.freshness or FreshnessThreshold(),
             quoting=quoting,
             resource_type=NodeType.Source,
             fqn=target.fqn,

--- a/tests/functional/sources/fixtures.py
+++ b/tests/functional/sources/fixtures.py
@@ -21,6 +21,7 @@ sources:
     loader: custom
     freshness:
       warn_after: {count: 18, period: hour}
+      error_after: {count: 24, period: hour}
     config:
       freshness: # default freshness, takes precedence over top-level key above
         warn_after: {count: 12, period: hour}

--- a/tests/functional/sources/fixtures.py
+++ b/tests/functional/sources/fixtures.py
@@ -503,3 +503,33 @@ sources:
         loaded_at_query: "select {{current_timestamp()}}"
 
 """
+
+freshness_with_explicit_null_in_table_schema_yml = """version: 2
+sources:
+  - name: test_source
+    schema: "{{ var(env_var('DBT_TEST_SCHEMA_NAME_VARIABLE')) }}"
+    freshness:
+        warn_after:
+          count: 24
+          period: hour
+    quoting:
+      identifier: True
+    tables:
+      - name: source_a
+        loaded_at_field: "{{ var('test_loaded_at') | as_text }}"
+        config:
+          freshness: null
+"""
+
+freshness_with_explicit_null_in_source_schema_yml = """version: 2
+sources:
+  - name: test_source
+    schema: "{{ var(env_var('DBT_TEST_SCHEMA_NAME_VARIABLE')) }}"
+    config:
+      freshness: null
+    quoting:
+      identifier: True
+    tables:
+      - name: source_a
+        loaded_at_field: "{{ var('test_loaded_at') | as_text }}"
+"""

--- a/tests/functional/sources/test_source_freshness.py
+++ b/tests/functional/sources/test_source_freshness.py
@@ -20,6 +20,8 @@ from tests.functional.sources.fixtures import (
     filtered_models_schema_yml,
     freshness_via_custom_sql_schema_yml,
     freshness_via_metadata_schema_yml,
+    freshness_with_explicit_null_in_source_schema_yml,
+    freshness_with_explicit_null_in_table_schema_yml,
     override_freshness_models_schema_yml,
 )
 
@@ -599,3 +601,23 @@ class TestSourceFreshnessCustomSQL(SuccessfulSourceFreshnessTest):
             "source_b": "warn",
             "source_c": "pass",
         }
+
+
+class TestSourceFreshnessExplicitNullInTable(SuccessfulSourceFreshnessTest):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"schema.yml": freshness_with_explicit_null_in_table_schema_yml}
+
+    def test_source_freshness_explicit_null_in_table(self, project):
+        result = self.run_dbt_with_vars(project, ["source", "freshness"], expect_pass=True)
+        assert {r.node.name: r.status for r in result} == {}
+
+
+class TestSourceFreshnessExplicitNullInSource(SuccessfulSourceFreshnessTest):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"schema.yml": freshness_with_explicit_null_in_source_schema_yml}
+
+    def test_source_freshness_explicit_null_in_source(self, project):
+        result = self.run_dbt_with_vars(project, ["source", "freshness"], expect_pass=True)
+        assert {r.node.name: r.status for r in result} == {}

--- a/tests/unit/parser/test_sources.py
+++ b/tests/unit/parser/test_sources.py
@@ -1,0 +1,77 @@
+from typing import List, Optional
+
+import pytest
+
+from core.dbt.artifacts.resources.v1.components import FreshnessThreshold, Time
+from core.dbt.parser.sources import merge_source_freshness
+
+
+class TestMergeSourceFreshness:
+    @pytest.mark.parametrize(
+        "thresholds,expected_result",
+        [
+            ([None, None], None),
+            (
+                [
+                    FreshnessThreshold(
+                        warn_after=Time(count=1, period="hour"),
+                        error_after=Time(count=1, period="day"),
+                    ),
+                    None,
+                ],
+                None,
+            ),
+            (
+                [
+                    FreshnessThreshold(
+                        warn_after=Time(count=1, period="hour"),
+                        error_after=Time(count=1, period="day"),
+                    ),
+                    None,
+                    FreshnessThreshold(),
+                ],
+                None,
+            ),
+            (
+                [
+                    FreshnessThreshold(warn_after=Time(count=1, period="hour")),
+                    FreshnessThreshold(error_after=Time(count=1, period="day")),
+                ],
+                FreshnessThreshold(
+                    warn_after=Time(count=1, period="hour"),
+                    error_after=Time(count=1, period="day"),
+                ),
+            ),
+            (
+                [
+                    None,
+                    FreshnessThreshold(warn_after=Time(count=1, period="hour")),
+                    FreshnessThreshold(error_after=Time(count=1, period="day")),
+                ],
+                FreshnessThreshold(
+                    warn_after=Time(count=1, period="hour"),
+                    error_after=Time(count=1, period="day"),
+                ),
+            ),
+            (
+                [
+                    FreshnessThreshold(
+                        warn_after=Time(count=1, period="hour"),
+                        error_after=Time(count=1, period="day"),
+                    ),
+                    FreshnessThreshold(error_after=Time(count=48, period="hour")),
+                ],
+                FreshnessThreshold(
+                    warn_after=Time(count=1, period="hour"),
+                    error_after=Time(count=48, period="hour"),
+                ),
+            ),
+        ],
+    )
+    def test_merge_source_freshness(
+        self,
+        thresholds: List[Optional[FreshnessThreshold]],
+        expected_result: Optional[FreshnessThreshold],
+    ):
+        result = merge_source_freshness(*thresholds)
+        assert result == expected_result


### PR DESCRIPTION
Resolves #11685 

### Problem

* Explicit null setting of freshness was causing errors
* setting freshness in dbt_project was only propagating if set at the top level

### Solution

* Catch freshness nulls
* get dbt_project freshness during config generation
  * preference schema freshness over dbt_project freshness via clobbering instead of merge (see d6ff8fdd4c00333630b2d3a24c2a39d107f7eb20 for details)

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
