### PR TITLE
[Backport 1.9.latest] Backport #11698 to 1.9.latest

### DIFF
--- a/.changes/unreleased/Fixes-20250530-005804.yaml
+++ b/.changes/unreleased/Fixes-20250530-005804.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix source freshness set via config to handle explicit nulls
+time: 2025-05-30T00:58:04.94133-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11685"

--- a/tests/functional/sources/fixtures.py
+++ b/tests/functional/sources/fixtures.py
@@ -21,6 +21,7 @@ sources:
     loader: custom
     freshness:
       warn_after: {count: 18, period: hour}
+      error_after: {count: 24, period: hour}
     config:
       freshness: # default freshness, takes precedence over top-level key above
         warn_after: {count: 12, period: hour}
@@ -479,4 +480,34 @@ sources:
     tables:
       - name: test_table
         identifier: source
+"""
+
+freshness_with_explicit_null_in_table_schema_yml = """version: 2
+sources:
+  - name: test_source
+    schema: "{{ var(env_var('DBT_TEST_SCHEMA_NAME_VARIABLE')) }}"
+    freshness:
+        warn_after:
+          count: 24
+          period: hour
+    quoting:
+      identifier: True
+    tables:
+      - name: source_a
+        loaded_at_field: "{{ var('test_loaded_at') | as_text }}"
+        config:
+          freshness: null
+"""
+
+freshness_with_explicit_null_in_source_schema_yml = """version: 2
+sources:
+  - name: test_source
+    schema: "{{ var(env_var('DBT_TEST_SCHEMA_NAME_VARIABLE')) }}"
+    config:
+      freshness: null
+    quoting:
+      identifier: True
+    tables:
+      - name: source_a
+        loaded_at_field: "{{ var('test_loaded_at') | as_text }}"
 """

--- a/tests/functional/sources/test_source_freshness.py
+++ b/tests/functional/sources/test_source_freshness.py
@@ -18,6 +18,8 @@ from tests.functional.sources.fixtures import (
     error_models_schema_yml,
     filtered_models_schema_yml,
     freshness_via_metadata_schema_yml,
+    freshness_with_explicit_null_in_source_schema_yml,
+    freshness_with_explicit_null_in_table_schema_yml,
     override_freshness_models_schema_yml,
 )
 
@@ -582,3 +584,23 @@ class TestHooksInSourceFreshnessDefault(SuccessfulSourceFreshnessTest):
         )
         # default behaviour - no hooks run in source freshness
         self._assert_project_hooks_not_called(log_output)
+
+
+class TestSourceFreshnessExplicitNullInTable(SuccessfulSourceFreshnessTest):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"schema.yml": freshness_with_explicit_null_in_table_schema_yml}
+
+    def test_source_freshness_explicit_null_in_table(self, project):
+        result = self.run_dbt_with_vars(project, ["source", "freshness"], expect_pass=True)
+        assert {r.node.name: r.status for r in result} == {}
+
+
+class TestSourceFreshnessExplicitNullInSource(SuccessfulSourceFreshnessTest):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"schema.yml": freshness_with_explicit_null_in_source_schema_yml}
+
+    def test_source_freshness_explicit_null_in_source(self, project):
+        result = self.run_dbt_with_vars(project, ["source", "freshness"], expect_pass=True)
+        assert {r.node.name: r.status for r in result} == {}

--- a/tests/unit/parser/test_sources.py
+++ b/tests/unit/parser/test_sources.py
@@ -1,0 +1,77 @@
+from typing import List, Optional
+
+import pytest
+
+from core.dbt.artifacts.resources.v1.components import FreshnessThreshold, Time
+from core.dbt.parser.sources import merge_freshness
+
+
+class TestMergeSourceFreshness:
+    @pytest.mark.parametrize(
+        "thresholds,expected_result",
+        [
+            ([None, None], None),
+            (
+                [
+                    FreshnessThreshold(
+                        warn_after=Time(count=1, period="hour"),
+                        error_after=Time(count=1, period="day"),
+                    ),
+                    None,
+                ],
+                None,
+            ),
+            (
+                [
+                    FreshnessThreshold(
+                        warn_after=Time(count=1, period="hour"),
+                        error_after=Time(count=1, period="day"),
+                    ),
+                    None,
+                    FreshnessThreshold(),
+                ],
+                None,
+            ),
+            (
+                [
+                    FreshnessThreshold(warn_after=Time(count=1, period="hour")),
+                    FreshnessThreshold(error_after=Time(count=1, period="day")),
+                ],
+                FreshnessThreshold(
+                    warn_after=Time(count=1, period="hour"),
+                    error_after=Time(count=1, period="day"),
+                ),
+            ),
+            (
+                [
+                    None,
+                    FreshnessThreshold(warn_after=Time(count=1, period="hour")),
+                    FreshnessThreshold(error_after=Time(count=1, period="day")),
+                ],
+                FreshnessThreshold(
+                    warn_after=Time(count=1, period="hour"),
+                    error_after=Time(count=1, period="day"),
+                ),
+            ),
+            (
+                [
+                    FreshnessThreshold(
+                        warn_after=Time(count=1, period="hour"),
+                        error_after=Time(count=1, period="day"),
+                    ),
+                    FreshnessThreshold(error_after=Time(count=48, period="hour")),
+                ],
+                FreshnessThreshold(
+                    warn_after=Time(count=1, period="hour"),
+                    error_after=Time(count=48, period="hour"),
+                ),
+            ),
+        ],
+    )
+    def test_merge_source_freshness(
+        self,
+        thresholds: List[Optional[FreshnessThreshold]],
+        expected_result: Optional[FreshnessThreshold],
+    ):
+        result = merge_freshness(*thresholds)
+        assert result == expected_result


### PR DESCRIPTION
When we backported #11628 to 1.9.latest via #11683 we backported a bug along with it. We fixed the bug in #11698, and thus we need to backport that fix (which this does)