### PR TITLE
fix: Properly quote event_time column names in sample mode filters

### DIFF
--- a/.changes/unreleased/Fixes-20250725-112903.yaml
+++ b/.changes/unreleased/Fixes-20250725-112903.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Quoting the event_time field when the configuration says so
+time: 2025-07-25T11:29:03.342884+02:00
+custom:
+    Author: pablomc87
+    Issue: "11858"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -264,7 +264,7 @@ class BaseResolver(metaclass=abc.ABCMeta):
         if should_quote:
             return column.quoted
         else:
-            return column.name
+            return target.config.event_time
         
     def resolve_event_time_filter(self, target: ManifestNode) -> Optional[EventTimeFilter]:
         event_time_filter = None

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -242,42 +242,55 @@ class BaseResolver(metaclass=abc.ABCMeta):
     def resolve_limit(self) -> Optional[int]:
         return 0 if getattr(self.config.args, "EMPTY", False) else None
 
-
     def _resolve_event_time_field_name(self, target: ManifestNode) -> str:
         """Get the event time field name with proper quoting based on configuration."""
         # Default to False for quoting
         should_quote = False
         column_found = False
         column = None
-        
+
+        # Check if config has event_time attribute
+        if not hasattr(target.config, "event_time") or target.config.event_time is None:
+            return ""
+
         # Check column-level quote configuration first (overrides source-level)
-        if hasattr(target, 'columns') and target.columns and isinstance(target.columns, dict):
+        if hasattr(target, "columns") and target.columns and isinstance(target.columns, dict):
             for _, column_info in target.columns.items():
                 if column_info.name == target.config.event_time:
                     column_found = True
                     # Create the column object
-                    column = Column.create(column_info.name, column_info.data_type if column_info.data_type else '')
+                    column = Column.create(
+                        column_info.name, column_info.data_type if column_info.data_type else ""
+                    )
                     # Column-level quote setting takes precedence
-                    if hasattr(column_info, 'quote') and column_info.quote is not None:
+                    if hasattr(column_info, "quote") and column_info.quote is not None:
                         should_quote = column_info.quote
                     # Fallback to source-level quote setting
-                    elif hasattr(target, 'quoting') and hasattr(target.quoting, 'column') and target.quoting.column is not None:
+                    elif (
+                        hasattr(target, "quoting")
+                        and hasattr(target.quoting, "column")
+                        and target.quoting.column is not None
+                    ):
                         should_quote = target.quoting.column
                     break
-        
+
         # If column not found, fall back to source-level quote setting
         if not column_found:
-            if hasattr(target, 'quoting') and hasattr(target.quoting, 'column') and target.quoting.column is not None:
+            if (
+                hasattr(target, "quoting")
+                and hasattr(target.quoting, "column")
+                and target.quoting.column is not None
+            ):
                 should_quote = target.quoting.column
             # Create column object for quoting
-            column = Column.create(target.config.event_time, '')
-        
+            column = Column.create(target.config.event_time, "")
+
         # Apply quoting logic
-        if should_quote:
+        if should_quote and column is not None:
             return column.quoted
         else:
             return target.config.event_time
-        
+
     def resolve_event_time_filter(self, target: ManifestNode) -> Optional[EventTimeFilter]:
         event_time_filter = None
         sample_mode = getattr(self.config.args, "sample", None) is not None

--- a/tests/unit/context/test_providers.py
+++ b/tests/unit/context/test_providers.py
@@ -44,6 +44,186 @@ class TestBaseResolver:
         assert resolver.resolve_limit == expected_resolve_limit
 
     @pytest.mark.parametrize(
+        "event_time_column,column_quote,source_quote,expected_field_name",
+        [
+            # Simple column name, no quoting needed
+            ("simple_column", None, None, "simple_column"),
+            ("no_quote_column", False, None, "no_quote_column"),
+            ("source_no_quote", None, False, "source_no_quote"),
+            ("both_no_quote", False, False, "both_no_quote"),
+            
+            # Column-level quote configuration (takes precedence)
+            ("column_quoted", True, None, '"column_quoted"'),
+            ("column_quoted_source_no", True, False, '"column_quoted_source_no"'),
+            ("column_quoted_source_yes", True, True, '"column_quoted_source_yes"'),
+            
+            # Source-level quote configuration (fallback when column-level is None)
+            ("source_quoted", None, True, '"source_quoted"'),
+            ("source_quoted_override", False, True, "source_quoted_override"),  # False overrides True
+            
+            # Camel case and spaced column names
+            ("camelCaseColumn", None, None, "camelCaseColumn"),
+            ("camelCaseQuoted", True, None, '"camelCaseQuoted"'),
+            ("snake_case_column", None, None, "snake_case_column"),
+            ("snake_case_quoted", True, None, '"snake_case_quoted"'),
+            ("Spaced Column Name", None, None, "Spaced Column Name"),
+            ("Spaced Column Quoted", True, None, '"Spaced Column Quoted"'),
+            ("Spaced Column Source Quoted", None, True, '"Spaced Column Source Quoted"'),
+            
+            # Edge cases
+            ("", None, None, ""),
+            ("", True, None, '""'),
+            ("edge_case_column", None, None, "edge_case_column"),
+            ("edge_case_quoted", True, None, '"edge_case_quoted"'),
+        ],
+    )
+    def test_resolve_event_time_field_name(
+        self, 
+        resolver, 
+        event_time_column, 
+        column_quote, 
+        source_quote, 
+        expected_field_name
+    ):
+        """Test the _resolve_event_time_field_name method with various quoting configurations."""
+        # Create a mock target with columns
+        target = mock.Mock()
+        target.config = mock.Mock()
+        target.config.event_time = event_time_column
+        
+        # Mock columns dictionary
+        mock_column = mock.Mock()
+        mock_column.name = event_time_column
+        mock_column.data_type = "timestamp"
+        
+        # Set column-level quote configuration
+        if column_quote is not None:
+            mock_column.quote = column_quote
+        else:
+            # Explicitly set to None to avoid Mock object being returned
+            mock_column.quote = None
+        
+        target.columns = {event_time_column: mock_column}
+        
+        # Set source-level quote configuration
+        if source_quote is not None:
+            target.quoting = mock.Mock()
+            target.quoting.column = source_quote
+        else:
+            # Explicitly set to None to avoid Mock object being returned
+            target.quoting = mock.Mock()
+            target.quoting.column = None
+        
+        # Call the method
+        result = resolver._resolve_event_time_field_name(target)
+        
+        # Assert the result
+        assert result == expected_field_name
+
+    @pytest.mark.parametrize(
+        "event_time_column,column_quote,source_quote,expected_field_name",
+        [
+            # Column not found in columns dict - should fall back to source-level quoting
+            ("missing_column", None, None, "missing_column"),
+            ("missing_column_source_quoted", None, True, '"missing_column_source_quoted"'),
+            ("missing_column_source_no_quote", None, False, "missing_column_source_no_quote"),
+            
+            # Column found but no quote attribute - should fall back to source-level quoting
+            ("found_no_quote_attr", None, None, "found_no_quote_attr"),
+            ("found_no_quote_attr_source_quoted", None, True, '"found_no_quote_attr_source_quoted"'),
+            ("found_no_quote_attr_source_no_quote", None, False, "found_no_quote_attr_source_no_quote"),
+        ],
+    )
+    def test_resolve_event_time_field_name_column_not_found(
+        self, 
+        resolver, 
+        event_time_column, 
+        column_quote, 
+        source_quote, 
+        expected_field_name
+    ):
+        """Test _resolve_event_time_field_name when column is not found or has no quote attribute."""
+        # Create a mock target with different columns
+        target = mock.Mock()
+        target.config = mock.Mock()
+        target.config.event_time = event_time_column
+        
+        # Mock columns dictionary with different column
+        mock_column = mock.Mock()
+        mock_column.name = "different_column_name"
+        mock_column.data_type = "timestamp"
+        
+        # Set column-level quote configuration (but for different column)
+        if column_quote is not None:
+            mock_column.quote = column_quote
+        else:
+            # Explicitly set to None to avoid Mock object being returned
+            mock_column.quote = None
+        
+        target.columns = {"different_column_name": mock_column}
+        
+        # Set source-level quote configuration
+        if source_quote is not None:
+            target.quoting = mock.Mock()
+            target.quoting.column = source_quote
+        else:
+            # Explicitly set to None to avoid Mock object being returned
+            target.quoting = mock.Mock()
+            target.quoting.column = None
+        
+        # Call the method
+        result = resolver._resolve_event_time_field_name(target)
+        
+        # Assert the result
+        assert result == expected_field_name
+
+    def test_resolve_event_time_field_name_no_columns(self, resolver):
+        """Test _resolve_event_time_field_name when target has no columns attribute."""
+        # Create a mock target without columns
+        target = mock.Mock()
+        target.config = mock.Mock()
+        target.config.event_time = "no_columns_column"
+        
+        # No columns attribute
+        target.columns = {}
+        
+        # Set source-level quote configuration
+        target.quoting = mock.Mock()
+        target.quoting.column = True
+        
+        # Call the method
+        result = resolver._resolve_event_time_field_name(target)
+        
+        # Should return quoted column name when source-level quoting is True
+        assert result == '"no_columns_column"'
+
+    def test_resolve_event_time_field_name_no_quoting_attribute(self, resolver):
+        """Test _resolve_event_time_field_name when target has no quoting attribute."""
+        # Create a mock target without quoting
+        target = mock.Mock()
+        target.config = mock.Mock()
+        target.config.event_time = "no_quoting_attr_column"
+        
+        # Mock columns dictionary
+        mock_column = mock.Mock()
+        mock_column.name = "no_quoting_attr_column"
+        mock_column.data_type = "timestamp"
+        # No quote attribute - explicitly set to None
+        mock_column.quote = None
+        
+        target.columns = {"no_quoting_attr_column": mock_column}
+        
+        # No quoting attribute - explicitly set to None
+        target.quoting = mock.Mock()
+        target.quoting.column = None
+        
+        # Call the method
+        result = resolver._resolve_event_time_field_name(target)
+        
+        # Should return unquoted column name
+        assert result == "no_quoting_attr_column"
+
+    @pytest.mark.parametrize(
         "use_microbatch_batches,materialized,incremental_strategy,sample,resolver_model_node,target_type,resolver_model_type,expect_filter",
         [
             # Microbatch model without sample

--- a/tests/unit/context/test_providers.py
+++ b/tests/unit/context/test_providers.py
@@ -51,16 +51,18 @@ class TestBaseResolver:
             ("no_quote_column", False, None, "no_quote_column"),
             ("source_no_quote", None, False, "source_no_quote"),
             ("both_no_quote", False, False, "both_no_quote"),
-            
             # Column-level quote configuration (takes precedence)
             ("column_quoted", True, None, '"column_quoted"'),
             ("column_quoted_source_no", True, False, '"column_quoted_source_no"'),
             ("column_quoted_source_yes", True, True, '"column_quoted_source_yes"'),
-            
             # Source-level quote configuration (fallback when column-level is None)
             ("source_quoted", None, True, '"source_quoted"'),
-            ("source_quoted_override", False, True, "source_quoted_override"),  # False overrides True
-            
+            (
+                "source_quoted_override",
+                False,
+                True,
+                "source_quoted_override",
+            ),  # False overrides True
             # Camel case and spaced column names
             ("camelCaseColumn", None, None, "camelCaseColumn"),
             ("camelCaseQuoted", True, None, '"camelCaseQuoted"'),
@@ -69,7 +71,6 @@ class TestBaseResolver:
             ("Spaced Column Name", None, None, "Spaced Column Name"),
             ("Spaced Column Quoted", True, None, '"Spaced Column Quoted"'),
             ("Spaced Column Source Quoted", None, True, '"Spaced Column Source Quoted"'),
-            
             # Edge cases
             ("", None, None, ""),
             ("", True, None, '""'),
@@ -78,33 +79,28 @@ class TestBaseResolver:
         ],
     )
     def test_resolve_event_time_field_name(
-        self, 
-        resolver, 
-        event_time_column, 
-        column_quote, 
-        source_quote, 
-        expected_field_name
+        self, resolver, event_time_column, column_quote, source_quote, expected_field_name
     ):
         """Test the _resolve_event_time_field_name method with various quoting configurations."""
         # Create a mock target with columns
         target = mock.Mock()
         target.config = mock.Mock()
         target.config.event_time = event_time_column
-        
+
         # Mock columns dictionary
         mock_column = mock.Mock()
         mock_column.name = event_time_column
         mock_column.data_type = "timestamp"
-        
+
         # Set column-level quote configuration
         if column_quote is not None:
             mock_column.quote = column_quote
         else:
             # Explicitly set to None to avoid Mock object being returned
             mock_column.quote = None
-        
+
         target.columns = {event_time_column: mock_column}
-        
+
         # Set source-level quote configuration
         if source_quote is not None:
             target.quoting = mock.Mock()
@@ -113,10 +109,10 @@ class TestBaseResolver:
             # Explicitly set to None to avoid Mock object being returned
             target.quoting = mock.Mock()
             target.quoting.column = None
-        
+
         # Call the method
         result = resolver._resolve_event_time_field_name(target)
-        
+
         # Assert the result
         assert result == expected_field_name
 
@@ -127,41 +123,45 @@ class TestBaseResolver:
             ("missing_column", None, None, "missing_column"),
             ("missing_column_source_quoted", None, True, '"missing_column_source_quoted"'),
             ("missing_column_source_no_quote", None, False, "missing_column_source_no_quote"),
-            
             # Column found but no quote attribute - should fall back to source-level quoting
             ("found_no_quote_attr", None, None, "found_no_quote_attr"),
-            ("found_no_quote_attr_source_quoted", None, True, '"found_no_quote_attr_source_quoted"'),
-            ("found_no_quote_attr_source_no_quote", None, False, "found_no_quote_attr_source_no_quote"),
+            (
+                "found_no_quote_attr_source_quoted",
+                None,
+                True,
+                '"found_no_quote_attr_source_quoted"',
+            ),
+            (
+                "found_no_quote_attr_source_no_quote",
+                None,
+                False,
+                "found_no_quote_attr_source_no_quote",
+            ),
         ],
     )
     def test_resolve_event_time_field_name_column_not_found(
-        self, 
-        resolver, 
-        event_time_column, 
-        column_quote, 
-        source_quote, 
-        expected_field_name
+        self, resolver, event_time_column, column_quote, source_quote, expected_field_name
     ):
         """Test _resolve_event_time_field_name when column is not found or has no quote attribute."""
         # Create a mock target with different columns
         target = mock.Mock()
         target.config = mock.Mock()
         target.config.event_time = event_time_column
-        
+
         # Mock columns dictionary with different column
         mock_column = mock.Mock()
         mock_column.name = "different_column_name"
         mock_column.data_type = "timestamp"
-        
+
         # Set column-level quote configuration (but for different column)
         if column_quote is not None:
             mock_column.quote = column_quote
         else:
             # Explicitly set to None to avoid Mock object being returned
             mock_column.quote = None
-        
+
         target.columns = {"different_column_name": mock_column}
-        
+
         # Set source-level quote configuration
         if source_quote is not None:
             target.quoting = mock.Mock()
@@ -170,10 +170,10 @@ class TestBaseResolver:
             # Explicitly set to None to avoid Mock object being returned
             target.quoting = mock.Mock()
             target.quoting.column = None
-        
+
         # Call the method
         result = resolver._resolve_event_time_field_name(target)
-        
+
         # Assert the result
         assert result == expected_field_name
 
@@ -183,17 +183,17 @@ class TestBaseResolver:
         target = mock.Mock()
         target.config = mock.Mock()
         target.config.event_time = "no_columns_column"
-        
+
         # No columns attribute
         target.columns = {}
-        
+
         # Set source-level quote configuration
         target.quoting = mock.Mock()
         target.quoting.column = True
-        
+
         # Call the method
         result = resolver._resolve_event_time_field_name(target)
-        
+
         # Should return quoted column name when source-level quoting is True
         assert result == '"no_columns_column"'
 
@@ -203,23 +203,23 @@ class TestBaseResolver:
         target = mock.Mock()
         target.config = mock.Mock()
         target.config.event_time = "no_quoting_attr_column"
-        
+
         # Mock columns dictionary
         mock_column = mock.Mock()
         mock_column.name = "no_quoting_attr_column"
         mock_column.data_type = "timestamp"
         # No quote attribute - explicitly set to None
         mock_column.quote = None
-        
+
         target.columns = {"no_quoting_attr_column": mock_column}
-        
+
         # No quoting attribute - explicitly set to None
         target.quoting = mock.Mock()
         target.quoting.column = None
-        
+
         # Call the method
         result = resolver._resolve_event_time_field_name(target)
-        
+
         # Should return unquoted column name
         assert result == "no_quoting_attr_column"
 


### PR DESCRIPTION
Resolves #11858 

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

# Problem

When using the `--sample` flag with models that have camel case or spaced column names as their `event_time` field, the generated SQL would fail because the column name wasn't properly quoted. This is especially problematic for PostgreSQL which requires quoted identifiers for column names with spaces, special characters or camel case.


# Solution

The fix introduces a robust quoting system that properly handles column-level and source-level quoting configurations:

## Key Improvements

1. **Dedicated Method**: Extracted `_resolve_event_time_field_name()` to centralize the quoting logic
2. **Proper Precedence**: Column-level quote settings take precedence over source-level settings
3. **Leverages Existing Infrastructure**: Uses the `Column.create()` and `column.quoted` functionality
4. **Eliminates Duplication**: Single source of truth for field name resolution across all code paths
5. **Maintainable Design**: Cleaner, more readable code that's easier to maintain

## Technical Details

- **Column-level configuration**: Checks for `column_info.quote` setting first
- **Source-level fallback**: Uses `target.quoting.column` as fallback
- **Proper quoting**: Uses `column.quoted` for quoted names, `column.name` for unquoted
- **Consistent application**: Same logic applied across all three event time filter scenarios

## Changes Made

- Added `_resolve_event_time_field_name()` method in `BaseResolver` class
- Refactored `resolve_event_time_filter()` to use the new method
- Eliminated duplicate quoting logic across three code paths
- Improved code maintainability and readability

## Testing

The fix ensures that:
- Models with simple column names continue to work as before
- Models with camel case or spaced column names now work correctly with the `--sample` flag
- Column-level quote settings are properly respected
- Source-level quote settings are used as fallback
- PostgreSQL adapters can properly handle quoted column names in event time filters

## Breaking Changes

None. This is a backward-compatible fix that only adds proper quoting when needed.

# Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
