### PR TITLE
Fix bad flag and link

### DIFF
--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1277,8 +1277,8 @@ class PackageNodeDependsOnRootProjectNode(WarnLevel):
     def message(self) -> str:
         msg = (
             f"The node '{self.node_name}'in package '{self.package_name}' depends on the root project node '{self.root_project_unique_id}'."
-            "This may lead to unexpected cycles downstream. Please set the 'require_ref_prefers_node_package_to_root' behavior change flag to True to avoid this issue."
-            "For more information, see the documentation at https://docs.getdbt.com/reference/global-configs/behavior-changes#require_ref_prefers_node_package_to_root"
+            "This may lead to unexpected cycles downstream. Please set the 'require_ref_searches_node_package_before_root' behavior change flag to True to avoid this issue."
+            "For more information, see the documentation at https://docs.getdbt.com/reference/global-configs/behavior-changes#package-ref-search-order"
         )
         return warning_tag(msg)
 


### PR DESCRIPTION
### Problem

Error message for [package ref search order](https://docs.getdbt.com/reference/global-configs/behavior-changes#package-ref-search-order) violation does not match the doc url and flag

### Solution

Fix the error message

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
