### PR TITLE
Add parser support for `dbt.config.meta_get()` in Python models

### DIFF
--- a/.changes/unreleased/Features-20260205-105228.yaml
+++ b/.changes/unreleased/Features-20260205-105228.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: add config.meta_get to python model parsing
+time: 2026-02-05T10:52:28.269954-08:00
+custom:
+    Author: venkaa28
+    Issue: "12458"

--- a/tests/unit/parser/test_parser.py
+++ b/tests/unit/parser/test_parser.py
@@ -1231,6 +1231,57 @@ def model(dbt, session):
     return pd.dataframe([1, 2])
 """
 
+python_model_meta_get = """
+def model(dbt, session):
+    dbt.config(
+        materialized='table',
+        meta={'owner': 'data-team', 'priority': 'high'}
+    )
+    owner = dbt.config.meta_get('owner')
+    priority = dbt.config.meta_get('priority')
+    return dbt.ref("some_model")
+"""
+
+python_model_meta_get_with_defaults = """
+def model(dbt, session):
+    dbt.config(
+        materialized='table',
+        meta={'owner': 'data-team'}
+    )
+    owner = dbt.config.meta_get('owner', 'default-owner')
+    priority = dbt.config.meta_get('priority', 'low')
+    env = dbt.config.meta_get('environment', 'dev')
+    return dbt.ref("some_model")
+"""
+
+python_model_mixed_config_and_meta_get = """
+def model(dbt, session):
+    dbt.config(
+        materialized='table',
+        meta={'owner': 'data-team', 'priority': 'high'}
+    )
+    # Regular config access
+    mat = dbt.config.get('materialized')
+    # Meta access
+    owner = dbt.config.meta_get('owner')
+    priority = dbt.config.meta_get('priority', 'low')
+    return dbt.ref("some_model")
+"""
+
+python_model_meta_get_no_args = """
+def model(dbt, session):
+    dbt.config(materialized='table')
+    value = dbt.config.meta_get()
+    return dbt.ref("some_model")
+"""
+
+python_model_meta_get_too_many_args = """
+def model(dbt, session):
+    dbt.config(materialized='table')
+    value = dbt.config.meta_get('key', 'default', 'extra')
+    return dbt.ref("some_model")
+"""
+
 
 class ModelParserTest(BaseParserTest):
     def setUp(self):
@@ -1432,6 +1483,61 @@ class ModelParserTest(BaseParserTest):
         self.parser.parse_file(block)
         node = list(self.parser.manifest.nodes.values())[0]
         self.assertEqual(node.get_materialization(), "incremental")
+
+    def test_python_model_meta_get(self):
+        """Test that dbt.config.meta_get() calls are tracked correctly"""
+        block = self.file_block_for(python_model_meta_get, "nested/py_model.py")
+        self.parser.manifest.files[block.file.file_id] = block.file
+        self.parser.parse_file(block)
+        node = list(self.parser.manifest.nodes.values())[0]
+        config_dict = node.config.to_dict()
+        self.assertEqual(config_dict["meta_keys_used"], ["owner", "priority"])
+        # Both keys should have None as default since no explicit default was provided
+        self.assertIsNone(config_dict["meta_keys_defaults"][0])
+        self.assertIsNone(config_dict["meta_keys_defaults"][1])
+
+    def test_python_model_meta_get_with_defaults(self):
+        """Test that dbt.config.meta_get() default values are tracked correctly"""
+        block = self.file_block_for(python_model_meta_get_with_defaults, "nested/py_model.py")
+        self.parser.manifest.files[block.file.file_id] = block.file
+        self.parser.parse_file(block)
+        node = list(self.parser.manifest.nodes.values())[0]
+        config_dict = node.config.to_dict()
+        self.assertEqual(config_dict["meta_keys_used"], ["owner", "priority", "environment"])
+        default_values = config_dict["meta_keys_defaults"]
+        self.assertEqual(default_values[0], "default-owner")
+        self.assertEqual(default_values[1], "low")
+        self.assertEqual(default_values[2], "dev")
+
+    def test_python_model_mixed_config_and_meta_get(self):
+        """Test that config.get() and config.meta_get() can be used together"""
+        block = self.file_block_for(python_model_mixed_config_and_meta_get, "nested/py_model.py")
+        self.parser.manifest.files[block.file.file_id] = block.file
+        self.parser.parse_file(block)
+        node = list(self.parser.manifest.nodes.values())[0]
+        config_dict = node.config.to_dict()
+        # Should track both config.get and meta_get calls
+        self.assertEqual(config_dict["config_keys_used"], ["materialized"])
+        self.assertEqual(config_dict["meta_keys_used"], ["owner", "priority"])
+        self.assertIsNone(config_dict["config_keys_defaults"][0])
+        self.assertIsNone(config_dict["meta_keys_defaults"][0])
+        self.assertEqual(config_dict["meta_keys_defaults"][1], "low")
+
+    def test_python_model_meta_get_no_args(self):
+        """Test that meta_get() with no arguments raises an error"""
+        block = self.file_block_for(python_model_meta_get_no_args, "nested/py_model.py")
+        self.parser.manifest.files[block.file.file_id] = block.file
+        with self.assertRaises(ParsingError) as exc:
+            self.parser.parse_file(block)
+        self.assertIn("dbt.config.meta_get() requires at least one argument", str(exc.exception))
+
+    def test_python_model_meta_get_too_many_args(self):
+        """Test that meta_get() with more than 2 arguments raises an error"""
+        block = self.file_block_for(python_model_meta_get_too_many_args, "nested/py_model.py")
+        self.parser.manifest.files[block.file.file_id] = block.file
+        with self.assertRaises(ParsingError) as exc:
+            self.parser.parse_file(block)
+        self.assertIn("dbt.config.meta_get() takes at most 2 arguments", str(exc.exception))
 
 
 class StaticModelParserTest(BaseParserTest):


### PR DESCRIPTION
Resolves #

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

Updates the Python model parser to recognize and track `dbt.config.meta_get()` calls, extracting keys and default values for runtime use.

**Note**: Python models only support `meta_get()`, not `meta_require()` (unlike SQL models which have both).

#### What Changed
- **Parser Updates**: Modified `models.py` to recognize `dbt.meta_get()` function calls
- **Key Tracking**: Extracts meta keys and default values from `meta_get()` calls
- **Validation**: Validates argument count (1-2 args required)
- **Context Passing**: Passes `meta_keys_used` and `meta_keys_defaults` to runtime macro
- **Tests**: Added 6 unit tests covering various meta_get scenarios

#### Backwards Compatibility
- Fully backwards compatible - parser only tracks new function, doesn't break existing code
- Old pattern (`dbt.config.get('meta_key')`) continues to be parsed (though it won't work at runtime)

#### Related PRs
- dbt-adapters PR: Runtime macro that uses parsed meta keys
- Fusion PR: Deprecation warnings for old pattern
- dbt-autofix PR: Automatic migration tool


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
