### PR TITLE
feat: add --no-full-refresh flag to dbt compile

### DIFF
--- a/.changes/unreleased/Features-20260310-165145.yaml
+++ b/.changes/unreleased/Features-20260310-165145.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: 'Add --no-full-refresh flag to dbt compile'
+time: 2026-03-10T16:51:45.813368+09:00
+custom:
+    Author: dtaniwaki
+    Issue: "10918"

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -38,6 +38,7 @@ FLAGS_DEFAULTS = {
     "WARN_ERROR": None,
     # Cli args without project_flags or env var option.
     "FULL_REFRESH": False,
+    "NO_FULL_REFRESH": False,
     "STRICT_MODE": False,
     "STORE_FAILURES": False,
     "INTROSPECT": True,

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -331,6 +331,7 @@ def docs_serve(ctx, **kwargs):
 @global_flags
 @p.exclude
 @p.full_refresh
+@p.no_full_refresh
 @p.show_output_format
 @p.introspect
 @p.profiles_dir

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -313,6 +313,13 @@ hints_enabled = _create_option_and_track_env_var(
     default=True,
 )
 
+no_full_refresh = _create_option_and_track_env_var(
+    "--no-full-refresh",
+    envvar="DBT_NO_FULL_REFRESH",
+    help="If specified, dbt compile will treat incremental models as running incrementally (is_incremental() returns True), without querying the database.",
+    is_flag=True,
+)
+
 host = _create_option_and_track_env_var(
     "--host",
     envvar="DBT_HOST",

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -497,6 +497,17 @@ class Compiler:
 
     def initialize(self):
         make_directory(self.config.project_target_path)
+        if getattr(self.config.args, "NO_FULL_REFRESH", False) and getattr(
+            self.config.args, "FULL_REFRESH", False
+        ):
+            raise DbtRuntimeError(
+                "--no-full-refresh and --full-refresh are mutually exclusive."
+            )
+
+    def _should_force_incremental(self, node: ManifestSQLNode) -> bool:
+        if not getattr(self.config.args, "NO_FULL_REFRESH", False):
+            return False
+        return isinstance(node, ModelNode) and node.config.materialized == "incremental"
 
     # creates a ModelContext which is converted to
     # a dict for jinja rendering of SQL
@@ -511,6 +522,10 @@ class Compiler:
         else:
             context = generate_runtime_model_context(node, self.config, manifest)
         context.update(extra_context)
+
+        if self._should_force_incremental(node):
+            context["is_incremental"] = lambda: True
+            context["should_full_refresh"] = lambda: False
 
         if isinstance(node, GenericTestNode):
             # for test nodes, add a special keyword args value to the context

--- a/tests/functional/compile/fixtures.py
+++ b/tests/functional/compile/fixtures.py
@@ -65,3 +65,19 @@ models:
         data_tests:
           - unique
 """
+
+incremental_model_sql = """
+{{ config(materialized='incremental') }}
+select 1 as fun
+{% if is_incremental() %}
+where fun > 0
+{% endif %}
+"""
+
+table_model_using_is_incremental_sql = """
+{{ config(materialized='table') }}
+select 1 as fun
+{% if is_incremental() %}
+where fun > 0
+{% endif %}
+"""

--- a/tests/functional/compile/test_compile.py
+++ b/tests/functional/compile/test_compile.py
@@ -13,11 +13,13 @@ from tests.functional.compile.fixtures import (
     first_ephemeral_model_sql,
     first_ephemeral_model_with_alias_sql,
     first_model_sql,
+    incremental_model_sql,
     model_multiline_jinja,
     schema_yml,
     second_ephemeral_model_sql,
     second_ephemeral_model_with_alias_sql,
     second_model_sql,
+    table_model_using_is_incremental_sql,
     third_ephemeral_model_sql,
     with_recursive_model_sql,
 )
@@ -367,3 +369,31 @@ class TestSqlParseOnlyDepthLeavesTokensNone:
     def test_only_depth_set_leaves_tokens_none(self, project):
         run_dbt(["compile", "--sqlparse", '{"MAX_GROUPING_DEPTH": "10000"}'])
         assert sqlparse.engine.grouping.MAX_GROUPING_TOKENS is None
+
+
+class TestNoFullRefreshFlag:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_model.sql": incremental_model_sql,
+            "table_model.sql": table_model_using_is_incremental_sql,
+        }
+
+    def _compiled(self, model_name):
+        return norm_whitespace(read_file("target", "compiled", "test", "models", model_name + ".sql"))
+
+    def test_incremental_model_treated_as_incremental(self, project):
+        run_dbt(["compile", "--no-full-refresh"])
+        assert "where fun > 0" in self._compiled("incremental_model")
+
+    def test_default_does_not_treat_as_incremental(self, project):
+        run_dbt(["compile"])
+        assert "where fun > 0" not in self._compiled("incremental_model")
+
+    def test_non_incremental_model_unaffected(self, project):
+        run_dbt(["compile", "--no-full-refresh"])
+        assert "where fun > 0" not in self._compiled("table_model")
+
+    def test_mutually_exclusive_with_full_refresh(self, project):
+        with pytest.raises(DbtRuntimeError, match="mutually exclusive"):
+            run_dbt(["compile", "--no-full-refresh", "--full-refresh"])


### PR DESCRIPTION
Resolves dbt-labs/dbt-core#10918

Thanks for maintaining dbt-core! I'd appreciate a review on this small addition.

### Problem

When compiling incremental models with `dbt compile`, `is_incremental()` always returns `False` because it requires the target relation to exist in the database. This makes it impossible to inspect the incremental SQL path (e.g., for linting with SQLFluff or dry-run validation in CI) without actually running the model.

Setting `full_refresh: false` in model config does not help here — even with that config, `is_incremental()` returns `False` if the table doesn't exist yet.

### Solution

Add a `--no-full-refresh` flag to `dbt compile` that forces `is_incremental()` to return `True` during compilation, without querying the database. This is compile-only and intentionally not available for `dbt run`, where the absence of the target relation would cause execution to fail.

```bash
dbt compile --select my_incremental_model --no-full-refresh
```

Also available via environment variable:

```bash
DBT_NO_FULL_REFRESH=true dbt compile --select my_incremental_model
```

The implementation follows the same pattern used by microbatch, which injects `is_incremental = lambda: True` into the Jinja context.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
