### PR TITLE
update ModelParamUsageDeprecation message

### DIFF
--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -709,7 +709,9 @@ class ModelParamUsageDeprecation(WarnLevel):
         return "D032"
 
     def message(self) -> str:
-        description = "Usage of `--models`, `--model`, and `-m` is deprecated in favor of `--resource-type model --select`"
+        description = (
+            "Usage of `--models`, `--model`, and `-m` is deprecated in favor of `--select`."
+        )
         return line_wrap_message(deprecation_tag(description))
 
 

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -709,9 +709,7 @@ class ModelParamUsageDeprecation(WarnLevel):
         return "D032"
 
     def message(self) -> str:
-        description = (
-            "Usage of `--models`, `--model`, and `-m` is deprecated in favor of `--select`."
-        )
+        description = "Usage of `--models`, `--model`, and `-m` is deprecated in favor of `--select` or `-s`."
         return line_wrap_message(deprecation_tag(description))
 
 


### PR DESCRIPTION
Resolves #N/A

Updating description message for --models deprecation warning, as it was confusing for customers applying `--resource-type` to commands that don't support it (e.g. dbt run).
