### PR TITLE
Ability to use functions in unit tests

### DIFF
--- a/.changes/unreleased/Features-20251002-182911.yaml
+++ b/.changes/unreleased/Features-20251002-182911.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support function nodes for unit tested models
+time: 2025-10-02T18:29:11.316884-05:00
+custom:
+  Author: QMalcolm
+  Issue: "12024"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -988,7 +988,9 @@ class RuntimeFunctionResolver(BaseFunctionResolver):
         )
 
 
-# TODO: Add RuntimeUnitTestFunctionResolver CT-12024
+# TODO: Right now the RuntimeUnitTestProvider uses the RuntimeFunctionResolver for functions,
+# but for CT-12025 we'll likely need to create a separate RuntimeUnitTestFunctionResolver to
+# handle function overrides (mocking functions)
 
 
 # Providers

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -186,6 +186,12 @@ class UnitTestManifestLoader:
             # Add unique ids of input_nodes to depends_on
             unit_test_node.depends_on.nodes.append(input_node.unique_id)
 
+        # Add functions to the manifest and depends_on
+        for unique_id in tested_node.depends_on.nodes:
+            if unique_id in self.manifest.functions:
+                unit_test_node.depends_on.nodes.append(unique_id)
+                self.unit_test_manifest.functions[unique_id] = self.manifest.functions[unique_id]
+
     def _build_fixture_raw_code(self, rows, column_name_to_data_types, fixture_format) -> str:
         # We're not currently using column_name_to_data_types, but leaving here for
         # possible future use.


### PR DESCRIPTION
Resolves #12024

### Problem

Functions weren't resolving correctly for unit tests of models that depend on them.

### Solution

Ensure that the functions of a model that is being unit tested get added to the manifest of that unit test scope and to the depends_on of the unit test.

### Note

Functions that the model being tested directly depend on must be created before running the unit test. This is similar to models that are directly depended on by the model being tested. To ensure that the function exists for a given unit test, we recommend running `dbt build --select "+my_model_to_test" --empty`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
