### PR TITLE
fix: collect all NoNodeForYamlKey errors instead of stopping at first when using --warn-error-options

### DIFF
--- a/.changes/unreleased/Fixes-20260228-221544.yaml
+++ b/.changes/unreleased/Fixes-20260228-221544.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix --warn-error-options only raising first error when multiple NoNodeForYamlKey warnings exist
+time: 2026-02-28T22:15:44.2252809Z
+custom:
+    Author: kalluripradeep
+    Issue: "12339"


### PR DESCRIPTION
Fixes #12339

## What changed

When using `--warn-error-options '{"error": ["NoNodeForYamlKey"]}'`, 
dbt was only surfacing the first missing node error and stopping. 
All subsequent patches in the YAML were never processed.

## Root cause

In `PatchParser.parse()`, `warn_or_error()` raises `EventCompilationError` 
immediately on the first missing node, exiting the loop early.

## Fix

Wrapped `self.parse_patch()` in a `try/except EventCompilationError` 
block so the loop continues, collects all errors, and raises them 
together at the end.