### PR TITLE
Fix generation of deprecations summary

### DIFF
--- a/.changes/unreleased/Fixes-20251124-155756.yaml
+++ b/.changes/unreleased/Fixes-20251124-155756.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix generation of deprecations summary
+time: 2025-11-24T15:57:56.544123-08:00
+custom:
+    Author: asiunov
+    Issue: "12146"

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -271,7 +271,7 @@ def show_deprecations_summary() -> None:
         deprecation_event = deprecations[deprecation].event()
         summaries.append(
             DeprecationSummary(
-                event_name=deprecation_event.__name__,
+                event_name=type(deprecation_event).__name__,
                 event_code=deprecation_event.code(),
                 occurrences=occurrences,
             ).to_msg_dict()


### PR DESCRIPTION
Resolves #12146

### Problem

`__name__` field is not accessible on event objects.

```
  File ".venv/lib/python3.12/site-packages/dbt/cli/requires.py", line 201, in wrapper
    show_deprecations_summary()
  File ".venv/lib/python3.12/site-packages/dbt/deprecations.py", line 270, in show_deprecations_summary
    event_name=deprecation_event.__name__,
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/dbt_common/events/base_types.py", line 88, in __getattr__
    return super().__getattribute__("pb_msg").__getattribute__(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'MissingArgumentsPropertyInGenericTestDeprecation' object has no attribute '__name__'. Did you mean: '__ne__'?
```

It is likely a regression after https://github.com/dbt-labs/dbt-core/pull/11544/files#diff-3277eb602a187d7bfbcb01f646fa8a17697750aa5886869fddaea6c3026f03e1R208

### Solution

As it was supposed to be, call `__name__` on a class rather than an object.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
