### PR TITLE
Warn when SQL function parameter name shadows a column in a referenced model

### DIFF
--- a/.changes/unreleased/Features-20260403-215850.yaml
+++ b/.changes/unreleased/Features-20260403-215850.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Warn at build time when a SQL function parameter name shadows a column in a referenced model
+time: 2026-04-03T21:58:50.48321-05:00
+custom:
+    Author: nitrajen
+    Issue: "12707"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1294,6 +1294,19 @@ class InvalidMacroAnnotation(WarnLevel):
         return warning_tag(self.msg)
 
 
+class FunctionParameterColumnConflict(WarnLevel):
+    def code(self) -> str:
+        return "I078"
+
+    def message(self) -> str:
+        return warning_tag(
+            f"SQL function '{self.function_name}' has a parameter '{self.param_name}' "
+            f"that conflicts with column '{self.column_name}' in '{self.model_name}'. "
+            f"The database will silently use the column value instead of the parameter argument. "
+            f"Rename the parameter or qualify it as '{self.function_name}.{self.param_name}'."
+        )
+
+
 class PackageNodeDependsOnRootProjectNode(WarnLevel):
     def code(self) -> str:
         return "I077"

--- a/core/dbt/task/function.py
+++ b/core/dbt/task/function.py
@@ -1,6 +1,7 @@
 import threading
 from typing import Any, Dict
 
+from dbt.adapters.capability import Capability
 from dbt.adapters.exceptions import MissingMaterializationError
 from dbt.artifacts.schemas.results import NodeStatus, RunStatus
 from dbt.artifacts.schemas.run import RunResult
@@ -8,12 +9,16 @@ from dbt.clients.jinja import MacroGenerator
 from dbt.context.providers import generate_runtime_function_context
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.nodes import FunctionNode
-from dbt.events.types import LogFunctionResult, LogStartLine
+from dbt.events.types import (
+    FunctionParameterColumnConflict,
+    LogFunctionResult,
+    LogStartLine,
+)
 from dbt.task import group_lookup
 from dbt.task.compile import CompileRunner
 from dbt_common.clients.jinja import MacroProtocol
 from dbt_common.events.base_types import EventLevel
-from dbt_common.events.functions import fire_event
+from dbt_common.events.functions import fire_event, warn_or_error
 from dbt_common.exceptions import DbtValidationError
 
 
@@ -87,7 +92,36 @@ class FunctionRunner(CompileRunner):
             batch_results=None,
         )
 
+    def _check_parameter_column_conflicts(
+        self, compiled_node: FunctionNode, manifest: Manifest
+    ) -> None:
+        """Warn if any SQL function parameter name matches a column name in a referenced model,
+        which the database resolves silently to the column."""
+        if compiled_node.language != "sql":
+            return
+        if not self.adapter.supports(Capability.SqlFunctionParameterColumnShadowing):
+            return
+        param_names = {arg.name for arg in compiled_node.arguments}
+        if not param_names:
+            return
+        for node_id in compiled_node.depends_on.nodes:
+            ref_node = manifest.nodes.get(node_id) or manifest.sources.get(node_id)
+            if ref_node is None:
+                continue
+            relation = self.adapter.Relation.create_from(self.config, ref_node)
+            for col in self.adapter.get_columns_in_relation(relation):
+                if col.name in param_names:
+                    warn_or_error(
+                        FunctionParameterColumnConflict(
+                            function_name=compiled_node.name,
+                            param_name=col.name,
+                            column_name=col.name,
+                            model_name=ref_node.name,
+                        )
+                    )
+
     def execute(self, compiled_node: FunctionNode, manifest: Manifest) -> RunResult:
+        self._check_parameter_column_conflicts(compiled_node, manifest)
         materialization_macro = self._get_materialization_macro(compiled_node, manifest)
         self._check_lang_supported(compiled_node, materialization_macro)
         context = generate_runtime_function_context(compiled_node, self.config, manifest)

--- a/tests/functional/functions/test_udfs.py
+++ b/tests/functional/functions/test_udfs.py
@@ -5,9 +5,12 @@ import pytest
 
 from dbt.artifacts.resources import FunctionReturns
 from dbt.artifacts.resources.types import FunctionType, FunctionVolatility
+from dbt.cli.main import dbtRunner
 from dbt.contracts.graph.nodes import FunctionNode
+from dbt.events.types import FunctionParameterColumnConflict
 from dbt.exceptions import ParsingError
 from dbt.tests.util import run_dbt, write_file
+from dbt_common.events.event_catcher import EventCatcher
 
 double_it_sql = """
 SELECT value * 2
@@ -703,3 +706,68 @@ class TestFunctionSchemasInOnRunEnd:
         assert (
             expected_fn_schema in schemas
         ), f"Expected function schema '{expected_fn_schema}' in schemas, got {schemas}"
+
+
+orders_model_sql = """
+SELECT 1 as customer_id, 100.00 as amount
+UNION ALL SELECT 2, 200.00
+"""
+
+get_order_total_sql = """
+SELECT sum(amount) FROM {{ ref('orders_model') }} WHERE customer_id = cust_id
+"""
+
+get_order_total_yml = """
+functions:
+  - name: get_order_total
+    arguments:
+      - name: cust_id
+        data_type: integer
+    returns:
+      data_type: numeric
+"""
+
+get_order_total_shadowed_sql = """
+SELECT sum(amount) FROM {{ ref('orders_model') }} WHERE customer_id = customer_id
+"""
+
+get_order_total_shadowed_yml = """
+functions:
+  - name: get_order_total_shadowed
+    arguments:
+      - name: customer_id
+        data_type: integer
+    returns:
+      data_type: numeric
+"""
+
+
+class TestParameterColumnShadowingWarning:
+    """Warn when a SQL function parameter name matches a column in a referenced model.
+
+    PostgreSQL silently resolves the parameter to the column, producing wrong results.
+    """
+
+    @pytest.fixture(scope="class")
+    def models(self) -> Dict[str, str]:
+        return {"orders_model.sql": orders_model_sql}
+
+    @pytest.fixture(scope="class")
+    def functions(self) -> Dict[str, str]:
+        return {
+            "get_order_total.sql": get_order_total_sql,
+            "get_order_total.yml": get_order_total_yml,
+            "get_order_total_shadowed.sql": get_order_total_shadowed_sql,
+            "get_order_total_shadowed.yml": get_order_total_shadowed_yml,
+        }
+
+    def test_warns_on_parameter_column_conflict(self, project):
+        catcher = EventCatcher(FunctionParameterColumnConflict)
+        runner = dbtRunner(callbacks=[catcher.catch])
+        runner.invoke(["build"])
+
+        # clean function: no conflict, no warning
+        # shadowed function: customer_id param matches column, warning fires
+        assert len(catcher.caught_events) == 1
+        assert "customer_id" in catcher.caught_events[0].info.msg
+        assert "get_order_total_shadowed" in catcher.caught_events[0].info.msg

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -314,6 +314,9 @@ sample_values = [
     core_types.MicrobatchModelNoEventTimeInputs(model_name=""),
     core_types.InvalidConcurrentBatchesConfig(num_models=1, adapter_type=""),
     core_types.InvalidMacroAnnotation(msg="", macro_file_path="", macro_unique_id=""),
+    core_types.FunctionParameterColumnConflict(
+        function_name="", param_name="", column_name="", model_name=""
+    ),
     core_types.PackageNodeDependsOnRootProjectNode(
         node_name="", node_package="", root_project_unique_id=""
     ),


### PR DESCRIPTION
Resolves #12707

### Problem

PostgreSQL SQL-language functions silently resolve a parameter name to a same-named column when both are in scope. Consider a function with a `customer_id` parameter that queries a model which also has a `customer_id` column:

```sql
CREATE FUNCTION get_order_total(customer_id integer)
RETURNS numeric AS $$
    SELECT sum(amount)
    FROM {{ ref('orders') }}
    WHERE customer_id = customer_id
$$ LANGUAGE sql;
```

Both sides of `WHERE customer_id = customer_id` resolve to the column. The function runs without error but silently returns wrong results.

### Solution

Added a check in `FunctionRunner.execute()`. At execution time, dbt has already run any models the function depends on. The check queries the database for their columns and warns if any parameter name matches. The check runs only for PostgreSQL. The warning is non-fatal and respects `--warn-error`.

**Also depends on:** companion PR to `dbt-labs/dbt-adapters` to enable this warning when parameter and column names conflict in PostgreSQL: https://github.com/dbt-labs/dbt-adapters/pull/1828

**Depends on a `dbt-protos` update** to add the following message:

```protobuf
message FunctionParameterColumnConflict {
  string function_name = 1;
  string param_name = 2;
  string column_name = 3;
  string model_name = 4;
}
```

To test locally, I updated the serialized descriptor blob in `core_types_pb2.py` and appended the following type stubs to `core_types_pb2.pyi`:

```python
@typing.final
class FunctionParameterColumnConflict(google.protobuf.message.Message):
    """I078"""
    function_name: builtins.str
    param_name: builtins.str
    column_name: builtins.str
    model_name: builtins.str

@typing.final
class FunctionParameterColumnConflictMsg(google.protobuf.message.Message):
    @property
    def info(self) -> Global___CoreEventInfo: ...
    @property
    def data(self) -> Global___FunctionParameterColumnConflict: ...
```

### How the change was tested

Added a functional test in `tests/functional/functions/test_udfs.py` that verifies warnings fire for shadowed parameters and not for clean ones.  
Also ran `dbt build` locally against PostgreSQL with two clean functions and two shadowed functions to confirm the same behavior end to end.
<img width="1391" height="468" alt="image" src="https://github.com/user-attachments/assets/7355329e-614c-41c0-a2a9-d17d980aa7b0" />


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.