### PR TITLE
Fix: Add @requires.catalogs decorator to test command

### DIFF
--- a/.changes/unreleased/Fixes-20260317-094953.yaml
+++ b/.changes/unreleased/Fixes-20260317-094953.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add @requires.catalogs decorator to test command to fix custom catalog integration support
+time: 2026-03-17T09:49:53.183758+01:00
+custom:
+    Author: rrittsteiger
+    Issue: "12662"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -835,6 +835,7 @@ cli.commands["source"].add_command(snapshot_freshness, "snapshot-freshness")  # 
 @requires.preflight
 @requires.profile
 @requires.project
+@requires.catalogs
 @requires.runtime_config
 @requires.manifest
 def test(ctx, **kwargs):


### PR DESCRIPTION
The test command was missing the @requires.catalogs decorator, causing it to fail when models use custom catalog integrations defined in catalogs.yml. This adds the decorator to match other commands like run, build, parse, compile, seed, and snapshot.
Fixes custom catalog integration support for dbt test command.

Resolves #12662

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

At the moment 'dbt test' is not parsing catalogs.yml. This leads to the following error running it:
```shell
> dbt test
07:00:45  Running with dbt=1.11.7
07:00:46  Registered adapter: snowflake=1.11.3
07:00:46  Unable to do partial parsing because saved manifest not found. Starting full parse.
07:00:47  Encountered an error:
Runtime Error
  Catalog not found.Received: GLUE_CATALOG_INTEGRATIONExpected one of: INFO_SCHEMA, SNOWFLAKE?
```

### Solution

Added @requires.catalogs decorator to the test function in core/dbt/cli/main.py.

With this fix tests will run properly.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

Resolves #12662