### PR TITLE
call adapter.add_catalog_integration during parse_manifest

### DIFF
--- a/.changes/unreleased/Under the Hood-20250804-211346.yaml
+++ b/.changes/unreleased/Under the Hood-20250804-211346.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: call adapter.add_catalog_integration during parse_manifest
+time: 2025-08-04T21:13:46.077488-07:00
+custom:
+  Author: colin-rogers-dbt
+  Issue: "11889"

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -428,5 +428,3 @@ def setup_manifest(ctx: Context, write: bool = True, write_perf_info: bool = Fal
         adapter.set_macro_resolver(ctx.obj["manifest"])
         query_header_context = generate_query_header_context(adapter.config, ctx.obj["manifest"])  # type: ignore[attr-defined]
         adapter.connections.set_query_header(query_header_context)
-        for integration in active_integrations:
-            adapter.add_catalog_integration(integration)

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -414,7 +414,11 @@ def setup_manifest(ctx: Context, write: bool = True, write_perf_info: bool = Fal
     # if a manifest has already been set on the context, don't overwrite it
     if ctx.obj.get("manifest") is None:
         ctx.obj["manifest"] = parse_manifest(
-            runtime_config, write_perf_info, write, ctx.obj["flags"].write_json
+            runtime_config,
+            write_perf_info,
+            write,
+            ctx.obj["flags"].write_json,
+            active_integrations,
         )
         adapter = get_adapter(runtime_config)
     else:
@@ -424,6 +428,5 @@ def setup_manifest(ctx: Context, write: bool = True, write_perf_info: bool = Fal
         adapter.set_macro_resolver(ctx.obj["manifest"])
         query_header_context = generate_query_header_context(adapter.config, ctx.obj["manifest"])  # type: ignore[attr-defined]
         adapter.connections.set_query_header(query_header_context)
-
-    for integration in active_integrations:
-        adapter.add_catalog_integration(integration)
+        for integration in active_integrations:
+            adapter.add_catalog_integration(integration)

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -25,7 +25,12 @@ from dbt.adapters.factory import (
     get_relation_class_by_name,
     register_adapter,
 )
-from dbt.artifacts.resources import FileHash, NodeRelation, NodeVersion
+from dbt.artifacts.resources import (
+    CatalogWriteIntegrationConfig,
+    FileHash,
+    NodeRelation,
+    NodeVersion,
+)
 from dbt.artifacts.resources.types import BatchSize
 from dbt.artifacts.schemas.base import Writable
 from dbt.clients.jinja import MacroStack, get_rendered
@@ -2108,10 +2113,13 @@ def parse_manifest(
     write_perf_info: bool,
     write: bool,
     write_json: bool,
+    active_integrations: List[CatalogWriteIntegrationConfig],
 ) -> Manifest:
     register_adapter(runtime_config, get_mp_context())
     adapter = get_adapter(runtime_config)
     adapter.set_macro_context_generator(generate_runtime_macro_context)
+    for integration in active_integrations:
+        adapter.add_catalog_integration(integration)
     manifest = ManifestLoader.get_full_manifest(
         runtime_config,
         write_perf_info=write_perf_info,

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -2113,7 +2113,7 @@ def parse_manifest(
     write_perf_info: bool,
     write: bool,
     write_json: bool,
-    active_integrations: List[CatalogWriteIntegrationConfig],
+    active_integrations: List[Optional[CatalogWriteIntegrationConfig]],
 ) -> Manifest:
     register_adapter(runtime_config, get_mp_context())
     adapter = get_adapter(runtime_config)

--- a/core/dbt/task/retry.py
+++ b/core/dbt/task/retry.py
@@ -117,7 +117,7 @@ class RetryTask(ConfiguredTask):
         retry_config = RuntimeConfig.from_args(args=retry_flags)
 
         # Parse manifest using resolved config/flags
-        manifest = parse_manifest(retry_config, False, True, retry_flags.write_json)  # type: ignore
+        manifest = parse_manifest(retry_config, False, True, retry_flags.write_json, [])  # type: ignore
         super().__init__(args, retry_config, manifest)
         self.task_class = TASK_DICT.get(self.previous_command_name)  # type: ignore
 


### PR DESCRIPTION
Discovered as part of improving support in databricks for using write catalogs (see: [this PR for dbt-databricks](https://github.com/databricks/dbt-databricks/pull/1129)) we sometimes need to update the database for a node if there is an external catalog attached to it. That macro is currently called _before_ we actually call `add_catalog_integration` on the adapter so this will always result in an exception from the adapter that the catalog is not found. 

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
