### PR TITLE
fix: schedule referencing nodes for reparse when access changes to private via config block

### DIFF
--- a/.changes/unreleased/Fixes-20260228-203631.yaml
+++ b/.changes/unreleased/Fixes-20260228-203631.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix partial parser not scheduling referencing nodes for reparse when access is changed to private via config block
+time: 2026-02-28T20:36:31.0051367Z
+custom:
+    Author: kalluripradeep
+    Issue: "12271"

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -945,8 +945,11 @@ class PartialParsing:
                     if self.saved_files[file_id]:
                         source_file = self.saved_files[file_id]
                         self.add_to_pp_files(source_file)
-                    # if the node's group has changed - need to reparse all referencing nodes to ensure valid ref access
-                    if node.group != elem.get("group"):
+                    # if the node's group or access has changed - need to reparse all referencing nodes to ensure valid ref access
+                    elem_config = elem.get("config", {})
+                    elem_group = elem.get("group") or elem_config.get("group")
+                    elem_access = elem.get("access") or elem_config.get("access")
+                    if node.group != elem_group or (elem_access == "private" and node.access != elem_access):
                         self.schedule_referencing_nodes_for_parsing(node.unique_id)
                     # If the latest version has changed, a version has been removed, or a version has been added,
                     #  we need to reparse referencing nodes.
@@ -1253,3 +1256,4 @@ class PartialParsing:
                         break  # if one env_var is changed we can stop
 
         return (env_vars_changed_source_files, env_vars_changed_schema_files)
+

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -949,7 +949,9 @@ class PartialParsing:
                     elem_config = elem.get("config", {})
                     elem_group = elem.get("group") or elem_config.get("group")
                     elem_access = elem.get("access") or elem_config.get("access")
-                    if node.group != elem_group or (elem_access == "private" and node.access != elem_access):
+                    if node.group != elem_group or (
+                        elem_access == "private" and node.access != elem_access
+                    ):
                         self.schedule_referencing_nodes_for_parsing(node.unique_id)
                     # If the latest version has changed, a version has been removed, or a version has been added,
                     #  we need to reparse referencing nodes.
@@ -1256,4 +1258,3 @@ class PartialParsing:
                         break  # if one env_var is changed we can stop
 
         return (env_vars_changed_source_files, env_vars_changed_schema_files)
-


### PR DESCRIPTION
Fixes #12271

## What changed

Fixed `core/dbt/parser/partial.py` where the partial parser only checked 
for `group` changes when deciding whether to schedule referencing nodes 
for re-validation. It missed two things:

1. `access` nested under `config:` block (e.g. `config: {access: private}`)
2. `access` changes entirely — only `group` changes were being checked

## Why

When a model's access is set to `private` via the `config` block, the 
partial parser reads `elem.get("group")` but never checks `elem.get("access")` 
or `elem.get("config", {}).get("access")`. So referencing nodes are never 
scheduled for re-validation, and the private access violation silently 
passes at parse time — only failing at runtime during `dbt build`.

When `access: private` is set at the top level (not nested under config), 
it works correctly because a different code path handles it.

## How I fixed it

Extended the group change check to also read access from both the top-level 
and config-nested YAML, and added an access change condition:
```python
# Before:
if node.group != elem.get("group"):
    self.schedule_referencing_nodes_for_parsing(node.unique_id)

# After:
elem_config = elem.get("config", {})
elem_group = elem.get("group") or elem_config.get("group")
elem_access = elem.get("access") or elem_config.get("access")
if node.group != elem_group or (elem_access == "private" and node.access != elem_access):
    self.schedule_referencing_nodes_for_parsing(node.unique_id)
```

## Files changed

- `core/dbt/parser/partial.py`