### PR TITLE
Fix rendering of function relaltions when filters are at play

### DIFF
--- a/.changes/unreleased/Fixes-20251002-160655.yaml
+++ b/.changes/unreleased/Fixes-20251002-160655.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Exclude `functions` from being filtered by `empty` and `event_time`
+time: 2025-10-02T16:06:55.689911-05:00
+custom:
+  Author: QMalcolm
+  Issue: "12066"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -20,7 +20,7 @@ from typing_extensions import Protocol
 
 from dbt import selected_resources
 from dbt.adapters.base.column import Column
-from dbt.adapters.base.relation import EventTimeFilter
+from dbt.adapters.base.relation import EventTimeFilter, RelationType
 from dbt.adapters.contracts.connection import AdapterResponse
 from dbt.adapters.exceptions import MissingConfigError
 from dbt.adapters.factory import (
@@ -953,7 +953,7 @@ class ParseFunctionResolver(BaseFunctionResolver):
     def resolve(self, name: str, package: Optional[str] = None):
         # When you call function(), this is what happens at parse time
         self.model.functions.append(self._repack_args(name, package))
-        return self.Relation.create_from(self.config, self.model)
+        return self.Relation.create_from(self.config, self.model, type=RelationType.Function)
 
 
 class RuntimeFunctionResolver(BaseFunctionResolver):
@@ -984,6 +984,7 @@ class RuntimeFunctionResolver(BaseFunctionResolver):
             target_function,
             limit=self.resolve_limit,
             event_time_filter=self.resolve_event_time_filter(target_function),
+            type=RelationType.Function,
         )
 
 


### PR DESCRIPTION
Resolves #12066

### Problem

Previously on creation of function relations we weren't passing a `type` value. This was problematic because in dbt-adapters we call `is_function` (which uses the relation `type`) to determine whether a relation can be filtered when filtering options (like `empty` or `event_time`) are present. Because `type` wasn't set for function relations, `is_function` would return `False` and thus in the present of a filter, we would attempt to filter it. This would raise an error because functions can't be filtered. 

### Solution

Set the `type` of a relation to `function` when creating a function relation.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
