### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260304-163132.yaml
+++ b/.changes/unreleased/Under the Hood-20260304-163132.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-03-04T16:31:32.721135081Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/0.0.110.json
+++ b/core/dbt/jsonschemas/project/0.0.110.json
@@ -1267,6 +1267,15 @@
             "null"
           ]
         },
+        "+job_execution_timeout_seconds": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "+kms_key_name": {
           "type": [
             "string",
@@ -1503,6 +1512,12 @@
           ]
         },
         "+source_alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "+sql_header": {
           "type": [
             "string",
             "null"
@@ -2364,6 +2379,15 @@
             "$ref": "#/definitions/AnyValue"
           }
         },
+        "+job_execution_timeout_seconds": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "+kms_key_name": {
           "type": [
             "string",
@@ -3194,6 +3218,14 @@
             "null"
           ]
         },
+        "+job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "+kms_key_name": {
           "type": [
             "string",
@@ -3837,6 +3869,15 @@
             "null"
           ]
         },
+        "+job_execution_timeout_seconds": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "+kms_key_name": {
           "type": [
             "string",
@@ -4455,6 +4496,15 @@
             "null"
           ]
         },
+        "+job_execution_timeout_seconds": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "+kms_key_name": {
           "type": [
             "string",
@@ -4982,6 +5032,15 @@
             "string",
             "null"
           ]
+        },
+        "+job_execution_timeout_seconds": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "+kms_key_name": {
           "type": [

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -1040,6 +1040,14 @@
             "null"
           ]
         },
+        "job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "kms_key_name": {
           "type": [
             "string",
@@ -1303,6 +1311,12 @@
           ]
         },
         "source_alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sql_header": {
           "type": [
             "string",
             "null"
@@ -2454,6 +2468,14 @@
             "string",
             "null"
           ]
+        },
+        "job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "kms_key_name": {
           "type": [
@@ -3960,6 +3982,14 @@
             "$ref": "#/definitions/AnyValue"
           }
         },
+        "job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "kms_key_name": {
           "type": [
             "string",
@@ -5456,6 +5486,14 @@
             "null"
           ]
         },
+        "job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "kms_key_name": {
           "type": [
             "string",
@@ -6220,6 +6258,14 @@
             "string",
             "null"
           ]
+        },
+        "job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "kms_key_name": {
           "type": [
@@ -6994,6 +7040,14 @@
             "string",
             "null"
           ]
+        },
+        "job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "kms_key_name": {
           "type": [
@@ -7909,6 +7963,14 @@
             "string",
             "null"
           ]
+        },
+        "job_execution_timeout_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "kms_key_name": {
           "type": [


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/0.0.110.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`078cee3db3c47d1790f43501a468cb4a53c72725`](https://github.com/dbt-labs/fs/commit/078cee3db3c47d1790f43501a468cb4a53c72725)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/22678818251)