### PR TITLE
Add project ID flag support in CLI (issue: #12113)

### DIFF
--- a/.changes/unreleased/Features-20251024-111854.yaml
+++ b/.changes/unreleased/Features-20251024-111854.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: add --project-id global flag
+time: 2025-10-24T11:18:54.505598+02:00
+custom:
+    Author: igor-dabrowski-affirm
+    Issue: "12113"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -144,6 +144,7 @@ def global_flags(func):
     @p.write_json
     @p.use_fast_test_edges
     @p.upload_artifacts
+    @p.project_id
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -795,3 +795,11 @@ upload_artifacts = _create_option_and_track_env_var(
     help="Whether or not to upload the artifacts to the dbt Cloud API",
     default=False,
 )
+
+project_id = _create_option_and_track_env_var(
+    "--project-id",
+    envvar="DBT_PROJECT_ID",
+    help="Override the dbt Cloud project ID. This value will be set in the dbt-cloud.project-id field of dbt_project.yml",
+    type=click.INT,
+    default=None,
+)

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -290,6 +290,13 @@ def project(func):
         project = load_project(
             flags.PROJECT_DIR, flags.VERSION_CHECK, ctx.obj["profile"], flags.VARS, validate=True
         )
+
+        # Override dbt-cloud.project-id if --project-id flag is provided
+        if hasattr(flags, 'PROJECT_ID') and flags.PROJECT_ID is not None:
+            if project.dbt_cloud is None:
+                project.dbt_cloud = {}
+            project.dbt_cloud['project-id'] = flags.PROJECT_ID
+   
         ctx.obj["project"] = project
 
         # Plugins


### PR DESCRIPTION
* Introduce --project-id flag to override dbt Cloud project ID
* Update main.py to include project_id decorator
* Modify requires.py to set project ID in dbt_cloud if provided

Resolves #12113 
I could not properly test it - it is my first open-source commit. Would appreciate the check or guidance how I can do it as I was getting errors trying to set up testing env following the docs.

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem
Hardcoded dbt-cloud project-id number in the `dbt_project.yml` making it very difficult to run the same repo against different dbt cloud projects.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
This PR solves the issue by adding the --project-id flag and enable teams to use it to run dbt project against different cloud projects via cli.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
