### PR TITLE
Add --max-column-width and --max-columns options to dbt show

### DIFF
--- a/.changes/unreleased/Features-20260205-145300.yaml
+++ b/.changes/unreleased/Features-20260205-145300.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add --max-column-width and --max-columns options to dbt show command
+time: 2026-02-05T14:53:00.000000-06:00
+custom:
+    Author: RamiNoodle733
+    Issue: "12448"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -358,6 +358,8 @@ def compile(ctx, **kwargs):
 @p.full_refresh
 @p.show_output_format
 @p.show_limit
+@p.show_max_column_width
+@p.show_max_columns
 @p.introspect
 @p.profiles_dir
 @p.project_dir

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -587,6 +587,22 @@ show_limit = _create_option_and_track_env_var(
     default=5,
 )
 
+show_max_column_width = _create_option_and_track_env_var(
+    "--max-column-width",
+    envvar=None,
+    help="Maximum width for each column when displaying table output. Pass 0 for unlimited width.",
+    type=click.INT,
+    default=20,
+)
+
+show_max_columns = _create_option_and_track_env_var(
+    "--max-columns",
+    envvar=None,
+    help="Maximum number of columns to display before truncating the data. Pass 0 to display all columns.",
+    type=click.INT,
+    default=6,
+)
+
 show_output_format = _create_option_and_track_env_var(
     "--output",
     envvar=None,

--- a/core/dbt/task/show.py
+++ b/core/dbt/task/show.py
@@ -95,7 +95,9 @@ class ShowTask(CompileTask):
             if self.args.output == "json":
                 table.to_json(path=output)
             else:
-                table.print_table(output=output, max_rows=None)
+                max_column_width = None if self.args.max_column_width == 0 else self.args.max_column_width
+                max_columns = None if self.args.max_columns == 0 else self.args.max_columns
+                table.print_table(output=output, max_rows=None, max_column_width=max_column_width, max_columns=max_columns)
 
             node_name = result.node.name
 
@@ -135,7 +137,9 @@ class ShowTaskDirect(ConfiguredTask):
             if self.args.output == "json":
                 table.to_json(path=output)
             else:
-                table.print_table(output=output, max_rows=None)
+                max_column_width = None if self.args.max_column_width == 0 else self.args.max_column_width
+                max_columns = None if self.args.max_columns == 0 else self.args.max_columns
+                table.print_table(output=output, max_rows=None, max_column_width=max_column_width, max_columns=max_columns)
 
             fire_event(
                 ShowNode(


### PR DESCRIPTION
## Description

This PR adds two new CLI options to the  command to give users more control over table output formatting when previewing query results:

- : Controls the maximum width for each column (default: 20, 0=unlimited)
- : Controls the maximum number of columns to display (default: 6, 0=unlimited)

These options are passed through to , allowing users to customize the output display for better readability when dealing with wide tables or many columns.

## Related Issue

Fixes #12448

## Changes

- Added  and  CLI parameters in 
- Updated  command to accept new options in 
- Modified  to pass options to agate's print_table in 
- Added tests for the new functionality in 
- Added changelog entry