### PR TITLE
bump dbt-common to 1.25.0 to access WarnErrorOptionsV2

### DIFF
--- a/.changes/unreleased/Fixes-20250624-091258.yaml
+++ b/.changes/unreleased/Fixes-20250624-091258.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Bump dbt-common to 1.25.0 to access WarnErrorOptionsV2
+time: 2025-06-24T09:12:58.904713-04:00
+custom:
+  Author: michelleark
+  Issue: "11755"

--- a/core/setup.py
+++ b/core/setup.py
@@ -72,7 +72,7 @@ setup(
         "dbt-extractor>=0.5.0,<=0.6",
         "dbt-semantic-interfaces>=0.8.3,<0.9",
         # Minor versions for these are expected to be backwards-compatible
-        "dbt-common>=1.22.0,<2.0",
+        "dbt-common>=1.25.0,<2.0",
         "dbt-adapters>=1.15.2,<2.0",
         "dbt-protos>=1.0.315,<2.0",
         # ----


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/11755

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
dbt-core==1.10 started using `WarnErrorOptionsV2` in dbt-common, which was released in 1.25.0.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Bump minimum requirement of dbt-common to avoid missing property exceptions.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
