### PR TITLE
Avoid redundant node patch removal during partial parsing

### DIFF
--- a/.changes/unreleased/Fixes-20250804-074006.yaml
+++ b/.changes/unreleased/Fixes-20250804-074006.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Avoid redundant node patch removal during partial parsing
+time: 2025-08-04T07:40:06.993913-06:00
+custom:
+    Author: wircho
+    Issue: "11886"

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -870,7 +870,10 @@ class PartialParsing:
                     if node.is_versioned or elem.get("versions"):
                         self.schedule_referencing_nodes_for_parsing(node.unique_id)
             # remove from patches
-            schema_file.node_patches.remove(elem_unique_id)
+            # For versioned models, the schedule_referencing_nodes_for_parsing call above
+            # could have caused a recursive visit to this file.
+            if elem_unique_id in schema_file.node_patches:
+                schema_file.node_patches.remove(elem_unique_id)
 
         # for models, seeds, snapshots (not analyses)
         if dict_key in ["models", "seeds", "snapshots"]:


### PR DESCRIPTION
Resolves #11886

### Problem

It is possible that by the time the code `schema_file.node_patches.remove(elem_unique_id)`, the list `schema_file.node_patches` no longer contains `elem_unique_id`. This is because for versioned models, there is a call to `schedule_referencing_nodes_for_parsing` which can cause this removal to happen twice (the second one failing). This can lead to a partial parsing error, as detailed in https://github.com/dbt-labs/dbt-core/issues/11886

### Solution

The solution here is to condition the `schema_file.node_patches.remove(elem_unique_id)` call to avoid an attempted redundant removal.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] ~This PR includes tests, or~ **tests are not required or relevant for this PR**.
- [x] **This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.)** ~or this PR has already received feedback and approval from Product or DX.~
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
