### PR TITLE
fix: Skip deprecation error for config key alias

### DIFF
--- a/.changes/unreleased/Fixes-20260206-204257.yaml
+++ b/.changes/unreleased/Fixes-20260206-204257.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Skip raising `CustomKeyInConfigDeprecation` for config key alias in sql
+time: 2026-02-06T20:42:57.134627+05:30
+custom:
+    Author: ash2shukla
+    Issue: "12396"

--- a/core/dbt/jsonschemas/jsonschemas.py
+++ b/core/dbt/jsonschemas/jsonschemas.py
@@ -310,6 +310,10 @@ def validate_model_config(
                     if key in python_model_internal_keys and is_python_model:
                         continue
 
+                    # Dont raise deprecation warnings for adapter specific config key aliases
+                    if key in _get_allowed_config_key_aliases():
+                        continue
+
                     # For everything else, emit deprecation warning
                     deprecations.warn(
                         "custom-key-in-config-deprecation",

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -400,6 +400,19 @@ class TestCustomKeyInConfigSQLDeprecation:
             in event_catcher.caught_events[0].info.msg
         )
 
+    @mock.patch("dbt.jsonschemas.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
+    @mock.patch(
+        "dbt.jsonschemas.jsonschemas._get_allowed_config_key_aliases",
+        return_value=["my_custom_key"],
+    )
+    def test_custom_key_in_config_sql_deprecation_adapter_specific_config_key_aliases(self, *_):
+        event_catcher = EventCatcher(CustomKeyInConfigDeprecation)
+        run_dbt(
+            ["parse", "--no-partial-parse", "--show-all-deprecations"],
+            callbacks=[event_catcher.catch],
+        )
+        assert len(event_catcher.caught_events) == 0
+
 
 class TestCustomKeyInConfigComplexSQLDeprecation(TestCustomKeyInConfigSQLDeprecation):
     @pytest.fixture(scope="class")


### PR DESCRIPTION
Resolves #12396

### Problem
In parsing json schema validation in `validate_model_config` does not skip adapter specific config key aliases.

### Solution
Skip raising `CustomKeyInDeprecationWarning` if key is in allowed config key aliases.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
