### PR TITLE
fix unit test to accept param names without DBT_ENGINE_ prefix

### DIFF
--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -39,7 +39,9 @@ class TestCLI:
                 # deprecated params are named "deprecated_x" and do not need to have
                 # a parallel name like "DBT_"
                 if param.envvar is not None and "deprecated_" not in param.name:
-                    assert "DBT_" + param.name.upper() == param.envvar
+                    assert ("DBT_" + param.name.upper() == param.envvar) or (
+                        "DBT_ENGINE_" + param.name.upper() == param.envvar
+                    )
             if type(command) is click.Group:
                 for command in command.commands.values():
                     run_test(command)


### PR DESCRIPTION
Follow-up to recent env var work that ensures all new framework env vars begin with `DBT_ENGINE` - this fix is necessary to avoid needing to prefix every corresponding click `--<option>` with `--engine-<option>`