### PR TITLE
Bump minimum click to 8.2.0

### DIFF
--- a/.changes/unreleased/Dependencies-20251219-153804.yaml
+++ b/.changes/unreleased/Dependencies-20251219-153804.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump minimum click to 8.2.0
+time: 2025-12-19T15:38:04.785842-06:00
+custom:
+  Author: QMalcolm
+  Issue: "12305"

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     # ----
     # dbt-core uses these packages in standard ways. Pin to the major version, and check compatibility
     # with major versions in each new minor version of dbt-core.
-    "click>=8.0.2,<9.0",
+    "click>=8.2.0,<9.0",
     "jsonschema>=4.19.1,<5.0",
     "networkx>=2.3,<4.0",
     "protobuf>=6.0,<7.0",


### PR DESCRIPTION
Resolves #12305

### Problem

`click` made a breaking change in `8.2.0`, that we depend on, but we allowed for `click>=8.0.2,9.0`. This was problematic in "dirty" environments when installing dbt-core. That is `dbt-core` would think the `click` requirement was fine when it wasn't.

### Solution

Bump the minimum `click` version to `8.2.0`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
