### PR TITLE
Fix cycle detection to raise CompilationError instead of built-in RuntimeError

### DIFF
--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -209,7 +209,7 @@ class Linker:
         cycle = self.find_cycles()
 
         if cycle:
-            raise RuntimeError("Found a cycle: {}".format(cycle))
+            raise CompilationError("Found a cycle: {}".format(cycle))
 
     def add_test_edges(self, manifest: Manifest) -> None:
         if not get_flags().USE_FAST_TEST_EDGES:

--- a/tests/functional/cycles/test_cycles.py
+++ b/tests/functional/cycles/test_cycles.py
@@ -1,6 +1,7 @@
 import pytest
 
 from dbt.tests.util import run_dbt
+from dbt_common.exceptions import CompilationError
 
 model_a_sql = """
 select * from {{ ref('model_b') }}
@@ -39,7 +40,7 @@ class TestSimpleCycle:
         return {"model_a.sql": model_a_sql, "model_b.sql": model_b_sql}
 
     def test_simple_cycle(self, project):
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(CompilationError) as exc:
             run_dbt(["run"])
         expected_msg = "Found a cycle"
         assert expected_msg in str(exc.value)
@@ -62,7 +63,7 @@ class TestComplexCycle:
         }
 
     def test_complex_cycle(self, project):
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(CompilationError) as exc:
             run_dbt(["run"])
         expected_msg = "Found a cycle"
         assert expected_msg in str(exc.value)


### PR DESCRIPTION
Resolves #N/A

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
Python's built-in RuntimeError was being raised when cycles were detected. This caused super ugly tracebacks.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
This changes it to raise a CompilationError so callers can catch the appropriate exception type.

  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
