### PR TITLE
Make metric filter by dimension parsing test case slightly richer

### DIFF
--- a/.changes/unreleased/Under the Hood-20260223-121653.yaml
+++ b/.changes/unreleased/Under the Hood-20260223-121653.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Make test case for parsing metric filters slightly more robust.
+time: 2026-02-23T12:16:53.395517-08:00
+custom:
+    Author: theyostalservice
+    Issue: "12528"

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -881,7 +881,7 @@ schema_yml_v2_metric_with_filter_dimension_jinja = """
         agg: count
         expr: id
         filter: |
-          {{ Dimension('id_entity__id_dim') }} > 0
+          {{ Dimension('id_entity__id_dim') }} > 0 and {{ TimeDimension('id_entity__id_dim', 'day') }} > '2020-01-01'
 """
 
 schema_yml_v2_cumulative_metric_missing_input_metric = """

--- a/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
@@ -748,7 +748,7 @@ class TestSimpleSemanticModelWithFilterWithFilterDimensionJinja:
         metric = manifest.metrics["metric.test.simple_metric_with_filter_dimension_jinja"]
         assert (
             metric.filter.where_filters[0].where_sql_template
-            == "{{ Dimension('id_entity__id_dim') }} > 0"
+            == "{{ Dimension('id_entity__id_dim') }} > 0 and {{ TimeDimension('id_entity__id_dim', 'day') }} > '2020-01-01'"
         )
 
 


### PR DESCRIPTION
### Problem

A user wanted to make sure that a compound dimension would still parse, and we couldn't verify that from the established tests alone.

### Solution

Improve the test case to be a slightly more robust filter.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
