### PR TITLE
fix: add model name and file path to semantic manifest validation error

### DIFF
--- a/.changes/unreleased/Fixes-20260412-220000.yaml
+++ b/.changes/unreleased/Fixes-20260412-220000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add model name and file path to semantic manifest validation error when relation_name is None (e.g. ephemeral time spine models).
+time: 2026-04-12T22:00:00.000000-07:00
+custom:
+  Author: psaikaushik
+  Issue: "12722"

--- a/core/dbt/contracts/graph/semantic_manifest.py
+++ b/core/dbt/contracts/graph/semantic_manifest.py
@@ -167,6 +167,21 @@ class SemanticManifest:
                     "Expected to find granularity set for time spine standard granularity column, but did not. "
                     "This should have been caught in YAML parsing."
                 )
+
+            # Validate relation_name before creating PydanticNodeRelation.
+            # Ephemeral models have relation_name=None since they don't create
+            # a warehouse relation, but time spine models must be queryable.
+            if not node.relation_name:
+                raise ParsingError(
+                    f'Semantic layer validation failed for model "{node.name}"'
+                    f" ({node.original_file_path}):"
+                    f" relation_name is required but was not set."
+                    f" Time spine models must have a materialization that creates"
+                    f" a relation in the warehouse (e.g. table, view, incremental)."
+                    f' Models with "ephemeral" materialization cannot be used as'
+                    f" time spines because they do not exist as queryable relations."
+                )
+
             pydantic_time_spine = PydanticTimeSpine(
                 node_relation=PydanticNodeRelation(
                     alias=node.alias,


### PR DESCRIPTION
## Summary

When `dbt compile` fails during semantic manifest validation because a time spine model has `relation_name=None`, the error is completely unhelpful:

```
1 validation error for PydanticNodeRelation
relation_name
  none is not an allowed value (type=type_error.none.not_allowed)
```

No model name. No file path. Nothing to debug with. This PR fixes that.

Closes #12722

## Root Cause

In `_get_pydantic_semantic_manifest()`, time spine models are iterated and their `relation_name` is passed to `PydanticNodeRelation`. Ephemeral models have `relation_name=None` because they don't create a warehouse relation. When pydantic validates this, it throws a generic `ValidationError` with no context about which model caused it.

## Fix

Added an explicit check for `node.relation_name` being falsy **before** it reaches the pydantic validator. The new `ParsingError` includes:

- The model name (`node.name`)
- The file path (`node.original_file_path`)
- A clear explanation that time spine models can't be ephemeral
- A hint about which materializations work (table, view, incremental)

**Before:**
```
none is not an allowed value (type=type_error.none.not_allowed)
```

**After:**
```
Semantic layer validation failed for model "my_time_spine" (models/my_time_spine.sql):
relation_name is required but was not set. Time spine models must have a 
materialization that creates a relation in the warehouse (e.g. table, view, 
incremental). Models with "ephemeral" materialization cannot be used as time 
spines because they do not exist as queryable relations.
```

## Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR has no interface changes
- [x] This PR includes type annotations for new and modified functions