### PR TITLE
Flip default for require_all_warnings_handled_by_warn_error to true

### DIFF
--- a/.changes/unreleased/Under the Hood-20260112-000042.yaml
+++ b/.changes/unreleased/Under the Hood-20260112-000042.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Flip default for require_all_warnings_handled_by_warn_error from false to true
+time: 2026-01-12T00:00:42.910114Z
+custom:
+    Author: Fury0508
+    Issue: "12162"

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -364,7 +364,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     require_yaml_configuration_for_mf_time_spines: bool = False
     require_nested_cumulative_type_params: bool = False
     validate_macro_args: bool = False
-    require_all_warnings_handled_by_warn_error: bool = False
+    require_all_warnings_handled_by_warn_error: bool = True
     require_generic_test_arguments_property: bool = True
     require_unique_project_resource_names: bool = False
     require_ref_searches_node_package_before_root: bool = False


### PR DESCRIPTION
- Changed default from false to true in core/dbt/contracts/project.py
- Added changelog entry for issue #12162

Resolves #12162

### Problem

The flag `require_all_warnings_handled_by_warn_error` was introduced with a default value of `false` for backward compatibility. As per issue #12162, we need to flip the default to `true` for the v1.12 milestone to ensure all warnings are properly handled by warn-error configurations.

### Solution

Changed the default value of `require_all_warnings_handled_by_warn_error` from `False` to `True` in `core/dbt/contracts/project.py`. 

This is a straightforward boolean flip. Existing tests explicitly set both `true` and `false` values, so no test modifications were needed. All unit tests pass (1540 tests) and code quality checks pass.

Users who need the old behavior can explicitly set `require_all_warnings_handled_by_warn_error: false` in their `dbt_project.yml` file.


### Checklist

- [x] I have read the contributing guide and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes type annotations for new and modified functions.
