### PR TITLE
Add unit tests to the Jinja `graph` object

### DIFF
--- a/.changes/unreleased/Features-20260129-110711.yaml
+++ b/.changes/unreleased/Features-20260129-110711.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add unit tests to the Jinja `graph` object, enabling tools like dbt-project-evaluator to run checks on unit tests.
+time: 2026-01-29T11:00:00.000000-08:00
+custom:
+    Author: b-per
+    Issue: "12033"

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1015,6 +1015,7 @@ class Manifest(MacroMethods, dbtClassMixin):
             "saved_queries": {
                 k: v.to_dict(omit_none=False) for k, v in self.saved_queries.items()
             },
+            "unit_tests": {k: v.to_dict(omit_none=False) for k, v in self.unit_tests.items()},
         }
 
     def build_disabled_by_file_id(self):


### PR DESCRIPTION
## Summary

Resolves #12033

Unit tests are now included in the `graph` context variable, making them accessible in Jinja templates via `graph.unit_tests`. This enables tools like dbt-project-evaluator to run checks on unit tests.

### Changes
- Added `unit_tests` to the `build_flat_graph()` method in the Manifest class
- Added tests to verify unit tests are included in `flat_graph`

### Usage

After this change, unit tests can be accessed in Jinja via:

```jinja
{% for unit_test_id, unit_test in graph.unit_tests.items() %}
  {{ unit_test.name }} tests {{ unit_test.model }}
{% endfor %}
```

## Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX