### PR TITLE
cache jsonschemas in _VALIDATOR_CACHE to avoid recompilation

### DIFF
--- a/core/dbt/jsonschemas/jsonschemas.py
+++ b/core/dbt/jsonschemas/jsonschemas.py
@@ -15,6 +15,11 @@ from dbt_common.context import get_invocation_context
 
 _PROJECT_SCHEMA: Optional[Dict[str, Any]] = None
 _RESOURCES_SCHEMA: Optional[Dict[str, Any]] = None
+_MODEL_CONFIG_SCHEMA: Optional[Dict[str, Any]] = None
+
+# Cache compiled validators keyed by schema object id. All schemas passed to
+# _validate_with_schema are module-level singletons whose ids are stable.
+_VALIDATOR_CACHE: Dict[int, Any] = {}
 
 _JSONSCHEMA_SUPPORTED_ADAPTERS = {
     "bigquery",
@@ -104,8 +109,10 @@ def _additional_properties_violation_keys(error: ValidationError) -> List[str]:
 def _validate_with_schema(
     schema: Dict[str, Any], json: Dict[str, Any]
 ) -> Iterator[ValidationError]:
-    validator = CustomDraft7Validator(schema)
-    return validator.iter_errors(json)
+    schema_id = id(schema)
+    if schema_id not in _VALIDATOR_CACHE:
+        _VALIDATOR_CACHE[schema_id] = CustomDraft7Validator(schema)
+    return _VALIDATOR_CACHE[schema_id].iter_errors(json)
 
 
 def _get_allowed_config_key_aliases() -> List[str]:
@@ -294,27 +301,31 @@ def jsonschema_validate(schema: Dict[str, Any], json: Dict[str, Any], file_path:
             )
 
 
+def _model_config_schema() -> Dict[str, Any]:
+    global _MODEL_CONFIG_SCHEMA
+    if _MODEL_CONFIG_SCHEMA is None:
+        resources_jsonschema = resources_schema()
+        nested_definition_name = "ModelConfig"
+        _MODEL_CONFIG_SCHEMA = {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": nested_definition_name,
+            **resources_jsonschema["definitions"][nested_definition_name],
+            "definitions": {
+                k: v
+                for k, v in resources_jsonschema["definitions"].items()
+                if k != nested_definition_name
+            },
+        }
+    return _MODEL_CONFIG_SCHEMA
+
+
 def validate_model_config(
     config: Dict[str, Any], file_path: str, is_python_model: bool = False
 ) -> None:
     if not _can_run_validations():
         return
 
-    resources_jsonschema = resources_schema()
-    nested_definition_name = "ModelConfig"
-
-    model_config_schema = {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": nested_definition_name,
-        **resources_jsonschema["definitions"][nested_definition_name],
-        "definitions": {
-            k: v
-            for k, v in resources_jsonschema["definitions"].items()
-            if k != nested_definition_name
-        },
-    }
-
-    errors = _validate_with_schema(model_config_schema, config)
+    errors = _validate_with_schema(_model_config_schema(), config)
     for error in errors:
         error_path = list(error.path)
         if error.validator == "additionalProperties":


### PR DESCRIPTION
Resolves #

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->                                                                                                                                                                              
  Changes in jsonschemas.py:                                                                                                                                                                
                                                                                                                                                                                            
  1. _VALIDATOR_CACHE: Dict[int, Any] = {} — a module-level dict that maps id(schema) → compiled validator. Since all schema dicts passed to _validate_with_schema are module-level         
  singletons (their id is stable for the process lifetime), this avoids re-compiling the same schema repeatedly.                                                                            
  2. _validate_with_schema — now checks the cache before constructing a new CustomDraft7Validator. Compilation happens at most once per unique schema object.                               
  3. _model_config_schema() — extracted the schema-building logic from validate_model_config into a lazily-cached function backed by _MODEL_CONFIG_SCHEMA. Previously, validate_model_config
   rebuilt the model_config_schema dict on every call, meaning each call produced a new object with a new id, defeating any id-based cache. Now it's a stable singleton, so the validator   
  for it is compiled once.    

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
