### PR TITLE
Tidy first fix jsonschema deprecation warning tests

### DIFF
--- a/core/dbt/include/jsonschemas/resources/latest.json
+++ b/core/dbt/include/jsonschemas/resources/latest.json
@@ -147,6 +147,15 @@
           "type": "null"
         }
       ]
+    },
+    "functions": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "object"
+      }
     }
   },
   "additionalProperties": false,

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -487,6 +487,7 @@ class TestCustomOutputPathInSourceFreshnessDeprecation:
 
 class TestHappyPathProjectHasNoDeprecations:
     @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
+    @mock.patch("dbt.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
     def test_happy_path_project_has_no_deprecations(self, happy_path_project):
         event_cathcer = EventCatcher(DeprecationsSummary)
         run_dbt(
@@ -498,6 +499,7 @@ class TestHappyPathProjectHasNoDeprecations:
 
 class TestBaseProjectHasNoDeprecations:
     @mock.patch.dict(os.environ, {"DBT_ENV_PRIVATE_RUN_JSONSCHEMA_VALIDATIONS": "True"})
+    @mock.patch("dbt.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
     def test_base_project_has_no_deprecations(self, project):
         event_cathcer = EventCatcher(DeprecationsSummary)
         run_dbt(

--- a/tests/functional/fixtures/happy_path_project/models/schema.yml
+++ b/tests/functional/fixtures/happy_path_project/models/schema.yml
@@ -36,10 +36,11 @@ models:
     columns:
       - name: id
         description: The id value
-        tags:
-          - "column_level_tag"
-        meta:
-          column_meta: "column_meta_value"
+        config:
+          tags:
+            - "column_level_tag"
+          meta:
+            column_meta: "column_meta_value"
         data_tests:
           - unique
           - not_null:


### PR DESCRIPTION
Resolves #N/A

### Problem

Our tests of JSONSchema validation deprecations weren't actually testing anything because the validation was being skipped due to the postgres adapter (which we use for testing) not being considered supported for validations. 

### Solution

Mock that the postgres adapter actually is supported

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
