### PR TITLE
Remove duplicative PropertyMovedToConfigDeprecation source `freshness` config move

### DIFF
--- a/.changes/unreleased/Fixes-20250805-104309.yaml
+++ b/.changes/unreleased/Fixes-20250805-104309.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove duplicative PropertyMovedToConfigDeprecation for source freshness
+time: 2025-08-05T10:43:09.502585-04:00
+custom:
+    Author: michelleark
+    Issue: "11880"

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -3,7 +3,6 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
-from dbt import deprecations
 from dbt.adapters.capability import Capability
 from dbt.adapters.factory import get_adapter
 from dbt.artifacts.resources import FreshnessThreshold, SourceConfig, Time
@@ -377,14 +376,6 @@ class SourcePatcher:
         source: UnparsedSourceDefinition = target.source
 
         source_freshness = source.freshness
-        if source_freshness and (target.path, source.name) not in self._deprecations:
-            deprecations.warn(
-                "property-moved-to-config-deprecation",
-                key="freshness",
-                file=target.path,
-                key_path=source.name,
-            )
-            self._deprecations.add((target.path, source.name))
 
         source_config_freshness_raw: Optional[Dict] = source.config.get(
             "freshness", {}
@@ -397,14 +388,6 @@ class SourcePatcher:
 
         table: UnparsedSourceTableDefinition = target.table
         table_freshness = table.freshness
-        if table_freshness and (target.path, table.name) not in self._deprecations:
-            deprecations.warn(
-                "property-moved-to-config-deprecation",
-                key="freshness",
-                file=target.path,
-                key_path=table.name,
-            )
-            self._deprecations.add((target.path, table.name))
 
         table_config_freshness_raw: Optional[Dict] = table.config.get(
             "freshness", {}

--- a/tests/functional/deprecations/fixtures.py
+++ b/tests/functional/deprecations/fixtures.py
@@ -199,6 +199,10 @@ sources:
   - name: seed_source
     schema: "{{ var('schema_override', target.schema) }}"
     tags: ["test"]  # deprecated - should be in config
+    freshness: # deprecated - should be in config
+      warn_after:
+        count: 1
+        period: day
     tables:
       - name: "seed"
         tags: ["test"]  # deprecated - should be in config

--- a/tests/functional/deprecations/fixtures.py
+++ b/tests/functional/deprecations/fixtures.py
@@ -206,9 +206,14 @@ sources:
     tables:
       - name: "seed"
         tags: ["test"]  # deprecated - should be in config
+        freshness: # deprecated - should be in config
+          warn_after:
+            count: 1
+            period: day
         columns:
           - name: id
             tags: ["test"]  # deprecated - should be in config
+      - name: "another_table"
 """
 
 test_with_arguments_yaml = """

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -858,4 +858,4 @@ class TestPropertyMovedToConfigDeprecation:
             ["parse", "--no-partial-parse", "--show-all-deprecations"],
             callbacks=[event_catcher.catch],
         )
-        assert len(event_catcher.caught_events) == 5
+        assert len(event_catcher.caught_events) == 6

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -858,4 +858,4 @@ class TestPropertyMovedToConfigDeprecation:
             ["parse", "--no-partial-parse", "--show-all-deprecations"],
             callbacks=[event_catcher.catch],
         )
-        assert len(event_catcher.caught_events) == 6
+        assert len(event_catcher.caught_events) == 7


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

Currently, the following yml raises 4 PropertyMovedToConfigDeprecation warnings when there should only be 2 - one set from the hand-rolled freshness check and one set from the now-correct jsonschemas are currently being raised. 

```yml
sources:
  - name: seed_source
    schema: "{{ var('schema_override', target.schema) }}"
    freshness: # deprecated - should be in config
      warn_after:
        count: 1
        period: day
    tables:
      - name: "seed"
        freshness: # deprecated - should be in config
          warn_after:
            count: 1
            period: day
      - name: "another_table"
```

```sh

Invoking dbt with ['parse', '--no-partial-parse', '--show-all-deprecations']
14:50:14  Running with dbt=1.11.0-a1
14:50:14  Registered adapter: postgres=1.9.1-a0
14:50:15  [WARNING][PropertyMovedToConfigDeprecation]: Deprecated functionality
Found `freshness` as a top-level property of `sources[0].tables[0]` in file
`models/models.yml`. The `freshness` top-level property should be moved into the
`config` of `sources[0].tables[0]`.
14:50:15  [WARNING][PropertyMovedToConfigDeprecation]: Deprecated functionality
Found `freshness` as a top-level property of `sources[0]` in file
`models/models.yml`. The `freshness` top-level property should be moved into the
`config` of `sources[0]`.
14:50:15  [WARNING][PropertyMovedToConfigDeprecation]: Deprecated functionality
Found `freshness` as a top-level property of `seed_source` in file
`models/models.yml`. The `freshness` top-level property should be moved into the
`config` of `seed_source`.
14:50:15  [WARNING][PropertyMovedToConfigDeprecation]: Deprecated functionality
Found `freshness` as a top-level property of `seed` in file `models/models.yml`.
The `freshness` top-level property should be moved into the `config` of `seed`.
14:50:15  The configured adapter does not support metadata-based freshness. A loaded_at_field must be specified for source 'seed_source.seed'.
14:50:15  The configured adapter does not support metadata-based freshness. A loaded_at_field must be specified for source 'seed_source.another_table'.
14:50:15  Performance info: /private/var/folders/yj/7kyhyl8s3ql8bb1vjwkh_8pr0000gp/T/pytest-of-michelleark/pytest-272/project38/target/perf_info.json
14:50:15  [WARNING][DeprecationsSummary]: Deprecated functionality
Summary of encountered deprecations:
- PropertyMovedToConfigDeprecation: 4 occurrences
```
### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Remove the handrolled deprecation, 🎩 we get the right number of deprecations afterwards:
```
Invoking dbt with ['parse', '--no-partial-parse', '--show-all-deprecations']
14:51:53  Running with dbt=1.11.0-a1
14:51:53  Registered adapter: postgres=1.9.1-a0
14:51:53  [WARNING][PropertyMovedToConfigDeprecation]: Deprecated functionality
Found `freshness` as a top-level property of `sources[0].tables[0]` in file
`models/models.yml`. The `freshness` top-level property should be moved into the
`config` of `sources[0].tables[0]`.
14:51:53  [WARNING][PropertyMovedToConfigDeprecation]: Deprecated functionality
Found `freshness` as a top-level property of `sources[0]` in file
`models/models.yml`. The `freshness` top-level property should be moved into the
`config` of `sources[0]`.
14:51:53  The configured adapter does not support metadata-based freshness. A loaded_at_field must be specified for source 'seed_source.seed'.
14:51:53  The configured adapter does not support metadata-based freshness. A loaded_at_field must be specified for source 'seed_source.another_table'.
14:51:53  Performance info: /private/var/folders/yj/7kyhyl8s3ql8bb1vjwkh_8pr0000gp/T/pytest-of-michelleark/pytest-273/project38/target/perf_info.json
14:51:53  [WARNING][DeprecationsSummary]: Deprecated functionality
Summary of encountered deprecations:
- PropertyMovedToConfigDeprecation: 2 occurrences
```


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
