### PR TITLE
[Feature] Configuration for runtime "priority" among models with satisfied dependencies #10632

### DIFF
--- a/.changes/unreleased/Features-20260404-213633.yaml
+++ b/.changes/unreleased/Features-20260404-213633.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add priority config to schedule DAG-ready models by relative execution priority
+time: 2026-04-04T21:36:33.46296201+02:00
+custom:
+    Author: naszly
+    Issue: "10632"

--- a/core/dbt/artifacts/resources/v1/config.py
+++ b/core/dbt/artifacts/resources/v1/config.py
@@ -135,6 +135,8 @@ class NodeConfig(NodeAndTestConfig):
     )
     event_time: Any = None
     concurrent_batches: Any = None
+    # Priority tie-breaker for nodes at the same topological level. Higher values are scheduled first.
+    priority: int = 0
 
     def __post_init__(self):
         super().__post_init__()

--- a/core/dbt/artifacts/resources/v1/config.py
+++ b/core/dbt/artifacts/resources/v1/config.py
@@ -135,7 +135,8 @@ class NodeConfig(NodeAndTestConfig):
     )
     event_time: Any = None
     concurrent_batches: Any = None
-    # Priority tie-breaker for nodes at the same topological level. Higher values are scheduled first.
+    # Priority orders DAG-ready nodes; higher values are scheduled first.
+    # Topological score is only used as a fallback/tie-breaker when priorities are equal.
     priority: int = 0
 
     def __post_init__(self):

--- a/core/dbt/graph/queue.py
+++ b/core/dbt/graph/queue.py
@@ -48,7 +48,7 @@ class GraphQueue:
         self.queued: Set[UniqueId] = set()
         # this lock controls most things
         self.lock = threading.Lock()
-        # store the 'score' of each node as a number. Lower is higher priority.
+        # store each node's topological score. Lower scores are dequeued first.
         self._scores = self._get_scores(self.graph)
         # populate the initial queue
         self._find_new_additions(list(self.graph.nodes()))
@@ -133,7 +133,7 @@ class GraphQueue:
         See `queue.PriorityQueue` for more information on `get()` behavior and
         exceptions.
         """
-        _, node_id = self.inner.get(block=block, timeout=timeout)
+        _, _, node_id = self.inner.get(block=block, timeout=timeout)
         node = self.manifest.expect(node_id)
         is_microbatch = (
             isinstance(node, ModelNode) and node.config.incremental_strategy == "microbatch"
@@ -179,8 +179,18 @@ class GraphQueue:
         """
         for node in candidates:
             if self.graph.in_degree(node) == 0 and not self._already_known(node):
-                self.inner.put((self._scores[node], node))
+                configured_priority = self._get_node_priority(node)
+                # PriorityQueue pops the smallest tuple first.
+                heap_priority = -configured_priority
+                self.inner.put((self._scores[node], heap_priority, node))
                 self.queued.add(node)
+
+    def _get_node_priority(self, node_id: UniqueId) -> int:
+        node = self.manifest.nodes.get(node_id)
+        if node is None:
+            return 0
+        priority = getattr(node.config, "priority", 0)
+        return priority if isinstance(priority, int) and not isinstance(priority, bool) else 0
 
     def mark_done(self, node_id: UniqueId) -> None:
         """Given a node's unique ID, mark it as done.

--- a/core/dbt/graph/queue.py
+++ b/core/dbt/graph/queue.py
@@ -181,8 +181,12 @@ class GraphQueue:
             if self.graph.in_degree(node) == 0 and not self._already_known(node):
                 configured_priority = self._get_node_priority(node)
                 # PriorityQueue pops the smallest tuple first.
+                # Negate priority so higher priority values are dequeued first.
                 heap_priority = -configured_priority
-                self.inner.put((self._scores[node], heap_priority, node))
+                # Priority is the primary sort key; topo score is only a fallback
+                # among ready nodes. DAG safety is enforced by the in_degree == 0
+                # check above.
+                self.inner.put((heap_priority, self._scores[node], node))
                 self.queued.add(node)
 
     def _get_node_priority(self, node_id: UniqueId) -> int:

--- a/tests/unit/contracts/graph/test_nodes.py
+++ b/tests/unit/contracts/graph/test_nodes.py
@@ -201,6 +201,7 @@ def basic_compiled_dict():
             "access": "protected",
             "lookback": 1,
             "latest_version_pointer": {},
+            "priority": 0,
         },
         "docs": {"show": True},
         "columns": {},

--- a/tests/unit/contracts/graph/test_nodes_parsed.py
+++ b/tests/unit/contracts/graph/test_nodes_parsed.py
@@ -107,6 +107,7 @@ def populated_node_config_dict():
         "access": "protected",
         "lookback": 1,
         "latest_version_pointer": {},
+        "priority": 0,
     }
 
 
@@ -238,6 +239,7 @@ def base_parsed_model_dict():
             "access": "protected",
             "lookback": 1,
             "latest_version_pointer": {},
+            "priority": 0,
         },
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
@@ -353,6 +355,7 @@ def complex_parsed_model_dict():
             "access": "protected",
             "lookback": 1,
             "latest_version_pointer": {},
+            "priority": 0,
         },
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
@@ -581,6 +584,7 @@ def basic_parsed_seed_dict():
             "contract": {"enforced": False, "alias_types": True},
             "packages": [],
             "lookback": 1,
+            "priority": 0,
         },
         "docs": {"show": True},
         "columns": {},
@@ -675,6 +679,7 @@ def complex_parsed_seed_dict():
             "contract": {"enforced": False, "alias_types": True},
             "packages": [],
             "lookback": 1,
+            "priority": 0,
         },
         "docs": {"show": True},
         "columns": {
@@ -888,6 +893,7 @@ def base_parsed_hook_dict():
             "contract": {"enforced": False, "alias_types": True},
             "packages": [],
             "lookback": 1,
+            "priority": 0,
         },
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
@@ -973,6 +979,7 @@ def complex_parsed_hook_dict():
             "contract": {"enforced": False, "alias_types": True},
             "packages": [],
             "lookback": 1,
+            "priority": 0,
         },
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
@@ -1345,6 +1352,7 @@ def basic_timestamp_snapshot_config_dict():
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
         "lookback": 1,
+        "priority": 0,
     }
 
 
@@ -1385,6 +1393,7 @@ def complex_timestamp_snapshot_config_dict():
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
         "lookback": 1,
+        "priority": 0,
     }
 
 
@@ -1453,6 +1462,7 @@ def basic_check_snapshot_config_dict():
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
         "lookback": 1,
+        "priority": 0,
     }
 
 
@@ -1493,6 +1503,7 @@ def complex_set_snapshot_config_dict():
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
         "lookback": 1,
+        "priority": 0,
     }
 
 
@@ -1620,6 +1631,7 @@ def basic_timestamp_snapshot_dict():
             "contract": {"enforced": False, "alias_types": True},
             "packages": [],
             "lookback": 1,
+            "priority": 0,
         },
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},
@@ -1727,6 +1739,7 @@ def basic_check_snapshot_dict():
             "contract": {"enforced": False, "alias_types": True},
             "packages": [],
             "lookback": 1,
+            "priority": 0,
         },
         "docs": {"show": True},
         "contract": {"enforced": False, "alias_types": True},

--- a/tests/unit/graph/test_queue.py
+++ b/tests/unit/graph/test_queue.py
@@ -85,3 +85,51 @@ class TestGraphQueue:
         third = graph_queue.get(block=False)
 
         assert third.unique_id == low_priority.unique_id
+
+    def test_priority_overrides_topology(self):
+        # Graph structure:
+        #
+        #   high_root(p=10)     unrelated(p=0)
+        #       |
+        #   high_leaf(p=1000)
+        #
+        # Expected dequeue order: high_root -> high_leaf -> unrelated
+        # Even though high_leaf is deeper in the DAG, its high priority (1000)
+        # causes it to be scheduled before unrelated once it becomes ready.
+        #
+        # If config.priority is missing or invalid, it falls back to 0.
+        high_root = MockNode(
+            package="test_package",
+            name="aaa_high_root",
+            config=mock.MagicMock(priority=10),
+        )
+        high_leaf = MockNode(
+            package="test_package",
+            name="bbb_high_leaf",
+            config=mock.MagicMock(priority=1000),
+        )
+        unrelated = MockNode(
+            package="test_package",
+            name="ccc_unrelated",
+            config=mock.MagicMock(),
+        )
+
+        manifest = make_manifest(nodes=[high_root, high_leaf, unrelated])
+        graph = nx.DiGraph()
+        graph.add_nodes_from(
+            [high_root.unique_id, high_leaf.unique_id, unrelated.unique_id]
+        )
+        graph.add_edge(high_root.unique_id, high_leaf.unique_id)
+
+        graph_queue = GraphQueue(graph=graph, manifest=manifest, selected=set())
+
+        first = graph_queue.get(block=False)
+        assert first.unique_id == high_root.unique_id
+
+        graph_queue.mark_done(first.unique_id)
+        second = graph_queue.get(block=False)
+        assert second.unique_id == high_leaf.unique_id
+
+        graph_queue.mark_done(second.unique_id)
+        third = graph_queue.get(block=False)
+        assert third.unique_id == unrelated.unique_id

--- a/tests/unit/graph/test_queue.py
+++ b/tests/unit/graph/test_queue.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import networkx as nx
 import pytest
 
@@ -27,7 +29,7 @@ class TestGraphQueue:
 
         assert graph_queue.manifest == manifest
         assert graph_queue.graph == graph
-        assert graph_queue.inner.queue == [(0, "model.test_package.upstream_model")]
+        assert graph_queue.inner.queue == [(0, 0, "model.test_package.upstream_model")]
         assert graph_queue.in_progress == set()
         assert graph_queue.queued == {"model.test_package.upstream_model"}
         assert graph_queue.lock
@@ -38,10 +40,48 @@ class TestGraphQueue:
         # when preserve_edges is set to false, dependencies between nodes are no longer tracked in the priority queue
         assert list(graph_queue.graph.edges) == []
         assert graph_queue.inner.queue == [
-            (0, "model.test_package.downstream_model"),
-            (0, "model.test_package.upstream_model"),
+            (0, 0, "model.test_package.downstream_model"),
+            (0, 0, "model.test_package.upstream_model"),
         ]
         assert graph_queue.queued == {
             "model.test_package.upstream_model",
             "model.test_package.downstream_model",
         }
+
+    def test_priority_tie_breaker(self):
+        # If config.priority is missing or invalid, it falls back to 0.
+        default_priority = MockNode(
+            package="test_package",
+            name="aaa_default_priority",
+            config=mock.MagicMock(),
+        )
+        low_priority = MockNode(
+            package="test_package",
+            name="nnn_low_priority",
+            config=mock.MagicMock(priority=-10),
+        )
+        high_priority = MockNode(
+            package="test_package",
+            name="zzz_high_priority",
+            config=mock.MagicMock(priority=10),
+        )
+        manifest = make_manifest(nodes=[default_priority, low_priority, high_priority])
+        graph = nx.DiGraph()
+        graph.add_nodes_from(
+            [default_priority.unique_id, low_priority.unique_id, high_priority.unique_id]
+        )
+
+        graph_queue = GraphQueue(graph=graph, manifest=manifest, selected=set())
+        first = graph_queue.get(block=False)
+
+        assert first.unique_id == high_priority.unique_id
+
+        graph_queue.mark_done(first.unique_id)
+        second = graph_queue.get(block=False)
+
+        assert second.unique_id == default_priority.unique_id
+
+        graph_queue.mark_done(second.unique_id)
+        third = graph_queue.get(block=False)
+
+        assert third.unique_id == low_priority.unique_id

--- a/tests/unit/test_compilation.py
+++ b/tests/unit/test_compilation.py
@@ -11,8 +11,8 @@ from dbt.graph.queue import GraphQueue
 from dbt.graph.selector import NodeSelector
 
 
-def _mock_manifest(nodes):
-    config = mock.MagicMock(enabled=True)
+def _mock_manifest(nodes, priorities=None):
+    priorities = priorities or {}
     manifest = mock.MagicMock(
         nodes={
             n: mock.MagicMock(
@@ -20,7 +20,7 @@ def _mock_manifest(nodes):
                 package_name="pkg",
                 name=n,
                 empty=False,
-                config=config,
+                config=mock.MagicMock(enabled=True, priority=priorities.get(n, 0)),
                 fqn=["pkg", n],
                 is_versioned=False,
             )
@@ -114,6 +114,21 @@ class TestLinker:
         queue.mark_done("A")
         self.assert_would_join(queue)
         assert queue.empty()
+
+    def test_priority_does_not_override_dependencies(self, linker: Linker) -> None:
+        linker.dependency("A", "B")
+
+        queue = self._get_graph_queue(
+            _mock_manifest("AB", priorities={"A": 100, "B": -100}),
+            linker,
+        )
+
+        first = queue.get(block=False)
+        assert first.unique_id == "B"
+        queue.mark_done("B")
+
+        second = queue.get(block=False)
+        assert second.unique_id == "A"
 
     def test_linker_add_disjoint_dependencies(self, linker: Linker) -> None:
         actual_deps = [("A", "B")]


### PR DESCRIPTION
Resolves #10632

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

When running dbt, models execute in DAG order, which is functionally correct but not always optimal for total run time. In projects with long-running models that have no upstream dependencies but many downstream dependents, users cannot influence which models run first, leading to suboptimal scheduling. For example, a long-running model deep in the DAG should ideally start early to minimize total run time, but currently would run only after its place in topological order is reached.

### Solution

This PR introduces a new optional `priority` configuration field (integer, default `0`) for models that allows users to specify relative scheduling hints within DAG-ready nodes at the same topological level:

- **Configuration**: Users can set `priority` in `dbt_project.yml` (e.g., `+priority: 10`) or in model `{{ config() }}` blocks (e.g., `{{ config(priority=5) }}`).
- **Scheduling behavior**: When multiple models are ready to execute (all dependencies satisfied), they are scheduled by priority. Higher priority values are scheduled first.
- **DAG safety**: Priority is strictly a tie-breaker; it never overrides dependency constraints. Models always execute after their dependencies, regardless of priority.
- **Fallback**: Missing or invalid priority values default to `0`, ensuring backward compatibility.

**Key implementation details:**
- Added `priority: int = 0` field to `NodeConfig` in `core/dbt/artifacts/resources/v1/config.py`
- Updated `GraphQueue._find_new_additions` in `core/dbt/graph/queue.py` to negate priority when enqueuing (since Python's `PriorityQueue` pops minimum tuples first)
- Added defensive `_get_node_priority` method to safely extract and validate priority values
- Extended queue tests to verify tie-breaking behavior with high/default/low priority nodes
- Added clarifying comments and documentation on priority tie-breaker semantics

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
