### PR TITLE
Prevent applying the "community" label to bot PRs (#11912)

### DIFF
--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -7,7 +7,6 @@
 # **when?**
 # When a PR is opened, not in draft or moved from draft to ready for review
 
-
 name: Label community PRs
 
 on:
@@ -29,9 +28,15 @@ jobs:
     # If this PR is opened and not draft, determine if it needs to be labeled
     # if the PR is converted out of draft, determine if it needs to be labeled
     if: |
-      (!contains(github.event.pull_request.labels.*.name, 'community') &&
-      (github.event.action == 'opened' && github.event.pull_request.draft == false ) ||
-       github.event.action == 'ready_for_review' )
+      (
+        !contains(github.event.pull_request.labels.*.name, 'community')
+        && (
+          (github.event.action == 'opened' && github.event.pull_request.draft == false)
+          || github.event.action == 'ready_for_review'
+        )
+        && github.event.pull_request.user.type != 'Bot'
+        && github.event.pull_request.user.login != 'dependabot[bot]'
+      )
     uses: dbt-labs/actions/.github/workflows/label-community.yml@main
     with:
         github_team: 'core-group'


### PR DESCRIPTION
### Resolves

Dependabot PRs should not have the community label (#11912)

### Problem

PRs by bots should not have the community label attached.

### Solution

Skip when PR author is a Bot (github.event.pull_request.user.type == 'Bot')
Skip when PR author is Dependabot (github.event.pull_request.user.login == 'dependabot[bot]')

This solution was originally developed by Username46786 in this pull request

https://github.com/dbt-labs/dbt-core/pull/12040

However, Username46786 did not wish to sign the CLA. This PR replicates his work.

### Checklist

dbeatty10, the maintainer wrote,

> Suggested Tests
> Guess and check manually is fine because there's no systems that depend directly on this that could break.

- [ X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
