### PR TITLE
Add test: semantic manifest unaffected by cache config

### DIFF
--- a/tests/functional/saved_queries/test_configs.py
+++ b/tests/functional/saved_queries/test_configs.py
@@ -383,7 +383,8 @@ class TestSemanticManifestUnaffectedByCacheConfig(BaseConfigProject):
         assert isinstance(result.result, Manifest)
 
         saved_query = result.result.saved_queries["saved_query.test.test_saved_query"]
-        assert saved_query.config.cache.enabled is False
+        baseline_cache_enabled = saved_query.config.cache.enabled
+        assert baseline_cache_enabled is False
 
         # Build semantic manifest and capture the saved query representation
         sm = SemanticManifest(result.result)
@@ -414,5 +415,7 @@ class TestSemanticManifestUnaffectedByCacheConfig(BaseConfigProject):
         assert len(pydantic_sm.saved_queries) == 1
         cache_enabled_sq_dict = pydantic_sm.saved_queries[0].dict()
 
-        # The semantic manifest output should be identical regardless of cache config
+        # Sanity: the Manifest *did* change (cache flipped False → True) ...
+        assert saved_query.config.cache.enabled is not baseline_cache_enabled
+        # ... but the semantic manifest output is identical regardless
         assert baseline_sq_dict == cache_enabled_sq_dict


### PR DESCRIPTION
## Summary
- Adds a functional test (`TestSemanticManifestUnaffectedByCacheConfig`) that proves the semantic manifest output is identical regardless of `cache.enabled` status on saved queries
- The `cache` config is a dbt-core-only concern stored in `SavedQueryConfig`; it is intentionally excluded from the semantic manifest because `PydanticSavedQuery` (from `dbt-semantic-interfaces`) does not define a `config` field
- This test guards against regressions where cache config might accidentally leak into the semantic manifest

## Test plan
- [x] New test parses a saved query with default cache (`enabled=False`), builds semantic manifest, then re-parses with cache enabled via project config and rebuilds — asserts both outputs are identical
- [x] Also asserts that neither `config` nor `cache` keys appear in the serialized semantic manifest saved query dict
- [x] Test passes locally: `pytest tests/functional/saved_queries/test_configs.py::TestSemanticManifestUnaffectedByCacheConfig -v`
- [x] All pre-commit hooks pass (black, isort, flake8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)