### PR TITLE
Fix: improve error message for similar database identifiers to reference correct node type

### DIFF
--- a/.changes/unreleased/Fixes-20260322-000000.yaml
+++ b/.changes/unreleased/Fixes-20260322-000000.yaml
@@ -3,4 +3,4 @@ body: "Improve error message for similar database identifiers to reference the c
 time: 2026-03-22T00:00:00.000000+00:00
 custom:
     Author: chinar-amrutkar
-    Issue: "12629"
+    Issue: "12691"

--- a/.changes/unreleased/Fixes-20260322-000000.yaml
+++ b/.changes/unreleased/Fixes-20260322-000000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: "Improve error message for similar database identifiers to reference the correct node type (source, model, seed, snapshot) instead of always saying 'model'"
+time: 2026-03-22T00:00:00.000000+00:00
+custom:
+    Author: chinar-amrutkar
+    Issue: "12629"

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -1235,6 +1235,7 @@ class AmbiguousCatalogMatchError(CompilationError):
 
         # Generic fallback when no prefix is available.
         return "node"
+
     def get_message(self) -> str:
         node_type = self._node_type_label(self.unique_id)
         msg = (

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -1216,9 +1216,25 @@ class AmbiguousCatalogMatchError(CompilationError):
     @staticmethod
     def _node_type_label(unique_id: str) -> str:
         """Derive a human-readable node type from a dbt unique_id prefix."""
-        prefix = unique_id.split(".", 1)[0] if unique_id else "node"
-        return prefix
+        # unique_id format is typically "<node_type>.<package>.<name>"
+        prefix = unique_id.split(".", 1)[0] if unique_id else ""
 
+        # Map known internal prefixes to nicer, human-readable labels.
+        known_labels = {
+            "saved_query": "saved query",
+            "unit_test": "unit test",
+            "test": "data test",
+        }
+
+        if prefix in known_labels:
+            return known_labels[prefix]
+
+        if prefix:
+            # Fall back to a generic transformation: replace underscores with spaces.
+            return prefix.replace("_", " ")
+
+        # Generic fallback when no prefix is available.
+        return "node"
     def get_message(self) -> str:
         node_type = self._node_type_label(self.unique_id)
         msg = (

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -1213,11 +1213,19 @@ class AmbiguousCatalogMatchError(CompilationError):
         match_name = match.get("metadata", {}).get("name")
         return f"{match_schema}.{match_name}"
 
+    @staticmethod
+    def _node_type_label(unique_id: str) -> str:
+        """Derive a human-readable node type from a dbt unique_id prefix."""
+        prefix = unique_id.split(".", 1)[0] if unique_id else "node"
+        return prefix
+
     def get_message(self) -> str:
+        node_type = self._node_type_label(self.unique_id)
         msg = (
             "dbt found two relations in your warehouse with similar database identifiers. "
-            "dbt\nis unable to determine which of these relations was created by the model "
-            f'"{self.unique_id}".\nIn order for dbt to correctly generate the catalog, one '
+            f"dbt\nis unable to determine which of these relations is associated with the "
+            f'{node_type} "{self.unique_id}".\n'
+            "In order for dbt to correctly generate the catalog, one "
             "of the following relations must be deleted or renamed:\n\n - "
             f"{self.get_match_string(self.match_1)}\n - {self.get_match_string(self.match_2)}"
         )

--- a/tests/unit/test_ambiguous_catalog_exception.py
+++ b/tests/unit/test_ambiguous_catalog_exception.py
@@ -1,4 +1,3 @@
-import pytest
 
 from dbt.exceptions import AmbiguousCatalogMatchError
 

--- a/tests/unit/test_ambiguous_catalog_exception.py
+++ b/tests/unit/test_ambiguous_catalog_exception.py
@@ -1,4 +1,3 @@
-
 from dbt.exceptions import AmbiguousCatalogMatchError
 
 

--- a/tests/unit/test_ambiguous_catalog_exception.py
+++ b/tests/unit/test_ambiguous_catalog_exception.py
@@ -1,0 +1,44 @@
+import pytest
+
+from dbt.exceptions import AmbiguousCatalogMatchError
+
+
+class TestAmbiguousCatalogMatchError:
+    def _make_error(self, unique_id: str) -> AmbiguousCatalogMatchError:
+        return AmbiguousCatalogMatchError(
+            unique_id,
+            {"metadata": {"schema": "raw_dcrm", "name": "Subject"}},
+            {"metadata": {"schema": "raw_dcrm", "name": "subject"}},
+        )
+
+    def test_message_for_source(self):
+        err = self._make_error("source.dbt_pipeline.raw_dcrm.subject")
+        msg = err.get_message()
+        assert 'associated with the source "source.dbt_pipeline.raw_dcrm.subject"' in msg
+        assert "created by the model" not in msg
+
+    def test_message_for_model(self):
+        err = self._make_error("model.my_project.my_model")
+        msg = err.get_message()
+        assert 'associated with the model "model.my_project.my_model"' in msg
+
+    def test_message_for_seed(self):
+        err = self._make_error("seed.my_project.my_seed")
+        msg = err.get_message()
+        assert 'associated with the seed "seed.my_project.my_seed"' in msg
+
+    def test_message_for_snapshot(self):
+        err = self._make_error("snapshot.my_project.my_snapshot")
+        msg = err.get_message()
+        assert 'associated with the snapshot "snapshot.my_project.my_snapshot"' in msg
+
+    def test_message_contains_both_relations(self):
+        err = self._make_error("source.dbt_pipeline.raw_dcrm.subject")
+        msg = err.get_message()
+        assert "raw_dcrm.Subject" in msg
+        assert "raw_dcrm.subject" in msg
+
+    def test_message_contains_similar_identifiers_warning(self):
+        err = self._make_error("source.dbt_pipeline.raw_dcrm.subject")
+        msg = err.get_message()
+        assert "similar database identifiers" in msg


### PR DESCRIPTION
## Summary

The `AmbiguousCatalogMatchError` always said "created by the model" regardless of whether the node was a source, seed, snapshot, or model. This confused users when the error appeared for sources (see #11776). Now it derives the node type from the unique_id prefix and uses "associated with the {type}".

## Example

Before:
dbt is unable to determine which of these relations was created by the model "source.dbt_pipeline.raw_dcrm.subject"


After:
dbt is unable to determine which of these relations is associated with the source "source.dbt_pipeline.raw_dcrm.subject"


## Changes
- Added `_node_type_label` static method to extract node type from unique_id prefix
- Changed message from "created by the model" to "associated with the {node_type}"
- Added 6 unit tests covering source, model, seed, snapshot
- Added changie entry

Fixes #12629