### PR TITLE
delete deprecated create_adapter_plugins script

### DIFF
--- a/core/scripts/create_adapter_plugins.py
+++ b/core/scripts/create_adapter_plugins.py
@@ -1,5 +1,0 @@
-# The create_adapter_plugins script is being replaced by a new interactive cookiecutter scaffold
-# that can be found https://github.com/dbt-labs/dbt-database-adapter-scaffold
-print(
-    "This script has been deprecated, to create a new adapter please visit https://github.com/dbt-labs/dbt-database-adapter-scaffold"
-)


### PR DESCRIPTION
Resolves #N/A

Removing `create_adapter_plugins.py` shim now that the new cookiecutter based tooling has been around for 3 years! This tooling was introduced for [dbt 1.2](https://github.com/dbt-labs/dbt-core/blob/1.2.latest/core/scripts/create_adapter_plugins.py) ([1.1.latest for comparison](https://github.com/dbt-labs/dbt-core/blob/1.1.latest/core/scripts/create_adapter_plugins.py)) which is also EOL.

Officially documented here: https://docs.getdbt.com/guides/adapter-creation?step=3
