### PR TITLE
fix: use tuple membership check instead of substring match in selection_arg

### DIFF
--- a/.changes/unreleased/Fixes-20260228-153039.yaml
+++ b/.changes/unreleased/Fixes-20260228-153039.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix substring match bug in show and compile task selection causing models with reserved substrings in name to be incorrectly filtered
+time: 2026-02-28T15:30:39.5307104Z
+custom:
+    Author: kalluripradeep
+    Issue: "12539"

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -78,7 +78,7 @@ class CompileTask(GraphRunnableTask):
         elif self.selection_arg:
             matched_results = []
             for result in results:
-                if result.node.name in self.selection_arg[0]:
+                if result.node.name in self.selection_arg:
                     matched_results.append(result)
                 else:
                     fire_event(
@@ -148,3 +148,4 @@ class CompileTask(GraphRunnableTask):
             and (self.args.select or getattr(self.args, "inline", None))
         ):
             self.node_results.append(result)
+

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -148,4 +148,3 @@ class CompileTask(GraphRunnableTask):
             and (self.args.select or getattr(self.args, "inline", None))
         ):
             self.node_results.append(result)
-

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -78,7 +78,15 @@ class CompileTask(GraphRunnableTask):
         elif self.selection_arg:
             matched_results = []
             for result in results:
-                if result.node.name in self.selection_arg:
+                node_name = result.node.name
+                versioned_name = (
+                    f"{node_name}.v{result.node.version}"
+                    if hasattr(result.node, "version") and result.node.version
+                    else None
+                )
+                if node_name in self.selection_arg or (
+                    versioned_name and versioned_name in self.selection_arg
+                ):
                     matched_results.append(result)
                 else:
                     fire_event(

--- a/core/dbt/task/show.py
+++ b/core/dbt/task/show.py
@@ -79,7 +79,7 @@ class ShowTask(CompileTask):
         else:
             matched_results = []
             for result in results:
-                if result.node.name in self.selection_arg[0]:
+                if result.node.name in self.selection_arg:
                     matched_results.append(result)
                 else:
                     fire_event(
@@ -147,3 +147,4 @@ class ShowTaskDirect(ConfiguredTask):
                     quiet=get_flags().QUIET,
                 )
             )
+

--- a/core/dbt/task/show.py
+++ b/core/dbt/task/show.py
@@ -147,4 +147,3 @@ class ShowTaskDirect(ConfiguredTask):
                     quiet=get_flags().QUIET,
                 )
             )
-

--- a/core/dbt/task/show.py
+++ b/core/dbt/task/show.py
@@ -79,7 +79,15 @@ class ShowTask(CompileTask):
         else:
             matched_results = []
             for result in results:
-                if result.node.name in self.selection_arg:
+                node_name = result.node.name
+                versioned_name = (
+                    f"{node_name}.v{result.node.version}"
+                    if hasattr(result.node, "version") and result.node.version
+                    else None
+                )
+                if node_name in self.selection_arg or (
+                    versioned_name and versioned_name in self.selection_arg
+                ):
                     matched_results.append(result)
                 else:
                     fire_event(

--- a/tests/functional/show/fixtures.py
+++ b/tests/functional/show/fixtures.py
@@ -107,3 +107,7 @@ seeds__sample_seed = """sample_num,sample_bool
 6,false
 7,true
 """
+
+models__model_with_show_in_name = """
+select 1 as id, 'test' as value
+"""

--- a/tests/functional/show/test_show.py
+++ b/tests/functional/show/test_show.py
@@ -271,10 +271,6 @@ class TestShowSubstringBug:
     name should not incorrectly match other nodes during result filtering."""
 
     @pytest.fixture(scope="class")
-    def dbt_profile_target(self):
-        return {"type": "duckdb", "threads": 1, "path": ":memory:"}
-
-    @pytest.fixture(scope="class")
     def models(self):
         return {
             "my_show_model.sql": models__model_with_show_in_name,
@@ -292,7 +288,7 @@ class TestShowSubstringBug:
         run_dbt(["build"])
 
     def test_show_does_not_match_substring(self, project):
-        """Selecting 'show' should not match 'my_show_model' via substring."""
+        """Selecting 'second_model' should not match 'my_show_model' via substring check."""
         (_, log_output) = run_dbt_and_capture(
             ["show", "--select", "second_model"],
         )

--- a/tests/functional/show/test_show.py
+++ b/tests/functional/show/test_show.py
@@ -7,6 +7,7 @@ from dbt_common.exceptions import DbtBaseException as DbtException
 from dbt_common.exceptions import DbtRuntimeError
 from tests.functional.show.fixtures import (
     models__ephemeral_model,
+    models__model_with_show_in_name,
     models__sample_model,
     models__sample_number_model,
     models__sample_number_model_with_nulls,
@@ -263,3 +264,45 @@ class TestShowPrivateModel:
     def test_version_unspecified(self, project):
         run_dbt(["build"])
         run_dbt(["show", "--inline", "select * from {{ ref('private_model') }}"])
+
+
+class TestShowSubstringBug:
+    """Regression test for #12539 — models with substrings like 'show' in their
+    name should not incorrectly match other nodes during result filtering."""
+
+    @pytest.fixture(scope="class")
+    def dbt_profile_target(self):
+        return {"type": "duckdb", "threads": 1, "path": ":memory:"}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_show_model.sql": models__model_with_show_in_name,
+            "second_model.sql": models__second_model,
+            "sample_model.sql": models__sample_model,
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"sample_seed.csv": seeds__sample_seed}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        run_dbt(["build"])
+
+    def test_show_does_not_match_substring(self, project):
+        """Selecting 'show' should not match 'my_show_model' via substring."""
+        (_, log_output) = run_dbt_and_capture(
+            ["show", "--select", "second_model"],
+        )
+        assert "Previewing node 'second_model'" in log_output
+        assert "Previewing node 'my_show_model'" not in log_output
+
+    def test_show_matches_exact_model_with_show_in_name(self, project):
+        """Selecting 'my_show_model' should only show that model."""
+        (_, log_output) = run_dbt_and_capture(
+            ["show", "--select", "my_show_model"],
+        )
+        assert "Previewing node 'my_show_model'" in log_output
+        assert "Previewing node 'second_model'" not in log_output


### PR DESCRIPTION
Fixes #12539

## What changed

Fixed a one-character bug in `core/dbt/task/show.py` and 
`core/dbt/task/compile.py` where `self.selection_arg[0]` was used 
instead of `self.selection_arg` in the result filtering loop.

## Why

`self.selection_arg` is a tuple like `('my_model_show',)`. 

Using `result.node.name in self.selection_arg[0]` does a **substring 
check on a string**, not a membership check on the tuple:
```python
# Buggy behaviour:
'show' in 'my_model_show'   # True  ← wrong, show is a substring
'show' in ('my_model_show',) # False ← correct, show is not in the tuple
```

So any model whose name contained a common substring like `show`, 
`model`, or `my` would incorrectly match other nodes during result 
filtering, causing inconsistent behaviour depending on the model name.

## How I fixed it

Removed the `[0]` index in both files so the check becomes a proper 
tuple membership check:
```python
# Before:
if result.node.name in self.selection_arg[0]:

# After:
if result.node.name in self.selection_arg:
```

## Files changed

- `core/dbt/task/show.py`
- `core/dbt/task/compile.py`