### PR TITLE
Validate that SL YAML V2 column with time dim has granularity

### DIFF
--- a/.changes/unreleased/Under the Hood-20260210-151244.yaml
+++ b/.changes/unreleased/Under the Hood-20260210-151244.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Handle missing column time granularities during parsing.
+time: 2026-02-10T15:12:44.460381-08:00
+custom:
+    Author: theyostalservice
+    Issue: "12472"

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -49,6 +49,7 @@ from dbt_common.dataclass_schema import (
 from dbt_common.exceptions import DbtInternalError
 from dbt_semantic_interfaces.type_enums import (
     ConversionCalculationType,
+    DimensionType,
     PeriodAggregation,
 )
 
@@ -233,6 +234,25 @@ class UnparsedColumn(HasConfig, HasColumnAndTestProps):
     # UnparsedColumnEntityV2 must come before str to parse correctly.  str is assumed to be EntityType enum value
     # Only used in v2 semantic layer.
     entity: Union[UnparsedColumnEntityV2, str, None] = None
+
+    @classmethod
+    @override
+    def validate(cls, data):
+        super().validate(data)
+        if (dimension := data.get("dimension")) is not None:
+            if isinstance(dimension, dict):
+                dim_type_str = dimension.get("type")
+                dim_name = dimension.get("name")
+            else:
+                dim_type_str = dimension
+                dim_name = data.get("name")
+            dim_type = DimensionType(dim_type_str) if dim_type_str is not None else None
+            if dim_type is DimensionType.TIME and not data.get("granularity"):
+                raise ValidationError(
+                    f"Dimension {dim_name} is a time dimension attached to "
+                    f"column {data.get('name')}, "
+                    "so that column must specify a granularity."
+                )
 
 
 @dataclass


### PR DESCRIPTION
Resolves #DI-3178

### Problem

In the case of columns with time dimensions, they will require a granularity to function.  Currently, an exceptions the user receives are vague and unclear because they'll be generated by dbt-semantic-interfaces validations that are unaware of the v2 YAML.  This PR validates the code at the start of parsing instead so we can be clear about the issue.

### Solution

Add validation to UnparsedColumn.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.