### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260210-161557.yaml
+++ b/.changes/unreleased/Under the Hood-20260210-161557.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-02-10T16:15:57.610698844Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -644,15 +644,6 @@
         "conversion_rate"
       ]
     },
-    "CustomCheckLevel": {
-      "type": "string",
-      "enum": [
-        "error",
-        "warn",
-        "advisory",
-        "off"
-      ]
-    },
     "CustomTest": {
       "anyOf": [
         {
@@ -3733,15 +3724,6 @@
             "null"
           ]
         },
-        "custom_checks": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": {
-            "$ref": "#/definitions/CustomCheckLevel"
-          }
-        },
         "database": {
           "type": [
             "string",
@@ -4351,16 +4333,6 @@
           "anyOf": [
             {
               "$ref": "#/definitions/StaticAnalysisKind"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "strictness": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/StrictnessMode"
             },
             {
               "type": "null"
@@ -7422,14 +7394,6 @@
         "ephemeral",
         "table",
         "view"
-      ]
-    },
-    "StrictnessMode": {
-      "type": "string",
-      "enum": [
-        "baseline",
-        "strict",
-        "custom"
       ]
     },
     "StringOrArrayOfStrings": {


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/0.0.110.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`66343dd97aa887a2932e8183ce181e0f85675f70`](https://github.com/dbt-labs/fs/commit/66343dd97aa887a2932e8183ce181e0f85675f70)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/21872829389)