### PR TITLE
accept generic test args under 'args'

### DIFF
--- a/.changes/unreleased/Features-20250721-173100.yaml
+++ b/.changes/unreleased/Features-20250721-173100.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Deprecate top-level argument properties in generic tests
+time: 2025-07-21T17:31:00.960402-04:00
+custom:
+    Author: michelleark
+    Issue: "11847"

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -361,7 +361,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     require_nested_cumulative_type_params: bool = False
     validate_macro_args: bool = False
     require_all_warnings_handled_by_warn_error: bool = False
-    require_generic_test_arguments: bool = False
+    require_generic_test_arguments_property: bool = False
 
     @property
     def project_only_flags(self) -> Dict[str, Any]:
@@ -377,7 +377,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
             "require_nested_cumulative_type_params": self.require_nested_cumulative_type_params,
             "validate_macro_args": self.validate_macro_args,
             "require_all_warnings_handled_by_warn_error": self.require_all_warnings_handled_by_warn_error,
-            "require_generic_test_arguments": self.require_generic_test_arguments,
+            "require_generic_test_arguments_property": self.require_generic_test_arguments_property,
         }
 
 

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -361,7 +361,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     require_nested_cumulative_type_params: bool = False
     validate_macro_args: bool = False
     require_all_warnings_handled_by_warn_error: bool = False
-    require_generic_test_args: bool = False
+    require_generic_test_arguments: bool = False
 
     @property
     def project_only_flags(self) -> Dict[str, Any]:
@@ -377,7 +377,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
             "require_nested_cumulative_type_params": self.require_nested_cumulative_type_params,
             "validate_macro_args": self.validate_macro_args,
             "require_all_warnings_handled_by_warn_error": self.require_all_warnings_handled_by_warn_error,
-            "require_generic_test_args": self.require_generic_test_args,
+            "require_generic_test_arguments": self.require_generic_test_arguments,
         }
 
 

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -361,6 +361,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     require_nested_cumulative_type_params: bool = False
     validate_macro_args: bool = False
     require_all_warnings_handled_by_warn_error: bool = False
+    require_generic_test_args: bool = False
 
     @property
     def project_only_flags(self) -> Dict[str, Any]:
@@ -376,6 +377,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
             "require_nested_cumulative_type_params": self.require_nested_cumulative_type_params,
             "validate_macro_args": self.validate_macro_args,
             "require_all_warnings_handled_by_warn_error": self.require_all_warnings_handled_by_warn_error,
+            "require_generic_test_args": self.require_generic_test_args,
         }
 
 

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -220,6 +220,11 @@ class ArgumentsPropertyInGenericTestDeprecation(DBTDeprecation):
     _event = "ArgumentsPropertyInGenericTestDeprecation"
 
 
+class MissingArgumentsPropertyInGenericTestDeprecation(DBTDeprecation):
+    _name = "missing-arguments-property-in-generic-test-deprecation"
+    _event = "MissingArgumentsPropertyInGenericTestDeprecation"
+
+
 def renamed_env_var(old_name: str, new_name: str):
     class EnvironmentVariableRenamed(DBTDeprecation):
         _name = f"environment-variable-renamed:{old_name}"
@@ -304,6 +309,7 @@ deprecations_list: List[DBTDeprecation] = [
     EnvironmentVariableNamespaceDeprecation(),
     MissingPlusPrefixDeprecation(),
     ArgumentsPropertyInGenericTestDeprecation(),
+    MissingArgumentsPropertyInGenericTestDeprecation(),
 ]
 
 deprecations: Dict[str, DBTDeprecation] = {d.name: d for d in deprecations_list}

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -215,6 +215,11 @@ class MissingPlusPrefixDeprecation(DBTDeprecation):
     _event = "MissingPlusPrefixDeprecation"
 
 
+class ArgumentsPropertyInGenericTestDeprecation(DBTDeprecation):
+    _name = "arguments-property-in-generic-test-deprecation"
+    _event = "ArgumentsPropertyInGenericTestDeprecation"
+
+
 def renamed_env_var(old_name: str, new_name: str):
     class EnvironmentVariableRenamed(DBTDeprecation):
         _name = f"environment-variable-renamed:{old_name}"
@@ -298,6 +303,7 @@ deprecations_list: List[DBTDeprecation] = [
     SourceOverrideDeprecation(),
     EnvironmentVariableNamespaceDeprecation(),
     MissingPlusPrefixDeprecation(),
+    ArgumentsPropertyInGenericTestDeprecation(),
 ]
 
 deprecations: Dict[str, DBTDeprecation] = {d.name: d for d in deprecations_list}

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -747,7 +747,7 @@ class ArgumentsPropertyInGenericTestDeprecation(WarnLevel):
         return "D038"
 
     def message(self) -> str:
-        description = f"Found `arguments` property in test definition of `{self.test_name}` without usage of `require_generic_test_arguments` behavior change flag. The `arguments` property is deprecated for custom usage and will be used to nest keyword arguments in future versions of dbt."
+        description = f"Found `arguments` property in test definition of `{self.test_name}` without usage of `require_generic_test_arguments_property` behavior change flag. The `arguments` property is deprecated for custom usage and will be used to nest keyword arguments in future versions of dbt."
         return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 
 

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -742,6 +742,15 @@ class MissingPlusPrefixDeprecation(WarnLevel):
         return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 
 
+class ArgumentsPropertyInGenericTestDeprecation(WarnLevel):
+    def code(self) -> str:
+        return "D038"
+
+    def message(self) -> str:
+        description = f"Found `arguments` in test definition of `{self.test_name}` without usage of `require_generic_test_arguments` flag. The `arguments` property is deprecated for custom usage and will be used to nest keyword arguments in future versions of dbt."
+        return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+
+
 # =======================================================
 # I - Project parsing
 # =======================================================

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -747,7 +747,7 @@ class ArgumentsPropertyInGenericTestDeprecation(WarnLevel):
         return "D038"
 
     def message(self) -> str:
-        description = f"Found `arguments` in test definition of `{self.test_name}` without usage of `require_generic_test_arguments` flag. The `arguments` property is deprecated for custom usage and will be used to nest keyword arguments in future versions of dbt."
+        description = f"Found `arguments` property in test definition of `{self.test_name}` without usage of `require_generic_test_arguments` behavior change flag. The `arguments` property is deprecated for custom usage and will be used to nest keyword arguments in future versions of dbt."
         return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 
 

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -751,6 +751,15 @@ class ArgumentsPropertyInGenericTestDeprecation(WarnLevel):
         return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 
 
+class MissingArgumentsPropertyInGenericTestDeprecation(WarnLevel):
+    def code(self) -> str:
+        return "D039"
+
+    def message(self) -> str:
+        description = f"Found top-level arguments to test `{self.test_name}`. Arguments to generic tests should be nested under the `arguments` property.`"
+        return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
+
+
 # =======================================================
 # I - Project parsing
 # =======================================================

--- a/core/dbt/include/jsonschemas/resources/latest.json
+++ b/core/dbt/include/jsonschemas/resources/latest.json
@@ -691,6 +691,101 @@
       },
       "additionalProperties": false
     },
+    "CustomTest": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/CustomTestMultiKey"
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/CustomTestInner"
+          }
+        }
+      ]
+    },
+    "CustomTestInner": {
+      "type": "object",
+      "properties": {
+        "args": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DataTestConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "CustomTestMultiKey": {
+      "type": "object",
+      "required": [
+        "test_name"
+      ],
+      "properties": {
+        "args": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DataTestConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "test_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "DataTestConfig": {
       "type": "object",
       "properties": {
@@ -1030,7 +1125,6 @@
           ]
         },
         "require_partition_filter": {
-          "default": false,
           "type": [
             "boolean",
             "null"
@@ -1225,7 +1319,9 @@
         {
           "$ref": "#/definitions/AcceptedValuesTest"
         },
-        true
+        {
+          "$ref": "#/definitions/CustomTest"
+        }
       ]
     },
     "DbtBatchSize": {
@@ -2234,13 +2330,9 @@
           ]
         },
         "offset_window": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/MetricTimeWindow"
-            },
-            {
-              "type": "null"
-            }
+          "type": [
+            "string",
+            "null"
           ]
         }
       },
@@ -2282,23 +2374,6 @@
           ]
         },
         "name": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false
-    },
-    "MetricTimeWindow": {
-      "type": "object",
-      "required": [
-        "count",
-        "granularity"
-      ],
-      "properties": {
-        "count": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "granularity": {
           "type": "string"
         }
       },
@@ -3004,7 +3079,6 @@
           ]
         },
         "require_partition_filter": {
-          "default": false,
           "type": [
             "boolean",
             "null"
@@ -3207,6 +3281,16 @@
           "anyOf": [
             {
               "$ref": "#/definitions/FreshnessRules"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "updates_on": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/UpdatesOn"
             },
             {
               "type": "null"
@@ -4139,7 +4223,6 @@
           ]
         },
         "require_partition_filter": {
-          "default": false,
           "type": [
             "boolean",
             "null"
@@ -4854,7 +4937,6 @@
           ]
         },
         "require_partition_filter": {
-          "default": false,
           "type": [
             "boolean",
             "null"
@@ -5430,7 +5512,6 @@
           ]
         },
         "require_partition_filter": {
-          "default": false,
           "type": [
             "boolean",
             "null"
@@ -6149,7 +6230,6 @@
           ]
         },
         "require_partition_filter": {
-          "default": false,
           "type": [
             "boolean",
             "null"
@@ -6337,6 +6417,13 @@
         "versions": true
       },
       "additionalProperties": false
+    },
+    "UpdatesOn": {
+      "type": "string",
+      "enum": [
+        "any",
+        "all"
+      ]
     },
     "Versions": {
       "type": "object",

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -230,8 +230,8 @@ class TestBuilder(Generic[Testable]):
         if name is not None:
             test_args["column_name"] = name
 
-        # Extract kwargs when they are nested under new 'arguments' property separately from 'config' if require_generic_test_arguments is enabled
-        if get_flags().require_generic_test_arguments:
+        # Extract kwargs when they are nested under new 'arguments' property separately from 'config' if require_generic_test_arguments_property is enabled
+        if get_flags().require_generic_test_arguments_property:
             arguments = test_args.pop("arguments", {})
             if not arguments and any(k not in ("config", "column_name") for k in test_args.keys()):
                 deprecations.warn(

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -235,7 +235,9 @@ class TestBuilder(Generic[Testable]):
             args = test_args.pop("arguments", {})
             test_args = {**test_args, **args}
         elif "arguments" in test_args:
-            deprecations.warn("arguments-property-in-generic-test-deprecation")
+            deprecations.warn(
+                "arguments-property-in-generic-test-deprecation", test_name=test_name
+            )
 
         return test_name, test_args
 

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -220,6 +220,13 @@ class TestBuilder(Generic[Testable]):
                 raise TestDefinitionDictLengthError(data_test)
             test_name, test_args = data_test[0]
 
+        # Handle when args are nested under 'args' separately from 'config'
+        args = test_args.pop("args", {})
+        test_args = {**test_args, **args}
+
+        # TODO: raise deprecation if args other than config are not nested under args
+        # if not args and any(k != "config" for k in test_args.keys()):
+
         if not isinstance(test_args, dict):
             raise TestArgsNotDictError(test_args)
         if not isinstance(test_name, str):

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -230,10 +230,14 @@ class TestBuilder(Generic[Testable]):
         if name is not None:
             test_args["column_name"] = name
 
-        # Handle when kwargs are nested under 'arguments' separately from 'config'
+        # Extract kwargs when they are nested under new 'arguments' property separately from 'config' if require_generic_test_arguments is enabled
         if get_flags().require_generic_test_arguments:
-            args = test_args.pop("arguments", {})
-            test_args = {**test_args, **args}
+            arguments = test_args.pop("arguments", {})
+            if not arguments and any(k not in ("config", "column_name") for k in test_args.keys()):
+                deprecations.warn(
+                    "missing-arguments-property-in-generic-test-deprecation", test_name=test_name
+                )
+            test_args = {**test_args, **arguments}
         elif "arguments" in test_args:
             deprecations.warn(
                 "arguments-property-in-generic-test-deprecation", test_name=test_name

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -2,6 +2,7 @@ import re
 from copy import deepcopy
 from typing import Any, Dict, Generic, List, Optional, Tuple
 
+from dbt import deprecations
 from dbt.artifacts.resources import NodeVersion
 from dbt.clients.jinja import GENERIC_TEST_KWARGS_NAME, get_rendered
 from dbt.contracts.graph.nodes import UnpatchedSourceDefinition
@@ -229,19 +230,12 @@ class TestBuilder(Generic[Testable]):
         if name is not None:
             test_args["column_name"] = name
 
-        # Handle when args are nested under 'args' separately from 'config'
-        if get_flags().require_generic_test_args:
-            args = test_args.pop("args", {})
+        # Handle when kwargs are nested under 'arguments' separately from 'config'
+        if get_flags().require_generic_test_arguments:
+            args = test_args.pop("arguments", {})
             test_args = {**test_args, **args}
-        elif "args" in test_args:
-            pass
-            # TODO: raise deprecation
-            # deprecations.warn(
-
-            # )
-
-        # TODO: raise deprecation if args other than config are not nested under args
-        # if not args and any(k != "config" for k in test_args.keys()):
+        elif "arguments" in test_args:
+            deprecations.warn("arguments-property-in-generic-test-deprecation")
 
         return test_name, test_args
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -74,7 +74,7 @@ setup(
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.27.0,<2.0",
         "dbt-adapters>=1.15.2,<2.0",
-        "dbt-protos>=1.0.339,<2.0",
+        "dbt-protos>=1.0.346,<2.0",
         "pydantic<3",
         # ----
         # Expect compatibility with all new versions of these packages, so lower bounds only.

--- a/tests/functional/deprecations/fixtures.py
+++ b/tests/functional/deprecations/fixtures.py
@@ -185,3 +185,18 @@ models:
     deprecation_date: 1999-01-01 00:00:00.00+00:00
     my_custom_property: "It's over, I have the high ground"
 """
+
+test_with_arguments_yaml = """
+models:
+  - name: models_trivial
+    tests:
+      - test_name: unique
+        arguments:
+          custom: arg
+      - custom_test:
+          arguments:
+            custom: arg
+      - unique
+      - not_null:
+          where: "1=1"
+"""

--- a/tests/functional/deprecations/fixtures.py
+++ b/tests/functional/deprecations/fixtures.py
@@ -200,3 +200,63 @@ models:
       - not_null:
           where: "1=1"
 """
+
+
+test_with_arguments_yaml = """
+models:
+  - name: models_trivial
+    tests:
+      - test_name: unique
+        arguments:
+          custom: arg
+      - custom_test:
+          arguments:
+            custom: arg
+      - unique
+      - not_null:
+          where: "1=1"
+    columns:
+      - name: column
+        tests:
+          - test_name: unique
+            arguments:
+              custom: arg
+          - custom_test:
+              arguments:
+                custom: arg
+          - custom_test2_valid:
+              column_name: id
+              config:
+                where: "1=1"
+              custom: arg
+"""
+
+
+test_missing_arguments_property_yaml = """
+models:
+  - name: models_trivial
+    tests:
+      - test_name: unique
+        custom: arg
+      - custom_test:
+          custom: arg
+      - custom_test2_valid:
+          column_name: id
+          config:
+            where: "1=1"
+          arguments:
+            custom: arg
+    columns:
+      - name: column
+        tests:
+          - test_name: unique
+            custom: arg
+          - custom_test:
+              custom: arg
+          - custom_test2_valid:
+              column_name: id
+              config:
+                where: "1=1"
+              arguments:
+                custom: arg
+      """

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -747,7 +747,7 @@ class TestArgumentsPropertyInGenericTestDeprecationBehaviorChange:
         return {
             "config-version": 2,
             "flags": {
-                "require_generic_test_arguments": True,
+                "require_generic_test_arguments_property": True,
             },
         }
 
@@ -773,7 +773,7 @@ class TestMissingArgumentsPropertyInGenericTestDeprecation:
         return {
             "config-version": 2,
             "flags": {
-                "require_generic_test_arguments": True,
+                "require_generic_test_arguments_property": True,
             },
         }
 

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -20,6 +20,7 @@ from dbt.events.types import (
     DuplicateYAMLKeysDeprecation,
     EnvironmentVariableNamespaceDeprecation,
     GenericJSONSchemaValidationDeprecation,
+    MissingArgumentsPropertyInGenericTestDeprecation,
     MissingPlusPrefixDeprecation,
     ModelParamUsageDeprecation,
     PackageRedirectDeprecation,
@@ -37,6 +38,7 @@ from tests.functional.deprecations.fixtures import (
     invalid_deprecation_date_yaml,
     models_trivial__model_sql,
     multiple_custom_keys_in_config_yaml,
+    test_missing_arguments_property_yaml,
     test_with_arguments_yaml,
 )
 from tests.utils import EventCatcher
@@ -736,7 +738,7 @@ class TestArgumentsPropertyInGenericTestDeprecation:
             ["parse", "--no-partial-parse", "--show-all-deprecations"],
             callbacks=[event_catcher.catch],
         )
-        assert len(event_catcher.caught_events) == 2
+        assert len(event_catcher.caught_events) == 4
 
 
 class TestArgumentsPropertyInGenericTestDeprecationBehaviorChange:
@@ -763,3 +765,29 @@ class TestArgumentsPropertyInGenericTestDeprecationBehaviorChange:
             callbacks=[event_catcher.catch],
         )
         assert len(event_catcher.caught_events) == 0
+
+
+class TestMissingArgumentsPropertyInGenericTestDeprecation:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "config-version": 2,
+            "flags": {
+                "require_generic_test_arguments": True,
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "models_trivial.sql": models_trivial__model_sql,
+            "models.yml": test_missing_arguments_property_yaml,
+        }
+
+    def test_missing_arguments_property_in_generic_test_deprecation(self, project):
+        event_catcher = EventCatcher(MissingArgumentsPropertyInGenericTestDeprecation)
+        run_dbt(
+            ["parse", "--no-partial-parse", "--show-all-deprecations"],
+            callbacks=[event_catcher.catch],
+        )
+        assert len(event_catcher.caught_events) == 4

--- a/tests/functional/fixtures.py
+++ b/tests/functional/fixtures.py
@@ -1,0 +1,34 @@
+models__my_model_sql = """
+with my_cte as (
+    select 1 as id, 'blue' as color
+    union all
+    select 2 as id, 'green' as red
+    union all
+    select 3 as id, 'red' as red
+)
+select * from my_cte
+"""
+
+models__schema_yml = """
+models:
+  - name: my_model
+    columns:
+      - name: id
+        tests:
+          - unique:
+              description: "id must be unique"
+          - not_null
+      - name: color
+        tests:
+          - accepted_values:
+              values: ['blue', 'green', 'red']
+              description: "{{ doc('color_accepted_values') }}"
+"""
+
+models__doc_block_md = """
+{% docs color_accepted_values %}
+
+The `color` column must be one of 'blue', 'green', or 'red'.
+
+{% enddocs %}
+"""

--- a/tests/unit/parser/test_parser.py
+++ b/tests/unit/parser/test_parser.py
@@ -67,7 +67,7 @@ set_from_args(
     Namespace(
         warn_error=False,
         state_modified_compare_more_unrendered_values=False,
-        require_generic_test_arguments=False,
+        require_generic_test_arguments_property=False,
     ),
     None,
 )
@@ -108,7 +108,7 @@ class BaseParserTest(unittest.TestCase):
             Namespace(
                 warn_error=True,
                 state_modified_compare_more_unrendered_values=False,
-                require_generic_test_arguments=False,
+                require_generic_test_arguments_property=False,
             ),
             None,
         )
@@ -514,7 +514,7 @@ class SchemaParserTest(BaseParserTest):
             Namespace(
                 warn_error=False,
                 state_modified_compare_more_unrendered_values=False,
-                require_generic_test_arguments=False,
+                require_generic_test_arguments_property=False,
             ),
             None,
         )

--- a/tests/unit/parser/test_parser.py
+++ b/tests/unit/parser/test_parser.py
@@ -64,7 +64,12 @@ from tests.unit.utils import (
 )
 
 set_from_args(
-    Namespace(warn_error=False, state_modified_compare_more_unrendered_values=False), None
+    Namespace(
+        warn_error=False,
+        state_modified_compare_more_unrendered_values=False,
+        require_generic_test_arguments=False,
+    ),
+    None,
 )
 
 
@@ -100,7 +105,11 @@ class BaseParserTest(unittest.TestCase):
 
     def setUp(self):
         set_from_args(
-            Namespace(warn_error=True, state_modified_compare_more_unrendered_values=False),
+            Namespace(
+                warn_error=True,
+                state_modified_compare_more_unrendered_values=False,
+                require_generic_test_arguments=False,
+            ),
             None,
         )
         # HACK: this is needed since tracking events can
@@ -502,7 +511,11 @@ class SchemaParserTest(BaseParserTest):
         super().setUp()
         # Reset `warn_error` to False so we don't raise warnigns about top level freshness as errors
         set_from_args(
-            Namespace(warn_error=False, state_modified_compare_more_unrendered_values=False),
+            Namespace(
+                warn_error=False,
+                state_modified_compare_more_unrendered_values=False,
+                require_generic_test_arguments=False,
+            ),
             None,
         )
 

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -174,6 +174,7 @@ sample_values = [
     core_types.EnvironmentVariableNamespaceDeprecation(env_var="", reserved_prefix=""),
     core_types.MissingPlusPrefixDeprecation(key="", key_path="", file=""),
     core_types.ArgumentsPropertyInGenericTestDeprecation(test_name=""),
+    core_types.MissingArgumentsPropertyInGenericTestDeprecation(test_name=""),
     # E - DB Adapter ======================
     adapter_types.AdapterEventDebug(),
     adapter_types.AdapterEventInfo(),

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -173,6 +173,7 @@ sample_values = [
     core_types.ModelParamUsageDeprecation(),
     core_types.EnvironmentVariableNamespaceDeprecation(env_var="", reserved_prefix=""),
     core_types.MissingPlusPrefixDeprecation(key="", key_path="", file=""),
+    core_types.ArgumentsPropertyInGenericTestDeprecation(test_name=""),
     # E - DB Adapter ======================
     adapter_types.AdapterEventDebug(),
     adapter_types.AdapterEventInfo(),


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/11847

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

* Raise `MissingArgumentsPropertyInGenericTestDeprecation` if non-`config`, non-`column_name` property found at top-level of generic test without `arguments` - behind `require_generic_test_arguments`
* merge `arguments` with existing arguments for backcompat - behind `require_generic_test_arguments`
* raise `ArgumentsPropertyInGenericTestDeprecation` if `arguments` detected as property and `require_generic_test_arguments` is not enabled (legacy behavior)
* bring in jsonschema updates

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
