### PR TITLE
Re-comment out test generation line that I uncommented and accidentally committed

### DIFF
--- a/tests/functional/artifacts/test_previous_version_state.py
+++ b/tests/functional/artifacts/test_previous_version_state.py
@@ -412,7 +412,7 @@ class TestPreviousVersionState:
             current_manifest_schema_version == self.CURRENT_EXPECTED_MANIFEST_VERSION
         ), "Sounds like you've bumped the manifest version and need to update this test!"
         # If we need a newly generated manifest, uncomment the following line and commit the result
-        self.generate_latest_manifest(project, current_manifest_schema_version)
+        # self.generate_latest_manifest(project, current_manifest_schema_version)
         self.compare_previous_state(project, current_manifest_schema_version, True, 0)
 
     def test_backwards_compatible_versions(self, project):


### PR DESCRIPTION
Resolves #N/A

### Problem

I accidentally committed the un-commenting of a `self.generate_latest_manifest` in our tests 🙈 

### Solution

Re-comment out the line 🫠 

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
