### PR TITLE
Move source overrides deprecation to jsonschema

### DIFF
--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -718,7 +718,7 @@ class SourceOverrideDeprecation(WarnLevel):
         return "D035"
 
     def message(self) -> str:
-        description = f"The deprecated property `overrides` was found on source `{self.source_name}` in file `{self.file}`."
+        description = f"The source property `overrides` is deprecated but was found on source `{self.source_name}` in file `{self.file}`. Instead, `enabled` should be used to disable the unwanted source."
         return line_wrap_message(deprecation_tag(description))
 
 

--- a/core/dbt/jsonschemas.py
+++ b/core/dbt/jsonschemas.py
@@ -106,12 +106,20 @@ def jsonschema_validate(schema: Dict[str, Any], json: Dict[str, Any], file_path:
             else:
                 key_path = error_path_to_string(error)
                 for key in keys:
-                    deprecations.warn(
-                        "custom-key-in-object-deprecation",
-                        key=key,
-                        file=file_path,
-                        key_path=key_path,
-                    )
+                    if key == "overrides" and key_path.startswith("sources"):
+
+                        deprecations.warn(
+                            "source-override-deprecation",
+                            source_name=key_path.split(".")[-1],
+                            file=file_path,
+                        )
+                    else:
+                        deprecations.warn(
+                            "custom-key-in-object-deprecation",
+                            key=key,
+                            file=file_path,
+                            key_path=key_path,
+                        )
         elif error.validator == "type" and "deprecation_date" not in error_path:
             # Not deprecating invalid types yet, except for pre-existing deprecation_date deprecation
             pass

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -17,7 +17,6 @@ from typing import (
     TypeVar,
 )
 
-import dbt.deprecations as deprecations
 from dbt.artifacts.resources import RefArgs
 from dbt.artifacts.resources.v1.model import CustomGranularity, TimeSpine
 from dbt.clients.checked_load import (
@@ -538,9 +537,6 @@ class SourceParser(YamlReader):
                     raise DuplicateSourcePatchNameError(patch, self.manifest.source_patches[key])
                 self.manifest.source_patches[key] = patch
                 source_file.source_patches.append(key)
-                deprecations.warn(
-                    "source-override-deprecation", source_name=patch.name, file=str(patch.path)
-                )
             else:
                 source = self._target_from_dict(UnparsedSourceDefinition, data)
                 # Store unrendered_database and unrendered_schema for state:modified comparisons

--- a/tests/functional/source_overrides/test_simple_source_override.py
+++ b/tests/functional/source_overrides/test_simple_source_override.py
@@ -1,4 +1,6 @@
+import os
 from datetime import datetime, timedelta, timezone
+from unittest import mock
 
 import pytest
 
@@ -96,6 +98,7 @@ class TestSourceOverride:
 
         return insert_id + 1
 
+    @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
     def test_source_overrides(self, project):
         insert_id = 101
 


### PR DESCRIPTION
Resolves #11566 

### Description

Source overrides were being identified and having a deprecation warning _outside_ the jsonschema validation flow. However, the jsonschema validation flow will also catch it. Thus it makes sense to move the identification + deprecation emitting to the jsonschema validation flow

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
