### PR TITLE
Make `GenericJSONSchemaValidationDeprecation` a "preview" deprecation

### DIFF
--- a/.changes/unreleased/Fixes-20250710-170148.yaml
+++ b/.changes/unreleased/Fixes-20250710-170148.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Make `GenericJSONSchemaValidationDeprecation` a "preview" deprecation
+time: 2025-07-10T17:01:48.903582-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11814"

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -152,6 +152,7 @@ class MicrobatchMacroOutsideOfBatchesDeprecation(DBTDeprecation):
 class GenericJSONSchemaValidationDeprecation(DBTDeprecation):
     _name = "generic-json-schema-validation-deprecation"
     _event = "GenericJSONSchemaValidationDeprecation"
+    _is_preview = True
 
 
 class UnexpectedJinjaBlockDeprecation(DBTDeprecation):

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -593,9 +593,11 @@ class GenericJSONSchemaValidationDeprecation(WarnLevel):
 
     def message(self) -> str:
         if self.key_path == "":
-            description = f"{self.violation} at top level in file `{self.file}`"
+            description = (
+                f"{self.violation} at top level in file `{self.file}` is possibly a deprecation"
+            )
         else:
-            description = f"{self.violation} in file `{self.file}` at path `{self.key_path}`"
+            description = f"{self.violation} in file `{self.file}` at path `{self.key_path}` is possibly a deprecation"
 
         return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -592,12 +592,12 @@ class GenericJSONSchemaValidationDeprecation(WarnLevel):
         return "D022"
 
     def message(self) -> str:
+        possible_causes = "This generally means that either we failed to catch this as a more specific deprecation type OR our JSONSchema had a regression (and this deprecation was erroneous)."
+
         if self.key_path == "":
-            description = (
-                f"{self.violation} at top level in file `{self.file}` is possibly a deprecation"
-            )
+            description = f"{self.violation} at top level in file `{self.file}` is possibly a deprecation. {possible_causes}"
         else:
-            description = f"{self.violation} in file `{self.file}` at path `{self.key_path}` is possibly a deprecation"
+            description = f"{self.violation} in file `{self.file}` at path `{self.key_path}` is possibly a deprecation. {possible_causes}"
 
         return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -10,7 +10,9 @@ import dbt_common
 from dbt import deprecations
 from dbt.cli.main import dbtRunner
 from dbt.clients.registry import _get_cached
-from dbt.deprecations import GenericJSONSchemaValidationDeprecation as GJVD
+from dbt.deprecations import (
+    GenericJSONSchemaValidationDeprecation as GenericJSONSchemaValidationDeprecationCore,
+)
 from dbt.events.types import (
     CustomKeyInConfigDeprecation,
     CustomKeyInObjectDeprecation,
@@ -319,7 +321,7 @@ class TestDeprecatedInvalidDeprecationDate:
                 True
             ), "Expected an exception to be raised, because a model object can't be created with a deprecation_date as an int"
 
-        if GJVD()._is_preview:
+        if GenericJSONSchemaValidationDeprecationCore()._is_preview:
             assert len(note_catcher.caught_events) == 1
             assert len(event_catcher.caught_events) == 0
             event = note_catcher.caught_events[0]

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -10,6 +10,7 @@ import dbt_common
 from dbt import deprecations
 from dbt.cli.main import dbtRunner
 from dbt.clients.registry import _get_cached
+from dbt.deprecations import GenericJSONSchemaValidationDeprecation as GJVD
 from dbt.events.types import (
     CustomKeyInConfigDeprecation,
     CustomKeyInObjectDeprecation,
@@ -23,6 +24,7 @@ from dbt.events.types import (
     WEOIncludeExcludeDeprecation,
 )
 from dbt.tests.util import run_dbt, run_dbt_and_capture, write_file
+from dbt_common.events.types import Note
 from dbt_common.exceptions import EventCompilationError
 from tests.functional.deprecations.fixtures import (
     bad_name_yaml,
@@ -306,17 +308,27 @@ class TestDeprecatedInvalidDeprecationDate:
     @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
     def test_deprecated_invalid_deprecation_date(self, project):
         event_catcher = EventCatcher(GenericJSONSchemaValidationDeprecation)
+        note_catcher = EventCatcher(Note)
         try:
-            run_dbt(["parse", "--no-partial-parse"], callbacks=[event_catcher.catch])
+            run_dbt(
+                ["parse", "--no-partial-parse"],
+                callbacks=[event_catcher.catch, note_catcher.catch],
+            )
         except:  # noqa
             assert (
                 True
             ), "Expected an exception to be raised, because a model object can't be created with a deprecation_date as an int"
 
-        assert len(event_catcher.caught_events) == 1
-        assert (
-            "1 is not of type 'string', 'null' in file" in event_catcher.caught_events[0].info.msg
-        )
+        if GJVD()._is_preview:
+            assert len(note_catcher.caught_events) == 1
+            assert len(event_catcher.caught_events) == 0
+            event = note_catcher.caught_events[0]
+        else:
+            assert len(event_catcher.caught_events) == 1
+            assert len(note_catcher.caught_events) == 0
+            event = event_catcher.caught_events[0]
+
+        assert "1 is not of type 'string', 'null' in file" in event.info.msg
 
 
 class TestDuplicateYAMLKeysInSchemaFiles:

--- a/tests/unit/config/test_project.py
+++ b/tests/unit/config/test_project.py
@@ -14,7 +14,9 @@ from dbt.adapters.factory import load_plugin
 from dbt.config.project import Project, _get_required_version
 from dbt.constants import DEPENDENCIES_FILE_NAME
 from dbt.contracts.project import GitPackage, LocalPackage, PackageConfig
-from dbt.deprecations import GenericJSONSchemaValidationDeprecation as GJVD
+from dbt.deprecations import (
+    GenericJSONSchemaValidationDeprecation as GenericJSONSchemaValidationDeprecationCore,
+)
 from dbt.events.types import GenericJSONSchemaValidationDeprecation
 from dbt.flags import set_from_args
 from dbt.jsonschemas import project_schema
@@ -635,7 +637,7 @@ class TestDeprecations:
             schema=project_schema(), json=project_dict, file_path="dbt_project.yml"
         )
 
-        if GJVD()._is_preview:
+        if GenericJSONSchemaValidationDeprecationCore()._is_preview:
             assert len(note_catcher.caught_events) == 1
             assert len(event_catcher.caught_events) == 0
             event = note_catcher.caught_events[0]

--- a/tests/unit/config/test_project.py
+++ b/tests/unit/config/test_project.py
@@ -14,12 +14,14 @@ from dbt.adapters.factory import load_plugin
 from dbt.config.project import Project, _get_required_version
 from dbt.constants import DEPENDENCIES_FILE_NAME
 from dbt.contracts.project import GitPackage, LocalPackage, PackageConfig
-from dbt.deprecations import GenericJSONSchemaValidationDeprecation
+from dbt.deprecations import GenericJSONSchemaValidationDeprecation as GJVD
+from dbt.events.types import GenericJSONSchemaValidationDeprecation
 from dbt.flags import set_from_args
 from dbt.jsonschemas import project_schema
 from dbt.node_types import NodeType
 from dbt.tests.util import safe_set_invocation_context
 from dbt_common.events.event_manager_client import get_event_manager
+from dbt_common.events.types import Note
 from dbt_common.exceptions import DbtRuntimeError
 from dbt_common.semver import VersionSpecifier
 from tests.unit.config import (
@@ -625,11 +627,21 @@ class TestDeprecations:
         project_dict: Dict[str, Any] = {}
 
         event_catcher = EventCatcher(GenericJSONSchemaValidationDeprecation)
+        note_catcher = EventCatcher(Note)
         get_event_manager().add_callback(event_catcher.catch)
+        get_event_manager().add_callback(note_catcher.catch)
 
         jsonschema_validate(
             schema=project_schema(), json=project_dict, file_path="dbt_project.yml"
         )
 
-        assert len(event_catcher.caught_events) == 1
-        assert "'name' is a required property at top level" in event_catcher.caught_events[0].info.msg  # type: ignore
+        if GJVD()._is_preview:
+            assert len(note_catcher.caught_events) == 1
+            assert len(event_catcher.caught_events) == 0
+            event = note_catcher.caught_events[0]
+        else:
+            assert len(event_catcher.caught_events) == 1
+            assert len(note_catcher.caught_events) == 0
+            event = event_catcher.caught_events[0]
+
+        assert "'name' is a required property at top level" in event.info.msg


### PR DESCRIPTION
Resolves #11814

### Problem

Currently, there are some inaccuracies with the JSONSchema we use for validation. These are getting raised as a `GenericJSONSchemaValidationDeprecation` deprecation. This is causing confusion because it's getting highlighted in the deprecation summary, but it's not always clear what to do.

### Solution

Make the deprecation a "preview"

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X]] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
