### PR TITLE
stop codecov CI checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install python dependencies
         run: |
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13" ]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     env:
       TOXENV: "unit"
@@ -118,6 +118,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit
+          fail_ci_if_error: false
 
   integration-metadata:
     name: integration test metadata generation
@@ -164,7 +165,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-latest"]
         split-group: ${{ fromJson(needs.integration-metadata.outputs.split-groups) }}
     env:
@@ -249,6 +250,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integration
+          fail_ci_if_error: false
 
   integration-mac-windows:
     name: (${{ matrix.split-group }}) integration test / python ${{ matrix.python-version }} / ${{ matrix.os }}
@@ -331,6 +333,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integration
+          fail_ci_if_error: false
 
   integration-report:
     if: ${{ always() }}
@@ -361,7 +364,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install python dependencies
         run: |

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,39 +2,22 @@ ignore:
   - ".github"
   - ".changes"
 
+# Disable all status checks to prevent red X's in CI
+# Coverage data is still uploaded and PR comments are still posted
 coverage:
   status:
-    project:
-      default:
-        target: auto
-        threshold: 0.1% # Reduce noise by ignoring rounding errors in coverage drops
-        informational: true
-    patch:
-      default:
-        target: auto
-        threshold: 80%
-        informational: true
+    project: off
+    patch: off
 
 comment:
-  layout: "header, diff, flags, components"  # show component info in the PR comment
+  layout: "header, diff, flags, components" # show component info in the PR comment
 
 component_management:
-  default_rules:  # default rules that will be inherited by all components
-    statuses:
-      - type: project # in this case every component that doens't have a status defined will have a project type one
-        target: auto
-        threshold: 0.1%
-      - type: patch
-        target: 80%
   individual_components:
     - component_id: unittests
       name: "Unit Tests"
       flag_regexes:
         - "unit"
-      statuses:
-        - type: patch
-          target: 80%
-          threshold: 5%
     - component_id: integrationtests
       name: "Integration Tests"
       flag_regexes:


### PR DESCRIPTION
### Problem

codecov failures add so.much.noise to our CI.

### Solution

Keep running codecov for historical tracking but stop failing CI for it.

PR comments still post as well.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
