### PR TITLE
Add missing return statement to RuntimeConfigObject.meta_require method

### DIFF
--- a/.changes/unreleased/Fixes-20251217-002813.yaml
+++ b/.changes/unreleased/Fixes-20251217-002813.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Adds omitted return statement to RuntimeConfigObject.meta_require method
+time: 2025-12-17T00:28:13.015416197Z
+custom:
+    Author: mjsqu
+    Issue: "12288"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -608,6 +608,8 @@ class RuntimeConfigObject(Config):
         if validator is not None:
             self._validate(validator, to_return)
 
+        return to_return
+
     def get(self, name, default=None, validator=None):
         to_return = self._lookup(name, default)
 

--- a/tests/functional/configs/test_get_default.py
+++ b/tests/functional/configs/test_get_default.py
@@ -101,4 +101,4 @@ class TestConfigGetMetaRequire:
         results = run_dbt(["run"], expect_pass=False)
         assert len(results) == 1
         assert str(results[0].status) == "error"
-        assert 'column "none" does not exist' in results[0].message
+        assert 'column "my_meta_value" does not exist' in results[0].message


### PR DESCRIPTION
Resolves #12288

Porting over @mjsqu's PR https://github.com/dbt-labs/dbt-core/pull/12289
