### PR TITLE
Fix Docker build failure caused by apt-get dist-upgrade conflicting with version-pinned packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ ARG py_version=3.11.2
 FROM python:$py_version-slim-bullseye AS base
 
 RUN apt-get update \
-  && apt-get dist-upgrade -y \
+  # Install version-pinned packages for reproducible builds
   && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
     ca-certificates=20210119 \
@@ -11,7 +11,18 @@ RUN apt-get update \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \
-    # Additional dependencies for building git from source
+  # Prevent dist-upgrade from changing pinned package versions
+  && apt-mark hold \
+    build-essential \
+    ca-certificates \
+    libpq-dev \
+    make \
+    openssh-client \
+    software-properties-common \
+  # Apply security updates to non-pinned base image packages
+  && apt-get dist-upgrade -y \
+  # Install temporary dependencies for building git from source (removed later)
+  && apt-get install -y --no-install-recommends \
     wget \
     libcurl4-gnutls-dev \
     libexpat1-dev \


### PR DESCRIPTION
## Problem

The Docker release build started failing with `exit code: 100` because `apt-get dist-upgrade -y` was upgrading packages (e.g., `ca-certificates` from `20210119` to `20230311`) before `apt-get install` could install the version-pinned packages. This worked for years because the pinned versions matched what was available in the Debian bullseye repositories, but recent repository updates introduced newer package versions that `dist-upgrade` now picks up, causing the conflict.

## Solution

Split the apt package installation into two phases:
1. Install version-pinned packages first, then use `apt-mark hold` to protect them from upgrades
2. Run `dist-upgrade` to apply security updates to non-pinned base image packages
3. Install temporary build dependencies (unpinned, since they get removed after building git)

This preserves reproducible builds via version pinning while still allowing security updates for other packages.

## Testing

- Tested the Docker build locally with `docker build -f docker/Dockerfile --target dbt-core .`

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
