### PR TITLE
flip require_generic_test_arguments_property behavior change flag

### DIFF
--- a/.changes/unreleased/Features-20250811-150347.yaml
+++ b/.changes/unreleased/Features-20250811-150347.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Flip require_generic_test_arguments_property flag
+time: 2025-08-11T15:03:47.369377+02:00
+custom:
+    Author: michelleark
+    Issue: "11911"

--- a/.changes/unreleased/Features-20250811-150347.yaml
+++ b/.changes/unreleased/Features-20250811-150347.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Flip require_generic_test_arguments_property flag
+body: Default require_generic_test_arguments_property flag to True - The 'arguments' property will be parsed as keyword arguments to data tests, if provided
 time: 2025-08-11T15:03:47.369377+02:00
 custom:
     Author: michelleark

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -361,7 +361,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     require_nested_cumulative_type_params: bool = False
     validate_macro_args: bool = False
     require_all_warnings_handled_by_warn_error: bool = False
-    require_generic_test_arguments_property: bool = False
+    require_generic_test_arguments_property: bool = True
 
     @property
     def project_only_flags(self) -> Dict[str, Any]:

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -233,7 +233,9 @@ class TestBuilder(Generic[Testable]):
         # Extract kwargs when they are nested under new 'arguments' property separately from 'config' if require_generic_test_arguments_property is enabled
         if get_flags().require_generic_test_arguments_property:
             arguments = test_args.pop("arguments", {})
-            if not arguments and any(k not in ("config", "column_name") for k in test_args.keys()):
+            if not arguments and any(
+                k not in ("config", "column_name", "description", "name") for k in test_args.keys()
+            ):
                 deprecations.warn(
                     "missing-arguments-property-in-generic-test-deprecation", test_name=test_name
                 )

--- a/core/dbt/parser/generic_test_builders.py
+++ b/core/dbt/parser/generic_test_builders.py
@@ -237,7 +237,8 @@ class TestBuilder(Generic[Testable]):
                 deprecations.warn(
                     "missing-arguments-property-in-generic-test-deprecation", test_name=test_name
                 )
-            test_args = {**test_args, **arguments}
+            if isinstance(arguments, dict):
+                test_args = {**test_args, **arguments}
         elif "arguments" in test_args:
             deprecations.warn(
                 "arguments-property-in-generic-test-deprecation",

--- a/tests/functional/defer_state/fixtures.py
+++ b/tests/functional/defer_state/fixtures.py
@@ -69,7 +69,8 @@ models:
       - name: id
         data_tests:
           - unique:
-              severity: error
+              config:
+                severity: error
           - not_null
       - name: name
 """

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -773,7 +773,16 @@ class TestJsonSchemaValidationGating:
         assert len(event_catcher.caught_events) == expected_events
 
 
-class TestArgumentsPropertyInGenericTestDeprecation:
+class TestArgumentsPropertyInGenericTestDeprecationFalse:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "config-version": 2,
+            "flags": {
+                "require_generic_test_arguments_property": False,
+            },
+        }
+
     @pytest.fixture(scope="class")
     def models(self):
         return {
@@ -790,7 +799,24 @@ class TestArgumentsPropertyInGenericTestDeprecation:
         assert len(event_catcher.caught_events) == 4
 
 
-class TestArgumentsPropertyInGenericTestDeprecationBehaviorChange:
+class TestArgumentsPropertyInGenericTestDeprecationBehaviorChangeDefault:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "models_trivial.sql": models_trivial__model_sql,
+            "models.yml": test_with_arguments_yaml,
+        }
+
+    def test_arguments_property_in_generic_test_deprecation(self, project):
+        event_catcher = EventCatcher(ArgumentsPropertyInGenericTestDeprecation)
+        run_dbt(
+            ["parse", "--no-partial-parse", "--show-all-deprecations"],
+            callbacks=[event_catcher.catch],
+        )
+        assert len(event_catcher.caught_events) == 0
+
+
+class TestArgumentsPropertyInGenericTestDeprecationTrue:
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {

--- a/tests/functional/fixtures/happy_path_project/seeds/s.yml
+++ b/tests/functional/fixtures/happy_path_project/seeds/s.yml
@@ -3,7 +3,8 @@ seeds:
     description: 'test_description'
     data_tests:
       - expression_is_true:
-          expression: "b = 2"
+          arguments:
+            expression: "b = 2"
     columns:
       - name: a
         description: a description

--- a/tests/functional/retry/fixtures.py
+++ b/tests/functional/retry/fixtures.py
@@ -14,8 +14,9 @@ models:
       - name: foo
         data_tests:
           - accepted_values:
-              values: [3]
-              quote: false
+              arguments:
+                values: [3]
+                quote: false
               config:
                 severity: warn
   - name: second_model
@@ -23,8 +24,9 @@ models:
       - name: bar
         data_tests:
           - accepted_values:
-              values: [3]
-              quote: false
+              arguments:
+                values: [3]
+                quote: false
               config:
                 severity: warn
   - name: union_model
@@ -32,8 +34,9 @@ models:
       - name: sum3
         data_tests:
           - accepted_values:
-              values: [3]
-              quote: false
+              arguments:
+                values: [3]
+                quote: false
 """
 
 macros__alter_timezone_sql = """


### PR DESCRIPTION
Resolves #n/a

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
* Need to start raising deprecation warnings regarding legacy un-strict generic test syntax

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

* flip `require_generic_test_arguments_property ` to true - this means that by default any custom arguments 
* add additional safety handling in case an existing `arguments` property is not a dictionary.
### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
