### PR TITLE
Upgrade to DSI 0.9.0 for more robust saved query support

### DIFF
--- a/.changes/unreleased/Dependencies-20250709-132213.yaml
+++ b/.changes/unreleased/Dependencies-20250709-132213.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Upgrade to dbt-semantic-interfaces==0.9.0 for more robust saved query support.
+time: 2025-07-09T13:22:13.688162-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "11809"

--- a/core/dbt/artifacts/resources/v1/semantic_layer_components.py
+++ b/core/dbt/artifacts/resources/v1/semantic_layer_components.py
@@ -2,9 +2,10 @@ from dataclasses import dataclass
 from typing import List, Sequence, Tuple
 
 from dbt_common.dataclass_schema import dbtClassMixin
-from dbt_semantic_interfaces.call_parameter_sets import FilterCallParameterSets
-from dbt_semantic_interfaces.parsing.where_filter.where_filter_parser import (
-    WhereFilterParser,
+from dbt_semantic_interfaces.call_parameter_sets import JinjaCallParameterSets
+from dbt_semantic_interfaces.parsing.where_filter.jinja_object_parser import (
+    JinjaObjectParser,
+    QueryItemLocation,
 )
 
 
@@ -14,9 +15,11 @@ class WhereFilter(dbtClassMixin):
 
     def call_parameter_sets(
         self, custom_granularity_names: Sequence[str]
-    ) -> FilterCallParameterSets:
-        return WhereFilterParser.parse_call_parameter_sets(
-            self.where_sql_template, custom_granularity_names=custom_granularity_names
+    ) -> JinjaCallParameterSets:
+        return JinjaObjectParser.parse_call_parameter_sets(
+            self.where_sql_template,
+            custom_granularity_names=custom_granularity_names,
+            query_item_location=QueryItemLocation.NON_ORDER_BY,
         )
 
 
@@ -26,7 +29,7 @@ class WhereFilterIntersection(dbtClassMixin):
 
     def filter_expression_parameter_sets(
         self, custom_granularity_names: Sequence[str]
-    ) -> Sequence[Tuple[str, FilterCallParameterSets]]:
+    ) -> Sequence[Tuple[str, JinjaCallParameterSets]]:
         raise NotImplementedError
 
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -70,7 +70,7 @@ setup(
         # These are major-version-0 packages also maintained by dbt-labs.
         # Accept patches but avoid automatically updating past a set minor version range.
         "dbt-extractor>=0.5.0,<=0.6",
-        "dbt-semantic-interfaces>=0.8.3,<0.9",
+        "dbt-semantic-interfaces>=0.9.0,<0.10",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.25.1,<2.0",
         "dbt-adapters>=1.15.2,<2.0",

--- a/tests/functional/saved_queries/fixtures.py
+++ b/tests/functional/saved_queries/fixtures.py
@@ -17,8 +17,8 @@ saved_queries:
             - "{{ TimeDimension('id__ds', 'DAY') }} >= '2023-01-01'"
             - "{{ Metric('txn_revenue', ['id']) }} > 1"
         order_by:
-            - "Metric('simple_metric')"
-            - "Dimension('id__ds')"
+            - Metric('simple_metric').descending(True)
+            - "Dimension('id__ds').descending(True)"
         limit: 10
     exports:
         - name: my_export


### PR DESCRIPTION
Resolves #11809


### Problem
On saved queries, `order_by` and `limit` are supported YAML keys, but full support has not been added previously.

### Solution
This is one step in finalizing support for them. The new DSI version has changes to the Jinja parsing logic that will better support the `order_by` key (e.g., allowing the `descending` param and object syntax for metrics).
Note this new version has some breaking changes (changes to class names). This won't impact semantic manifest parsing.
The artifact change action seems to be responding to changes to the python files, though the actual manifest artifacts should not be changed.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
