### PR TITLE
fix: reduce snowplow telemetry connection timeout from 5s to 1s

### DIFF
--- a/.changes/unreleased/Fixes-20260329-190000.yaml
+++ b/.changes/unreleased/Fixes-20260329-190000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Reduce snowplow telemetry HTTP timeout from 5s to 1s so an unreachable collector does not stall dbt at the end of every invocation
+time: 2026-03-29T19:00:00.000000-04:00
+custom:
+  Author: claygeo
+  Issue: "9989"

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -101,7 +101,10 @@ class TimeoutEmitter(Emitter):
             self.endpoint,
             data=payload,
             headers={"content-type": "application/json; charset=utf-8"},
-            timeout=5.0,
+            # Keep the timeout short so that a missing or unreachable collector
+            # does not noticeably delay the end of every dbt invocation.
+            # See https://github.com/dbt-labs/dbt-core/issues/9989
+            timeout=1.0,
         )
 
         self._log_result("GET", r.status_code)
@@ -110,7 +113,14 @@ class TimeoutEmitter(Emitter):
     def http_get(self, payload):
         self._log_request("GET", payload)
 
-        r = requests.get(self.endpoint, params=payload, timeout=5.0)
+        r = requests.get(
+            self.endpoint,
+            params=payload,
+            # Keep the timeout short so that a missing or unreachable collector
+            # does not noticeably delay the end of every dbt invocation.
+            # See https://github.com/dbt-labs/dbt-core/issues/9989
+            timeout=1.0,
+        )
 
         self._log_result("GET", r.status_code)
         return r

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -1,6 +1,7 @@
 import datetime
 import tempfile
 from unittest import mock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -258,3 +259,38 @@ class TestTrackModelRun:
         opts = mock_track.call_args[0][0]
         assert opts["catalog_type"] == "ICEBERG_REST"
         adapter.get_catalog_integration.assert_called_once_with("test_catalog")
+
+
+class TestTimeoutEmitter:
+    """Verify that the TimeoutEmitter uses short timeouts so an unreachable
+    collector doesn't stall dbt at the end of every invocation.
+    See https://github.com/dbt-labs/dbt-core/issues/9989
+    """
+
+    def test_http_post_uses_short_timeout(self):
+        emitter = dbt.tracking.TimeoutEmitter()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch("dbt.tracking.requests.post", return_value=mock_response) as mock_post:
+            emitter.http_post('{"test": "payload"}')
+            _, kwargs = mock_post.call_args
+            assert "timeout" in kwargs
+            assert kwargs["timeout"] <= 2.0, (
+                f"POST timeout {kwargs['timeout']}s is too long; keep it <= 2s so an unreachable "
+                "collector doesn't stall dbt at the end of every invocation."
+            )
+
+    def test_http_get_uses_short_timeout(self):
+        emitter = dbt.tracking.TimeoutEmitter()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch("dbt.tracking.requests.get", return_value=mock_response) as mock_get:
+            emitter.http_get({"test": "payload"})
+            _, kwargs = mock_get.call_args
+            assert "timeout" in kwargs
+            assert kwargs["timeout"] <= 2.0, (
+                f"GET timeout {kwargs['timeout']}s is too long; keep it <= 2s so an unreachable "
+                "collector doesn't stall dbt at the end of every invocation."
+            )


### PR DESCRIPTION
## Summary

Fixes #9989.

An unreachable or firewalled snowplow collector previously stalled dbt for several seconds at the end of every invocation while the anonymous telemetry call waited out a 5s timeout. (The reporter saw ~30s on macOS, where OS resolver retries compound on top of the request timeout.)

This reduces both the `POST` and `GET` timeouts in `TimeoutEmitter` from `5.0s` to `1.0s`, so a missing or unreachable collector fails near-instantly. It matches @dbeatty10's guidance on the issue:

> It seems reasonable to give the anonymous tracking a quick shot and give up after a very short amount of time (1 or 2 seconds total) if it isn't able to establish a connection (rather than 30 seconds before giving up).

Telemetry here is best-effort and anonymous, and `handle_failure()` already disables tracking after the first failed send, so the shorter timeout only trades a little telemetry deliverability for users on very slow links in exchange for a much snappier exit for everyone offline or firewalled.

### Scope note (honest about what this does and doesn't fix)

`requests`' `timeout` bounds the TCP connect + read, **not** OS-level DNS resolution (`getaddrinfo`). So this fully fixes the common case where the stall is in connect/read (firewalled collector, connected-but-no-internet, cached DNS); a pure no-DNS environment may still see some residual delay in the system resolver. Bounding that would need an async/background-telemetry change, which is out of scope here.

## Test plan

- `core/dbt/tracking.py`: both HTTP methods now pass `timeout=1.0`.
- New `tests/unit/test_tracking.py::TestTimeoutEmitter` asserts `http_post` and `http_get` each send `timeout <= 2.0` (tests the intent, not the exact literal, so a future tweak within the 1-2s window won't break it).
- Verified locally: a connect against an unroutable host drops from ~5.0s to ~1.0s per failed send.

## Base branch

`main` is now dbt Core v2.0 (the Rust engine), so this PR targets **`1.latest`**, where the Python codebase and v1.12.x patch releases live (per the June 2026 roadmap). Rebased onto current `1.latest`; conflict-free.
