### PR TITLE
drop model freshness as top level model property (in favor of config freshness)

### DIFF
--- a/.changes/unreleased/Fixes-20250616-085600.yaml
+++ b/.changes/unreleased/Fixes-20250616-085600.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: "Remove model freshness property support in favor of config level support"
+time: 2025-06-16T08:56:00.641553-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11713"

--- a/core/dbt/artifacts/resources/v1/model.py
+++ b/core/dbt/artifacts/resources/v1/model.py
@@ -114,7 +114,6 @@ class Model(CompiledResource):
     defer_relation: Optional[DeferRelation] = None
     primary_key: List[str] = field(default_factory=list)
     time_spine: Optional[TimeSpine] = None
-    freshness: Optional[ModelFreshness] = None
 
     def __post_serialize__(self, dct: Dict, context: Optional[Dict] = None):
         dct = super().__post_serialize__(dct, context)

--- a/core/dbt/context/context_config.py
+++ b/core/dbt/context/context_config.py
@@ -141,17 +141,21 @@ class BaseContextConfigGenerator(Generic[T]):
 
     def calculate_node_config(
         self,
+        # this is the config from the sql file
         config_call_dict: Dict[str, Any],
         fqn: List[str],
         resource_type: NodeType,
         project_name: str,
         base: bool,
+        # this is the config from the schema file
         patch_config_dict: Optional[Dict[str, Any]] = None,
     ) -> BaseConfig:
         own_config = self.get_node_project(project_name)
 
         result = self.initial_result(resource_type=resource_type, base=base)
 
+        # builds the config from what was specified in the runtime_config, which generally
+        # comes from the project's dbt_project.yml file.
         project_configs = self._project_configs(own_config, fqn, resource_type)
         for fqn_config in project_configs:
             result = self._update_from_config(result, fqn_config)

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -225,7 +225,6 @@ class UnparsedModelUpdate(UnparsedNodeUpdate):
     versions: Sequence[UnparsedVersion] = field(default_factory=list)
     deprecation_date: Optional[datetime.datetime] = None
     time_spine: Optional[TimeSpine] = None
-    freshness: Optional[Dict[str, Any]] = None
 
     def __post_init__(self) -> None:
         if self.latest_version:

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -18,12 +18,7 @@ from typing import (
 )
 
 from dbt.artifacts.resources import RefArgs
-from dbt.artifacts.resources.v1.model import (
-    CustomGranularity,
-    ModelFreshness,
-    TimeSpine,
-    merge_model_freshness,
-)
+from dbt.artifacts.resources.v1.model import CustomGranularity, TimeSpine
 from dbt.clients.checked_load import (
     checked_load,
     issue_deprecation_warnings_for_failures,
@@ -766,8 +761,6 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
         deprecation_date: Optional[datetime.datetime] = None
         time_spine: Optional[TimeSpine] = None
 
-        freshness: Optional[ModelFreshness] = None
-
         if isinstance(block.target, UnparsedModelUpdate):
             deprecation_date = block.target.deprecation_date
             time_spine = (
@@ -785,30 +778,6 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
                 else None
             )
 
-            try:
-                project_freshness_dict = self.project.models.get("+freshness", None)
-                project_freshness = (
-                    ModelFreshness.from_dict(project_freshness_dict)
-                    if project_freshness_dict and "build_after" in project_freshness_dict
-                    else None
-                )
-            except ValueError:
-                fire_event(
-                    Note(
-                        msg="Could not validate `freshness` for `models` in 'dbt_project.yml', ignoring.",
-                    ),
-                    EventLevel.WARN,
-                )
-                project_freshness = None
-
-            config_freshness_dict = block.target.config.get("freshness", None)
-            config_freshness = (
-                ModelFreshness.from_dict(config_freshness_dict)
-                if config_freshness_dict and "build_after" in config_freshness_dict
-                else None
-            )
-            freshness = merge_model_freshness(project_freshness, config_freshness)
-
         patch = ParsedNodePatch(
             name=block.target.name,
             original_file_path=block.target.original_file_path,
@@ -825,7 +794,6 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
             constraints=block.target.constraints,
             deprecation_date=deprecation_date,
             time_spine=time_spine,
-            freshness=freshness,
         )
         assert isinstance(self.yaml.file, SchemaSourceFile)
         source_file: SchemaSourceFile = self.yaml.file
@@ -1115,7 +1083,6 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
         # These two will have to be reapplied after config is built for versioned models
         self.patch_constraints(node, patch.constraints)
         self.patch_time_spine(node, patch.time_spine)
-        node.freshness = patch.freshness
         node.build_contract_checksum()
 
     def patch_constraints(self, node: ModelNode, constraints: List[Dict[str, Any]]) -> None:

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -801,20 +801,13 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
                 )
                 project_freshness = None
 
-            model_freshness_dict = block.target.freshness or None
-            model_freshness = (
-                ModelFreshness.from_dict(model_freshness_dict)
-                if model_freshness_dict and "build_after" in model_freshness_dict
-                else None
-            )
-
             config_freshness_dict = block.target.config.get("freshness", None)
             config_freshness = (
                 ModelFreshness.from_dict(config_freshness_dict)
                 if config_freshness_dict and "build_after" in config_freshness_dict
                 else None
             )
-            freshness = merge_model_freshness(project_freshness, model_freshness, config_freshness)
+            freshness = merge_model_freshness(project_freshness, config_freshness)
 
         patch = ParsedNodePatch(
             name=block.target.name,

--- a/tests/functional/artifacts/expected_manifest.py
+++ b/tests/functional/artifacts/expected_manifest.py
@@ -383,7 +383,6 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                 "version": None,
                 "latest_version": None,
                 "time_spine": None,
-                "freshness": None,
                 "doc_blocks": [],
             },
             "model.test.second_model": {
@@ -494,7 +493,6 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
                 "version": None,
                 "latest_version": None,
                 "time_spine": None,
-                "freshness": None,
                 "doc_blocks": [],
             },
             "seed.test.seed": {
@@ -1055,7 +1053,6 @@ def expected_references_manifest(project):
                 "latest_version": None,
                 "constraints": [],
                 "time_spine": None,
-                "freshness": None,
                 "doc_blocks": [],
             },
             "model.test.ephemeral_summary": {
@@ -1133,7 +1130,6 @@ def expected_references_manifest(project):
                 "latest_version": None,
                 "constraints": [],
                 "time_spine": None,
-                "freshness": None,
                 "doc_blocks": ["doc.test.ephemeral_summary"],
             },
             "model.test.view_summary": {
@@ -1207,7 +1203,6 @@ def expected_references_manifest(project):
                 "latest_version": None,
                 "constraints": [],
                 "time_spine": None,
-                "freshness": None,
                 "doc_blocks": ["doc.test.view_summary"],
             },
             "seed.test.seed": {
@@ -1709,7 +1704,6 @@ def expected_versions_manifest(project):
                 "version": 1,
                 "latest_version": 2,
                 "time_spine": None,
-                "freshness": None,
                 "doc_blocks": [],
             },
             "model.test.versioned_model.v2": {
@@ -1792,7 +1786,6 @@ def expected_versions_manifest(project):
                 "version": 2,
                 "latest_version": 2,
                 "time_spine": None,
-                "freshness": None,
                 "doc_blocks": [],
             },
             "model.test.ref_versioned_model": {
@@ -1852,7 +1845,6 @@ def expected_versions_manifest(project):
                 "version": None,
                 "latest_version": None,
                 "time_spine": None,
-                "freshness": None,
                 "doc_blocks": [],
             },
             "test.test.unique_versioned_model_v1_first_name.6138195dec": {

--- a/tests/functional/model_config/test_freshness_config.py
+++ b/tests/functional/model_config/test_freshness_config.py
@@ -22,9 +22,10 @@ sources:
   - name: my_source
     database: "{{ target.database }}"
     schema: "{{ target.schema }}"
-    freshness:
-      warn_after: {count: 24, period: hour}
-      error_after: {count: 48, period: hour}
+    config:
+      freshness:
+        warn_after: {count: 24, period: hour}
+        error_after: {count: 48, period: hour}
     loaded_at_field: _loaded_at
     tables:
       - name: source_table
@@ -35,16 +36,18 @@ models:
     description: Model with no freshness defined
   - name: model_b
     description: Model with only model freshness defined
-    freshness:
-      build_after:
-        count: 1
-        period: day
-        updates_on: all
+    config:
+      freshness:
+        build_after:
+          count: 1
+          period: day
+          updates_on: all
   - name: model_c
     description: Model with only source freshness defined
-    freshness:
-      warn_after: {count: 24, period: hour}
-      error_after: {count: 48, period: hour}
+    config:
+      freshness:
+        warn_after: {count: 24, period: hour}
+        error_after: {count: 48, period: hour}
     loaded_at_field: _loaded_at
     tables:
       - name: source_table

--- a/tests/unit/contracts/graph/test_manifest.py
+++ b/tests/unit/contracts/graph/test_manifest.py
@@ -98,7 +98,6 @@ REQUIRED_PARSED_NODE_KEYS = frozenset(
         "defer_relation",
         "time_spine",
         "batch",
-        "freshness",
     }
 )
 

--- a/tests/unit/parser/test_parser.py
+++ b/tests/unit/parser/test_parser.py
@@ -311,7 +311,7 @@ models:
       description: A description of my model
       config:
         freshness:
-          build_after: {count: 1, period: day, updates_on: any}
+          build_after: {count: 1, period: day, updates_on: all}
 """
 
 SINGLE_TABLE_MODEL_TOP_LEVEL_FRESHNESS = """
@@ -329,9 +329,9 @@ models:
       config:
         freshness:
           build_after:
-          updates_on: all
-          period: hour
-          count: 0
+            updates_on: all
+            period: hour
+            count: 5
 """
 
 
@@ -745,7 +745,7 @@ class SchemaParserModelsTest(SchemaParserTest):
         my_model_node = MockNode(
             package="root",
             name="my_model",
-            config=mock.MagicMock(enabled=True),
+            config=ModelConfig(enabled=True),
             refs=[],
             sources=[],
             patch_path=None,
@@ -778,7 +778,7 @@ class SchemaParserModelsTest(SchemaParserTest):
 
         assert self.parser.manifest.nodes[
             "model.root.my_model"
-        ].freshness.build_after == ModelBuildAfter(
+        ].config.freshness.build_after == ModelBuildAfter(
             count=1, period="day", updates_on=ModelFreshnessUpdatesOnOptions.all
         )
 
@@ -789,7 +789,11 @@ class SchemaParserModelsTest(SchemaParserTest):
         self.parser.parse_file(block, dct)
         self.assert_has_manifest_lengths(self.parser.manifest, nodes=1)
 
-        assert self.parser.manifest.nodes["model.root.my_model"].freshness is None
+        # we can't use hasattr because the model node is a mock, and checking with hasattr will add it to the mock
+        assert "freshness" not in self.parser.manifest.nodes["model.root.my_model"].__dir__()
+
+        # should be None because nothing set it
+        assert self.parser.manifest.nodes["model.root.my_model"].config.freshness is None
 
     def test__parse_model_freshness_depend_on(self):
         block = self.file_block_for(SINGLE_TABLE_MODEL_FRESHNESS_ONLY_DEPEND_ON, "test_one.yml")
@@ -799,8 +803,8 @@ class SchemaParserModelsTest(SchemaParserTest):
         self.assert_has_manifest_lengths(self.parser.manifest, nodes=1)
         assert self.parser.manifest.nodes[
             "model.root.my_model"
-        ].freshness.build_after == ModelBuildAfter(
-            count=0, period="hour", updates_on=ModelFreshnessUpdatesOnOptions.all
+        ].config.freshness.build_after == ModelBuildAfter(
+            count=5, period="hour", updates_on=ModelFreshnessUpdatesOnOptions.all
         )
 
     def test__read_basic_model_tests_wrong_severity(self):


### PR DESCRIPTION
Resolves #11713 

### Problem

We first started building model freshness _before_ we decided to move freshness speciations from top level resource properties to config level properties. Since model freshness hasn't been release in any minor version yet, we should take the time now to drop the top level resource property so that we don't introduce something that's immediately going to be deprecated

### Solution

Remove the top level `freshness` property on models

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
