### PR TITLE
fix: multiple calls of dbt-retry fail with exit code 2

### DIFF
--- a/.changes/unreleased/Fixes-20260310-064146.yaml
+++ b/.changes/unreleased/Fixes-20260310-064146.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: resolved an issue duling multiple retry
+time: 2026-03-10T06:41:46.915676777Z
+custom:
+    Author: showyou
+    Issue: "8848"

--- a/core/dbt/task/retry.py
+++ b/core/dbt/task/retry.py
@@ -77,7 +77,7 @@ class RetryTask(ConfiguredTask):
         self.previous_results = load_result_state(
             Path(config.project_root) / Path(state_path) / RUN_RESULTS_FILE_NAME
         )
-        if not self.previous_results:
+        if self.previous_results is None:
             raise DbtRuntimeError(
                 f"Could not find previous run in '{state_path}' target directory"
             )

--- a/tests/functional/retry/test_retry.py
+++ b/tests/functional/retry/test_retry.py
@@ -141,6 +141,29 @@ class TestRetryPreviousRun(BaseTestRetry):
         write_file(models__sample_model, "models", "sample_model.sql")
 
 
+class TestRetryAfterEmptyRetry(BaseTestRetry):
+    def test_retry_after_empty_retry(self, project):
+        # Run build with a failure
+        results = run_dbt(["build"], expect_pass=False)
+        assert any(r.status == RunStatus.Error for r in results.results)
+
+        # Fix the broken model and retry — everything should pass
+        fixed_sql = "select 1 as id, 1 as foo"
+        write_file(fixed_sql, "models", "sample_model.sql")
+
+        results = run_dbt(["retry"])
+        assert len(results) > 0
+
+        # Nothing left to retry — empty result set
+        results = run_dbt(["retry"])
+        assert {n.node.name: n.status for n in results.results} == {}
+
+        # Retry again after the empty retry — should still return empty result set
+        results = run_dbt(["retry"])
+        assert {n.node.name: n.status for n in results.results} == {}
+        write_file(models__sample_model, "models", "sample_model.sql")
+
+
 class TestRetryWarnError(BaseTestRetry):
     def test_warn_error(self, project):
         # Our test command should succeed when run normally...


### PR DESCRIPTION
Resolves #8848

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

When calling dbt retry multiple times, if the previous run returned zero results and completed successfully, the next run resulted in an error.

The cause is as described in the issue, but to put it simply: when the count of results in the ExecutionResult class is 0, `not self.previous_results` evaluates to True in dbt/core/dbt/task/retry.py, leading to unexpected results.

```python
self.previous_results = load_result_state(
    Path(config.project_root) / Path(state_path) / RUN_RESULTS_FILE_NAME
        )
if not self.previous_results:
    raise DbtRuntimeError(
```

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

```python
if not self.previous_results:
```
have been changed to
```
if self.previous_results is none:
```

I also added test class about this issue.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
