### PR TITLE
Gate jsonschema validations by adapter support

### DIFF
--- a/.changes/unreleased/Features-20250714-232524.yaml
+++ b/.changes/unreleased/Features-20250714-232524.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Gate jsonschema validations by adapter
+time: 2025-07-14T23:25:24.475471-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11680"

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -267,6 +267,7 @@ def profile(func):
         threads = getattr(flags, "THREADS", None)
         profile = load_profile(flags.PROJECT_DIR, flags.VARS, flags.PROFILE, flags.TARGET, threads)
         ctx.obj["profile"] = profile
+        get_invocation_context().uses_adapter(profile.credentials.type)
 
         return func(*args, **kwargs)
 

--- a/core/dbt/jsonschemas.py
+++ b/core/dbt/jsonschemas.py
@@ -92,12 +92,16 @@ def _validate_with_schema(
     return validator.iter_errors(json)
 
 
-def jsonschema_validate(schema: Dict[str, Any], json: Dict[str, Any], file_path: str) -> None:
+def _can_run_validations() -> bool:
     if not os.environ.get("DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS"):
-        return
+        return False
 
     invocation_context = get_invocation_context()
-    if not _JSONSCHEMA_SUPPORTED_ADAPTERS.issubset(invocation_context.adapter_types):
+    return _JSONSCHEMA_SUPPORTED_ADAPTERS.issubset(invocation_context.adapter_types)
+
+
+def jsonschema_validate(schema: Dict[str, Any], json: Dict[str, Any], file_path: str) -> None:
+    if not _can_run_validations():
         return
 
     errors = _validate_with_schema(schema, json)
@@ -158,11 +162,7 @@ def jsonschema_validate(schema: Dict[str, Any], json: Dict[str, Any], file_path:
 
 
 def validate_model_config(config: Dict[str, Any], file_path: str) -> None:
-    if not os.environ.get("DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS"):
-        return
-
-    invocation_context = get_invocation_context()
-    if not _JSONSCHEMA_SUPPORTED_ADAPTERS.issubset(invocation_context.adapter_types):
+    if not _can_run_validations():
         return
 
     resources_jsonschema = resources_schema()

--- a/core/dbt/jsonschemas.py
+++ b/core/dbt/jsonschemas.py
@@ -19,7 +19,8 @@ _RESOURCES_SCHEMA: Optional[Dict[str, Any]] = None
 
 _JSONSCHEMA_SUPPORTED_ADAPTERS = {
     "bigquery",
-    "databricks" "redshift",
+    "databricks",
+    "redshift",
     "snowflake",
 }
 
@@ -97,7 +98,7 @@ def _can_run_validations() -> bool:
         return False
 
     invocation_context = get_invocation_context()
-    return _JSONSCHEMA_SUPPORTED_ADAPTERS.issubset(invocation_context.adapter_types)
+    return invocation_context.adapter_types.issubset(_JSONSCHEMA_SUPPORTED_ADAPTERS)
 
 
 def jsonschema_validate(schema: Dict[str, Any], json: Dict[str, Any], file_path: str) -> None:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-adapters
 git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-tests-adapter
-git+https://github.com/dbt-labs/dbt-common.git@main
+git+https://github.com/dbt-labs/dbt-common.git@qmalcolm--292-add-adapter-type-to-invocation-context
 git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-postgres
 # black must match what's in .pre-commit-config.yaml to be sure local env matches CI
 black==24.3.0

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -296,6 +296,7 @@ class TestDeprecationSummary:
         assert found_summary, "Expected to find PackageRedirectDeprecation in deprecations summary"
 
 
+@mock.patch("dbt.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
 class TestDeprecatedInvalidDeprecationDate:
     @pytest.fixture(scope="class")
     def models(self):
@@ -346,6 +347,7 @@ class TestCustomKeyInConfigDeprecation:
             "models.yml": custom_key_in_config_yaml,
         }
 
+    @mock.patch("dbt.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
     @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
     def test_custom_key_in_config_deprecation(self, project):
         event_catcher = EventCatcher(CustomKeyInConfigDeprecation)
@@ -368,6 +370,7 @@ class TestMultipleCustomKeysInConfigDeprecation:
             "models.yml": multiple_custom_keys_in_config_yaml,
         }
 
+    @mock.patch("dbt.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
     @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
     def test_multiple_custom_keys_in_config_deprecation(self, project):
         event_catcher = EventCatcher(CustomKeyInConfigDeprecation)
@@ -394,6 +397,7 @@ class TestCustomKeyInObjectDeprecation:
             "models.yml": custom_key_in_object_yaml,
         }
 
+    @mock.patch("dbt.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
     @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
     def test_custom_key_in_object_deprecation(self, project):
         event_catcher = EventCatcher(CustomKeyInObjectDeprecation)

--- a/tests/functional/source_overrides/test_simple_source_override.py
+++ b/tests/functional/source_overrides/test_simple_source_override.py
@@ -98,6 +98,7 @@ class TestSourceOverride:
 
         return insert_id + 1
 
+    @mock.patch("dbt.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
     @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
     def test_source_overrides(self, project):
         insert_id = 101

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -18,6 +18,7 @@ class TestProjectJsonschemaValidatedOnlyOnce:
         assert mocked_jsonschema_validate.call_count == 1
 
 
+@mock.patch("dbt.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
 class TestGenericJsonSchemaValidationDeprecation:
     """Ensure that the generic jsonschema validation deprecation can be fired"""
 

--- a/tests/unit/test_jsonschemas.py
+++ b/tests/unit/test_jsonschemas.py
@@ -7,6 +7,8 @@ from dbt.deprecations import (
     GenericJSONSchemaValidationDeprecation,
 )
 from dbt.jsonschemas import validate_model_config
+from dbt.tests.util import safe_set_invocation_context
+from dbt_common.context import get_invocation_context
 from dbt_common.events.event_manager_client import add_callback_to_manager
 from tests.utils import EventCatcher
 
@@ -14,6 +16,8 @@ from tests.utils import EventCatcher
 class TestValidateModelConfigNoError:
     @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
     def test_validate_model_config_no_error(self):
+        safe_set_invocation_context()
+        get_invocation_context().uses_adapter("snowflake")
         caught_events = []
         add_callback_to_manager(caught_events.append)
 
@@ -25,6 +29,8 @@ class TestValidateModelConfigNoError:
 
     @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
     def test_validate_model_config_error(self):
+        safe_set_invocation_context()
+        get_invocation_context().uses_adapter("snowflake")
         ckiod_catcher = EventCatcher(CustomKeyInObjectDeprecation)
         ckicd_catcher = EventCatcher(CustomKeyInConfigDeprecation)
         gjsvd_catcher = EventCatcher(GenericJSONSchemaValidationDeprecation)


### PR DESCRIPTION
Resolves #11680

Only run jsonschema validations if our jsonschemas support the given adapter in use

### Problem

We could be running jsonschema validations on projects where an adapter is in use that the jsonschemas don't yet support. This will 99% of the time cause incorrect deprecations to be raised.

### Solution

Track the adapter being used. Track which adapters are supporte by the jsonschemas. Only run the jsonschema validations if supported adapter is being used

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
