### PR TITLE
Fix flaky TestModelContractNumericNoPrecision test by excluding DeprecationsSummary from warn-error

### DIFF
--- a/tests/functional/contracts/test_contract_precision.py
+++ b/tests/functional/contracts/test_contract_precision.py
@@ -44,7 +44,10 @@ class TestModelContractNumericNoPrecision:
         expected_msg = "Detected columns with numeric type and unspecified precision/scale, this can lead to unintended rounding: ['non_integer']"
         _, logs = run_dbt_and_capture(["run"], expect_pass=True)
         assert expected_msg in logs
-        _, logs = run_dbt_and_capture(["--warn-error", "run"], expect_pass=False)
+        _, logs = run_dbt_and_capture(
+            ["--warn-error-options", "{'error': 'all', 'warn': ['DeprecationsSummary']}", "run"],
+            expect_pass=False,
+        )
         assert "Compilation Error in model my_numeric_model" in logs
         assert expected_msg in logs
 


### PR DESCRIPTION
Resolves #N/A

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->                                                                                                                                                       
  The test uses --warn-error with expect_pass=False, expecting dbt to fail on a numeric precision warning. Occasionally, a DeprecationsSummary warning fires and gets promoted to an error by     
  --warn-error. This sets res.exception in run_dbt, which is raised immediately (line 103-104 of core/dbt/tests/util.py) before the expect_pass check (line 107) is ever evaluated. The test fails
   with an unhandled exception even though expect_pass=False should accommodate the failure.    

Noticed in: https://github.com/dbt-labs/dbt-core/pull/12602, https://github.com/dbt-labs/dbt-common/actions/runs/22868691437/job/66342409837


### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

  - Replace bare --warn-error with --warn-error-options "{'error': 'all', 'warn': ['DeprecationsSummary']}" so that an unrelated DeprecationsSummary warning doesn't become the error instead of
  the expected Compilation Error

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
