### PR TITLE
Use resolved profile/target names in partial parsing state check

### DIFF
--- a/.changes/12465.profile-target-state-check.md
+++ b/.changes/12465.profile-target-state-check.md
@@ -1,0 +1,6 @@
+kind: Fix
+body: >
+  Use resolved profile_name and target_name in partial parsing state checks
+  instead of raw CLI arguments, ensuring profile/target are populated even
+  when --profile/--target flags are not passed.
+time: 2026-02-07

--- a/.changes/fix-partial-parsing-profile-target.md
+++ b/.changes/fix-partial-parsing-profile-target.md
@@ -1,3 +1,0 @@
-### Fixes
-
-- Use resolved profile and target names (from profiles.yml/dbt_project.yml) in the partial parsing state check instead of raw CLI arguments.

--- a/.changes/fix-partial-parsing-profile-target.md
+++ b/.changes/fix-partial-parsing-profile-target.md
@@ -1,0 +1,3 @@
+### Fixes
+
+- Use resolved profile and target names (from profiles.yml/dbt_project.yml) in the partial parsing state check instead of raw CLI arguments.

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1034,8 +1034,8 @@ class ManifestLoader:
             "\x00".join(
                 [
                     stringified_cli_vars,
-                    getattr(config.args, "profile", "") or "",
-                    getattr(config.args, "target", "") or "",
+                    config.profile_name,
+                    config.target_name,
                     __version__,
                 ]
             )
@@ -1044,8 +1044,8 @@ class ManifestLoader:
             StateCheckVarsHash(
                 checksum=vars_hash.checksum,
                 vars=scrub_secrets(stringified_cli_vars, secret_vars),
-                profile=config.args.profile,
-                target=config.args.target,
+                profile=config.profile_name,
+                target=config.target_name,
                 version=__version__,
             )
         )


### PR DESCRIPTION
Problem:
When running `dbt parse` without `--profile/--target`, the partial parsing state check used `config.args.profile`/`config.args.target`,
which are often empty/None, even though dbt has resolved `profile_name` and `target_name` from configuration.

Change:
Use `config.profile_name` and `config.target_name` when computing and logging StateCheckVarsHash.

Files changed:
- core/dbt/parser/manifest.py
