### PR TITLE
Fix FK constraint ref() resolving to wrong node during deferral

### DIFF
--- a/.changes/unreleased/Fixes-20260205-120000.yaml
+++ b/.changes/unreleased/Fixes-20260205-120000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix foreign key constraint ref() resolving to deferred relation even when target model is selected for build
+time: 2026-02-05T12:00:00.00000Z
+custom:
+  Author: b-per
+  Issue: "12455"


### PR DESCRIPTION
## Summary

Fixes #12455

During deferral with `--defer`, foreign key constraint `ref()` was always resolving to the deferred (production) relation, even when the referenced model was being built as part of the current selection. This caused FK constraints to reference the wrong schema.

**Before (bug):**
```sql
-- bar is built in CI schema
create or replace db.ci.bar as (...)

-- foo's FK constraint incorrectly points to prod
create or replace db.ci.foo (
  fk int references db.prod.bar (id)  -- WRONG!
) as (
  select * from db.ci.bar  -- body ref is correct
)
```

**After (fix):**
```sql
-- bar is built in CI schema
create or replace db.ci.bar as (...)

-- foo's FK constraint correctly points to CI
create or replace db.ci.foo (
  fk int references db.ci.bar (id)  -- CORRECT!
) as (
  select * from db.ci.bar
)
```

## Changes

- Added `selected_node_ids` attribute to `Compiler` class to track nodes selected for the current run
- Modified `_compile_relation_for_foreign_key_constraint_to()` to use deferred relation **only if** FK target is NOT in selection
- Propagate selection info from task compiler to runner compilers
- Updated tests to verify both scenarios (target selected vs not selected)

This mirrors the behavior of `RuntimeRefResolver.create_relation()` for model body refs, ensuring FK constraints behave consistently.

## Test plan

- [x] Added tests for FK target NOT selected → uses deferred relation
- [x] Added tests for FK target IS selected → uses current relation  
- [x] All 12 FK constraint tests pass
- [x] Unit tests pass

## Disclaimer

This fix was developed mostly with the assistance of Claude Code.