### PR TITLE
fix: include model name in unit test alias to prevent temp table collisions

### DIFF
--- a/.changes/unreleased/Fixes-20260323-120000.yaml
+++ b/.changes/unreleased/Fixes-20260323-120000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Include model name in unit test alias to prevent temp table collisions with duplicate test names across models
+time: 2026-03-23T12:00:00.000000Z
+custom:
+    Author: joaquinhuigomez
+    Issue: "12665"

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -94,7 +94,7 @@ class UnitTestManifestLoader:
             raw_code=tested_node.raw_code,
             database=tested_node.database,
             schema=tested_node.schema,
-            alias=name,
+            alias=f"{test_case.model}__{name}",
             fqn=test_case.unique_id.split("."),
             checksum=FileHash.empty(),
             tested_node_unique_id=tested_node.unique_id,


### PR DESCRIPTION
### Problem

When two unit tests across different models share the same name, running with `--threads > 1` causes temp table collisions because the unit test alias is just the test name (e.g. `test_basic__dbt_tmp`). Both tests try to create/drop the same temp table simultaneously.

Changed the alias from `{test_name}` to `{model_name}__{test_name}` — single line in `core/dbt/parser/unit_tests.py`. Display names in logs are unaffected.

Fixes #12665