### PR TITLE
Add catalogs.yml parsing to parse, test, and snapshot

### DIFF
--- a/.changes/unreleased/Features-20250910-144554.yaml
+++ b/.changes/unreleased/Features-20250910-144554.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Parse catalogs.yml during parse, seed, and test commands
+time: 2025-09-10T14:45:54.065327-04:00
+custom:
+    Author: michelleark
+    Issue: "12002"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -541,6 +541,7 @@ cli.add_command(ls, "ls")
 @requires.preflight
 @requires.profile
 @requires.project
+@requires.catalogs
 @requires.runtime_config
 @requires.manifest(write_perf_info=True)
 def parse(ctx, **kwargs):
@@ -704,6 +705,7 @@ def run_operation(ctx, **kwargs):
 @requires.preflight
 @requires.profile
 @requires.project
+@requires.catalogs
 @requires.runtime_config
 @requires.manifest
 def seed(ctx, **kwargs):
@@ -737,6 +739,7 @@ def seed(ctx, **kwargs):
 @requires.preflight
 @requires.profile
 @requires.project
+@requires.catalogs
 @requires.runtime_config
 @requires.manifest
 def snapshot(ctx, **kwargs):


### PR DESCRIPTION
### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

Currently dbt-core is only parsing catalogs.yml during `dbt run` and `dbt build` command. Providing the adapter with active catalog integrations will also be necessary during parse (to catch config exceptions), as well as snapshot and test for correct execution.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Declare catalogs parsing requirement on parse, test, and seed commands.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
