### PR TITLE
Add a warning when regenerating the lockfile for packages and there is a hash mismatch

### DIFF
--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1517,6 +1517,14 @@ class DepsFoundDuplicatePackage(InfoLevel):
         return f"Found duplicate package in packages.yml, removing: {self.removed_package}"
 
 
+class DepsLockfileRegenerating(WarnLevel):
+    def code(self):
+        return "M034"
+
+    def message(self) -> str:
+        return f"Package lockfile is out of sync with packages.yml. Regenerating lockfile at: {self.lock_filepath}"
+
+
 class DepsScrubbedPackageName(WarnLevel):
     def code(self):
         return "M035"

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -21,6 +21,7 @@ from dbt.events.types import (
     DepsFoundDuplicatePackage,
     DepsInstallInfo,
     DepsListSubdirectory,
+    DepsLockfileRegenerating,
     DepsLockUpdating,
     DepsNoPackagesFound,
     DepsNotifyUpdatesAvailable,
@@ -220,6 +221,7 @@ class DepsTask(BaseTask):
             current_hash = _create_sha1_hash(self.project.packages.packages)
             previous_hash = load_yml_dict(lock_file_path).get(PACKAGE_LOCK_HASH_KEY, None)
             if previous_hash != current_hash:
+                fire_event(DepsLockfileRegenerating(lock_filepath=lock_file_path))
                 self.lock()
 
         # Early return when 'dbt deps --lock'


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/11913

### Problem

Sometimes, the lockfile is regenerated and this is not very visible to the user. This can cause package updates at unexpected times, leading to instability.

### Solution

Add a warning when the lockfile is regenerated

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
