### PR TITLE
[TIDY-FIRST] Type the runners - Part 3

### DIFF
--- a/.changes/unreleased/Under the Hood-20260409-144221.yaml
+++ b/.changes/unreleased/Under the Hood-20260409-144221.yaml
@@ -1,0 +1,9 @@
+kind: Under the Hood
+body: GenericSqlRunner (used for programmatic SQL execution via SqlCompileRunner/SqlExecuteRunner)
+  is now a standalone class instead of inheriting from CompileRunner. This fixes a
+  latent AttributeError in handle_exception and correctly separates the programmatic
+  SQL execution path from the DAG runner hierarchy.
+time: 2026-04-09T14:42:21.321229-05:00
+custom:
+  Author: QMalcolm
+  Issue: "12811"

--- a/core/dbt/task/sql.py
+++ b/core/dbt/task/sql.py
@@ -1,10 +1,15 @@
+import time
 import traceback
-from abc import abstractmethod
+from abc import ABCMeta, abstractmethod
+from contextlib import nullcontext
 from datetime import datetime, timezone
-from typing import Generic, TypeVar
+from typing import Generic, List, TypeVar
 
-import dbt.exceptions
 import dbt_common.exceptions.base
+from dbt.adapters.base.impl import BaseAdapter
+from dbt.artifacts.schemas.results import RunningStatus, TimingInfo, collect_timing_info
+from dbt.compilation import Compiler
+from dbt.config import RuntimeConfig
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.sql import (
     RemoteCompileResult,
@@ -12,61 +17,125 @@ from dbt.contracts.sql import (
     RemoteRunResult,
     ResultTable,
 )
-from dbt.events.types import SQLRunnerException
-from dbt.task.compile import CompileRunner
+from dbt.events.types import (
+    NodeCompiling,
+    NodeConnectionReleaseError,
+    NodeExecuting,
+    SQLRunnerException,
+)
+from dbt.flags import get_flags
+from dbt.task.base import ExecutionContext
 from dbt_common.events.functions import fire_event
 
 SQLResult = TypeVar("SQLResult", bound=RemoteCompileResultMixin)
 
 
-# GenericSqlRunner intentionally violates the CompileRunner[RunResult] contract:
-# its result type (SQLResult bound to RemoteCompileResultMixin) is a completely
-# separate hierarchy from NodeResult/RunResult, used for programmatic SQL execution.
-# The overriding methods are marked accordingly.
-class GenericSqlRunner(CompileRunner, Generic[SQLResult]):  # type: ignore[misc]
-    def __init__(self, config, adapter, node, node_index, num_nodes) -> None:
-        CompileRunner.__init__(self, config, adapter, node, node_index, num_nodes)  # type: ignore[arg-type]
+class GenericSqlRunner(Generic[SQLResult], metaclass=ABCMeta):
+    """Standalone runner for programmatic SQL execution (compile/execute).
 
-    def handle_exception(self, e, ctx):
+    Intentionally NOT a subclass of BaseRunner — its result type
+    (RemoteCompileResultMixin) lives in a separate hierarchy from NodeResult/RunResult
+    and is used for programmatic SQL execution, not DAG running.
+    """
+
+    def __init__(
+        self,
+        config: RuntimeConfig,
+        adapter: BaseAdapter,
+        node,
+        node_index: int,
+        num_nodes: int,
+    ) -> None:
+        self.config = config
+        self.compiler = Compiler(config)
+        self.adapter = adapter
+        self.node = node
+        self.node_index = node_index
+        self.num_nodes = num_nodes
+
+    def compile(self, manifest: Manifest):
+        return self.compiler.compile_node(self.node, manifest, {}, write=False)
+
+    def before_execute(self) -> None:
+        pass
+
+    def after_execute(self, result: SQLResult) -> None:
+        pass
+
+    def handle_exception(self, e: Exception, ctx: ExecutionContext) -> Exception:
         fire_event(
             SQLRunnerException(
                 exc=str(e), exc_info=traceback.format_exc(), node_info=self.node.node_info
             )
         )
-        # REVIEW: This code is invalid and will always throw.
-        if isinstance(e, dbt.exceptions.Exception):
-            if isinstance(e, dbt_common.exceptions.DbtRuntimeError):
-                e.add_node(ctx.node)
-            return e
-
-    def before_execute(self) -> None:
-        pass
-
-    def after_execute(self, result) -> None:  # type: ignore[override]
-        pass
-
-    def compile(self, manifest: Manifest):
-        return self.compiler.compile_node(self.node, manifest, {}, write=False)  # type: ignore[arg-type]
+        return e
 
     @abstractmethod
-    def execute(self, compiled_node, manifest) -> SQLResult:  # type: ignore[override]
+    def execute(self, compiled_node, manifest: Manifest) -> SQLResult:
         pass
 
     @abstractmethod
-    def from_run_result(self, result, start_time, timing_info) -> SQLResult:  # type: ignore[override]
+    def from_run_result(
+        self, result: SQLResult, start_time: float, timing_info: List[TimingInfo]
+    ) -> SQLResult:
         pass
 
-    def error_result(self, node, error, start_time, timing_info):  # type: ignore[override]
+    def error_result(
+        self, node, error: Exception, start_time: float, timing_info: List[TimingInfo]
+    ) -> SQLResult:
         raise error
 
-    def ephemeral_result(self, node, start_time, timing_info):  # type: ignore[override]
+    def ephemeral_result(
+        self, node, start_time: float, timing_info: List[TimingInfo]
+    ) -> SQLResult:
         raise dbt_common.exceptions.base.NotImplementedError(
             "cannot execute ephemeral nodes remotely!"
         )
 
+    def _safe_release_connection(self) -> None:
+        try:
+            self.adapter.release_connection()
+        except Exception as exc:
+            fire_event(
+                NodeConnectionReleaseError(
+                    node_name=self.node.name, exc=str(exc), exc_info=traceback.format_exc()
+                )
+            )
+
+    def safe_run(self, manifest: Manifest) -> SQLResult:
+        started = time.time()
+        ctx = ExecutionContext(self.node)
+        error = None
+        result = None
+
+        try:
+            with (
+                self.adapter.connection_named(self.node.unique_id, self.node)
+                if get_flags().INTROSPECT
+                else nullcontext()
+            ):
+                ctx.node.update_event_status(node_status=RunningStatus.Compiling)
+                fire_event(NodeCompiling(node_info=ctx.node.node_info))
+                with collect_timing_info("compile", ctx.timing.append):
+                    ctx.node = self.compile(manifest)
+
+                ctx.node.update_event_status(node_status=RunningStatus.Executing)
+                fire_event(NodeExecuting(node_info=ctx.node.node_info))
+                with collect_timing_info("execute", ctx.timing.append):
+                    result = self.execute(ctx.node, manifest)
+        except Exception as e:
+            error = self.handle_exception(e, ctx)
+        finally:
+            self._safe_release_connection()
+
+        if error is not None:
+            return self.error_result(ctx.node, error, started, ctx.timing)
+        assert result is not None
+        return self.from_run_result(result, started, ctx.timing)
+
 
 class SqlCompileRunner(GenericSqlRunner[RemoteCompileResult]):
-    def execute(self, compiled_node, manifest) -> RemoteCompileResult:  # type: ignore[override]
+    def execute(self, compiled_node, manifest: Manifest) -> RemoteCompileResult:
         return RemoteCompileResult(
             raw_code=compiled_node.raw_code,
             compiled_code=compiled_node.compiled_code,
@@ -75,7 +144,9 @@ class SqlCompileRunner(GenericSqlRunner[RemoteCompileResult]):
             generated_at=datetime.now(timezone.utc).replace(tzinfo=None),
         )
 
-    def from_run_result(self, result, start_time, timing_info) -> RemoteCompileResult:  # type: ignore[override]
+    def from_run_result(
+        self, result: RemoteCompileResult, start_time: float, timing_info: List[TimingInfo]
+    ) -> RemoteCompileResult:
         return RemoteCompileResult(
             raw_code=result.raw_code,
             compiled_code=result.compiled_code,
@@ -86,7 +157,7 @@ class SqlCompileRunner(GenericSqlRunner[RemoteCompileResult]):
 
 
 class SqlExecuteRunner(GenericSqlRunner[RemoteRunResult]):
-    def execute(self, compiled_node, manifest) -> RemoteRunResult:  # type: ignore[override]
+    def execute(self, compiled_node, manifest: Manifest) -> RemoteRunResult:
         _, execute_result = self.adapter.execute(compiled_node.compiled_code, fetch=True)
 
         table = ResultTable(
@@ -103,7 +174,9 @@ class SqlExecuteRunner(GenericSqlRunner[RemoteRunResult]):
             generated_at=datetime.now(timezone.utc).replace(tzinfo=None),
         )
 
-    def from_run_result(self, result, start_time, timing_info) -> RemoteRunResult:  # type: ignore[override]
+    def from_run_result(
+        self, result: RemoteRunResult, start_time: float, timing_info: List[TimingInfo]
+    ) -> RemoteRunResult:
         return RemoteRunResult(
             raw_code=result.raw_code,
             compiled_code=result.compiled_code,


### PR DESCRIPTION
## Summary

- `GenericSqlRunner`'s result type (`RemoteCompileResultMixin`) lives in a separate hierarchy from `NodeResult`/`RunResult`, so it cannot satisfy the `RunnerResultT` bound on `BaseRunner`.
- Makes `GenericSqlRunner` a standalone `Generic[SQLResult]` class with its own `__init__`, `compile`, `safe_run`, and exception handling — eliminating all 11 `# type: ignore` comments in `sql.py`.
- Also removes dead code in `handle_exception`: `dbt.exceptions.Exception` does not exist, making the `isinstance` branch an `AttributeError` at runtime. A `REVIEW` comment already flagged this; removing it now that the method has explicit type annotations that surface the issue.

## Test plan

- [x] `hatch run default:mypy core/dbt/` passes (or ignore count decreases)
- [x] `hatch run default:pytest tests/unit/` passes
- [x] SQL runner functional tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)