### PR TITLE
Pre-release model versions should warn (not error) on contract breaking changes

### DIFF
--- a/.changes/unreleased/Features-20260309-163700.yaml
+++ b/.changes/unreleased/Features-20260309-163700.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Pre-release model versions now warn instead of error on contract breaking changes
+time: 2026-03-09T16:37:00.000000-04:00
+custom:
+  Author: jecolvin
+  Issue: "12164"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -530,6 +530,14 @@ class ModelNode(ModelResource, CompiledNode):
         return self.version is not None and self.version == self.latest_version
 
     @property
+    def is_prerelease(self) -> bool:
+        if self.version is None or self.latest_version is None:
+            return False
+        from dbt.contracts.graph.unparsed import UnparsedVersion
+
+        return UnparsedVersion(v=self.version) > UnparsedVersion(v=self.latest_version)
+
+    @property
     def is_past_deprecation_date(self) -> bool:
         return (
             self.deprecation_date is not None
@@ -687,6 +695,16 @@ class ModelNode(ModelResource, CompiledNode):
                 UnversionedBreakingChange(
                     breaking_changes=[breaking_change],
                     model_name=self.name,
+                    model_file_path=self.original_file_path,
+                ),
+                node=self,
+            )
+            return False
+        elif self.is_prerelease:
+            warn_or_error(
+                UnversionedBreakingChange(
+                    breaking_changes=[breaking_change],
+                    model_name=f"{self.name}.v{self.version} (pre-release)",
                     model_file_path=self.original_file_path,
                 ),
                 node=self,
@@ -908,6 +926,15 @@ class ModelNode(ModelResource, CompiledNode):
                         enforced_model_constraint_removed=enforced_model_constraint_removed,
                         breaking_changes=breaking_changes,
                         model_name=self.name,
+                        model_file_path=self.original_file_path,
+                    ),
+                    node=self,
+                )
+            elif self.is_prerelease:
+                warn_or_error(
+                    UnversionedBreakingChange(
+                        breaking_changes=breaking_changes,
+                        model_name=f"{self.name}.v{self.version} (pre-release)",
                         model_file_path=self.original_file_path,
                     ),
                     node=self,

--- a/tests/functional/defer_state/fixtures.py
+++ b/tests/functional/defer_state/fixtures.py
@@ -242,6 +242,55 @@ models:
         data_type: text
 """
 
+prerelease_versioned_contract_schema_yml = """
+version: 2
+models:
+  - name: table_model
+    latest_version: 1
+    config:
+      contract:
+        enforced: True
+    versions:
+      - v: 1
+      - v: 2
+    columns:
+      - name: id
+        data_type: integer
+        data_tests:
+          - unique:
+              severity: error
+          - not_null
+      - name: name
+        data_type: text
+"""
+
+prerelease_versioned_modified_contract_schema_yml = """
+version: 2
+models:
+  - name: table_model
+    latest_version: 1
+    config:
+      contract:
+        enforced: True
+    versions:
+      - v: 1
+      - v: 2
+        columns:
+          - name: id
+            data_type: integer
+          - name: user_name
+            data_type: text
+    columns:
+      - name: id
+        data_type: integer
+        data_tests:
+          - unique:
+              severity: error
+          - not_null
+      - name: name
+        data_type: text
+"""
+
 versioned_modified_contract_schema_yml = """
 version: 2
 models:

--- a/tests/functional/defer_state/test_modified_state.py
+++ b/tests/functional/defer_state/test_modified_state.py
@@ -33,6 +33,8 @@ from tests.functional.defer_state.fixtures import (
     no_contract_schema_yml,
     numeric_precision_contract_schema_yml,
     numeric_precision_increased_contract_schema_yml,
+    prerelease_versioned_contract_schema_yml,
+    prerelease_versioned_modified_contract_schema_yml,
     schema_yml,
     seed_csv,
     semantic_model_schema_yml,
@@ -660,6 +662,72 @@ class TestChangedContractVersioned(BaseModifiedState):
         write_file(self.UNENFORCED_SCHEMA_YML, "models", "schema.yml")
         with pytest.raises(ContractBreakingChangeError):
             results = run_dbt(["run", "--models", "state:modified.contract", "--state", "./state"])
+
+
+class TestChangedContractPrereleaseVersioned(BaseModifiedState):
+    """Pre-release versioned models should warn (not error) on breaking contract changes."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "table_model_v1.sql": table_model_sql,
+            "table_model_v2.sql": table_model_sql,
+            "view_model.sql": view_model_sql,
+            "ephemeral_model.sql": ephemeral_model_sql,
+            "schema.yml": schema_yml,
+            "exposures.yml": exposures_yml,
+        }
+
+    def test_changed_contract_prerelease_versioned(self, project):
+        # Set up with v1 (latest) and v2 (prerelease), both with same columns
+        write_file(prerelease_versioned_contract_schema_yml, "models", "schema.yml")
+        self.run_and_save_state()
+
+        # Make a breaking change ONLY to v2 (prerelease) via per-version columns
+        # v1 keeps the original columns, v2 gets a renamed column
+        write_file(prerelease_versioned_modified_contract_schema_yml, "models", "schema.yml")
+
+        # Should NOT raise ContractBreakingChangeError for the prerelease version (v2)
+        # The run will fail with a compilation error (SQL columns don't match contract)
+        # but it should NOT raise ContractBreakingChangeError
+        results = run_dbt(
+            ["run", "--models", "state:modified.contract", "--state", "./state"],
+            expect_pass=False,
+        )
+        # v2 was selected (contract changed) but no ContractBreakingChangeError
+        assert len(results) == 1
+        assert results[0].node.name == "table_model"
+
+
+class TestDeletePrereleaseVersionedContractedModel(BaseModifiedState):
+    """Deleting a pre-release versioned model should warn (not error)."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "table_model_v1.sql": table_model_sql,
+            "table_model_v2.sql": table_model_sql,
+            "view_model.sql": view_model_sql,
+            "ephemeral_model.sql": ephemeral_model_sql,
+            "schema.yml": schema_yml,
+            "exposures.yml": exposures_yml,
+        }
+
+    def test_delete_prerelease_versioned_contracted_model(self, project):
+        # Set up with v1 (latest) and v2 (prerelease)
+        write_file(prerelease_versioned_contract_schema_yml, "models", "schema.yml")
+        self.run_and_save_state()
+
+        # Delete only the prerelease version (v2) and update schema to only have v1
+        rm_file(project.project_root, "models", "table_model_v2.sql")
+        write_file(versioned_contract_schema_yml, "models", "schema.yml")
+
+        # Should NOT raise ContractBreakingChangeError for the deleted prerelease version
+        _, logs = run_dbt_and_capture(
+            ["run", "--models", "state:modified.contract", "--state", "./state"]
+        )
+        assert "ContractBreakingChangeError" not in logs
+        assert "pre-release" in logs.lower()
 
 
 class TestDeleteUnversionedContractedModel(BaseModifiedState):


### PR DESCRIPTION
## Summary
Resolves #12164

- Pre-release model versions (where `version > latest_version`) now produce a **warning** instead of a hard `ContractBreakingChangeError` when a breaking contract change is detected
- Applies to both contract modifications (`same_contract`) and model deletion/disabling (`same_contract_removed`)
- Non-prerelease versioned models continue to raise errors as before
- Users can restore the old strict behavior via `--warn-error` or `--warn-error-options`

### Implementation notes

Adds an `is_prerelease` property to `ModelNode` that reuses the existing version comparison logic from `VersionSelectorMethod`. The two decision points in `same_contract()` and `same_contract_removed()` are updated from a 2-way branch (unversioned→warn, versioned→error) to a 3-way branch (unversioned→warn, prerelease→warn, non-prerelease versioned→error).

**dbt-protos workaround:** The event/logging system requires protobuf messages defined in the external `dbt-protos` package, which cannot be modified from within dbt-core. Rather than introducing a new `PrereleaseBreakingChange` event type (which would require a corresponding proto message), this PR reuses the existing `UnversionedBreakingChange` event with `"(pre-release)"` appended to the model name to clearly identify the source.

## Test plan
- [x] New `TestChangedContractPrereleaseVersioned` — makes a breaking change only to a pre-release version (v2), verifies no `ContractBreakingChangeError` is raised
- [x] New `TestDeletePrereleaseVersionedContractedModel` — deletes a pre-release version, verifies warning instead of error
- [x] All 46 existing `test_modified_state` integration tests pass
- [x] All 1610 unit tests pass
- [x] Linting (flake8 + mypy) passes