### PR TITLE
fix: suppress store_failures table hint only when a test errors (#11350)

### DIFF
--- a/.changes/unreleased/Fixes-20260619-120000.yaml
+++ b/.changes/unreleased/Fixes-20260619-120000.yaml
@@ -1,0 +1,11 @@
+kind: Fixes
+body: >-
+  Only emit the "see test failures table" log message for `store_failures` tests
+  that actually ran and stored failing rows (fail or warn severity). When a test
+  errors (e.g. a SQL or database compilation error) the failures table is never
+  created, so the message is now suppressed to avoid pointing users at a missing
+  relation.
+time: 2026-06-19T12:00:00.0000000Z
+custom:
+    Author: claygeo
+    Issue: "11350"

--- a/core/dbt/task/printer.py
+++ b/core/dbt/task/printer.py
@@ -125,7 +125,17 @@ def print_run_result_error(
             fire_event(Formatting(""))
             fire_event(SQLCompiledPath(path=result.node.compiled_path, node_info=node_info))
 
-        if getattr(result.node, "should_store_failures", None):
+        # Only point users to the test failures table when the test actually ran
+        # and stored its failing rows. Tests that Fail or Warn both execute the
+        # query and write the failures table (store_failures is independent of
+        # severity), so the message is useful in both cases. When the status is
+        # Error, the SQL compilation or DB execution failed before the table could
+        # be created, so directing users there would produce a confusing "table
+        # not found" error. Suppress the message only in that (Error) case.
+        if (
+            getattr(result.node, "should_store_failures", None)
+            and result.status != NodeStatus.Error
+        ):
             fire_event(Formatting(""))
             fire_event(
                 CheckNodeTestFailure(relation_name=result.node.relation_name, node_info=node_info)

--- a/tests/unit/task/test_printer.py
+++ b/tests/unit/task/test_printer.py
@@ -1,0 +1,92 @@
+"""Unit tests for dbt.task.printer.print_run_result_error.
+
+Issue #11350: When ``store_failures=True`` and a test errors due to a
+SQL/database compilation error (``NodeStatus.Error``), dbt was still logging
+``CheckNodeTestFailure`` ("see test failures table") even though the failures
+table was never created. The message should appear when the test actually ran
+and stored its failing rows (``Fail`` or ``Warn``) but be suppressed on
+``Error``.
+"""
+
+from unittest import mock
+
+from dbt.contracts.results import NodeStatus
+from dbt.task.printer import print_run_result_error
+
+
+def _make_result(status: NodeStatus, should_store_failures: bool = True) -> mock.Mock:
+    """Build a minimal result mock for print_run_result_error.
+
+    Attributes are set explicitly so ``getattr(result.node, "should_store_failures")``
+    returns the real boolean (a bare Mock would auto-create a truthy attribute).
+    """
+    result = mock.Mock()
+    result.status = status
+    result.message = "test message"
+    result.node.should_store_failures = should_store_failures
+    result.node.relation_name = "test_schema.test_failures"
+    result.node.node_info = {}
+    result.node.compiled_path = None
+    result.node.resource_type = "test"
+    result.node.name = "my_test"
+    result.node.original_file_path = "tests/my_test.sql"
+    return result
+
+
+def _fired_event_types(mock_fire: mock.Mock) -> list:
+    return [type(call[0][0]).__name__ for call in mock_fire.call_args_list if call[0]]
+
+
+class TestPrintRunResultErrorStoreFailures:
+    """CheckNodeTestFailure must fire only when the failures table was actually
+    created. A test that Fails or Warns runs the query and stores the failing
+    rows, so the message is useful. A test that Errors never created the table,
+    so the message would point users at a non-existent relation."""
+
+    def test_check_node_test_failure_fires_for_fail_status(self):
+        """NodeStatus.Fail + should_store_failures → CheckNodeTestFailure fires."""
+        result = _make_result(NodeStatus.Fail, should_store_failures=True)
+        with mock.patch("dbt.task.printer.fire_event") as mock_fire:
+            print_run_result_error(result)
+        assert "CheckNodeTestFailure" in _fired_event_types(mock_fire), (
+            "Expected CheckNodeTestFailure to fire when status=Fail and "
+            "should_store_failures=True"
+        )
+
+    def test_check_node_test_failure_fires_for_warn_status(self):
+        """NodeStatus.Warn + should_store_failures → CheckNodeTestFailure fires.
+
+        A ``severity: warn`` test still runs its query and writes the failures
+        table (store_failures is independent of severity), so users should be
+        pointed at the real table. Warn only reaches this code path via
+        ``is_warning=True``, mirroring print_run_end_messages.
+        """
+        result = _make_result(NodeStatus.Warn, should_store_failures=True)
+        with mock.patch("dbt.task.printer.fire_event") as mock_fire:
+            print_run_result_error(result, is_warning=True)
+        assert "CheckNodeTestFailure" in _fired_event_types(mock_fire), (
+            "Expected CheckNodeTestFailure to fire when status=Warn and "
+            "should_store_failures=True - the failures table is created for "
+            "warn-severity tests too"
+        )
+
+    def test_check_node_test_failure_suppressed_for_error_status(self):
+        """NodeStatus.Error + should_store_failures → CheckNodeTestFailure must NOT fire.
+
+        The failures table was never created when the SQL/DB itself errored, so
+        pointing users there would produce a confusing 'table not found' error.
+        """
+        result = _make_result(NodeStatus.Error, should_store_failures=True)
+        with mock.patch("dbt.task.printer.fire_event") as mock_fire:
+            print_run_result_error(result)
+        assert "CheckNodeTestFailure" not in _fired_event_types(mock_fire), (
+            "CheckNodeTestFailure must not fire when status=Error: the failures "
+            "table was never created"
+        )
+
+    def test_check_node_test_failure_suppressed_when_store_failures_false(self):
+        """should_store_failures=False → CheckNodeTestFailure never fires regardless of status."""
+        result = _make_result(NodeStatus.Fail, should_store_failures=False)
+        with mock.patch("dbt.task.printer.fire_event") as mock_fire:
+            print_run_result_error(result)
+        assert "CheckNodeTestFailure" not in _fired_event_types(mock_fire)


### PR DESCRIPTION
## Summary

Fixes #11350.

When a test has `store_failures: true` and the run produces a database/SQL compilation error (`NodeStatus.Error`), dbt still logged:

> See test failures: `schema.test_failures_table`

The failures table was never created in that case, because the SQL errored before any rows could be written. Following that pointer gives a confusing "relation does not exist" error, which hides the real cause (a compilation error, not actual test failures).

## Fix

In `core/dbt/task/printer.py`, guard the `CheckNodeTestFailure` hint so it only fires when the test actually ran and stored its rows:

```python
if getattr(result.node, "should_store_failures", None) and result.status != NodeStatus.Error:
```

`should_store_failures` is config-driven and independent of severity, so both `Fail` and `Warn` results execute the query and write the failures table. The enclosing block in `print_run_result_error` only handles `Fail`, `Error`, and (via `is_warning`) `Warn`, so suppressing on `!= Error` keeps the hint for `Fail` and `Warn` and drops it only for `Error`.

This uses `!= NodeStatus.Error` rather than `== NodeStatus.Fail`. The `== Fail` form would also have suppressed the hint for warn-severity `store_failures` tests, where the failures table does exist, so it would have hidden a real table.

## Rebase / base change

This branch was rebased onto `1.latest` and the base was retargeted from `main_backup` to `1.latest`. The repo's `main` now hosts the Rust "Fusion" v2.0 rewrite; per the `main` README, Python dbt Core v1 development moved to `1.latest`.

## Tests

`tests/unit/task/test_printer.py` covers every status that reaches the guard:

- `Fail` + `store_failures` -> hint fires
- `Warn` + `store_failures` (`is_warning=True`) -> hint fires
- `Error` + `store_failures` -> hint suppressed (the fix)
- `store_failures=False` -> hint never fires

All 4 pass. I confirmed the bug reproduces on the pre-fix code (the `Error` case fires the hint) and that the fix resolves it without regressing `Fail`/`Warn`. `black`, `isort`, and `flake8` are clean.

## Checklist

- [x] I have signed the CLA
- [x] I have added unit tests to cover new behavior
- [x] I have added a changie entry (references #11350)
- [x] black / isort / flake8 clean
