### PR TITLE
Support environment variables for selector parameters

### DIFF
--- a/.changes/unreleased/Features-20260317-120557.yaml
+++ b/.changes/unreleased/Features-20260317-120557.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support environment variables for selector parameters
+time: 2026-03-17T12:05:57.950375475+01:00
+custom:
+    Author: fornwall
+    Issue: "12193"

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -22,7 +22,7 @@ from dbt_common.exceptions import DbtInternalError
 model_decls = ("-m", "--models", "--model")
 select_decls = ("-s", "--select")
 select_attrs = {
-    "envvar": None,
+    "envvar": "DBT_ENGINE_SELECT",
     "help": "Specify the nodes to include.",
     "cls": MultiOption,
     "multiple": True,
@@ -242,7 +242,7 @@ event_time_start = _create_option_and_track_env_var(
 
 exclude = _create_option_and_track_env_var(
     "--exclude",
-    envvar=None,
+    envvar="DBT_ENGINE_EXCLUDE",
     type=tuple,
     cls=MultiOption,
     multiple=True,
@@ -604,7 +604,7 @@ select = _create_option_and_track_env_var(*select_decls, *model_decls, **select_
 
 selector = _create_option_and_track_env_var(
     "--selector",
-    envvar=None,
+    envvar="DBT_ENGINE_SELECTOR",
     help="The selector name to use, as defined in selectors.yml",
 )
 


### PR DESCRIPTION
Resolves #12193.

Submitted for feedback - not tested or looked through where changes might be necessary in more places.

### Problem

It's not possible to specify values for `--select`, `--selector` or `--exclude` from environment variables, making it harder to setup workflow invocations from systems where users configure environment variables.

### Solution

Introduce support for the following environment variables:

- `DBT_ENGINE_SELECTOR`: For `--selector`.
- `DBT_ENGINE_SELECT`: For `--select`.
- `DBT_ENGINE_EXCLUDE`: For `--exclude`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
