### PR TITLE
Restructure warn_error_options testing for better isolation

### DIFF
--- a/tests/functional/configs/test_warn_error_options.py
+++ b/tests/functional/configs/test_warn_error_options.py
@@ -49,7 +49,7 @@ class BaseTestWarnErrorOptions:
         assert "Model my_model has passed its deprecation date of" in str(result.exception)
 
 
-class TestWarnErrorOptionsFromCLI(BaseTestWarnErrorOptions):
+class TestWarnErrorOptionsFromCLICanSilence(BaseTestWarnErrorOptions):
     def test_can_silence(self, project, catcher: EventCatcher, runner: dbtRunner) -> None:
         result = runner.invoke(["run"])
         self.assert_deprecation_warning(result, catcher)
@@ -59,6 +59,8 @@ class TestWarnErrorOptionsFromCLI(BaseTestWarnErrorOptions):
         assert result.success
         assert len(catcher.caught_events) == 0
 
+
+class TestWarnErrorOptionsFromCLICanRaiseWarningToError(BaseTestWarnErrorOptions):
     def test_can_raise_warning_to_error(
         self, project, catcher: EventCatcher, runner: dbtRunner
     ) -> None:
@@ -89,6 +91,8 @@ class TestWarnErrorOptionsFromCLI(BaseTestWarnErrorOptions):
         )
         self.assert_deprecation_error(result)
 
+
+class TestWarnErrorOptionsFromCLICanExcludeSpecificEvent(BaseTestWarnErrorOptions):
     def test_can_exclude_specific_event(
         self, project, catcher: EventCatcher, runner: dbtRunner
     ) -> None:
@@ -117,6 +121,8 @@ class TestWarnErrorOptionsFromCLI(BaseTestWarnErrorOptions):
         )
         self.assert_deprecation_warning(result, catcher)
 
+
+class TestWarnErrorOptionsFromCLICantSetBothIncludeAndError(BaseTestWarnErrorOptions):
     def test_cant_set_both_include_and_error(self, project, runner: dbtRunner) -> None:
         result = runner.invoke(
             ["run", "--warn-error-options", "{'include': 'all', 'error': 'all'}"]
@@ -138,12 +144,15 @@ class TestWarnErrorOptionsFromCLI(BaseTestWarnErrorOptions):
         assert "Only `exclude` or `warn` can be specified" in str(result.exception)
 
 
-class TestWarnErrorOptionsFromProject(BaseTestWarnErrorOptions):
+class BaseTestWarnErrorOptionsFromProject(BaseTestWarnErrorOptions):
     @pytest.fixture(scope="function")
     def clear_project_flags(self, project_root) -> None:
+        # TODO: Is this still necessary now that the project based tests are broken into separate test classes?
         flags: Dict[str, Any] = {"flags": {}}
         update_config_file(flags, project_root, "dbt_project.yml")
 
+
+class TestWarnErrorOptionsFromProjectCanSilence(BaseTestWarnErrorOptionsFromProject):
     def test_can_silence(
         self, project, clear_project_flags, project_root, catcher: EventCatcher, runner: dbtRunner
     ) -> None:
@@ -158,6 +167,8 @@ class TestWarnErrorOptionsFromProject(BaseTestWarnErrorOptions):
         assert result.success
         assert len(catcher.caught_events) == 0
 
+
+class TestWarnErrorOptionsFromProjectCanRaiseWarningToError(BaseTestWarnErrorOptionsFromProject):
     def test_can_raise_warning_to_error(
         self, project, clear_project_flags, project_root, catcher: EventCatcher, runner: dbtRunner
     ) -> None:
@@ -182,6 +193,8 @@ class TestWarnErrorOptionsFromProject(BaseTestWarnErrorOptions):
         result = runner.invoke(["run"])
         self.assert_deprecation_error(result)
 
+
+class TestWarnErrorOptionsFromProjectCanExcludeSpecificEvent(BaseTestWarnErrorOptionsFromProject):
     def test_can_exclude_specific_event(
         self, project, clear_project_flags, project_root, catcher: EventCatcher, runner: dbtRunner
     ) -> None:
@@ -206,6 +219,10 @@ class TestWarnErrorOptionsFromProject(BaseTestWarnErrorOptions):
         result = runner.invoke(["run"])
         self.assert_deprecation_warning(result, catcher)
 
+
+class TestWarnErrorOptionsFromProjectCantSetBothIncludeAndError(
+    BaseTestWarnErrorOptionsFromProject
+):
     def test_cant_set_both_include_and_error(
         self, project, clear_project_flags, project_root, runner: dbtRunner
     ) -> None:
@@ -216,6 +233,10 @@ class TestWarnErrorOptionsFromProject(BaseTestWarnErrorOptions):
         assert result.exception is not None
         assert "Only `include` or `error` can be specified" in str(result.exception)
 
+
+class TestWarnErrorOptionsFromProjectCantSetBothExcludeAndWarn(
+    BaseTestWarnErrorOptionsFromProject
+):
     def test_cant_set_both_exclude_and_warn(
         self, project, clear_project_flags, project_root, runner: dbtRunner
     ) -> None:


### PR DESCRIPTION
Resolves #N/A

### Problem

We've been fighting our CI for a few days now. We were seeing slowness on of our runners after the recent github incidents related to action runners. Because of that slowness on our runners, our jobs were timing out. To fix that, we increased the concurrency of our tests (splitting our test suite into more parts handled by separate runners). However, in doing so, some flakiness in our test suite was uncovered, most persistently with our `warn_error_options` testing.

### Solution

Refactor our warn error options tests to be more in line with our typical testing integration/functional testing structure
1. Fixtures shouldn't be at the top level, but in `Base` test classes that are then inherited
2. Only one test per test class
  a. This is because dbt writes to the operating system. Multiple tests in the same class means they share an operating system, meaning tests can possibly clobber one another / become dependent on one another

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
