### PR TITLE
Fix legacy time spine deprecation warning logic

### DIFF
--- a/.changes/unreleased/Fixes-20250915-152227.yaml
+++ b/.changes/unreleased/Fixes-20250915-152227.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fixes a bug in the logic for legacy time spine deprecation warnings.
+time: 2025-09-15T15:22:27.791819-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "11690"

--- a/tests/functional/time_spines/test_time_spines.py
+++ b/tests/functional/time_spines/test_time_spines.py
@@ -87,12 +87,6 @@ class TestValidTimeSpines:
         semantic_manifest = SemanticManifest(manifest)
         assert semantic_manifest.validate()
         project_config = semantic_manifest._get_pydantic_semantic_manifest().project_configuration
-        # Legacy config
-        assert len(project_config.time_spine_table_configurations) == 1
-        legacy_time_spine_config = project_config.time_spine_table_configurations[0]
-        assert legacy_time_spine_config.column_name == day_column_name
-        assert legacy_time_spine_config.location.replace('"', "").split(".")[-1] == day_model_name
-        assert legacy_time_spine_config.grain == TimeGranularity.DAY
         # Current configs
         assert len(project_config.time_spines) == 2
         sl_time_spine_aliases: Set[str] = set()

--- a/tests/unit/contracts/graph/test_semantic_manifest.py
+++ b/tests/unit/contracts/graph/test_semantic_manifest.py
@@ -3,13 +3,16 @@ from unittest.mock import patch
 import pytest
 
 from core.dbt.contracts.graph.manifest import Manifest
-from core.dbt.contracts.graph.nodes import Metric, ModelNode
 from dbt.artifacts.resources.types import NodeType
 from dbt.artifacts.resources.v1.metric import (
     CumulativeTypeParams,
     MetricTimeWindow,
     MetricTypeParams,
 )
+from dbt.artifacts.resources.v1.model import ModelConfig, TimeSpine
+from dbt.constants import LEGACY_TIME_SPINE_MODEL_NAME
+from dbt.contracts.files import FileHash
+from dbt.contracts.graph.nodes import ColumnInfo, DependsOn, Metric, ModelNode
 from dbt.contracts.graph.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.type_enums import TimeGranularity
 from dbt_semantic_interfaces.type_enums.metric_type import MetricType
@@ -54,6 +57,57 @@ class TestSemanticManifest:
             sm_manifest = SemanticManifest(manifest)
             assert sm_manifest.validate()
             assert patched_deprecations.warn.call_count == 1
+
+    def test_metricflow_time_spine_non_day_grain_deprecation_warning(
+        self, manifest: Manifest, metricflow_time_spine_model: ModelNode
+    ):
+        """Test that a metricflow_time_spine with non-day grain does not trigger deprecation warning."""
+        # Create a metricflow_time_spine model with HOUR granularity
+        metricflow_time_spine_hour = ModelNode(
+            name=LEGACY_TIME_SPINE_MODEL_NAME,
+            database="dbt",
+            schema="analytics",
+            alias=LEGACY_TIME_SPINE_MODEL_NAME,
+            resource_type=NodeType.Model,
+            unique_id="model.test.metricflow_time_spine",
+            fqn=["test", "metricflow_time_spine"],
+            package_name="test",
+            refs=[],
+            sources=[],
+            metrics=[],
+            depends_on=DependsOn(),
+            config=ModelConfig(),
+            tags=[],
+            path="metricflow_time_spine.sql",
+            original_file_path="metricflow_time_spine.sql",
+            meta={},
+            language="sql",
+            raw_code="SELECT DATEADD(hour, ROW_NUMBER() OVER (ORDER BY 1), '2020-01-01'::timestamp) as ts_hour",
+            checksum=FileHash.empty(),
+            relation_name="",
+            columns={
+                "ts_hour": ColumnInfo(
+                    name="ts_hour",
+                    description="",
+                    meta={},
+                    data_type="timestamp",
+                    constraints=[],
+                    quote=None,
+                    tags=[],
+                    granularity=TimeGranularity.HOUR,
+                )
+            },
+            time_spine=TimeSpine(standard_granularity_column="ts_hour"),
+        )
+
+        with patch("dbt.contracts.graph.semantic_manifest.get_flags") as patched_get_flags, patch(
+            "dbt.contracts.graph.semantic_manifest.deprecations"
+        ) as patched_deprecations:
+            patched_get_flags.return_value.require_yaml_configuration_for_mf_time_spines = False
+            manifest.nodes[metricflow_time_spine_hour.unique_id] = metricflow_time_spine_hour
+            sm_manifest = SemanticManifest(manifest)
+            assert sm_manifest.validate()
+            assert patched_deprecations.warn.call_count == 0
 
     @pytest.mark.parametrize(
         "metric_type_params, num_warns, should_error, flag_value",

--- a/tests/unit/utils/manifest.py
+++ b/tests/unit/utils/manifest.py
@@ -19,6 +19,12 @@ from dbt.artifacts.resources import (
 )
 from dbt.artifacts.resources.types import ModelLanguage
 from dbt.artifacts.resources.v1.model import ModelConfig
+from dbt.artifacts.resources.v1.semantic_model import (
+    Defaults,
+    Dimension,
+    DimensionTypeParams,
+    Measure,
+)
 from dbt.contracts.files import AnySourceFile, FileHash
 from dbt.contracts.graph.manifest import Manifest, ManifestMetadata
 from dbt.contracts.graph.nodes import (
@@ -44,7 +50,12 @@ from dbt.contracts.graph.nodes import (
 )
 from dbt.contracts.graph.unparsed import UnitTestInputFixture, UnitTestOutputFixture
 from dbt.node_types import NodeType
-from dbt_semantic_interfaces.type_enums import MetricType
+from dbt_semantic_interfaces.type_enums import (
+    AggregationType,
+    DimensionType,
+    MetricType,
+    TimeGranularity,
+)
 
 
 def make_model(
@@ -485,6 +496,21 @@ def make_semantic_model(
         unique_id=f"semantic_model.{pkg}.{name}",
         original_file_path=path,
         fqn=[pkg, "semantic_models", name],
+        defaults=Defaults(agg_time_dimension="created_at"),
+        dimensions=[
+            Dimension(
+                name="created_at",
+                type=DimensionType.TIME,
+                type_params=DimensionTypeParams(time_granularity=TimeGranularity.DAY),
+            )
+        ],
+        measures=[
+            Measure(
+                name="a_measure",
+                agg=AggregationType.COUNT,
+                expr="1",
+            )
+        ],
     )
 
 


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/11690

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem
Users still seeing a deprecation warning for their `metricflow_time_spine` model even when they have added a YAML config for the time spine.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
Previously, we were checking only the `node.relation_name` in one place, and using `ref_lookup.find()` in another. That mismatched logic was the source of the bug, and this updates the logic to be more unified.
This PR also adds better testing in this area and fixes a potential `UnboundLocalError`.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
