### PR TITLE
Introduce `DBT_SELECTOR` as environment variable for `--selector`

### DIFF
--- a/.changes/unreleased/Features-20251124-002455.yaml
+++ b/.changes/unreleased/Features-20251124-002455.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Introduce DBT_SELECTOR as environment variable for --selector
+time: 2025-11-24T00:24:55.698098+01:00
+custom:
+    Author: fornwall
+    Issue: "12193"

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -561,7 +561,7 @@ select = _create_option_and_track_env_var(*select_decls, *model_decls, **select_
 
 selector = _create_option_and_track_env_var(
     "--selector",
-    envvar=None,
+    envvar="DBT_SELECTOR",
     help="The selector name to use, as defined in selectors.yml",
 )
 


### PR DESCRIPTION
Resolves #12193

### Problem

It's not possible to specify a named selector for dbt runs using an environment variable.

### Solution

Introduce support for `DBT_SELECTOR`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
