### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260225-092728.yaml
+++ b/.changes/unreleased/Under the Hood-20260225-092728.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-02-25T09:27:28.498892233Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/0.0.110.json
+++ b/core/dbt/jsonschemas/project/0.0.110.json
@@ -1267,6 +1267,15 @@
             "null"
           ]
         },
+        "+job_execution_timeout_seconds": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "+kms_key_name": {
           "type": [
             "string",
@@ -2364,6 +2373,15 @@
             "$ref": "#/definitions/AnyValue"
           }
         },
+        "+job_execution_timeout_seconds": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "+kms_key_name": {
           "type": [
             "string",
@@ -3194,6 +3212,14 @@
             "null"
           ]
         },
+        "+job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "+kms_key_name": {
           "type": [
             "string",
@@ -3837,6 +3863,15 @@
             "null"
           ]
         },
+        "+job_execution_timeout_seconds": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "+kms_key_name": {
           "type": [
             "string",
@@ -4455,6 +4490,15 @@
             "null"
           ]
         },
+        "+job_execution_timeout_seconds": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "+kms_key_name": {
           "type": [
             "string",
@@ -4982,6 +5026,15 @@
             "string",
             "null"
           ]
+        },
+        "+job_execution_timeout_seconds": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "+kms_key_name": {
           "type": [

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -1040,6 +1040,14 @@
             "null"
           ]
         },
+        "job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "kms_key_name": {
           "type": [
             "string",
@@ -2454,6 +2462,14 @@
             "string",
             "null"
           ]
+        },
+        "job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "kms_key_name": {
           "type": [
@@ -3960,6 +3976,14 @@
             "$ref": "#/definitions/AnyValue"
           }
         },
+        "job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "kms_key_name": {
           "type": [
             "string",
@@ -5456,6 +5480,14 @@
             "null"
           ]
         },
+        "job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "kms_key_name": {
           "type": [
             "string",
@@ -6220,6 +6252,14 @@
             "string",
             "null"
           ]
+        },
+        "job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "kms_key_name": {
           "type": [
@@ -6994,6 +7034,14 @@
             "string",
             "null"
           ]
+        },
+        "job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "kms_key_name": {
           "type": [
@@ -7909,6 +7957,14 @@
             "string",
             "null"
           ]
+        },
+        "job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "kms_key_name": {
           "type": [


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/0.0.110.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`6b34c5c270d17cad473686392881e3b0427588b5`](https://github.com/dbt-labs/fs/commit/6b34c5c270d17cad473686392881e3b0427588b5)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/22390593114)