### PR TITLE
deprecation warnings for --models, --model, -m

### DIFF
--- a/.changes/unreleased/Features-20250611-160217.yaml
+++ b/.changes/unreleased/Features-20250611-160217.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: "11561"
+time: 2025-06-11T16:02:17.334525-04:00
+custom:
+  Author: michelleark
+  Issue: deprecate --models,--model, and -m flags

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -399,7 +399,7 @@ class Flags:
         # Handle firing deprecations of CLI aliases separately using argv
         # because click because it difficult to disambiguite which CLI option was used
         # and only preserves the 'canonical' representation.
-        for deprecated_flags, warning in DEPRECATED_FLAGS_TO_WARNINGS.item():
+        for deprecated_flags, warning in DEPRECATED_FLAGS_TO_WARNINGS.items():
             for deprecated_flag in deprecated_flags:
                 if deprecated_flag in sys.argv:
                     warn(warning)

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -387,7 +387,7 @@ class Flags:
                     "Value for `--event-time-start` must be less than `--event-time-end`"
                 )
 
-    def fire_deprecations(self, ctx):
+    def fire_deprecations(self, ctx: Optional[Context] = None):
         """Fires events for deprecated env_var usage."""
         [dep_fn() for dep_fn in self.deprecated_env_var_warnings]
         # It is necessary to remove this attr from the class so it does
@@ -399,7 +399,11 @@ class Flags:
         # Handle firing deprecations of CLI aliases separately using argv or dbtRunner args
         # because click doesn't make it possible to disambiguite which literal CLI option was used
         # and only preserves the 'canonical' representation.
-        original_command_args = ctx.obj.get("dbt_runner_command_args") or sys.argv
+        original_command_args = (
+            ctx.obj["dbt_runner_command_args"]
+            if (ctx and ctx.obj and "dbt_runner_command_args" in ctx.obj)
+            else sys.argv
+        )
         for deprecated_flags, warning in DEPRECATED_FLAGS_TO_WARNINGS.items():
             for deprecated_flag in deprecated_flags:
                 if deprecated_flag in original_command_args:

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -397,7 +397,7 @@ class Flags:
         fire_buffered_deprecations()
 
         # Handle firing deprecations of CLI aliases separately using argv
-        # because click because it difficult to disambiguite which CLI option was used
+        # because click makes it difficult to disambiguite which CLI option was used
         # and only preserves the 'canonical' representation.
         for deprecated_flags, warning in DEPRECATED_FLAGS_TO_WARNINGS.items():
             for deprecated_flag in deprecated_flags:

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -387,7 +387,7 @@ class Flags:
                     "Value for `--event-time-start` must be less than `--event-time-end`"
                 )
 
-    def fire_deprecations(self):
+    def fire_deprecations(self, ctx):
         """Fires events for deprecated env_var usage."""
         [dep_fn() for dep_fn in self.deprecated_env_var_warnings]
         # It is necessary to remove this attr from the class so it does
@@ -396,12 +396,13 @@ class Flags:
 
         fire_buffered_deprecations()
 
-        # Handle firing deprecations of CLI aliases separately using argv
-        # because click makes it difficult to disambiguite which CLI option was used
+        # Handle firing deprecations of CLI aliases separately using argv or dbtRunner args
+        # because click doesn't make it possible to disambiguite which literal CLI option was used
         # and only preserves the 'canonical' representation.
+        original_command_args = ctx.obj.get("dbt_runner_command_args") or sys.argv
         for deprecated_flags, warning in DEPRECATED_FLAGS_TO_WARNINGS.items():
             for deprecated_flag in deprecated_flags:
-                if deprecated_flag in sys.argv:
+                if deprecated_flag in original_command_args:
                     warn(warning)
 
     @classmethod
@@ -409,7 +410,7 @@ class Flags:
         command_arg_list = command_params(command, args_dict)
         ctx = args_to_context(command_arg_list)
         flags = cls(ctx=ctx)
-        flags.fire_deprecations()
+        flags.fire_deprecations(ctx=ctx)
         return flags
 
     def set_common_global_flags(self):

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -56,6 +56,7 @@ class dbtRunner:
             dbt_ctx.obj = {
                 "manifest": self.manifest,
                 "callbacks": self.callbacks,
+                "dbt_runner_command_args": args,
             }
 
             for key, value in kwargs.items():

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -96,7 +96,7 @@ def preflight(func):
         fire_event(MainReportArgs(args=flags_dict_str))
 
         # Deprecation warnings
-        flags.fire_deprecations()
+        flags.fire_deprecations(ctx)
 
         if active_user is not None:  # mypy appeasement, always true
             fire_event(MainTrackingUserState(user_state=active_user.state()))

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -194,6 +194,11 @@ class PropertyMovedToConfigDeprecation(DBTDeprecation):
     _event = "PropertyMovedToConfigDeprecation"
 
 
+class ModelParamUsageDeprecation(DBTDeprecation):
+    _name = "model-param-usage-deprecation"
+    _event = "ModelParamUsageDeprecation"
+
+
 def renamed_env_var(old_name: str, new_name: str):
     class EnvironmentVariableRenamed(DBTDeprecation):
         _name = f"environment-variable-renamed:{old_name}"
@@ -272,6 +277,7 @@ deprecations_list: List[DBTDeprecation] = [
     CustomKeyInObjectDeprecation(),
     CustomOutputPathInSourceFreshnessDeprecation(),
     PropertyMovedToConfigDeprecation(),
+    ModelParamUsageDeprecation(),
     WEOInlcudeExcludeDeprecation(),
 ]
 

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -700,6 +700,15 @@ class WEOIncludeExcludeDeprecation(WarnLevel):
         return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 
 
+class ModelParamUsageDeprecation(WarnLevel):
+    def code(self) -> str:
+        return "D032"
+
+    def message(self) -> str:
+        description = "Usage of `--models`, `--model`, and `-m` is deprecated in favor of `--resource-type model --select`"
+        return line_wrap_message(deprecation_tag(description))
+
+
 # =======================================================
 # I - Project parsing
 # =======================================================

--- a/core/setup.py
+++ b/core/setup.py
@@ -73,7 +73,7 @@ setup(
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.22.0,<2.0",
         "dbt-adapters>=1.15.2,<2.0",
-        "dbt-protos>=1.0.312,<2.0",
+        "dbt-protos>=1.0.315,<2.0",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.
         "packaging>20.9",

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -8,6 +8,7 @@ import yaml
 
 import dbt_common
 from dbt import deprecations
+from dbt.cli.main import dbtRunner
 from dbt.clients.registry import _get_cached
 from dbt.events.types import (
     CustomKeyInConfigDeprecation,
@@ -509,6 +510,16 @@ class TestModelsParamUsageDeprecation:
         assert len(event_catcher.caught_events) == 1
 
 
+class TestModelsParamUsageRunnerDeprecation:
+
+    def test_models_usage(self, project):
+        event_catcher = EventCatcher(ModelParamUsageDeprecation)
+
+        assert len(event_catcher.caught_events) == 0
+        dbtRunner(callbacks=[event_catcher.catch]).invoke(["ls", "--models", "some_model"])
+        assert len(event_catcher.caught_events) == 1
+
+
 class TestModelParamUsageDeprecation:
     @mock.patch.object(sys, "argv", ["dbt", "ls", "--model", "some_model"])
     def test_model_usage(self, project):
@@ -519,6 +530,16 @@ class TestModelParamUsageDeprecation:
             ["ls", "--model", "some_model"],
             callbacks=[event_catcher.catch],
         )
+        assert len(event_catcher.caught_events) == 1
+
+
+class TestModelParamUsageRunnerDeprecation:
+
+    def test_model_usage(self, project):
+        event_catcher = EventCatcher(ModelParamUsageDeprecation)
+
+        assert len(event_catcher.caught_events) == 0
+        dbtRunner(callbacks=[event_catcher.catch]).invoke(["ls", "--model", "some_model"])
         assert len(event_catcher.caught_events) == 1
 
 
@@ -535,6 +556,15 @@ class TestMParamUsageDeprecation:
         assert len(event_catcher.caught_events) == 1
 
 
+class TestMParamUsageRunnerDeprecation:
+    def test_m_usage(self, project):
+        event_catcher = EventCatcher(ModelParamUsageDeprecation)
+
+        assert len(event_catcher.caught_events) == 0
+        dbtRunner(callbacks=[event_catcher.catch]).invoke(["ls", "-m", "some_model"])
+        assert len(event_catcher.caught_events) == 1
+
+
 class TestSelectParamNoModelUsageDeprecation:
 
     @mock.patch.object(sys, "argv", ["dbt", "ls", "--select", "some_model"])
@@ -546,4 +576,13 @@ class TestSelectParamNoModelUsageDeprecation:
             ["ls", "--select", "some_model"],
             callbacks=[event_catcher.catch],
         )
+        assert len(event_catcher.caught_events) == 0
+
+
+class TestSelectParamNoModelUsageRunnerDeprecation:
+    def test_select_usage(self, project):
+        event_catcher = EventCatcher(ModelParamUsageDeprecation)
+
+        assert len(event_catcher.caught_events) == 0
+        dbtRunner(callbacks=[event_catcher.catch]).invoke(["ls", "--select", "some_model"])
         assert len(event_catcher.caught_events) == 0

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from collections import defaultdict
 from unittest import mock
 
@@ -15,6 +16,7 @@ from dbt.events.types import (
     DeprecationsSummary,
     DuplicateYAMLKeysDeprecation,
     GenericJSONSchemaValidationDeprecation,
+    ModelParamUsageDeprecation,
     PackageRedirectDeprecation,
     WEOIncludeExcludeDeprecation,
 )
@@ -491,3 +493,57 @@ class TestWEOIncludeExcludeDeprecation:
                 assert "exclude" in event_catcher.caught_events[0].info.msg
             else:
                 assert "exclude" not in event_catcher.caught_events[0].info.msg
+
+
+class TestModelsParamUsageDeprecation:
+
+    @mock.patch.object(sys, "argv", ["dbt", "ls", "--models", "some_model"])
+    def test_models_usage(self, project):
+        event_catcher = EventCatcher(ModelParamUsageDeprecation)
+
+        assert len(event_catcher.caught_events) == 0
+        run_dbt(
+            ["ls", "--models", "some_model"],
+            callbacks=[event_catcher.catch],
+        )
+        assert len(event_catcher.caught_events) == 1
+
+
+class TestModelParamUsageDeprecation:
+    @mock.patch.object(sys, "argv", ["dbt", "ls", "--model", "some_model"])
+    def test_model_usage(self, project):
+        event_catcher = EventCatcher(ModelParamUsageDeprecation)
+
+        assert len(event_catcher.caught_events) == 0
+        run_dbt(
+            ["ls", "--model", "some_model"],
+            callbacks=[event_catcher.catch],
+        )
+        assert len(event_catcher.caught_events) == 1
+
+
+class TestMParamUsageDeprecation:
+    @mock.patch.object(sys, "argv", ["dbt", "ls", "-m", "some_model"])
+    def test_m_usage(self, project):
+        event_catcher = EventCatcher(ModelParamUsageDeprecation)
+
+        assert len(event_catcher.caught_events) == 0
+        run_dbt(
+            ["ls", "-m", "some_model"],
+            callbacks=[event_catcher.catch],
+        )
+        assert len(event_catcher.caught_events) == 1
+
+
+class TestSelectParamNoModelUsageDeprecation:
+
+    @mock.patch.object(sys, "argv", ["dbt", "ls", "--select", "some_model"])
+    def test_select_usage(self, project):
+        event_catcher = EventCatcher(ModelParamUsageDeprecation)
+
+        assert len(event_catcher.caught_events) == 0
+        run_dbt(
+            ["ls", "--select", "some_model"],
+            callbacks=[event_catcher.catch],
+        )
+        assert len(event_catcher.caught_events) == 0

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -169,6 +169,7 @@ sample_values = [
     core_types.CustomOutputPathInSourceFreshnessDeprecation(path=""),
     core_types.PropertyMovedToConfigDeprecation(key="", key_path="", file=""),
     core_types.WEOIncludeExcludeDeprecation(found_include=True, found_exclude=True),
+    core_types.ModelParamUsageDeprecation(),
     # E - DB Adapter ======================
     adapter_types.AdapterEventDebug(),
     adapter_types.AdapterEventInfo(),


### PR DESCRIPTION
Resolves #11561

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
--models, --model, and -m are getting deprecated! but they aren't straightforward to intercept via click because they are aliases for --select in many commands, and all get represented the same in click's internal params post-parsing.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Do a simple check within argv during the rest of deprecation firing when parsing flags.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

🎩 
```
❯ dbt compile -m microbatch_input
19:57:16  Running with dbt=1.11.0-a1
19:57:16  [WARNING]: Deprecated functionality
Usage of `--models`, `--model`, and `-m` is deprecated in favor of
`--resource-type model --select`
19:57:16  target not specified in profile 'snowflake', using 'default'
19:57:17  Registered adapter: snowflake=1.9.4
19:57:17  Unable to do partial parsing because saved manifest not found. Starting full parse.
...
19:57:18  [WARNING][DeprecationsSummary]: Deprecated functionality
Summary of encountered deprecations:
- ModelParamUsageDeprecation: 1 occurrence
To see all deprecation instances instead of just the first occurrence of each,
run command again with the `--show-all-deprecations` flag. You may also need to
run with `--no-partial-parse` as some deprecations are only encountered during
parsing.
```

```
❯ dbt compile --models microbatch_input
20:04:52  Running with dbt=1.11.0-a1
20:04:52  [WARNING]: Deprecated functionality
Usage of `--models`, `--model`, and `-m` is deprecated in favor of
`--resource-type model --select`
20:04:52  target not specified in profile 'snowflake', using 'default'
20:04:53  Registered adapter: snowflake=1.9.4
20:04:54  Unable to do partial parsing because saved manifest not found. Starting full parse.
...
20:04:55  [WARNING][DeprecationsSummary]: Deprecated functionality
Summary of encountered deprecations:
- ModelParamUsageDeprecation: 1 occurrence
To see all deprecation instances instead of just the first occurrence of each,
run command again with the `--show-all-deprecations` flag. You may also need to
run with `--no-partial-parse` as some deprecations are only encountered during
parsing.
```