### PR TITLE
feat(context): warn when load_result returns None during parse phase (#11070)

### DIFF
--- a/.changes/unreleased/Features-20260411-184500.yaml
+++ b/.changes/unreleased/Features-20260411-184500.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Warn when `load_result` is called during the parse phase and returns None,
+  pointing users at the `{% if execute %}` guard so introspective-query mistakes
+  surface before the downstream "'None' has no attribute 'table'" error
+time: 2026-04-11T18:45:00.000000+00:00
+custom:
+  Author: SarthakB11
+  Issue: "11070"

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1180,7 +1180,33 @@ class ProviderContext(ManifestContext):
                 self.sql_results[name] = None
                 return ret_val
         else:
-            # Handle trying to load a result that was never stored
+            # Handle trying to load a result that was never stored.
+            #
+            # During the parse phase `execute == False`, so no SQL has been run
+            # and `sql_results` is always empty. A `load_result` call that
+            # lands here is almost always a user who forgot to wrap an
+            # introspective query (e.g. `run_query` / `load_result`) in an
+            # `{% if execute %}` block — which later surfaces as the cryptic
+            # "'None' has no attribute 'table'" compilation error. Emit an
+            # upfront warning pointing at the execute docs so the root cause
+            # is visible before the downstream error.
+            #
+            # See dbt-labs/dbt-core#11070.
+            if not self.provider.execute:
+                model_name = getattr(self.model, "name", None) or getattr(
+                    self.model, "unique_id", "<unknown>"
+                )
+                fire_event(
+                    JinjaLogWarning(
+                        msg=(
+                            f"`load_result('{name}')` was called in {model_name} during "
+                            "the parse phase and returned None because no SQL has been "
+                            "run yet. Wrap introspective calls like `run_query` / "
+                            "`load_result` in an `{% if execute %}` block — see "
+                            "https://docs.getdbt.com/reference/dbt-jinja-functions/execute"
+                        )
+                    )
+                )
             return None
 
     @contextmember()

--- a/tests/functional/load_result/test_parse_phase_warning.py
+++ b/tests/functional/load_result/test_parse_phase_warning.py
@@ -1,0 +1,83 @@
+"""Regression tests for #11070.
+
+`load_result` must emit a `JinjaLogWarning` pointing at the `execute` guard
+when called during the parse phase with a name that was never stored. The
+downstream "'None' has no attribute 'table'" compilation error otherwise
+hides the real cause (a missing `{% if execute %}` block).
+
+The warning must NOT fire when the call is properly guarded.
+"""
+
+import pytest
+
+from dbt.events.types import JinjaLogWarning
+from dbt.tests.util import run_dbt
+from dbt_common.events.event_catcher import EventCatcher
+
+
+# Calls `load_result` from a model body without an `{% if execute %}` guard.
+# This is the bug class the warning targets.
+unguarded_load_result_sql = """
+{% set result = load_result('does_not_exist') %}
+select 1 as fun
+"""
+
+
+# Same `load_result` call, but properly wrapped in `{% if execute %}`. The
+# warning must stay silent here — firing on guarded calls would punish
+# correct user code.
+guarded_load_result_sql = """
+{% if execute %}
+  {% set result = load_result('does_not_exist') %}
+{% endif %}
+select 1 as fun
+"""
+
+
+class TestLoadResultParsePhaseWarningFires:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"unguarded.sql": unguarded_load_result_sql}
+
+    def test_warning_fires_during_parse(self, project) -> None:
+        event_catcher = EventCatcher(event_to_catch=JinjaLogWarning)
+        run_dbt(["parse"], callbacks=[event_catcher.catch])
+
+        relevant = [
+            ev
+            for ev in event_catcher.caught_events
+            if "load_result('does_not_exist')" in ev.data.msg
+        ]
+        assert len(relevant) >= 1, (
+            f"expected a load_result warning during parse, got: "
+            f"{[ev.data.msg for ev in event_catcher.caught_events]}"
+        )
+
+        msg = relevant[0].data.msg
+        # message identifies the offending model so users can find it
+        assert "unguarded" in msg
+        # message names the phase and the suggested guard
+        assert "parse phase" in msg
+        assert "{% if execute %}" in msg
+        # message links to the canonical docs page
+        assert "docs.getdbt.com" in msg
+
+
+class TestLoadResultParsePhaseWarningStaysSilentWhenGuarded:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"guarded.sql": guarded_load_result_sql}
+
+    def test_warning_does_not_fire_when_guarded(self, project) -> None:
+        event_catcher = EventCatcher(event_to_catch=JinjaLogWarning)
+        run_dbt(["parse"], callbacks=[event_catcher.catch])
+
+        relevant = [
+            ev
+            for ev in event_catcher.caught_events
+            if "load_result('does_not_exist')" in ev.data.msg
+        ]
+        assert relevant == [], (
+            f"expected no load_result warning when guarded, got: "
+            f"{[ev.data.msg for ev in relevant]}"
+        )


### PR DESCRIPTION
Fixes #11070.

## What

Extends `ProviderContext.load_result` in `core/dbt/context/providers.py` so that when it's about to return `None` for a name that was never stored, *and* the provider is in parse mode (`self.provider.execute is False`), it fires a `JinjaLogWarning` pointing the user at the `{% if execute %}` docs.

## Why

Quoting @joellabes on the issue:

> Any Jinja that relies on a result being returned from the database will error during the parse phase. For example [...]
>
> Encountered an error:
> Compilation Error in model order_payment_methods (models/order_payment_methods.sql)
> 'None' has no attribute 'table'

and the alternative suggestion:

> we could also add a warning line inside of run_query and friends so you wind up with something like this:
>
> WARN: run_query was invoked in the model order_payment_methods, but dbt is currently not running in execute mode so accessing the result will fail. Wrap in an `if execute` block https://docs.getdbt.com/reference/dbt-jinja-functions/execute

@graciegoheen on 2026-03-10:

> Good call! This would definitely help improve debugging.

(Also noting that #12736, a prior attempt, was self-closed by @claygeo on 2026-03-30 for queue management, not on merits — so the direction is still open.)

## Where

The `run_query` macro path is:

1. User calls `{% set r = run_query(sql) %}` in a model.
2. `run_query` (defined in dbt-adapters) calls `{% call statement("run_query_statement", ...) %}` and then `load_result("run_query_statement")`.
3. During parse, `execute` is False, `statement()`'s body is skipped, nothing is stored.
4. `load_result("run_query_statement")` drops into the `else` branch of `ProviderContext.load_result` in dbt-core and returns `None`.
5. User code dereferences `None.table` / `None.columns` → the cryptic compile error.

That `else` branch is a narrow, dbt-core-owned choke point that sees every `run_query` call during parse, which is why it's a better hook than trying to patch `run_query` or `statement` in dbt-adapters.

## Diff summary

```python
else:
    # Handle trying to load a result that was never stored.
    #
    # During the parse phase `execute == False`, so no SQL has been run
    # and `sql_results` is always empty. A `load_result` call that
    # lands here is almost always a user who forgot to wrap an
    # introspective query (e.g. `run_query` / `load_result`) in an
    # `{% if execute %}` block — which later surfaces as the cryptic
    # "'None' has no attribute 'table'" compilation error. Emit an
    # upfront warning pointing at the execute docs so the root cause
    # is visible before the downstream error.
    #
    # See dbt-labs/dbt-core#11070.
    if not self.provider.execute:
        model_name = getattr(self.model, "name", None) or getattr(
            self.model, "unique_id", "<unknown>"
        )
        fire_event(
            JinjaLogWarning(
                msg=(
                    f"`load_result('{name}')` was called in {model_name} during "
                    "the parse phase and returned None because no SQL has been "
                    "run yet. Wrap introspective calls like `run_query` / "
                    "`load_result` in an `{% if execute %}` block — see "
                    "https://docs.getdbt.com/reference/dbt-jinja-functions/execute"
                )
            )
        )
    return None
```

Uses the same `fire_event(JinjaLogWarning(msg=...))` pattern already used in `store_seed_results` a few hundred lines below, so no new imports are needed.

## Behaviour

- **Parse phase** + name not stored → warns (this is the new behaviour, targeting the reported bug).
- **Execute phase** + name not stored → unchanged: returns `None` silently. A missing name in execute mode is a real user bug (typo, or calling `load_result` on a name never wrapped in a `statement` block) and should not be converted into a spurious "wrap in execute" warning.
- **Both phases** + name in `sql_results` → completely unchanged.

## Tests

- No unit test added in this PR — the existing `tests/unit/context/test_context.py` only validates the set of keys available on the context, and there's no existing `load_result` behavioral test harness. Adding one would require spinning up a full `ProviderContext` with model fixtures; happy to add that in a follow-up if a maintainer prefers.
- Smoke-tested the branch logic with a minimal fake `ProviderContext` (parse + unknown name → warns; execute + unknown name → no warn; `_sql_results`-present branches unchanged).
- `python -m py_compile core/dbt/context/providers.py` passes.

## Changelog

Added `.changes/unreleased/Features-20260411-184500.yaml` via the standard changie format.