### PR TITLE
skip type checking deprecation_date on the basis of jsonschemas

### DIFF
--- a/core/dbt/jsonschemas.py
+++ b/core/dbt/jsonschemas.py
@@ -120,8 +120,8 @@ def jsonschema_validate(schema: Dict[str, Any], json: Dict[str, Any], file_path:
                             file=file_path,
                             key_path=key_path,
                         )
-        elif error.validator == "type" and "deprecation_date" not in error_path:
-            # Not deprecating invalid types yet, except for pre-existing deprecation_date deprecation
+        elif error.validator == "type":
+            # Not deprecating invalid types yet
             pass
         elif error.validator == "anyOf" and len(error_path) > 0 and error_path[-1] == "config":
             for sub_error in error.context or []:

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -10,9 +10,6 @@ import dbt_common
 from dbt import deprecations
 from dbt.cli.main import dbtRunner
 from dbt.clients.registry import _get_cached
-from dbt.deprecations import (
-    GenericJSONSchemaValidationDeprecation as GenericJSONSchemaValidationDeprecationCore,
-)
 from dbt.events.types import (
     CustomKeyInConfigDeprecation,
     CustomKeyInObjectDeprecation,
@@ -321,16 +318,9 @@ class TestDeprecatedInvalidDeprecationDate:
                 True
             ), "Expected an exception to be raised, because a model object can't be created with a deprecation_date as an int"
 
-        if GenericJSONSchemaValidationDeprecationCore()._is_preview:
-            assert len(note_catcher.caught_events) == 1
-            assert len(event_catcher.caught_events) == 0
-            event = note_catcher.caught_events[0]
-        else:
-            assert len(event_catcher.caught_events) == 1
-            assert len(note_catcher.caught_events) == 0
-            event = event_catcher.caught_events[0]
-
-        assert "1 is not of type 'string', 'null' in file" in event.info.msg
+        # type-based jsonschema validation is not enabled, so no deprecations are raised even though deprecation_date is an int
+        assert len(event_catcher.caught_events) == 0
+        assert len(note_catcher.caught_events) == 0
 
 
 class TestDuplicateYAMLKeysInSchemaFiles:


### PR DESCRIPTION
Resolves #N/A

Follow up to: https://github.com/dbt-labs/dbt-core/pull/11673, which erroneously used jsonschemas to type-check deprecation_date. This exception was not necessary, as the deprecation_date related warnings are separately raised with `DeprecatedReference` and `UpcomingReferenceDeprecation` via `check_for_model_deprecations`
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
