### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260214-181659.yaml
+++ b/.changes/unreleased/Under the Hood-20260214-181659.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-02-14T18:16:59.71097177Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/0.0.110.json
+++ b/core/dbt/jsonschemas/project/0.0.110.json
@@ -5413,6 +5413,8 @@
       "enum": [
         "unsafe",
         "off",
+        "baseline",
+        "strict",
         "on"
       ]
     },

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -644,15 +644,6 @@
         "conversion_rate"
       ]
     },
-    "CustomCheckLevel": {
-      "type": "string",
-      "enum": [
-        "error",
-        "warn",
-        "advisory",
-        "off"
-      ]
-    },
     "CustomTest": {
       "anyOf": [
         {
@@ -1353,6 +1344,7 @@
           ]
         },
         "tags": {
+          "default": [],
           "anyOf": [
             {
               "$ref": "#/definitions/StringOrArrayOfStrings"
@@ -1966,6 +1958,7 @@
           }
         },
         "tags": {
+          "default": [],
           "anyOf": [
             {
               "$ref": "#/definitions/StringOrArrayOfStrings"
@@ -3193,6 +3186,7 @@
           }
         },
         "tags": {
+          "default": [],
           "anyOf": [
             {
               "$ref": "#/definitions/StringOrArrayOfStrings"
@@ -3732,15 +3726,6 @@
             "boolean",
             "null"
           ]
-        },
-        "custom_checks": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": {
-            "$ref": "#/definitions/CustomCheckLevel"
-          }
         },
         "database": {
           "type": [
@@ -4357,16 +4342,6 @@
             }
           ]
         },
-        "strictness": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/StrictnessMode"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "submission_method": {
           "type": [
             "string",
@@ -4403,6 +4378,7 @@
           ]
         },
         "tags": {
+          "default": [],
           "anyOf": [
             {
               "$ref": "#/definitions/StringOrArrayOfStrings"
@@ -5099,6 +5075,7 @@
           ]
         },
         "tags": {
+          "default": [],
           "anyOf": [
             {
               "$ref": "#/definitions/StringOrArrayOfStrings"
@@ -5774,6 +5751,7 @@
           ]
         },
         "tags": {
+          "default": [],
           "anyOf": [
             {
               "$ref": "#/definitions/StringOrArrayOfStrings"
@@ -6561,6 +6539,7 @@
           ]
         },
         "tags": {
+          "default": [],
           "anyOf": [
             {
               "$ref": "#/definitions/StringOrArrayOfStrings"
@@ -7284,6 +7263,7 @@
           ]
         },
         "tags": {
+          "default": [],
           "anyOf": [
             {
               "$ref": "#/definitions/StringOrArrayOfStrings"
@@ -7413,6 +7393,8 @@
       "enum": [
         "unsafe",
         "off",
+        "baseline",
+        "strict",
         "on"
       ]
     },
@@ -7422,14 +7404,6 @@
         "ephemeral",
         "table",
         "view"
-      ]
-    },
-    "StrictnessMode": {
-      "type": "string",
-      "enum": [
-        "baseline",
-        "strict",
-        "custom"
       ]
     },
     "StringOrArrayOfStrings": {


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/0.0.110.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`a03a578bd78233ef885cca21dbe7c3ed122185dd`](https://github.com/dbt-labs/fs/commit/a03a578bd78233ef885cca21dbe7c3ed122185dd)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/22022052720)