### PR TITLE
Update version for libpq-dev in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
     ca-certificates=20210119 \
-    libpq-dev=13.22-0+deb11u1 \
+    libpq-dev=13.23-0+deb11u1 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \


### PR DESCRIPTION
Resolves N/A

### Problem

Docker releases were broken. We were attempting to install `libpq-dev=13.22-0+deb11u1` in our Dockerfile. However, on December 25th, 2025 a `libpq-dev=13.23-0+deb11u1` was released to fix a security vulnerability in `13.22-0+deb11u1` (and afterwards `13.22-0+deb11u1` was delisted). This caused our docker builds to begin failing because `libpq-dev=13.22-0+deb11u1` couldn't be found.

### Solution

Move to installing `libpq-dev=13.23-0+deb11u1`. Similar to previous work https://github.com/dbt-labs/dbt-core/pull/11937

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
