### PR TITLE
fix: re-run macro argument validation after partial parse reuse (#12574)

### DIFF
--- a/.changes/unreleased/Fixes-20260308-154406.yaml
+++ b/.changes/unreleased/Fixes-20260308-154406.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Re-run macro argument validation warnings after partial parse reuse so that mismatched macro arguments in YAML are always reported
+time: 2026-03-08T15:44:06.4181157Z
+custom:
+    Author: kalluripradeep
+    Issue: "12574"

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -117,7 +117,7 @@ from dbt.parser.read_files import (
     ReadFilesFromFileSystem,
     load_source_file,
 )
-from dbt.parser.schemas import SchemaParser
+from dbt.parser.schemas import SchemaParser, validate_macro_arguments
 from dbt.parser.search import FileBlock
 from dbt.parser.seeds import SeedParser
 from dbt.parser.singular_test import SingularTestParser
@@ -531,7 +531,75 @@ class ManifestLoader:
         self.check_function_default_arguments_ordering()
 
         return self.manifest
+    def _revalidate_macro_arguments(self) -> None:
+        """Re-run macro argument validation on cached macros after partial parse reuse.
 
+        When partial parsing skips all parsing (nothing changed), macros are reused
+        from the saved manifest without going through parse_patch, so argument
+        validation must be re-run explicitly here.
+
+        We re-extract Jinja arguments from macro_sql and compare against the YAML
+        arguments stored in the schema file's dict_from_yaml, mirroring what
+        MacroParser and MacroPatchParser do during a full parse.
+        """
+        import jinja2
+        from dbt.artifacts.resources import MacroArgument
+        from dbt.contracts.files import SchemaSourceFile
+        from dbt.contracts.graph.nodes import ParsedMacroPatch
+        from dbt_common.clients import jinja as jinja_client
+        
+
+        for macro in self.manifest.macros.values():
+            if not macro.patch_path:
+                continue
+
+            # Re-extract Jinja arguments from macro_sql
+            try:
+                ast = jinja_client.parse(macro.macro_sql)
+                macro_nodes = list(ast.find_all(jinja2.nodes.Macro))
+                if len(macro_nodes) != 1:
+                    continue
+                jinja_macro = macro_nodes[0]
+                jinja_args = [MacroArgument(name=arg.name) for arg in jinja_macro.args]
+            except Exception:
+                continue
+
+            # Get YAML arguments from the schema file
+            file_id = macro.patch_path
+            if file_id not in self.manifest.files:
+                continue
+            schema_file = self.manifest.files[file_id]
+            if not isinstance(schema_file, SchemaSourceFile):
+                continue
+            macro_dicts = schema_file.dict_from_yaml.get("macros", [])
+            yaml_macro = next((m for m in macro_dicts if m.get("name") == macro.name), None)
+            if not yaml_macro:
+                continue
+            yaml_arguments = yaml_macro.get("arguments", [])
+            if not yaml_arguments:
+                continue
+            patch_args = [
+                MacroArgument(name=a["name"], type=a.get("type"), description=a.get("description", ""))
+                for a in yaml_arguments
+            ]
+
+            # Build a temporary macro object with Jinja args for comparison
+            from copy import copy
+            jinja_macro_node = copy(macro)
+            jinja_macro_node.arguments = jinja_args
+
+            patch = ParsedMacroPatch(
+                name=macro.name,
+                original_file_path=macro.original_file_path,
+                yaml_key="macros",
+                package_name=macro.package_name,
+                arguments=patch_args,
+                description="",
+                meta={},
+                docs=macro.docs,
+                config=macro.config if hasattr(macro, "config") else {},
+            )
+            validate_macro_arguments(jinja_macro_node, patch)
     def safe_update_project_parser_files_partially(self, project_parser_files: Dict) -> Dict:
         if self.saved_manifest is None:
             return project_parser_files
@@ -544,6 +612,8 @@ class ManifestLoader:
                 Note(msg="Nothing changed, skipping partial parsing."), level=EventLevel.DEBUG
             )
             self.manifest = self.saved_manifest  # type: ignore[assignment]
+            if getattr(get_flags(), "validate_macro_args", False):
+                self._revalidate_macro_arguments()
         else:
             # create child_map and parent_map
             self.saved_manifest.build_parent_and_child_maps()  # type: ignore[union-attr]

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -1355,7 +1355,45 @@ class FunctionPatchParser(NodePatchParser[UnparsedFunctionUpdate]):
             returns=target.returns,
         )
 
+def validate_macro_arguments(macro: Macro, patch: ParsedMacroPatch) -> None:
+    """Validate macro arguments from YAML match the Jinja definition.
 
+    Extracted as a standalone function so it can be called both during full
+    parsing and after partial parsing reuses a cached manifest, ensuring the
+    warning is always emitted when arguments are mismatched.
+    """
+    if not patch.arguments:
+        return
+    for macro_arg, patch_arg in zip(macro.arguments, patch.arguments):
+        if patch_arg.name != macro_arg.name:
+            msg = f"Argument {patch_arg.name} in yaml for macro {macro.name} does not match the jinja definition."
+            warn_or_error(
+                InvalidMacroAnnotation(
+                    msg=msg,
+                    macro_unique_id=macro.unique_id,
+                    macro_file_path=macro.original_file_path,
+                )
+            )
+    if len(patch.arguments) != len(macro.arguments):
+        msg = f"The number of arguments in the yaml for macro {macro.name} does not match the jinja definition."
+        warn_or_error(
+            InvalidMacroAnnotation(
+                msg=msg,
+                macro_unique_id=macro.unique_id,
+                macro_file_path=macro.original_file_path,
+            )
+        )
+    for patch_arg in patch.arguments:
+        arg_type = patch_arg.type
+        if arg_type is not None and arg_type.strip() != "" and not is_valid_type(arg_type):
+            msg = f"Argument {patch_arg.name} in the yaml for macro {macro.name} has an invalid type."
+            warn_or_error(
+                InvalidMacroAnnotation(
+                    msg=msg,
+                    macro_unique_id=macro.unique_id,
+                    macro_file_path=macro.original_file_path,
+                )
+            )
 class MacroPatchParser(PatchParser[UnparsedMacroUpdate, ParsedMacroPatch]):
     def get_block(self, node: UnparsedMacroUpdate) -> TargetBlock:
         return TargetBlock.from_yaml_block(self.yaml, node)
@@ -1402,30 +1440,7 @@ class MacroPatchParser(PatchParser[UnparsedMacroUpdate, ParsedMacroPatch]):
             macro.arguments = patch.arguments
 
     def _check_patch_arguments(self, macro: Macro, patch: ParsedMacroPatch) -> None:
-        if not patch.arguments:
-            return
-
-        for macro_arg, patch_arg in zip(macro.arguments, patch.arguments):
-            if patch_arg.name != macro_arg.name:
-                msg = f"Argument {patch_arg.name} in yaml for macro {macro.name} does not match the jinja definition."
-                self._fire_macro_arg_warning(msg, macro)
-
-        if len(patch.arguments) != len(macro.arguments):
-            msg = f"The number of arguments in the yaml for macro {macro.name} does not match the jinja definition."
-            self._fire_macro_arg_warning(msg, macro)
-
-        for patch_arg in patch.arguments:
-            arg_type = patch_arg.type
-            if arg_type is not None and arg_type.strip() != "" and not is_valid_type(arg_type):
-                msg = f"Argument {patch_arg.name} in the yaml for macro {macro.name} has an invalid type."
-                self._fire_macro_arg_warning(msg, macro)
-
-    def _fire_macro_arg_warning(self, msg: str, macro: Macro) -> None:
-        warn_or_error(
-            InvalidMacroAnnotation(
-                msg=msg, macro_unique_id=macro.unique_id, macro_file_path=macro.original_file_path
-            )
-        )
+        validate_macro_arguments(macro, patch)
 
 
 # valid type names, along with the number of parameters they require

--- a/tests/functional/macros/test_macro_annotations.py
+++ b/tests/functional/macros/test_macro_annotations.py
@@ -119,3 +119,37 @@ class TestMacroNonEnforcement:
         event_catcher = EventCatcher(event_to_catch=InvalidMacroAnnotation)
         run_dbt(["parse"], callbacks=[event_catcher.catch])
         assert len(event_catcher.caught_events) == 0
+
+
+class TestMacroArgValidationAfterPartialParse:
+    """Regression test for partial parse bug where macro argument validation
+    warnings were silenced on the second run of dbt parse (skip_parsing=True)."""
+
+    @pytest.fixture(scope="class")
+    def dbt_profile_target(self):
+        return {"type": "duckdb", "threads": 1, "path": ":memory:"}
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"macros.sql": macros_sql, "macros.yml": bad_arg_count_macros_yml}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"validate_macro_args": True}}
+
+    def test_warning_persists_after_partial_parse(self, project) -> None:
+        # First parse — full parse, warning should fire
+        event_catcher = EventCatcher(event_to_catch=InvalidMacroAnnotation)
+        run_dbt(["parse"], callbacks=[event_catcher.catch])
+        assert len(event_catcher.caught_events) >= 1, (
+            "Expected warning on first parse but got none"
+        )
+
+        # Second parse — partial parse with nothing changed (skip_parsing=True)
+        # Bug: warning was silently dropped here
+        event_catcher2 = EventCatcher(event_to_catch=InvalidMacroAnnotation)
+        run_dbt(["parse"], callbacks=[event_catcher2.catch])
+        assert len(event_catcher2.caught_events) >= 1, (
+            "Expected warning on second parse (partial) but got none — "
+            "macro argument validation was skipped during partial parse reuse"
+        )


### PR DESCRIPTION
## Problem

Fixes #12574

When `dbt parse` is run a second time without any file changes, partial parsing determines nothing has changed (`skip_parsing=True`) and reuses the saved manifest as-is. In this path, `MacroPatchParser.parse_patch` is never called, so `_check_patch_arguments` is never triggered — causing macro argument mismatch warnings to silently disappear on all subsequent runs.

## Root Cause

`_check_patch_arguments` was only reachable through `parse_patch`, which is skipped entirely during `skip_parsing` partial parse reuse. There was no mechanism to re-run validation against the cached manifest.

## Fix

1. **Extracted** validation logic from `MacroPatchParser._check_patch_arguments` into a standalone module-level function `validate_macro_arguments()` in `schemas.py`, so it can be called from multiple call sites.

2. **Added** `ManifestLoader._revalidate_macro_arguments()` in `manifest.py`, which runs after `self.manifest = self.saved_manifest` when `validate_macro_args` is enabled. It re-extracts Jinja arguments directly from `macro_sql` and compares them against the YAML arguments stored in the schema file's `dict_from_yaml`, mirroring what `MacroParser` and `MacroPatchParser` do during a full parse.

## Test

Added `TestMacroArgValidationAfterPartialParse` to `tests/functional/macros/test_macro_annotations.py` which:
- Runs `dbt parse` once (full parse) and asserts the warning fires 
- Runs `dbt parse` again with no changes (partial parse, `skip_parsing=True`) and asserts the warning still fires 

This is the exact repro case from the issue.