### PR TITLE
Fix Dimension() jinja in nested metric filters rendered during v2 YAML parsing

### DIFF
--- a/.changes/unreleased/Fixes-20260223-132342.yaml
+++ b/.changes/unreleased/Fixes-20260223-132342.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix Dimension() jinja in nested metric filters (input_metrics, numerator, denominator) being incorrectly rendered during YAML parsing for v2 semantic layer schema
+time: 2026-02-23T13:23:42.353928-08:00
+custom:
+    Author: theyostalservice
+    Issue: 12529

--- a/core/dbt/parser/schema_renderer.py
+++ b/core/dbt/parser/schema_renderer.py
@@ -106,7 +106,7 @@ class SchemaYamlRenderer(BaseRenderer):
             elif self._is_norender_key(keypath[0:]):
                 return False
         else:  # models, seeds, snapshots, analyses
-            if keypath[-1] == "filter" and len(keypath) >= 3 and keypath[-3] == "metrics":
+            if keypath[-1] == "filter" and "metrics" in keypath:
                 return False
             if self._is_norender_key(keypath[0:]):
                 return False

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -884,6 +884,53 @@ schema_yml_v2_metric_with_filter_dimension_jinja = """
           {{ Dimension('id_entity__id_dim') }} > 0
 """
 
+schema_yml_v2_metric_with_input_metrics_filter_dimension_jinja = """
+    metrics:
+      - name: simple_metric
+        description: This is our first simple metric.
+        label: Simple Metric
+        type: simple
+        agg: count
+        expr: id
+      - name: derived_metric_with_jinja_filter
+        description: This is a derived metric with a jinja filter on an input metric.
+        label: Derived Metric With Jinja Filter
+        type: derived
+        expr: simple_metric - offset_metric
+        input_metrics:
+          - name: simple_metric
+          - name: simple_metric
+            alias: offset_metric
+            filter: |
+              {{ Dimension('id_entity__id_dim') }} > 0
+            offset_window: 1 week
+"""
+
+schema_yml_v2_metric_with_numerator_filter_dimension_jinja = """
+    metrics:
+      - name: simple_metric
+        description: This is our first simple metric.
+        label: Simple Metric
+        type: simple
+        agg: count
+        expr: id
+      - name: simple_metric_2
+        description: This is our second simple metric.
+        label: Simple Metric 2
+        type: simple
+        agg: count
+        expr: second_col
+      - name: ratio_metric_with_jinja_filter
+        description: This is a ratio metric with a jinja filter on the numerator.
+        label: Ratio Metric With Jinja Filter
+        type: ratio
+        numerator:
+          name: simple_metric
+          filter: |
+            {{ Dimension('id_entity__id_dim') }} > 0
+        denominator: simple_metric_2
+"""
+
 schema_yml_v2_cumulative_metric_missing_input_metric = """
     metrics:
       - name: cumulative_metric


### PR DESCRIPTION
Resolves #

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

SchemaYamlRenderer.should_render_keypath() incorrectly rendered
{{ Dimension(...) }} jinja in metric filter fields at deeper nesting
levels under models:. Filters in input_metrics[].filter,
numerator.filter, and denominator.filter were being rendered during
YAML parsing, causing 'Dimension' is undefined errors.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

The fix broadens the filter skip condition from checking keypath[-3]
== "metrics" (only matching direct metric filters) to checking
"metrics" in keypath (matching filters at any depth under metrics).

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.