### PR TITLE
improve snapshot error message for unique-key violations

### DIFF
--- a/.changes/unreleased/Fixes-20260327-120000.yaml
+++ b/.changes/unreleased/Fixes-20260327-120000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Improve error messaging for snapshot unique-key violations
+time: 2026-03-27T12:00:00.000000+01:00
+custom:
+  Author: knQzx
+  Issue: "10864"

--- a/core/dbt/task/snapshot.py
+++ b/core/dbt/task/snapshot.py
@@ -1,3 +1,4 @@
+import re
 from typing import Optional, Type
 
 from dbt.artifacts.schemas.results import NodeStatus
@@ -5,17 +6,46 @@ from dbt.events.types import LogSnapshotResult
 from dbt.graph import ResourceTypeSelector
 from dbt.node_types import NodeType
 from dbt.task import group_lookup
-from dbt.task.base import BaseRunner
+from dbt.task.base import BaseRunner, ExecutionContext
 from dbt.task.run import ModelRunner, RunTask
 from dbt_common.events.base_types import EventLevel
 from dbt_common.events.functions import fire_event
 from dbt_common.exceptions import DbtInternalError
 from dbt_common.utils import cast_dict_to_dict_of_strings
 
+# Patterns that indicate a unique key violation across different databases
+_DUPLICATE_KEY_PATTERNS = re.compile(
+    r"duplicate row|duplicate key|unique constraint|unique.*violation|"
+    r"duplicate entry|cannot insert duplicate|violates unique|"
+    r"integrity constraint.*unique|duplicate value",
+    re.IGNORECASE,
+)
+
 
 class SnapshotRunner(ModelRunner):
     def describe_node(self) -> str:
         return "snapshot {}".format(self.get_node_representation())
+
+    def handle_exception(self, e: Exception, ctx: ExecutionContext) -> str:
+        error = super().handle_exception(e, ctx)
+        if _DUPLICATE_KEY_PATTERNS.search(error):
+            unique_key = getattr(self.node.config, "unique_key", None)
+            unique_key_str = (
+                ", ".join(unique_key) if isinstance(unique_key, list) else str(unique_key)
+            )
+            hint = (
+                "\n\nThis error is likely because the configured unique_key"
+                f" ({unique_key_str}) is not actually unique in the source"
+                " data. You can verify this by running:\n\n"
+                f"  select {unique_key_str}, count(*)\n"
+                f"  from <your_source_table>\n"
+                f"  group by {unique_key_str}\n"
+                f"  having count(*) > 1\n\n"
+                "See https://docs.getdbt.com/docs/build/snapshots"
+                "#ensure-your-unique-key-is-really-unique"
+            )
+            error += hint
+        return error
 
     def print_result_line(self, result):
         model = result.node


### PR DESCRIPTION
When a snapshot fails due to duplicate rows (e.g. "Duplicate row detected during DML action"), the error now includes a hint explaining that the configured `unique_key` may not be truly unique, along with a diagnostic query and a link to the relevant docs

fixes #10864