### PR TITLE
Test: Add unit tests for python model verification

### DIFF
--- a/.changes/unreleased/Under the Hood-20260117-194609.yaml
+++ b/.changes/unreleased/Under the Hood-20260117-194609.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Added unit tests for python model verification
+time: 2026-01-17T19:46:09.6578971+05:30
+custom:
+    Author: abhishek09827
+    Issue: ' '

--- a/core/dbt/parser/models.py
+++ b/core/dbt/parser/models.py
@@ -158,7 +158,6 @@ class PythonParseVisitor(ast.NodeVisitor):
 
 
 def verify_python_model_code(node):
-    # TODO: add a test for this
     try:
         rendered_python = get_rendered(
             node.raw_code,

--- a/tests/unit/parser/test_python_model_verification.py
+++ b/tests/unit/parser/test_python_model_verification.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import MagicMock
+from dbt.exceptions import ParsingError
+from dbt.parser.models import verify_python_model_code
+from tests.unit.utils import MockNode
+
+class TestPythonModelVerification(unittest.TestCase):
+    def test_valid_python_code(self):
+        # Valid Python code
+        code = """
+import pandas as pd
+
+def model(dbt, session):
+    dbt.config(materialized='table')
+    return pd.DataFrame()
+"""
+        node = MockNode(
+            package="test_package",
+            name="test_model",
+            raw_code=code,
+            original_file_path="models/test_model.py"
+        )
+        # Should not raise exception
+        verify_python_model_code(node)
+
+    def test_python_code_with_jinja(self):
+        # Python code containing Jinja
+        code = """
+import pandas as pd
+
+def model(dbt, session):
+    dbt.config(materialized='{{ "table" }}')  # Jinja here
+    return pd.DataFrame()
+"""
+        node = MockNode(
+            package="test_package",
+            name="test_model",
+            raw_code=code,
+            original_file_path="models/test_model.py"
+        )
+
+        with self.assertRaises(ParsingError):
+            verify_python_model_code(node)


### PR DESCRIPTION
Resolves #12359

### Problem

There was a `# TODO` comment in `core/dbt/parser/models.py` indicating that `verify_python_model_code` lacked unit tests.

### Solution

I added a new unit test file [tests/unit/parser/test_python_model_verification.py](cci:7://file:///e:/Personal%20Projects/OpenSource/dbt/dbt-core/tests/unit/parser/test_python_model_verification.py:0:0-0:0) which covers:
- Valid python model code.
- Python model code incorrectly containing Jinja templates (which should raise a `ParsingError`).

I also removed the TODO comment from the source code.

> **Note:** This is my first contribution to dbt-core! I'm excited to help out. Please let me know if there are any changes needed.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.