### PR TITLE
fix: surface real profile error when dbt debug encounters duplicate connection attributes

### DIFF
--- a/.changes/unreleased/Fixes-20260228-102039.yaml
+++ b/.changes/unreleased/Fixes-20260228-102039.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Surface real profile error when dbt debug encounters duplicate connection attributes
+time: 2026-02-28T10:20:39.1497187Z
+custom:
+    Author: kalluripradeep
+    Issue: "12502"

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -354,9 +354,7 @@ class DebugTask(BaseTask):
                 log_msg=red("ERROR invalid"),
                 run_status=RunStatus.Error,
                 details=details,
-                summary_message=(
-                    f"Project loading failed for the following reason:\n{details}\n"
-                ),
+                summary_message=(f"Project loading failed for the following reason:\n{details}\n"),
             )
         else:
             return SubtaskStatus(

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -338,13 +338,24 @@ class DebugTask(BaseTask):
                 renderer,
                 verify_version=self.args.VERSION_CHECK,
             )
-        except dbt_common.exceptions.DbtConfigError as exc:
+        except (
+            dbt_common.exceptions.DbtConfigError,
+            dbt_common.exceptions.CompilationError,
+        ) as exc:
+            details = str(exc)
+            if self.profile is None:
+                details = (
+                    f"{details}\n"
+                    "Note: The profile was not loaded successfully. "
+                    "Project rendering errors (such as undefined 'target') "
+                    "may be caused by the profile failure above."
+                )
             return SubtaskStatus(
                 log_msg=red("ERROR invalid"),
                 run_status=RunStatus.Error,
-                details=str(exc),
+                details=details,
                 summary_message=(
-                    f"Project loading failed for the following reason:" f"\n{str(exc)}" f"\n"
+                    f"Project loading failed for the following reason:\n{details}\n"
                 ),
             )
         else:

--- a/tests/functional/cli/test_debug_error_handling.py
+++ b/tests/functional/cli/test_debug_error_handling.py
@@ -1,0 +1,75 @@
+import pytest
+from dbt.cli.main import dbtRunner
+
+
+broken_profile = """
+broken_profile:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: localhost
+      port: 5432
+      user: myuser
+      password: mypassword
+      dbname: mydb
+      schema: myschema
+      threads: 1
+      connect_timeout: 10
+      # These two keys are aliases for the same parameter.
+      # This misconfiguration triggers the bug.
+      connect_timeout: 10
+"""
+
+dbt_project_yml = """
+name: 'core_12502'
+profile: 'broken_profile'
+models:
+  core_12502:
+    +enabled: "{{ target.name == 'prod' }}"
+"""
+
+
+class TestDebugWithDuplicateProfileKeys:
+    @pytest.fixture(scope="class")
+    def dbt_profile_data(self):
+        return {
+            "broken_profile": {
+                "target": "dev",
+                "outputs": {
+                    "dev": {
+                        "type": "postgres",
+                        "host": "localhost",
+                        "port": 5432,
+                        "user": "myuser",
+                        "password": "mypassword",
+                        "dbname": "mydb",
+                        "schema": "myschema",
+                        "threads": 1,
+                    }
+                },
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {}
+
+    def test_debug_surfaces_profile_error_not_compilation_error(self, project):
+        """
+        Regression test for https://github.com/dbt-labs/dbt-core/issues/12502
+
+        When a profile has duplicate connection attributes, dbt debug should
+        surface the real profile validation error, not a misleading
+        CompilationError about 'target' being undefined.
+        """
+        events = []
+        result = dbtRunner(callbacks=[events.append]).invoke(["debug"])
+
+        assert not result.success
+        messages = [e.info.msg for e in events if hasattr(e, "info")]
+
+        # Should NOT show the misleading CompilationError
+        assert not any("'target' is undefined" in m for m in messages)
+        # Should show something about the profile failure
+        assert any("profile" in m.lower() for m in messages)


### PR DESCRIPTION
Resolves: #12502

Problem: When a profile has duplicate connection attributes, dbt debug shows a misleading 'target' is undefined CompilationError instead of the real profile validation error.

Solution: Extended the except clause in _load_project() to also catch CompilationError. Since CompilationError and DbtConfigError are siblings under DbtRuntimeError (not parent/child), the original except missed it. When self.profile is None, a note is added pointing the user to the profile failure.