### PR TITLE
Ability to list and select function nodes

### DIFF
--- a/.changes/unreleased/Features-20250827-163400.yaml
+++ b/.changes/unreleased/Features-20250827-163400.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support listing functions via `list` command
+time: 2025-08-27T16:34:00.216146-05:00
+custom:
+  Author: QMalcolm
+  Issue: "11967"

--- a/.changes/unreleased/Features-20250827-173103.yaml
+++ b/.changes/unreleased/Features-20250827-173103.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: 'Support selecting funciton nodes via: name, file path, and resource type'
+time: 2025-08-27T17:31:03.518839-05:00
+custom:
+  Author: QMalcolm
+  Issue: 11962 11958 11961

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -527,6 +527,7 @@ resource_type = _create_option_and_track_env_var(
             "saved_query",
             "source",
             "analysis",
+            "function",
             "model",
             "test",
             "unit_test",

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -37,6 +37,7 @@ class ListTask(GraphRunnableTask):
             NodeType.SavedQuery,
             NodeType.SemanticModel,
             NodeType.Unit,
+            NodeType.Function,
         )
     )
     ALL_RESOURCE_VALUES = DEFAULT_RESOURCE_VALUES | frozenset((NodeType.Analysis,))

--- a/tests/functional/fixtures/happy_path_project/functions/area_of_circle.sql
+++ b/tests/functional/fixtures/happy_path_project/functions/area_of_circle.sql
@@ -1,0 +1,1 @@
+pi() * radius * radius

--- a/tests/functional/fixtures/happy_path_project/functions/area_of_circle.yml
+++ b/tests/functional/fixtures/happy_path_project/functions/area_of_circle.yml
@@ -1,0 +1,9 @@
+functions:
+  - name: area_of_circle
+    description: Calculates the area of a circle for a given radius
+    arguments:
+      - name: radius
+        type: float
+        description: A floating point number representing the radius of the circle
+    return_type:
+      type: float

--- a/tests/functional/list/test_commands.py
+++ b/tests/functional/list/test_commands.py
@@ -78,7 +78,6 @@ skipped_resource_types = {
     "group",
     "unit_test",
     "fixture",
-    "function",  # TODO: #11958 implement `function` resource type selection
 }
 resource_types = [
     node_type.value for node_type in NodeType if node_type.value not in skipped_resource_types

--- a/tests/functional/list/test_list.py
+++ b/tests/functional/list/test_list.py
@@ -1065,6 +1065,7 @@ class TestList:
             "test.t",
             "test.my_favorite_test",
             "test.my_second_favorite_test",
+            "test.area_of_circle",
             "semantic_model:test.my_sm",
             "metric:test.total_outer",
             "metric:test.conversion_metric",
@@ -1246,6 +1247,7 @@ class TestList:
         results = self.run_dbt_ls()
         assert set(results) == {
             "exposure:test.weekly_jaffle_metrics",
+            "test.area_of_circle",
             "test.ephemeral",
             "test.incremental",
             "test.outer",

--- a/tests/functional/list/test_list.py
+++ b/tests/functional/list/test_list.py
@@ -1040,7 +1040,20 @@ class TestList:
         self.expect_given_output(["--resource-type", "test"], expectations)
 
     def expect_function_output(self):
+        # using `--resource-type`
         results = self.run_dbt_ls(["--resource-type", "function"])
+        assert set(results) == {"test.area_of_circle"}
+
+        # using `--select` with `resource_type`
+        results = self.run_dbt_ls(["--select", "resource_type:function"])
+        assert set(results) == {"test.area_of_circle"}
+
+        # using `--select` with path spec
+        results = self.run_dbt_ls(["--select", "functions/area_of_circle.sql"])
+        assert set(results) == {"test.area_of_circle"}
+
+        # using `--select` with path function name
+        results = self.run_dbt_ls(["--select", "area_of_circle"])
         assert set(results) == {"test.area_of_circle"}
 
     def expect_all_output(self):

--- a/tests/functional/list/test_list.py
+++ b/tests/functional/list/test_list.py
@@ -1039,6 +1039,10 @@ class TestList:
         }
         self.expect_given_output(["--resource-type", "test"], expectations)
 
+    def expect_function_output(self):
+        results = self.run_dbt_ls(["--resource-type", "function"])
+        assert set(results) == {"test.area_of_circle"}
+
     def expect_all_output(self):
         # generic test FQNS include the resource + column they're defined on
         # models are just package, subdirectory path, name
@@ -1367,6 +1371,7 @@ class TestList:
         self.expect_source_output()
         self.expect_seed_output()
         self.expect_test_output()
+        self.expect_function_output()
         self.expect_select()
         self.expect_resource_type_multiple()
         self.expect_resource_type_env_var()


### PR DESCRIPTION
Resolves #11967
Resolves #11962
Resolves #11958 
Resolves #11961 

### Problem

Functions should be listable and selectable!

### Solution

Make them listable and selectable!

1. Functions will now show up when running `dbt list`
2. Functions can be "selected" in list via
  a. `--resource_type function`
  b. `--select resource_type:function`
  c. `--select path/to/my_function.sql`
  d. `--select my_function`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
