### PR TITLE
Fix partial parse cache drop when meta contains integer keys

### DIFF
--- a/.changes/unreleased/Fixes-20260403-151724.yaml
+++ b/.changes/unreleased/Fixes-20260403-151724.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Preserve partial parse cache when meta contains integer keys; promote ParsedFileLoadFailed to WarnLevel so users see why the cache was discarded
+time: 2026-04-03T19:17:24.000000+00:00
+custom:
+    Author: ujjwalredd
+    Issue: "12578"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -911,7 +911,7 @@ class PartialParsingNotEnabled(DebugLevel):
         return "Partial parsing not enabled"
 
 
-class ParsedFileLoadFailed(DebugLevel):
+class ParsedFileLoadFailed(WarnLevel):
     def code(self) -> str:
         return "I029"
 

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -160,7 +160,9 @@ def extended_msgpack_encoder(obj):
 
 
 def extended_mashumuro_decoder(data):
-    return msgpack.unpackb(data, ext_hook=extended_msgpack_decoder, raw=False)
+    return msgpack.unpackb(
+        data, ext_hook=extended_msgpack_decoder, raw=False, strict_map_key=False
+    )
 
 
 def extended_msgpack_decoder(code, data):

--- a/tests/functional/partial_parsing/test_pp_integer_meta_keys.py
+++ b/tests/functional/partial_parsing/test_pp_integer_meta_keys.py
@@ -1,0 +1,136 @@
+"""
+Functional tests for partial_parse.msgpack deserialization when `meta`
+contains integer keys.
+
+Reproduces: https://github.com/dbt-labs/dbt-core/issues/12578
+
+Root cause
+----------
+PyYAML's SafeLoader resolves bare integer keys (e.g. ``0: foo``) in YAML
+maps to Python ``int`` objects.  When dbt writes the manifest to
+``partial_parse.msgpack`` via msgpack.packb, integer keys are accepted
+silently.  However on the subsequent run, ``msgpack.unpackb`` was called
+with ``strict_map_key=True`` (the library default), which raises::
+
+    ValueError: int is not allowed for map key when strict_map_key=True
+
+This caused dbt to discard the cache and fall back to a full re-parse on
+every run — silently, because the failure event was fired at DebugLevel.
+
+The fix
+-------
+* ``core/dbt/parser/manifest.py`` — pass ``strict_map_key=False`` to
+  ``msgpack.unpackb`` so that the decoder accepts integer keys, mirroring
+  what the packer already allows.
+* ``core/dbt/events/types.py`` — promote ``ParsedFileLoadFailed`` from
+  ``DebugLevel`` to ``WarnLevel`` so users are notified when the cache
+  cannot be loaded.
+"""
+
+import pytest
+
+from dbt.tests.util import get_manifest, run_dbt, write_file
+
+# --------------------------------------------------------------------------- #
+# Fixtures                                                                     #
+# --------------------------------------------------------------------------- #
+
+_MODEL_SQL = "select 1 as id"
+
+# PyYAML SafeLoader parses bare integers as Python int objects, so keys
+# ``0`` and ``1`` below are stored in the manifest node's meta dict as
+# int(0) and int(1) — exactly the values that triggered the bug.
+_SCHEMA_WITH_INT_META_KEYS_YML = """
+version: 2
+
+models:
+  - name: my_model
+    description: "model with integer keys in meta"
+    meta:
+      0: first
+      1: second
+      label: also_a_string_key
+"""
+
+_SCHEMA_UPDATED_YML = """
+version: 2
+
+models:
+  - name: my_model
+    description: "updated description to trigger partial re-parse"
+    meta:
+      0: first
+      1: second
+      label: also_a_string_key
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Tests                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+class TestPartialParseIntegerMetaKeys:
+    """
+    Verifies that partial_parse.msgpack round-trips correctly when a node's
+    ``meta`` dict contains integer keys.
+
+    Without the fix, the second ``dbt parse`` call raises
+    ``ValueError: int is not allowed for map key when strict_map_key=True``
+    internally and falls back to a full re-parse (or raises, depending on
+    dbt version).  With the fix, the cache is loaded successfully on every
+    subsequent run.
+    """
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": _MODEL_SQL,
+            "schema.yml": _SCHEMA_WITH_INT_META_KEYS_YML,
+        }
+
+    def test_first_parse_writes_msgpack_with_int_keys(self, project):
+        """Initial parse should succeed and write partial_parse.msgpack."""
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        assert manifest is not None
+        assert "model.test.my_model" in manifest.nodes
+        node = manifest.nodes["model.test.my_model"]
+        # Confirm integer keys survived the parse round-trip
+        assert node.meta.get(0) == "first"
+        assert node.meta.get(1) == "second"
+        assert node.meta.get("label") == "also_a_string_key"
+
+    def test_second_parse_loads_msgpack_without_error(self, project):
+        """
+        A second parse must load the cached msgpack without raising
+        ``ValueError: int is not allowed for map key``.
+
+        Before the fix, dbt would silently discard the cache (or raise) and
+        perform a full re-parse.  With the fix, the cache is reused.
+        """
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        assert manifest is not None
+        node = manifest.nodes["model.test.my_model"]
+        assert node.meta.get(0) == "first"
+        assert node.meta.get(1) == "second"
+
+    def test_partial_reparse_after_schema_change_preserves_int_keys(self, project):
+        """
+        Editing the schema YAML (triggers a partial re-parse) must also
+        round-trip integer meta keys correctly.
+        """
+        write_file(
+            _SCHEMA_UPDATED_YML,
+            project.project_root,
+            "models",
+            "schema.yml",
+        )
+        run_dbt(["--partial-parse", "parse"])
+        manifest = get_manifest(project.project_root)
+        assert manifest is not None
+        node = manifest.nodes["model.test.my_model"]
+        assert node.meta.get(0) == "first"
+        assert node.meta.get(1) == "second"
+        assert node.description == "updated description to trigger partial re-parse"


### PR DESCRIPTION
Resolves #12578

### Problem

PyYAML's `SafeLoader` resolves bare integer keys (e.g. `0: value`) in YAML maps to Python `int` objects. When a model's `meta` dict is defined with integer keys in `schema.yml`:

```yaml
models:
  - name: my_model
    meta:
      0: first
      1: second
```

dbt's msgpack encoder (`msgpack.packb`) silently accepts integer keys on write. However, the decoder (`msgpack.unpackb`) was called with `strict_map_key=True` (the library's default), which raises:

```
ValueError: int is not allowed for map key when strict_map_key=True
```

This causes dbt to silently discard `partial_parse.msgpack` and fall back to a full re-parse on **every subsequent run** — adding 30–120 seconds of overhead on large projects (1000+ models) with no user-visible explanation, because `ParsedFileLoadFailed` was fired at `DebugLevel`.

### Solution

**1. Symmetric encoder/decoder behavior** (`core/dbt/parser/manifest.py`):

Pass `strict_map_key=False` to `msgpack.unpackb` so the decoder accepts the same key types the packer already produces. The msgpack library documents this flag specifically for this case.

**2. Visible failure signal** (`core/dbt/events/types.py`):

Promote `ParsedFileLoadFailed` from `DebugLevel` to `WarnLevel` so users always see *why* partial parse was discarded, even without `--debug`. This is consistent with all other `PartialParsing*` events and the general principle that cache invalidation should be observable.

**3. Regression tests** (`tests/functional/partial_parsing/test_pp_integer_meta_keys.py`):

Three tests covering the full lifecycle:
- First parse writes `partial_parse.msgpack` with integer-key meta
- Second parse loads the cache without error (the previously broken path)
- Partial re-parse after a schema change also round-trips correctly

The encoder/decoder asymmetry was first introduced when `strict_map_key` defaulted to `True` in msgpack `1.0.0`. Projects using integer meta keys have been silently losing the partial parse cache ever since.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes type annotations for new and modified functions.