### PR TITLE
fix: suppress stacktrace when snapshot validation fails

### DIFF
--- a/.changes/unreleased/Fixes-20260323-220600.yaml
+++ b/.changes/unreleased/Fixes-20260323-220600.yaml
@@ -1,4 +1,6 @@
-kind: Fix
-change_type: bug
-issue_num: 12692
-onesentence: Suppress stacktrace when snapshot validation fails due to missing strategy or unique_key
+kind: Fixes
+body: Suppress stacktrace when snapshot validation fails due to missing strategy or unique_key
+time: 2026-03-23T22:06:00.000000+00:00
+custom:
+    Author: chinar-amrutkar
+    Issue: "12692"

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -41,11 +41,11 @@ from dbt.utils.artifact_upload import upload_artifacts
 from dbt.version import installed as installed_version
 from dbt_common.clients.system import get_env
 from dbt_common.context import get_invocation_context, set_invocation_context
+from dbt_common.dataclass_schema import ValidationError
 from dbt_common.events.base_types import EventLevel
 from dbt_common.events.event_manager_client import get_event_manager
 from dbt_common.events.functions import LOG_VERSION, fire_event
 from dbt_common.events.helpers import get_json_string_utcnow
-from dbt_common.dataclass_schema import ValidationError
 from dbt_common.exceptions import DbtBaseException as DbtException
 from dbt_common.invocation import reset_invocation_id
 from dbt_common.record import (


### PR DESCRIPTION
Resolves #12692

### Problem

When YAML snapshots are missing `strategy` and/or `unique_key`, dbt shows a full Python stacktrace instead of just the clear error message. The `ValidationError` raised by `SnapshotConfig.final_validate()` is not a `DbtException`, so the CLI postflight decorator catches it as a `BaseException` and prints the traceback.

### Solution

Added a specific `ValidationError` catch in the `postflight` decorator (`core/dbt/cli/requires.py`) alongside the existing `DbtException` catch. Now users see just:

Encountered an error: Snapshots must be configured with a 'strategy' and 'unique_key'.


The traceback is still available via `logs/dbt_log.log` or `--debug`.

### Checklist

- [x] I have read the contributing guide
- [x] I have run this code in development and it resolves the stated issue
- [x] This PR includes tests, or tests are not required
- [x] This PR has no interface changes