### PR TITLE
[1.9.latest] Pin dbt-adapters to dev-requirements to fix python 3.9 support

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,9 @@
-git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-tests-adapter
+git+https://github.com/dbt-labs/dbt-postgres.git@main
 # Pinning to 1.34.latest to maintain Python 3.9 compatibility
 git+https://github.com/dbt-labs/dbt-common.git@1.34.latest
-git+https://github.com/dbt-labs/dbt-postgres.git@main
 # Last adapters patch that supports Python 3.9
 dbt-adapters==1.17.3
+dbt-tests-adapter==1.19.1
 
 # black must match what's in .pre-commit-config.yaml to be sure local env matches CI
 black==24.3.0


### PR DESCRIPTION
Fixing CI builds now that python 3.9 has been dropped from dbt-adapters and dbt-test-adapter

Example failing run: https://github.com/dbt-labs/dbt-core/actions/runs/19044890273