### PR TITLE
feat: add config.tags and +tags support for metrics

### DIFF
--- a/.changes/unreleased/Features-20260306-152125.yaml
+++ b/.changes/unreleased/Features-20260306-152125.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add tags support for metrics via config.tags in YAML or +tags in dbt_project.yml
+time: 2026-03-06T15:21:25.806855+09:00
+custom:
+    Author: dtaniwaki
+    Issue: "12607"

--- a/core/dbt/artifacts/resources/v1/metric.py
+++ b/core/dbt/artifacts/resources/v1/metric.py
@@ -1,6 +1,6 @@
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from metricflow_semantic_interfaces.references import MeasureReference, MetricReference
 from metricflow_semantic_interfaces.type_enums import (
@@ -20,7 +20,9 @@ from dbt.artifacts.resources.v1.semantic_layer_components import (
     SourceFileMetadata,
     WhereFilterIntersection,
 )
+from dbt.artifacts.resources.v1.config import list_str, metas
 from dbt_common.contracts.config.base import BaseConfig, CompareBehavior, MergeBehavior
+from dbt_common.contracts.config.metadata import ShowBehavior
 from dbt_common.dataclass_schema import dbtClassMixin
 
 """
@@ -151,8 +153,12 @@ class MetricConfig(BaseConfig):
         default=None,
         metadata=CompareBehavior.Exclude.meta(),
     )
-
     meta: Dict[str, Any] = field(default_factory=dict, metadata=MergeBehavior.Update.meta())
+
+    tags: Union[List[str], str] = field(
+        default_factory=list_str,
+        metadata=metas(ShowBehavior.Hide, MergeBehavior.Append, CompareBehavior.Exclude),
+    )
 
 
 @dataclass
@@ -177,6 +183,7 @@ class Metric(GraphResource):
 
     # These fields are only used in v1 metrics.
     meta: Dict[str, Any] = field(default_factory=dict, metadata=MergeBehavior.Update.meta())
+
     tags: List[str] = field(default_factory=list)
 
     @property

--- a/core/dbt/parser/common.py
+++ b/core/dbt/parser/common.py
@@ -57,6 +57,16 @@ resource_types_to_schema_file_keys = {
 schema_file_keys = list(schema_file_keys_to_resource_types.keys())
 
 
+def normalize_tags(*sources: Union[List[str], str, None]) -> List[str]:
+    """Return a deduplicated list of tags from all sources, preserving order."""
+    tags: List[str] = []
+    for source in sources:
+        if source is None:
+            continue
+        tags.extend([source] if isinstance(source, str) else source)
+    return list(dict.fromkeys(tags))
+
+
 def trimmed(inp: str) -> str:
     if len(inp) < 50:
         return inp

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -87,12 +87,14 @@ from dbt.contracts.graph.unparsed import (
     UnparsedSemanticModelConfig,
     UnparsedSemanticResourceConfig,
 )
+from dbt.events.types import ValidationWarning
 from dbt.exceptions import JSONValidationError, YamlParseDictError
 from dbt.node_types import NodeType
-from dbt.parser.common import YamlBlock
+from dbt.parser.common import YamlBlock, normalize_tags
 from dbt.parser.schemas import ParseResult, SchemaParser, YamlReader
 from dbt_common.dataclass_schema import ValidationError
 from dbt_common.exceptions import DbtInternalError
+from dbt_common.events.functions import warn_or_error
 
 
 def parse_where_filter(
@@ -141,10 +143,7 @@ class ExposureParser(YamlReader):
                 f"Calculated a {type(config)} for an exposure, but expected an ExposureConfig"
             )
 
-        # Null tags caught during deserialization, but guard here defensively.
-        tags = sorted(
-            set((self.project.exposures.get("tags") or []) + unparsed.tags + config.tags)
-        )
+        tags = normalize_tags(self.project.exposures.get("tags"), unparsed.tags, config.tags)
         meta = {**self.project.exposures.get("meta", {}), **unparsed.meta, **config.meta}
 
         config.tags = tags
@@ -542,6 +541,8 @@ class MetricParser(YamlReader):
             rendered=True,
         )
 
+        config.tags = normalize_tags(config.tags)
+
         config = config.finalize_and_validate()
 
         unrendered_config = self._generate_metric_config(
@@ -562,12 +563,21 @@ class MetricParser(YamlReader):
             if "meta" in config and config["meta"]:
                 unparsed.meta = config["meta"]
             meta = unparsed.meta
-            tags = unparsed.tags
+            if unparsed.tags:
+                # Top-level tags on v1 metrics are ignored; use config.tags instead.
+                warn_or_error(
+                    ValidationWarning(
+                        field_name=(
+                            "top-level `tags:` (ignored; use `config.tags` in YAML "
+                            "or `+tags` in dbt_project.yml instead)"
+                        ),
+                        resource_type="metric (v1)",
+                        node_name=unparsed.name,
+                    )
+                )
         elif isinstance(unparsed, UnparsedMetricV2):
-            # V2 Metrics do not have a top-level meta field; this should be part of
-            # the config.
+            # V2 Metrics do not have a top-level meta or tags field; use config only.
             meta = {}
-            tags = []
         else:
             raise DbtInternalError(
                 f"Tried to parse a {type(unparsed)} into a metric, but expected "
@@ -593,7 +603,7 @@ class MetricParser(YamlReader):
             time_granularity=unparsed.time_granularity,
             filter=parse_where_filter(unparsed.filter),
             meta=meta,
-            tags=tags,
+            tags=config.tags,
             config=config,
             unrendered_config=unrendered_config,
             group=config.group,
@@ -1295,17 +1305,7 @@ class SavedQueryParser(YamlReader):
             rendered=False,
         )
 
-        # The parser handles plain strings just fine, but we need to be able
-        # to join two lists, remove duplicates, and sort, so we have to wrap things here.
-        def wrap_tags(s: Union[List[str], str]) -> List[str]:
-            if s is None:
-                return []
-            return [s] if isinstance(s, str) else s
-
-        config_tags = wrap_tags(config.get("tags"))
-        unparsed_tags = wrap_tags(unparsed.tags)
-        tags = list(set([*unparsed_tags, *config_tags]))
-        tags.sort()
+        tags = normalize_tags(unparsed.tags, config.get("tags"))
 
         parsed = SavedQuery(
             description=unparsed.description,

--- a/tests/functional/metrics/fixtures.py
+++ b/tests/functional/metrics/fixtures.py
@@ -114,6 +114,88 @@ models:
         granularity: day
 """
 
+models_people_metrics_shared_tag_yml = """
+version: 2
+
+metrics:
+
+  - name: number_of_people
+    label: "Number of people"
+    description: Total count of people
+    type: simple
+    type_params:
+      measure: people
+    time_granularity: month
+    config:
+      tags:
+        - shared_tag
+
+"""
+
+models_people_metrics_top_level_tags_yml = """
+version: 2
+
+metrics:
+
+  - name: number_of_people
+    label: "Number of people"
+    description: Total count of people
+    type: simple
+    type_params:
+      measure: people
+    time_granularity: month
+    tags:
+      - top_level_tag
+
+"""
+
+models_people_metrics_tags_yml = """
+version: 2
+
+metrics:
+
+  - name: number_of_people
+    label: "Number of people"
+    description: Total count of people
+    type: simple
+    type_params:
+      measure: people
+    time_granularity: month
+    config:
+      tags:
+        - yaml_tag
+
+  - name: collective_tenure
+    label: "Collective tenure"
+    description: Total number of years of team experience
+    type: simple
+    type_params:
+      measure:
+        name: years_tenure
+        filter: "{{ Dimension('id__loves_dbt') }} is true"
+        join_to_timespine: true
+        fill_nulls_with: 0
+
+  - name: average_tenure
+    label: Average Tenure
+    description: The average tenure of our people
+    type: ratio
+    type_params:
+      numerator: collective_tenure
+      denominator: number_of_people
+
+  - name: average_tenure_minus_people
+    label: Average Tenure minus People
+    description: Well this isn't really useful is it?
+    type: derived
+    type_params:
+      expr: average_tenure - number_of_people
+      metrics:
+        - average_tenure
+        - number_of_people
+
+"""
+
 models_people_metrics_yml = """
 version: 2
 

--- a/tests/functional/metrics/test_metric_configs.py
+++ b/tests/functional/metrics/test_metric_configs.py
@@ -1,9 +1,11 @@
 import pytest
 
 from dbt.artifacts.resources import MetricConfig
+from dbt.events.types import ValidationWarning
 from dbt.exceptions import CompilationError, ParsingError
 from dbt.tests.util import get_manifest, run_dbt, update_config_file
 from dbt_common.dataclass_schema import ValidationError
+from dbt_common.events.event_catcher import EventCatcher
 from tests.functional.metrics.fixtures import (
     disabled_metric_level_schema_yml,
     enabled_metric_level_schema_yml,
@@ -12,6 +14,9 @@ from tests.functional.metrics.fixtures import (
     metricflow_time_spine_yml,
     models_people_metrics_meta_top_yml,
     models_people_metrics_sql,
+    models_people_metrics_shared_tag_yml,
+    models_people_metrics_tags_yml,
+    models_people_metrics_top_level_tags_yml,
     models_people_metrics_yml,
     models_people_sql,
     semantic_model_people_yml,
@@ -297,3 +302,159 @@ class TestMetricMetaTopLevel(MetricConfigTests):
             "my_meta_top": "top"
         }
         assert manifest.metrics.get("metric.test.number_of_people").meta == {"my_meta_top": "top"}
+
+
+# Test tags config in dbt_project.yml
+class TestMetricTagsConfigProjectLevel(MetricConfigTests):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people.sql": models_people_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "semantic_model_people.yml": semantic_model_people_yml,
+            "schema.yml": models_people_metrics_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "metrics": {
+                "test": {
+                    "+tags": ["project_tag"],
+                }
+            }
+        }
+
+    def test_tags_metric_config_dbt_project(self, project):
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        for metric_id in [
+            "metric.test.number_of_people",
+            "metric.test.collective_tenure",
+            "metric.test.average_tenure",
+            "metric.test.average_tenure_minus_people",
+        ]:
+            metric = manifest.metrics.get(metric_id)
+            assert metric is not None, f"{metric_id} not found in manifest"
+            assert isinstance(metric.tags, list), f"{metric_id}.tags should be a list"
+            assert "project_tag" in metric.tags, f"{metric_id} missing project_tag in tags"
+            assert "project_tag" in metric.config.tags, f"{metric_id} missing project_tag in config.tags"
+
+
+# Test tags config in yaml config block
+class TestMetricTagsConfigYamlLevel(MetricConfigTests):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people.sql": models_people_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "semantic_model_people.yml": semantic_model_people_yml,
+            "schema.yml": models_people_metrics_tags_yml,
+        }
+
+    def test_tags_metric_config_yaml(self, project):
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        metric = manifest.metrics.get("metric.test.number_of_people")
+        assert metric is not None
+        assert isinstance(metric.tags, list)
+        assert metric.tags == ["yaml_tag"]
+        assert metric.config.tags == ["yaml_tag"]
+
+
+# Test tags merging from both dbt_project.yml and yaml config block
+class TestMetricTagsConfigMerge(MetricConfigTests):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people.sql": models_people_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "semantic_model_people.yml": semantic_model_people_yml,
+            "schema.yml": models_people_metrics_tags_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "metrics": {
+                "test": {
+                    "+tags": ["project_tag"],
+                }
+            }
+        }
+
+    def test_tags_merge(self, project):
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        metric = manifest.metrics.get("metric.test.number_of_people")
+        assert metric is not None
+        assert isinstance(metric.tags, list)
+        assert "project_tag" in metric.tags
+        assert "yaml_tag" in metric.tags
+        assert "project_tag" in metric.config.tags
+        assert "yaml_tag" in metric.config.tags
+
+    def test_tags_deduplicated(self, project):
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        metric = manifest.metrics.get("metric.test.number_of_people")
+        assert metric is not None
+        assert len(metric.tags) == len(set(metric.tags)), "Duplicate tags found in metric.tags"
+        assert len(metric.config.tags) == len(set(metric.config.tags))
+
+
+# Test that when the same tag appears in both +tags (dbt_project.yml) and config.tags (YAML),
+# it appears only once after normalization.
+class TestMetricTagsConfigDeduplication(MetricConfigTests):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people.sql": models_people_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "semantic_model_people.yml": semantic_model_people_yml,
+            "schema.yml": models_people_metrics_shared_tag_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "metrics": {
+                "test": {
+                    "+tags": ["shared_tag"],
+                }
+            }
+        }
+
+    def test_same_tag_deduplicated(self, project):
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        metric = manifest.metrics.get("metric.test.number_of_people")
+        assert metric is not None
+        assert metric.tags == ["shared_tag"], f"Expected ['shared_tag'], got {metric.tags}"
+        assert metric.config.tags == ["shared_tag"]
+
+
+class TestMetricTopLevelTagsWarning(MetricConfigTests):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people.sql": models_people_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "semantic_model_people.yml": semantic_model_people_yml,
+            "schema.yml": models_people_metrics_top_level_tags_yml,
+        }
+
+    def test_top_level_tags_emits_warning_and_tags_are_ignored(self, project):
+        catcher = EventCatcher(event_to_catch=ValidationWarning)
+        run_dbt(["parse"], callbacks=[catcher.catch])
+        manifest = get_manifest(project.project_root)
+        metric = manifest.metrics.get("metric.test.number_of_people")
+        assert metric is not None
+        assert "top_level_tag" not in metric.tags
+        assert "top_level_tag" not in metric.config.tags
+        assert len(catcher.caught_events) >= 1
+        warning_messages = [str(e.data) for e in catcher.caught_events]
+        assert any(
+            "top-level" in msg and "number_of_people" in msg and "ignored" in msg
+            for msg in warning_messages
+        )

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -878,6 +878,19 @@ schema_yml_v2_simple_metric_on_model_1 = """
         conversion_metric: simple_metric_2
 """
 
+schema_yml_v2_metric_with_config_tags = """
+    metrics:
+      - name: simple_metric_with_tag
+        description: A simple V2 metric with config.tags.
+        label: Simple Metric With Tag
+        type: simple
+        agg: count
+        expr: id
+        config:
+          tags:
+            - v2_yaml_tag
+"""
+
 schema_yml_v2_metrics_with_hidden = """
     metrics:
       - name: public_metric

--- a/tests/functional/semantic_models/test_semantic_model_configs.py
+++ b/tests/functional/semantic_models/test_semantic_model_configs.py
@@ -14,6 +14,9 @@ from tests.functional.semantic_models.fixtures import (
     semantic_model_dimensions_entities_measures_meta_config,
     semantic_model_meta_clobbering_yml,
     semantic_model_people_yml,
+    base_schema_yml_v2,
+    fct_revenue_sql,
+    schema_yml_v2_metric_with_config_tags,
 )
 
 
@@ -313,3 +316,23 @@ class TestMetaConfigClobbering:
             "model_level": "should_be_inherited",
             "component_level": "should_be_overridden",
         }
+
+
+class TestV2MetricTagsConfig:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "schema.yml": base_schema_yml_v2 + schema_yml_v2_metric_with_config_tags,
+        }
+
+    def test_v2_metric_config_tags(self, project):
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        metric = manifest.metrics.get("metric.test.simple_metric_with_tag")
+        assert metric is not None, "V2 metric 'simple_metric_with_tag' not found in manifest"
+        assert isinstance(metric.tags, list)
+        assert metric.tags == ["v2_yaml_tag"], f"Expected ['v2_yaml_tag'], got {metric.tags}"
+        assert metric.config.tags == ["v2_yaml_tag"]
+

--- a/tests/unit/parser/test_normalize_tags.py
+++ b/tests/unit/parser/test_normalize_tags.py
@@ -1,0 +1,50 @@
+from dbt.parser.common import normalize_tags
+
+
+def test_normalize_tags_none():
+    assert normalize_tags(None) == []
+
+
+def test_normalize_tags_empty_list():
+    assert normalize_tags([]) == []
+
+
+def test_normalize_tags_string():
+    assert normalize_tags("single") == ["single"]
+
+
+def test_normalize_tags_preserves_order():
+    assert normalize_tags(["b", "a", "c"]) == ["b", "a", "c"]
+
+
+def test_normalize_tags_deduplication():
+    assert normalize_tags(["a", "a", "b"]) == ["a", "b"]
+
+
+def test_normalize_tags_dedup_preserves_first_occurrence():
+    assert normalize_tags(["z", "a", "z", "b"]) == ["z", "a", "b"]
+
+
+def test_normalize_tags_single_item_list():
+    assert normalize_tags(["only"]) == ["only"]
+
+
+def test_normalize_tags_empty_string():
+    assert normalize_tags("") == [""]
+    assert normalize_tags([""]) == [""]
+
+
+def test_normalize_tags_no_sources():
+    assert normalize_tags() == []
+
+
+def test_normalize_tags_multiple_sources():
+    assert normalize_tags(["a"], ["b", "c"]) == ["a", "b", "c"]
+
+
+def test_normalize_tags_multiple_sources_with_string_and_none():
+    assert normalize_tags("project_tag", None, ["yaml_tag"]) == ["project_tag", "yaml_tag"]
+
+
+def test_normalize_tags_multiple_sources_dedup_across():
+    assert normalize_tags(["shared"], "shared") == ["shared"]


### PR DESCRIPTION
Resolves #12607

### Problem

Metrics do not support `config.tags` in YAML or `+tags` in `dbt_project.yml`. There is no way to apply tags to metrics through the standard config system, making it inconsistent with other resource types.

Additionally, v1 metrics had a top-level `tags:` field that was silently applied to the node outside of the config system, which is inconsistent with how other resource types handle tags.

### Solution

Add `tags` to `MetricConfig` using `MergeBehavior.Append`, so tags from `dbt_project.yml` (`+tags`) and from `config.tags` in YAML are merged and deduplicated while preserving order.

**YAML config block:**
```yaml
metrics:
  - name: my_metric
    ...
    config:
      tags:
        - finance
```

**`dbt_project.yml`:**
```yaml
metrics:
  my_project:
    +tags:
      - finance
```

Top-level `tags:` on v1 metrics (outside of a `config:` block) now emit a `ValidationWarning` directing users to use `config.tags` instead, since metrics implement tags via the config system only.

A `normalize_tags()` helper is introduced in `parser/common.py` to deduplicate tags while preserving order, and is reused across `ExposureParser`, `MetricParser`, and `SavedQueryParser`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
