### PR TITLE
reorder hatch build checks

### DIFF
--- a/core/hatch.toml
+++ b/core/hatch.toml
@@ -154,6 +154,8 @@ dependencies = [
 
 [envs.build.scripts]
 check-all = [
+    # Run check-wheel-contents first, before any installation overwrites dependencies
+    "check-wheel-contents ../dist/*.whl --ignore W007,W008",
     "check-wheel",
     "check-sdist",
 ]
@@ -164,7 +166,6 @@ check-wheel = [
     "dbt --version",
 ]
 check-sdist = [
-    "check-wheel-contents ../dist/*.whl --ignore W007,W008",
     "find ../dist/dbt_core-*.gz -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=../dist/",
     "pip freeze | grep dbt-core",
     "dbt --version",


### PR DESCRIPTION
### Problem

We checked the wheel contents after trying to install it.  That doesn't make sense.

### Solution

Check wheel contents before we do anything else.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
