### PR TITLE
fixed bug in dotenv loading when executed as dbt cli

### DIFF
--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -7,7 +7,7 @@ import click
 from click.exceptions import BadOptionUsage
 from click.exceptions import Exit as ClickExit
 from click.exceptions import NoSuchOption, UsageError
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 from dbt.adapters.factory import register_adapter
 from dbt.artifacts.schemas.catalog import CatalogArtifact
@@ -22,7 +22,9 @@ from dbt_common.events.base_types import EventMsg
 
 # Load .env from current working directory before Click processes any parameters.
 # override=False ensures shell env vars take precedence over .env values.
-load_dotenv(override=False)
+# usecwd=True is required so find_dotenv searches from the user's cwd rather than
+# walking up from this source file's directory.
+load_dotenv(find_dotenv(usecwd=True), override=False)
 
 
 @dataclass
@@ -57,7 +59,7 @@ class dbtRunner:
 
     def invoke(self, args: List[str], **kwargs) -> dbtRunnerResult:
         try:
-            load_dotenv(override=False)
+            load_dotenv(find_dotenv(usecwd=True), override=False)
             dbt_ctx = cli.make_context(cli.name, args.copy())
             dbt_ctx.obj = {
                 "manifest": self.manifest,


### PR DESCRIPTION
Resolves #

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

When dbt executes as binary, `.env` file was not detected. This is because `load_dotenv` from `python-dotenv` tries to load `.env` from `main.py` instead of the CWD of the project.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

We use `find_dotenv(usecwd=True)` which will find `.env` file from the current working directory and makes it work as expected

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
