### PR TITLE
Explicitly check for RunTask or BuildTask during dbt retry for microbatch models

### DIFF
--- a/core/dbt/task/retry.py
+++ b/core/dbt/task/retry.py
@@ -171,9 +171,7 @@ class RetryTask(ConfiguredTask):
             self.manifest,
         )
 
-        # issubclass ensures that BuildTask (which extends RunTask)
-        # also gets microbatch retry behavior
-        if issubclass(self.task_class, RunTask):
+        if self.task_class == RunTask or self.task_class == BuildTask:
             task.batch_map = batch_map
             task.original_invocation_started_at = (
                 self.previous_results.metadata.invocation_started_at


### PR DESCRIPTION
explicitly check for RunTask or BuildTask during dbt retry for microbatch models



### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.