### PR TITLE
add argument values to ArgumentsPropertyInGenericTestDeprecation message

### DIFF
--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -758,7 +758,7 @@ class ArgumentsPropertyInGenericTestDeprecation(WarnLevel):
         return "D038"
 
     def message(self) -> str:
-        description = f"Found `arguments` property in test definition of `{self.test_name}` without usage of `require_generic_test_arguments_property` behavior change flag. The `arguments` property is deprecated for custom usage and will be used to nest keyword arguments in future versions of dbt."
+        description = f"Found `arguments` property in test definition of {self.test_name} without usage of `require_generic_test_arguments_property` behavior change flag. The `arguments` property is deprecated for custom usage and will be used to nest keyword arguments in future versions of dbt."
         return line_wrap_message(deprecation_tag(description, self.__class__.__name__))
 
 

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -240,7 +240,8 @@ class TestBuilder(Generic[Testable]):
             test_args = {**test_args, **arguments}
         elif "arguments" in test_args:
             deprecations.warn(
-                "arguments-property-in-generic-test-deprecation", test_name=test_name
+                "arguments-property-in-generic-test-deprecation",
+                test_name=f"`{test_name}` ({test_args['arguments']})",
             )
 
         return test_name, test_args


### PR DESCRIPTION
Improving error message for ArgumentsPropertyInGenericTestDeprecation warning