### PR TITLE
Bump dbt-common minimum to 1.25.1

### DIFF
--- a/.changes/unreleased/Dependencies-20250702-144720.yaml
+++ b/.changes/unreleased/Dependencies-20250702-144720.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump dbt-common minimum to 1.25.1
+time: 2025-07-02T14:47:20.772002-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11789"

--- a/core/setup.py
+++ b/core/setup.py
@@ -72,7 +72,7 @@ setup(
         "dbt-extractor>=0.5.0,<=0.6",
         "dbt-semantic-interfaces>=0.8.3,<0.9",
         # Minor versions for these are expected to be backwards-compatible
-        "dbt-common>=1.25.0,<2.0",
+        "dbt-common>=1.25.1,<2.0",
         "dbt-adapters>=1.15.2,<2.0",
         "dbt-protos>=1.0.335,<2.0",
         "pydantic<3",


### PR DESCRIPTION
Resolves #11789

### Problem

dbt-common `1.25.0` doesn't have a bug fix that was introduced in `1.25.1`. We want to guarantee that bug fix is installed

### Solution

Bump minimum dbt-common to `1.25.1`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
