### PR TITLE
deprecate modules.itertools usage

### DIFF
--- a/.changes/unreleased/Features-20250728-115443.yaml
+++ b/.changes/unreleased/Features-20250728-115443.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Deprecate {{ modules.itertools }} usage
+time: 2025-07-28T11:54:43.28275-04:00
+custom:
+    Author: michelleark
+    Issue: "11725"

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Dict, Iterable, List, Mapping, NoReturn, Optio
 # approaches which will extend well to potentially many modules
 import pytz
 
+import dbt.deprecations as deprecations
 import dbt.flags as flags_module
 from dbt import tracking, utils
 from dbt.clients.jinja import get_rendered
@@ -85,8 +86,7 @@ def get_itertools_module_context() -> Dict[str, Any]:
 
     def deprecation_wrapper(fn):
         def deprecation_wrapper_inner():
-            # TODO: call dbt.deprecations.warn + plumb that through
-            print("deprecated!")
+            deprecations.warn("modules-itertools-usage-deprecation")
             return fn
 
         return deprecation_wrapper_inner

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -83,7 +83,15 @@ def get_itertools_module_context() -> Dict[str, Any]:
         "combinations_with_replacement",
     ]
 
-    return {name: getattr(itertools, name) for name in context_exports}
+    def deprecation_wrapper(fn):
+        def deprecation_wrapper_inner():
+            # TODO: call dbt.deprecations.warn + plumb that through
+            print("deprecated!")
+            return fn
+
+        return deprecation_wrapper_inner
+
+    return {name: deprecation_wrapper(getattr(itertools, name)) for name in context_exports}
 
 
 def get_context_modules() -> Dict[str, Dict[str, Any]]:

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -85,9 +85,9 @@ def get_itertools_module_context() -> Dict[str, Any]:
     ]
 
     def deprecation_wrapper(fn):
-        def deprecation_wrapper_inner():
+        def deprecation_wrapper_inner(*args, **kwargs):
             deprecations.warn("modules-itertools-usage-deprecation")
-            return fn
+            return fn(*args, **kwargs)
 
         return deprecation_wrapper_inner
 

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -225,6 +225,11 @@ class MissingArgumentsPropertyInGenericTestDeprecation(DBTDeprecation):
     _event = "MissingArgumentsPropertyInGenericTestDeprecation"
 
 
+class ModulesItertoolsUsageDeprecation(DBTDeprecation):
+    _name = "modules-itertools-usage-deprecation"
+    _event = "ModulesItertoolsUsageDeprecation"
+
+
 def renamed_env_var(old_name: str, new_name: str):
     class EnvironmentVariableRenamed(DBTDeprecation):
         _name = f"environment-variable-renamed:{old_name}"
@@ -310,6 +315,7 @@ deprecations_list: List[DBTDeprecation] = [
     MissingPlusPrefixDeprecation(),
     ArgumentsPropertyInGenericTestDeprecation(),
     MissingArgumentsPropertyInGenericTestDeprecation(),
+    ModulesItertoolsUsageDeprecation(),
 ]
 
 deprecations: Dict[str, DBTDeprecation] = {d.name: d for d in deprecations_list}

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -715,6 +715,17 @@ class ModelParamUsageDeprecation(WarnLevel):
         return line_wrap_message(deprecation_tag(description))
 
 
+class ModulesItertoolsUsageDeprecation(WarnLevel):
+    def code(self) -> str:
+        return "D034"
+
+    def message(self) -> str:
+        description = (
+            "Usage of itertools modules is deprecated. Please use the built-in functions instead."
+        )
+        return line_wrap_message(deprecation_tag(description))
+
+
 class SourceOverrideDeprecation(WarnLevel):
     def code(self) -> str:
         return "D035"

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -838,12 +838,3 @@ class TestMissingArgumentsPropertyInGenericTestDeprecation:
             callbacks=[event_catcher.catch],
         )
         assert len(event_catcher.caught_events) == 4
-class TestModulesItertoolsDeprecation:
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "models_itertools.sql": "select {{ modules.itertools.count() }}",
-        }
-
-    def test_models_itertools(self, project):
-        run_dbt(["parse", "--no-partial-parse"])  # , callbacks=[event_catcher.catch])

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -23,6 +23,7 @@ from dbt.events.types import (
     MissingArgumentsPropertyInGenericTestDeprecation,
     MissingPlusPrefixDeprecation,
     ModelParamUsageDeprecation,
+    ModulesItertoolsUsageDeprecation,
     PackageRedirectDeprecation,
     WEOIncludeExcludeDeprecation,
 )
@@ -506,6 +507,39 @@ class TestWEOIncludeExcludeDeprecation:
                 assert "exclude" in event_catcher.caught_events[0].info.msg
             else:
                 assert "exclude" not in event_catcher.caught_events[0].info.msg
+
+
+class TestModulesItertoolsDeprecation:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "models_itertools.sql": "select {{ modules.itertools.count() }}",
+        }
+
+    def test_models_itertools(self, project):
+        event_catcher = EventCatcher(ModulesItertoolsUsageDeprecation)
+
+        run_dbt(["parse", "--no-partial-parse"], callbacks=[event_catcher.catch])
+
+        assert len(event_catcher.caught_events) == 1
+        assert (
+            "Usage of itertools modules is deprecated" in event_catcher.caught_events[0].info.msg
+        )
+
+
+class TestNoModulesItertoolsDeprecation:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "models_itertools.sql": "select {{ modules.datetime.datetime.now() }}",
+        }
+
+    def test_models_itertools(self, project):
+        event_catcher = EventCatcher(ModulesItertoolsUsageDeprecation)
+
+        run_dbt(["parse", "--no-partial-parse"], callbacks=[event_catcher.catch])
+
+        assert len(event_catcher.caught_events) == 0
 
 
 class TestModelsParamUsageDeprecation:

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -791,3 +791,12 @@ class TestMissingArgumentsPropertyInGenericTestDeprecation:
             callbacks=[event_catcher.catch],
         )
         assert len(event_catcher.caught_events) == 4
+class TestModulesItertoolsDeprecation:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "models_itertools.sql": "select {{ modules.itertools.count() }}",
+        }
+
+    def test_models_itertools(self, project):
+        run_dbt(["parse", "--no-partial-parse"])  # , callbacks=[event_catcher.catch])

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -27,7 +27,7 @@ from dbt.events.types import (
     PackageRedirectDeprecation,
     WEOIncludeExcludeDeprecation,
 )
-from dbt.tests.util import run_dbt, run_dbt_and_capture, write_file
+from dbt.tests.util import read_file, run_dbt, run_dbt_and_capture, write_file
 from dbt_common.events.types import Note
 from dbt_common.exceptions import EventCompilationError
 from tests.functional.deprecations.fixtures import (
@@ -513,17 +513,30 @@ class TestModulesItertoolsDeprecation:
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "models_itertools.sql": "select {{ modules.itertools.count() }}",
+            "models_itertools.sql": """
+            {%- set A = [1] -%}
+            {%- set B = ['x'] -%}
+            {%- set AB_cartesian = modules.itertools.product(A, B) -%}
+
+            {%- for item in AB_cartesian %}
+              select {{ item[0] }}
+            {%- endfor -%}
+            """,
         }
 
     def test_models_itertools(self, project):
         event_catcher = EventCatcher(ModulesItertoolsUsageDeprecation)
 
-        run_dbt(["parse", "--no-partial-parse"], callbacks=[event_catcher.catch])
+        run_dbt(["run", "--no-partial-parse"], callbacks=[event_catcher.catch])
 
         assert len(event_catcher.caught_events) == 1
         assert (
             "Usage of itertools modules is deprecated" in event_catcher.caught_events[0].info.msg
+        )
+
+        assert (
+            read_file("target/compiled/test/models/models_itertools.sql").strip()
+            == "select 1".strip()
         )
 
 

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -175,6 +175,7 @@ sample_values = [
     core_types.MissingPlusPrefixDeprecation(key="", key_path="", file=""),
     core_types.ArgumentsPropertyInGenericTestDeprecation(test_name=""),
     core_types.MissingArgumentsPropertyInGenericTestDeprecation(test_name=""),
+    core_types.ModulesItertoolsUsageDeprecation(),
     # E - DB Adapter ======================
     adapter_types.AdapterEventDebug(),
     adapter_types.AdapterEventInfo(),


### PR DESCRIPTION
Resolves #11725

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
modules.itertools will not be supported by the fusion engine

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
* raise deprecation warning on access of modules.itertools method

🎩 
```
(core) ➜  jaffle-shop git:(main) ✗ dbt --no-partial-parse parse 
15:49:32  Running with dbt=1.11.0-a1
15:49:32  Registered adapter: postgres=1.9.1-a0
15:49:33  [WARNING]: Deprecated functionality
Usage of itertools modules is deprecated. Please use the built-in functions
instead.
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
