### PR TITLE
fix failing tests after macro msg change

### DIFF
--- a/tests/functional/duplicates/test_duplicate_macro.py
+++ b/tests/functional/duplicates/test_duplicate_macro.py
@@ -41,7 +41,7 @@ class TestDuplicateMacroEnabledSameFile:
         }
 
     def test_duplicate_macros(self, project):
-        message = 'dbt found two macros named "some_macro" in the project'
+        message = 'dbt found multiple macros named "some_macro" in the project'
         with pytest.raises(CompilationError) as exc:
             run_dbt(["parse"])
         exc_str = " ".join(str(exc.value).split())  # flatten all whitespace
@@ -62,7 +62,7 @@ class TestDuplicateMacroEnabledDifferentFiles:
         }
 
     def test_duplicate_macros(self, project):
-        message = 'dbt found two macros named "some_macro" in the project'
+        message = 'dbt found multiple macros named "some_macro" in the project'
         with pytest.raises(CompilationError) as exc:
             run_dbt(["compile"])
         exc_str = " ".join(str(exc.value).split())  # flatten all whitespace


### PR DESCRIPTION
Resolves #

### Problem
The message was revised in [this](https://github.com/dbt-labs/dbt-adapters/pull/1631/changes) PR but the corresponding test assertions were not changed in dbt-core.

### Solution
Change the assertion messages to new message.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
