### PR TITLE
fix: avoid false positive AmbiguousCatalogMatchError for case-only differences

### DIFF
--- a/.changes/unreleased/Fixes-20260311-163500.yaml
+++ b/.changes/unreleased/Fixes-20260311-163500.yaml
@@ -1,0 +1,4 @@
+kind: Fix
+change_type: bug
+issue_num: 11776
+onesentence: Avoid false positive AmbiguousCatalogMatchError when database has tables differing only by case

--- a/core/dbt/task/docs/generate.py
+++ b/core/dbt/task/docs/generate.py
@@ -133,6 +133,17 @@ class Catalog(Dict[CatalogKey, CatalogTable]):
             unique_ids = source_map.get(table.key(), set())
             for unique_id in unique_ids:
                 if unique_id in sources:
+                    # Check if this is a case-sensitivity issue (database has both "Subject" and "subject")
+                    # Only raise error if there are actually multiple sources defined in the manifest
+                    # that would map to the same key
+                    existing_table = sources[unique_id]
+                    # If the table names differ only by case, skip adding the duplicate
+                    if (
+                        existing_table.metadata.name.lower() == table.metadata.name.lower()
+                        and existing_table.metadata.name != table.metadata.name
+                    ):
+                        # Case-only difference - skip the duplicate to avoid false positive errors
+                        continue
                     raise AmbiguousCatalogMatchError(
                         unique_id,
                         sources[unique_id].to_dict(omit_none=True),
@@ -188,24 +199,26 @@ def format_stats(stats: PrimitiveDict) -> StatsDict:
     return stats_collector
 
 
-def mapping_key(node: ResultNode) -> CatalogKey:
+def mapping_key(node: ResultNode, case_sensitive: bool = False) -> CatalogKey:
     dkey = dbt_common.utils.formatting.lowercase(node.database)
+    if case_sensitive:
+        return CatalogKey(dkey, node.schema, node.identifier)
     return CatalogKey(dkey, node.schema.lower(), node.identifier.lower())
 
 
 def get_unique_id_mapping(
-    manifest: Manifest,
+    manifest: Manifest, case_sensitive: bool = False
 ) -> Tuple[Dict[CatalogKey, str], Dict[CatalogKey, Set[str]]]:
     # A single relation could have multiple unique IDs pointing to it if a
     # source were also a node.
     node_map: Dict[CatalogKey, str] = {}
     source_map: Dict[CatalogKey, Set[str]] = {}
     for unique_id, node in manifest.nodes.items():
-        key = mapping_key(node)
+        key = mapping_key(node, case_sensitive)
         node_map[key] = unique_id
 
     for unique_id, source in manifest.sources.items():
-        key = mapping_key(source)
+        key = mapping_key(source, case_sensitive)
         if key not in source_map:
             source_map[key] = set()
         source_map[key].add(unique_id)


### PR DESCRIPTION




Resolves #11776

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

When a database has tables that differ only by case (e.g., 'Subject' and 'subject'), dbt docs generate incorrectly raises an error because the CatalogKey lowercases both the schema and table name, causing them to collide.


### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

This fix:
1. Adds a check to detect case-only differences between existing and new table entries
2. When such a case-only difference is detected, skip adding the duplicate to avoid false positive errors
3. Keeps backward compatibility by adding optional case_sensitive parameter to mapping_key and get_unique_id_mapping for future use

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
