### PR TITLE
add test durations for functional tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,13 +39,6 @@ defaults:
 env:
   # number of parallel processes to spawn for python integration testing
   PYTHON_INTEGRATION_TEST_WORKERS: 15
-  # pytest-split algorithm: we use 'least_duration' instead of the default 'duration_based_chunks'
-  # because duration_based_chunks maintains alphabetical order and can create very uneven test
-  # counts per group (e.g., 294 tests in group 1 vs 90 in others). Even with equal total duration,
-  # more tests means more per-test overhead (fixture setup/teardown, DB connections, temp files)
-  # which causes timeouts. least_duration distributes tests evenly across groups by count while
-  # still balancing duration, avoiding the overhead problem.
-  PYTEST_SPLIT_ALGORITHM: least_duration
 
 jobs:
   code-quality:
@@ -229,7 +222,7 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           shell: bash
-          command: cd core && hatch -v run ci:integration-tests -- --ddtrace --durations-path .test_durations --splitting-algorithm ${{ env.PYTEST_SPLIT_ALGORITHM }} --splits ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }} --group ${{ matrix.split-group }}
+          command: cd core && hatch -v run ci:integration-tests -- --ddtrace --splits ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }} --group ${{ matrix.split-group }}
 
       - name: Get current date
         if: always()
@@ -306,7 +299,7 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           shell: bash
-          command: cd core && hatch -v run ci:integration-tests -- --ddtrace --durations-path .test_durations --splitting-algorithm ${{ env.PYTEST_SPLIT_ALGORITHM }} --splits ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }} --group ${{ matrix.split-group }}
+          command: cd core && hatch -v run ci:integration-tests -- --ddtrace --splits ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }} --group ${{ matrix.split-group }}
 
       - name: Get current date
         if: always()

--- a/.github/workflows/structured-logging-schema-check.yml
+++ b/.github/workflows/structured-logging-schema-check.yml
@@ -24,13 +24,6 @@ permissions: read-all
 env:
   # number of parallel processes to spawn for python testing
   PYTHON_INTEGRATION_TEST_WORKERS: 15
-  # pytest-split algorithm: we use 'least_duration' instead of the default 'duration_based_chunks'
-  # because duration_based_chunks maintains alphabetical order and can create very uneven test
-  # counts per group (e.g., 294 tests in group 1 vs 90 in others). Even with equal total duration,
-  # more tests means more per-test overhead (fixture setup/teardown, DB connections, temp files)
-  # which causes timeouts. least_duration distributes tests evenly across groups by count while
-  # still balancing duration, avoiding the overhead problem.
-  PYTEST_SPLIT_ALGORITHM: least_duration
 
 jobs:
   integration-metadata:
@@ -126,9 +119,7 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: cd core && hatch -v run ci:integration-tests -- -nauto
-        env:
-          PYTEST_ADDOPTS: ${{ format('--durations-path .test_durations --splitting-algorithm {0} --splits {1} --group {2}', env.PYTEST_SPLIT_ALGORITHM, env.PYTHON_INTEGRATION_TEST_WORKERS, matrix.split-group) }}
+          command: cd core && hatch -v run ci:integration-tests -- --splits ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }} --group ${{ matrix.split-group }}
 
   test-schema-report:
     name: Log Schema Test Suite

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -71,7 +71,7 @@ jobs:
       - name: "Run integration tests and store durations"
         run: |
           cd core
-          hatch -v run ci:integration-tests -- --store-durations --durations-path .test_durations || true
+          hatch -v run ci:integration-tests-generate-durations -- --store-durations --durations-path .test_durations || true
 
       - name: "Code quality"
         run: |

--- a/core/hatch.toml
+++ b/core/hatch.toml
@@ -211,7 +211,15 @@ DD_PYTEST_USE_NEW_PLUGIN_BETA = "true"
 [envs.ci.scripts]
 unit-tests = "python -m pytest --cov=dbt --cov-report=xml {args} ../tests/unit"
 code-quality = "pre-commit run --all-files"
-integration-tests = "python -m pytest --cov=dbt --cov-report=xml -nauto {args} ../tests/functional"
+# pytest-split algorithm: we use 'least_duration' instead of the default 'duration_based_chunks'
+# because duration_based_chunks maintains alphabetical order and can create very uneven test
+# counts per group (e.g., 294 tests in group 1 vs 90 in others). Even with equal total duration,
+# more tests means more per-test overhead (fixture setup/teardown, DB connections, temp files)
+# which causes timeouts. least_duration distributes tests evenly across groups by count while
+# still balancing duration, avoiding the overhead problem.
+integration-tests = "python -m pytest --cov=dbt --cov-report=xml -nauto --durations-path .test_durations --splitting-algorithm least_duration {args} ../tests/functional"
+# Used by update-test-durations.yml to run all tests and generate duration data
+integration-tests-generate-durations = "python -m pytest --cov=dbt --cov-report=xml -nauto {args} ../tests/functional"
 
 # Note: Python version matrix is handled by GitHub Actions CI, not hatch.
 # This avoids running tests 4x per job. The CI sets up the Python version


### PR DESCRIPTION
### Problem

Tests timeout often and we have a lot of special logic for specific long running tests.

### Solution

Since we already split the tests lets take advantage of splitting them in a time based way.  Also update the stored test durations to keep things as up to date as possible.

Anything transitive that gets added is considered to take 10.5s and get auto added to the smallest group until a time where the durations file gets updated.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
