### PR TITLE
Fix changelog entry for sqlparse upper bound

### DIFF
--- a/.changes/1.10.17.md
+++ b/.changes/1.10.17.md
@@ -2,4 +2,4 @@
 
 ### Fixes
 
-- Upper bound sqlmesh to  <0.5.5 ([#12311](https://github.com/dbt-labs/dbt-core/issues/12311))
+- Upper bound sqlparse to <0.5.5 ([#12311](https://github.com/dbt-labs/dbt-core/issues/12311))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 
 ### Fixes
 
-- Upper bound sqlmesh to  <0.5.5 ([#12311](https://github.com/dbt-labs/dbt-core/issues/12311))
+- Upper bound sqlparse to <0.5.5 ([#12311](https://github.com/dbt-labs/dbt-core/issues/12311))
 
 ## dbt-core 1.10.16 - December 16, 2025
 


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->
### Problem

The changelog for v1.10.17 is incorrect, for some reason when https://github.com/dbt-labs/dbt-core/pull/12308 was ported over to v1.10 via https://github.com/dbt-labs/dbt-core/pull/12311, the docs changed from referencing `sqlparse` to `sqlmesh`. 

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

This PR fixes both the changelog and the set of changes defined in `.changes` on the 1.10 branch.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
