### PR TITLE
[Backport 1.10] implement checked_agg_time_dimension_for_simple_metric on SemanticModel

### DIFF
--- a/.changes/unreleased/Fixes-20250909-171132.yaml
+++ b/.changes/unreleased/Fixes-20250909-171132.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Implement checked_agg_time_dimension_for_simple_metric to satisfy dbt-semantic-interfaces>0.9.0
+time: 2025-09-09T17:11:32.936696-04:00
+custom:
+    Author: michelleark
+    Issue: "11998"

--- a/core/dbt/artifacts/resources/__init__.py
+++ b/core/dbt/artifacts/resources/__init__.py
@@ -42,6 +42,7 @@ from dbt.artifacts.resources.v1.metric import (
     ConversionTypeParams,
     CumulativeTypeParams,
     Metric,
+    MetricAggregationParams,
     MetricConfig,
     MetricInput,
     MetricInputMeasure,
@@ -66,6 +67,8 @@ from dbt.artifacts.resources.v1.saved_query import (
 from dbt.artifacts.resources.v1.seed import Seed, SeedConfig
 from dbt.artifacts.resources.v1.semantic_layer_components import (
     FileSlice,
+    MeasureAggregationParameters,
+    NonAdditiveDimension,
     SourceFileMetadata,
     WhereFilter,
     WhereFilterIntersection,
@@ -77,9 +80,8 @@ from dbt.artifacts.resources.v1.semantic_model import (
     DimensionValidityParams,
     Entity,
     Measure,
-    MeasureAggregationParameters,
     NodeRelation,
-    NonAdditiveDimension,
+    SemanticLayerElementConfig,
     SemanticModel,
     SemanticModelConfig,
 )

--- a/core/dbt/artifacts/resources/v1/metric.py
+++ b/core/dbt/artifacts/resources/v1/metric.py
@@ -6,6 +6,8 @@ from dbt.artifacts.resources.base import GraphResource
 from dbt.artifacts.resources.types import NodeType
 from dbt.artifacts.resources.v1.components import DependsOn, RefArgs
 from dbt.artifacts.resources.v1.semantic_layer_components import (
+    MeasureAggregationParameters,
+    NonAdditiveDimension,
     SourceFileMetadata,
     WhereFilterIntersection,
 )
@@ -13,6 +15,7 @@ from dbt_common.contracts.config.base import BaseConfig, CompareBehavior, MergeB
 from dbt_common.dataclass_schema import dbtClassMixin
 from dbt_semantic_interfaces.references import MeasureReference, MetricReference
 from dbt_semantic_interfaces.type_enums import (
+    AggregationType,
     ConversionCalculationType,
     MetricType,
     PeriodAggregation,
@@ -93,6 +96,17 @@ class CumulativeTypeParams(dbtClassMixin):
     window: Optional[MetricTimeWindow] = None
     grain_to_date: Optional[str] = None
     period_agg: PeriodAggregation = PeriodAggregation.FIRST
+    metric: Optional[MetricInput] = None
+
+
+@dataclass
+class MetricAggregationParams(dbtClassMixin):
+    semantic_model: str
+    agg: AggregationType
+    agg_params: Optional[MeasureAggregationParameters] = None
+    agg_time_dimension: Optional[str] = None
+    non_additive_dimension: Optional[NonAdditiveDimension] = None
+    expr: Optional[str] = None
 
 
 @dataclass
@@ -109,6 +123,7 @@ class MetricTypeParams(dbtClassMixin):
     metrics: Optional[List[MetricInput]] = None
     conversion_type_params: Optional[ConversionTypeParams] = None
     cumulative_type_params: Optional[CumulativeTypeParams] = None
+    metric_aggregation_params: Optional[MetricAggregationParams] = None
 
 
 @dataclass

--- a/core/dbt/artifacts/resources/v1/semantic_layer_components.py
+++ b/core/dbt/artifacts/resources/v1/semantic_layer_components.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Sequence, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 from dbt_common.dataclass_schema import dbtClassMixin
 from dbt_semantic_interfaces.call_parameter_sets import JinjaCallParameterSets
@@ -7,6 +7,7 @@ from dbt_semantic_interfaces.parsing.where_filter.jinja_object_parser import (
     JinjaObjectParser,
     QueryItemLocation,
 )
+from dbt_semantic_interfaces.type_enums import AggregationType
 
 
 @dataclass
@@ -55,3 +56,17 @@ class SourceFileMetadata(dbtClassMixin):
 
     repo_file_path: str
     file_slice: FileSlice
+
+
+@dataclass
+class MeasureAggregationParameters(dbtClassMixin):
+    percentile: Optional[float] = None
+    use_discrete_percentile: bool = False
+    use_approximate_percentile: bool = False
+
+
+@dataclass
+class NonAdditiveDimension(dbtClassMixin):
+    name: str
+    window_choice: AggregationType
+    window_groupings: List[str]

--- a/core/setup.py
+++ b/core/setup.py
@@ -70,7 +70,7 @@ setup(
         # These are major-version-0 packages also maintained by dbt-labs.
         # Accept patches but avoid automatically updating past a set minor version range.
         "dbt-extractor>=0.5.0,<=0.6",
-        "dbt-semantic-interfaces>=0.9.0,<0.10",
+        "dbt-semantic-interfaces>=0.9.2,<0.10",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.27.0,<2.0",
         "dbt-adapters>=1.15.5,<2.0",


### PR DESCRIPTION
Manual backport of 7cab7538639b6aa5d9ac89268e61b7bacd2cfdc2

https://github.com/dbt-labs/dbt-core/pull/11995