### PR TITLE
Fix hatch CI env failing due to pre-commit command ordering

### DIFF
--- a/core/hatch.toml
+++ b/core/hatch.toml
@@ -87,10 +87,13 @@ dependencies = [
     "protobuf>=6.0,<7.0",
 ]
 
+pre-install-commands = [
+    "pip install -e .",
+]
+
 [envs.default.scripts]
 # Setup commands
 setup = [
-    "pip install -e .",
     "pre-commit install",
 ]
 
@@ -191,7 +194,6 @@ dependencies = [
 
 pre-install-commands = [
     "pip install -e .",
-    "pre-commit install",
 ]
 
 [envs.ci.env-vars]
@@ -202,7 +204,6 @@ DBT_TEST_USER_3 = "dbt_test_user_3"
 [envs.ci.scripts]
 unit-tests = "python -m pytest --cov=dbt --cov-report=xml {args} ../tests/unit"
 code-quality = "pre-commit run --all-files"
-# Run as single command to avoid pre-install-commands running twice
 integration-tests = """
 python -m pytest --cov=dbt --cov-append --cov-report=xml {args} ../tests/functional -k "not tests/functional/graph_selection" && \
 python -m pytest --cov=dbt --cov-append --cov-report=xml {args} ../tests/functional/graph_selection


### PR DESCRIPTION
### Problem

The CI env in core/hatch.toml was failing with:

```
pre-install [2] | pre-commit install
/bin/sh: 1: pre-commit: not found
Failed with exit code: 127
```
This happened because pre-commit commands run before dependencies are installed. The pre-commit install command was trying to run before pre-commit was available, even though pre-commit was listed in dependencies.

Hatch environment creation order:
1. Create virtual environment
2. Run pre-install-commands ← pre-commit not installed yet
3. Install dependencies ← pre-commit installed here
4. Install the project
5. Run post-install-commands

### Solution

Removed pre-commit commands from the CI env entirely. This block was unnecessary because we don't need it for CI. We run `pre-commit run --all-files` directly via the code-quality script instead of relying on git hooks

Test run in dbt-common CI: https://github.com/dbt-labs/dbt-common/actions/runs/21148474248

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
