### PR TITLE
Fix script for setting up postgres development database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ interop: clean
 setup-db: ## Setup Postgres database with docker-compose for system testing.
 	@\
 	docker compose up -d database && \
-	PGHOST=localhost PGUSER=root PGPASSWORD=password PGDATABASE=postgres bash test/setup_db.sh
+	PGHOST=localhost PGUSER=root PGPASSWORD=password PGDATABASE=postgres SKIP_HOMEBREW=true bash test/setup_db.sh
 
 # This rule creates a file named .env that is used by docker-compose for passing
 # the USER_ID and GROUP_ID arguments to the Docker image.

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ interop: clean
 .PHONY: setup-db
 setup-db: ## Setup Postgres database with docker-compose for system testing.
 	@\
-	docker-compose up -d database && \
+	docker compose up -d database && \
 	PGHOST=localhost PGUSER=root PGPASSWORD=password PGDATABASE=postgres bash test/setup_db.sh
 
 # This rule creates a file named .env that is used by docker-compose for passing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ version: "3.5"
 services:
   database:
     image: postgres
+    shm_size: 1gb
     environment:
       POSTGRES_USER: "root"
       POSTGRES_PASSWORD: "password"

--- a/test/setup_db.sh
+++ b/test/setup_db.sh
@@ -1,31 +1,33 @@
 #!/bin/bash
 set -x
 
-brew install postgresql@16
-brew link postgresql@16 --force
-export PATH="/opt/homebrew/opt/postgresql@16/bin:$PATH"
+if [ "${SKIP_HOMEBREW:-false}" = "false" ]; then
+    brew install postgresql@16
+    brew link postgresql@16 --force
+    export PATH="/opt/homebrew/opt/postgresql@16/bin:$PATH"
 
-# Start PostgreSQL using the full command instead of brew services
-pg_ctl -D /opt/homebrew/var/postgresql@16 start
+    # Start PostgreSQL using the full command instead of brew services
+    pg_ctl -D /opt/homebrew/var/postgresql@16 start
 
-echo "Check PostgreSQL service is running"
-i=10
-COMMAND='pg_isready'
-while [ $i -gt -1 ]; do
-    if [ $i == 0 ]; then
-        echo "PostgreSQL service not ready, all attempts exhausted"
-        exit 1
-    fi
-    echo "Check PostgreSQL service status"
-    eval $COMMAND && break
-    echo "PostgreSQL service not ready, wait 10 more sec, attempts left: $i"
-    sleep 10
-    ((i--))
-done
+    echo "Check PostgreSQL service is running"
+    i=10
+    COMMAND='pg_isready'
+    while [ $i -gt -1 ]; do
+        if [ $i == 0 ]; then
+            echo "PostgreSQL service not ready, all attempts exhausted"
+            exit 1
+        fi
+        echo "Check PostgreSQL service status"
+        eval $COMMAND && break
+        echo "PostgreSQL service not ready, wait 10 more sec, attempts left: $i"
+        sleep 10
+        ((i--))
+    done
 
-createuser -s postgres
+    createuser -s postgres
 
-env | grep '^PG'
+    env | grep '^PG'
+fi
 
 # If you want to run this script for your own postgresql (run with
 # docker-compose) it will look like this:

--- a/test/setup_db.sh
+++ b/test/setup_db.sh
@@ -37,6 +37,18 @@ export PGUSER
 PGPORT="${PGPORT:-5432}"
 export PGPORT
 PGHOST="${PGHOST:-localhost}"
+export PGHOST
+PGDATABASE="${PGDATABASE:-postgres}"
+export PGDATABASE
+: "${PGPASSWORD:=password}"
+export PGPASSWORD
+
+# Normalize localhost to IPv4 to avoid IPv6 (::1) surprises
+if [ "${PGHOST}" = "localhost" ]; then
+    PGHOST="127.0.0.1"
+    export PGHOST
+fi
+
 
 for i in {1..10}; do
 	if pg_isready -h "${PGHOST}" -p "${PGPORT}" -U "${PGUSER}" ; then


### PR DESCRIPTION
### Problem

There are two problems
* My development postgres database in a docker container was running out of memory
  * errors looked like `could not resize shared memory segment "/PostgreSQL.3814850474" to 2097152 bytes: No space left on device`
* Running `make setup-db` was broken because it would run postgres with both docker AND homebrew

### Solution

* Increase the shared memory allocated for the postgres database docker container to 1GB
* Have `make setup-db` skip the homebrew portions of `setup_db.sh`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
