### PR TITLE
Fix: propagate incremental_batch to all microbatch submissions

### DIFF
--- a/.changes/unreleased/Fixes-20260320-120000.yaml
+++ b/.changes/unreleased/Fixes-20260320-120000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Pass incremental_batch flag to all microbatch batch submissions, not just the first
+time: 2026-03-20T12:00:00.000000+00:00
+custom:
+    Author: TheRoot-1
+    Issue: "12682"

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -764,6 +764,7 @@ class MicrobatchModelRunner(ModelRunner):
 
         batch_results: List[RunResult] = []
         batch_idx = 0
+        is_incremental = self._is_incremental(model=model)
 
         # Run first batch not in parallel
         relation_exists = self.parent_task._submit_batch(
@@ -775,7 +776,7 @@ class MicrobatchModelRunner(ModelRunner):
             batch_results=batch_results,
             pool=self.pool,
             force_sequential_run=True,
-            incremental_batch=self._is_incremental(model=model),
+            incremental_batch=is_incremental,
         )
         batch_idx += 1
         skip_batches = batch_results[0].status != RunStatus.Success
@@ -791,6 +792,7 @@ class MicrobatchModelRunner(ModelRunner):
                 batch_results=batch_results,
                 pool=self.pool,
                 skip=skip_batches,
+                incremental_batch=is_incremental,
             )
             batch_idx += 1
 
@@ -824,6 +826,7 @@ class MicrobatchModelRunner(ModelRunner):
                 pool=self.pool,
                 force_sequential_run=True,
                 skip=skip_batches,
+                incremental_batch=is_incremental,
             )
 
         # Finalize run: merge results, track model run, and print final result line

--- a/tests/unit/task/test_run.py
+++ b/tests/unit/task/test_run.py
@@ -378,6 +378,70 @@ class TestMicrobatchModelRunner:
         assert builder.default_end_time == current_time
 
 
+    @pytest.mark.parametrize("is_incremental", [True, False])
+    def test_execute_passes_incremental_batch_to_all_batches(
+        self,
+        mocker: MockerFixture,
+        model_runner: MicrobatchModelRunner,
+        is_incremental: bool,
+    ) -> None:
+        """incremental_batch should be propagated to all _submit_batch calls,
+        not just the first one."""
+        model = model_runner.node
+
+        # Mock _is_incremental to return parameterized value
+        mocker.patch.object(model_runner, "_is_incremental", return_value=is_incremental)
+
+        # Mock _has_relation
+        mocker.patch.object(model_runner, "_has_relation", return_value=True)
+
+        # Mock get_batches to return 3 batches (exercises first, middle, last paths)
+        batches = {0: ("2024-01-01", "2024-01-02"), 1: ("2024-01-02", "2024-01-03"), 2: ("2024-01-03", "2024-01-04")}
+        mocker.patch.object(model_runner, "get_batches", return_value=batches)
+
+        # Track _submit_batch calls
+        submit_calls = []
+        first_result = RunResult(
+            node=model,
+            status=RunStatus.Success,
+            timing=[],
+            thread_id="thread-1",
+            execution_time=0.1,
+            message="SUCCESS",
+            adapter_response={"_message": "OK"},
+            failures=0,
+            batch_results=None,
+        )
+
+        def fake_submit_batch(**kwargs):
+            submit_calls.append(kwargs)
+            kwargs["batch_results"].append(first_result)
+            return True
+
+        mock_parent = mocker.Mock(spec=RunTask)
+        mock_parent._submit_batch = mocker.Mock(side_effect=fake_submit_batch)
+        model_runner._parent_task = mock_parent
+
+        # Mock pool property
+        mock_pool = mocker.Mock()
+        mock_pool.is_closed.return_value = False
+        mocker.patch.object(
+            MicrobatchModelRunner, "pool", new_callable=mocker.PropertyMock, return_value=mock_pool
+        )
+
+        # Mock merge_batch_results to avoid side effects
+        mocker.patch.object(model_runner, "merge_batch_results")
+
+        model_runner.execute(model, mocker.Mock(spec=Manifest))
+
+        # All 3 batches should have been submitted
+        assert mock_parent._submit_batch.call_count == 3
+
+        # All calls should have incremental_batch set to our parameterized value
+        for call in mock_parent._submit_batch.call_args_list:
+            assert call.kwargs["incremental_batch"] == is_incremental
+
+
 class TestRunTask:
     @pytest.fixture
     def hook_node(self) -> HookNode:


### PR DESCRIPTION
Resolves #12682

### Problem

In `MicrobatchModelRunner.execute()`, the `incremental_batch` parameter is only passed to `_submit_batch()` for the first batch. Middle and last batches omit it, defaulting to `True`. During `--full-refresh` or initial runs, this causes `is_incremental()` to incorrectly return `True` for batches 2+.

### Solution

Compute `incremental_batch` once before the batch loop and pass it to all three `_submit_batch()` calls (first, middle, and last batches).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.