### PR TITLE
Default parse-time nodes' `raw_code` property to `""` (empty string) to comply with strict `str` type

### DIFF
--- a/.changes/unreleased/Fixes-20250804-074254.yaml
+++ b/.changes/unreleased/Fixes-20250804-074254.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Comply with strict `str` type when `block.contents` is `None`
+time: 2025-08-04T07:42:54.612616-06:00
+custom:
+    Author: wircho
+    Issue: "11492"

--- a/core/dbt/parser/base.py
+++ b/core/dbt/parser/base.py
@@ -244,7 +244,7 @@ class ConfiguredParser(
             "path": path,
             "original_file_path": block.path.original_file_path,
             "package_name": self.project.project_name,
-            "raw_code": block.contents,
+            "raw_code": block.contents or "",
             "language": language,
             "unique_id": self.generate_unique_id(name),
             "config": self.config_dict(config),


### PR DESCRIPTION
Resolves #11492

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

This code creates a dictionary to be deserialized into a node. The `raw_code` field of parsed nodes is `str` (see [here](https://github.com/dbt-labs/dbt-core/blob/b1705fb6f341baf97efa57d185976a39cb7fe135/core/dbt/artifacts/resources/v1/components.py#L227)). However, the value `block.contents` can be null (see [here](https://github.com/dbt-labs/dbt-core/blob/b1705fb6f341baf97efa57d185976a39cb7fe135/core/dbt/contracts/files.py#L115-L116)), which can cause a deserialization error, as seen in #11492, where full parsing fails after cached snapshot YAML files (without cached contents), are leveraged

### Solution

The solution here is simple. Instead of assigning `block.contents` to the `raw_code` field, we assign `block.contents or ""`. This empty string is consistent with [the default value](https://github.com/dbt-labs/dbt-core/blob/b1705fb6f341baf97efa57d185976a39cb7fe135/core/dbt/artifacts/resources/v1/components.py#L227) of the `raw_code` field in dbt nodes.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] ~This PR includes tests~, or **tests are not required or relevant for this PR**.
- [x] **This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.)** or ~this PR has already received feedback and approval from Product or DX.~
- [x] ~This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.~
