### PR TITLE
fix: populate model constraints regardless of contract enforcement

### DIFF
--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -370,6 +370,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     require_ref_searches_node_package_before_root: bool = False
     require_valid_schema_from_generate_schema_name: bool = False
     require_sql_header_in_test_configs: bool = False
+    require_valid_unenforced_constraint: bool = False
     support_custom_ref_kwargs: bool = False
 
     @property
@@ -391,6 +392,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
             "require_ref_searches_node_package_before_root": self.require_ref_searches_node_package_before_root,
             "require_valid_schema_from_generate_schema_name": self.require_valid_schema_from_generate_schema_name,
             "require_sql_header_in_test_configs": self.require_sql_header_in_test_configs,
+            "require_valid_unenforced_constraint": self.require_valid_unenforced_constraint,
             "support_custom_ref_kwargs": self.support_custom_ref_kwargs,
         }
 

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -1159,6 +1159,10 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
                     f"Invalid constraint type on model {node.name}: "
                     f"Type must be one of {[ct.value for ct in ConstraintType]}"
                 )
+        else:
+            constraints = [
+                c for c in constraints if "type" in c and ConstraintType.is_valid(c["type"])
+            ]
 
         self._validate_pk_constraints(node, constraints)
         node.constraints = [ModelLevelConstraint.from_dict(c) for c in constraints]

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -1160,9 +1160,34 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
                     f"Type must be one of {[ct.value for ct in ConstraintType]}"
                 )
         else:
-            constraints = [
-                c for c in constraints if "type" in c and ConstraintType.is_valid(c["type"])
-            ]
+            if getattr(get_flags(), "require_valid_unenforced_constraint", False):
+                if any(
+                    c
+                    for c in constraints
+                    if "type" not in c or not ConstraintType.is_valid(c["type"])
+                ):
+                    raise ParsingError(
+                        f"Invalid constraint type on model {node.name}: "
+                        f"Type must be one of {[ct.value for ct in ConstraintType]}"
+                    )
+            else:
+                invalid = [
+                    c
+                    for c in constraints
+                    if "type" not in c or not ConstraintType.is_valid(c["type"])
+                ]
+                if invalid:
+                    fire_event(
+                        Note(
+                            msg=f"Skipping {len(invalid)} invalid constraint(s) on model {node.name} "
+                            f"(contract not enforced). Type must be one of {[ct.value for ct in ConstraintType]}. "
+                            f"Set behavior flag 'require_valid_unenforced_constraint' to raise an error instead."
+                        ),
+                        level=EventLevel.WARN,
+                    )
+                constraints = [
+                    c for c in constraints if "type" in c and ConstraintType.is_valid(c["type"])
+                ]
 
         self._validate_pk_constraints(node, constraints)
         node.constraints = [ModelLevelConstraint.from_dict(c) for c in constraints]

--- a/tests/functional/configs/test_constraints_unenforced.py
+++ b/tests/functional/configs/test_constraints_unenforced.py
@@ -1,6 +1,10 @@
 import pytest
 
-from dbt.tests.util import get_manifest, run_dbt
+from dbt.cli.main import dbtRunner
+from dbt.tests.util import get_manifest, run_dbt, run_dbt_and_capture, update_config_file
+from dbt_common.events.base_types import EventLevel
+from dbt_common.events.event_catcher import EventCatcher
+from dbt_common.events.types import Note
 
 my_model_sql = """
 select 1 as id, 'blue' as color
@@ -40,6 +44,16 @@ models:
   - name: my_model
     constraints:
       - type: primary_key
+        columns: [id]
+"""
+
+schema_invalid_constraint_type_yml = """
+models:
+  - name: my_model
+    constraints:
+      - type: primary_key
+        columns: [id]
+      - type: not_a_real_type
         columns: [id]
 """
 

--- a/tests/functional/configs/test_constraints_unenforced.py
+++ b/tests/functional/configs/test_constraints_unenforced.py
@@ -1,0 +1,101 @@
+import pytest
+
+from dbt.tests.util import get_manifest, run_dbt
+
+my_model_sql = """
+select 1 as id, 'blue' as color
+"""
+
+schema_enforced_false_yml = """
+models:
+  - name: my_model
+    config:
+      contract:
+        enforced: false
+    constraints:
+      - type: primary_key
+        columns: [id]
+    columns:
+      - name: id
+        data_type: integer
+      - name: color
+        data_type: string
+"""
+
+schema_no_contract_yml = """
+models:
+  - name: my_model
+    constraints:
+      - type: primary_key
+        columns: [id]
+    columns:
+      - name: id
+        data_type: integer
+      - name: color
+        data_type: string
+"""
+
+schema_no_columns_yml = """
+models:
+  - name: my_model
+    constraints:
+      - type: primary_key
+        columns: [id]
+"""
+
+
+class TestModelConstraintsEnforcedFalse:
+    """model['constraints'] is populated even when contract.enforced is false."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "schema.yml": schema_enforced_false_yml,
+        }
+
+    def test_constraints_populated(self, project):
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        node = manifest.nodes["model.test.my_model"]
+        assert node.contract.enforced is False
+        assert len(node.constraints) == 1
+        assert node.constraints[0].columns == ["id"]
+
+
+class TestModelConstraintsNoContract:
+    """model['constraints'] is populated when no contract config is set (defaults to unenforced)."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "schema.yml": schema_no_contract_yml,
+        }
+
+    def test_constraints_populated(self, project):
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        node = manifest.nodes["model.test.my_model"]
+        assert node.contract.enforced is False
+        assert len(node.constraints) == 1
+        assert node.constraints[0].columns == ["id"]
+
+
+class TestModelConstraintsNoColumns:
+    """model-level constraints can be defined without specifying columns when unenforced."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "schema.yml": schema_no_columns_yml,
+        }
+
+    def test_constraints_populated_without_columns(self, project):
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        node = manifest.nodes["model.test.my_model"]
+        assert node.contract.enforced is False
+        assert len(node.constraints) == 1
+        assert node.constraints[0].columns == ["id"]


### PR DESCRIPTION
Resolves #10219

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

  When contract.enforced is false, model-level constraints are now
  serialized to node.constraints as expected. Invalid constraint types
  are filtered out silently (rather than causing a mashumaro error)
  when the contract is not enforced.

  Adds functional tests covering constraints with enforced: false,
  no contract config, and no columns defined.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
