### PR TITLE
docs: add TESTING.md guide for contributors (resolves #9351)

### DIFF
--- a/.changes/unreleased/docs-add-testing-guide.yaml
+++ b/.changes/unreleased/docs-add-testing-guide.yaml
@@ -1,0 +1,3 @@
+kind: Under the Hood
+body: Added TESTING.md to guide contributors on writing unit and functional tests
+time: 2026-03-29T19:30:00.000000Z

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,6 +257,9 @@ Here are some general rules for adding tests:
 * unit tests (`tests/unit`) don’t need to access a database; "pure Python" tests should be written as unit tests
 * functional tests (`tests/functional`) cover anything that interacts with a database, namely adapter
 
+For detailed guidance on writing tests and examples to follow, see [TESTING.md](TESTING.md).
+
+
 ## Debugging
 
 1. The logs for a `dbt run` have stack traces and other information for debugging errors (in `logs/dbt.log` in your project directory).

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,72 @@
+# Testing Guide for dbt-core Contributors
+
+This is a living document intended to help external contributors understand
+how to write and add tests when submitting a Pull Request to dbt-core.
+
+---
+
+## 🧪 When to Add a Unit Test
+
+Unit tests are fast, isolated tests that validate a single function
+or class in Python without running dbt end-to-end.
+
+**Add a unit test when:**
+- You are fixing a bug in a Python utility or helper function
+- You are adding new logic to an existing class/method
+- Your change does not require a database or dbt project to verify
+
+**Location:** `tests/unit/`
+
+**Examples to follow:**
+- [`tests/unit/test_graph.py`](tests/unit/test_graph.py)
+- [`tests/unit/test_contracts.py`](tests/unit/test_contracts.py)
+
+**How to run unit tests:**
+```bash
+python -m pytest tests/unit
+```
+
+---
+
+## 🔗 When to Add a Functional / Integration Test
+
+Functional tests run dbt against a real (or in-memory) project and validate
+end-to-end behavior — compiling, running models, parsing YAML, etc.
+
+**Add a functional test when:**
+- Your change affects dbt's CLI behavior or output
+- You are modifying how models, sources, or configs are parsed
+- You want to verify correct behavior across an entire dbt run
+
+**Location:** `tests/functional/`
+
+**Examples to follow:**
+- [`tests/functional/sources/`](tests/functional/sources/)
+- [`tests/functional/configs/`](tests/functional/configs/)
+
+**How to run functional tests:**
+```bash
+python -m pytest tests/functional
+```
+
+**Considerations:**
+- Functional tests are slower — only add them when unit tests are insufficient
+- Each test folder typically has a `fixtures/` subfolder with sample dbt projects
+- Use `project` fixtures provided by `dbt-tests-adapter` where possible
+
+---
+
+## 🏃 Running All Tests
+
+```bash
+python -m pytest tests/unit           # fast
+python -m pytest tests/functional     # slower
+python -m pytest tests/                # everything
+```
+
+---
+
+## 💡 Not Sure Which Test to Write?
+
+When in doubt, ask in your Pull Request and a maintainer will guide you.
+You can also check similar merged PRs for patterns.


### PR DESCRIPTION
docs: add TESTING.md guide for contributors (resolves #9351)

Resolves #9351

### Problem

External contributors to `dbt-core` currently have no dedicated reference 
for understanding what types of tests to add when submitting a PR. This 
makes it harder for first-time contributors to know whether to write a unit 
test or a functional test, and where to find existing examples to follow.

### Solution

Added a new `TESTING.md` living document at the root of the repo that covers:
- When to write unit tests (`tests/unit/`) with links to existing examples
- When to write functional/integration tests (`tests/functional/`) with examples and considerations
- How to run each type of test locally using `hatch` and `pytest`

Also added a reference link to `TESTING.md` in the `### Unit, Integration, Functional?` 
section of `CONTRIBUTING.md` so contributors can discover it naturally.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.