### PR TITLE
Fix failing tests in sync

### DIFF
--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -718,13 +718,13 @@ derived_semantics_yml = """
         - name: derived_id_entity
           description: This is the id entity, and it is the primary entity.
           label: ID Entity
-          type: primary
+          type: foreign
           expr: "id + foreign_id_col"
           config:
             meta:
               test_label_thing: derived_entity_1
         - name: derived_id_entity_with_no_optional_fields
-          type: primary
+          type: foreign
           expr: id + foreign_id_col
       dimensions:
         - name: derived_id_dimension

--- a/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
@@ -289,13 +289,13 @@ class TestDerivedSemanticsParsingWorks:
         )  # length is so long because it is column entities + derived entities
 
         id_entity = entities["derived_id_entity"]
-        assert id_entity.type == EntityType.PRIMARY
+        assert id_entity.type == EntityType.FOREIGN
         assert id_entity.description == "This is the id entity, and it is the primary entity."
         assert id_entity.expr == "id + foreign_id_col"
         assert id_entity.config.meta == {"test_label_thing": "derived_entity_1"}
 
         id_entity_with_no_optional_fields = entities["derived_id_entity_with_no_optional_fields"]
-        assert id_entity_with_no_optional_fields.type == EntityType.PRIMARY
+        assert id_entity_with_no_optional_fields.type == EntityType.FOREIGN
         assert id_entity_with_no_optional_fields.expr == "id + foreign_id_col"
         assert id_entity_with_no_optional_fields.config.meta == {}
 


### PR DESCRIPTION
Resolves #

### Problem

Tests are failing on sync because dbt semantic interfaces doesn't support multiple primary keys per semantic model.

### Solution

I changed some of the entities to be non-primary.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.