### PR TITLE
feat: warn on unknown flags in dbt_project.yml

### DIFF
--- a/.changes/unreleased/Features-20260321-225400.yaml
+++ b/.changes/unreleased/Features-20260321-225400.yaml
@@ -3,5 +3,4 @@ body: Warn on unknown flags in dbt_project.yml
 time: 2026-03-21T22:54:00.000000+00:00
 custom:
     Author: chinar-amrutkar
-issues:
-- "12590"
+    Issue: "12590"

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -36,9 +36,11 @@ from dbt.exceptions import (
 from dbt.flags import get_flags
 from dbt.graph import SelectionSpec
 from dbt.node_types import NodeType
+from dbt.events.types import InvalidOptionYAML
 from dbt.utils import MultiDict, coerce_dict_str, md5
 from dbt.version import get_installed_version
 from dbt_common.clients.system import load_file_contents, path_exists
+from dbt_common.events.functions import fire_event
 from dbt_common.dataclass_schema import ValidationError
 from dbt_common.exceptions import SemverError
 from dbt_common.helper_types import NoValue
@@ -935,8 +937,6 @@ def read_project_flags(project_dir: str, profiles_dir: str) -> ProjectFlags:
         known_flag_names = {f.name for f in fields(ProjectFlags)}
         unknown_flags = set(project_flags.keys()) - known_flag_names
         if unknown_flags:
-            from dbt.events.types import InvalidOptionYAML
-            from dbt_common.events.functions import fire_event
             fire_event(InvalidOptionYAML(
                 option_name=f"flags: {', '.join(sorted(unknown_flags))}",
                 valid_options=", ".join(sorted(known_flag_names)[:10]) + "..."

--- a/tests/unit/config/test_project.py
+++ b/tests/unit/config/test_project.py
@@ -11,13 +11,13 @@ import dbt.config
 import dbt.exceptions
 from dbt.adapters.contracts.connection import DEFAULT_QUERY_COMMENT, QueryComment
 from dbt.adapters.factory import load_plugin
-from dbt.config.project import Project, _get_required_version
+from dbt.config.project import Project, _get_required_version, read_project_flags
 from dbt.constants import DEPENDENCIES_FILE_NAME
 from dbt.contracts.project import GitPackage, LocalPackage, PackageConfig
 from dbt.deprecations import (
     GenericJSONSchemaValidationDeprecation as GenericJSONSchemaValidationDeprecationCore,
 )
-from dbt.events.types import GenericJSONSchemaValidationDeprecation
+from dbt.events.types import GenericJSONSchemaValidationDeprecation, InvalidOptionYAML
 from dbt.flags import set_from_args
 from dbt.jsonschemas.jsonschemas import project_schema
 from dbt.node_types import NodeType
@@ -651,9 +651,6 @@ class TestDeprecations:
 class TestUnknownFlagsWarning:
 
     def test_unknown_flag_in_project_yml_fires_warning(self, tmp_path) -> None:
-        from dbt.events.types import InvalidOptionYAML
-        from dbt.config.project import read_project_flags
-
         # Create a minimal dbt_project.yml with an unknown flag
         project_dir = tmp_path
         profiles_dir = tmp_path / "profiles"


### PR DESCRIPTION
Closes https://github.com/dbt-labs/dbt-core/issues/12590

### Problem

When users set flags in `dbt_project.yml` that dbt doesn't recognize (e.g., typos like `prrint` instead of `print`), dbt silently ignores them. There's no feedback to the user that their configuration is being ignored, leading to confusion when expected behavior doesn't change.

### Solution

Added validation in `read_project_flags()` at `core/dbt/config/project.py` that compares the user's flags against known `ProjectFlags` field names. Unknown flags trigger a warning via `fire_event(InvalidOptionYAML(...))`, guiding users to fix their config.

The warning message lists the first 10 known flag names to help users identify the correct option.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes type annotations for new and modified functions.