### PR TITLE
skip flaky TestWarnErrorOptionsFromProjectCanExcludeSpecificEventtest

### DIFF
--- a/tests/functional/configs/test_warn_error_options.py
+++ b/tests/functional/configs/test_warn_error_options.py
@@ -195,6 +195,9 @@ class TestWarnErrorOptionsFromProjectCanRaiseWarningToError(BaseTestWarnErrorOpt
 
 
 class TestWarnErrorOptionsFromProjectCanExcludeSpecificEvent(BaseTestWarnErrorOptionsFromProject):
+    @pytest.mark.skip(
+        reason="Flaky on structured logging tests, EventCatcher inexplicably picks up on 'include' usage across classes"
+    )
     def test_can_exclude_specific_event(
         self, project, clear_project_flags, project_root, catcher: EventCatcher, runner: dbtRunner
     ) -> None:


### PR DESCRIPTION
Skipping flaky test for now to unblock PRs that add tests (thereby changing test groupings) that trigger this flaky test. For example, in https://github.com/dbt-labs/dbt-core/pull/12532


Already went down this rabbit hole on 1.11.latest: https://github.com/dbt-labs/dbt-core/pull/12476, could not find any mitigation for it even after major refactor of the tests.
