### PR TITLE
fix: state:modified does not detect .yml property changes for resource_type:function

### DIFF
--- a/.changes/unreleased/Fixes-20260304-140229.yaml
+++ b/.changes/unreleased/Fixes-20260304-140229.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix state:modified not detecting .yml property changes for resource_type:function
+time: 2026-03-04T14:02:29.38595+01:00
+custom:
+    Author: Thrasi
+    Issue: "12547"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1597,6 +1597,19 @@ class FunctionNode(CompiledNode, FunctionResource):
     def resource_class(cls) -> Type[FunctionResource]:
         return FunctionResource
 
+    def same_arguments(self, old: "FunctionNode") -> bool:
+        return self.arguments == old.arguments
+
+    def same_returns(self, old: "FunctionNode") -> bool:
+        return self.returns == old.returns
+
+    def same_contents(self, old, adapter_type) -> bool:
+        return (
+            super().same_contents(old, adapter_type)
+            and self.same_arguments(old)
+            and self.same_returns(old)
+        )
+
 
 # ====================================
 # SemanticModel node

--- a/tests/unit/contracts/graph/test_nodes.py
+++ b/tests/unit/contracts/graph/test_nodes.py
@@ -5,7 +5,14 @@ from dataclasses import replace
 
 import pytest
 
-from dbt.artifacts.resources import ColumnInfo, FunctionArgument, FunctionConfig, FunctionReturns, TestConfig, TestMetadata
+from dbt.artifacts.resources import (
+    ColumnInfo,
+    FunctionArgument,
+    FunctionConfig,
+    FunctionReturns,
+    TestConfig,
+    TestMetadata,
+)
 from dbt.compilation import inject_ctes_into_sql
 from dbt.contracts.files import FileHash
 from dbt.contracts.graph.nodes import (


### PR DESCRIPTION
Resolves #12547

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

FunctionNode does not override same_contents(), so it inherited ParsedNode's implementation which compares the SQL body, config, persisted_description, fqn and database representation. The arguments and returns fields are not compared.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Override same_contents() in FunctionNode to compare arguments and returns as well
### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
