### PR TITLE
fix: remove exact version pin for libpq-dev in Dockerfile

### DIFF
--- a/.changes/unreleased/Fixes-20260412-215000.yaml
+++ b/.changes/unreleased/Fixes-20260412-215000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove exact version pin for libpq-dev in Dockerfile to prevent recurring build failures when Debian publishes security updates.
+time: 2026-04-12T21:50:00.000000-07:00
+custom:
+  Author: psaikaushik
+  Issue: "12808"

--- a/.changes/unreleased/Fixes-20260412-215100.yaml
+++ b/.changes/unreleased/Fixes-20260412-215100.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove exact version pin for libpq-dev in Dockerfile to prevent recurring build breakage on Debian security updates
+time: 2026-04-12T21:51:00.000000-04:00
+custom:
+    Author: psaikaushik
+    Issue: "12808"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
     ca-certificates=20210119 \
-    libpq-dev=13.23-0+deb11u2 \
+    libpq-dev \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \


### PR DESCRIPTION
## Summary

Remove the exact version pin for `libpq-dev` in the Dockerfile. This has required **5 manual bumps in ~18 months** because Debian removes old versions from apt repos when it publishes security updates, breaking Docker builds until someone notices and bumps the pin.

Closes #12808

## What Changed

`docker/Dockerfile`: Changed `libpq-dev=13.23-0+deb11u2` to just `libpq-dev`.

## Why This Is Safe

The `apt-mark hold` on the next line already prevents `dist-upgrade` from changing the installed version during the build. The pin was providing zero additional protection — it was only causing breakage.

| Before | After |
|--------|-------|
| Debian publishes PG13 security update → old version removed → builds break → someone manually bumps pin | Debian publishes PG13 security update → builds continue working → security fix picked up automatically |

## History of breakage from this pin

| Date | Commit | Bump |
|------|--------|------|
| 2024-11 | `f5f0735d0` | → `13.18-0+deb11u1` |
| 2025-03 | `88ada4aa3` | → `13.20-0+deb11u1` |
| 2025-08 | `9bc7333e1` | → `13.21-0+deb11u1` |
| 2026-01 | `2ef17b836` | → `13.23-0+deb11u1` |
| 2026-04 | #12806 | → `13.23-0+deb11u2` |

## Checklist
- [x] I have performed a self-review of my code
- [x] Change is minimal and low-risk