### PR TITLE
skip health check on flaky test

### DIFF
--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -2,7 +2,7 @@ import copy
 from typing import Protocol, runtime_checkable
 
 import pytest
-from hypothesis import given
+from hypothesis import HealthCheck, given, settings
 from hypothesis.strategies import builds, none, text
 
 from dbt.artifacts.resources import (
@@ -506,5 +506,6 @@ def test_non_additive_dimension_satisfies_protocol(non_additive_dimension):
         metadata=builds(SourceFileMetadata) | none(),
     )
 )
+@settings(suppress_health_check=(HealthCheck.too_slow,))
 def test_saved_query_satisfies_protocol(saved_query: SavedQuery):
     assert isinstance(saved_query, SavedQuery)


### PR DESCRIPTION
Resolves #N/A

This test has been flaking because the hypothesis health check (not the test itself) errors when data generation takes too long (time-based == flaky). Removing the health check to mitigate.

Example failure: https://github.com/dbt-labs/dbt-common/actions/runs/15858347062/job/44709118840