### PR TITLE
set version to 1.11.0rc2 on 1.11.latest

### DIFF
--- a/core/dbt/__version__.py
+++ b/core/dbt/__version__.py
@@ -1,1 +1,1 @@
-version = "1.12.0a1"
+version = "1.11.0rc2"


### PR DESCRIPTION
https://github.com/dbt-labs/dbt-core/pull/12257/files#diff-ed10e4ac3a515b1047b7a88fab59e5ecb2223c1bf588efe5d518aff6a06f256eR1

Don't think the change to version should have gotten into the 1.11.latest branch!

Causing:
> raise ValueError(message)
ValueError: Version `1.11.0rc3` is not higher than the original version `1.12.0a1`

https://github.com/dbt-labs/dbt-core/actions/runs/20045618795/job/57490438168