### PR TITLE
Add missing return statement to RuntimeConfigObject.meta_require method

### DIFF
--- a/.changes/unreleased/Fixes-20251217-002813.yaml
+++ b/.changes/unreleased/Fixes-20251217-002813.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Adds omitted return statement to RuntimeConfigObject.meta_require method
+time: 2025-12-17T00:28:13.015416197Z
+custom:
+    Author: mjsqu
+    Issue: "12288"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -607,6 +607,8 @@ class RuntimeConfigObject(Config):
 
         if validator is not None:
             self._validate(validator, to_return)
+        
+        return to_return
 
     def get(self, name, default=None, validator=None):
         to_return = self._lookup(name, default)

--- a/tests/functional/configs/test_get_default.py
+++ b/tests/functional/configs/test_get_default.py
@@ -101,4 +101,4 @@ class TestConfigGetMetaRequire:
         results = run_dbt(["run"], expect_pass=False)
         assert len(results) == 1
         assert str(results[0].status) == "error"
-        assert 'column "none" does not exist' in results[0].message
+        assert 'column "my_meta_value" does not exist' in results[0].message


### PR DESCRIPTION
Resolves #12288 

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

`config.meta_require` always returns None

### Solution

Adds omitted return statement to have `config.meta_require` return the config.meta value requested

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
