### PR TITLE
Add 'primary_entity' field for semantic YAML v2

### DIFF
--- a/.changes/unreleased/Features-20260129-185659.yaml
+++ b/.changes/unreleased/Features-20260129-185659.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Implement primary_entity field for semantic models in semantic YAML v2.
+time: 2026-01-29T18:56:59.184109-08:00
+custom:
+    Author: theyostalservice
+    Issue: "12414"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1770,6 +1770,7 @@ class ParsedNodePatch(ParsedPatch):
     metrics: Optional[List[UnparsedMetricV2]] = None
     derived_semantics: Optional[UnparsedDerivedSemantics] = None
     agg_time_dimension: Optional[str] = None
+    primary_entity: Optional[str] = None
     freshness: Optional[ModelFreshness] = None
 
 

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -519,6 +519,7 @@ class UnparsedModelUpdate(UnparsedNodeUpdate):
     # Using an UnparsedSemanticModelConfig object allows user to override some of the
     # values instead.
     semantic_model: Union[UnparsedSemanticModelConfig, bool, None] = None
+    primary_entity: Optional[str] = None
     agg_time_dimension: Optional[str] = None
     metrics: Optional[List[UnparsedMetricV2]] = None
     derived_semantics: Optional[UnparsedDerivedSemantics] = None

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -1060,7 +1060,7 @@ class SemanticModelParser(YamlReader):
             label=None,  # does not seem to be available in v2 YAML, unless it is part of the semantic model config's 'group'?
             model=f"ref('{patch.name}')",
             defaults=Defaults(agg_time_dimension=patch.agg_time_dimension),
-            primary_entity=None,  # Not yet implemented; should become patch.primary_entity
+            primary_entity=patch.primary_entity,
             entities=entities,
             dimensions=dimensions,
             # Measures are not part of the v2 YAML design.

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -785,6 +785,7 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
         metrics = None
         derived_semantics = None
         agg_time_dimension = None
+        primary_entity = None
 
         if isinstance(block.target, UnparsedModelUpdate):
             deprecation_date = block.target.deprecation_date
@@ -806,7 +807,7 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
             metrics = block.target.metrics
             derived_semantics = block.target.derived_semantics
             agg_time_dimension = block.target.agg_time_dimension
-
+            primary_entity = block.target.primary_entity
         return ParsedNodePatch(
             name=block.target.name,
             original_file_path=block.target.original_file_path,
@@ -827,6 +828,7 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
             metrics=metrics,
             derived_semantics=derived_semantics,
             agg_time_dimension=agg_time_dimension,
+            primary_entity=primary_entity,
         )
 
     def parse_patch(self, block: TargetBlock[NodeTarget], refs: ParserRef) -> None:

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -545,7 +545,7 @@ semantic_models:
 """
 
 
-semantic_model_schema_yml_v2_template = """models:
+semantic_model_schema_yml_v2_template_for_model_configs = """models:
   - name: fct_revenue
     description: This is the model fct_revenue. It should be able to use doc blocks
     {semantic_model_value}
@@ -594,12 +594,14 @@ semantic_model_schema_yml_v2_template = """models:
 """
 
 # You can replace the semantic_model variable in the template like this:
-semantic_model_schema_yml_v2 = semantic_model_schema_yml_v2_template.format(
+semantic_model_schema_yml_v2 = semantic_model_schema_yml_v2_template_for_model_configs.format(
     semantic_model_value="semantic_model: true",
 )
 
-semantic_model_schema_yml_v2_disabled = semantic_model_schema_yml_v2_template.format(
-    semantic_model_value="semantic_model: false",
+semantic_model_schema_yml_v2_disabled = (
+    semantic_model_schema_yml_v2_template_for_model_configs.format(
+        semantic_model_value="semantic_model: false",
+    )
 )
 
 semantic_model_test_groups_yml = """groups:
@@ -612,7 +614,7 @@ semantic_model_test_groups_yml = """groups:
         data_owner: Finance team
 """
 
-semantic_model_schema_yml_v2_renamed = semantic_model_schema_yml_v2_template.format(
+semantic_model_schema_yml_v2_renamed = semantic_model_schema_yml_v2_template_for_model_configs.format(
     semantic_model_value="""semantic_model:
       name: renamed_semantic_model
       enabled: true
@@ -623,25 +625,115 @@ semantic_model_schema_yml_v2_renamed = semantic_model_schema_yml_v2_template.for
     """,
 )
 
-semantic_model_schema_yml_v2_default_values = semantic_model_schema_yml_v2_template.format(
+semantic_model_schema_yml_v2_default_values = semantic_model_schema_yml_v2_template_for_model_configs.format(
     semantic_model_value="""semantic_model:
       enabled: true
     """
 )
 
-semantic_model_schema_yml_v2_disabled = semantic_model_schema_yml_v2_template.format(
+semantic_model_schema_yml_v2_disabled = semantic_model_schema_yml_v2_template_for_model_configs.format(
     semantic_model_value="""semantic_model:
       enabled: false
     """,
 )
 
-semantic_model_schema_yml_v2_false_config = semantic_model_schema_yml_v2_template.format(
-    semantic_model_value="semantic_model: false",
+semantic_model_schema_yml_v2_false_config = (
+    semantic_model_schema_yml_v2_template_for_model_configs.format(
+        semantic_model_value="semantic_model: false",
+    )
 )
 
-semantic_model_config_does_not_exist = semantic_model_schema_yml_v2_template.format(
-    semantic_model_value="",
+semantic_model_config_does_not_exist = (
+    semantic_model_schema_yml_v2_template_for_model_configs.format(
+        semantic_model_value="",
+    )
 )
+
+semantic_model_schema_yml_v2_template_for_primary_entity_tests = """models:
+  - name: fct_revenue
+    description: This is the model fct_revenue. It should be able to use doc blocks
+    semantic_model: true
+    {primary_entity_setting}
+    columns:
+      - name: id
+        description: This is the id column dim.
+        config:
+          meta:
+          component_level: "original_meta"
+        dimension:
+          name: id_dim
+          label: "ID Dimension"
+          type: categorical
+          is_partition: true
+        entity:
+          name: id_entity
+          description: This is the id entity, and it is the primary entity.
+          label: ID Entity
+          type: {id_entity_type}
+      - name: second_col
+        description: This is the second column.
+        granularity: day
+        dimension:
+          name: second_dim
+          description: This is the second column (dim).
+          label: Second Dimension
+          type: time
+          validity_params:
+            is_start: true
+            is_end: true
+      - name: other_id_col
+        description: This is the other id column.
+        entity:
+          name: other_id_entity
+          type: {other_id_entity_type}
+      - name: col_with_default_dimensions
+        description: This is the column with default dimension settings.
+        dimension: categorical
+        entity:
+          name: col_with_default_entity_testing_default_desc
+          type: natural
+"""
+
+semantic_model_schema_yml_v2_with_primary_entity_only_on_column = (
+    semantic_model_schema_yml_v2_template_for_primary_entity_tests.format(
+        primary_entity_setting="",
+        id_entity_type="primary",
+        other_id_entity_type="foreign",
+    )
+)
+
+semantic_model_schema_yml_v2_with_twice_declared_primary_entity = (
+    semantic_model_schema_yml_v2_template_for_primary_entity_tests.format(
+        primary_entity_setting="primary_entity: id_entity",
+        id_entity_type="primary",
+        other_id_entity_type="foreign",
+    )
+)
+
+semantic_model_schema_yml_v2_primary_entity_only_on_model = (
+    semantic_model_schema_yml_v2_template_for_primary_entity_tests.format(
+        primary_entity_setting="primary_entity: id_entity",
+        id_entity_type="foreign",
+        other_id_entity_type="foreign",
+    )
+)
+
+semantic_model_schema_yml_v2_with_two_primary_entities_and_no_model_declaration = (
+    semantic_model_schema_yml_v2_template_for_primary_entity_tests.format(
+        primary_entity_setting="",
+        id_entity_type="primary",
+        other_id_entity_type="primary",
+    )
+)
+
+semantic_model_schema_yml_v2_with_two_primary_entities_and_model_declaration = (
+    semantic_model_schema_yml_v2_template_for_primary_entity_tests.format(
+        primary_entity_setting="primary_entity: id_entity",
+        id_entity_type="primary",
+        other_id_entity_type="primary",
+    )
+)
+
 
 semantic_model_schema_yml_v2 = """models:
   - name: fct_revenue

--- a/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
@@ -24,7 +24,12 @@ from tests.functional.semantic_models.fixtures import (
     semantic_model_schema_yml_v2_default_values,
     semantic_model_schema_yml_v2_disabled,
     semantic_model_schema_yml_v2_false_config,
+    semantic_model_schema_yml_v2_primary_entity_only_on_model,
     semantic_model_schema_yml_v2_renamed,
+    semantic_model_schema_yml_v2_with_primary_entity_only_on_column,
+    semantic_model_schema_yml_v2_with_twice_declared_primary_entity,
+    semantic_model_schema_yml_v2_with_two_primary_entities_and_model_declaration,
+    semantic_model_schema_yml_v2_with_two_primary_entities_and_no_model_declaration,
     semantic_model_test_groups_yml,
 )
 
@@ -430,6 +435,131 @@ class TestDerivedSemanticsParsingWorks:
         assert dimensions["derived_id_dimension"].config.meta == {}
         assert dimensions["derived_id_dimension"].type_params.validity_params.is_start is True
         assert dimensions["derived_id_dimension"].type_params.validity_params.is_end is True
+
+
+class TestSemanticModelWithPrimaryEntityOnlyOnColumn:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": semantic_model_schema_yml_v2_with_primary_entity_only_on_column,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
+
+    def test_primary_entity_type_is_id_entity(self, project):
+        runner = dbtTestRunner()
+        result = runner.invoke(["parse"])
+        assert result.success
+        manifest = result.result
+        assert len(manifest.semantic_models) == 1
+        semantic_model = list(manifest.semantic_models.values())[0]
+        entities = {entity.name: entity for entity in semantic_model.entities}
+        primary_entity = [
+            entity for entity in entities.values() if entity.type == EntityType.PRIMARY
+        ]
+        assert len(primary_entity) == 1
+        primary_entity = primary_entity[0]
+        assert primary_entity.name == "id_entity"
+        assert semantic_model.primary_entity is None
+
+
+class TestSemanticModelWithTwiceDeclaredPrimaryEntity:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": semantic_model_schema_yml_v2_with_twice_declared_primary_entity,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
+
+    def test_primary_entity_type_is_id_entity(self, project):
+        runner = dbtTestRunner()
+        result = runner.invoke(["parse"])
+        assert result.success
+        manifest = result.result
+        assert len(manifest.semantic_models) == 1
+        semantic_model = list(manifest.semantic_models.values())[0]
+        entities = {entity.name: entity for entity in semantic_model.entities}
+        primary_entity = [
+            entity for entity in entities.values() if entity.type == EntityType.PRIMARY
+        ]
+        assert len(primary_entity) == 1
+        primary_entity = primary_entity[0]
+        assert primary_entity.name == "id_entity"
+        assert semantic_model.primary_entity == "id_entity"
+
+
+class TestSemanticModelWithPrimaryEntityOnlyOnModel:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": semantic_model_schema_yml_v2_primary_entity_only_on_model,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
+
+    def test_primary_entities_empty(self, project):
+        runner = dbtTestRunner()
+        result = runner.invoke(["parse"])
+        assert result.success
+        manifest = result.result
+        assert len(manifest.semantic_models) == 1
+        semantic_model = list(manifest.semantic_models.values())[0]
+        entities = {entity.name: entity for entity in semantic_model.entities}
+        primary_entity = [
+            entity for entity in entities.values() if entity.type == EntityType.PRIMARY
+        ]
+        assert len(primary_entity) == 0
+        assert semantic_model.primary_entity == "id_entity"
+
+
+class TestSemanticModelWithTwoPrimaryEntitiesNoModelDeclaration:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": semantic_model_schema_yml_v2_with_two_primary_entities_and_no_model_declaration,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
+
+    def test_primary_entity_type_is_id_entity(self, project):
+        runner = dbtTestRunner()
+        result = runner.invoke(["parse"])
+        assert result.success
+        manifest = result.result
+        assert len(manifest.semantic_models) == 1
+        semantic_model = list(manifest.semantic_models.values())[0]
+        entities = {entity.name: entity for entity in semantic_model.entities}
+        primary_entity = [
+            entity for entity in entities.values() if entity.type == EntityType.PRIMARY
+        ]
+        assert len(primary_entity) == 2
+        assert [e.name for e in primary_entity] == ["id_entity", "other_id_entity"]
+        assert semantic_model.primary_entity is None
+
+
+class TestSemanticModelWithTwoPrimaryEntitiesAndModelDeclaration:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": semantic_model_schema_yml_v2_with_two_primary_entities_and_model_declaration,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
+
+    def test_primary_entity_type_is_id_entity(self, project):
+        runner = dbtTestRunner()
+        result = runner.invoke(["parse"])
+        assert result.success
+        manifest = result.result
+        assert len(manifest.semantic_models) == 1
+        semantic_model = list(manifest.semantic_models.values())[0]
+        entities = {entity.name: entity for entity in semantic_model.entities}
+        primary_entity = [
+            entity for entity in entities.values() if entity.type == EntityType.PRIMARY
+        ]
+        assert len(primary_entity) == 2
+        assert semantic_model.primary_entity == "id_entity"
 
 
 # TODO DI-4605: add enforcement and a test for when there are validity params with no column granularity


### PR DESCRIPTION
Resolves JIRA LINEAR

DEPENDS ON #12413 !

### Problem

We need to support this field for semantic YAML v2.  Internal users can review this part of the spec [here](https://github.com/dbt-labs/sl-schema-evolution/blob/main/schema.py#L277) .  It should work the same as primary entities in the v1 YAML as specified in these [public docs](https://docs.getdbt.com/docs/build/semantic-models) (just CMD+F for 'Primary Entity').

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Simple solution just like #12413, only smaller.  Add it to the unparsed model, attach it to the ParsedNodePatch update, and pass it to the semantic model when we parse it in schema_yaml_readers.py.  
  
NOTE: I actually don't anticipate that all these tests will pass in mantle because of the more intense validation standards.  However, I'd like to verify that and know exactly which ones fail, and I think the easiest way to put this up for review, sync it, then rip out any tests that fail and document the behavior very clearly.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.