### PR TITLE
Fix schema file patch collection

### DIFF
--- a/.changes/unreleased/Fixes-20250925-212728.yaml
+++ b/.changes/unreleased/Fixes-20250925-212728.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix errors in partial parsing when working with versioned models
+time: 2025-09-25T21:27:28.591187-04:00
+custom:
+    Author: gshank
+    Issue: "11869"

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -178,6 +178,10 @@ class PartialParsing:
             self.add_to_saved(file_id)
         # Need to process schema files next, because the dictionaries
         # need to be in place for handling SQL file changes
+        # The reverse sort here is just to ensure that the schema file
+        # processing order test case works, because otherwise the order
+        # of processing the schema files is not guaranteed.
+        self.file_diff["changed_schema_files"].sort(reverse=True)
         for file_id in self.file_diff["changed_schema_files"]:
             self.processing_file = file_id
             self.change_schema_file(file_id)
@@ -628,8 +632,8 @@ class PartialParsing:
         new_schema_file = deepcopy(self.new_files[file_id])
         saved_yaml_dict = saved_schema_file.dict_from_yaml
         new_yaml_dict = new_schema_file.dict_from_yaml
-        print(f"--- in change_schema_file. pp_dict: {saved_schema_file.pp_dict}")
-        saved_schema_file.pp_dict = {}
+        if saved_schema_file.pp_dict is None:
+            saved_schema_file.pp_dict = {}
         self.handle_schema_file_changes(saved_schema_file, saved_yaml_dict, new_yaml_dict)
 
         # copy from new schema_file to saved_schema_file to preserve references

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -628,6 +628,7 @@ class PartialParsing:
         new_schema_file = deepcopy(self.new_files[file_id])
         saved_yaml_dict = saved_schema_file.dict_from_yaml
         new_yaml_dict = new_schema_file.dict_from_yaml
+        print(f"--- in change_schema_file. pp_dict: {saved_schema_file.pp_dict}")
         saved_schema_file.pp_dict = {}
         self.handle_schema_file_changes(saved_schema_file, saved_yaml_dict, new_yaml_dict)
 

--- a/tests/functional/partial_parsing/test_pp_schema_file_order.py
+++ b/tests/functional/partial_parsing/test_pp_schema_file_order.py
@@ -157,6 +157,9 @@ class TestNewVersionedSchemaFile:
         }
 
     def test_schema_file_order_new_versions(self, project):
+        # This tests that when a model referring to an existing model
+        # which has had a version added in a yaml file has been re-parsed
+        # in order to fix the depends_on to the correct versioned model
 
         # initial run
         results = run_dbt(["compile"])

--- a/tests/functional/partial_parsing/test_pp_schema_file_order.py
+++ b/tests/functional/partial_parsing/test_pp_schema_file_order.py
@@ -1,10 +1,8 @@
 import os
-from pathlib import Path
 
 import pytest
 
-from dbt.exceptions import ParsingError
-from dbt.tests.util import get_manifest, run_dbt, run_dbt_and_capture, write_file
+from dbt.tests.util import get_manifest, run_dbt, write_file
 
 os.environ["DBT_PP_TEST"] = "true"
 
@@ -36,6 +34,8 @@ models:
     description: "a list of colors"
   - name: another
     description: "YET another model"
+    versions:
+      - v: 1
 """
 
 foo_model_sql = """
@@ -57,6 +57,7 @@ models:
   - name: foo_model
     description: "some random other model"
 """
+
 
 class TestSchemaFileOrder:
     @pytest.fixture(scope="class")
@@ -87,4 +88,6 @@ class TestSchemaFileOrder:
         assert len(results) == 4
         manifest = get_manifest(project.project_root)
         model = manifest.nodes.get(model_id)
+        assert model.name == "another_ref"
+        # The description here would be '' without the bug fix
         assert model.description == "model with reference to another ref"

--- a/tests/functional/partial_parsing/test_pp_schema_file_order.py
+++ b/tests/functional/partial_parsing/test_pp_schema_file_order.py
@@ -1,0 +1,90 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from dbt.exceptions import ParsingError
+from dbt.tests.util import get_manifest, run_dbt, run_dbt_and_capture, write_file
+
+os.environ["DBT_PP_TEST"] = "true"
+
+colors_sql = """
+    select 'green' as first, 'red' as second, 'blue' as third
+"""
+
+another_v1_sql = """
+select * from {{ ref("colors") }}
+"""
+
+another_ref_sql = """
+select * from {{ ref("another") }}
+"""
+
+colors_yml = """
+models:
+  - name: colors
+    description: "a list of colors"
+  - name: another
+    description: "another model"
+    versions:
+      - v: 1
+"""
+
+colors_alt_yml = """
+models:
+  - name: colors
+    description: "a list of colors"
+  - name: another
+    description: "YET another model"
+"""
+
+foo_model_sql = """
+select 1 as id
+"""
+
+another_ref_yml = """
+models:
+  - name: another_ref
+    description: "model with reference to another ref"
+  - name: foo_model
+    description: "some random model"
+"""
+
+another_ref_alt_yml = """
+models:
+  - name: another_ref
+    description: "model with reference to another ref"
+  - name: foo_model
+    description: "some random other model"
+"""
+
+class TestSchemaFileOrder:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "colors.sql": colors_sql,
+            "colors.yml": colors_yml,
+            "another_v1.sql": another_v1_sql,
+            "another_ref.sql": another_ref_sql,
+            "foo_model.sql": foo_model_sql,
+            "another_ref.yml": another_ref_yml,
+        }
+
+    def test_schema_file_order(self, project):
+
+        # initial run
+        results = run_dbt(["run"])
+        assert len(results) == 4
+
+        manifest = get_manifest(project.project_root)
+        model_id = "model.test.another_ref"
+        model = manifest.nodes.get(model_id)
+        assert model.description == "model with reference to another ref"
+
+        write_file(colors_alt_yml, project.project_root, "models", "colors.yml")
+        write_file(another_ref_alt_yml, project.project_root, "models", "another_ref.yml")
+        results = run_dbt(["--partial-parse", "run"])
+        assert len(results) == 4
+        manifest = get_manifest(project.project_root)
+        model = manifest.nodes.get(model_id)
+        assert model.description == "model with reference to another ref"


### PR DESCRIPTION
Resolves #11869

### Problem

Child dependencies of a versioned model with a change were not having patches re-applied because a patch might be stored in the dependency patch file, but when that file was processed the patches that were already stored were deleted.

### Solution

Only initialize the patch dictionary if it's set to None.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
