### PR TITLE
Stop allowing hyphens in metric names and add name validation tests

### DIFF
--- a/.changes/unreleased/Fixes-20251107-160515.yaml
+++ b/.changes/unreleased/Fixes-20251107-160515.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: For metric names, fix bug allowing hyphens (not allowed in metricflow already), make validation throw ValidationErrors (not ParsingErrors), and add tests.
+time: 2025-11-07T16:05:15.946331-08:00
+custom:
+    Author: theyostalservice
+    Issue: n/a

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -638,11 +638,11 @@ class UnparsedMetric(dbtClassMixin):
                 errors.append("cannot contain more than 250 characters")
             if not (re.match(r"^[A-Za-z]", data["name"])):
                 errors.append("must begin with a letter")
-            if not (re.match(r"[\w-]+$", data["name"])):
+            if not (re.match(r"[\w]+$", data["name"])):
                 errors.append("must contain only letters, numbers and underscores")
 
             if errors:
-                raise ParsingError(
+                raise ValidationError(
                     f"The metric name '{data['name']}' is invalid.  It {', '.join(e for e in errors)}"
                 )
 

--- a/tests/unit/contracts/graph/test_unparsed.py
+++ b/tests/unit/contracts/graph/test_unparsed.py
@@ -933,6 +933,41 @@ class TestUnparsedMetric(ContractTestCase):
         tst["tags"] = [123]
         self.assert_fails_validation(tst)
 
+    def test_bad_metric_name_with_spaces(self):
+        tst = self.get_ok_dict()
+        tst["name"] = "metric name with spaces"
+        self.assert_fails_validation(tst)
+
+    def test_bad_metric_name_too_long(self):
+        tst = self.get_ok_dict()
+        tst["name"] = "a" * 251
+        self.assert_fails_validation(tst)
+
+    def test_bad_metric_name_does_not_start_with_letter(self):
+        tst = self.get_ok_dict()
+        tst["name"] = "123metric"
+        self.assert_fails_validation(tst)
+
+        tst["name"] = "_metric"
+        self.assert_fails_validation(tst)
+
+    def test_bad_metric_name_contains_special_characters(self):
+        tst = self.get_ok_dict()
+        tst["name"] = "metric!name"
+        self.assert_fails_validation(tst)
+
+        tst["name"] = "metric@name"
+        self.assert_fails_validation(tst)
+
+        tst["name"] = "metric#name"
+        self.assert_fails_validation(tst)
+
+        tst["name"] = "metric$name"
+        self.assert_fails_validation(tst)
+
+        tst["name"] = "metric-name"
+        self.assert_fails_validation(tst)
+
 
 class TestUnparsedVersion(ContractTestCase):
     ContractType = UnparsedVersion


### PR DESCRIPTION
### Problem

Problems:
1. The validation for metric names should not allow hyphens.  They are already disallowed in dbt-semantic-interfaces and metricflow, and the error message here correctly identifies that they're not allowed, but a mistake in the regex allows them to slip through.
2. These name errors are validation errors, not parsing errors, and should be treated as such.
3. We don't have any tests showing that these work and protecting them during maintenance.

### Solution

Fix the regex, change the error type that we raise, and add tests!

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
