### PR TITLE
Bump minimum jsonschema version to `4.19.1`

### DIFF
--- a/.changes/unreleased/Dependencies-20250616-144408.yaml
+++ b/.changes/unreleased/Dependencies-20250616-144408.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump minimum jsonschema version to `4.19.1`
+time: 2025-06-16T14:44:08.512306-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11740"

--- a/core/setup.py
+++ b/core/setup.py
@@ -56,6 +56,7 @@ setup(
         # dbt-core uses these packages in standard ways. Pin to the major version, and check compatibility
         # with major versions in each new minor version of dbt-core.
         "click>=8.0.2,<9.0",
+        "jsonschema>=4.19.1,<5.0",
         "networkx>=2.3,<4.0",
         "protobuf>=5.0,<6.0",
         "requests<3.0.0",  # should match dbt-common


### PR DESCRIPTION
Resolves #11740 

### Description

In 1.10.0 we began utilizing `jsonschema._keywords`. However, the submodule `_keywords` wasn't added until jsonschema `4.19.1` which came out September 20th, 2023. Our jsonschema requirement was being set transitively via dbt-common as `>=4.0,<5`. This mean people doing a _non_ fresh install of dbt-core `1.10.0` could end up with a broken system if their existing jsonschema dependency was anywhere in the range `>=4.0,<4.19.1`. By bumping the minimum jsonschema version we make it such that anyone install dbt-core 1.10.1 will automatically get there jsonschema updated (assuming they don't have an exclusionary pin)

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
