### PR TITLE
[Backport 1.11.latest] Fix #12353: Add @requires.catalogs decorator to compile command

### DIFF
--- a/.changes/unreleased/Fixes-20260124-212300.yaml
+++ b/.changes/unreleased/Fixes-20260124-212300.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add @requires.catalogs decorator to compile command to fix REST Catalog-Linked database compilation
+time: 2026-01-24T21:23:00.00000Z
+custom:
+  Author: kalluripradeep
+  Issue: "12353"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -334,6 +334,7 @@ def docs_serve(ctx, **kwargs):
 @requires.preflight
 @requires.profile
 @requires.project
+@requires.catalogs
 @requires.runtime_config
 @requires.manifest
 def compile(ctx, **kwargs):


### PR DESCRIPTION
Backport e25958c from #12388.