### PR TITLE
Bump minimum jsonschema version to `4.19.1` (#11741)

### DIFF
--- a/.changes/unreleased/Dependencies-20250616-144408.yaml
+++ b/.changes/unreleased/Dependencies-20250616-144408.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump minimum jsonschema version to `4.19.1`
+time: 2025-06-16T14:44:08.512306-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11740"

--- a/core/setup.py
+++ b/core/setup.py
@@ -56,6 +56,7 @@ setup(
         # dbt-core uses these packages in standard ways. Pin to the major version, and check compatibility
         # with major versions in each new minor version of dbt-core.
         "click>=8.0.2,<9.0",
+        "jsonschema>=4.19.1,<5.0",
         "networkx>=2.3,<4.0",
         "protobuf>=5.0,<6.0",
         "requests<3.0.0",  # should match dbt-common


### PR DESCRIPTION
Backports #11741 (resolving #11740) to 1.10.latest