### PR TITLE
Add derived_semantics.entities to models

### DIFF
--- a/.changes/unreleased/Features-20260128-125727.yaml
+++ b/.changes/unreleased/Features-20260128-125727.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add the ability to process derived semantic entities to dbt models, as required by new YAML schema.
+time: 2026-01-28T12:57:27.576354-08:00
+custom:
+    Author: theyostalservice
+    Issue: "12401"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -72,6 +72,7 @@ from dbt.contracts.graph.unparsed import (
     TestDef,
     UnitTestOverrides,
     UnparsedColumn,
+    UnparsedDerivedSemantics,
     UnparsedMetricV2,
     UnparsedSourceDefinition,
     UnparsedSourceTableDefinition,
@@ -1766,6 +1767,7 @@ class ParsedNodePatch(ParsedPatch):
     time_spine: Optional[TimeSpine] = None
     semantic_model: Optional[bool] = None
     metrics: Optional[List[UnparsedMetricV2]] = None
+    derived_semantics: Optional[UnparsedDerivedSemantics] = None
     freshness: Optional[ModelFreshness] = None
 
 

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -199,8 +199,15 @@ class UnparsedEntity(UnparsedEntityBase):
 class UnparsedColumnEntityV2(UnparsedEntityBase):
     """Used for dbt Semantic Layer column entities (v2 YAML)."""
 
-    # TODO: add a matching UnparsedDerivedEntityV2 class that adds an expr field
     pass
+
+
+# kw_only allows this child to define required fields
+@dataclass(kw_only=True)
+class UnparsedDerivedEntityV2(UnparsedEntityBase):
+    """Used for dbt Semantic Layer derived entities (v2 YAML)."""
+
+    expr: str
 
 
 @dataclass
@@ -473,6 +480,12 @@ class UnparsedNodeUpdate(HasConfig, HasColumnTests, HasColumnAndTestProps, HasYa
 
 
 @dataclass
+class UnparsedDerivedSemantics(dbtClassMixin):
+    # TODO DI-4618 Add dimensions field here
+    entities: List[UnparsedDerivedEntityV2] = field(default_factory=list)
+
+
+@dataclass
 class UnparsedModelUpdate(UnparsedNodeUpdate):
     quote_columns: Optional[bool] = None
     access: Optional[str] = None
@@ -480,10 +493,10 @@ class UnparsedModelUpdate(UnparsedNodeUpdate):
     versions: Sequence[UnparsedVersion] = field(default_factory=list)
     deprecation_date: Optional[datetime.datetime] = None
     time_spine: Optional[TimeSpine] = None
-    # TODO: allow semantic model to accept a semantic model config object OR a bool
+    # TODO DI-4579: allow semantic model to accept a semantic model config object OR a bool
     semantic_model: Optional[bool] = None
     metrics: Optional[List[UnparsedMetricV2]] = None
-    # TODO: add derived_semantics section with dimensions, metrics, and entities
+    derived_semantics: Optional[UnparsedDerivedSemantics] = None
 
     def __post_init__(self) -> None:
         if self.latest_version:

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -783,6 +783,7 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
         time_spine: Optional[TimeSpine] = None
         semantic_model = None
         metrics = None
+        derived_semantics = None
 
         if isinstance(block.target, UnparsedModelUpdate):
             deprecation_date = block.target.deprecation_date
@@ -802,6 +803,7 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
             )
             semantic_model = block.target.semantic_model
             metrics = block.target.metrics
+            derived_semantics = block.target.derived_semantics
 
         return ParsedNodePatch(
             name=block.target.name,
@@ -821,6 +823,7 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
             time_spine=time_spine,
             semantic_model=semantic_model,
             metrics=metrics,
+            derived_semantics=derived_semantics,
         )
 
     def parse_patch(self, block: TargetBlock[NodeTarget], refs: ParserRef) -> None:

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -701,3 +701,19 @@ schema_yml_v2_conversion_metric_missing_base_metric = """
 """
 
 schema_yml_v2_standalone_simple_metric = textwrap.dedent(schema_yml_v2_simple_metric_on_model_1)
+
+derived_semantics_yml = """
+    derived_semantics:
+      entities:
+        - name: derived_id_entity
+          description: This is the id entity, and it is the primary entity.
+          label: ID Entity
+          type: primary
+          expr: "id + foreign_id_col"
+          config:
+            meta:
+              test_label_thing: derived_entity_1
+        - name: derived_id_entity_with_no_optional_fields
+          type: primary
+          expr: id + foreign_id_col
+"""

--- a/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
@@ -12,6 +12,7 @@ from dbt_semantic_interfaces.type_enums import (
 from tests.functional.assertions.test_runner import dbtTestRunner
 from tests.functional.semantic_models.fixtures import (
     base_schema_yml_v2,
+    derived_semantics_yml,
     fct_revenue_sql,
     metricflow_time_spine_sql,
     schema_yml_v2_conversion_metric_missing_base_metric,
@@ -234,7 +235,7 @@ class TestCumulativeMetricNoInputMetricFails:
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
         }
 
-    def test_cumulative_metric_no_input_metric_parsing_fails(self, project):
+    def test_cumulative_metric_no_input_metric_parsing_fails(self, project) -> None:
         runner = dbtTestRunner()
         result = runner.invoke(["parse"])
         assert not result.success
@@ -250,11 +251,44 @@ class TestConversionMetricNoBaseMetricFails:
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
         }
 
-    def test_conversion_metric_no_base_metric_parsing_fails(self, project):
+    def test_conversion_metric_no_base_metric_parsing_fails(self, project) -> None:
         runner = dbtTestRunner()
         result = runner.invoke(["parse"])
         assert not result.success
         assert "base_metric is required for conversion metrics." in str(result.exception)
+
+
+class TestDerivedSemanticsParsingWorks:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": semantic_model_schema_yml_v2 + derived_semantics_yml,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
+
+    def test_derived_semantics_parsing(self, project) -> None:
+        runner = dbtTestRunner()
+        result = runner.invoke(["parse"])
+        assert result.success
+        manifest = result.result
+        assert len(manifest.semantic_models) == 1
+        semantic_model = manifest.semantic_models["semantic_model.test.fct_revenue"]
+        entities = {entity.name: entity for entity in semantic_model.entities}
+        assert (
+            len(entities) == 5
+        )  # length is so long because it is column entities + derived entities
+
+        id_entity = entities["derived_id_entity"]
+        assert id_entity.type == EntityType.PRIMARY
+        assert id_entity.description == "This is the id entity, and it is the primary entity."
+        assert id_entity.expr == "id + foreign_id_col"
+        assert id_entity.config.meta == {"test_label_thing": "derived_entity_1"}
+
+        id_entity_with_no_optional_fields = entities["derived_id_entity_with_no_optional_fields"]
+        assert id_entity_with_no_optional_fields.type == EntityType.PRIMARY
+        assert id_entity_with_no_optional_fields.expr == "id + foreign_id_col"
+        assert id_entity_with_no_optional_fields.config.meta == {}
 
 
 # TODO DI-4605: add enforcement and a test for when there are validity params with no column granularity


### PR DESCRIPTION
Resolves [LINEAR](https://linear.app/dbt-labs/issue/DI-4617/enable-derived-semantics-entities) [JIRA](https://dbtlabs.atlassian.net/browse/SEMANTIC-3192) 

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

Depends on #12397 (cannot be re=ordered)

### Problem

We need to support derived entities for semantic V2 YAML.  The YAML spec that is shared with fusion for this can be seen [here](https://github.com/dbt-labs/sl-schema-evolution/blob/main/schema.py#L273) (internal users only).

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

This is one of the more straightforward of the changes I've made recently.  Using https://github.com/dbt-labs/dbt-core/pull/12368 as a model, added new entries to UnparsedModelUpdate and ParsedNodePatch and then processed the entities in schema_yaml_readers.py .

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.