### PR TITLE
Update nightly release date to start be %Y%m%d

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: "Get Current Date"
         id: current-date
-        run: echo "date=$(date +'%m%d%Y')" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
 
       - name: "Generate Nightly Release Version Number"
         id: nightly-release-version


### PR DESCRIPTION
### Problem

Leading zeros are stripped from the nightly date-based releases with hatch.  When we moved to January we started having 0 based months.

```
Version not set to 1.12.0a1.post01052026. Current version is 1.12.0a1.post1052026. The version bump workflow must be complete before running this workflow.
```

### Solution

Change date format to start with year so it's never 0 based.

Tested: https://github.com/dbt-labs/dbt-core/actions/runs/20719675210

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
