### PR TITLE
Fix: Improve error messaging for snapshot unique-key violations (#10864)

### DIFF
--- a/.changes/unreleased/10864.yaml
+++ b/.changes/unreleased/10864.yaml
@@ -1,0 +1,3 @@
+kind: Fix 
+body: "Improve error messaging for snapshot unique-key violations" 
+issue: 10864 

--- a/core/dbt/task/snapshot.py
+++ b/core/dbt/task/snapshot.py
@@ -17,6 +17,25 @@ class SnapshotRunner(ModelRunner):
     def describe_node(self) -> str:
         return "snapshot {}".format(self.get_node_representation())
 
+    def execute(self, compiled_node, manifest):
+        try:
+            # Call the parent class (ModelRunner) execution logic
+            return super().execute(compiled_node, manifest)
+        except Exception as e:
+            # Intercept the specific database error for snapshots
+            if "Duplicate row detected during DML action" in str(e):
+                hint = "\n\nHint: Ensure the unique_key column(s) are really unique."
+
+                # dbt exceptions usually store their message in the 'msg' attribute
+                if hasattr(e, "msg"):
+                    e.msg += hint
+                # Fallback for standard Python exception arguments
+                elif hasattr(e, "args") and len(e.args) > 0 and isinstance(e.args[0], str):
+                    e.args = (e.args[0] + hint,) + e.args[1:]
+
+            # Re-raise the error so dbt's terminal logger prints it normally
+            raise e
+
     def print_result_line(self, result):
         model = result.node
         group = group_lookup.get(model.unique_id)


### PR DESCRIPTION
Resolves #10864

### Problem
Currently, when a snapshot fails because the `unique_key` is not actually unique, dbt passes through the raw database error (e.g., `Duplicate row detected during DML action`). This leads users down a rabbit hole of querying data to uncover the root cause, rather than clearly pointing out that the snapshot configuration is flawed. 

### Solution
Added an `execute` method to the `SnapshotRunner` class that wraps the parent execution logic in a `try/except` block. When a `unique_key` violation occurs, it intercepts the specific DML database error and appends a user-friendly hint (*"Hint: Ensure the unique_key column(s) are really unique."*) before the error is raised to the terminal.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.