### PR TITLE
Add event_timezone to support custom time zones for microbatch event …

### DIFF
--- a/.changes/unreleased/Features-20260122-173717.yaml
+++ b/.changes/unreleased/Features-20260122-173717.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: add event_timezone to support custom time zones for microbatch event time filter
+time: 2026-01-22T17:37:17.771208+09:00
+custom:
+    Author: huangxingyi-git
+    Issue: "11578"

--- a/core/dbt/artifacts/resources/v1/config.py
+++ b/core/dbt/artifacts/resources/v1/config.py
@@ -127,6 +127,7 @@ class NodeConfig(NodeAndTestConfig):
     )
     event_time: Any = None
     concurrent_batches: Any = None
+    event_timezone: Any = "UTC"
 
     def __post_init__(self):
         # we validate that node_color has a suitable value to prevent dbt-docs from crashing

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1517,6 +1517,13 @@ class ManifestLoader:
                             f"Microbatch model '{node.name}' optional 'concurrent_batches' config must be of type `bool` if specified, but got: {type(concurrent_batches)})."
                         )
 
+                    # Optional config: event_timezone (str)
+                    event_timezone = node.config.event_timezone
+                    if not isinstance(event_timezone, str) and event_timezone is not None:
+                        raise dbt.exceptions.ParsingError(
+                            f"Microbatch model '{node.name}' must provide the optional 'event_timezone' config as type str, but got: {type(event_timezone)})."
+                        )
+
     def check_forcing_batch_concurrency(self) -> None:
         if self.manifest.use_microbatch_batches(project_name=self.root_project.project_name):
             adapter = get_adapter(self.root_project)

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -18,6 +18,7 @@ from typing import (
     Tuple,
     Type,
 )
+from zoneinfo import ZoneInfo
 
 from dbt import tracking, utils
 from dbt.adapters.base import BaseAdapter, BaseRelation
@@ -732,7 +733,7 @@ class MicrobatchModelRunner(ModelRunner):
             is_incremental=self._is_incremental(model),
             event_time_start=event_time_start,
             event_time_end=event_time_end,
-            default_end_time=get_invocation_started_at(),
+            default_end_time=get_invocation_started_at().replace(tzinfo=ZoneInfo("UTC")),
         )
 
     def get_batches(self, model: ModelNode) -> Dict[int, BatchType]:

--- a/tests/unit/contracts/graph/test_nodes.py
+++ b/tests/unit/contracts/graph/test_nodes.py
@@ -192,6 +192,7 @@ def basic_compiled_dict():
             "docs": {"show": True},
             "access": "protected",
             "lookback": 1,
+            "event_timezone": "UTC",
         },
         "docs": {"show": True},
         "columns": {},

--- a/tests/unit/contracts/graph/test_nodes_parsed.py
+++ b/tests/unit/contracts/graph/test_nodes_parsed.py
@@ -105,6 +105,7 @@ def populated_node_config_dict():
         "contract": {"enforced": False, "alias_types": True},
         "access": "protected",
         "lookback": 1,
+        "event_timezone": "UTC",
     }
 
 
@@ -194,6 +195,7 @@ def base_parsed_model_dict():
             "packages": [],
             "access": "protected",
             "lookback": 1,
+            "event_timezone": "UTC",
         },
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
@@ -308,6 +310,7 @@ def complex_parsed_model_dict():
             "packages": [],
             "access": "protected",
             "lookback": 1,
+            "event_timezone": "UTC",
         },
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
@@ -536,6 +539,7 @@ def basic_parsed_seed_dict():
             "contract": {"enforced": False, "alias_types": True},
             "packages": [],
             "lookback": 1,
+            "event_timezone": "UTC",
         },
         "docs": {"show": True},
         "columns": {},
@@ -630,6 +634,7 @@ def complex_parsed_seed_dict():
             "contract": {"enforced": False, "alias_types": True},
             "packages": [],
             "lookback": 1,
+            "event_timezone": "UTC",
         },
         "docs": {"show": True},
         "columns": {
@@ -843,6 +848,7 @@ def base_parsed_hook_dict():
             "contract": {"enforced": False, "alias_types": True},
             "packages": [],
             "lookback": 1,
+            "event_timezone": "UTC",
         },
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
@@ -928,6 +934,7 @@ def complex_parsed_hook_dict():
             "contract": {"enforced": False, "alias_types": True},
             "packages": [],
             "lookback": 1,
+            "event_timezone": "UTC",
         },
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
@@ -1300,6 +1307,7 @@ def basic_timestamp_snapshot_config_dict():
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
         "lookback": 1,
+        "event_timezone": "UTC",
     }
 
 
@@ -1340,6 +1348,7 @@ def complex_timestamp_snapshot_config_dict():
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
         "lookback": 1,
+        "event_timezone": "UTC",
     }
 
 
@@ -1408,6 +1417,7 @@ def basic_check_snapshot_config_dict():
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
         "lookback": 1,
+        "event_timezone": "UTC",
     }
 
 
@@ -1448,6 +1458,7 @@ def complex_set_snapshot_config_dict():
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
         "lookback": 1,
+        "event_timezone": "UTC",
     }
 
 
@@ -1575,6 +1586,7 @@ def basic_timestamp_snapshot_dict():
             "contract": {"enforced": False, "alias_types": True},
             "packages": [],
             "lookback": 1,
+            "event_timezone": "UTC",
         },
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
@@ -1682,6 +1694,7 @@ def basic_check_snapshot_dict():
             "contract": {"enforced": False, "alias_types": True},
             "packages": [],
             "lookback": 1,
+            "event_timezone": "UTC",
         },
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/11578

### Problem

Currently, microbatch renders UTC timestamp as event time filter and does not support calculating local timestamp.

For example, a data team who wants to use local time as 'base line' for ingesting and transforming data.

Assume the team invocated dbt at `2026-01-15 08:00:00+09:00` with below configurations and would like to ingest and transform data between **`2026-01-07 00:00:00+09:00`** and **`2026-01-16 00:00:00+09:00`**.

| config | value |
|-|-|
| batch_size | day |
| lookback | 8 |

Microbatch renders first batch filter as `where sale_date >= to_timestamp_tz('2026-01-06 00:00:00+00:00') and sale_date < to_timestamp_tz('2026-01-07 00:00:00+00:00'))` and  last batch filter as `where sale_date >= to_timestamp_tz('2026-01-14 00:00:00+00:00') and sale_date < to_timestamp_tz('2026-01-15 00:00:00+00:00'))`.

Eventually, the rendered SQL ingest data between **`2026-01-06 09:00:00+09:00`** and **`2026-01-15 09:00:00+09:00`**.

### Solution

Added `event_timezone` to model config. When `--event-time-start`, `--event-time-end` or `get_invocation_started_at` is passed to `MicrobatchBuilder`, convert them to configured timezone timestamp firstly. Then, truncate the converted timestamp with local timezone. Finally, render the truncated timestamp with local timezone in SQL.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
