### PR TITLE
Feature: Allow support for custom macros in `selectors.yml`

### DIFF
--- a/.changes/unreleased/Features-20260223-231634.yaml
+++ b/.changes/unreleased/Features-20260223-231634.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Added support for custom project macros in `\selectors.yml` definitions by rendering selectors with root-project macro context when needed.
+time: 2026-02-23T23:16:34.288843-08:00
+custom:
+    Author: adaviscourt
+    Issue: "12530"

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -229,7 +229,7 @@ def load_raw_project(project_root: str, validate: bool = False) -> Dict[str, Any
 
 
 def _query_comment_from_cfg(
-    cfg_query_comment: Union[QueryComment, NoValue, str, None]
+    cfg_query_comment: Union[QueryComment, NoValue, str, None],
 ) -> QueryComment:
     if not cfg_query_comment:
         return QueryComment(comment="")
@@ -329,7 +329,9 @@ class PartialProject(RenderComponents):
         rendered_packages = renderer.render_packages(
             self.packages_dict, self.packages_specified_path
         )
-        rendered_selectors = renderer.render_selectors(self.selectors_dict)
+        rendered_selectors = renderer.render_selectors(
+            self.selectors_dict, rendered_project, self.project_root
+        )
 
         return RenderComponents(
             project_dict=rendered_project,

--- a/tests/functional/selectors/test_selector_macro_rendering.py
+++ b/tests/functional/selectors/test_selector_macro_rendering.py
@@ -1,0 +1,63 @@
+import os
+
+import pytest
+
+from dbt.tests.util import run_dbt
+
+MACROS__TAG_SELECTOR_SQL = """
+{% macro selector_from_tag_env() %}
+  {{ return({
+    'method': 'tag',
+    'value': env_var('SELECTOR_TAG', 'alpha')
+  }) }}
+{% endmacro %}
+"""
+
+SELECTORS_YML = """
+selectors:
+  - name: dynamic_tag_selector
+    definition: "{{ selector_from_tag_env() }}"
+"""
+
+MODELS__MODEL_ALPHA_SQL = """
+{{ config(tags=['alpha']) }}
+select 1 as id
+"""
+
+MODELS__MODEL_BETA_SQL = """
+{{ config(tags=['beta']) }}
+select 2 as id
+"""
+
+
+class TestSelectorMacroRendering:
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"tag_selector.sql": MACROS__TAG_SELECTOR_SQL}
+
+    @pytest.fixture(scope="class")
+    def selectors(self):
+        return SELECTORS_YML
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_alpha.sql": MODELS__MODEL_ALPHA_SQL,
+            "model_beta.sql": MODELS__MODEL_BETA_SQL,
+        }
+
+    def test_selector_macro_renders_with_env_var(self, project):
+        os.environ["SELECTOR_TAG"] = "alpha"
+        try:
+            first = run_dbt(
+                ["ls", "--resource-type", "model", "--selector", "dynamic_tag_selector"]
+            )
+            assert first == ["test.model_alpha"]
+
+            os.environ["SELECTOR_TAG"] = "beta"
+            second = run_dbt(
+                ["ls", "--resource-type", "model", "--selector", "dynamic_tag_selector"]
+            )
+            assert second == ["test.model_beta"]
+        finally:
+            os.environ.pop("SELECTOR_TAG", None)

--- a/tests/unit/config/test_selector_renderer_with_macros.py
+++ b/tests/unit/config/test_selector_renderer_with_macros.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import pytest
+
+from dbt.config.renderer import DbtProjectYamlRenderer
+from dbt_common.exceptions import CompilationError
+
+
+class TestSelectorRendererWithMacros:
+    def test_render_selectors_with_root_project_macro(self, tmp_path: Path):
+        macro_dir = tmp_path / "macros"
+        macro_dir.mkdir()
+        (macro_dir / "selector_for.sql").write_text(
+            "{% macro selector_for(name) %}{{ return('tag:' ~ name) }}{% endmacro %}"
+        )
+
+        renderer = DbtProjectYamlRenderer(profile=None, cli_vars={})
+        selectors = {
+            "selectors": [
+                {
+                    "name": "dynamic_selector",
+                    "definition": "{{ selector_for('nightly') }}",
+                }
+            ]
+        }
+        project = {"name": "test_project", "macro-paths": ["macros"]}
+
+        rendered = renderer.render_selectors(
+            selectors, project=project, project_root=str(tmp_path)
+        )
+
+        assert rendered["selectors"][0]["definition"] == "tag:nightly"
+
+    def test_render_selectors_undefined_macro_without_project_context_errors(self):
+        renderer = DbtProjectYamlRenderer(profile=None, cli_vars={})
+        selectors = {
+            "selectors": [
+                {
+                    "name": "dynamic_selector",
+                    "definition": "{{ selector_for('nightly') }}",
+                }
+            ]
+        }
+
+        with pytest.raises(CompilationError, match="is undefined"):
+            renderer.render_selectors(selectors)


### PR DESCRIPTION
Resolves: N/A
There are some issues like #2995 which touch on a desire to leverage macros in non-model files but none that explicitly discuss adding the enablement to `selectors.yaml`

### Problem

`selectors.yml` is rendered without project macros, so macro-based selector definitions fail with undefined symbol errors.

### Solution

Add a scoped fallback for selector rendering:

- Keep existing selector rendering path unchanged.
- If rendering fails due to an undefined symbol, retry with a macro-augmented context built from root-project macros.
- Use project `macro-paths` (default `macros`) and `MacroNamespaceBuilder` to load/attach macros.
- Pass rendered project metadata/root into selector rendering from `PartialProject.get_rendered`.
- Keep parser imports lazy in the fallback to avoid config/parser import cycles.

This change is limited to `selectors.yml` rendering behavior.

### Tests

#### Added new tests

- Unit: `tests/unit/config/test_selector_renderer_with_macros.py`
  - selector macro renders with root-project macro context
  - undefined macro still errors without project context
- Functional: `tests/functional/selectors/test_selector_macro_rendering.py`
  - macro-backed selector drives `dbt ls --selector ...`
  - env var changes alter selected models as expected

#### Manual testing

In addition to adding tests to the codebase, I did a manual test based on a use case I have encountered, which is the enablement of models based on an environment variable.

Here's the setup
```
• models/testing
  ├── enabler.sql
  ├── models_a
  │   └── model_a.sql
  ├── models_b
  │   └── model_b.sql
  └── models_c
      └── model_c.sql
```
``` sql
{% macro enabled_models_selector() %}
  {% set enabled = env_var('ENABLED_MODELS', '') | replace(' ', '') %}
  {% if enabled == '' %}
    {{ return({'method': 'fqn', 'value': '__no_models_selected__'}) }}
  {% endif %}

  {% set definitions = [] %}
  {% for model_name in enabled.split(',') %}
    {% if model_name %}
      {% do definitions.append({'method': 'fqn', 'value': model_name}) %}
    {% endif %}
  {% endfor %}

  {{ return({'union': definitions}) }}
{% endmacro %}
```
``` yaml
selectors:
  - name: testing
    definition: "{{ enabled_models_selector() }}"
```
``` bash
export ENABLED_MODELS="model_a,model_c"
```

Then, I ran `dbt ls --selector testing`
**Current Behavior**
```
Compilation Error
  Could not render {{ enabled_models_selector() }}: 'enabled_models_selector' is undefined
```

**Proposed Behavior**
```
dbt_local.testing.models_a.model_a
dbt_local.testing.models_c.model_c
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
