### PR TITLE
[Tidy First] Don't allow for the direct import of versioned artifact resources in dbt-core's modules

### DIFF
--- a/.changes/unreleased/Under the Hood-20250822-162752.yaml
+++ b/.changes/unreleased/Under the Hood-20250822-162752.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Ensure dbt-core modules aren't importing versioned artifact resources directly
+time: 2025-08-22T16:27:52.403177-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11951"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,3 +69,12 @@ repos:
     args: [--show-error-codes, --pretty]
     files: ^core/dbt/
     language: system
+- repo: local
+  hooks:
+    - id: no_versioned_artifact_resource_imports
+      name: no_versioned_artifact_resource_imports
+      entry: python custom-hooks/no_versioned_artifact_resource_imports.py
+      language: system
+      files: ^core/dbt/
+      types: [python]
+      pass_filenames: true

--- a/core/dbt/artifacts/resources/__init__.py
+++ b/core/dbt/artifacts/resources/__init__.py
@@ -25,6 +25,8 @@ from dbt.artifacts.resources.v1.config import (
     NodeAndTestConfig,
     NodeConfig,
     TestConfig,
+    list_str,
+    metas,
 )
 from dbt.artifacts.resources.v1.documentation import Documentation
 from dbt.artifacts.resources.v1.exposure import (
@@ -49,6 +51,7 @@ from dbt.artifacts.resources.v1.metric import (
     MetricTypeParams,
 )
 from dbt.artifacts.resources.v1.model import (
+    CustomGranularity,
     Model,
     ModelConfig,
     ModelFreshness,
@@ -80,6 +83,7 @@ from dbt.artifacts.resources.v1.semantic_model import (
     MeasureAggregationParameters,
     NodeRelation,
     NonAdditiveDimension,
+    SemanticLayerElementConfig,
     SemanticModel,
     SemanticModelConfig,
 )

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -23,7 +23,7 @@ from dbt.adapters.contracts.connection import (
 )
 from dbt.adapters.contracts.relation import ComponentName
 from dbt.adapters.factory import get_include_paths, get_relation_class_by_name
-from dbt.artifacts.resources.v1.components import Quoting
+from dbt.artifacts.resources import Quoting
 from dbt.config.project import load_raw_project
 from dbt.contracts.graph.manifest import ManifestMetadata
 from dbt.contracts.project import Configuration

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -32,8 +32,13 @@ from dbt.adapters.exceptions import (
 from dbt.adapters.factory import get_adapter_package_names
 
 # to preserve import paths
-from dbt.artifacts.resources import BaseResource, DeferRelation, NodeVersion, RefArgs
-from dbt.artifacts.resources.v1.config import NodeConfig
+from dbt.artifacts.resources import (
+    BaseResource,
+    DeferRelation,
+    NodeConfig,
+    NodeVersion,
+    RefArgs,
+)
 from dbt.artifacts.schemas.manifest import ManifestMetadata, UniqueID, WritableManifest
 from dbt.clients.jinja_static import statically_parse_ref_or_source
 from dbt.contracts.files import (

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -45,6 +45,7 @@ from dbt.artifacts.resources import MetricInputMeasure
 from dbt.artifacts.resources import Model as ModelResource
 from dbt.artifacts.resources import (
     ModelConfig,
+    ModelFreshness,
     NodeConfig,
     NodeVersion,
     ParsedResource,
@@ -60,7 +61,6 @@ from dbt.artifacts.resources import SourceDefinition as SourceDefinitionResource
 from dbt.artifacts.resources import SqlOperation as SqlOperationResource
 from dbt.artifacts.resources import TimeSpine
 from dbt.artifacts.resources import UnitTestDefinition as UnitTestDefinitionResource
-from dbt.artifacts.resources.v1.model import ModelFreshness
 from dbt.artifacts.schemas.batch_results import BatchResults
 from dbt.clients.jinja_static import statically_extract_has_name_this
 from dbt.contracts.graph.model_config import UnitTestNodeConfig

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -26,8 +26,9 @@ from dbt.artifacts.resources import (
     UnitTestNodeVersions,
     UnitTestOutputFixture,
     UnitTestOverrides,
+    list_str,
+    metas,
 )
-from dbt.artifacts.resources.v1.config import list_str, metas
 from dbt.exceptions import ParsingError
 from dbt.node_types import NodeType
 from dbt_common.contracts.config.base import CompareBehavior, MergeBehavior

--- a/core/dbt/parser/macros.py
+++ b/core/dbt/parser/macros.py
@@ -2,7 +2,7 @@ from typing import Iterable, List
 
 import jinja2
 
-from dbt.artifacts.resources.v1.macro import MacroArgument
+from dbt.artifacts.resources import MacroArgument
 from dbt.clients.jinja import get_supported_languages
 from dbt.contracts.files import FilePath, SourceFile
 from dbt.contracts.graph.nodes import Macro

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -19,10 +19,10 @@ from dbt.artifacts.resources import (
     NonAdditiveDimension,
     QueryParams,
     SavedQueryConfig,
+    SemanticLayerElementConfig,
     WhereFilter,
     WhereFilterIntersection,
 )
-from dbt.artifacts.resources.v1.semantic_model import SemanticLayerElementConfig
 from dbt.clients.jinja import get_rendered
 from dbt.context.context_config import (
     BaseContextConfigGenerator,

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -17,8 +17,7 @@ from typing import (
     TypeVar,
 )
 
-from dbt.artifacts.resources import RefArgs
-from dbt.artifacts.resources.v1.model import CustomGranularity, TimeSpine
+from dbt.artifacts.resources import CustomGranularity, RefArgs, TimeSpine
 from dbt.clients.checked_load import (
     checked_load,
     issue_deprecation_warnings_for_failures,

--- a/custom-hooks/no_versioned_artifact_resource_imports.py
+++ b/custom-hooks/no_versioned_artifact_resource_imports.py
@@ -52,7 +52,8 @@ def main():
     for filepath in sys.argv[1:]:
         if has_bad_artifact_resource_imports(filepath):
             all_passed = False
-    return all_passed
+
+    return 0 if all_passed else 1
 
 
 if __name__ == "__main__":

--- a/custom-hooks/no_versioned_artifact_resource_imports.py
+++ b/custom-hooks/no_versioned_artifact_resource_imports.py
@@ -1,0 +1,59 @@
+import os
+import sys
+
+
+def normalize(path: str) -> str:
+    """On windows, neither is enough on its own:
+    >>> normcase('C:\\documents/ALL CAPS/subdir\\..')
+    'c:\\documents\\all caps\\subdir\\..'
+    >>> normpath('C:\\documents/ALL CAPS/subdir\\..')
+    'C:\\documents\\ALL CAPS'
+    >>> normpath(normcase('C:\\documents/ALL CAPS/subdir\\..'))
+    'c:\\documents\\all caps'
+    """
+    return os.path.normcase(os.path.normpath(path))
+
+
+def has_bad_artifact_resource_imports(filepath: str) -> bool:
+    """
+    Checks for improper artifact resource imports outside of the artifacts module.
+
+    Returns:
+        True if a file imports from a versioned artifacts module
+        False otherwise
+    """
+
+    if not filepath.endswith(".py"):
+        # skip non-python files
+        return False
+    elif normalize("core/dbt/artifacts") in filepath:
+        # skip files in the artifacts module
+        return False
+
+    with open(filepath, "r") as f:
+        lines = f.readlines()
+
+    has_bad_imports = False
+    for line_number, line in enumerate(lines):
+        line_without_whitespace = line.strip()
+        if line_without_whitespace.startswith(
+            "from dbt.artifacts.resources.v1"
+        ) or line_without_whitespace.startswith("import dbt.artifacts.resources.v1"):
+            has_bad_imports = True
+            print(
+                f"{filepath}:{line_number}: Imports from versioned artifacts resource. Instead import from dbt.artifacts.resource directly."
+            )
+
+    return has_bad_imports
+
+
+def main():
+    all_passed = True
+    for filepath in sys.argv[1:]:
+        if has_bad_artifact_resource_imports(filepath):
+            all_passed = False
+    return all_passed
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Resolves #11951 

### Problem
A number of direct imports of versioned artifact resources have slipped into dbt-modules. When we created artifacts, we made it so that resources could be versioned AND that the artifacts module would handle which version of a resource is "current". As such, it's problematic if dbt-core modules import the versioned artifact resource directly.

### Solution

* Create a pre-commit hook which checks for imports of versioned artifact resources
* Clean-up existing imports of versioned artifact resources

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
