### PR TITLE
Set `flags.INVOCATION_COMMAND` for programmatic invocations on a best-effort basis

### DIFF
--- a/.changes/unreleased/Fixes-20250627-093325.yaml
+++ b/.changes/unreleased/Fixes-20250627-093325.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Set `flags.INVOCATION_COMMAND` for programmatic invocations on a best-effort basis
+time: 2025-06-27T09:33:25.560217-06:00
+custom:
+    Author: dbeatty10
+    Issue: "10313"

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -261,8 +261,9 @@ class Flags:
             else:
                 project_flags = None
 
-        # Add entire invocation command to flags
-        object.__setattr__(self, "INVOCATION_COMMAND", "dbt " + " ".join(sys.argv[1:]))
+        # Add entire invocation command to flags on a best-effort basis (either from env var or from sys.argv)
+        invocation_command = os.getenv("DBT_EQUIVALENT_COMMAND", "dbt " + " ".join(sys.argv[1:]))
+        object.__setattr__(self, "INVOCATION_COMMAND", invocation_command)
 
         if project_flags:
             # Overwrite default assignments with project flags if available.

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -66,7 +66,7 @@ def get_equivalent_cli_command(args: List[str], **kwargs) -> str:
             # Add both the flag and its value for other types
             # This is a best-effort conversion, so we ignore exceptions
             try:
-                cli_command.extend([cli_key, str(value)])
+                cli_args.extend([cli_key, str(value)])
             except Exception as e:
                 pass
 

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -67,7 +67,7 @@ def get_equivalent_cli_command(args: List[str], **kwargs) -> str:
             # This is a best-effort conversion, so we ignore exceptions
             try:
                 cli_args.extend([get_equivalent_cli_flag(key), str(value)])
-            except Exception as e:
+            except Exception:
                 pass
 
     # Ensure all CLI arguments are quoted as needed

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -39,9 +39,12 @@ class dbtRunnerResult:
     ] = None
 
 
-def get_equivalent_cli_flag(config_name: str) -> str:
+def get_equivalent_cli_flag(config_name: str, positive_config: bool = True) -> str:
     """Convert a config name to its equivalent CLI flag"""
-    return f"--{config_name.replace('_', '-')}"
+    if positive_config:
+        return f"--{config_name.replace('_', '-')}"
+    else:
+        return f"--no-{config_name.replace('_', '-')}"
 
 
 def get_equivalent_cli_command(args: List[str], **kwargs) -> str:
@@ -50,23 +53,20 @@ def get_equivalent_cli_command(args: List[str], **kwargs) -> str:
     # Convert all values in `args` to strings
     cli_args = [str(arg) for arg in args]
 
+    # Convert each keyword arg to its CLI flag equivalent
     for key, value in kwargs.items():
-        # Convert all keyword args to their CLI flag equivalent
-        cli_key = get_equivalent_cli_flag(key)
-
         if type(value) is bool:
-            # Add just the flag (without the value) for booleans (and only if True)
-            if value:
-                cli_args.append(cli_key)
+            # Add just the flag (without the value) for booleans
+            cli_args.append(get_equivalent_cli_flag(key, value))
         elif type(value) in {list, tuple}:
             # Add both the flag and its values for lists/tuples
-            cli_args.append(cli_key)
+            cli_args.append(get_equivalent_cli_flag(key))
             cli_args.extend(map(str, value))
         else:
             # Add both the flag and its value for other types
             # This is a best-effort conversion, so we ignore exceptions
             try:
-                cli_args.extend([cli_key, str(value)])
+                cli_args.extend([get_equivalent_cli_flag(key), str(value)])
             except Exception as e:
                 pass
 


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/10313

### Problem

For programmatic invocations, the `flags.INVOCATION_COMMAND` within the invocation has whatever args were passed to the python script rather than the equivalent CLI command for dbt.

There is currently no testing in CI related to `flags.INVOCATION_COMMAND`, and we consider this an informal feature rather than a fully-supported one.

### Solution

Set a global variable named `DBT_EQUIVALENT_COMMAND` within `dbtRunner.invoke` and read from it within `Flags.__init__`.

### Testing

Since this is still merely best-effort, no new functional tests are included in this PR.

All the dbt functional tests will hit these code paths though, so we can see that they don't generate any exceptions.

### Behavior for boolean flags

This code results in the following behavior:

```py
        if type(value) is bool:
            # Add just the flag (without the value) for booleans (and only if True)
            if value:
                cli_args.append(cli_key)
```

Actual behavior in the comments:

```py
    dbt_runner.invoke(["compile", "--use-colors"])  # INVOCATION_COMMAND = dbt compile --use-colors
    dbt_runner.invoke(["compile", "--no-use-colors"])  # INVOCATION_COMMAND = dbt compile --no-use-colors
    dbt_runner.invoke(["compile"], use_colors=True)  # INVOCATION_COMMAND = dbt compile --use-colors
    dbt_runner.invoke(["compile"], use_colors=False)  # INVOCATION_COMMAND = dbt compile
    dbt_runner.invoke(["compile"], no_use_colors=True)  # INVOCATION_COMMAND = dbt compile --no-use-colors
    dbt_runner.invoke(["compile"], no_use_colors=False)  # INVOCATION_COMMAND = dbt compile
```

In an ideal world, the code above would provide convert into the _opposite_ CLI flag whenever the boolean value is false. But I don't think it is necessary to do here since users can do it on their end.

### Assumptions

### Implementation decisions

Went with a environment variable rather than a global variable with thread-safety in mind:

Method | Thread-safe? | Best when...
-- | -- | --
Environment variable | ✅ Yes | Config shared across subprocesses or between programs
Global variable | ❌ No | Quick access across functions or modules in one process

### Caveats

If `flags.INVOCATION_COMMAND` is accessed without actually running a `click`-based CLI command or without using `invoke`, this solution still won't have the equivalent CLI command. For example, some unit testing in the dbt-core repo will access `flags` without `invoke` or running a CLI command.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
