### PR TITLE
Allow for the defining of basic SQL UDFs

### DIFF
--- a/.changes/unreleased/Features-20250826-132700.yaml
+++ b/.changes/unreleased/Features-20250826-132700.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support UDFs by allowing user definition of `function` nodes
+time: 2025-08-26T13:27:00.607953-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11923"

--- a/core/dbt/artifacts/resources/__init__.py
+++ b/core/dbt/artifacts/resources/__init__.py
@@ -35,6 +35,13 @@ from dbt.artifacts.resources.v1.exposure import (
     ExposureType,
     MaturityType,
 )
+from dbt.artifacts.resources.v1.function import (
+    Function,
+    FunctionArgument,
+    FunctionConfig,
+    FunctionMandatory,
+    FunctionReturnType,
+)
 from dbt.artifacts.resources.v1.generic_test import GenericTest, TestMetadata
 from dbt.artifacts.resources.v1.group import Group, GroupConfig
 from dbt.artifacts.resources.v1.hook import HookNode

--- a/core/dbt/artifacts/resources/types.py
+++ b/core/dbt/artifacts/resources/types.py
@@ -35,6 +35,7 @@ class NodeType(StrEnum):
     SemanticModel = "semantic_model"
     Unit = "unit_test"
     Fixture = "fixture"
+    Function = "function"
 
     def pluralize(self) -> str:
         if self is self.Analysis:

--- a/core/dbt/artifacts/resources/v1/function.py
+++ b/core/dbt/artifacts/resources/v1/function.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass, field
+from typing import List, Literal, Optional
+
+from dbt.artifacts.resources.types import NodeType
+from dbt.artifacts.resources.v1.components import CompiledResource
+from dbt.artifacts.resources.v1.config import NodeConfig
+from dbt_common.dataclass_schema import dbtClassMixin
+
+# =============
+# Function config, and supporting classes
+# =============
+
+
+@dataclass
+class FunctionConfig(NodeConfig):
+    pass
+
+
+# =============
+# Function resource, and supporting classes
+# =============
+
+
+@dataclass
+class FunctionArgument(dbtClassMixin):
+    name: str
+    type: str
+    description: Optional[str] = None
+
+
+@dataclass
+class FunctionReturnType(dbtClassMixin):
+    type: str
+    description: Optional[str] = None
+
+
+@dataclass
+class FunctionMandatory(dbtClassMixin):
+    return_type: FunctionReturnType
+
+
+@dataclass
+class Function(CompiledResource, FunctionMandatory):
+    resource_type: Literal[NodeType.Function]
+    config: FunctionConfig
+    arguments: List[FunctionArgument] = field(default_factory=list)

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -420,9 +420,16 @@ class PartialProject(RenderComponents):
         test_paths: List[str] = value_or(cfg.test_paths, ["tests"])
         analysis_paths: List[str] = value_or(cfg.analysis_paths, ["analyses"])
         snapshot_paths: List[str] = value_or(cfg.snapshot_paths, ["snapshots"])
+        function_paths: List[str] = value_or(cfg.function_paths, ["functions"])
 
         all_source_paths: List[str] = _all_source_paths(
-            model_paths, seed_paths, snapshot_paths, analysis_paths, macro_paths, test_paths
+            model_paths,
+            seed_paths,
+            snapshot_paths,
+            analysis_paths,
+            macro_paths,
+            test_paths,
+            function_paths,
         )
 
         docs_paths: List[str] = value_or(cfg.docs_paths, all_source_paths)
@@ -509,6 +516,7 @@ class PartialProject(RenderComponents):
             asset_paths=asset_paths,
             target_path=target_path,
             snapshot_paths=snapshot_paths,
+            function_paths=function_paths,
             clean_targets=clean_targets,
             log_path=log_path,
             packages_install_path=packages_install_path,
@@ -626,6 +634,7 @@ class Project:
     asset_paths: List[str]
     target_path: str
     snapshot_paths: List[str]
+    function_paths: List[str]
     clean_targets: List[str]
     log_path: str
     packages_install_path: str

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -675,6 +675,7 @@ class Project:
             self.analysis_paths,
             self.macro_paths,
             self.test_paths,
+            self.function_paths,
         )
 
     @property

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -155,6 +155,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
             analysis_paths=project.analysis_paths,
             docs_paths=project.docs_paths,
             asset_paths=project.asset_paths,
+            function_paths=project.function_paths,
             target_path=project.target_path,
             snapshot_paths=project.snapshot_paths,
             clean_targets=project.clean_targets,

--- a/core/dbt/contracts/files.py
+++ b/core/dbt/contracts/files.py
@@ -23,6 +23,7 @@ class ParseFileType(StrEnum):
     Schema = "schema"
     Hook = "hook"  # not a real filetype, from dbt_project.yml
     Fixture = "fixture"
+    Function = "function"
 
 
 parse_file_type_to_parser = {
@@ -37,6 +38,7 @@ parse_file_type_to_parser = {
     ParseFileType.Schema: "SchemaParser",
     ParseFileType.Hook: "HookParser",
     ParseFileType.Fixture: "FixtureParser",
+    ParseFileType.Function: "FunctionParser",
 }
 
 

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -178,7 +178,7 @@ class SourceLookup(dbtClassMixin):
 
 
 class RefableLookup(dbtClassMixin):
-    # model, seed, snapshot
+    # model, seed, snapshot, function
     _lookup_types: ClassVar[set] = set(REFABLE_NODE_TYPES)
     _versioned_types: ClassVar[set] = set(VERSIONED_NODE_TYPES)
 

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1740,6 +1740,7 @@ class ParsedSingularTestPatch(ParsedPatch):
 # SQL related attributes
 ManifestSQLNode = Union[
     AnalysisNode,
+    FunctionNode,
     SingularTestNode,
     HookNode,
     ModelNode,

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -32,6 +32,7 @@ from dbt.artifacts.resources import (
 from dbt.artifacts.resources import Documentation as DocumentationResource
 from dbt.artifacts.resources import Exposure as ExposureResource
 from dbt.artifacts.resources import FileHash
+from dbt.artifacts.resources import Function as FunctionResource
 from dbt.artifacts.resources import GenericTest as GenericTestResource
 from dbt.artifacts.resources import GraphResource
 from dbt.artifacts.resources import Group as GroupResource
@@ -1534,6 +1535,19 @@ class Group(GroupResource, BaseNode):
             "package_name": self.package_name,
             "owner": {k: str(v) for k, v in self.owner.to_dict(omit_none=True).items()},
         }
+
+
+# ====================================
+# Function node
+# ====================================
+
+
+@dataclass
+class FunctionNode(CompiledNode, FunctionResource):
+
+    @classmethod
+    def resource_class(cls) -> Type[FunctionResource]:
+        return FunctionResource
 
 
 # ====================================

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -33,6 +33,7 @@ from dbt.artifacts.resources import Documentation as DocumentationResource
 from dbt.artifacts.resources import Exposure as ExposureResource
 from dbt.artifacts.resources import FileHash
 from dbt.artifacts.resources import Function as FunctionResource
+from dbt.artifacts.resources import FunctionArgument, FunctionReturnType
 from dbt.artifacts.resources import GenericTest as GenericTestResource
 from dbt.artifacts.resources import GraphResource
 from dbt.artifacts.resources import Group as GroupResource
@@ -1719,6 +1720,20 @@ class ParsedNodePatch(ParsedPatch):
     deprecation_date: Optional[datetime]
     time_spine: Optional[TimeSpine] = None
     freshness: Optional[ModelFreshness] = None
+
+
+# TODO: Maybe this shouldn't be a subclass of ParsedNodePatch, but ParsedPatch instead
+# Currently, `functions` have the fields like `columns`, `access`, `version`, and etc,
+# but they don't actually do anything. If we remove those properties from FunctionNode,
+# we can remove this class and use ParsedPatch instead.
+@dataclass
+class ParsedFunctionPatchRequired:
+    return_type: FunctionReturnType
+
+
+@dataclass
+class ParsedFunctionPatch(ParsedNodePatch, ParsedFunctionPatchRequired):
+    arguments: List[FunctionArgument] = field(default_factory=list)
 
 
 @dataclass

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -15,6 +15,8 @@ from dbt.artifacts.resources import (
     ExposureType,
     ExternalTable,
     FreshnessThreshold,
+    FunctionArgument,
+    FunctionReturnType,
     MacroArgument,
     MaturityType,
     MeasureAggregationParameters,
@@ -657,6 +659,19 @@ class UnparsedGroup(dbtClassMixin):
         super(UnparsedGroup, cls).validate(data)
         if data["owner"].get("name") is None and data["owner"].get("email") is None:
             raise ValidationError("Group owner must have at least one of 'name' or 'email'.")
+
+
+@dataclass
+class UnparsedFunctionReturnType(dbtClassMixin):
+    return_type: FunctionReturnType
+
+
+@dataclass
+class UnparsedFunctionUpdate(
+    HasConfig, HasColumnProps, HasYamlMetadata, UnparsedFunctionReturnType
+):
+    access: Optional[str] = None
+    arguments: List[FunctionArgument] = field(default_factory=list)
 
 
 #

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -236,6 +236,7 @@ class Project(dbtClassMixin):
     analysis_paths: Optional[List[str]] = None
     docs_paths: Optional[List[str]] = None
     asset_paths: Optional[List[str]] = None
+    function_paths: Optional[List[str]] = None
     target_path: Optional[str] = None
     snapshot_paths: Optional[List[str]] = None
     clean_targets: Optional[List[str]] = None
@@ -285,6 +286,7 @@ class Project(dbtClassMixin):
             "analysis_paths": "analysis-paths",
             "docs_paths": "docs-paths",
             "asset_paths": "asset-paths",
+            "function_paths": "function-paths",
             "target_path": "target-path",
             "snapshot_paths": "snapshot-paths",
             "clean_targets": "clean-targets",

--- a/core/dbt/node_types.py
+++ b/core/dbt/node_types.py
@@ -24,6 +24,7 @@ REFABLE_NODE_TYPES: List["NodeType"] = [
     NodeType.Model,
     NodeType.Seed,
     NodeType.Snapshot,
+    NodeType.Function,
 ]
 
 TEST_NODE_TYPES: List["NodeType"] = [

--- a/core/dbt/parser/base.py
+++ b/core/dbt/parser/base.py
@@ -252,6 +252,12 @@ class ConfiguredParser(
         }
         dct.update(kwargs)
 
+        # TODO: we're doing this becaus return type is _required_ for the FunctionNode
+        # but we don't get the return type until we patch the node with the yml definition
+        # so we need to set it to a default value here.
+        if self.resource_type == NodeType.Function:
+            dct["return_type"] = {"type": "INVALID_TYPE"}
+
         try:
             return self.parse_from_dict(dct, validate=True)
         except ValidationError as exc:

--- a/core/dbt/parser/common.py
+++ b/core/dbt/parser/common.py
@@ -10,6 +10,7 @@ from dbt.contracts.graph.unparsed import (
     UnparsedAnalysisUpdate,
     UnparsedColumn,
     UnparsedExposure,
+    UnparsedFunctionUpdate,
     UnparsedMacroUpdate,
     UnparsedModelUpdate,
     UnparsedNodeUpdate,
@@ -33,6 +34,7 @@ schema_file_keys_to_resource_types = {
     "metrics": NodeType.Metric,
     "semantic_models": NodeType.SemanticModel,
     "saved_queries": NodeType.SavedQuery,
+    "functions": NodeType.Function,
 }
 
 resource_types_to_schema_file_keys = {
@@ -59,6 +61,7 @@ Target = TypeVar(
     UnpatchedSourceDefinition,
     UnparsedExposure,
     UnparsedModelUpdate,
+    UnparsedFunctionUpdate,
     UnparsedSingularTestUpdate,
 )
 

--- a/core/dbt/parser/functions.py
+++ b/core/dbt/parser/functions.py
@@ -1,0 +1,19 @@
+from dbt.artifacts.resources.types import NodeType
+from dbt.contracts.graph.nodes import FunctionNode
+from dbt.parser.base import SimpleSQLParser
+from dbt.parser.search import FileBlock
+
+
+class FunctionParser(SimpleSQLParser[FunctionNode]):
+    def parse_from_dict(self, dct, validate=True) -> FunctionNode:
+        if validate:
+            FunctionNode.validate(dct)
+        return FunctionNode.from_dict(dct)
+
+    @property
+    def resource_type(self) -> NodeType:
+        return NodeType.Function
+
+    @classmethod
+    def get_compiled_path(cls, block: FileBlock):
+        return block.path.relative_path

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -101,6 +101,7 @@ from dbt.parser.analysis import AnalysisParser
 from dbt.parser.base import Parser
 from dbt.parser.docs import DocumentationParser
 from dbt.parser.fixtures import FixtureParser
+from dbt.parser.functions import FunctionParser
 from dbt.parser.generic_test import GenericTestParser
 from dbt.parser.hooks import HookParser
 from dbt.parser.macros import MacroParser
@@ -418,6 +419,7 @@ class ManifestLoader:
                 DocumentationParser,
                 HookParser,
                 FixtureParser,
+                FunctionParser,
             ]
             for project in self.all_projects.values():
                 if project.project_name not in project_parser_files:

--- a/core/dbt/parser/read_files.py
+++ b/core/dbt/parser/read_files.py
@@ -436,5 +436,10 @@ def get_file_types_for_project(project):
             "extensions": [".csv", ".sql"],
             "parser": "FixtureParser",
         },
+        ParseFileType.Function: {
+            "paths": project.function_paths,
+            "extensions": [".sql"],
+            "parser": "FunctionParser",
+        },
     }
     return file_types

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -772,7 +772,7 @@ class PatchParser(YamlReader, Generic[NonSourceTarget, Parsed]):
 # Subclasses of NodePatchParser: TestablePatchParser, ModelPatchParser, AnalysisPatchParser, FunctionPatchParser
 # so models, seeds, snapshots, analyses, functions
 class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarget]):
-    def parse_patch(self, block: TargetBlock[NodeTarget], refs: ParserRef) -> None:
+    def _get_node_patch(self, block: TargetBlock[NodeTarget], refs: ParserRef) -> ParsedNodePatch:
         # We're not passing the ParsedNodePatch around anymore, so we
         # could possibly skip creating one. Leaving here for now for
         # code consistency.
@@ -796,7 +796,7 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
                 else None
             )
 
-        patch = ParsedNodePatch(
+        return ParsedNodePatch(
             name=block.target.name,
             original_file_path=block.target.original_file_path,
             yaml_key=block.target.yaml_key,
@@ -813,8 +813,14 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
             deprecation_date=deprecation_date,
             time_spine=time_spine,
         )
+
+    def parse_patch(self, block: TargetBlock[NodeTarget], refs: ParserRef) -> None:
+        patch = self._get_node_patch(block, refs)
+
         assert isinstance(self.yaml.file, SchemaSourceFile)
         source_file: SchemaSourceFile = self.yaml.file
+
+        # TODO: I'd like to refactor this out but the early return makes doing so a bit messy
         if patch.yaml_key in ["models", "seeds", "snapshots", "functions"]:
             unique_id = self.manifest.ref_lookup.get_unique_id(
                 patch.name, self.project.project_name, None
@@ -880,7 +886,7 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
                         file_path=source_file.path.original_file_path,
                     )
                 )
-                return
+                return  # we only return early if no disabled early nodes are found. Why don't we return after patching the disabled nodes?
 
         # patches can't be overwritten
         node = self.manifest.nodes.get(unique_id)
@@ -1282,14 +1288,11 @@ class FunctionPatchParser(NodePatchParser[UnparsedFunctionUpdate]):
         node.arguments = patch.arguments
         node.return_type = patch.return_type
 
-    # TODO: This started as a Copy-Paste of NodePatchParser.parse_patch. It has been slimmed down
-    # slightly, and modified to be FunctionNode specific. However, we should refactor this and the
-    # original to reduce code duplication.
-    def parse_patch(self, block: TargetBlock[NodeTarget], refs: ParserRef) -> None:
+    def _get_node_patch(self, block: TargetBlock[NodeTarget], refs: ParserRef) -> ParsedNodePatch:
         target = block.target
         assert isinstance(target, UnparsedFunctionUpdate)
 
-        patch = ParsedFunctionPatch(
+        return ParsedFunctionPatch(
             name=target.name,
             original_file_path=target.original_file_path,
             yaml_key=target.yaml_key,
@@ -1308,94 +1311,6 @@ class FunctionPatchParser(NodePatchParser[UnparsedFunctionUpdate]):
             arguments=target.arguments,
             return_type=target.return_type,
         )
-        assert isinstance(self.yaml.file, SchemaSourceFile)
-        source_file: SchemaSourceFile = self.yaml.file
-
-        # TODO: Refactor this out into a separate helper function to avoid duplication
-        if patch.yaml_key in ["models", "seeds", "snapshots", "functions"]:
-            unique_id = self.manifest.ref_lookup.get_unique_id(
-                patch.name, self.project.project_name, None
-            ) or self.manifest.ref_lookup.get_unique_id(patch.name, None, None)
-
-            if unique_id:
-                resource_type = NodeType(unique_id.split(".")[0])
-                if resource_type.pluralize() != patch.yaml_key:
-                    warn_or_error(
-                        WrongResourceSchemaFile(
-                            patch_name=patch.name,
-                            resource_type=resource_type,
-                            plural_resource_type=resource_type.pluralize(),
-                            yaml_key=patch.yaml_key,
-                            file_path=patch.original_file_path,
-                        )
-                    )
-                    return
-
-        elif patch.yaml_key == "analyses":
-            unique_id = self.manifest.analysis_lookup.get_unique_id(patch.name, None, None)
-        else:
-            raise DbtInternalError(
-                f"Unexpected yaml_key {patch.yaml_key} for patch in "
-                f"file {source_file.path.original_file_path}"
-            )
-
-        # TODO: Refactor this out into a separate helper function to avoid duplication
-        # handle disabled nodes
-        if unique_id is None:
-            # Node might be disabled. Following call returns list of matching disabled nodes
-            resource_type = schema_file_keys_to_resource_types[patch.yaml_key]
-            found_nodes = self.manifest.disabled_lookup.find(
-                patch.name, patch.package_name, resource_types=[resource_type]
-            )
-            if found_nodes:
-                if len(found_nodes) > 1 and patch.config.get("enabled"):
-                    # There are multiple disabled nodes for this model and the schema file wants to enable one.
-                    # We have no way to know which one to enable.
-                    resource_type = found_nodes[0].unique_id.split(".")[0]
-                    msg = (
-                        f"Found {len(found_nodes)} matching disabled nodes for "
-                        f"{resource_type} '{patch.name}'. Multiple nodes for the same "
-                        "unique id cannot be enabled in the schema file. They must be enabled "
-                        "in `dbt_project.yml` or in the sql files."
-                    )
-                    raise ParsingError(msg)
-
-                # all nodes in the disabled dict have the same unique_id so just grab the first one
-                # to append with the unique id
-                source_file.append_patch(patch.yaml_key, found_nodes[0].unique_id)
-                for node in found_nodes:
-                    node.patch_path = source_file.file_id
-                    # re-calculate the node config with the patch config.  Always do this
-                    # for the case when no config is set to ensure the default of true gets captured
-                    if patch.config:
-                        self.patch_node_config(node, patch)
-
-                    self.patch_node_properties(node, patch)
-            else:
-                warn_or_error(
-                    NoNodeForYamlKey(
-                        patch_name=patch.name,
-                        yaml_key=patch.yaml_key,
-                        file_path=source_file.path.original_file_path,
-                    )
-                )
-                return
-
-        # TODO: Refactor this out into a separate helper function to avoid duplication
-        # patches can't be overwritten
-        node = self.manifest.nodes.get(unique_id)
-        if node:
-            if node.patch_path:
-                package_name, existing_file_path = node.patch_path.split("://")
-                raise DuplicatePatchPathError(patch, existing_file_path)
-
-            source_file.append_patch(patch.yaml_key, node.unique_id)
-            # re-calculate the node config with the patch config.  Always do this
-            # for the case when no config is set to ensure the default of true gets captured
-            if patch.config:
-                self.patch_node_config(node, patch)
-
-            self.patch_node_properties(node, patch)
 
 
 class MacroPatchParser(PatchParser[UnparsedMacroUpdate, ParsedMacroPatch]):

--- a/core/dbt/tests/fixtures/project.py
+++ b/core/dbt/tests/fixtures/project.py
@@ -3,7 +3,7 @@ import random
 from argparse import Namespace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Mapping
+from typing import Dict, Mapping
 
 import pytest  # type: ignore
 import yaml
@@ -387,6 +387,11 @@ def analyses():
     return {}
 
 
+@pytest.fixture(scope="class")
+def functions() -> Dict[str, str]:
+    return {}
+
+
 # Write out the files provided by models, macros, properties, snapshots, seeds, tests, analyses
 @pytest.fixture(scope="class")
 def project_files(
@@ -398,6 +403,7 @@ def project_files(
     seeds,
     tests,
     analyses,
+    functions,
     selectors_yml,
     dependencies_yml,
     packages_yml,
@@ -409,6 +415,7 @@ def project_files(
     write_project_files(project_root, "seeds", seeds)
     write_project_files(project_root, "tests", tests)
     write_project_files(project_root, "analyses", analyses)
+    write_project_files(project_root, "functions", functions)
 
 
 # We have a separate logs dir for every test

--- a/tests/functional/functions/test_udfs.py
+++ b/tests/functional/functions/test_udfs.py
@@ -1,0 +1,47 @@
+from typing import Dict
+
+import pytest
+
+from dbt.contracts.graph.nodes import FunctionNode
+from dbt.tests.util import run_dbt
+
+area_of_circle_sql = """
+pi() * radius * radius
+"""
+
+area_of_circle_yml = """
+functions:
+  - name: area of circle
+    description: Calculates the area of a circle for a given radius
+    arguments:
+      - name: radius
+        type: float
+        description: A floating point number representing the radius of the circle
+    returns:
+      type: float
+"""
+
+
+class TestBasicSQLUDF:
+    @pytest.fixture(scope="class")
+    def functions(self) -> Dict[str, str]:
+        return {
+            "area_of_circle.sql": area_of_circle_sql,
+            "area_of_circle.yml": area_of_circle_yml,
+        }
+
+    def test_basic_sql_udf_parsing(self, project):
+        manifest = run_dbt(["parse"])
+        assert len(manifest.nodes) == 1
+        assert "function.test.area_of_circle" in manifest.nodes
+        function_node = manifest.nodes["function.test.area_of_circle"]
+        assert isinstance(function_node, FunctionNode)
+        assert function_node.description == "Calculates the area of a circle for a given radius"
+        assert len(function_node.arguments) == 1
+        argument = function_node.arguments[0]
+        assert argument.name == "radius"
+        assert argument.type == "float"
+        assert (
+            argument.description == "A floating point number representing the radius of the circle"
+        )
+        assert function_node.return_type == "float"

--- a/tests/functional/functions/test_udfs.py
+++ b/tests/functional/functions/test_udfs.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 import pytest
 
+from dbt.artifacts.resources import FunctionReturnType
 from dbt.contracts.graph.nodes import FunctionNode
 from dbt.tests.util import run_dbt
 
@@ -44,4 +45,4 @@ class TestBasicSQLUDF:
         assert (
             argument.description == "A floating point number representing the radius of the circle"
         )
-        assert function_node.return_type == "float"
+        assert function_node.return_type == FunctionReturnType(type="float")

--- a/tests/functional/functions/test_udfs.py
+++ b/tests/functional/functions/test_udfs.py
@@ -11,13 +11,13 @@ pi() * radius * radius
 
 area_of_circle_yml = """
 functions:
-  - name: area of circle
+  - name: area_of_circle
     description: Calculates the area of a circle for a given radius
     arguments:
       - name: radius
         type: float
         description: A floating point number representing the radius of the circle
-    returns:
+    return_type:
       type: float
 """
 

--- a/tests/functional/list/test_commands.py
+++ b/tests/functional/list/test_commands.py
@@ -78,6 +78,7 @@ skipped_resource_types = {
     "group",
     "unit_test",
     "fixture",
+    "function",  # TODO: #11958 implement `function` resource type selection
 }
 resource_types = [
     node_type.value for node_type in NodeType if node_type.value not in skipped_resource_types

--- a/tests/unit/config/test_project.py
+++ b/tests/unit/config/test_project.py
@@ -108,7 +108,7 @@ class TestProjectInitialization(BaseConfigTest):
         self.assertEqual(project.analysis_paths, ["analyses"])
         self.assertEqual(
             set(project.docs_paths),
-            {"models", "seeds", "snapshots", "analyses", "macros", "tests"},
+            {"models", "seeds", "snapshots", "analyses", "macros", "tests", "functions"},
         )
         self.assertEqual(project.asset_paths, [])
         self.assertEqual(project.target_path, "target")
@@ -137,7 +137,7 @@ class TestProjectInitialization(BaseConfigTest):
         )
         self.assertEqual(
             set(project.docs_paths),
-            {"other-models", "seeds", "snapshots", "analyses", "macros", "tests"},
+            {"other-models", "seeds", "snapshots", "analyses", "macros", "tests", "functions"},
         )
 
     def test_all_overrides(self):

--- a/tests/unit/config/test_runtime.py
+++ b/tests/unit/config/test_runtime.py
@@ -129,7 +129,8 @@ class TestRuntimeConfigFiles(BaseConfigTest):
         self.assertEqual(config.test_paths, ["tests"])
         self.assertEqual(config.analysis_paths, ["analyses"])
         self.assertEqual(
-            set(config.docs_paths), {"models", "seeds", "snapshots", "analyses", "macros", "tests"}
+            set(config.docs_paths),
+            {"models", "seeds", "snapshots", "analyses", "macros", "tests", "functions"},
         )
         self.assertEqual(config.asset_paths, [])
         self.assertEqual(config.target_path, "target")

--- a/tests/unit/test_node_types.py
+++ b/tests/unit/test_node_types.py
@@ -21,6 +21,7 @@ node_type_pluralizations = {
     NodeType.Unit: "unit_tests",
     NodeType.SavedQuery: "saved_queries",
     NodeType.Fixture: "fixtures",
+    NodeType.Function: "functions",
 }
 
 

--- a/tests/unit/utils/project.py
+++ b/tests/unit/utils/project.py
@@ -35,6 +35,7 @@ def project(selector_config: SelectorConfig) -> Project:
         model_paths=["models"],
         macro_paths=["macros"],
         seed_paths=["seeds"],
+        function_paths=["functions"],
         test_paths=["tests"],
         analysis_paths=["analyses"],
         docs_paths=["docs"],


### PR DESCRIPTION
resolves #11923

### Problem

There is no way to define UDFs in dbt today.

### Solution

Allow for the definition of UDFs! Note, this PR _only_ addresses defining a UDF and that definition resulting in a new node in your manifest. It does not: create the UDF in the data warehouse, ensure the UDF can be ref'd in other dbt nodes, allow for the selection of UDFs, handle DAG execution, explicitly support jinja in UDFs, nor support non-SQL UDF definitions.

With all those qualifiers out of the way, this how one can define a UDF. First all files related to UDFs will be in a new folder/director `functions`. A UDF consists of a logical definition (currently only SQL) and a YAML definiton. Both of these parts are _required_. The SQL logical definition should be in a `.sql` file and should just be raw SQL. So if I want a function to calculate the area of a circle then I might have a `functions/area_of_circle.sql` file like
```sql
# functions/area_of_circle.sql
pi() * radius * radius
```
Then in the YAML file we define a description (required), any arguments (optional), and a return type (required). The coresponding YAML definition for the `area_of_circle.sql` UDF might live in `functions/schema.yml` that looks like the following
```yml
# functions/schema.yml
functions:
  - name: area_of_circle  # required
    description: Calculates the area of a circle for a given radius  # required
    arguments:  # optional
      - name: radius  # required
        type: float  # required
        description: A floating point number representing the radius of the circle  # optional
    return_type:  # required
      type: float  # required
      description: The area of the circle  # optional
```
### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
