### PR TITLE
dont use default token

### DIFF
--- a/.github/workflows/artifact-reviews.yml
+++ b/.github/workflows/artifact-reviews.yml
@@ -165,15 +165,20 @@ jobs:
 
       - name: "Post Event"
         run: |
+          # Convert our status to GitHub status state
+          if [[ "${{ steps.status_check.outputs.current_status }}" == "success" ]]; then
+            state="success"
+          else
+            state="pending"
+          fi
+
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
-            /repos/${{ github.repository }}/check-runs \
-            -f name='Artifact Review Check' \
-            -f head_sha=${{ github.event.pull_request_target.head.sha || github.event.pull_request.head.sha }} \
-            -f status='completed' \
-            -f conclusion='${{ steps.status_check.outputs.current_status }}' \
-            -f force=true \
-            -f details_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            /repos/${{ github.repository }}/statuses/${{ github.event.pull_request_target.head.sha || github.event.pull_request.head.sha }} \
+            -f state="$state" \
+            -f description="Artifact Review Check" \
+            -f context="Artifact Review Check" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.IT_TEAM_MEMBERSHIP }}

--- a/.github/workflows/artifact-reviews.yml
+++ b/.github/workflows/artifact-reviews.yml
@@ -164,21 +164,23 @@ jobs:
           fi
 
       - name: "Post Event"
+        # This step posts the status of the check because the workflow is triggered by multiple events
+        # and we need to ensure the check is always updated.  Otherwise we would end up with duplicate
+        # checks in the GitHub UI.
         run: |
-          # Convert our status to GitHub status state
           if [[ "${{ steps.status_check.outputs.current_status }}" == "success" ]]; then
             state="success"
           else
-            state="pending"
+            state="failure"
           fi
 
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
-            /repos/${{ github.repository }}/statuses/${{ github.event.pull_request_target.head.sha || github.event.pull_request.head.sha }} \
+            /repos/${{ github.repository }}/statuses/${{ github.event.pull_request.base.sha }} \
             -f state="$state" \
             -f description="Artifact Review Check" \
             -f context="Artifact Review Check" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
-          GH_TOKEN: ${{ secrets.IT_TEAM_MEMBERSHIP }}
+          GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}


### PR DESCRIPTION
Resolves #11899 

### Problem

Community PRs can never pass the artifact check for number of reviews because the GITHUB_TOKEN doesn't have sufficient permissions.

### Solution

Use the fishtown bot.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
