### PR TITLE
fix flaky invocation context + warn error settings in parser unit tests

### DIFF
--- a/tests/unit/parser/test_parser.py
+++ b/tests/unit/parser/test_parser.py
@@ -56,6 +56,7 @@ from dbt.parser.schemas import (
 )
 from dbt.parser.search import FileBlock
 from dbt.parser.sources import SourcePatcher
+from dbt.tests.util import safe_set_invocation_context
 from tests.unit.utils import (
     MockNode,
     config_from_parts_or_dicts,
@@ -112,6 +113,8 @@ class BaseParserTest(unittest.TestCase):
             ),
             None,
         )
+
+        safe_set_invocation_context()
         # HACK: this is needed since tracking events can
         # be sent when using the model parser
         tracking.do_not_track()
@@ -1232,6 +1235,15 @@ def model(dbt, session):
 class ModelParserTest(BaseParserTest):
     def setUp(self):
         super().setUp()
+        set_from_args(
+            Namespace(
+                warn_error=False,
+                state_modified_compare_more_unrendered_values=False,
+                require_generic_test_arguments_property=False,
+            ),
+            None,
+        )
+
         self.parser = ModelParser(
             project=self.snowplow_project_config,
             manifest=self.manifest,


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
tests/unit/parser/test_parser.py are flaky for a couple reasons
* unreliably invocation context setting - was previously relying on other files to have this global set
* warn_error set to False for BaseParserTest, and depending on execution order, for ModelParserTest

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
* Set invocation context in BaseParserTest setup, since all tests need this
* Explicitly set `warn_error`=False in the `ModelParserTest`, since it being True is not necessary for its test cases

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
