### PR TITLE
Add derived dimensions for SL v2 YAML

### DIFF
--- a/.changes/unreleased/Features-20260128-172052.yaml
+++ b/.changes/unreleased/Features-20260128-172052.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Enable parsing derived dimensions for v2 semantic layer YAML.
+time: 2026-01-28T17:20:52.400188-08:00
+custom:
+    Author: theyostalservice
+    Issue: "12404"

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -178,6 +178,14 @@ class UnparsedDimensionV2(UnparsedDimensionBase):
     validity_params: Optional[DimensionValidityParams] = None
 
 
+@dataclass(kw_only=True)
+class UnparsedDerivedDimensionV2(UnparsedDimensionV2):
+    """Used for dbt Semantic Layer derived dimensions (v2 YAML)."""
+
+    expr: str
+    granularity: Optional[str] = None  # str is really a TimeGranularity Enum
+
+
 @dataclass
 class UnparsedEntityBase(dbtClassMixin):
     name: str
@@ -481,8 +489,8 @@ class UnparsedNodeUpdate(HasConfig, HasColumnTests, HasColumnAndTestProps, HasYa
 
 @dataclass
 class UnparsedDerivedSemantics(dbtClassMixin):
-    # TODO DI-4618 Add dimensions field here
     entities: List[UnparsedDerivedEntityV2] = field(default_factory=list)
+    dimensions: List[UnparsedDerivedDimensionV2] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -716,4 +716,12 @@ derived_semantics_yml = """
         - name: derived_id_entity_with_no_optional_fields
           type: primary
           expr: id + foreign_id_col
+      dimensions:
+        - name: derived_id_dimension
+          type: categorical
+          expr: id
+          granularity: day
+          validity_params:
+            is_start: true
+            is_end: true
 """

--- a/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
@@ -290,6 +290,14 @@ class TestDerivedSemanticsParsingWorks:
         assert id_entity_with_no_optional_fields.expr == "id + foreign_id_col"
         assert id_entity_with_no_optional_fields.config.meta == {}
 
+        dimensions = {dimension.name: dimension for dimension in semantic_model.dimensions}
+        assert len(dimensions) == 4  # includes non-derived dimensions
+        assert dimensions["derived_id_dimension"].type == DimensionType.CATEGORICAL
+        assert dimensions["derived_id_dimension"].expr == "id"
+        assert dimensions["derived_id_dimension"].config.meta == {}
+        assert dimensions["derived_id_dimension"].type_params.validity_params.is_start is True
+        assert dimensions["derived_id_dimension"].type_params.validity_params.is_end is True
+
 
 # TODO DI-4605: add enforcement and a test for when there are validity params with no column granularity
 # TODO DI-4603: add enforcement and a test for a TIME type dimension and a column that has no granularity set


### PR DESCRIPTION
Resolves [LINEAR](https://linear.app/dbt-labs/issue/DI-4618/enable-derived-semantics-dimensions) [JIRA](https://dbtlabs.atlassian.net/browse/SEMANTIC-3193)

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

Just like #12401 added derived entities, this PR adds derived dimensions.

Internal users can see the YAML spec being used for both this and fusion [here](https://github.com/dbt-labs/sl-schema-evolution/blob/main/schema.py#L150).

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

This is the exact same approach used in the aforementioned #12401.  I just added another field to the derived_semantics inputs and then parsed them in schema_yaml_readers.py.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.