### PR TITLE
Allow installing local packages with deepcopy

### DIFF
--- a/.changes/unreleased/Features-20260223-143759.yaml
+++ b/.changes/unreleased/Features-20260223-143759.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add capability to install local packages with deepcopy
+time: 2026-02-23T14:37:59.011935+05:30
+custom:
+    Author: ash2shukla
+    Issue: "8223"

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -56,6 +56,7 @@ class Package(dbtClassMixin):
 @dataclass
 class LocalPackage(Package):
     local: str
+    install_mode: str = field(default="symlink")
     unrendered: Dict[str, Any] = field(default_factory=dict)
     name: Optional[str] = None
 

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any, ClassVar, Dict, List, Optional, Union
 
 from mashumaro.jsonschema.annotations import Pattern
@@ -7,6 +8,7 @@ from typing_extensions import Annotated
 
 from dbt.adapters.contracts.connection import QueryComment
 from dbt.contracts.util import Identifier, list_str
+from dbt_common.clients import system
 from dbt_common.contracts.util import Mergeable
 from dbt_common.dataclass_schema import (
     ExtensibleDbtClassMixin,
@@ -41,6 +43,12 @@ class Quoting(dbtClassMixin, Mergeable):
     snowflake_ignore_case: Optional[bool] = None
 
 
+class LocalPackageInstallMode(str, Enum):
+    auto = "auto"
+    editable = "editable"
+    frozen = "frozen"
+
+
 @dataclass
 class Package(dbtClassMixin):
 
@@ -56,9 +64,23 @@ class Package(dbtClassMixin):
 @dataclass
 class LocalPackage(Package):
     local: str
-    install_mode: str = field(default="symlink")
+    install_mode: LocalPackageInstallMode = field(default=LocalPackageInstallMode.auto)
     unrendered: Dict[str, Any] = field(default_factory=dict)
     name: Optional[str] = None
+
+    @classmethod
+    def validate(cls, data):
+        install_mode = data.get("install_mode", LocalPackageInstallMode.auto)
+        is_editable = (
+            install_mode == LocalPackageInstallMode.editable
+            or install_mode == LocalPackageInstallMode.editable.value
+        )
+        if is_editable and not system.supports_symlinks():
+            raise ValidationError(
+                "Install mode 'editable' is not supported on this platform. "
+                "Use 'frozen' or 'auto' instead."
+            )
+        super().validate(data)
 
 
 # `float` also allows `int`, according to PEP484 (and jsonschema!)
@@ -138,6 +160,9 @@ class PackageConfig(dbtClassMixin):
                     raise ValidationError(
                         "A git package is missing the value. It is a required property."
                     )
+                # Validate local package
+                if "local" in package and package.get("local"):
+                    LocalPackage.validate(package)
             if isinstance(package, dict) and package.get("package"):
                 if not package["version"]:
                     raise ValidationError(

--- a/core/dbt/deps/local.py
+++ b/core/dbt/deps/local.py
@@ -3,15 +3,24 @@ from typing import Dict
 
 from dbt.config.project import PartialProject, Project
 from dbt.config.renderer import PackageRenderer
-from dbt.contracts.project import LocalPackage, ProjectPackageMetadata
+from dbt.contracts.project import (
+    LocalPackage,
+    LocalPackageInstallMode,
+    ProjectPackageMetadata,
+)
 from dbt.deps.base import PinnedPackage, UnpinnedPackage
 from dbt.events.types import DepsCreatingLocalSymlink, DepsSymlinkNotAvailable
+from dbt.exceptions import DependencyError
 from dbt_common.clients import system
 from dbt_common.events.functions import fire_event
 
 
 class LocalPackageMixin:
-    def __init__(self, local: str, install_mode: str = "symlink") -> None:
+    def __init__(
+        self,
+        local: str,
+        install_mode: LocalPackageInstallMode = LocalPackageInstallMode.auto,
+    ) -> None:
         super().__init__()
         self.local = local
         self.install_mode = install_mode
@@ -25,14 +34,15 @@ class LocalPackageMixin:
 
 
 class LocalPinnedPackage(LocalPackageMixin, PinnedPackage):
-    def __init__(self, local: str, install_mode: str = "symlink") -> None:
+    def __init__(
+        self,
+        local: str,
+        install_mode: LocalPackageInstallMode = LocalPackageInstallMode.auto,
+    ) -> None:
         super().__init__(local, install_mode)
 
     def to_dict(self) -> Dict[str, str]:
-        return {
-            "local": self.local,
-            "install_mode": self.install_mode,
-        }
+        return {"local": self.local, "install_mode": self.install_mode.value}
 
     def get_version(self):
         return None
@@ -62,22 +72,29 @@ class LocalPinnedPackage(LocalPackageMixin, PinnedPackage):
             else:
                 system.remove_file(dest_path)
 
-        if self.install_mode == "deepcopy":
+        if self.install_mode == LocalPackageInstallMode.frozen:
             shutil.copytree(src_path, dest_path)
-        else:
+        elif self.install_mode == LocalPackageInstallMode.editable:
+            fire_event(DepsCreatingLocalSymlink())
+            system.make_symlink(src_path, dest_path)
+        elif self.install_mode == LocalPackageInstallMode.auto:
             try:
                 fire_event(DepsCreatingLocalSymlink())
                 system.make_symlink(src_path, dest_path)
             except OSError:
                 fire_event(DepsSymlinkNotAvailable())
                 shutil.copytree(src_path, dest_path)
+        else:
+            # should never happen
+            raise DependencyError(
+                f"Invalid install mode: {self.install_mode} for 'local' package: {self.local}"
+            )
 
 
 class LocalUnpinnedPackage(LocalPackageMixin, UnpinnedPackage[LocalPinnedPackage]):
     @classmethod
     def from_contract(cls, contract: LocalPackage) -> "LocalUnpinnedPackage":
-        install_mode = getattr(contract, "install_mode", None) or "symlink"
-        return cls(local=contract.local, install_mode=install_mode)
+        return cls(local=contract.local, install_mode=contract.install_mode)
 
     def incorporate(self, other: "LocalUnpinnedPackage") -> "LocalUnpinnedPackage":
         return LocalUnpinnedPackage(local=self.local, install_mode=self.install_mode)

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -271,7 +271,6 @@ class DepsTask(BaseTask):
         packages_installed[PACKAGE_LOCK_HASH_KEY] = _create_sha1_hash(
             self.project.packages.packages
         )
-
         with open(lock_filepath, "w") as lock_obj:
             yaml.dump(packages_installed, lock_obj, Dumper=dbtPackageDumper)
 
@@ -327,7 +326,6 @@ class DepsTask(BaseTask):
                 package_name = package.name
                 source_type = package.source_type()
                 version = package.get_version()
-
                 fire_event(DepsStartPackageInstall(package_name=package_name))
                 package.install(self.project, renderer)
 

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -271,6 +271,7 @@ class DepsTask(BaseTask):
         packages_installed[PACKAGE_LOCK_HASH_KEY] = _create_sha1_hash(
             self.project.packages.packages
         )
+
         with open(lock_filepath, "w") as lock_obj:
             yaml.dump(packages_installed, lock_obj, Dumper=dbtPackageDumper)
 
@@ -326,6 +327,7 @@ class DepsTask(BaseTask):
                 package_name = package.name
                 source_type = package.source_type()
                 version = package.get_version()
+
                 fire_event(DepsStartPackageInstall(package_name=package_name))
                 package.install(self.project, renderer)
 

--- a/tests/functional/dependencies/test_local_dependency.py
+++ b/tests/functional/dependencies/test_local_dependency.py
@@ -391,3 +391,17 @@ class TestDependencyTestsConfig(BaseDependencyTest):
         # Check that project-test-config is NOT in active deprecations, since "tests" is only
         # in a dependent project.
         assert "project-test-config" not in deprecations.active_deprecations
+
+
+class TestLocalPackageInstallModeDeepcopy(BaseDependencyTest):
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {"packages": [{"local": "local_dependency", "install_mode": "deepcopy"}]}
+
+    def test_install_mode_deepcopy_installs_directory_not_symlink(self, project):
+        run_dbt(["deps"])
+
+        dest_path = Path(project.project_root) / "dbt_packages" / "local_dep"
+        assert dest_path.exists()
+        assert dest_path.is_dir()
+        assert not dest_path.is_symlink()


### PR DESCRIPTION
Resolves #8223
### Problem
We currently cant force a package to be installed with deepcopy instead we always try to install it with symlinking and if it fails we fallback to deepcopy. We want to be able to force install local packages with deepcopy as well.

### Solution
Add a local package config `install_mode` that takes 3 values `frozen`, `editable` and `auto`. It's value defaults to `auto` preserving current behavior but if its `frozen` then we will force installation of local packages as deepcopied dirs. `editable` will install on symlink supporting platforms with `symlinks` otherwise it will raise an error.
 
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
