### PR TITLE
Raise PropertyMovedToConfigDeprecation instead of CustomTopLevelKeyDeprecation when additional attribute is a valid config

### DIFF
--- a/.changes/unreleased/Fixes-20250731-162142.yaml
+++ b/.changes/unreleased/Fixes-20250731-162142.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Raise PropertyMovedToConfigDeprecation instead of CustomTopLevelKeyDeprecation when additional attribute is a valid node config
+time: 2025-07-31T16:21:42.938703-04:00
+custom:
+    Author: michelleark
+    Issue: "11879"

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -59,7 +59,7 @@ args = _create_option_and_track_env_var(
 browser = _create_option_and_track_env_var(
     "--browser/--no-browser",
     envvar=None,
-    help="Wether or not to open a local web browser after starting the server",
+    help="Whether or not to open a local web browser after starting the server",
     default=True,
 )
 

--- a/core/dbt/jsonschemas.py
+++ b/core/dbt/jsonschemas.py
@@ -110,18 +110,16 @@ def _validate_with_schema(
 def _get_allowed_config_fields_from_error_path(
     yml_schema: Dict[str, Any], error_path: List[Union[str, int]]
 ) -> Optional[List[str]]:
-    if len(error_path) < 2:
-        return None
-
     property_field_name = None
     node_schema = yml_schema["properties"]
     for part in error_path:
         if isinstance(part, str):
             if part in node_schema:
-                property_field_name = node_schema[part]["items"]["$ref"].split("/")[-1]
-
                 if "items" not in node_schema[part]:
                     break
+
+                # Update property field name
+                property_field_name = node_schema[part]["items"]["$ref"].split("/")[-1]
 
                 # Jump to the next level of the schema
                 item_definition = node_schema[part]["items"]["$ref"].split("/")[-1]

--- a/tests/functional/deprecations/fixtures.py
+++ b/tests/functional/deprecations/fixtures.py
@@ -186,6 +186,13 @@ models:
     my_custom_property: "It's over, I have the high ground"
 """
 
+property_moved_to_config_yaml = """
+models:
+  - name: models_trivial
+    description: "This is a test model"
+    access: public
+"""
+
 test_with_arguments_yaml = """
 models:
   - name: models_trivial

--- a/tests/functional/deprecations/fixtures.py
+++ b/tests/functional/deprecations/fixtures.py
@@ -190,7 +190,21 @@ property_moved_to_config_yaml = """
 models:
   - name: models_trivial
     description: "This is a test model"
-    access: public
+    access: public  # deprecated - should be in config
+    columns:
+      - name: id
+        tags: ["test"]  # deprecated - should be in config
+
+sources:
+  - name: seed_source
+    schema: "{{ var('schema_override', target.schema) }}"
+    tags: ["test"]  # deprecated - should be in config
+    tables:
+      - name: "seed"
+        tags: ["test"]  # deprecated - should be in config
+        columns:
+          - name: id
+            tags: ["test"]  # deprecated - should be in config
 """
 
 test_with_arguments_yaml = """

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -858,5 +858,4 @@ class TestPropertyMovedToConfigDeprecation:
             ["parse", "--no-partial-parse", "--show-all-deprecations"],
             callbacks=[event_catcher.catch],
         )
-        assert len(event_catcher.caught_events) == 1
-        assert event_catcher.caught_events[0].data.key == "access"
+        assert len(event_catcher.caught_events) == 5

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -25,6 +25,7 @@ from dbt.events.types import (
     ModelParamUsageDeprecation,
     ModulesItertoolsUsageDeprecation,
     PackageRedirectDeprecation,
+    PropertyMovedToConfigDeprecation,
     WEOIncludeExcludeDeprecation,
 )
 from dbt.tests.util import read_file, run_dbt, run_dbt_and_capture, write_file
@@ -39,6 +40,7 @@ from tests.functional.deprecations.fixtures import (
     invalid_deprecation_date_yaml,
     models_trivial__model_sql,
     multiple_custom_keys_in_config_yaml,
+    property_moved_to_config_yaml,
     test_missing_arguments_property_yaml,
     test_with_arguments_yaml,
 )
@@ -838,3 +840,23 @@ class TestMissingArgumentsPropertyInGenericTestDeprecation:
             callbacks=[event_catcher.catch],
         )
         assert len(event_catcher.caught_events) == 4
+
+
+class TestPropertyMovedToConfigDeprecation:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "models_trivial.sql": models_trivial__model_sql,
+            "models.yml": property_moved_to_config_yaml,
+        }
+
+    @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
+    @mock.patch("dbt.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
+    def test_property_moved_to_config_deprecation(self, project):
+        event_catcher = EventCatcher(PropertyMovedToConfigDeprecation)
+        run_dbt(
+            ["parse", "--no-partial-parse", "--show-all-deprecations"],
+            callbacks=[event_catcher.catch],
+        )
+        assert len(event_catcher.caught_events) == 1
+        assert event_catcher.caught_events[0].data.key == "access"


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

Currently the following model definition:
```
models:
  - name: models_trivial
    description: "This is a test model"
    access: public
```

raises a `CustomTopLevelKeyDeprecation` - which is misleading because access is not 'custom' to the user - it's an accepted config part of the dbt framework. dbt-autofix reports fixing this issue as fixing `PropertyMovedToConfigDeprecation` as well. 

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Check if a field is a valid config prior and raising the more appropriate `PropertyMovedToConfigDeprecation` if it is.
Finding what valid fields are based on the schema was a little challenging to get right since we have many levels of nesting and fields with config! (e.g. sources, tables, columns)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
