### PR TITLE
fix: Skip rendering data_tests in per-version columns

### DIFF
--- a/.changes/unreleased/Fixes-20260223-191000.yaml
+++ b/.changes/unreleased/Fixes-20260223-191000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix custom macros in per-version column `data_tests` failing with "is undefined"
+time: 2026-02-23T19:10:00.000000-00:00
+custom:
+    Author: mshelto3
+    Issue: "12526"

--- a/core/dbt/parser/schema_renderer.py
+++ b/core/dbt/parser/schema_renderer.py
@@ -73,6 +73,10 @@ class SchemaYamlRenderer(BaseRenderer):
         ):
             return True
 
+        # per-version column data_tests (e.g. versions.0.columns.0.data_tests.*)
+        if any(k in ("tests", "data_tests") for k in keypath):
+            return True
+
         return False
 
     # don't render descriptions or test keyword arguments

--- a/tests/unit/parser/test_schema_renderer.py
+++ b/tests/unit/parser/test_schema_renderer.py
@@ -44,6 +44,46 @@ class TestYamlRendering(unittest.TestCase):
         dct = renderer.render_data(dct)
         self.assertEqual(expected, dct)
 
+        # Verify data_tests in per-version columns are not rendered
+        dct = {
+            "name": "my_model",
+            "attribute": "{{ test_var }}",
+            "versions": [
+                {
+                    "v": 1,
+                    "columns": [
+                        {
+                            "name": "my_col",
+                            "data_tests": [
+                                "not_null",
+                                {"accepted_values": {"arguments": {"values": "{{ test_var }}"}}},
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+        expected = {
+            "name": "my_model",
+            "attribute": "1234",
+            "versions": [
+                {
+                    "v": 1,
+                    "columns": [
+                        {
+                            "name": "my_col",
+                            "data_tests": [
+                                "not_null",
+                                {"accepted_values": {"arguments": {"values": "{{ test_var }}"}}},
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+        dct = renderer.render_data(dct)
+        self.assertEqual(expected, dct)
+
     def test__sources(self):
 
         context = {


### PR DESCRIPTION
Resolves #12526

### Problem

Custom project macros (e.g., `{{ get_valid_statuses() }}`) used in `data_tests` on per-version columns fail during `dbt compile` / `dbt parse` with:

```
Compilation Error: 'get_valid_statuses' is undefined
```

The same macros work correctly on top-level columns and unversioned model entries.

The root cause is in `SchemaYamlRenderer._is_norender_key()`. It correctly defers rendering of `data_tests` at the top level (keypath length 1) and column level (keypath length 2), but does not handle per-version column tests where the keypath is deeper:

```
('versions', 1, 'columns', 1, 'data_tests', 1, 'accepted_values', 'arguments', 'values')
```

These deeper keypaths fall through to the default rendering path, which uses `SchemaYamlContext` — a restricted context that only supports `var()` and `env_var()`, not custom project macros.

This was likely introduced in #9412 (Rename tests -> data_tests for model-level + versions) which added per-version `data_tests` support without updating the norender checks for the deeper keypath.

### Solution

Add a check for `data_tests` or `tests` anywhere in the keypath, so test blocks are always deferred for rendering regardless of nesting depth:

```python
if any(k in ("tests", "data_tests") for k in keypath):
    return True
```

This is safe because `data_tests`/`tests` blocks should never be rendered during initial YAML parsing — they are always rendered later with the full macro context, regardless of where they appear in the YAML structure.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
