### PR TITLE
Support `quoting.snowflake_ignore_case`

### DIFF
--- a/.changes/unreleased/Features-20250821-092532.yaml
+++ b/.changes/unreleased/Features-20250821-092532.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: No-op when project-level `quoting.snowflake_ignore_case` is set.
+time: 2025-08-21T09:25:32.049328307+02:00
+custom:
+    Author: aksestok
+    Issue: "11882"

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -38,6 +38,7 @@ class Quoting(dbtClassMixin, Mergeable):
     database: Optional[bool] = None
     project: Optional[bool] = None
     identifier: Optional[bool] = None
+    snowflake_ignore_case: Optional[bool] = None
 
 
 @dataclass
@@ -396,6 +397,7 @@ class ConfiguredQuoting(Quoting):
     schema: bool = True
     database: Optional[bool] = None
     project: Optional[bool] = None
+    snowflake_ignore_case: Optional[bool] = None
 
 
 @dataclass

--- a/core/dbt/include/jsonschemas/project/0.0.110.json
+++ b/core/dbt/include/jsonschemas/project/0.0.110.json
@@ -514,6 +514,12 @@
             "boolean",
             "null"
           ]
+        },
+        "snowflake_ignore_case": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/core/dbt/include/jsonschemas/project/0.0.110.json
+++ b/core/dbt/include/jsonschemas/project/0.0.110.json
@@ -514,12 +514,6 @@
             "boolean",
             "null"
           ]
-        },
-        "snowflake_ignore_case": {
-          "type": [
-            "boolean",
-            "null"
-          ]
         }
       },
       "additionalProperties": false

--- a/tests/unit/config/test_project.py
+++ b/tests/unit/config/test_project.py
@@ -153,7 +153,7 @@ class TestProjectInitialization(BaseConfigTest):
                 "asset-paths": ["other-assets"],
                 "clean-targets": ["another-target"],
                 "packages-install-path": "other-dbt_packages",
-                "quoting": {"identifier": False},
+                "quoting": {"identifier": False, "snowflake_ignore_case": True},
                 "models": {
                     "pre-hook": ["{{ logging.log_model_start_event() }}"],
                     "post-hook": ["{{ logging.log_model_end_event() }}"],
@@ -214,7 +214,7 @@ class TestProjectInitialization(BaseConfigTest):
         self.assertEqual(project.asset_paths, ["other-assets"])
         self.assertEqual(project.clean_targets, ["another-target"])
         self.assertEqual(project.packages_install_path, "other-dbt_packages")
-        self.assertEqual(project.quoting, {"identifier": False})
+        self.assertEqual(project.quoting, {"identifier": False, "snowflake_ignore_case": True})
         self.assertEqual(
             project.models,
             {


### PR DESCRIPTION
Resolves #11882.

I couldn't for the life of me get `flake8` or `mypy` to run in pre-commit, but they did run successfully outside of the pre-commit context.

### Problem

dbt Fusion users can't set `quoting.snowflake_ignore_case` in their project files if they also use dbt core.

### Solution

Implements the proposed solution in #11882.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
