### PR TITLE
Bump dbt adapters minimum to 1.16.5

### DIFF
--- a/.changes/unreleased/Dependencies-20250819-085714.yaml
+++ b/.changes/unreleased/Dependencies-20250819-085714.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump dbt-adapters minimum to 1.16.5
+time: 2025-08-19T08:57:14.396843-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11932"

--- a/core/setup.py
+++ b/core/setup.py
@@ -73,7 +73,7 @@ setup(
         "dbt-semantic-interfaces>=0.9.0,<0.10",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.27.0,<2.0",
-        "dbt-adapters>=1.15.2,<2.0",
+        "dbt-adapters>=1.15.5,<2.0",
         "dbt-protos>=1.0.346,<2.0",
         "pydantic<3",
         # ----


### PR DESCRIPTION
Resolves #11932 

### Problem

There is an important bug fix in dbt-adapters 1.16.5, as such dbt-adapters 1.16.5 should be the minimum we allow

### Solution

Bump the minimum dbt-adapters spec to 1.16.5

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
