### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260306-182611.yaml
+++ b/.changes/unreleased/Under the Hood-20260306-182611.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-03-06T18:26:11.89001132Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/0.0.110.json
+++ b/core/dbt/jsonschemas/project/0.0.110.json
@@ -1517,6 +1517,12 @@
             "null"
           ]
         },
+        "+sql_header": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+static_analysis": {
           "anyOf": [
             {

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -1316,6 +1316,12 @@
             "null"
           ]
         },
+        "sql_header": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "static_analysis": {
           "anyOf": [
             {
@@ -8386,6 +8392,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "deprecation_date": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "v": {


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/0.0.110.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`b0833ea2185cb6760475502a50c5c96ba5990678`](https://github.com/dbt-labs/fs/commit/b0833ea2185cb6760475502a50c5c96ba5990678)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/22776463950)