### PR TITLE
Fix bug `function` wasn't specifiable with `--exlcude-resource-type` flag

### DIFF
--- a/.changes/unreleased/Fixes-20251119-195034.yaml
+++ b/.changes/unreleased/Fixes-20251119-195034.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Allow the usage of `function` with `--exclude-resource-type` flag
+time: 2025-11-19T19:50:34.703236-06:00
+custom:
+  Author: QMalcolm
+  Issue: "12143"

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -235,6 +235,7 @@ exclude_resource_type = _create_option_and_track_env_var(
             "exposure",
             "snapshot",
             "seed",
+            "function",
             "default",
         ],
         case_sensitive=False,

--- a/tests/functional/functions/test_udfs.py
+++ b/tests/functional/functions/test_udfs.py
@@ -521,3 +521,21 @@ class TestDefaultArgumentsMustComeLast:
             "Non-defaulted argument 'val2' of function 'sum_2_values' comes after a defaulted argument. Non-defaulted arguments cannot come after defaulted arguments. "
             in str(excinfo.value)
         )
+
+
+class TestFunctionsIncludeAndExcludeByResourceType:
+    @pytest.fixture(scope="class")
+    def functions(self) -> Dict[str, str]:
+        return {
+            "double_it.sql": double_it_sql,
+            "double_it.yml": double_it_yml,
+        }
+
+    def test_udfs(self, project):
+        result = run_dbt(["build", "--resource-type", "function"])
+        assert len(result.results) == 1
+        function_node = result.results[0].node
+        assert isinstance(function_node, FunctionNode)
+
+        result = run_dbt(["build", "--exclude-resource-type", "function"])
+        assert len(result.results) == 0


### PR DESCRIPTION
Resolves #12143

### Problem

`function` wasn't allowed as a specifiable resource type to the `--exclude-resource-type` flag.

### Solution

Add it to the list of specifiable types for the `--exclude-resource-type` flag

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
