### PR TITLE
Fix `Dockerfile` used for dockerized release image

### DIFF
--- a/.changes/unreleased/Under the Hood-20250819-123448.yaml
+++ b/.changes/unreleased/Under the Hood-20250819-123448.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Fix docker os dependency install issue
+time: 2025-08-19T12:34:48.402158-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11934"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG py_version=3.11.2
 
-FROM python:$py_version-slim-bullseye as base
+FROM python:$py_version-slim-bullseye AS base
 
 RUN apt-get update \
   && apt-get dist-upgrade -y \
@@ -24,7 +24,7 @@ ENV LANG=C.UTF-8
 RUN python -m pip install --upgrade "pip==24.0" "setuptools==69.2.0" "wheel==0.43.0" --no-cache-dir
 
 
-FROM base as dbt-core
+FROM base AS dbt-core
 
 ARG commit_ref=main
 
@@ -36,7 +36,7 @@ ENTRYPOINT ["dbt"]
 RUN python -m pip install --no-cache-dir "dbt-core @ git+https://github.com/dbt-labs/dbt-core@${commit_ref}#subdirectory=core"
 
 
-FROM base as dbt-postgres
+FROM base AS dbt-postgres
 
 ARG commit_ref=main
 
@@ -48,7 +48,7 @@ ENTRYPOINT ["dbt"]
 RUN python -m pip install --no-cache-dir "dbt-postgres @ git+https://github.com/dbt-labs/dbt-core@${commit_ref}#subdirectory=plugins/postgres"
 
 
-FROM dbt-core as dbt-third-party
+FROM dbt-core AS dbt-third-party
 
 ARG dbt_third_party
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
     build-essential=12.9 \
     ca-certificates=20210119 \
     git=1:2.30.2-1+deb11u2 \
-    libpq-dev=13.21-0+deb11u1 \
+    libpq-dev=13.22-0+deb11u1 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \


### PR DESCRIPTION
Resolves #11934 

### Problem

The docker release was failing during the release action

### Solution

Debugged the Dockerfile to see what was broken. Turned out to be an issue with the version of `libpq-dev` we were specifying

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
