### PR TITLE
bump integration test timeout-minutes to 45

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
     name: "(${{ matrix.split-group }}) integration test / python ${{ matrix.python-version }} / ${{ matrix.os }}"
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 45
     needs:
       - integration-metadata
     strategy:
@@ -257,7 +257,7 @@ jobs:
     name: (${{ matrix.split-group }}) integration test / python ${{ matrix.python-version }} / ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 45
     needs:
       - integration-metadata
     strategy:

--- a/.github/workflows/structured-logging-schema-check.yml
+++ b/.github/workflows/structured-logging-schema-check.yml
@@ -48,7 +48,7 @@ jobs:
   test-schema:
     name: Test Log Schema
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 45
     needs:
       - integration-metadata
     strategy:


### PR DESCRIPTION
Still hitting 30 minute mark consistently enough on windows after merging https://github.com/dbt-labs/dbt-core/pull/12477, bumping timeout to unblock operational development work and releases.