### PR TITLE
Implement and test agg_time_dimension for v2 semantic YAML

### DIFF
--- a/.changes/unreleased/Features-20260129-114832.yaml
+++ b/.changes/unreleased/Features-20260129-114832.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Implement agg_time_dimension for new semantic YAML.
+time: 2026-01-29T11:48:32.100015-08:00
+custom:
+    Author: theyostalservice
+    Issue: "12410"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1768,6 +1768,7 @@ class ParsedNodePatch(ParsedPatch):
     semantic_model: Optional[bool] = None
     metrics: Optional[List[UnparsedMetricV2]] = None
     derived_semantics: Optional[UnparsedDerivedSemantics] = None
+    agg_time_dimension: Optional[str] = None
     freshness: Optional[ModelFreshness] = None
 
 

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -503,6 +503,7 @@ class UnparsedModelUpdate(UnparsedNodeUpdate):
     time_spine: Optional[TimeSpine] = None
     # TODO DI-4579: allow semantic model to accept a semantic model config object OR a bool
     semantic_model: Optional[bool] = None
+    agg_time_dimension: Optional[str] = None
     metrics: Optional[List[UnparsedMetricV2]] = None
     derived_semantics: Optional[UnparsedDerivedSemantics] = None
 

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -7,6 +7,7 @@ from dbt.artifacts.resources import (
     ColumnInfo,
     ConversionTypeParams,
     CumulativeTypeParams,
+    Defaults,
     Dimension,
     DimensionTypeParams,
     DimensionValidityParams,
@@ -1030,7 +1031,7 @@ class SemanticModelParser(YamlReader):
             label=None,  # does not seem to be available in v2 YAML, unless it is part of the semantic model config's 'group'?
             model=f"ref('{patch.name}')",
             name=node.name,
-            defaults=None,  # TODO DI-4604: support agg_time_dimension default here for v2 YAML
+            defaults=Defaults(agg_time_dimension=patch.agg_time_dimension),
             primary_entity=None,  # Not yet implemented; should become patch.primary_entity
             entities=entities,
             dimensions=dimensions,

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -784,6 +784,7 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
         semantic_model = None
         metrics = None
         derived_semantics = None
+        agg_time_dimension = None
 
         if isinstance(block.target, UnparsedModelUpdate):
             deprecation_date = block.target.deprecation_date
@@ -804,6 +805,7 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
             semantic_model = block.target.semantic_model
             metrics = block.target.metrics
             derived_semantics = block.target.derived_semantics
+            agg_time_dimension = block.target.agg_time_dimension
 
         return ParsedNodePatch(
             name=block.target.name,
@@ -824,6 +826,7 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
             semantic_model=semantic_model,
             metrics=metrics,
             derived_semantics=derived_semantics,
+            agg_time_dimension=agg_time_dimension,
         )
 
     def parse_patch(self, block: TargetBlock[NodeTarget], refs: ParserRef) -> None:

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -599,6 +599,7 @@ base_schema_yml_v2 = """models:
   - name: fct_revenue
     description: This is the model fct_revenue. It should be able to use doc blocks
     semantic_model: true
+    agg_time_dimension: second_dim
     columns:
       - name: id
         description: This is the id column dim.
@@ -632,6 +633,14 @@ base_schema_yml_v2 = """models:
       - name: foreign_id_col
         description: This is a foreign id column.
         entity: foreign
+      - name: created_at
+        description: This is the time the entry was created.
+        granularity: day
+        dimension:
+          name: ds
+          description: the ds column
+          label: DS Column
+          type: time
 """
 
 schema_yml_v2_simple_metric_on_model_1 = """
@@ -644,6 +653,7 @@ schema_yml_v2_simple_metric_on_model_1 = """
         expr: id
       - name: simple_metric_2
         description: This is our second simple metric.
+        agg_time_dimension: ds
         label: Simple Metric 2
         type: simple
         agg: count

--- a/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
@@ -129,6 +129,10 @@ class TestStandaloneMetricParsingWorks:
         result = runner.invoke(["parse"])
         assert result.success
         manifest = result.result
+
+        semantic_model = manifest.semantic_models["semantic_model.test.fct_revenue"]
+        assert semantic_model.defaults.agg_time_dimension == "second_dim"
+
         metrics = manifest.metrics
         assert len(metrics) == 5
 
@@ -139,6 +143,7 @@ class TestStandaloneMetricParsingWorks:
         assert simple_metric.type_params.metric_aggregation_params.agg == AggregationType.COUNT
         assert simple_metric.type_params.metric_aggregation_params.semantic_model == "fct_revenue"
         assert "semantic_model.test.fct_revenue" in simple_metric.depends_on.nodes
+        assert simple_metric.type_params.metric_aggregation_params.agg_time_dimension is None
 
         simple_metric_2 = metrics["metric.test.simple_metric_2"]
         assert simple_metric_2.name == "simple_metric_2"
@@ -149,6 +154,7 @@ class TestStandaloneMetricParsingWorks:
             simple_metric_2.type_params.metric_aggregation_params.semantic_model == "fct_revenue"
         )
         assert "semantic_model.test.fct_revenue" in simple_metric_2.depends_on.nodes
+        assert simple_metric_2.type_params.metric_aggregation_params.agg_time_dimension == "ds"
 
         percentile_metric = metrics["metric.test.percentile_metric"]
         assert percentile_metric.name == "percentile_metric"
@@ -173,6 +179,7 @@ class TestStandaloneMetricParsingWorks:
             is False
         )
         assert "semantic_model.test.fct_revenue" in percentile_metric.depends_on.nodes
+        assert percentile_metric.type_params.metric_aggregation_params.agg_time_dimension is None
 
         cumulative_metric = metrics["metric.test.cumulative_metric"]
         assert cumulative_metric.name == "cumulative_metric"
@@ -185,6 +192,7 @@ class TestStandaloneMetricParsingWorks:
         )
         assert cumulative_metric.type_params.cumulative_type_params.metric.name == "simple_metric"
         assert "metric.test.simple_metric" in cumulative_metric.depends_on.nodes
+        assert cumulative_metric.type_params.metric_aggregation_params is None
 
         conversion_metric = metrics["metric.test.conversion_metric"]
         assert conversion_metric.name == "conversion_metric"
@@ -205,6 +213,7 @@ class TestStandaloneMetricParsingWorks:
         )
         assert "metric.test.simple_metric" in conversion_metric.depends_on.nodes
         assert "metric.test.simple_metric_2" in conversion_metric.depends_on.nodes
+        assert conversion_metric.type_params.metric_aggregation_params is None
 
 
 class TestStandaloneMetricParsingSimpleMetricFails:


### PR DESCRIPTION
Resolves [LINEAR](https://linear.app/dbt-labs/issue/DI-4604/parse-agg-time-dimension-into-defaults-on-the-internal-semantic-model) [JIRA](https://dbtlabs.atlassian.net/browse/SEMANTIC-3179)

### Problem

We need to properly handle agg_time_dimension on metrics (already done, but without integration tests until now) and semantic models in the new v2 YAML.

The spec for this that is shared with Fusion can be seen by internal users [here](https://github.com/dbt-labs/sl-schema-evolution/blob/main/schema.py#L176).

### Solution

Since this change amounts to little more than adding a field and wrapping it up in a semantic Defaults object (under the hood, we process it into the same object as the v1 YAML), it's pretty straightforward and follows the same pattern as #12368 .  We add entries to UnparsedModelUpdate and ParsedNodePatch and then consume them when parsing the semantic model in schema_yaml_readers.py.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.