### PR TITLE
Add macros to manifest flat graph to be accessed in graph API through jinja

### DIFF
--- a/.changes/unreleased/Features-20260316-011007.yaml
+++ b/.changes/unreleased/Features-20260316-011007.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Expose macros in the Jinja graph context by adding macros to Manifest.build_flat_graph().T
+time: 2026-03-16T01:10:07.389475+05:30
+custom:
+    Author: chinmaypandya
+    Issue: "12656"

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -1017,6 +1017,7 @@ class Manifest(MacroMethods, dbtClassMixin):
                 k: v.to_dict(omit_none=False) for k, v in self.saved_queries.items()
             },
             "unit_tests": {k: v.to_dict(omit_none=False) for k, v in self.unit_tests.items()},
+            "macros": {k: v.to_dict(omit_none=False) for k, v in self.macros.items()},
         }
 
     def build_disabled_by_file_id(self):

--- a/tests/unit/contracts/graph/test_manifest.py
+++ b/tests/unit/contracts/graph/test_manifest.py
@@ -16,6 +16,7 @@ from dbt import tracking
 from dbt.adapters.base.plugin import AdapterPlugin
 from dbt.artifacts.resources import (
     ExposureType,
+    MacroDependsOn,
     MaturityType,
     MetricInputMeasure,
     MetricTypeParams,
@@ -31,6 +32,7 @@ from dbt.contracts.graph.nodes import (
     DependsOn,
     Exposure,
     Group,
+    Macro,
     Metric,
     ModelConfig,
     ModelNode,
@@ -347,6 +349,20 @@ class ManifestTest(unittest.TestCase):
             ),
         }
 
+        self.macros = {
+            "macro.root.my_macro": Macro(
+                name="my_macro",
+                resource_type=NodeType.Macro,
+                unique_id="macro.root.my_macro",
+                package_name="root",
+                path="macros/my_macro.sql",
+                original_file_path="macros/my_macro.sql",
+                macro_sql="select 1",
+                depends_on=MacroDependsOn(),
+                description="Test macro",
+            )
+        }
+
         self.semantic_models = {}
         self.saved_queries = {}
 
@@ -358,6 +374,8 @@ class ManifestTest(unittest.TestCase):
             node.validate(node.to_dict(omit_none=True))
         for source in self.sources.values():
             source.validate(source.to_dict(omit_none=True))
+        for macro in self.macros.values():
+            macro.validate(macro.to_dict(omit_none=True))
 
         os.environ["DBT_ENV_CUSTOM_ENV_key"] = "value"
 
@@ -487,6 +505,7 @@ class ManifestTest(unittest.TestCase):
 
     def test_build_flat_graph(self):
         exposures = deepcopy(self.exposures)
+        macros = deepcopy(self.macros)
         metrics = deepcopy(self.metrics)
         groups = deepcopy(self.groups)
         nodes = deepcopy(self.nested_nodes)
@@ -494,7 +513,7 @@ class ManifestTest(unittest.TestCase):
         manifest = Manifest(
             nodes=nodes,
             sources=sources,
-            macros={},
+            macros=macros,
             docs={},
             disabled={},
             files={},
@@ -507,6 +526,7 @@ class ManifestTest(unittest.TestCase):
         flat_graph = manifest.flat_graph
         flat_exposures = flat_graph["exposures"]
         flat_groups = flat_graph["groups"]
+        flat_macros = flat_graph["macros"]
         flat_metrics = flat_graph["metrics"]
         flat_nodes = flat_graph["nodes"]
         flat_sources = flat_graph["sources"]
@@ -522,6 +542,7 @@ class ManifestTest(unittest.TestCase):
                     "groups",
                     "nodes",
                     "sources",
+                    "macros",
                     "metrics",
                     "semantic_models",
                     "saved_queries",
@@ -531,6 +552,7 @@ class ManifestTest(unittest.TestCase):
         )
         self.assertEqual(set(flat_exposures), set(self.exposures))
         self.assertEqual(set(flat_groups), set(self.groups))
+        self.assertEqual(set(flat_macros), set(self.macros))
         self.assertEqual(set(flat_metrics), set(self.metrics))
         self.assertEqual(set(flat_nodes), set(self.nested_nodes))
         self.assertEqual(set(flat_sources), set(self.sources))
@@ -562,7 +584,7 @@ class ManifestTest(unittest.TestCase):
         manifest = Manifest(
             nodes=nodes,
             sources=deepcopy(self.sources),
-            macros={},
+            macros=deepcopy(self.macros),
             docs={},
             disabled={},
             files={},
@@ -1090,6 +1112,7 @@ class MixedManifestTest(unittest.TestCase):
                     "exposures",
                     "functions",
                     "groups",
+                    "macros",
                     "metrics",
                     "nodes",
                     "sources",


### PR DESCRIPTION
### Resolves

Closes https://github.com/dbt-labs/dbt-core/issues/12647

### Problem

The `graph` context variable in Jinja exposes metadata for several resource types (e.g. nodes, sources, metrics, exposures, etc.), but macros are not currently available through this interface.

Macro metadata exists in manifest.json, but it cannot be accessed from within the Jinja context during execution.

This makes it difficult to programmatically inspect macros or their metadata (e.g. depends_on, package name, path, etc.) during a dbt run.

For example, users cannot currently do something like:

```
{% if execute %}
  {% for macro in graph.macros.values() %}
    {{ log(macro.name, info=True) }}
  {% endfor %}
{% endif %}
```

### Solution

Expose macros through the graph context variable by adding the macros collection to `Manifest.build_flat_graph()`.

Specifically, this change adds:

```
"macros": {k: v.to_dict(omit_none=False) for k, v in self.macros.items()}
```

to the flat_graph structure.

Since the Jinja graph context is backed directly by manifest.flat_graph, 

```
@contextproperty()
def graph(self) -> Dict[str, Any]:
    return self.manifest.flat_graph
```

this makes macro metadata accessible via:

```
graph.macros
```

during execution.

Unit tests were updated to reflect the new macros key in the flat graph structure and to validate that macro metadata is included correctly.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
