### PR TITLE
[BACKPORT 1.10.latest] Default parse-time nodes' raw_code property to "" (empty string) to comply with strict str type

### DIFF
--- a/.changes/unreleased/Fixes-20250804-074254.yaml
+++ b/.changes/unreleased/Fixes-20250804-074254.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Comply with strict `str` type when `block.contents` is `None`
+time: 2025-08-04T07:42:54.612616-06:00
+custom:
+    Author: wircho
+    Issue: "11492"

--- a/core/dbt/parser/base.py
+++ b/core/dbt/parser/base.py
@@ -241,7 +241,7 @@ class ConfiguredParser(
             "path": path,
             "original_file_path": block.path.original_file_path,
             "package_name": self.project.project_name,
-            "raw_code": block.contents,
+            "raw_code": block.contents or "",
             "language": language,
             "unique_id": self.generate_unique_id(name),
             "config": self.config_dict(config),


### PR DESCRIPTION
Manual backport of #11884 to 1.10.latest by cherry-picking [64b58ec](https://github.com/dbt-labs/dbt-core/commit/64b58ec628fec40fe4e35be427eb37a999da0630)