### PR TITLE
[Feature] Implement `week` batch size for microbatch incremental strategy

### DIFF
--- a/.changes/unreleased/Features-20260330-175839.yaml
+++ b/.changes/unreleased/Features-20260330-175839.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Implement week batch size for microbatch incremental strategy
+time: 2026-03-30T17:58:39.551005181Z
+custom:
+    Author: burglarhobbit
+    Issue: "11141"

--- a/core/dbt/artifacts/resources/types.py
+++ b/core/dbt/artifacts/resources/types.py
@@ -74,6 +74,7 @@ class TimePeriod(StrEnum):
 class BatchSize(StrEnum):
     hour = "hour"
     day = "day"
+    week = "week"
     month = "month"
     year = "year"
 

--- a/core/dbt/artifacts/resources/v1/config.py
+++ b/core/dbt/artifacts/resources/v1/config.py
@@ -128,6 +128,7 @@ class NodeConfig(NodeAndTestConfig):
     )
     event_time: Any = None
     concurrent_batches: Any = None
+    week_start: Any = None
 
     def __post_init__(self):
         # we validate that node_color has a suitable value to prevent dbt-docs from crashing

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1246,7 +1246,7 @@ class ProviderContext(ManifestContext):
             and self.model.config.get("incremental_strategy") == "microbatch"
             and self.model.batch is not None
         ):
-            week_start = getattr(self.model.config, "week_start", 0) or 0
+            week_start = getattr(self.model.config, "week_start", None) or 0
             split_suffix = MicrobatchBuilder.format_batch_start(
                 self.model.batch.event_time_start,
                 self.model.config.batch_size,

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1246,9 +1246,11 @@ class ProviderContext(ManifestContext):
             and self.model.config.get("incremental_strategy") == "microbatch"
             and self.model.batch is not None
         ):
+            week_start = getattr(self.model.config, "week_start", 0) or 0
             split_suffix = MicrobatchBuilder.format_batch_start(
                 self.model.batch.event_time_start,
                 self.model.config.batch_size,
+                week_start,
             )
 
         self.model.build_path = self.model.get_target_write_path(

--- a/core/dbt/event_time/event_time.py
+++ b/core/dbt/event_time/event_time.py
@@ -20,6 +20,8 @@ def offset_timestamp(timestamp=datetime, batch_size=BatchSize, offset=int) -> da
     2024-09-17 16:06:00 + Batchsize.hour +1 -> 2024-09-17 17:06:00
     2024-09-17 16:06:00 + Batchsize.day -1 -> 2024-09-16 16:06:00
     2024-09-17 16:06:00 + Batchsize.day +1 -> 2024-09-18 16:06:00
+    2024-09-17 16:06:00 + Batchsize.week -1 -> 2024-09-10 16:06:00
+    2024-09-17 16:06:00 + Batchsize.week +1 -> 2024-09-24 16:06:00
     2024-09-17 16:06:00 + Batchsize.month -1 -> 2024-08-17 16:06:00
     2024-09-17 16:06:00 + Batchsize.month +1 -> 2024-10-17 16:06:00
     2024-09-17 16:06:00 + Batchsize.year -1 -> 2023-09-17 16:06:00
@@ -32,6 +34,8 @@ def offset_timestamp(timestamp=datetime, batch_size=BatchSize, offset=int) -> da
         return timestamp + relativedelta(hours=offset)
     elif batch_size == BatchSize.day:
         return timestamp + relativedelta(days=offset)
+    elif batch_size == BatchSize.week:
+        return timestamp + relativedelta(weeks=offset)
     elif batch_size == BatchSize.month:
         return timestamp + relativedelta(months=offset)
     elif batch_size == BatchSize.year:

--- a/core/dbt/materializations/incremental/microbatch.py
+++ b/core/dbt/materializations/incremental/microbatch.py
@@ -41,7 +41,11 @@ class MicrobatchBuilder:
     def build_end_time(self):
         """Defaults the end_time to the current time in UTC unless a non `None` event_time_end was provided"""
         end_time = self.event_time_end or self.default_end_time
-        return MicrobatchBuilder.ceiling_timestamp(end_time, self.model.config.batch_size)
+        week_start = getattr(self.model.config, "week_start", 0)
+        week_start = week_start if isinstance(week_start, int) else 0
+        return MicrobatchBuilder.ceiling_timestamp(
+            end_time, self.model.config.batch_size, week_start
+        )
 
     def build_start_time(self, checkpoint: Optional[datetime]):
         """Create a start time based off the passed in checkpoint.
@@ -53,10 +57,14 @@ class MicrobatchBuilder:
         """
         assert isinstance(self.model.config, NodeConfig)
         batch_size = self.model.config.batch_size
+        week_start = getattr(self.model.config, "week_start", 0)
+        week_start = week_start if isinstance(week_start, int) else 0
 
         # Use event_time_start if it is provided.
         if self.event_time_start:
-            return MicrobatchBuilder.truncate_timestamp(self.event_time_start, batch_size)
+            return MicrobatchBuilder.truncate_timestamp(
+                self.event_time_start, batch_size, week_start
+            )
 
         # First run, use model's configured 'begin' as start.
         if not self.is_incremental or checkpoint is None:
@@ -65,7 +73,9 @@ class MicrobatchBuilder:
                     f"Microbatch model '{self.model.name}' requires a 'begin' configuration."
                 )
 
-            return MicrobatchBuilder.truncate_timestamp(self.model.config.begin, batch_size)
+            return MicrobatchBuilder.truncate_timestamp(
+                self.model.config.begin, batch_size, week_start
+            )
 
         lookback = self.model.config.lookback
 
@@ -73,10 +83,12 @@ class MicrobatchBuilder:
         # the batch line. In this case the last batch will end with the checkpoint, but start
         # should be the previous hour/day/month/year. Thus we need to increase the lookback by
         # 1 to get this affect properly.
-        if checkpoint == MicrobatchBuilder.truncate_timestamp(checkpoint, batch_size):
+        if checkpoint == MicrobatchBuilder.truncate_timestamp(checkpoint, batch_size, week_start):
             lookback += 1
 
-        return MicrobatchBuilder.offset_timestamp(checkpoint, batch_size, -1 * lookback)
+        return MicrobatchBuilder.offset_timestamp(
+            checkpoint, batch_size, -1 * lookback, week_start
+        )
 
     def build_batches(self, start: datetime, end: datetime) -> List[BatchType]:
         """
@@ -84,15 +96,19 @@ class MicrobatchBuilder:
         the size of the model's batch_size.
         """
         batch_size = self.model.config.batch_size
+        week_start = getattr(self.model.config, "week_start", 0)
+        week_start = week_start if isinstance(week_start, int) else 0
         curr_batch_start: datetime = start
         curr_batch_end: datetime = MicrobatchBuilder.offset_timestamp(
-            curr_batch_start, batch_size, 1
+            curr_batch_start, batch_size, 1, week_start
         )
 
         batches: List[BatchType] = [(curr_batch_start, curr_batch_end)]
         while curr_batch_end < end:
             curr_batch_start = curr_batch_end
-            curr_batch_end = MicrobatchBuilder.offset_timestamp(curr_batch_start, batch_size, 1)
+            curr_batch_end = MicrobatchBuilder.offset_timestamp(
+                curr_batch_start, batch_size, 1, week_start
+            )
             batches.append((curr_batch_start, curr_batch_end))
 
         # use exact end value as stop
@@ -122,7 +138,9 @@ class MicrobatchBuilder:
         return jinja_context
 
     @staticmethod
-    def offset_timestamp(timestamp: datetime, batch_size: BatchSize, offset: int) -> datetime:
+    def offset_timestamp(
+        timestamp: datetime, batch_size: BatchSize, offset: int, week_start: int = 0
+    ) -> datetime:
         """Truncates the passed in timestamp based on the batch_size and then applies the offset by the batch_size.
 
         Note: It's important to understand that the offset applies to the truncated timestamp, not
@@ -142,7 +160,7 @@ class MicrobatchBuilder:
         2024-09-17 16:06:00 + Batchsize.year -1 -> 2023-01-01 00:00:00
         2024-09-17 16:06:00 + Batchsize.year +1 -> 2025-01-01 00:00:00
         """
-        truncated = MicrobatchBuilder.truncate_timestamp(timestamp, batch_size)
+        truncated = MicrobatchBuilder.truncate_timestamp(timestamp, batch_size, week_start)
 
         offset_timestamp: datetime
         if batch_size == BatchSize.hour:
@@ -167,12 +185,17 @@ class MicrobatchBuilder:
         return offset_timestamp
 
     @staticmethod
-    def truncate_timestamp(timestamp: datetime, batch_size: BatchSize) -> datetime:
+    def truncate_timestamp(
+        timestamp: datetime, batch_size: BatchSize, week_start: int = 0
+    ) -> datetime:
         """Truncates the passed in timestamp based on the batch_size.
+
+        The week_start parameter (0=Monday, 6=Sunday) controls which day a week begins on,
+        and is only relevant when batch_size is BatchSize.week.
 
         2024-09-17 16:06:00 + Batchsize.hour -> 2024-09-17 16:00:00
         2024-09-17 16:06:00 + Batchsize.day -> 2024-09-17 00:00:00
-        2024-09-17 16:06:00 + Batchsize.week -> 2024-09-16 00:00:00
+        2024-09-17 16:06:00 + Batchsize.week -> 2024-09-16 00:00:00  (week_start=0, Monday)
         2024-09-17 16:06:00 + Batchsize.month -> 2024-09-01 00:00:00
         2024-09-17 16:06:00 + Batchsize.year -> 2024-01-01 00:00:00
         """
@@ -192,11 +215,11 @@ class MicrobatchBuilder:
                 timestamp.year, timestamp.month, timestamp.day, 0, 0, 0, 0, pytz.utc
             )
         elif batch_size == BatchSize.week:
-            # Truncate to the start of the ISO week (Monday)
-            days_since_monday = timestamp.weekday()
+            # Truncate to the start of the week based on week_start (0=Monday, 6=Sunday)
+            days_since_week_start = (timestamp.weekday() - week_start) % 7
             truncated = datetime(
                 timestamp.year, timestamp.month, timestamp.day, 0, 0, 0, 0, pytz.utc
-            ) - timedelta(days=days_since_monday)
+            ) - timedelta(days=days_since_week_start)
         elif batch_size == BatchSize.month:
             truncated = datetime(timestamp.year, timestamp.month, 1, 0, 0, 0, 0, pytz.utc)
         elif batch_size == BatchSize.year:
@@ -205,16 +228,21 @@ class MicrobatchBuilder:
         return truncated
 
     @staticmethod
-    def batch_id(start_time: datetime, batch_size: BatchSize) -> str:
-        return MicrobatchBuilder.format_batch_start(start_time, batch_size).replace("-", "")
+    def batch_id(start_time: datetime, batch_size: BatchSize, week_start: int = 0) -> str:
+        return MicrobatchBuilder.format_batch_start(start_time, batch_size, week_start).replace(
+            "-", ""
+        )
 
     @staticmethod
-    def format_batch_start(batch_start: datetime, batch_size: BatchSize) -> str:
+    def format_batch_start(
+        batch_start: datetime, batch_size: BatchSize, week_start: int = 0
+    ) -> str:
         """Format the passed in datetime based on the batch_size.
 
         2024-09-17 16:06:00 + Batchsize.hour  -> 2024-09-17T16
         2024-09-17 16:06:00 + Batchsize.day   -> 2024-09-17
-        2024-09-17 16:06:00 + Batchsize.week  -> 2024-W38
+        2024-09-17 16:06:00 + Batchsize.week  -> 2024-W38  (when week_start=0, Monday-based ISO week)
+        2024-09-15 00:00:00 + Batchsize.week  -> 2024-09-15 (when week_start != 0, date of week start)
         2024-09-17 16:06:00 + Batchsize.month -> 2024-09
         2024-09-17 16:06:00 + Batchsize.year  -> 2024
         """
@@ -223,14 +251,19 @@ class MicrobatchBuilder:
         elif batch_size == BatchSize.month:
             return batch_start.strftime("%Y-%m")
         elif batch_size == BatchSize.week:
-            return batch_start.strftime("%G-W%V")
+            if week_start == 0:
+                return batch_start.strftime("%G-W%V")
+            else:
+                return batch_start.strftime("%Y-%m-%d")
         elif batch_size == BatchSize.day:
             return batch_start.strftime("%Y-%m-%d")
         else:  # batch_size == BatchSize.hour
             return batch_start.strftime("%Y-%m-%dT%H")
 
     @staticmethod
-    def ceiling_timestamp(timestamp: datetime, batch_size: BatchSize) -> datetime:
+    def ceiling_timestamp(
+        timestamp: datetime, batch_size: BatchSize, week_start: int = 0
+    ) -> datetime:
         """Takes the given timestamp and moves it to the ceiling for the given batch size
 
         Note, if the timestamp is already the batch size ceiling, that is returned
@@ -244,7 +277,9 @@ class MicrobatchBuilder:
         2024-01-01 00:00:00 + BatchSize.year -> 2024-01-01 00:00:00
 
         """
-        ceiling = truncated = MicrobatchBuilder.truncate_timestamp(timestamp, batch_size)
+        ceiling = truncated = MicrobatchBuilder.truncate_timestamp(
+            timestamp, batch_size, week_start
+        )
         if truncated != timestamp:
-            ceiling = MicrobatchBuilder.offset_timestamp(truncated, batch_size, 1)
+            ceiling = MicrobatchBuilder.offset_timestamp(truncated, batch_size, 1, week_start)
         return ceiling

--- a/core/dbt/materializations/incremental/microbatch.py
+++ b/core/dbt/materializations/incremental/microbatch.py
@@ -135,6 +135,8 @@ class MicrobatchBuilder:
         2024-09-17 16:06:00 + Batchsize.hour +1 -> 2024-09-17 17:00:00
         2024-09-17 16:06:00 + Batchsize.day -1 -> 2024-09-16 00:00:00
         2024-09-17 16:06:00 + Batchsize.day +1 -> 2024-09-18 00:00:00
+        2024-09-17 16:06:00 + Batchsize.week -1 -> 2024-09-09 00:00:00
+        2024-09-17 16:06:00 + Batchsize.week +1 -> 2024-09-23 00:00:00
         2024-09-17 16:06:00 + Batchsize.month -1 -> 2024-08-01 00:00:00
         2024-09-17 16:06:00 + Batchsize.month +1 -> 2024-10-01 00:00:00
         2024-09-17 16:06:00 + Batchsize.year -1 -> 2023-01-01 00:00:00
@@ -147,6 +149,8 @@ class MicrobatchBuilder:
             offset_timestamp = truncated + timedelta(hours=offset)
         elif batch_size == BatchSize.day:
             offset_timestamp = truncated + timedelta(days=offset)
+        elif batch_size == BatchSize.week:
+            offset_timestamp = truncated + timedelta(weeks=offset)
         elif batch_size == BatchSize.month:
             offset_timestamp = truncated
             for _ in range(abs(offset)):
@@ -168,6 +172,7 @@ class MicrobatchBuilder:
 
         2024-09-17 16:06:00 + Batchsize.hour -> 2024-09-17 16:00:00
         2024-09-17 16:06:00 + Batchsize.day -> 2024-09-17 00:00:00
+        2024-09-17 16:06:00 + Batchsize.week -> 2024-09-16 00:00:00
         2024-09-17 16:06:00 + Batchsize.month -> 2024-09-01 00:00:00
         2024-09-17 16:06:00 + Batchsize.year -> 2024-01-01 00:00:00
         """
@@ -186,6 +191,12 @@ class MicrobatchBuilder:
             truncated = datetime(
                 timestamp.year, timestamp.month, timestamp.day, 0, 0, 0, 0, pytz.utc
             )
+        elif batch_size == BatchSize.week:
+            # Truncate to the start of the ISO week (Monday)
+            days_since_monday = timestamp.weekday()
+            truncated = datetime(
+                timestamp.year, timestamp.month, timestamp.day, 0, 0, 0, 0, pytz.utc
+            ) - timedelta(days=days_since_monday)
         elif batch_size == BatchSize.month:
             truncated = datetime(timestamp.year, timestamp.month, 1, 0, 0, 0, 0, pytz.utc)
         elif batch_size == BatchSize.year:
@@ -203,6 +214,7 @@ class MicrobatchBuilder:
 
         2024-09-17 16:06:00 + Batchsize.hour  -> 2024-09-17T16
         2024-09-17 16:06:00 + Batchsize.day   -> 2024-09-17
+        2024-09-17 16:06:00 + Batchsize.week  -> 2024-W38
         2024-09-17 16:06:00 + Batchsize.month -> 2024-09
         2024-09-17 16:06:00 + Batchsize.year  -> 2024
         """
@@ -210,6 +222,8 @@ class MicrobatchBuilder:
             return batch_start.strftime("%Y")
         elif batch_size == BatchSize.month:
             return batch_start.strftime("%Y-%m")
+        elif batch_size == BatchSize.week:
+            return batch_start.strftime("%G-W%V")
         elif batch_size == BatchSize.day:
             return batch_start.strftime("%Y-%m-%d")
         else:  # batch_size == BatchSize.hour

--- a/core/dbt/materializations/incremental/microbatch.py
+++ b/core/dbt/materializations/incremental/microbatch.py
@@ -38,13 +38,19 @@ class MicrobatchBuilder:
         self.event_time_end = event_time_end.replace(tzinfo=pytz.UTC) if event_time_end else None
         self.default_end_time = default_end_time or datetime.now(pytz.UTC)
 
+    def _get_week_start(self) -> int:
+        """Returns the configured week_start as an integer (0=Monday, 6=Sunday).
+
+        Defaults to 0 (Monday) if week_start is not set or is not a valid integer.
+        """
+        week_start = getattr(self.model.config, "week_start", None)
+        return week_start if isinstance(week_start, int) else 0
+
     def build_end_time(self):
         """Defaults the end_time to the current time in UTC unless a non `None` event_time_end was provided"""
         end_time = self.event_time_end or self.default_end_time
-        week_start = getattr(self.model.config, "week_start", 0)
-        week_start = week_start if isinstance(week_start, int) else 0
         return MicrobatchBuilder.ceiling_timestamp(
-            end_time, self.model.config.batch_size, week_start
+            end_time, self.model.config.batch_size, self._get_week_start()
         )
 
     def build_start_time(self, checkpoint: Optional[datetime]):
@@ -57,8 +63,7 @@ class MicrobatchBuilder:
         """
         assert isinstance(self.model.config, NodeConfig)
         batch_size = self.model.config.batch_size
-        week_start = getattr(self.model.config, "week_start", 0)
-        week_start = week_start if isinstance(week_start, int) else 0
+        week_start = self._get_week_start()
 
         # Use event_time_start if it is provided.
         if self.event_time_start:
@@ -96,8 +101,7 @@ class MicrobatchBuilder:
         the size of the model's batch_size.
         """
         batch_size = self.model.config.batch_size
-        week_start = getattr(self.model.config, "week_start", 0)
-        week_start = week_start if isinstance(week_start, int) else 0
+        week_start = self._get_week_start()
         curr_batch_start: datetime = start
         curr_batch_end: datetime = MicrobatchBuilder.offset_timestamp(
             curr_batch_start, batch_size, 1, week_start

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1523,6 +1523,17 @@ class ManifestLoader:
                             f"Microbatch model '{node.name}' optional 'concurrent_batches' config must be of type `bool` if specified, but got: {type(concurrent_batches)})."
                         )
 
+                    # optional config: week_start (int 0-6, only meaningful for batch_size='week')
+                    week_start = node.config.week_start
+                    if week_start is not None and not isinstance(week_start, int):
+                        raise dbt.exceptions.ParsingError(
+                            f"Microbatch model '{node.name}' optional 'week_start' config must be of type `int` (0=Monday through 6=Sunday) if specified, but got: {type(week_start)})."
+                        )
+                    if isinstance(week_start, int) and not (0 <= week_start <= 6):
+                        raise dbt.exceptions.ParsingError(
+                            f"Microbatch model '{node.name}' optional 'week_start' config must be an integer between 0 (Monday) and 6 (Sunday), but got: {week_start}."
+                        )
+
     def check_forcing_batch_concurrency(self) -> None:
         if self.manifest.use_microbatch_batches(project_name=self.root_project.project_name):
             adapter = get_adapter(self.root_project)

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -361,7 +361,7 @@ class MicrobatchBatchRunner(ModelRunner):
 
     def describe_batch(self) -> str:
         batch_start = self.batches[self.batch_idx][0]
-        week_start = getattr(self.node.config, "week_start", 0) or 0
+        week_start = getattr(self.node.config, "week_start", None) or 0
         formatted_batch_start = MicrobatchBuilder.format_batch_start(
             batch_start, self.node.config.batch_size, week_start
         )
@@ -448,7 +448,7 @@ class MicrobatchBatchRunner(ModelRunner):
 
     def compile(self, manifest: Manifest):
         batch = self.batches[self.batch_idx]
-        week_start = getattr(self.node.config, "week_start", 0) or 0
+        week_start = getattr(self.node.config, "week_start", None) or 0
 
         # LEGACY: Set start/end in context prior to re-compiling (Will be removed for 1.10+)
         # TODO: REMOVE before 1.10 GA

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -361,8 +361,9 @@ class MicrobatchBatchRunner(ModelRunner):
 
     def describe_batch(self) -> str:
         batch_start = self.batches[self.batch_idx][0]
+        week_start = getattr(self.node.config, "week_start", 0) or 0
         formatted_batch_start = MicrobatchBuilder.format_batch_start(
-            batch_start, self.node.config.batch_size
+            batch_start, self.node.config.batch_size, week_start
         )
         return f"batch {formatted_batch_start} of {self.get_node_representation()}"
 
@@ -447,6 +448,7 @@ class MicrobatchBatchRunner(ModelRunner):
 
     def compile(self, manifest: Manifest):
         batch = self.batches[self.batch_idx]
+        week_start = getattr(self.node.config, "week_start", 0) or 0
 
         # LEGACY: Set start/end in context prior to re-compiling (Will be removed for 1.10+)
         # TODO: REMOVE before 1.10 GA
@@ -454,7 +456,7 @@ class MicrobatchBatchRunner(ModelRunner):
         self.node.config["__dbt_internal_microbatch_event_time_end"] = batch[1]
         # Create batch context on model node prior to re-compiling
         self.node.batch = BatchContext(
-            id=MicrobatchBuilder.batch_id(batch[0], self.node.config.batch_size),
+            id=MicrobatchBuilder.batch_id(batch[0], self.node.config.batch_size, week_start),
             event_time_start=batch[0],
             event_time_end=batch[1],
         )
@@ -464,7 +466,7 @@ class MicrobatchBatchRunner(ModelRunner):
             manifest,
             {},
             split_suffix=MicrobatchBuilder.format_batch_start(
-                batch[0], self.node.config.batch_size
+                batch[0], self.node.config.batch_size, week_start
             ),
         )
 

--- a/docs/arch/6.2_dbt_run.md
+++ b/docs/arch/6.2_dbt_run.md
@@ -55,7 +55,7 @@ Microbatch is a special incremental strategy for processing time-series data in 
 
 Rather than processing all data in a single transaction, microbatch:
 
-1. Divides the time range into batches based on `batch_size` (hour, day, month, year)
+1. Divides the time range into batches based on `batch_size` (hour, day, week, month, year)
 2. Executes each batch as a separate transaction
 3. Supports parallel batch execution after the first batch succeeds
 4. Tracks batch-level success/failure for retry capability
@@ -109,7 +109,7 @@ models:
   my_model:
     materialized: incremental
     incremental_strategy: microbatch
-    batch_size: day  # hour, day, month, year
+    batch_size: day  # hour, day, week, month, year
     begin: '2020-01-01'
     lookback: 1  # number of batches to re-process for late-arriving data
 ```

--- a/tests/unit/event_time/test_event_time.py
+++ b/tests/unit/event_time/test_event_time.py
@@ -50,6 +50,18 @@ class TestEventTime:
             ),
             (
                 datetime(2024, 9, 5, 3, 56, 1, 1, pytz.UTC),
+                BatchSize.week,
+                1,
+                datetime(2024, 9, 12, 3, 56, 1, 1, pytz.UTC),
+            ),
+            (
+                datetime(2024, 9, 5, 3, 56, 1, 1, pytz.UTC),
+                BatchSize.week,
+                -1,
+                datetime(2024, 8, 29, 3, 56, 1, 1, pytz.UTC),
+            ),
+            (
+                datetime(2024, 9, 5, 3, 56, 1, 1, pytz.UTC),
                 BatchSize.hour,
                 1,
                 datetime(2024, 9, 5, 4, 56, 1, 1, pytz.UTC),

--- a/tests/unit/event_time/test_sample_mode.py
+++ b/tests/unit/event_time/test_sample_mode.py
@@ -126,8 +126,30 @@ from dbt_common.exceptions import DbtRuntimeError
         ),
         (
             "1 week",
-            DbtRuntimeError(
-                "Invalid grain size 'week'. Must be one of ['hour', 'day', 'month', 'year', 'hours', 'days', 'months', 'years']."
+            SampleWindow(
+                start=datetime(2025, 1, 21, 18, 4, 0, 0, pytz.UTC),
+                end=datetime(2025, 1, 28, 18, 4, 0, 0, pytz.UTC),
+            ),
+        ),
+        (
+            "4 weeks",
+            SampleWindow(
+                start=datetime(2024, 12, 31, 18, 4, 0, 0, pytz.UTC),
+                end=datetime(2025, 1, 28, 18, 4, 0, 0, pytz.UTC),
+            ),
+        ),
+        (
+            "1 WEEK",
+            SampleWindow(
+                start=datetime(2025, 1, 21, 18, 4, 0, 0, pytz.UTC),
+                end=datetime(2025, 1, 28, 18, 4, 0, 0, pytz.UTC),
+            ),
+        ),
+        (
+            "4 WEEKS",
+            SampleWindow(
+                start=datetime(2024, 12, 31, 18, 4, 0, 0, pytz.UTC),
+                end=datetime(2025, 1, 28, 18, 4, 0, 0, pytz.UTC),
             ),
         ),
         ("an hour", DbtRuntimeError("Unable to convert 'an' to an integer.")),

--- a/tests/unit/materializations/incremental/test_microbatch.py
+++ b/tests/unit/materializations/incremental/test_microbatch.py
@@ -396,6 +396,26 @@ class TestMicrobatchBuilder:
                     ),
                 ],
             ),
+            # BatchSize.week
+            (
+                datetime(2024, 9, 2, 0, 0, 0, 0, pytz.UTC),
+                datetime(2024, 9, 18, 3, 56, 0, 0, pytz.UTC),
+                BatchSize.week,
+                [
+                    (
+                        datetime(2024, 9, 2, 0, 0, 0, 0, pytz.UTC),
+                        datetime(2024, 9, 9, 0, 0, 0, 0, pytz.UTC),
+                    ),
+                    (
+                        datetime(2024, 9, 9, 0, 0, 0, 0, pytz.UTC),
+                        datetime(2024, 9, 16, 0, 0, 0, 0, pytz.UTC),
+                    ),
+                    (
+                        datetime(2024, 9, 16, 0, 0, 0, 0, pytz.UTC),
+                        datetime(2024, 9, 18, 3, 56, 0, 0, pytz.UTC),
+                    ),
+                ],
+            ),
             # BatchSize.hour
             (
                 datetime(2024, 9, 5, 1, 0, 0, 0, pytz.UTC),
@@ -545,6 +565,18 @@ class TestMicrobatchBuilder:
             ),
             (
                 datetime(2024, 9, 5, 3, 56, 1, 1, pytz.UTC),
+                BatchSize.week,
+                1,
+                datetime(2024, 9, 9, 0, 0, 0, 0, pytz.UTC),
+            ),
+            (
+                datetime(2024, 9, 5, 3, 56, 1, 1, pytz.UTC),
+                BatchSize.week,
+                -1,
+                datetime(2024, 8, 26, 0, 0, 0, 0, pytz.UTC),
+            ),
+            (
+                datetime(2024, 9, 5, 3, 56, 1, 1, pytz.UTC),
                 BatchSize.day,
                 1,
                 datetime(2024, 9, 6, 0, 0, 0, 0, pytz.UTC),
@@ -589,6 +621,11 @@ class TestMicrobatchBuilder:
             ),
             (
                 datetime(2024, 9, 5, 3, 56, 1, 1, pytz.UTC),
+                BatchSize.week,
+                datetime(2024, 9, 2, 0, 0, 0, 0, pytz.UTC),
+            ),
+            (
+                datetime(2024, 9, 5, 3, 56, 1, 1, pytz.UTC),
                 BatchSize.day,
                 datetime(2024, 9, 5, 0, 0, 0, 0, pytz.UTC),
             ),
@@ -607,6 +644,7 @@ class TestMicrobatchBuilder:
         [
             (BatchSize.year, datetime(2020, 1, 1, 1), "2020"),
             (BatchSize.month, datetime(2020, 1, 1, 1), "202001"),
+            (BatchSize.week, datetime(2020, 1, 6, 1), "2020W02"),
             (BatchSize.day, datetime(2020, 1, 1, 1), "20200101"),
             (BatchSize.hour, datetime(2020, 1, 1, 1), "20200101T01"),
         ],
@@ -621,6 +659,7 @@ class TestMicrobatchBuilder:
         [
             (BatchSize.year, datetime(2020, 1, 1, 1), "2020"),
             (BatchSize.month, datetime(2020, 1, 1, 1), "2020-01"),
+            (BatchSize.week, datetime(2020, 1, 6, 1), "2020-W02"),
             (BatchSize.day, datetime(2020, 1, 1, 1), "2020-01-01"),
             (BatchSize.hour, datetime(2020, 1, 1, 1), "2020-01-01T01"),
         ],
@@ -655,6 +694,16 @@ class TestMicrobatchBuilder:
                 datetime(2024, 9, 17, 0, 0, 0, 0, pytz.UTC),
                 BatchSize.day,
                 datetime(2024, 9, 17, 0, 0, 0, 0, pytz.UTC),
+            ),
+            (
+                datetime(2024, 9, 17, 16, 6, 0, 0, pytz.UTC),
+                BatchSize.week,
+                datetime(2024, 9, 23, 0, 0, 0, 0, pytz.UTC),
+            ),
+            (
+                datetime(2024, 9, 16, 0, 0, 0, 0, pytz.UTC),
+                BatchSize.week,
+                datetime(2024, 9, 16, 0, 0, 0, 0, pytz.UTC),
             ),
             (
                 datetime(2024, 9, 17, 16, 6, 0, 0, pytz.UTC),

--- a/tests/unit/materializations/incremental/test_microbatch.py
+++ b/tests/unit/materializations/incremental/test_microbatch.py
@@ -888,7 +888,7 @@ class TestMicrobatchBuilder:
             model=microbatch_model, is_incremental=True, event_time_start=None, event_time_end=None
         )
 
-        # 2024-09-01 is a Sunday, 2024-09-22 is a Sunday
+        # 2024-09-01 is a Sunday; end date is 2024-09-18 (a Wednesday)
         start = datetime(2024, 9, 1, 0, 0, 0, 0, pytz.UTC)
         end = datetime(2024, 9, 18, 3, 56, 0, 0, pytz.UTC)
         batches = microbatch_builder.build_batches(start, end)

--- a/tests/unit/materializations/incremental/test_microbatch.py
+++ b/tests/unit/materializations/incremental/test_microbatch.py
@@ -732,3 +732,180 @@ class TestMicrobatchBuilder:
     ) -> None:
         ceilinged = MicrobatchBuilder.ceiling_timestamp(timestamp, batch_size)
         assert ceilinged == expected_datetime
+
+    @pytest.mark.parametrize(
+        "timestamp,week_start,expected_timestamp",
+        [
+            # week_start=0 (Monday) - same as default behavior
+            (
+                datetime(2024, 9, 5, 3, 56, 1, 1, pytz.UTC),  # Thursday
+                0,
+                datetime(2024, 9, 2, 0, 0, 0, 0, pytz.UTC),  # Monday
+            ),
+            # week_start=6 (Sunday)
+            (
+                datetime(2024, 9, 5, 3, 56, 1, 1, pytz.UTC),  # Thursday
+                6,
+                datetime(2024, 9, 1, 0, 0, 0, 0, pytz.UTC),  # Sunday
+            ),
+            # week_start=6 (Sunday) when timestamp is Sunday (no change)
+            (
+                datetime(2024, 9, 1, 0, 0, 0, 0, pytz.UTC),  # Sunday
+                6,
+                datetime(2024, 9, 1, 0, 0, 0, 0, pytz.UTC),  # Sunday
+            ),
+            # week_start=6 (Sunday) when timestamp is Monday
+            (
+                datetime(2024, 9, 2, 0, 0, 0, 0, pytz.UTC),  # Monday
+                6,
+                datetime(2024, 9, 1, 0, 0, 0, 0, pytz.UTC),  # Sunday
+            ),
+            # week_start=6 (Sunday) when timestamp is Saturday
+            (
+                datetime(2024, 9, 7, 0, 0, 0, 0, pytz.UTC),  # Saturday
+                6,
+                datetime(2024, 9, 1, 0, 0, 0, 0, pytz.UTC),  # Sunday
+            ),
+            # week_start=1 (Tuesday)
+            (
+                datetime(2024, 9, 5, 3, 56, 1, 1, pytz.UTC),  # Thursday
+                1,
+                datetime(2024, 9, 3, 0, 0, 0, 0, pytz.UTC),  # Tuesday
+            ),
+        ],
+    )
+    def test_truncate_timestamp_week_start(
+        self, timestamp: datetime, week_start: int, expected_timestamp: datetime
+    ) -> None:
+        assert (
+            MicrobatchBuilder.truncate_timestamp(timestamp, BatchSize.week, week_start)
+            == expected_timestamp
+        )
+
+    @pytest.mark.parametrize(
+        "timestamp,week_start,offset,expected_timestamp",
+        [
+            # week_start=6 (Sunday), offset +1
+            (
+                datetime(2024, 9, 5, 3, 56, 1, 1, pytz.UTC),  # Thursday
+                6,
+                1,
+                datetime(2024, 9, 8, 0, 0, 0, 0, pytz.UTC),  # next Sunday
+            ),
+            # week_start=6 (Sunday), offset -1
+            (
+                datetime(2024, 9, 5, 3, 56, 1, 1, pytz.UTC),  # Thursday
+                6,
+                -1,
+                datetime(2024, 8, 25, 0, 0, 0, 0, pytz.UTC),  # previous Sunday
+            ),
+        ],
+    )
+    def test_offset_timestamp_week_start(
+        self,
+        timestamp: datetime,
+        week_start: int,
+        offset: int,
+        expected_timestamp: datetime,
+    ) -> None:
+        assert (
+            MicrobatchBuilder.offset_timestamp(timestamp, BatchSize.week, offset, week_start)
+            == expected_timestamp
+        )
+
+    @pytest.mark.parametrize(
+        "timestamp,week_start,expected_datetime",
+        [
+            # week_start=6 (Sunday), timestamp not on boundary
+            (
+                datetime(2024, 9, 5, 3, 56, 1, 1, pytz.UTC),  # Thursday
+                6,
+                datetime(2024, 9, 8, 0, 0, 0, 0, pytz.UTC),  # next Sunday
+            ),
+            # week_start=6 (Sunday), timestamp already on Sunday boundary
+            (
+                datetime(2024, 9, 1, 0, 0, 0, 0, pytz.UTC),  # Sunday
+                6,
+                datetime(2024, 9, 1, 0, 0, 0, 0, pytz.UTC),  # same Sunday
+            ),
+        ],
+    )
+    def test_ceiling_timestamp_week_start(
+        self, timestamp: datetime, week_start: int, expected_datetime: datetime
+    ) -> None:
+        assert (
+            MicrobatchBuilder.ceiling_timestamp(timestamp, BatchSize.week, week_start)
+            == expected_datetime
+        )
+
+    @pytest.mark.parametrize(
+        "week_start,batch_start,expected_formatted_batch_start",
+        [
+            # week_start=0 (Monday) uses ISO week format
+            (0, datetime(2020, 1, 6, 0), "2020-W02"),
+            # week_start=6 (Sunday) uses date format
+            (6, datetime(2020, 1, 5, 0), "2020-01-05"),
+            # week_start=1 (Tuesday) uses date format
+            (1, datetime(2020, 1, 7, 0), "2020-01-07"),
+        ],
+    )
+    def test_format_batch_start_week_start(
+        self,
+        week_start: int,
+        batch_start: datetime,
+        expected_formatted_batch_start: str,
+    ) -> None:
+        assert (
+            MicrobatchBuilder.format_batch_start(batch_start, BatchSize.week, week_start)
+            == expected_formatted_batch_start
+        )
+
+    @pytest.mark.parametrize(
+        "week_start,batch_start,expected_batch_id",
+        [
+            # week_start=0 (Monday) uses ISO week format (no dashes)
+            (0, datetime(2020, 1, 6, 0), "2020W02"),
+            # week_start=6 (Sunday) uses date format (no dashes)
+            (6, datetime(2020, 1, 5, 0), "20200105"),
+        ],
+    )
+    def test_batch_id_week_start(
+        self,
+        week_start: int,
+        batch_start: datetime,
+        expected_batch_id: str,
+    ) -> None:
+        assert (
+            MicrobatchBuilder.batch_id(batch_start, BatchSize.week, week_start)
+            == expected_batch_id
+        )
+
+    def test_build_batches_week_start_sunday(self, microbatch_model):
+        """Test that build_batches respects week_start=6 (Sunday) for weekly batches."""
+        microbatch_model.config.batch_size = BatchSize.week
+        microbatch_model.config.week_start = 6  # Sunday
+        microbatch_builder = MicrobatchBuilder(
+            model=microbatch_model, is_incremental=True, event_time_start=None, event_time_end=None
+        )
+
+        # 2024-09-01 is a Sunday, 2024-09-22 is a Sunday
+        start = datetime(2024, 9, 1, 0, 0, 0, 0, pytz.UTC)
+        end = datetime(2024, 9, 18, 3, 56, 0, 0, pytz.UTC)
+        batches = microbatch_builder.build_batches(start, end)
+
+        expected_batches = [
+            (
+                datetime(2024, 9, 1, 0, 0, 0, 0, pytz.UTC),
+                datetime(2024, 9, 8, 0, 0, 0, 0, pytz.UTC),
+            ),
+            (
+                datetime(2024, 9, 8, 0, 0, 0, 0, pytz.UTC),
+                datetime(2024, 9, 15, 0, 0, 0, 0, pytz.UTC),
+            ),
+            (
+                datetime(2024, 9, 15, 0, 0, 0, 0, pytz.UTC),
+                datetime(2024, 9, 18, 3, 56, 0, 0, pytz.UTC),
+            ),
+        ]
+        assert len(batches) == len(expected_batches)
+        assert batches == expected_batches


### PR DESCRIPTION
Resolves #11141

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

The current microbatch incremental strategy in dbt-core supports `daily`, `hourly`, and `monthly` granularities. However, many financial and reporting workflows operate on a weekly cadence. Without native weekly support, users are forced to use daily batches (which creates unnecessary overhead with 7x the number of queries) or monthly batches (which may be too broad for their data loading windows).


### Solution

I have extended the microbatch logic to include the week grain.
- Logic: Added `week` to the supported list of granularities within the microbatch engine.
- Batch Calculation: The system now correctly calculates the start and end boundaries for weekly intervals, ensuring that the event_time filtering logic aligns with standard ISO weeks.
- Consistency: Updated the validation logic to ensure `batch_size: week` is recognized as a valid configuration in `dbt_project.yml` or model config blocks.

Tradeoffs considered:

- ISO vs. Non-ISO weeks: Stuck with the standard Python/SQL ISO week definitions to maintain consistency with how dbt handles date parts across most supported adapters.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
