### PR TITLE
Unhide sample mode CLI flag

### DIFF
--- a/.changes/unreleased/Fixes-20250826-144859.yaml
+++ b/.changes/unreleased/Fixes-20250826-144859.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Unhide sample mode CLI flag
+time: 2025-08-26T14:48:59.685423-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11959"

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -549,7 +549,6 @@ sample = _create_option_and_track_env_var(
     help="Run in sample mode with given SAMPLE_WINDOW spec, such that ref/source calls are sampled by the sample window.",
     default=None,
     type=SampleType(),
-    hidden=True,  # TODO: Unhide
 )
 
 # `--select` and `--models` are analogous for most commands except `dbt list` for legacy reasons.


### PR DESCRIPTION
Resolves #11959 

### Problem

Sample mode CLI flag was hidden

### Solution

Stop hiding it

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
