### PR TITLE
Allow catalogs in any schema yml file

### DIFF
--- a/.changes/unreleased/Fixes-20260309-184158.yaml
+++ b/.changes/unreleased/Fixes-20260309-184158.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Allow `catalogs` definitions in any schema YAML file, not only `catalogs.yml`
+time: 2026-03-09T18:41:58+01:00
+custom:
+  Author: ankit-khare-2015
+  Issue: "11707"

--- a/License.md
+++ b/License.md
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -385,7 +385,9 @@ def catalogs(func):
         flags = ctx.obj["flags"]
         ctx_project = ctx.obj["project"]
 
-        _catalogs = load_catalogs(flags.PROJECT_DIR, ctx_project.project_name, flags.VARS)
+        _catalogs = load_catalogs(
+            flags.PROJECT_DIR, ctx_project.project_name, ctx_project.all_source_paths, flags.VARS
+        )
         ctx.obj["catalogs"] = _catalogs
 
         return func(*args, **kwargs)

--- a/core/dbt/config/catalogs.py
+++ b/core/dbt/config/catalogs.py
@@ -11,9 +11,7 @@ from dbt_common.clients.system import load_file_contents
 from dbt_common.exceptions import CompilationError, DbtValidationError
 
 
-def load_catalogs_yml(project_dir: str, project_name: str) -> Dict[str, Any]:
-    path = os.path.join(project_dir, CATALOGS_FILE_NAME)
-
+def load_catalogs_yml(path: str, project_name: str, relative_path: str) -> Dict[str, Any]:
     if os.path.isfile(path):
         try:
             contents = load_file_contents(path, strip=False)
@@ -24,9 +22,55 @@ def load_catalogs_yml(project_dir: str, project_name: str) -> Dict[str, Any]:
 
             return yaml_content
         except DbtValidationError as e:
-            raise YamlLoadError(project_name=project_name, path=CATALOGS_FILE_NAME, exc=e)
+            raise YamlLoadError(project_name=project_name, path=relative_path, exc=e)
 
     return {}
+
+
+def load_catalogs_from_schema_yml(
+    path: str, project_name: str, relative_path: str
+) -> List[Dict[str, Any]]:
+    if not os.path.isfile(path):
+        return []
+
+    try:
+        contents = load_file_contents(path, strip=False)
+        yaml_content = load_yaml_text(contents)
+    except DbtValidationError as e:
+        raise YamlLoadError(project_name=project_name, path=relative_path, exc=e)
+
+    if not yaml_content:
+        return []
+
+    if not isinstance(yaml_content, dict):
+        raise YamlLoadError(
+            project_name=project_name,
+            path=relative_path,
+            exc=DbtValidationError(
+                f"Contents of file '{relative_path}' are not valid. Dictionary expected."
+            ),
+        )
+
+    return yaml_content.get("catalogs", [])
+
+
+def _schema_yml_paths(project_dir: str, source_paths: List[str]) -> List[str]:
+    schema_paths = set()
+
+    for source_path in source_paths:
+        absolute_source_path = os.path.join(project_dir, source_path)
+        if not os.path.isdir(absolute_source_path):
+            continue
+
+        for root, _, files in os.walk(absolute_source_path):
+            for file_name in files:
+                if not file_name.endswith((".yml", ".yaml")):
+                    continue
+
+                absolute_path = os.path.join(root, file_name)
+                schema_paths.add(os.path.relpath(absolute_path, project_dir))
+
+    return sorted(schema_paths)
 
 
 def load_single_catalog(raw_catalog: Dict[str, Any], renderer: SecretRenderer) -> Catalog:
@@ -76,8 +120,20 @@ def load_single_catalog(raw_catalog: Dict[str, Any], renderer: SecretRenderer) -
     )
 
 
-def load_catalogs(project_dir: str, project_name: str, cli_vars: Dict[str, Any]) -> List[Catalog]:
-    raw_catalogs = load_catalogs_yml(project_dir, project_name).get("catalogs", [])
+def load_catalogs(
+    project_dir: str, project_name: str, source_paths: List[str], cli_vars: Dict[str, Any]
+) -> List[Catalog]:
+    raw_catalogs = load_catalogs_yml(
+        os.path.join(project_dir, CATALOGS_FILE_NAME), project_name, CATALOGS_FILE_NAME
+    ).get("catalogs", [])
+
+    for relative_path in _schema_yml_paths(project_dir, source_paths):
+        raw_catalogs.extend(
+            load_catalogs_from_schema_yml(
+                os.path.join(project_dir, relative_path), project_name, relative_path
+            )
+        )
+
     catalogs_renderer = SecretRenderer(cli_vars)
 
     return [load_single_catalog(raw_catalog, catalogs_renderer) for raw_catalog in raw_catalogs]

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -21,6 +21,15 @@
         "$ref": "#/definitions/AnyValue"
       }
     },
+    "catalogs": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/AnyValue"
+      }
+    },
     "data_tests": {
       "type": [
         "array",

--- a/tests/functional/catalogs/test_catalogs_parsing.py
+++ b/tests/functional/catalogs/test_catalogs_parsing.py
@@ -159,3 +159,34 @@ class TestDuplicateWriteIntegration:
             error_msg = "Catalog 'write_catalog' cannot have multiple 'write_integrations' with the same name: 'write_integration_1'."
             with pytest.raises(DbtValidationError, match=error_msg):
                 run_dbt(["run"])
+
+
+class TestCatalogsInSchemaYml:
+    @pytest.fixture
+    def schema_yml(self):
+        return {
+            "version": 2,
+            "catalogs": [
+                {"name": "write_catalog_1", "write_integrations": [write_integration_1]},
+                {"name": "write_catalog_2", "write_integrations": [write_integration_2]},
+            ],
+        }
+
+    def test_integration(self, project, schema_yml, adapter):
+        write_config_file(schema_yml, project.project_root, "models", "schema.yml")
+
+        with mock.patch.object(
+            type(project.adapter), "CATALOG_INTEGRATIONS", [WriteCatalogIntegration]
+        ):
+            run_dbt(["run"])
+
+            for i in range(1, 3):
+                write_integration = project.adapter.get_catalog_integration(f"write_catalog_{i}")
+                assert isinstance(write_integration, WriteCatalogIntegration)
+                assert write_integration.name == f"write_catalog_{i}"
+                assert write_integration.catalog_type == "write"
+                assert write_integration.catalog_name == f"write_integration_{i}"
+                assert write_integration.table_format == "write_format"
+                assert write_integration.external_volume == "write_external_volume"
+                assert write_integration.allows_writes is True
+                assert write_integration.my_custom_property == f"foo_{i}"

--- a/tests/unit/config/test_catalogs.py
+++ b/tests/unit/config/test_catalogs.py
@@ -1,0 +1,57 @@
+from dbt.config.catalogs import load_catalogs
+from dbt.tests.util import write_config_file
+
+write_integration_1 = {
+    "name": "write_integration_1",
+    "external_volume": "write_external_volume",
+    "table_format": "write_format",
+    "catalog_type": "write",
+    "adapter_properties": {"my_custom_property": "foo_1"},
+}
+
+write_integration_2 = {
+    "name": "write_integration_2",
+    "external_volume": "write_external_volume",
+    "table_format": "write_format",
+    "catalog_type": "write",
+    "adapter_properties": {"my_custom_property": "foo_2"},
+}
+
+
+def test_load_catalogs_from_schema_yml(tmp_path):
+    (tmp_path / "models").mkdir()
+    write_config_file(
+        {
+            "version": 2,
+            "catalogs": [{"name": "schema_catalog", "write_integrations": [write_integration_1]}],
+        },
+        tmp_path,
+        "models",
+        "schema.yml",
+    )
+
+    catalogs = load_catalogs(str(tmp_path), "test", ["models"], {})
+
+    assert [catalog.name for catalog in catalogs] == ["schema_catalog"]
+
+
+def test_load_catalogs_combines_root_and_schema_yml_files(tmp_path):
+    (tmp_path / "models").mkdir()
+    write_config_file(
+        {"catalogs": [{"name": "root_catalog", "write_integrations": [write_integration_1]}]},
+        tmp_path,
+        "catalogs.yml",
+    )
+    write_config_file(
+        {
+            "version": 2,
+            "catalogs": [{"name": "schema_catalog", "write_integrations": [write_integration_2]}],
+        },
+        tmp_path,
+        "models",
+        "schema.yml",
+    )
+
+    catalogs = load_catalogs(str(tmp_path), "test", ["models"], {})
+
+    assert [catalog.name for catalog in catalogs] == ["root_catalog", "schema_catalog"]


### PR DESCRIPTION
Resolves #11707

### Problem

Catalog definitions are currently loaded only from a dedicated root-level `catalogs.yml` file.  
This prevents users from defining `catalogs` in regular schema YAML files (for example, `models/schema.yml`), unlike `groups`, which can be defined in any schema YAML file.

### Solution

This PR updates catalog loading so `catalogs` can be defined in any schema YAML file under project source paths, while preserving support for root `catalogs.yml`.

Changes included:

- Updated catalog loading logic in `core/dbt/config/catalogs.py`:
  - Continue reading root `catalogs.yml` if present
  - Also scan schema YAML files under project source paths (`all_source_paths`)
  - Merge all discovered top-level `catalogs:` entries
- Updated CLI integration in `core/dbt/cli/requires.py`:
  - Pass `ctx_project.all_source_paths` into `load_catalogs(...)` so runtime commands load catalogs from schema YAML files
- Updated schema validation in `core/dbt/jsonschemas/resources/latest.json`:
  - Added `catalogs` as a valid top-level key for resource YAML schema validation
- Added tests:
  - `tests/unit/config/test_catalogs.py` (new): verifies loading from schema YAML and merge behavior with root `catalogs.yml`
  - `tests/functional/catalogs/test_catalogs_parsing.py`: adds end-to-end regression proving catalogs from `models/schema.yml` are loaded and applied

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
