### PR TITLE
Fix #12379 : Add warning and tests for missing seed column_types

### DIFF
--- a/.changes/unreleased/Fixes-20260125-022647.yaml
+++ b/.changes/unreleased/Fixes-20260125-022647.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Warn (with seed name/path) when seed column_types references columns not present in the seed CSV header, and ignore those entries to prevent agate warnings.
+time: 2026-01-25T02:26:47.44683+01:00
+custom:
+    Author: hamza-dri
+    Issue: "12379"


### PR DESCRIPTION
Resolves #12379

### Problem

dbt lets you override seed column types via `column_types` in config, so you can force a specific database type when the default inference isn’t what you want.

The issue is when a project config includes a `column_types` entry for a column that **doesn’t exist in the seed CSV** (e.g. the CSV header changed, or the config has a typo). In that case, agate (used during seed loading) emits a warning like:

`RuntimeWarning: "<column>" does not match the name of any column in this table.`

That warning is hard to act on because it **doesn’t identify which seed** (or which seed file) caused it. In projects with many seeds—especially when the same column name appears across multiple seeds—this turns into a time-consuming hunt through configs and CSV headers to find the incorrect override.

### Solution

dbt now validates `column_types` against the seed CSV **before** handing those overrides to agate.

What changes:
- When loading a seed, dbt reads the CSV header row to determine the set of valid column names.
- dbt compares the configured `column_types` keys to that header.
- If any configured keys are missing from the CSV header:
  - dbt emits a warning that includes **which seed** and **which file path** is affected, plus the list of missing columns.
  - dbt removes those invalid entries from the `column_types` mapping before calling agate.

Resulting behavior:
- Users get a single warning that is immediately actionable (you can go straight to the right seed + file).
- agate no longer emits its generic warning for the same case.
- Valid column type overrides still apply as usual, and this remains non-fatal (warning only).

New warning format:
`Seed '{package}.{seed}' ({path}) has column_types configured for columns not present in the CSV header: {missing_columns}. Those entries will be ignored.`

### Testing

Added unit tests in `tests/unit/context/test_providers.py` to cover:
- Warning emitted for missing configured columns and agate warning suppressed
- No warning when `column_types` is empty
- No warning when all configured columns exist and overrides are passed through unchanged
- Multiple missing columns included in warning message (stable sorted order) and only valid overrides passed to agate

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.