### PR TITLE
use .post instead of .dev for test versioning

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: "Generate Nightly Release Version Number"
         id: nightly-release-version
         run: |
-          number="${{ steps.semver.outputs.version }}.dev${{ steps.current-date.outputs.date }}"
+          number="${{ steps.semver.outputs.version }}.post${{ steps.current-date.outputs.date }}"
           echo "number=$number" >> $GITHUB_OUTPUT
 
       - name: "Audit Nightly Release Version And Parse Into Parts"


### PR DESCRIPTION
### Problem

Nightly release test is broken because in PEP 440 version ordering semantics .dev releases are considered lower than the base version, not higher so hatch is failing to version bump.  

### Solution

Use the post prefix instead of dev since PEP 440 treats that as higher.

Test: https://github.com/dbt-labs/dbt-core/actions/runs/20339628468 
- note, this test run failed on the integration tests but the version bump was successful.  The failing tests will be fixed by https://github.com/dbt-labs/dbt-release/pull/164 and is unrelated to this change

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
