### PR TITLE
Fix using `ref`s in function nodes

### DIFF
--- a/.changes/unreleased/Fixes-20251006-175813.yaml
+++ b/.changes/unreleased/Fixes-20251006-175813.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix `ref` support in function nodes
+time: 2025-10-06T17:58:13.853195-05:00
+custom:
+  Author: QMalcolm
+  Issue: "12076"

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1164,6 +1164,10 @@ class ManifestLoader:
                 continue
             _process_refs(self.manifest, current_project, semantic_model, dependencies)
             self.update_semantic_model(semantic_model)
+        for function in self.manifest.functions.values():
+            if function.created_at < self.started_at:
+                continue
+            _process_refs(self.manifest, current_project, function, dependencies)
 
     # Takes references in 'metrics' array of nodes and exposures, finds the target
     # node, and updates 'depends_on.nodes' with the unique id


### PR DESCRIPTION
Resolves #12076

### Problem

Using a static `ref` in a function would cause an error

### Solution

Ensure we process the `ref`s of function nodes

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
