### PR TITLE
Backport #11719 to 1.9.latest

### DIFF
--- a/.changes/unreleased/Fixes-20250609-175239.yaml
+++ b/.changes/unreleased/Fixes-20250609-175239.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Ensure source node `.freshness` is equal to node's `.config.freshness`
+time: 2025-06-09T17:52:39.978403-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11717"

--- a/core/dbt/artifacts/resources/v1/source_definition.py
+++ b/core/dbt/artifacts/resources/v1/source_definition.py
@@ -20,7 +20,7 @@ from dbt_common.exceptions import CompilationError
 class SourceConfig(BaseConfig):
     enabled: bool = True
     event_time: Any = None
-    freshness: Optional[FreshnessThreshold] = None
+    freshness: Optional[FreshnessThreshold] = field(default_factory=FreshnessThreshold)
 
 
 @dataclass

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -184,8 +184,7 @@ class SourcePatcher:
             meta=meta,
             loader=source.loader,
             loaded_at_field=loaded_at_field,
-            # The setting to an empty freshness object is to maintain what we were previously doing if no freshenss was specified
-            freshness=config.freshness or FreshnessThreshold(),
+            freshness=config.freshness,
             quoting=quoting,
             resource_type=NodeType.Source,
             fqn=target.fqn,

--- a/tests/functional/artifacts/expected_manifest.py
+++ b/tests/functional/artifacts/expected_manifest.py
@@ -792,7 +792,11 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                 "config": {
                     "enabled": True,
                     "event_time": None,
-                    "freshness": None,
+                    "freshness": {
+                        "error_after": {"count": None, "period": None},
+                        "warn_after": {"count": None, "period": None},
+                        "filter": None,
+                    },
                 },
                 "quoting": {
                     "database": None,
@@ -1308,7 +1312,11 @@ def expected_references_manifest(project):
                 "config": {
                     "enabled": True,
                     "event_time": None,
-                    "freshness": None,
+                    "freshness": {
+                        "error_after": {"count": None, "period": None},
+                        "warn_after": {"count": None, "period": None},
+                        "filter": None,
+                    },
                 },
                 "quoting": {
                     "database": False,

--- a/tests/unit/contracts/graph/test_nodes_parsed.py
+++ b/tests/unit/contracts/graph/test_nodes_parsed.py
@@ -1886,6 +1886,10 @@ def basic_parsed_source_definition_dict():
         "tags": [],
         "config": {
             "enabled": True,
+            "freshness": {
+                "warn_after": {},
+                "error_after": {},
+            },
         },
         "unrendered_config": {},
     }
@@ -1916,6 +1920,10 @@ def complex_parsed_source_definition_dict():
         "tags": ["my_tag"],
         "config": {
             "enabled": True,
+            "freshness": {
+                "warn_after": {},
+                "error_after": {},
+            },
         },
         "freshness": {"warn_after": {"period": "hour", "count": 1}, "error_after": {}},
         "loaded_at_field": "loaded_at",


### PR DESCRIPTION
Resolves #11717

### Problem

We had broken the backwards compatibility of `freshness` on the parsed source node

### Solution

Backport #11719 

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
