### PR TITLE
Feat/add optional header support to seeds

### DIFF
--- a/.changes/unreleased/Features-20260105-000635.yaml
+++ b/.changes/unreleased/Features-20260105-000635.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add seed header option support
+time: 2026-01-05T00:06:35.693542+01:00
+custom:
+    Author: aammett
+    Issue: "11334"

--- a/core/dbt/artifacts/resources/v1/seed.py
+++ b/core/dbt/artifacts/resources/v1/seed.py
@@ -16,6 +16,7 @@ class SeedConfig(NodeConfig):
     materialized: str = "seed"
     delimiter: str = ","
     quote_columns: Optional[bool] = None
+    header: bool = True
 
     @classmethod
     def validate(cls, data):

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1269,8 +1269,19 @@ class ProviderContext(ManifestContext):
 
         column_types = self.model.config.column_types
         delimiter = self.model.config.delimiter
+        header = self.model.config.header
+        column_names = None
+        if not self.model.config.header:
+            column_names = list(self.model.columns.keys())
+
         try:
-            table = agate_helper.from_csv(path, text_columns=column_types, delimiter=delimiter)
+            table = agate_helper.from_csv(
+                path,
+                column_names=column_names,
+                text_columns=column_types,
+                delimiter=delimiter,
+                header=header,
+            )
         except ValueError as e:
             raise LoadAgateTableValueError(e, node=self.model)
         # this is used by some adapters

--- a/tests/unit/contracts/graph/test_nodes_parsed.py
+++ b/tests/unit/contracts/graph/test_nodes_parsed.py
@@ -523,6 +523,7 @@ def basic_parsed_seed_dict():
             "delimiter": ",",
             "enabled": True,
             "materialized": "seed",
+            "header": True,
             "persist_docs": {},
             "post-hook": [],
             "pre-hook": [],
@@ -616,6 +617,7 @@ def complex_parsed_seed_dict():
             "delimiter": ",",
             "enabled": True,
             "materialized": "seed",
+            "header": True,
             "persist_docs": {"relation": True, "columns": True},
             "post-hook": [],
             "pre-hook": [],
@@ -677,6 +679,7 @@ def complex_parsed_seed_object():
         config=SeedConfig(
             quote_columns=True,
             delimiter=",",
+            header=True,
             persist_docs={"relation": True, "columns": True},
         ),
         docs=Docs(show=True),


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/11334

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

If I've configured my seed's column names in a yml file, I don't want to also keep a header row up-to-date in my csv seed file.

```
seeds:
  - name: my_seed
    columns:
      - name: country_code
        data_type: varchar(2)
      - name: country_name
        data_type: varchar(32)
```
```
country_code,country_name
US,United States
CA,Canada
GB,United Kingdom
```
Instead, I should be able to configure my seed to not need a header row if I've configured my column names in yml already.

```
seeds:
  - name: my_seed
    config:
      header: false
    columns:
      - name: country_code
        data_type: varchar(2)
      - name: country_name
        data_type: varchar(32)

```
```
US,United States
CA,Canada
GB,United Kingdom
```

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
Add an optional header parameter to seed config
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
