### PR TITLE
move TestConfig.post_init logic to finalize_and_validate to respect hierarchical configs

### DIFF
--- a/.changes/unreleased/Fixes-20250612-145159.yaml
+++ b/.changes/unreleased/Fixes-20250612-145159.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix store_failures hierarachical config parsing
+time: 2025-06-12T14:51:59.358498-04:00
+custom:
+  Author: michelleark
+  Issue: "10165"

--- a/core/dbt/artifacts/resources/v1/config.py
+++ b/core/dbt/artifacts/resources/v1/config.py
@@ -181,7 +181,7 @@ class TestConfig(NodeAndTestConfig):
     warn_if: str = "!= 0"
     error_if: str = "!= 0"
 
-    def __post_init__(self):
+    def finalize_and_validate(self):
         """
         The presence of a setting for `store_failures_as` overrides any existing setting for `store_failures`,
         regardless of level of granularity. If `store_failures_as` is not set, then `store_failures` takes effect.
@@ -207,6 +207,7 @@ class TestConfig(NodeAndTestConfig):
         but still allow for backwards compatibility for `store_failures`.
         See https://github.com/dbt-labs/dbt-core/issues/6914 for more information.
         """
+        super().finalize_and_validate()
 
         # if `store_failures_as` is not set, it gets set by `store_failures`
         # the settings below mimic existing behavior prior to `store_failures_as`
@@ -228,6 +229,8 @@ class TestConfig(NodeAndTestConfig):
             self.store_failures_as = get_store_failures_as_map[self.store_failures]
         else:
             self.store_failures = get_store_failures_map.get(self.store_failures_as, True)
+
+        return self
 
     @classmethod
     def same_contents(cls, unrendered: Dict[str, Any], other: Dict[str, Any]) -> bool:

--- a/tests/functional/schema_tests/fixtures.py
+++ b/tests/functional/schema_tests/fixtures.py
@@ -1273,3 +1273,31 @@ models:
     data_tests:
       - my_custom_test
 """
+
+store_failures_models__my_model_sql = """
+select 1 as id
+"""
+
+store_failures_models_true__config_yml = """
+version: 2
+models:
+  - name: my_model
+    columns:
+      - name: id
+        tests:
+          - not_null:
+              config:
+                store_failures: true
+"""
+
+store_failures_models_false__config_yml = """
+version: 2
+models:
+  - name: my_model
+    columns:
+      - name: id
+        tests:
+          - not_null:
+              config:
+                store_failures: false
+"""


### PR DESCRIPTION
Resolves #10165

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

Hierarchical configs were not being respected when it came to store_failures. This was because the TestConfig.post_init method would mutate store_failures based on the. Because this method is called multiple times as configs are layered (first fqn, then node-level), this would prevent node-level configs from being applied correctly.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Move post_init logic to finalize_and_validate, which is only called at the end of config building, which this implementation had previously assumed.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
