### PR TITLE
Add test coverage for SL metric parsing

### DIFF
--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1940,7 +1940,7 @@ def _process_metric_node(
 
             if target_metric is None:
                 raise dbt.exceptions.ParsingError(
-                    f"The metric `{input_metric.name}` does not exist but was referenced.",
+                    f"The metric `{input_metric.name}` does not exist but was referenced by metric `{metric.name}`.",
                     node=metric,
                 )
             elif isinstance(target_metric, Disabled):

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -222,7 +222,7 @@ semantic_models:
 """
 
 
-schema_yml = """models:
+base_schema_yml = """models:
   - name: fct_revenue
     description: This is the model fct_revenue. It should be able to use doc blocks
 
@@ -249,6 +249,14 @@ semantic_models:
       - name: sum_of_things
         expr: 2
         agg: sum
+        agg_time_dimension: ds
+      - name: count_of_things
+        agg: count
+        expr: 1
+        agg_time_dimension: ds
+      - name: count_of_things_2
+        agg: count
+        expr: 1
         agg_time_dimension: ds
       - name: has_revenue
         expr: true
@@ -295,7 +303,49 @@ metrics:
     type: simple
     type_params:
       measure: sum_of_things
+  - name: test_cumulative_metric
+    label: Cumulative Metric
+    type: cumulative
+    type_params:
+      measure: sum_of_things
+      cumulative_type_params:
+        grain_to_date: day
+        period_agg: first
 """
+
+conversion_metric_yml = """
+  - name: test_conversion_metric
+    label: Conversion Metric
+    type: conversion
+    type_params:
+      conversion_type_params:
+        base_measure: count_of_things
+        conversion_measure: count_of_things_2
+        entity: user
+        calculation: conversion_rate
+"""
+
+ratio_metric_yml = """
+  - name: test_ratio_metric
+    label: Ratio Metric
+    type: ratio
+    type_params:
+      numerator: simple_metric
+      denominator: test_conversion_metric
+"""
+
+derived_metric_yml = """
+  - name: test_derived_metric
+    label: Derived Metric
+    type: derived
+    type_params:
+      metrics:
+        - simple_metric
+        - test_conversion_metric
+      expr: simple_metric + 1
+"""
+
+schema_yml = base_schema_yml + conversion_metric_yml + ratio_metric_yml + derived_metric_yml
 
 schema_without_semantic_model_yml = """models:
   - name: fct_revenue

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -2,21 +2,29 @@ from typing import List
 
 import pytest
 
+from dbt.artifacts.resources.v1.semantic_model import MetricType
 from dbt.contracts.graph.manifest import Manifest
 from dbt.tests.util import run_dbt, write_file
 from dbt_common.events.base_types import BaseEvent
+from dbt_semantic_interfaces.type_enums.conversion_calculation_type import (
+    ConversionCalculationType,
+)
+from dbt_semantic_interfaces.type_enums.period_agg import PeriodAggregation
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from tests.functional.assertions.test_runner import dbtTestRunner
 from tests.functional.semantic_models.fixtures import (
+    base_schema_yml,
+    conversion_metric_yml,
     fct_revenue_sql,
     metricflow_time_spine_sql,
     multi_sm_schema_yml,
+    ratio_metric_yml,
     schema_without_semantic_model_yml,
     schema_yml,
 )
 
 
-class TestSemanticModelParsing:
+class TestSemanticModelParsingWorks:
     @pytest.fixture(scope="class")
     def models(self):
         return {
@@ -38,14 +46,24 @@ class TestSemanticModelParsing:
             semantic_model.node_relation.relation_name
             == f'"dbt"."{project.test_schema}"."fct_revenue"'
         )
-        assert len(semantic_model.measures) == 7
+        assert len(semantic_model.measures) == 9
         # manifest should have two metrics created from measures
-        assert len(manifest.metrics) == 3
+        assert len(manifest.metrics) == 7
         metric = manifest.metrics["metric.test.txn_revenue"]
         assert metric.name == "txn_revenue"
         metric_with_label = manifest.metrics["metric.test.txn_revenue_with_label"]
         assert metric_with_label.name == "txn_revenue_with_label"
         assert metric_with_label.label == "Transaction Revenue with label"
+
+
+class TestSemanticModelParsingErrors:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": schema_yml,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
 
     def test_semantic_model_error(self, project):
         # Next, modify the default schema.yml to remove the semantic model.
@@ -60,7 +78,155 @@ class TestSemanticModelParsing:
         assert validation_errors
 
 
-class TestSemanticModelPartialParsing:
+class TestSemanticModelParsingForCumulativeMetrics:
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": schema_yml,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
+
+    def test_cumulative_metric_parsing(self, project):
+        runner = dbtTestRunner()
+        result = runner.invoke(["parse"])
+        assert result.success
+        manifest = result.result
+        assert "metric.test.test_cumulative_metric" in manifest.metrics
+        metric = manifest.metrics["metric.test.test_cumulative_metric"]
+        assert metric.name == "test_cumulative_metric"
+        # Check type and params for cumulative metric
+        assert metric.type is MetricType.CUMULATIVE
+        cumulative_params = metric.type_params.cumulative_type_params
+        assert cumulative_params is not None
+        assert cumulative_params.grain_to_date == "day"
+        assert cumulative_params.period_agg is PeriodAggregation.FIRST
+
+        assert len(metric.type_params.input_measures) == 1
+        assert "sum_of_things" in [im.name for im in metric.type_params.input_measures]
+
+        # Not sure where dbt uses this, but for now, let's just make sure we know
+        # we're keeping the contract that these metrics are marked as depending on
+        # the semantic model.
+        assert "semantic_model.test.revenue" in metric.depends_on.nodes
+
+
+class TestSemanticModelParsingForConversionMetrics:
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": schema_yml,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
+
+    def test_conversion_metric_parsing(self, project):
+        runner = dbtTestRunner()
+        result = runner.invoke(["parse"])
+        assert result.success
+        manifest = result.result
+        assert "metric.test.test_conversion_metric" in manifest.metrics
+        metric = manifest.metrics["metric.test.test_conversion_metric"]
+        assert metric.name == "test_conversion_metric"
+        # Check type and params for conversion metric
+        assert metric.type is MetricType.CONVERSION
+        conversion_params = metric.type_params.conversion_type_params
+        assert conversion_params is not None
+        # Confirm measures, entity, and calculation are correct
+        assert conversion_params.base_measure.name == "count_of_things"
+        assert conversion_params.conversion_measure.name == "count_of_things_2"
+        assert conversion_params.entity == "user"
+        assert conversion_params.calculation == ConversionCalculationType.CONVERSION_RATE
+
+        assert len(metric.type_params.input_measures) == 2
+        assert "count_of_things" in [im.name for im in metric.type_params.input_measures]
+        assert "count_of_things_2" in [im.name for im in metric.type_params.input_measures]
+
+        # Not sure where dbt uses this, but for now, let's just make sure
+        # we're keeping the contract that these metrics are marked as depending on
+        # the semantic model.
+        assert "semantic_model.test.revenue" in metric.depends_on.nodes
+
+
+class TestSemanticModelParsingForRatioMetrics:
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": schema_yml,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
+
+    def test_ratio_metric_parsing(self, project):
+        runner = dbtTestRunner()
+        result = runner.invoke(["parse"])
+        assert result.success
+        manifest = result.result
+        assert "metric.test.test_ratio_metric" in manifest.metrics
+        metric = manifest.metrics["metric.test.test_ratio_metric"]
+        assert metric.name == "test_ratio_metric"
+        assert metric.type is MetricType.RATIO
+        type_params = metric.type_params
+        assert type_params.numerator.name == "simple_metric"
+        assert type_params.denominator.name == "test_conversion_metric"
+
+        assert len(metric.type_params.input_measures) == 3
+        assert "sum_of_things" in [im.name for im in metric.type_params.input_measures]
+        assert "count_of_things" in [im.name for im in metric.type_params.input_measures]
+        assert "count_of_things_2" in [im.name for im in metric.type_params.input_measures]
+
+        # I don't know for sure why, but it seems like we've never marked the
+        # 'depends_on' semantic model for ratio metrics, so let's document that here
+        # as a test.  These are not used in metricflow.
+        assert len(metric.depends_on.nodes) == 2
+        assert "metric.test.simple_metric" in metric.depends_on.nodes
+        assert "metric.test.test_conversion_metric" in metric.depends_on.nodes
+
+
+class TestSemanticModelParsingForDerivedMetrics:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": schema_yml,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
+
+    def test_derived_metric_parsing(self, project):
+        runner = dbtTestRunner()
+        result = runner.invoke(["parse"])
+        assert result.success
+        manifest = result.result
+        assert "metric.test.test_derived_metric" in manifest.metrics
+        metric = manifest.metrics["metric.test.test_derived_metric"]
+        assert metric.name == "test_derived_metric"
+        assert metric.type is MetricType.DERIVED
+        assert len(metric.type_params.input_measures) == 3
+        assert "sum_of_things" in [im.name for im in metric.type_params.input_measures]
+        assert "count_of_things" in [im.name for im in metric.type_params.input_measures]
+        assert "count_of_things_2" in [im.name for im in metric.type_params.input_measures]
+
+        assert len(metric.type_params.metrics) == 2
+        assert "simple_metric" in [m.name for m in metric.type_params.metrics]
+        assert "test_conversion_metric" in [m.name for m in metric.type_params.metrics]
+
+        # I don't know for sure why, but it seems like we've never marked the
+        # 'depends_on' semantic model for derived metrics, so let's document that here
+        # as a test.  These are not used in metricflow.
+        assert len(metric.depends_on.nodes) == 2
+        assert "metric.test.simple_metric" in metric.depends_on.nodes
+        assert "metric.test.test_conversion_metric" in metric.depends_on.nodes
+
+
+# ------------------------------------------------------------------------------
+# Partial Parsing tests below
+# ------------------------------------------------------------------------------
+
+
+class TestSemanticModelPartialParsingWithModelChanged:
     @pytest.fixture(scope="class")
     def models(self):
         return {
@@ -90,6 +256,44 @@ class TestSemanticModelPartialParsing:
         semantic_model = manifest.semantic_models["semantic_model.test.revenue"]
         assert semantic_model.dimensions[0].type_params.time_granularity == TimeGranularity.WEEK
 
+
+# TODO DI-4421 (Linear) / SEMANTIC-2997 (Jira): fix the partial parsing bug that breaks this.
+# class TestSemanticModelPartialParsingWithModelDeleted:
+#     @pytest.fixture(scope="class")
+#     def models(self):
+#         return {
+#             "schema.yml": schema_yml,
+#             "fct_revenue.sql": fct_revenue_sql,
+#             "metricflow_time_spine.sql": metricflow_time_spine_sql,
+#         }
+
+#     def test_semantic_model_deleted_partial_parsing__dependency_bug_causes_failure(self, project):
+#         # First, use the default schema.yml to define our semantic model, and
+#         # run the dbt parse command
+#         runner = dbtTestRunner()
+#         result = runner.invoke(["parse"])
+#         assert result.success
+#         assert "semantic_model.test.revenue" in result.result.semantic_models
+
+#         # Next, modify the default schema.yml to remove the semantic model.
+#         write_file(schema_without_semantic_model_yml, project.project_root, "models", "schema.yml")
+
+#         # Now, run the dbt parse command again.
+#         result = runner.invoke(["parse"])
+#         # Known bug: we don't remove metrics in any particular order, so we'll remove
+#         # simple_metric before the metrics that rely on it and have problems... but only SOMETIMES.
+#         assert result.success
+
+
+class TestSemanticModelPartialParsingWithModelDeletedIteratively:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": base_schema_yml + conversion_metric_yml + ratio_metric_yml,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
+
     def test_semantic_model_deleted_partial_parsing(self, project):
         # First, use the default schema.yml to define our semantic model, and
         # run the dbt parse command
@@ -98,22 +302,45 @@ class TestSemanticModelPartialParsing:
         assert result.success
         assert "semantic_model.test.revenue" in result.result.semantic_models
 
-        # Next, modify the default schema.yml to remove the semantic model.
-        write_file(schema_without_semantic_model_yml, project.project_root, "models", "schema.yml")
-
+        # Next, modify the default schema.yml to remove the semantic model ITERATIVELY
+        # (removing it all at once doesn't work because of a bug right now.
+        # see test_semantic_model_deleted_partial_parsing__dependency_bug_causes_failure.)
+        write_file(
+            base_schema_yml + conversion_metric_yml,
+            project.project_root,
+            "models",
+            "schema.yml",
+        )
         # Now, run the dbt parse command again.
+        result = runner.invoke(["parse"])
+        assert result.success
+
+        write_file(base_schema_yml, project.project_root, "models", "schema.yml")
+        result = runner.invoke(["parse"])
+        assert result.success
+
+        write_file(schema_without_semantic_model_yml, project.project_root, "models", "schema.yml")
         result = runner.invoke(["parse"])
         assert result.success
 
         # Finally, verify that the manifest reflects the deletion
         assert "semantic_model.test.revenue" not in result.result.semantic_models
 
+
+class TestSemanticModelPartialParsingWithModelFlippingCreateMetric:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": schema_yml,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
+
     def test_semantic_model_flipping_create_metric_partial_parsing(self, project):
         generated_metric = "metric.test.txn_revenue"
         generated_metric_with_label = "metric.test.txn_revenue_with_label"
         # First, use the default schema.yml to define our semantic model, and
         # run the dbt parse command
-        write_file(schema_yml, project.project_root, "models", "schema.yml")
         runner = dbtTestRunner()
         result = runner.invoke(["parse"])
         assert result.success


### PR DESCRIPTION
### Problem

We don't have tests describing the expected behaviors for metrics in our current parsing logic, and that makes it harder to reason about said behaviors with confidence.  More urgently, it is making it hard for me to change that logic for the newer type of Semantic Layer YAML with confidence that I'm not disturbing the logic that controls parsing for the older yaml.

### Solution

Add tests!  :)

There's a particular focus on making sure the input measures, metrics, and depends_on (only used in core, not in metricflow I believe) are being handled as expected since these are most relevant to the work I'm doing elsewhere.

There are several things to note:
* I broke the tests into separate classes.  This is how tests are handled elsewhere in the codebase, and it seems necessary for proper isolation while we're reading and writing test files.
* I discovered a bug in how partial parsing is handled when removing large swathes of semantic layer objects (we don't order the removals in a way that necessarily respects the dependencies, which causes errors), so you will see the old test commented out (it no longer runs reliably now that the test yaml is more complex) as well as a new version of the test that removes metrics iteratively and shows that that at least is safe.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
