### PR TITLE
Add `type` property to function nodes

### DIFF
--- a/.changes/unreleased/Features-20250926-140315.yaml
+++ b/.changes/unreleased/Features-20250926-140315.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add `type` property to `function` nodes
+time: 2025-09-26T14:03:15.728495-05:00
+custom:
+  Author: QMalcolm
+  Issue: 12042 12037

--- a/core/dbt/artifacts/resources/types.py
+++ b/core/dbt/artifacts/resources/types.py
@@ -79,3 +79,9 @@ class BatchSize(StrEnum):
 
     def plural(self) -> str:
         return str(self) + "s"
+
+
+class FunctionType(StrEnum):
+    Scalar = "scalar"
+    Aggregate = "aggregate"
+    Table = "table"

--- a/core/dbt/artifacts/resources/v1/function.py
+++ b/core/dbt/artifacts/resources/v1/function.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import List, Literal, Optional
 
-from dbt.artifacts.resources.types import NodeType
+from dbt.artifacts.resources.types import FunctionType, NodeType
 from dbt.artifacts.resources.v1.components import CompiledResource
 from dbt.artifacts.resources.v1.config import NodeConfig
 from dbt_common.dataclass_schema import dbtClassMixin
@@ -46,3 +46,4 @@ class Function(CompiledResource, FunctionMandatory):
     resource_type: Literal[NodeType.Function]
     config: FunctionConfig
     arguments: List[FunctionArgument] = field(default_factory=list)
+    type: FunctionType = FunctionType.Scalar

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -63,6 +63,7 @@ from dbt.artifacts.resources import SourceDefinition as SourceDefinitionResource
 from dbt.artifacts.resources import SqlOperation as SqlOperationResource
 from dbt.artifacts.resources import TimeSpine
 from dbt.artifacts.resources import UnitTestDefinition as UnitTestDefinitionResource
+from dbt.artifacts.resources.types import FunctionType
 from dbt.artifacts.schemas.batch_results import BatchResults
 from dbt.clients.jinja_static import statically_extract_has_name_this
 from dbt.contracts.graph.model_config import UnitTestNodeConfig
@@ -1722,18 +1723,19 @@ class ParsedNodePatch(ParsedPatch):
     freshness: Optional[ModelFreshness] = None
 
 
-# TODO: Maybe this shouldn't be a subclass of ParsedNodePatch, but ParsedPatch instead
-# Currently, `functions` have the fields like `columns`, `access`, `version`, and etc,
-# but they don't actually do anything. If we remove those properties from FunctionNode,
-# we can remove this class and use ParsedPatch instead.
 @dataclass
 class ParsedFunctionPatchRequired:
     return_type: FunctionReturnType
 
 
+# TODO: Maybe this shouldn't be a subclass of ParsedNodePatch, but ParsedPatch instead
+# Currently, `functions` have the fields like `columns`, `access`, `version`, and etc,
+# but they don't actually do anything. If we remove those properties from FunctionNode,
+# we can remove this class and use ParsedPatch instead.
 @dataclass
 class ParsedFunctionPatch(ParsedNodePatch, ParsedFunctionPatchRequired):
     arguments: List[FunctionArgument] = field(default_factory=list)
+    type: FunctionType = FunctionType.Scalar
 
 
 @dataclass

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Sequence, Union
 
-# trigger the PathEncoder
 import dbt_common.helper_types  # noqa:F401
 from dbt import deprecations
 from dbt.artifacts.resources import (
@@ -31,6 +30,9 @@ from dbt.artifacts.resources import (
     list_str,
     metas,
 )
+
+# trigger the PathEncoder
+from dbt.artifacts.resources.types import FunctionType
 from dbt.exceptions import ParsingError
 from dbt.node_types import NodeType
 from dbt_common.contracts.config.base import CompareBehavior, MergeBehavior
@@ -672,6 +674,7 @@ class UnparsedFunctionUpdate(
 ):
     access: Optional[str] = None
     arguments: List[FunctionArgument] = field(default_factory=list)
+    type: FunctionType = FunctionType.Scalar
 
 
 #

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Sequence, Union
 
+# trigger the PathEncoder
 import dbt_common.helper_types  # noqa:F401
 from dbt import deprecations
 from dbt.artifacts.resources import (
@@ -30,8 +31,6 @@ from dbt.artifacts.resources import (
     list_str,
     metas,
 )
-
-# trigger the PathEncoder
 from dbt.artifacts.resources.types import FunctionType
 from dbt.exceptions import ParsingError
 from dbt.node_types import NodeType

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -1292,6 +1292,7 @@ class FunctionPatchParser(NodePatchParser[UnparsedFunctionUpdate]):
 
         node.arguments = patch.arguments
         node.return_type = patch.return_type
+        node.type = patch.type
 
     def _get_node_patch(self, block: TargetBlock[NodeTarget], refs: ParserRef) -> ParsedNodePatch:
         target = block.target
@@ -1315,6 +1316,7 @@ class FunctionPatchParser(NodePatchParser[UnparsedFunctionUpdate]):
             time_spine=None,
             arguments=target.arguments,
             return_type=target.return_type,
+            type=target.type,
         )
 
 

--- a/schemas/dbt/manifest/v12.json
+++ b/schemas/dbt/manifest/v12.json
@@ -9007,6 +9007,14 @@
                     "type"
                   ]
                 }
+              },
+              "type": {
+                "enum": [
+                  "scalar",
+                  "aggregate",
+                  "table"
+                ],
+                "default": "scalar"
               }
             },
             "additionalProperties": false,
@@ -20597,6 +20605,14 @@
                           "type"
                         ]
                       }
+                    },
+                    "type": {
+                      "enum": [
+                        "scalar",
+                        "aggregate",
+                        "table"
+                      ],
+                      "default": "scalar"
                     }
                   },
                   "additionalProperties": false,
@@ -27107,6 +27123,14 @@
                 "type"
               ]
             }
+          },
+          "type": {
+            "enum": [
+              "scalar",
+              "aggregate",
+              "table"
+            ],
+            "default": "scalar"
           }
         },
         "additionalProperties": false,

--- a/tests/functional/functions/test_udafs.py
+++ b/tests/functional/functions/test_udafs.py
@@ -1,0 +1,53 @@
+from typing import Dict
+
+import pytest
+
+from dbt.artifacts.resources import FunctionReturnType
+from dbt.artifacts.resources.types import FunctionType
+from dbt.contracts.graph.nodes import FunctionNode
+from dbt.tests.util import run_dbt
+
+double_total_sql = """
+SELECT SUM(values) * 2
+"""
+
+double_total_yml = """
+functions:
+  - name: double_total
+    type: aggregate
+    description: Sums the sequence of numbers and then doubles the result
+    arguments:
+      - name: values
+        type: float
+        description: A sequence of numbers
+    return_type:
+      type: float
+"""
+
+
+class BasicUDAFSetup:
+    @pytest.fixture(scope="class")
+    def functions(self) -> Dict[str, str]:
+        return {
+            "double_total.sql": double_total_sql,
+            "double_total.yml": double_total_yml,
+        }
+
+
+class TestBasicSQLUDAF(BasicUDAFSetup):
+    def test_basic_sql_udaf_parsing(self, project):
+        manifest = run_dbt(["parse"])
+        assert len(manifest.functions) == 1
+        assert "function.test.double_total" in manifest.functions
+        function_node = manifest.functions["function.test.double_total"]
+        assert isinstance(function_node, FunctionNode)
+        assert function_node.type == FunctionType.Aggregate
+        assert (
+            function_node.description == "Sums the sequence of numbers and then doubles the result"
+        )
+        assert len(function_node.arguments) == 1
+        argument = function_node.arguments[0]
+        assert argument.name == "values"
+        assert argument.type == "float"
+        assert argument.description == "A sequence of numbers"
+        assert function_node.return_type == FunctionReturnType(type="float")

--- a/tests/functional/functions/test_udfs.py
+++ b/tests/functional/functions/test_udfs.py
@@ -4,6 +4,7 @@ import agate
 import pytest
 
 from dbt.artifacts.resources import FunctionReturnType
+from dbt.artifacts.resources.types import FunctionType
 from dbt.contracts.graph.nodes import FunctionNode
 from dbt.tests.util import run_dbt
 
@@ -40,6 +41,7 @@ class TestBasicSQLUDF(BasicUDFSetup):
         assert "function.test.double_it" in manifest.functions
         function_node = manifest.functions["function.test.double_it"]
         assert isinstance(function_node, FunctionNode)
+        assert function_node.type == FunctionType.Scalar
         assert function_node.description == "Doubles whatever number is passed in"
         assert len(function_node.arguments) == 1
         argument = function_node.arguments[0]


### PR DESCRIPTION
Resolves #12042 
Resolves #12037 

### Problem

There are three distinct types of functions: `scalar`, `aggregate`, and `table`. We need to know which the user is specifying. Of note, the only built-in supported type in dbt-adapters currently is `scalar`.

### Solution

* Add a `type` property to function nodes
* The `type` function node property supports values: `scalar`, `aggregate`, and `table
* The `type` function node property defaults to `scalar` if not explicitly specified

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
