### PR TITLE
Return resolved nearest project dir before chainging current dir

### DIFF
--- a/.changes/unreleased/Fixes-20260202-123453.yaml
+++ b/.changes/unreleased/Fixes-20260202-123453.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Return correctly resolved project path when changing dirs
+time: 2026-02-02T12:34:53.454501+05:30
+custom:
+    Author: ash2shukla
+    Issue: "9138"

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -109,8 +109,9 @@ def get_nearest_project_dir(project_dir: Optional[str]) -> Path:
 
 def move_to_nearest_project_dir(project_dir: Optional[str]) -> Path:
     nearest_project_dir = get_nearest_project_dir(project_dir)
-    os.chdir(nearest_project_dir)
-    return nearest_project_dir
+    resolved_nearest_project_dir = nearest_project_dir.resolve()
+    os.chdir(resolved_nearest_project_dir)
+    return resolved_nearest_project_dir
 
 
 # TODO: look into deprecating this class in favor of several small functions that

--- a/tests/functional/clean/test_clean.py
+++ b/tests/functional/clean/test_clean.py
@@ -1,7 +1,10 @@
+from pathlib import Path
+
 import pytest
 
 from dbt.exceptions import DbtRuntimeError
 from dbt.tests.util import run_dbt
+from tests.functional.utils import up_one
 
 
 class TestCleanSourcePath:
@@ -54,3 +57,10 @@ class TestCleanPathOutsideProjectWithFlag:
             match="dbt will not clean the following directories outside the project",
         ):
             run_dbt(["clean", "--clean-project-files-only"])
+
+
+class TestCleanRelativeProjectDir:
+    def test_clean_relative_project_dir(self, project):
+        with up_one():
+            project_dir = Path(project.project_root).relative_to(Path.cwd())
+            run_dbt(["clean", "--project-dir", str(project_dir)])


### PR DESCRIPTION
Resolves #9138

### Problem
`move_to_nearest_project_dir` returns relative path which incorrectly resolves the project path after `os.chdir`. This causes `project_dir` not being a valid parent of `clean_paths` which causes clean failure if `clean_project_files_only` is not unset.

### Solution
Return resolved project path instead of relative path and add an integration test for this case.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
