### PR TITLE
Update comment about metric label optionality in v1 vs v2

### DIFF
--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -328,7 +328,7 @@ class UnparsedMetricBase(dbtClassMixin):
 
     name: str
     type: str = "simple"
-    label: Optional[str] = None
+    label: Optional[str] = None  # in v1 this is required, but in v2 it is optional
     description: str = ""
     # Note: `Union` must be the outermost part of the type annotation for serialization to work properly.
     filter: Union[str, List[str], None] = None
@@ -362,7 +362,7 @@ class UnparsedMetricBase(dbtClassMixin):
 class UnparsedMetric(UnparsedMetricBase):
     """Old-style YAML metric; prefer UnparsedMetricV2 instead as of late 2025."""
 
-    label: str  # TODO: follow up - v1 made this required, but in v2 it appears optional
+    label: str
 
     type_params: UnparsedMetricTypeParams  # old-style YAML
     # metadata: Optional[Unparsedetadata] = None # TODO


### PR DESCRIPTION
Resolves #NA

### Problem

See this [internal slack conversation](https://dbt-labs.slack.com/archives/C09A2CMCW2H/p1769710758702669?thread_ts=1769381484.380089&cid=C09A2CMCW2H) for context - the new YAML will not require users to define a label for their metrics.  With the discussion resolved, I wanted to update the comments here for accuracy.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Update comments to reflect the design choices.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.