### PR TITLE
fix target file for dbt-common CI

### DIFF
--- a/scripts/update_dev_packages.sh
+++ b/scripts/update_dev_packages.sh
@@ -5,7 +5,7 @@ set -e
 
 repo=$1
 ref=$2
-target_req_file="dev-requirements.txt"
+target_req_file="core/hatch.toml"
 
 req_sed_pattern="s|${repo}.git@main|${repo}.git@${ref}|g"
 if [[ "$OSTYPE" == darwin* ]]; then


### PR DESCRIPTION
### Problem

`dbt-common` CI runs tests with dbt-core.  We need to update the ref to be the one we want to test against.  The file we were updating no longer exists due to hatch implementation.

### Solution

Use `core/hatch.toml`


### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
