### PR TITLE
perf: replace 'in dict.keys()' with 'in dict' for better performance

### DIFF
--- a/.changes/unreleased/Under the Hood-20251120-175805.yaml
+++ b/.changes/unreleased/Under the Hood-20251120-175805.yaml
@@ -1,0 +1,5 @@
+kind: Under the Hood
+body: Optimize dictionary membership checks by replacing 'in dict.keys()' with 'in dict' for better performance
+time: 2025-11-20T17:58:05.215680-08:00
+custom:
+    Author: christopherrya

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -714,7 +714,7 @@ class BaseContext(metaclass=ContextMeta):
         dict_diff = {}
         dict_b_lowered = {k.casefold(): [x.casefold() for x in v] for k, v in dict_b.items()}
         for k in dict_a:
-            if k.casefold() in dict_b_lowered.keys():
+            if k.casefold() in dict_b_lowered:
                 diff = []
                 for v in dict_a[k]:
                     if v.casefold() not in dict_b_lowered[k.casefold()]:

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -579,7 +579,7 @@ def build_node_edges(nodes: List[ManifestNode]):
     for node in nodes:
         backward_edges[node.unique_id] = node.depends_on_nodes[:]
         for unique_id in backward_edges[node.unique_id]:
-            if unique_id in forward_edges.keys():
+            if unique_id in forward_edges:
                 forward_edges[unique_id].append(node.unique_id)
     return _sort_values(forward_edges), _sort_values(backward_edges)
 
@@ -591,7 +591,7 @@ def build_macro_edges(nodes: List[Any]):
     }
     for node in nodes:
         for unique_id in node.depends_on_macros:
-            if unique_id in forward_edges.keys():
+            if unique_id in forward_edges:
                 forward_edges[unique_id].append(node.unique_id)
     return _sort_values(forward_edges)
 

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -207,7 +207,7 @@ class InitTask(BaseTask):
         profile_name = profile_name or self.get_profile_name_from_current_project()
         with open(profiles_file, "r") as f:
             profiles = yaml.safe_load(f) or {}
-        if profile_name in profiles.keys():
+        if profile_name in profiles:
             response = click.confirm(
                 f"The profile {profile_name} already exists in "
                 f"{profiles_file}. Continue and overwrite it?"


### PR DESCRIPTION
Remove unnecessary .keys() calls in dictionary membership checks. This avoids creating view objects and improves readability.

- core/dbt/context/base.py: diff_of_two_dicts()
- core/dbt/contracts/graph/manifest.py: build_node_edges(), build_macro_edges()
- core/dbt/task/init.py: profile check

Resolves #

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
