### PR TITLE
Fix: allow macros invoked via run-operation to ref() private and protected models

### DIFF
--- a/.changes/unreleased/Fixes-20260227-133424.yaml
+++ b/.changes/unreleased/Fixes-20260227-133424.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Allow macros invoked via run-operation to ref() private and protected models
+time: 2026-02-27T13:34:24.449177+05:30
+custom:
+    Author: aahel
+    Issue: 8248

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1585,6 +1585,8 @@ class Manifest(MacroMethods, dbtClassMixin):
             # don't raise this reference error for ad hoc 'preview' queries
             and node.resource_type != NodeType.SqlOperation
             and node.resource_type != NodeType.RPCCall  # TODO: rm
+            # macros are outside the group/access system (e.g. run-operation)
+            and node.resource_type != NodeType.Macro
         )
         target_dependency = dependencies.get(target_model.package_name)
         restrict_package_access = target_dependency.restrict_access if target_dependency else False
@@ -1611,6 +1613,8 @@ class Manifest(MacroMethods, dbtClassMixin):
             # don't raise this reference error for ad hoc 'preview' queries
             and node.resource_type != NodeType.SqlOperation
             and node.resource_type != NodeType.RPCCall  # TODO: rm
+            # macros are outside the group/access system (e.g. run-operation)
+            and node.resource_type != NodeType.Macro
         )
         target_dependency = dependencies.get(target_model.package_name)
         restrict_package_access = target_dependency.restrict_access if target_dependency else False

--- a/tests/functional/run_operations/fixtures.py
+++ b/tests/functional/run_operations/fixtures.py
@@ -70,3 +70,28 @@ sad_macros_sql = """
 model_sql = """
 select 1 as id
 """
+
+private_model_sql = """
+select 1 as id
+"""
+
+groups_yml = """
+groups:
+  - name: analytics
+    owner:
+      name: analytics_owner
+"""
+
+private_model_schema_yml = """
+models:
+  - name: private_model
+    access: private
+    group: analytics
+"""
+
+ref_private_model_macro_sql = """
+{% macro ref_private_model() %}
+  {% set result = run_query("select * from " ~ ref('private_model')) %}
+  {{ log("Successfully referenced private model", info=true) }}
+{% endmacro %}
+"""


### PR DESCRIPTION
Resolves #8248

### Problem

When executing `dbt run-operation` with a macro that calls `ref()` on a private model, dbt raises a `DbtReferenceError`:

```
Node macro.my_project.my_macro attempted to reference node model.my_project.private_model,
which is not allowed because the referenced node is private to the 'analytics' group.
```

The access validation methods `is_invalid_private_ref()` and `is_invalid_protected_ref()` in `manifest.py` already exclude `NodeType.SqlOperation` and `NodeType.RPCCall` from group checks (since those represent ad-hoc preview queries), but they do not exclude `NodeType.Macro`. Since macros are outside the group/access control system and don't have a `group` attribute, they should be permitted to reference any model.

### Solution

Add `NodeType.Macro` to the exclusion list in both `is_invalid_private_ref()` and `is_invalid_protected_ref()`, alongside the existing `SqlOperation` and `RPCCall` exclusions. This follows the same pattern already established for other node types that operate outside the group/access framework.

**Changes:**
- `core/dbt/contracts/graph/manifest.py` — add `and node.resource_type != NodeType.Macro` to both validation methods
- `tests/functional/run_operations/` — add regression test (`TestRunOperationRefPrivateModel`) that materializes a private model and verifies `run-operation` can `ref()` it successfully

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.