### PR TITLE
Fix: convert kwargs to cli params, add aliases

### DIFF
--- a/.changes/unreleased/Fixes-20250918-152852.yaml
+++ b/.changes/unreleased/Fixes-20250918-152852.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: On programmatic invocations set CLI parameters before creating the context to prevent failure due to type validations.
+time: 2025-09-18T15:28:52.584487+02:00
+custom:
+    Author: dumkydewilde
+    Issue: "12028"

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -538,6 +538,7 @@ def command_args(command: CliCommand) -> ArgsList:
         CliCommand.DEPS: cli.deps,
         CliCommand.INIT: cli.init,
         CliCommand.LIST: cli.list,
+        CliCommand.LS: cli.list,
         CliCommand.PARSE: cli.parse,
         CliCommand.RUN: cli.run,
         CliCommand.RUN_OPERATION: cli.run_operation,

--- a/core/dbt/cli/types.py
+++ b/core/dbt/cli/types.py
@@ -15,6 +15,7 @@ class Command(Enum):
     DEPS = "deps"
     INIT = "init"
     LIST = "list"
+    LS = "list"
     PARSE = "parse"
     RUN = "run"
     RUN_OPERATION = "run-operation"


### PR DESCRIPTION
Resolves #12028

### Problem
On programatic invocations, i.e. using dbtRunner.invoke(), the runner fails when e.g. a profiles_dir is specified. This appears to be because, when this is provided as a keyword argument (e.g. dbtRunner.invoke(["build"], profiles_dir='./my_profiles') the kwargs are only passed to the context after creation, meaning any validation on creating the context fails. And this is exactly what happens, because the profiles_dir option checks for type=click.Path(exists=True).

Why is this annoying? Because everytime you run this in a Docker container (or e.g. through an orchestrator) it will fall back to the default directory for this option (~/username/.dbt) which it of course doesn't find.

### Solution
Params can not be added to the Click context before it is created, which means they have to be added as string arguments. `flags.py` already provides functionality for this with the `command_params()` function. What we can do is take the kwargs through this function, and combine them with provided args so that params can be set _before_ the context creation and validation happens. 


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
