### PR TITLE
Support configuring model.config.freshness.build_after.update_on without period or count

### DIFF
--- a/.changes/unreleased/Features-20250917-164941.yaml
+++ b/.changes/unreleased/Features-20250917-164941.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support configuring model.config.freshness.build_after.update_on without period or count
+time: 2025-09-17T16:49:41.528385-04:00
+custom:
+    Author: michelleark
+    Issue: "12019"

--- a/.changes/unreleased/Features-20250917-164941.yaml
+++ b/.changes/unreleased/Features-20250917-164941.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Support configuring model.config.freshness.build_after.update_on without period or count
+body: Support configuring model.config.freshness.build_after.updates_on without period or count
 time: 2025-09-17T16:49:41.528385-04:00
 custom:
     Author: michelleark

--- a/core/dbt/artifacts/resources/v1/model.py
+++ b/core/dbt/artifacts/resources/v1/model.py
@@ -31,19 +31,6 @@ class ModelBuildAfter(ExtensibleDbtClassMixin):
     period: Optional[TimePeriod] = None
     updates_on: ModelFreshnessUpdatesOnOptions = ModelFreshnessUpdatesOnOptions.any
 
-    @classmethod
-    def validate(cls, data):
-        super().validate(data)
-
-        if data.get("period") and not data.get("count"):
-            raise ValidationError(
-                "`build_after` must have a value for `count` if a `period` is provided"
-            )
-        elif data.get("count") and not data.get("period"):
-            raise ValidationError(
-                "`build_after` must have a value for `period` if a `count` is provided"
-            )
-
 
 @dataclass
 class ModelFreshness(ExtensibleDbtClassMixin, Mergeable):
@@ -91,6 +78,25 @@ class ModelConfig(NodeConfig):
         metadata=MergeBehavior.Clobber.meta(),
     )
     freshness: Optional[ModelFreshness] = None
+
+    def __post_init__(self):
+        super().__post_init__()
+        if (
+            self.freshness
+            and self.freshness.build_after.period
+            and not self.freshness.build_after.count
+        ):
+            raise ValidationError(
+                "`freshness.build_after` must have a value for `count` if a `period` is provided"
+            )
+        elif (
+            self.freshness
+            and self.freshness.build_after.count
+            and not self.freshness.build_after.period
+        ):
+            raise ValidationError(
+                "`freshness.build_after` must have a value for `period` if a `count` is provided"
+            )
 
     @classmethod
     def __pre_deserialize__(cls, data):

--- a/tests/functional/model_config/test_freshness_config.py
+++ b/tests/functional/model_config/test_freshness_config.py
@@ -151,8 +151,12 @@ class TestModelFreshnessConfigParseBuildPeriodRequiresCount:
         }
 
     def test_model_freshness_configs(self, project):
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError) as excinfo:
             run_dbt(["parse"])
+        expected_msg = (
+            "`freshness.build_after` must have a value for `count` if a `period` is provided"
+        )
+        assert expected_msg in str(excinfo.value)
 
 
 class TestModelFreshnessConfigParseBuildCountRequiresPeriod:
@@ -164,5 +168,9 @@ class TestModelFreshnessConfigParseBuildCountRequiresPeriod:
         }
 
     def test_model_freshness_configs(self, project):
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError) as excinfo:
             run_dbt(["parse"])
+        expected_msg = (
+            "`freshness.build_after` must have a value for `period` if a `count` is provided"
+        )
+        assert expected_msg in str(excinfo.value)

--- a/tests/functional/model_config/test_freshness_config.py
+++ b/tests/functional/model_config/test_freshness_config.py
@@ -1,6 +1,7 @@
 import pytest
 
 from dbt.tests.util import run_dbt
+from dbt_common.dataclass_schema import ValidationError
 
 # Seed data for source tables
 seeds__source_table_csv = """id,_loaded_at
@@ -77,6 +78,39 @@ select * from {{ source('my_source', 'source_table') }}
 """
 
 
+models__model_freshness_schema_yml_build_after_only = """
+models:
+  - name: model_a
+    description: Model with only model freshness defined
+    config:
+      freshness:
+        build_after:
+          updates_on: all
+"""
+
+
+models__model_freshness_schema_yml_build_period_requires_count = """
+models:
+  - name: model_a
+    description: Model with only model freshness defined
+    config:
+      freshness:
+        build_after:
+          period: day
+"""
+
+
+models__model_freshness_schema_yml_build_count_requires_period = """
+models:
+  - name: model_a
+    description: Model with only model freshness defined
+    config:
+      freshness:
+        build_after:
+          count: 1
+"""
+
+
 class TestModelFreshnessConfig:
 
     @pytest.fixture(scope="class")
@@ -94,3 +128,41 @@ class TestModelFreshnessConfig:
         run_dbt(["parse"])
         compile_results = run_dbt(["compile"])
         assert len(compile_results) == 5  # All 4 models compiled successfully
+
+
+class TestModelFreshnessConfigParseBuildAfterOnly:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": models__model_freshness_schema_yml_build_after_only,
+            "model_a.sql": models__no_freshness_sql,
+        }
+
+    def test_model_freshness_configs(self, project):
+        run_dbt(["parse"])
+
+
+class TestModelFreshnessConfigParseBuildPeriodRequiresCount:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": models__model_freshness_schema_yml_build_period_requires_count,
+            "model_a.sql": models__no_freshness_sql,
+        }
+
+    def test_model_freshness_configs(self, project):
+        with pytest.raises(ValidationError):
+            run_dbt(["parse"])
+
+
+class TestModelFreshnessConfigParseBuildCountRequiresPeriod:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": models__model_freshness_schema_yml_build_count_requires_period,
+            "model_a.sql": models__no_freshness_sql,
+        }
+
+    def test_model_freshness_configs(self, project):
+        with pytest.raises(ValidationError):
+            run_dbt(["parse"])


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/12019

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

* build_fater.update_on should be able to be configured independently of count and period. 
* but count & period should still be provided together.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
* make count & period optional
* add validation to ensure that count & period must be provided together.
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
