### PR TITLE
[draft] Prototype a possible target_def() function.

### DIFF
--- a/core/dbt/artifacts/resources/v1/components.py
+++ b/core/dbt/artifacts/resources/v1/components.py
@@ -54,6 +54,7 @@ class RefArgs(dbtClassMixin):
     name: str
     package: Optional[str] = None
     version: Optional[NodeVersion] = None
+    is_target: bool = False  # True for target_ref(), affects lineage direction and unit test fixtures
 
     @property
     def positional_args(self) -> List[str]:

--- a/core/dbt/clients/jinja_static.py
+++ b/core/dbt/clients/jinja_static.py
@@ -47,7 +47,7 @@ def statically_extract_macro_calls(
             _TESTING_MACRO_CACHE[source] = parsed
             setattr(parsed, "_dbt_cached_calls", func_calls)
 
-    standard_calls = ["source", "ref", "config"]
+    standard_calls = ["source", "ref", "config", "target_ref"]
     possible_macro_calls = []
     for func_call in func_calls:
         func_name = None

--- a/core/dbt/parser/models.py
+++ b/core/dbt/parser/models.py
@@ -27,8 +27,8 @@ from dbt_common.dataclass_schema import ValidationError
 from dbt_common.exceptions.macros import UndefinedMacroError
 from dbt_extractor import ExtractionError, py_extract_from_source  # type: ignore
 
-dbt_function_key_words = set(["ref", "source", "config", "get"])
-dbt_function_full_names = set(["dbt.ref", "dbt.source", "dbt.config", "dbt.config.get"])
+dbt_function_key_words = set(["ref", "source", "config", "get", "target_ref"])
+dbt_function_full_names = set(["dbt.ref", "dbt.source", "dbt.config", "dbt.config.get", "dbt.target_ref"])
 
 
 class PythonValidationVisitor(ast.NodeVisitor):
@@ -420,7 +420,7 @@ class ModelParser(SimpleSQLParser[ModelNode]):
         # first check if there is a banned macro defined in scope for this model file
         root_project_name = self.root_project.project_name
         project_name = node.package_name
-        banned_macros = ["ref", "source", "config"]
+        banned_macros = ["ref", "source", "config", "target_ref"]
 
         all_banned_macro_keys: Iterator[str] = chain.from_iterable(
             map(

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -125,6 +125,8 @@ class UnitTestManifestLoader:
             original_input_node = self._get_original_input_node(
                 given.input, tested_node, test_case.name
             )
+            if original_input_node is None:  # target_ref() inputs don't need fixtures
+                continue
             input_name = original_input_node.name
             common_fields = {
                 "resource_type": NodeType.Model,
@@ -212,6 +214,8 @@ class UnitTestManifestLoader:
             - "source('my_source_schema', 'my_source_name')"
             - "this"
         tested_node: ModelNode of representing node being tested
+
+        Returns None for target_ref() inputs (they don't need fixture data).
         """
         if input.strip() == "this":
             original_input_node = tested_node
@@ -239,6 +243,8 @@ class UnitTestManifestLoader:
                     self.manifest,
                 )
             else:
+                if input.strip().startswith("target_ref("):
+                    return None
                 raise InvalidUnitTestGivenInput(input=input)
 
         if not original_input_node:


### PR DESCRIPTION
Related to https://github.com/dbt-labs/dbt-core/issues/12319

This is just a prototype to test a possible solution to this issue. This prototype includes:
- a new `target_ref()` function that behaves in the same way as `ref()`, but:
  - When creating unit-test, references defined by `target_ref()` don't require to be defined with data in the `given` section
  - In the generated documentation, the dependecy graph now shows correctly that the target table depends on the MVs instead of the opposite.

