### PR TITLE
Stop dynamically setting ubuntu version for `main.yml` and structured logging actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
   code-quality:
     name: code-quality
 
-    runs-on: ${{ vars.UBUNTU_LATEST }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -69,7 +69,7 @@ jobs:
   unit:
     name: unit test / python ${{ matrix.python-version }}
 
-    runs-on: ${{ vars.UBUNTU_LATEST }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     strategy:
@@ -119,7 +119,7 @@ jobs:
 
   integration-metadata:
     name: integration test metadata generation
-    runs-on: ${{ vars.UBUNTU_LATEST }}
+    runs-on: ubuntu-latest
     outputs:
       split-groups: ${{ steps.generate-split-groups.outputs.split-groups }}
       include: ${{ steps.generate-include.outputs.include }}
@@ -163,7 +163,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
-        os: ["${{ vars.UBUNTU_LATEST }}"]
+        os: ["ubuntu-latest"]
         split-group: ${{ fromJson(needs.integration-metadata.outputs.split-groups) }}
     env:
       TOXENV: integration
@@ -334,7 +334,7 @@ jobs:
   integration-report:
     if: ${{ always() }}
     name: Integration Test Suite
-    runs-on: ${{ vars.UBUNTU_LATEST }}
+    runs-on: ubuntu-latest
     needs: [integration-mac-windows, integration-postgres]
     steps:
       - name: "Integration Tests Failed"
@@ -351,7 +351,7 @@ jobs:
   build:
     name: build packages
 
-    runs-on: ${{ vars.UBUNTU_LATEST }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/structured-logging-schema-check.yml
+++ b/.github/workflows/structured-logging-schema-check.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   integration-metadata:
     name: integration test metadata generation
-    runs-on: ${{ vars.UBUNTU_LATEST }}
+    runs-on: ubuntu-latest
     outputs:
       split-groups: ${{ steps.generate-split-groups.outputs.split-groups }}
 
@@ -45,7 +45,7 @@ jobs:
   # run the performance measurements on the current or default branch
   test-schema:
     name: Test Log Schema
-    runs-on: ${{ vars.UBUNTU_LATEST }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     needs:
       - integration-metadata
@@ -127,7 +127,7 @@ jobs:
 
   test-schema-report:
     name: Log Schema Test Suite
-    runs-on: ${{ vars.UBUNTU_LATEST }}
+    runs-on: ubuntu-latest
     needs: test-schema
     steps:
       - name: "[Notification] Log test suite passes"


### PR DESCRIPTION
Resolves #N/A

Of note, I did this as a fork in order to test the changes

### Description

These actions are important to run on community PRs. However these workflows use `on: pull_request` instead of `on: pull_request_target`. That is intentional, as `on: pull_request` doesn't give access to variables or secrets, and we need to keep it that way for security purposes. The these actions were trying to access a variable, which they don't have access to. This was a nicety for us, because sometimes we'd delay moving to github's `ubuntu-latest`. However, the security concern is more important, and thus we lose the variable for these workflows.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
