### PR TITLE
Update pathspec version constraint in pyproject.toml

### DIFF
--- a/.changes/unreleased/Dependencies-20260502-045523.yaml
+++ b/.changes/unreleased/Dependencies-20260502-045523.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Update pathspec version constraint upper bound in pyproject.toml
+time: 2026-05-02T04:55:23.25202471Z
+custom:
+    Author: aebrahim
+    Issue: "12702"

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -40,10 +40,10 @@ dependencies = [
     "click>=8.3.0,<9.0",
     "jsonschema>=4.19.1,<5.0",
     "networkx>=2.3,<4.0",
+    "pathspec>=1.0.0,<2.0",
     "protobuf>=6.0,<7.0",
     "requests<3.0.0",  # should match dbt-common
     "snowplow-tracker>=1.0.2,<2.0",
-    "pathspec>=0.9,<1.1",
     # ----
     # These packages are major-version-0. Keep upper bounds on upcoming minor versions (which could have breaking changes)
     # and check compatibility / bump in each new minor version of dbt-core.


### PR DESCRIPTION
### Problem

Pinning an old version is causing resolution issues for my use case, and likely others as well.

### Solution

Upgrading pathspec unblocks my pip resolution issues.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue. (N/A)
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions. (N/A)
