### PR TITLE
fix: normalize line endings on the file-diff parse path to prevent false state:modified (#11473)

### DIFF
--- a/.changes/unreleased/Fixes-20260619-212305.yaml
+++ b/.changes/unreleased/Fixes-20260619-212305.yaml
@@ -1,0 +1,12 @@
+kind: Fixes
+body: >-
+  Normalize line endings when hashing file contents delivered through a file
+  diff (the `--partial-parse-file-diff` / dbt Cloud path), matching the
+  normalization the on-disk read path (`load_source_file`) already applies.
+  Previously `ReadFilesFromDiff` hashed the raw content, so a model or YAML file
+  authored with Windows (CRLF) line endings was falsely reported as
+  `state:modified` when compared against a manifest built on another platform.
+time: 2026-06-19T21:23:06.0000000Z
+custom:
+    Author: claygeo
+    Issue: "11473"

--- a/core/dbt/parser/read_files.py
+++ b/core/dbt/parser/read_files.py
@@ -316,7 +316,15 @@ class ReadFilesFromDiff:
                 # Get the existing source_file object and update the contents and mod time
                 source_file = self.files[file_id]
                 source_file.contents = input_file.content
-                source_file.checksum = FileHash.from_contents(input_file.content)
+                # Normalize line endings/whitespace before hashing so that
+                # content delivered via a file diff (e.g. dbt Cloud / the
+                # ``--partial-parse-file-diff`` path) produces the same checksum
+                # as the same file read from disk, which normalizes via
+                # load_source_file(). Otherwise a CRLF author vs LF baseline
+                # falsely reports state:modified (#11473).
+                source_file.checksum = FileHash.from_contents(
+                    normalize_file_contents(input_file.content)
+                )
                 source_file.path.modification_time = input_file.modification_time
                 # Handle creation of dictionary version of schema file content
                 if isinstance(source_file, SchemaSourceFile) and source_file.contents:
@@ -378,7 +386,10 @@ class ReadFilesFromDiff:
             source_file = source_file_cls(
                 path=input_file_path,
                 contents=input_file.content,
-                checksum=FileHash.from_contents(input_file.content),
+                # Match the on-disk read path (load_source_file) so a file
+                # added via a file diff hashes the same regardless of the line
+                # endings of the platform it was authored on (#11473).
+                checksum=FileHash.from_contents(normalize_file_contents(input_file.content)),
                 project_name=project_name,
                 parse_file_type=parse_ft,
             )

--- a/tests/functional/partial_parsing/test_file_diff.py
+++ b/tests/functional/partial_parsing/test_file_diff.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from dbt.tests.util import run_dbt, write_artifact, write_file
+from dbt.tests.util import get_manifest, run_dbt, write_artifact, write_file
 from tests.functional.partial_parsing.fixtures import model_one_sql, model_two_sql
 
 first_file_diff = {
@@ -61,3 +61,47 @@ class TestFileDiffs:
         # default behaviour - parse with computing a file diff
         manifest = run_dbt(["--partial-parse", "parse"])
         assert len(manifest.nodes) == 2
+
+
+# A model authored on Windows (CRLF) and delivered through a file diff must
+# hash the same as the normalized on-disk (LF) form, otherwise state:modified
+# is falsely triggered for cross-platform manifests (#11473). The on-disk read
+# path already normalizes via load_source_file(); this guards that the file
+# diff path (ReadFilesFromDiff) stays consistent with it.
+crlf_model_content = "select 1 as fun\r\nunion all\r\nselect 2 as fun\r\n"
+
+crlf_file_diff = {
+    "deleted": [],
+    "changed": [],
+    "added": [{"path": "models/crlf_model.sql", "content": crlf_model_content}],
+}
+
+
+class TestFileDiffLineEndings:
+    def test_file_diff_normalizes_line_endings(self, project):
+        from dbt.artifacts.resources.base import FileHash
+        from dbt.parser.read_files import normalize_file_contents
+
+        os.environ["DBT_PP_FILE_DIFF_TEST"] = "true"
+
+        run_dbt(["deps"])
+        run_dbt(["seed"])
+
+        # Start from an empty project (writes the baseline manifest).
+        run_dbt()
+
+        # Deliver a new model via the file diff with CRLF line endings.
+        write_artifact(crlf_file_diff, "file_diff.json")
+        run_dbt()
+
+        manifest = get_manifest(project.project_root)
+        node = next(n for n in manifest.nodes.values() if n.name == "crlf_model")
+
+        lf_content = crlf_model_content.replace("\r\n", "\n")
+        # CRLF content delivered via the file diff hashes the same as its
+        # normalized LF equivalent (and as the on-disk read path), so it is not
+        # falsely reported as state:modified.
+        assert node.checksum == FileHash.from_contents(normalize_file_contents(crlf_model_content))
+        assert node.checksum == FileHash.from_contents(normalize_file_contents(lf_content))
+        # And specifically not the raw CRLF-sensitive hash (the pre-fix behavior).
+        assert node.checksum != FileHash.from_contents(crlf_model_content)

--- a/tests/unit/parser/test_read_files.py
+++ b/tests/unit/parser/test_read_files.py
@@ -1,13 +1,10 @@
+from types import SimpleNamespace
+
 import pytest
 
 from dbt.artifacts.resources.base import FileHash
 from dbt.contracts.files import FilePath, ParseFileType, SchemaSourceFile, SourceFile
-from dbt.parser.read_files import (
-    FileDiff,
-    InputFile,
-    ReadFilesFromDiff,
-    normalize_file_contents,
-)
+from dbt.parser.read_files import FileDiff, InputFile, ReadFilesFromDiff, normalize_file_contents
 
 
 @pytest.mark.parametrize(
@@ -106,6 +103,62 @@ def test_read_files_from_diff_normalizes_line_endings(
     reader.read_files()
 
     actual = reader.files[file_id].checksum
+    # CRLF content hashes the same as the normalized LF baseline (no false-modified).
+    assert actual == FileHash.from_contents(normalize_file_contents(crlf_content))
+    assert actual == FileHash.from_contents(normalize_file_contents(lf_content))
+    # And specifically NOT the raw CRLF hash (the pre-fix, CRLF-sensitive behavior).
+    assert actual != FileHash.from_contents(crlf_content)
+
+
+def _stub_project(project_root="/project"):
+    """Minimal stand-in for a dbt Project exposing only the path attributes
+    ReadFilesFromDiff.get_project_file_types() reads when resolving an *added*
+    file's parse type. Only ``model_paths`` contains ``models`` so a
+    ``models/*.sql`` file resolves unambiguously to a model."""
+    return SimpleNamespace(
+        project_root=project_root,
+        macro_paths=["macros"],
+        model_paths=["models"],
+        snapshot_paths=["snapshots"],
+        analysis_paths=["analyses"],
+        test_paths=["tests"],
+        generic_test_paths=["tests/generic"],
+        seed_paths=["seeds"],
+        docs_paths=["docs"],
+        all_source_paths=["models-properties"],
+        fixture_paths=["fixtures"],
+        function_paths=["functions"],
+    )
+
+
+def test_read_files_from_diff_added_normalizes_line_endings():
+    """The *added* branch of ReadFilesFromDiff hashes brand-new files at a
+    second site (read_files.py, the ``self.file_diff.added`` loop) that is
+    distinct from the *changed* branch covered above. A model added via the file
+    diff with CRLF line endings must hash the same as its normalized LF
+    equivalent so it is not falsely flagged ``state:modified`` (#11473). This
+    guards that site without needing the heavier functional harness."""
+    lf_content = "select 1 as id\nfrom my_table\n"
+    crlf_content = lf_content.replace("\n", "\r\n")
+
+    reader = ReadFilesFromDiff(
+        root_project_name="test",
+        all_projects={"test": _stub_project()},
+        file_diff=FileDiff(
+            deleted=[],
+            changed=[],
+            added=[InputFile(path="models/crlf_added.sql", content=crlf_content)],
+        ),
+        saved_files={},
+    )
+    reader.read_files()
+
+    # Exactly one file is added; read its checksum from the created entry rather
+    # than reconstructing the file_id (which is built with the OS path separator).
+    added_files = list(reader.files.values())
+    assert len(added_files) == 1
+    assert added_files[0].parse_file_type == ParseFileType.Model
+    actual = added_files[0].checksum
     # CRLF content hashes the same as the normalized LF baseline (no false-modified).
     assert actual == FileHash.from_contents(normalize_file_contents(crlf_content))
     assert actual == FileHash.from_contents(normalize_file_contents(lf_content))

--- a/tests/unit/parser/test_read_files.py
+++ b/tests/unit/parser/test_read_files.py
@@ -1,6 +1,13 @@
 import pytest
 
-from dbt.parser.read_files import normalize_file_contents
+from dbt.artifacts.resources.base import FileHash
+from dbt.contracts.files import FilePath, ParseFileType, SchemaSourceFile, SourceFile
+from dbt.parser.read_files import (
+    FileDiff,
+    InputFile,
+    ReadFilesFromDiff,
+    normalize_file_contents,
+)
 
 
 @pytest.mark.parametrize(
@@ -18,7 +25,89 @@ from dbt.parser.read_files import normalize_file_contents
         ("  a b  ", "a b"),
         ("\na b\n", "a b"),
         ("\n\na b\n\n", "a b"),
+        # Windows (CRLF) and legacy-Mac (CR) line endings must normalize
+        # identically to Unix (LF) so checksums match across platforms (#11473).
+        ("a\r\nb", "a b"),
+        ("a\rb", "a b"),
+        ("a\r\n\r\nb", "a b"),
+        ("select 1\r\nfrom t\r\n", "select 1 from t"),
+        ("select 1\nfrom t\n", "select 1 from t"),
     ],
 )
 def test_normalize_file_contents(file_contents: str, expected_normalized_file_contents: str):
     assert normalize_file_contents(file_contents) == expected_normalized_file_contents
+
+
+def _saved_source_file(project_name, input_path, source_cls, parse_file_type):
+    """Build a SourceFile/SchemaSourceFile standing in for an entry already in
+    the saved manifest. Its checksum is a placeholder; ReadFilesFromDiff
+    recomputes it from the incoming diff content."""
+    parts = input_path.split("/")
+    file_path = FilePath(
+        searched_path=parts[0],
+        relative_path="/".join(parts[1:]),
+        modification_time=0.0,
+        project_root="/project",
+    )
+    return source_cls(
+        path=file_path,
+        checksum=FileHash.from_contents("stale"),
+        project_name=project_name,
+        parse_file_type=parse_file_type,
+        contents="stale",
+    )
+
+
+@pytest.mark.parametrize(
+    "input_path,parse_file_type,source_cls,lf_content",
+    [
+        (
+            "models/my_model.sql",
+            ParseFileType.Model,
+            SourceFile,
+            "select 1 as id\nfrom my_table\n",
+        ),
+        # A non-SQL project file (schema YAML) flows through the same checksum
+        # line in ReadFilesFromDiff, so it must be normalized too.
+        (
+            "models/_schema.yml",
+            ParseFileType.Schema,
+            SchemaSourceFile,
+            "version: 2\nmodels:\n  - name: my_model\n",
+        ),
+    ],
+)
+def test_read_files_from_diff_normalizes_line_endings(
+    input_path, parse_file_type, source_cls, lf_content
+):
+    """ReadFilesFromDiff (the ``--partial-parse-file-diff`` / dbt Cloud path)
+    must canonicalize line endings the same way on-disk reads do (#11473), so a
+    file delivered with CRLF content hashes identically to its LF equivalent and
+    to the normalized on-disk baseline. Without normalization the FileDiff path
+    produces a CRLF-sensitive checksum and falsely flags ``state:modified``."""
+    project_name = "test"
+    file_id = f"{project_name}://{input_path}"
+    crlf_content = lf_content.replace("\n", "\r\n")
+
+    saved_files = {
+        file_id: _saved_source_file(project_name, input_path, source_cls, parse_file_type)
+    }
+    file_diff = FileDiff(
+        deleted=[],
+        changed=[InputFile(path=input_path, content=crlf_content)],
+        added=[],
+    )
+    reader = ReadFilesFromDiff(
+        root_project_name=project_name,
+        all_projects={},
+        file_diff=file_diff,
+        saved_files=saved_files,
+    )
+    reader.read_files()
+
+    actual = reader.files[file_id].checksum
+    # CRLF content hashes the same as the normalized LF baseline (no false-modified).
+    assert actual == FileHash.from_contents(normalize_file_contents(crlf_content))
+    assert actual == FileHash.from_contents(normalize_file_contents(lf_content))
+    # And specifically NOT the raw CRLF hash (the pre-fix, CRLF-sensitive behavior).
+    assert actual != FileHash.from_contents(crlf_content)


### PR DESCRIPTION
## Problem

Fixes #11473.

`dbt ls/build --select state:modified` can report files as modified when only their **line endings** differ (e.g. a model authored on Windows with CRLF, compared against a manifest built on Linux with LF).

The on-disk read path was already fixed for this: `load_source_file()` runs file contents through `normalize_file_contents()` before hashing (added in #13033). But the **file-diff parse path** — `ReadFilesFromDiff`, used by `--partial-parse-file-diff` / dbt Cloud's state-aware orchestration — still hashed the raw content:

```python
# core/dbt/parser/read_files.py — "changed" and "added" branches
source_file.checksum = FileHash.from_contents(input_file.content)   # raw, CRLF-sensitive
```

So the same model/YAML file hashed differently depending on whether it was read from disk (normalized) or delivered via a file diff (raw), producing a false `state:modified` when the two are compared across platforms. This is the cross-platform scenario users have hit (see also the now-closed #10574).

## Fix

Apply the existing `normalize_file_contents()` to the file-diff checksums (the `changed` and `added` branches of `ReadFilesFromDiff`) so the file-diff path matches `load_source_file()`.

This is deliberately at the read/content layer, **not** in `FileHash.from_contents`: that method is a generic primitive also used for synthetic hashes (vars / env / profile / run-operation), so normalizing inside it would change unrelated checksums and wouldn't match `normalize_file_contents`' canonical form. (An earlier version of this PR edited `FileHash.from_contents` directly; that approach predated #13033's helper and is superseded.)

## Tests

- **Unit** (`tests/unit/parser/test_read_files.py`): drives `ReadFilesFromDiff.read_files()` for **both** patched sites — the `changed` branch (a `.sql` model and a `.yml` schema file) and the `added` branch (a new `.sql` model) — asserting the resulting checksum equals the normalized LF baseline and is not the raw CRLF hash. Each case fails without the fix and passes with it. Also adds CRLF/CR cases to `test_normalize_file_contents`.
- **Functional** (`tests/functional/partial_parsing/test_file_diff.py`): delivers a model via `file_diff.json` with CRLF line endings and asserts its node checksum matches the normalized form.

## Notes / scope

- **One-time churn:** manifests previously built through the file-diff path will see those checksums change once on the next build, moving to the normalized/canonical form. This is a self-healing one-time correction that brings the file-diff path in line with the on-disk baseline.
- **Seeds remain a separate, pre-existing item:** on-disk seeds hash via `FileHash.from_path` (text-mode read, internal whitespace preserved), not `normalize_file_contents` — they are deliberately excluded from normalization on disk. An *added* seed delivered via a file diff does flow through the generic `added`-branch checksum line this PR normalizes, so its hash *value* changes; but the seed-via-file-diff hash already diverged from the on-disk `from_path` baseline both **before and after** this change, so this PR neither fixes nor regresses seed line-ending handling. Bringing seeds into parity is out of scope here.
- **Rebased onto `1.latest`** (the maintained Python branch). The previous base, `main_backup`, no longer contains the Python implementation (`main` is now the Rust/Fusion v2 rewrite).
