### PR TITLE
Fix cut_release_branch.yml for cut 1.11.latest

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -1,25 +1,44 @@
 # **what?**
-# Cuts a new `*.latest` branch
-# Also cleans up all files in `.changes/unreleased` and `.changes/previous verion on
-# `main` and bumps `main` to the input version.
+# Cuts the `*.latest` branch, bumps dependencies on it, cleans up all files in `.changes/unreleased`
+# and `.changes/previous verion on main and bumps main to the input version.
 
 # **why?**
-# Generally reduces the workload of engineers and reduces error.  Allow automation.
+# Clean up the main branch after a release branch is cut and automate cutting the release branch.
+# Generally reduces the workload of engineers and reducing error.
 
 # **when?**
-# This will run when called manually.
+# This will run when called manually or when triggered in another workflow.
+
+# Example Usage including required permissions:  TODO: update once finalized
+
+# permissions:
+#   contents: read
+#   pull-requests: write
+#
+# name: Cut Release Branch
+# jobs:
+#   changelog:
+#     uses: dbt-labs/actions/.github/workflows/cut-release-branch.yml@main
+#     with:
+#       new_branch_name: 1.7.latest
+#       PR_title: "Cleanup main after cutting new 1.7.latest branch"
+#       PR_body: "All adapter PRs will fail CI until the dbt-core PR has been merged due to release version conflicts."
+#     secrets:
+#       FISHTOWN_BOT_PAT: ${{ secrets.FISHTOWN_BOT_PAT }}
+
+# TODOs
+# add note to eventually commit changes directly and bypass checks - same as release - when we move to this model run test action after merge
 
 name: Cut new release branch
+run-name: "Cutting New Branch:  ${{ inputs.new_branch_name }}"
 
 on:
   workflow_dispatch:
     inputs:
-      version_to_bump_main:
-        description: 'The alpha version main should bump to (ex. 1.6.0a1)'
-        required: true
       new_branch_name:
-        description: 'The full name of the new branch (ex. 1.5.latest)'
+        description: "The full name of the new branch (ex. 1.5.latest)"
         required: true
+        type: string
 
 defaults:
   run:
@@ -27,15 +46,347 @@ defaults:
 
 permissions:
   contents: write
+  pull-requests: write
+
+env:
+  PYTHON_TARGET_VERSION: "3.10"
+  PR_TITLE: "Cleanup main after cutting new ${{ inputs.new_branch_name }} branch"
+  PR_BODY: "All adapter PRs will fail CI until the dbt-core PR has been merged due to release version conflicts."
 
 jobs:
-  cut_branch:
-    name: "Cut branch and clean up main for dbt-core"
-    uses: dbt-labs/actions/.github/workflows/cut-release-branch.yml@main
-    with:
-      version_to_bump_main: ${{ inputs.version_to_bump_main }}
-      new_branch_name: ${{ inputs.new_branch_name }}
-      PR_title: "Cleanup main after cutting new ${{ inputs.new_branch_name }} branch"
-      PR_body: "All adapter PRs will fail CI until the dbt-core PR has been merged due to release version conflicts."
-    secrets:
-      FISHTOWN_BOT_PAT: ${{ secrets.FISHTOWN_BOT_PAT }}
+  prep_work:
+    name: "Prep Work"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "[DEBUG] Print Inputs"
+        run: |
+          echo "new_branch_name:        ${{ inputs.new_branch_name }}"
+          echo "PR_title:               ${{ env.PR_TITLE }}"
+          echo "PR_body:                ${{ env.PR_BODY }}"
+
+  create_temp_branch:
+    name: "Create Temp branch off main"
+    runs-on: ubuntu-latest
+    outputs:
+      temp_branch_name: ${{ steps.variables.outputs.BRANCH_NAME }}
+
+    steps:
+      - name: "Set Branch Value"
+        id: variables
+        run: |
+          echo "BRANCH_NAME=cutting_release_branch/main_cleanup_$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
+      - name: "Checkout ${{ github.repository }}"
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        with:
+          ref: "main"
+          token: ${{ secrets.FISHTOWN_BOT_PAT }}
+
+      - name: "Create PR Branch"
+        run: |
+          user="Github Build Bot"
+          email="buildbot@fishtownanalytics.com"
+          git config user.name "$user"
+          git config user.email "$email"
+          git checkout -b ${{ steps.variables.outputs.BRANCH_NAME }}
+          git push --set-upstream origin ${{ steps.variables.outputs.BRANCH_NAME }}
+
+      - name: "[Notification] Temp branch created"
+        run: |
+          message="Temp branch ${{ steps.variables.outputs.BRANCH_NAME }} created"
+          echo "::notice title="Temporary branch created": $title::$message"
+
+  cleanup_changelog:
+    name: "Clean Up Changelog"
+    needs: ["create_temp_branch"]
+    runs-on: ubuntu-latest
+    outputs:
+      next-version: ${{ steps.semver-current.outputs.next-minor-alpha-version }}
+
+    steps:
+      - name: "Checkout ${{ github.repository }}"
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        with:
+          ref: ${{ needs.create_temp_branch.outputs.temp_branch_name }}
+          token: ${{ secrets.FISHTOWN_BOT_PAT }}
+
+      - name: "Add Homebrew To PATH"
+        run: |
+          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+
+      - name: "Install Homebrew Packages"
+        run: |
+          brew install pre-commit
+          brew tap miniscruff/changie https://github.com/miniscruff/changie
+          brew install changie
+
+      - name: "Check Current Version In Code"
+        id: determine_version
+        run: |
+          current_version=$(grep '^version = ' core/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "current_version=$current_version" >> $GITHUB_OUTPUT
+
+      - name: "[Notification] Check Current Version In Code"
+        run: |
+          message="The current version is ${{ steps.determine_version.outputs.current_version }}"
+          echo "::notice title="Version Bump Check": $title::$message"
+
+      - name: "Parse Current Version Into Parts for Changelog Directories"
+        id: semver-current
+        uses: dbt-labs/actions/parse-semver@main
+        with:
+          version: ${{ steps.determine_version.outputs.current_version }}
+
+      - name: "[Notification] Next Alpha Version"
+        run: |
+          message="The next alpha version is ${{ steps.semver-current.outputs.next-minor-alpha-version }}"
+          echo "::notice title="Version Bump Check": $title::$message"
+
+      - name: "Delete Unreleased Changelog YAMLs"
+        # removal fails if no files exist. OK to continue since we're just cleaning up the files.
+        continue-on-error: true
+        run: |
+          rm .changes/unreleased/*.yaml || true
+
+      - name: "Delete Pre Release Changelogs and YAMLs"
+        # removal fails if no files exist. OK to continue since we're just cleaning up the files.
+        continue-on-error: true
+        run: |
+          rm .changes/${{ steps.semver-current.outputs.base-version }}/*.yaml || true
+          rm .changes/${{ steps.semver-current.outputs.major }}.${{ steps.semver-current.outputs.minor }}.*.md || true
+
+      - name: "Cleanup CHANGELOG.md"
+        run: |
+          changie merge
+
+      - name: "Commit Changelog Cleanup to Branch"
+        run: |
+          user="Github Build Bot"
+          email="buildbot@fishtownanalytics.com"
+          git config user.name "$user"
+          git config user.email "$email"
+          git status
+          git add .
+          git commit -m "Clean up changelog on main"
+          git push
+
+      - name: "[Notification] Changelog cleaned up"
+        run: |
+          message="Changelog on ${{ needs.create_temp_branch.outputs.temp_branch_name }} cleaned up"
+          echo "::notice title="Changelog cleaned up": $title::$message"
+
+  bump_version:
+    name: "Bump to next minor version"
+    needs: ["cleanup_changelog", "create_temp_branch"]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout ${{ github.repository }}"
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        with:
+          ref: ${{ needs.create_temp_branch.outputs.temp_branch_name }}
+          token: ${{ secrets.FISHTOWN_BOT_PAT }}
+
+      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # actions/setup-python@v5
+        with:
+          python-version: "${{ env.PYTHON_TARGET_VERSION }}"
+
+      - name: "Install Spark Dependencies"
+        if: ${{ contains(github.repository, 'dbt-labs/dbt-spark') }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsasl2-dev
+
+      - name: "Install Python Dependencies"
+        run: |
+          python -m venv env
+          source env/bin/activate
+          python -m pip install --upgrade pip
+
+      - name: "Bump Version To ${{ needs.cleanup_changelog.outputs.next-version }}"
+        run: |
+          source env/bin/activate
+          python -m pip install -r dev-requirements.txt
+          env/bin/bumpversion --allow-dirty --new-version ${{ needs.cleanup_changelog.outputs.next-version }} major
+          git status
+
+      - name: "Commit Version Bump to Branch"
+        run: |
+          user="Github Build Bot"
+          email="buildbot@fishtownanalytics.com"
+          git config user.name "$user"
+          git config user.email "$email"
+          git status
+          git add .
+          git commit -m "Bumping version to ${{ needs.cleanup_changelog.outputs.next-version }}"
+          git push
+
+      - name: "[Notification] Version Bump completed"
+        run: |
+          message="Version on ${{ needs.create_temp_branch.outputs.temp_branch_name }} bumped to ${{ needs.cleanup_changelog.outputs.next-version }}"
+          echo "::notice title="Version Bump Completed": $title::$message"
+
+  cleanup:
+    name: "Cleanup Code Quality"
+    needs: ["create_temp_branch", "bump_version"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout ${{ github.repository }}"
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        with:
+          ref: ${{ needs.create_temp_branch.outputs.temp_branch_name }}
+          token: ${{ secrets.FISHTOWN_BOT_PAT }}
+
+      - name: "Add Homebrew To PATH"
+        run: |
+          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+
+      - name: "brew install pre-commit"
+        run: |
+          brew install pre-commit
+
+      # this step will fail on whitespace errors but also correct them
+      - name: "Cleanup - Remove Trailing Whitespace Via Pre-commit"
+        continue-on-error: true
+        run: |
+          pre-commit run trailing-whitespace --files .bumpversion.cfg CHANGELOG.md .changes/* || true
+
+      # this step will fail on newline errors but also correct them
+      - name: "Cleanup - Remove Extra Newlines Via Pre-commit"
+        continue-on-error: true
+        run: |
+          pre-commit run end-of-file-fixer --files .bumpversion.cfg CHANGELOG.md .changes/* || true
+
+      - name: "Commit Version Bump to Branch"
+        run: |
+          user="Github Build Bot"
+          email="buildbot@fishtownanalytics.com"
+          git config user.name "$user"
+          git config user.email "$email"
+          git status
+          git add .
+          git commit -m "Code quality cleanup"
+          git push
+
+  open_pr:
+    name: "Open PR Against main"
+    needs: ["cleanup_changelog", "create_temp_branch", "cleanup"]
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.create_pr.outputs.pull-request-number }}
+
+    steps:
+      - name: "Checkout ${{ github.repository }}"
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        with:
+          ref: ${{ needs.create_temp_branch.outputs.temp_branch_name }}
+          token: ${{ secrets.FISHTOWN_BOT_PAT }}
+
+      - name: "Determine PR Title"
+        id: pr_title
+        run: |
+          echo "pr_title=${{ env.PR_TITLE }}" >> $GITHUB_OUTPUT
+          if [${{ env.PR_TITLE }} == ""]; then
+            echo "pr_title='Clean up changelogs and bump to version ${{ needs.cleanup_changelog.outputs.next-version }}'" >> $GITHUB_OUTPUT
+          fi
+
+      - name: "Determine PR Body"
+        id: pr_body
+        run: |
+          echo "pr_body=${{ env.PR_BODY }}" >> $GITHUB_OUTPUT
+          if [${{ env.PR_BODY }} == ""]; then
+            echo "pr_body='Clean up changelogs and bump to version ${{ needs.cleanup_changelog.outputs.next-version }}'" >> $GITHUB_OUTPUT
+          fi
+
+      - name: "Add Branch Details"
+        id: pr_body_branch
+        run: |
+          branch_details="The workflow that generated this PR also created a new branch: ${{ inputs.new_branch_name }}"
+          full_body="${{ steps.pr_body.outputs.pr_body }} $branch_details"
+          echo "pr_full_body=$full_body" >> $GITHUB_OUTPUT
+
+      - name: "Open Pull Request"
+        id: create_pr
+        run: |
+          pr_url=$(gh pr create -B main -H ${{ needs.create_temp_branch.outputs.temp_branch_name }} -l "Skip Changelog" -t "${{ steps.pr_title.outputs.pr_title }}" -b "${{ steps.pr_body_branch.outputs.pr_full_body }}")
+          echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
+
+      - name: "[Notification] Pull Request Opened"
+        run: |
+          message="PR opened at ${{ steps.create_pr.outputs.pr_url }}"
+          echo "::notice title="Pull Request Opened": $title::$message"
+
+  cut_new_branch:
+    # don't cut the new branch until we're done opening the PR against main
+    name: "Cut New Branch ${{ inputs.new_branch_name }}"
+    needs: [open_pr]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout ${{ github.repository }}"
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        with:
+          token: ${{ secrets.FISHTOWN_BOT_PAT }}
+          fetch-depth: 0
+
+      - name: "Ensure New Branch Does Not Exist"
+        id: check_new_branch
+        run: |
+          title="Check New Branch Existence"
+          if git show-ref --quiet ${{ inputs.new_branch_name }}; then
+            message="Branch ${{ inputs.new_branch_name }} already exists.  Exiting."
+            echo "::error $title::$message"
+            exit 1
+          fi
+
+      - name: "Create New Release Branch"
+        run: |
+          git checkout -b ${{ inputs.new_branch_name }}
+
+      - name: "Push up New Branch"
+        run: |
+          #Data for commit
+          user="Github Build Bot"
+          email="buildbot@fishtownanalytics.com"
+          git config user.name "$user"
+          git config user.email "$email"
+          git push --set-upstream origin ${{ inputs.new_branch_name }}
+
+      - name: "[Notification] New branch created"
+        run: |
+          message="New branch ${{ inputs.new_branch_name }} created"
+          echo "::notice title="New branch created": $title::$message"
+
+      - name: "Bump dependencies via script"
+        # This bumps the dependency on dbt-core in the adapters
+        if: ${{ !contains(github.repository, 'dbt-core') }}
+        run: |
+          echo ${{ github.repository }}
+          echo "running update_dependencies script"
+          bash ${GITHUB_WORKSPACE}/.github/scripts/update_dependencies.sh ${{ inputs.new_branch_name }}
+          commit_message="bumping .latest branch variable in update_dependencies.sh to ${{ inputs.new_branch_name }}"
+          git status
+          git add .
+          git commit -m "$commit_message"
+          git push
+
+      - name: "Bump env variable via script"
+        # bumps the RELEASE_BRANCH variable in nightly-release.yml in adapters
+        if: ${{ !contains(github.repository, 'dbt-core') }}
+        run: |
+          file="./.github/scripts/update_release_branch.sh"
+          if test -f "$file"; then
+            echo ${{ github.repository }}
+            echo "running some script yet to be written now"
+            bash $file ${{ inputs.new_branch_name }}
+            commit_message="updating env variable to ${{ inputs.new_branch_name }} in nightly-release.yml"
+            git status
+            git add .
+            git commit -m "$commit_message"
+            git push
+          else
+            echo "no $file seen skipping step"
+          fi


### PR DESCRIPTION
### Problem

Cutting new release branches fails because #12129 moved where the current version lives.

### Solution

Look at the right file for version (pyproject.toml) and also move this workflow directly into this repo since adapters no longer uses it.  No need for it to be centralized anymore.

Testing: https://github.com/dbt-labs/dbt-core/actions/runs/19470506924

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
