### PR TITLE
fix: handle permission errors gracefully when writing package-lock.yml

### DIFF
--- a/.changes/unreleased/Fixes-20260329-142228-9241.yaml
+++ b/.changes/unreleased/Fixes-20260329-142228-9241.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: "Handle permission errors gracefully when writing package-lock.yml"
+time: 2026-03-29T14:22:22.117206+00:00
+custom:
+    Author: claygeo
+    Issue: "9241"

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -1,4 +1,5 @@
 import json
+import os
 from hashlib import sha1
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -31,7 +32,7 @@ from dbt.events.types import (
 from dbt.task.base import BaseTask, move_to_nearest_project_dir
 from dbt_common.clients import system
 from dbt_common.events.functions import fire_event
-from dbt_common.events.types import Formatting
+from dbt_common.events.types import Formatting, Note
 
 
 class dbtPackageDumper(yaml.Dumper):
@@ -272,10 +273,34 @@ class DepsTask(BaseTask):
             self.project.packages.packages
         )
 
-        with open(lock_filepath, "w") as lock_obj:
-            yaml.dump(packages_installed, lock_obj, Dumper=dbtPackageDumper)
-
-        fire_event(DepsLockUpdating(lock_filepath=lock_filepath))
+        # Write the lock file atomically: serialize to a temporary file in the
+        # same directory, then os.replace() it into place. This guarantees that
+        # a write that fails part-way through (for example, a full disk) can
+        # never truncate or corrupt an existing package-lock.yml.
+        lock_tmp_filepath = f"{lock_filepath}.tmp"
+        try:
+            with open(lock_tmp_filepath, "w") as lock_obj:
+                yaml.dump(packages_installed, lock_obj, Dumper=dbtPackageDumper)
+            os.replace(lock_tmp_filepath, lock_filepath)
+            fire_event(DepsLockUpdating(lock_filepath=lock_filepath))
+        except OSError as exc:
+            # The lock file is an optimization, not a requirement: dbt deps can
+            # still install from an existing package-lock.yml when one is
+            # present. A read-only project directory or read-only mounted volume
+            # raises PermissionError (EACCES) or a bare OSError (EROFS) here, so
+            # we treat the failure as non-fatal, surface the reason at INFO via
+            # Note (visible by default, and not escalated to a hard error under
+            # --warn-error the way a WarnLevel event would be), and proceed.
+            try:
+                os.remove(lock_tmp_filepath)
+            except OSError:
+                pass
+            fire_event(
+                Note(
+                    msg=f"Could not write package lock file {lock_filepath}: {exc}. "
+                    "Proceeding without updating the lock file."
+                )
+            )
 
     def run(self) -> None:
         move_to_nearest_project_dir(self.args.project_dir)

--- a/tests/unit/deps/test_deps.py
+++ b/tests/unit/deps/test_deps.py
@@ -1,6 +1,8 @@
 import os
+import tempfile
 import unittest
 from argparse import Namespace
+from contextlib import nullcontext
 from copy import deepcopy
 from unittest import mock
 
@@ -21,10 +23,12 @@ from dbt.deps.local import LocalPinnedPackage, LocalUnpinnedPackage
 from dbt.deps.registry import RegistryUnpinnedPackage
 from dbt.deps.resolver import resolve_packages
 from dbt.deps.tarball import TarballUnpinnedPackage
+from dbt.events.types import DepsLockUpdating
 from dbt.flags import set_from_args
 from dbt.task.deps import DepsTask
 from dbt.version import get_installed_version
 from dbt_common.dataclass_schema import ValidationError
+from dbt_common.events.types import Note
 from dbt_common.semver import VersionSpecifier
 
 set_from_args(Namespace(WARN_ERROR=False), None)
@@ -1241,3 +1245,106 @@ class TestCheckForDuplicatePackagesWithBooleans(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(len(result["packages"]), 1)
         self.assertIn("dbt-utils-extra", result["packages"][0]["git"])
+
+
+class TestDepsLockWriteErrors(unittest.TestCase):
+    """Regression tests for dbt-labs/dbt-core#9241.
+
+    `dbt deps` must not crash when it cannot write ``package-lock.yml`` (for
+    example, a read-only project directory or a read-only mounted volume in a
+    container). ``DepsTask.lock()`` should catch the filesystem error, emit a
+    ``Note`` so the failure is visible, and let ``dbt deps`` proceed without
+    updating the lock file.
+    """
+
+    def _run_lock_with_open_error(self, error):
+        """Drive ``DepsTask.lock()`` for a project that has packages but whose
+        lock-file path cannot be opened for writing. Returns the fired events.
+        """
+        with mock.patch("dbt.task.deps.BaseTask.__init__"):
+            task = DepsTask.__new__(DepsTask)
+        task.cli_vars = {}
+        task.project = mock.MagicMock()
+        task.project.project_root = "/read-only-project"
+        task.project.packages.packages = ["a-package"]
+
+        fired = []
+
+        with mock.patch("dbt.task.deps.resolve_packages", return_value=[]), mock.patch(
+            "dbt.task.deps.downloads_directory", return_value=nullcontext()
+        ), mock.patch("dbt.task.deps.PackageRenderer"), mock.patch(
+            "dbt.task.deps._create_sha1_hash", return_value="hash"
+        ), mock.patch(
+            "dbt.task.deps.fire_event", side_effect=fired.append
+        ), mock.patch(
+            "builtins.open", side_effect=error
+        ):
+            # Must not raise: an unhandled error here is the bug in #9241.
+            task.lock()
+
+        return fired
+
+    def test_lock_handles_permission_error(self):
+        # A read-only directory/file raises PermissionError (errno EACCES).
+        fired = self._run_lock_with_open_error(PermissionError(13, "Permission denied"))
+
+        fired_types = [type(event) for event in fired]
+        self.assertIn(Note, fired_types)
+        self.assertNotIn(DepsLockUpdating, fired_types)
+
+        note = next(event for event in fired if isinstance(event, Note))
+        self.assertIn("/read-only-project", note.msg)
+        self.assertIn("Proceeding without updating the lock file", note.msg)
+
+    def test_lock_handles_read_only_filesystem_error(self):
+        # A read-only mounted volume raises a bare OSError (errno EROFS), which
+        # is NOT a PermissionError. Catching OSError (not PermissionError) is
+        # what covers the common container case.
+        fired = self._run_lock_with_open_error(OSError(30, "Read-only file system"))
+
+        fired_types = [type(event) for event in fired]
+        self.assertIn(Note, fired_types)
+        self.assertNotIn(DepsLockUpdating, fired_types)
+
+        note = next(event for event in fired if isinstance(event, Note))
+        self.assertIn("/read-only-project", note.msg)
+        self.assertIn("Proceeding without updating the lock file", note.msg)
+
+    def test_lock_preserves_existing_lock_file_on_write_failure(self):
+        # If writing the new lock file fails part-way through (for example, a
+        # full disk), the atomic write must leave an existing package-lock.yml
+        # intact rather than truncating it to an empty or partial file.
+        with tempfile.TemporaryDirectory() as project_root:
+            lock_path = f"{project_root}/package-lock.yml"
+            original_contents = "packages:\n- package: dbt-labs/dbt_utils\n  version: 1.0.0\n"
+            with open(lock_path, "w") as existing_lock:
+                existing_lock.write(original_contents)
+
+            with mock.patch("dbt.task.deps.BaseTask.__init__"):
+                task = DepsTask.__new__(DepsTask)
+            task.cli_vars = {}
+            task.project = mock.MagicMock()
+            task.project.project_root = project_root
+            task.project.packages.packages = ["a-package"]
+
+            fired = []
+
+            with mock.patch("dbt.task.deps.resolve_packages", return_value=[]), mock.patch(
+                "dbt.task.deps.downloads_directory", return_value=nullcontext()
+            ), mock.patch("dbt.task.deps.PackageRenderer"), mock.patch(
+                "dbt.task.deps._create_sha1_hash", return_value="hash"
+            ), mock.patch(
+                "dbt.task.deps.fire_event", side_effect=fired.append
+            ), mock.patch(
+                "dbt.task.deps.yaml.dump", side_effect=OSError(28, "No space left on device")
+            ):
+                # Must not raise, and must not corrupt the existing lock file.
+                task.lock()
+
+            with open(lock_path) as preserved_lock:
+                self.assertEqual(preserved_lock.read(), original_contents)
+            self.assertFalse(os.path.exists(f"{lock_path}.tmp"))
+
+            fired_types = [type(event) for event in fired]
+            self.assertIn(Note, fired_types)
+            self.assertNotIn(DepsLockUpdating, fired_types)


### PR DESCRIPTION
Fixes #9241.

## Problem

`dbt deps` crashes with an unhandled `PermissionError` / `OSError` when it cannot write `package-lock.yml`. This happens in read-only project directories and read-only mounted project volumes, which are common in containerized environments. `DepsTask.lock()` opens the lock file with `open(lock_filepath, "w")`, which raises, so `dbt deps` exits with a traceback and no packages installed.

The maintainer [endorsed handling the error and proceeding without writing the lock file](https://github.com/dbt-labs/dbt-core/issues/9241#issuecomment-1847160419) (option 2), rather than adding a flag.

## Fix

`DepsTask.lock()` now writes the lock file **atomically** and treats a write failure as non-fatal:

- **Atomic write:** serialize to a temporary file in the same directory, then `os.replace()` it into place. A write that fails part-way through (for example, a full disk) can no longer truncate or corrupt an existing `package-lock.yml`.
- **Catch `OSError`, not just `PermissionError`:** a read-only mounted volume raises a bare `OSError` (`EROFS`), while a read-only directory raises `PermissionError` (`EACCES`). Both need to be handled.
- On failure, fire a `Note` event with the path and the underlying error, then proceed. `dbt deps` continues and installs from an existing `package-lock.yml` if one is present.

### Why `Note` (INFO) and not a `WarnLevel` event

`Note` is visible by default, so the failure is surfaced (the original bug is that it failed silently). A `WarnLevel` event would be escalated to a hard error under `--warn-error`, which would re-introduce the exact crash this change is meant to avoid. (A dedicated typed event is no longer addable from within dbt-core either, since the event protobufs now live in an external dependency.)

## Behavior

```
Before:  unhandled PermissionError traceback; dbt deps exits non-zero, no packages installed.

After:   [INFO] Could not write package lock file /project/package-lock.yml:
         [Errno 13] Permission denied. Proceeding without updating the lock file.
         ... (packages install from the existing lock file)
```

## Tests

`tests/unit/deps/test_deps.py::TestDepsLockWriteErrors`:

- `test_lock_handles_permission_error` — `PermissionError` (EACCES) is handled, a `Note` is fired, `DepsLockUpdating` is not.
- `test_lock_handles_read_only_filesystem_error` — a bare `OSError` (EROFS) is handled too.
- `test_lock_preserves_existing_lock_file_on_write_failure` — a mid-write failure leaves an existing `package-lock.yml` intact (verifies the atomic write).

## Note on the base branch

This PR was retargeted from `main_backup` to **`1.latest`**. `main`/`main_backup` are now the dbt Fusion (Rust) engine and no longer contain `core/dbt/task/deps.py`; `1.latest` is the active Python dbt-core development branch, where the bug still reproduces.

## Checklist

- [x] My code follows the [dbt coding conventions](https://github.com/dbt-labs/dbt-core/blob/HEAD/CONTRIBUTING.md#coding-conventions)
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to work correctly
- [x] I have added a changie entry
