### PR TITLE
fix: improve error message when snapshot unique_key has duplicate values

### DIFF
--- a/.changes/unreleased/Fixes-20260412-225900.yaml
+++ b/.changes/unreleased/Fixes-20260412-225900.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Improve error message when snapshot unique_key has duplicate values in source query
+time: 2026-04-12T22:59:00.000000-04:00
+custom:
+    Author: psaikaushik
+    Issue: "12775"

--- a/core/dbt/task/snapshot.py
+++ b/core/dbt/task/snapshot.py
@@ -5,11 +5,11 @@ from dbt.events.types import LogSnapshotResult
 from dbt.graph import ResourceTypeSelector
 from dbt.node_types import NodeType
 from dbt.task import group_lookup
-from dbt.task.base import BaseRunner
+from dbt.task.base import BaseRunner, ExecutionContext
 from dbt.task.run import ModelRunner, RunTask
 from dbt_common.events.base_types import EventLevel
 from dbt_common.events.functions import fire_event
-from dbt_common.exceptions import DbtInternalError, DbtRuntimeError
+from dbt_common.exceptions import DbtInternalError
 from dbt_common.utils import cast_dict_to_dict_of_strings
 
 # Common database error patterns that indicate duplicate key violations
@@ -61,32 +61,26 @@ class SnapshotRunner(ModelRunner):
             level=level,
         )
 
-    def handle_exception(self, e, ctx):
+    def handle_exception(self, e: Exception, ctx: ExecutionContext) -> str:
         """Override to provide better error messages for duplicate key violations.
 
         When a snapshot MERGE fails due to duplicate values in the unique_key
         column(s), the database error is typically cryptic (e.g., "Duplicate row
         detected during DML action"). This override detects such errors and
-        re-raises with a message that includes the snapshot name, unique_key
+        returns a descriptive message that includes the snapshot name, unique_key
         column(s), and actionable guidance.
         """
         error_message = str(e)
 
         if _is_duplicate_key_error(error_message):
             node = self.node
-            snapshot_name = node.name if hasattr(node, "name") else "unknown"
-            unique_key = (
-                node.config.unique_key
-                if hasattr(node, "config") and hasattr(node.config, "unique_key")
-                else "unknown"
-            )
-            file_path = (
-                node.original_file_path
-                if hasattr(node, "original_file_path")
-                else "unknown"
-            )
+            snapshot_name = getattr(node, "name", "unknown")
+            unique_key = "unknown"
+            if hasattr(node, "config") and hasattr(node.config, "unique_key"):
+                unique_key = node.config.unique_key
+            file_path = getattr(node, "original_file_path", "unknown")
 
-            raise DbtRuntimeError(
+            return (
                 f'Snapshot "{snapshot_name}" ({file_path}) failed due to '
                 f"duplicate values in unique_key: {_format_unique_key(unique_key)}.\n\n"
                 f"The unique_key column(s) must uniquely identify each row in the "
@@ -97,7 +91,7 @@ class SnapshotRunner(ModelRunner):
                 f"  2. Add a filter or deduplication step to ensure uniqueness\n"
                 f"  3. Consider using a composite unique_key if a single column is not sufficient\n\n"
                 f"Original error: {error_message}"
-            ) from e
+            )
 
         # For all other errors, use default handling
         return super().handle_exception(e, ctx)

--- a/core/dbt/task/snapshot.py
+++ b/core/dbt/task/snapshot.py
@@ -9,8 +9,32 @@ from dbt.task.base import BaseRunner
 from dbt.task.run import ModelRunner, RunTask
 from dbt_common.events.base_types import EventLevel
 from dbt_common.events.functions import fire_event
-from dbt_common.exceptions import DbtInternalError
+from dbt_common.exceptions import DbtInternalError, DbtRuntimeError
 from dbt_common.utils import cast_dict_to_dict_of_strings
+
+# Common database error patterns that indicate duplicate key violations
+# during snapshot MERGE operations. These are checked case-insensitively.
+_DUPLICATE_KEY_ERROR_PATTERNS = [
+    "duplicate row",
+    "duplicate key",
+    "unique constraint",
+    "cardinality violation",
+    "matched more than one",
+    "merge keys are not unique",
+]
+
+
+def _is_duplicate_key_error(error_message: str) -> bool:
+    """Check if a database error message indicates a duplicate key violation."""
+    lower_msg = error_message.lower()
+    return any(pattern in lower_msg for pattern in _DUPLICATE_KEY_ERROR_PATTERNS)
+
+
+def _format_unique_key(unique_key) -> str:
+    """Format the unique_key config for display, handling both string and list forms."""
+    if isinstance(unique_key, list):
+        return ", ".join(str(k) for k in unique_key)
+    return str(unique_key)
 
 
 class SnapshotRunner(ModelRunner):
@@ -36,6 +60,47 @@ class SnapshotRunner(ModelRunner):
             ),
             level=level,
         )
+
+    def handle_exception(self, e, ctx):
+        """Override to provide better error messages for duplicate key violations.
+
+        When a snapshot MERGE fails due to duplicate values in the unique_key
+        column(s), the database error is typically cryptic (e.g., "Duplicate row
+        detected during DML action"). This override detects such errors and
+        re-raises with a message that includes the snapshot name, unique_key
+        column(s), and actionable guidance.
+        """
+        error_message = str(e)
+
+        if _is_duplicate_key_error(error_message):
+            node = self.node
+            snapshot_name = node.name if hasattr(node, "name") else "unknown"
+            unique_key = (
+                node.config.unique_key
+                if hasattr(node, "config") and hasattr(node.config, "unique_key")
+                else "unknown"
+            )
+            file_path = (
+                node.original_file_path
+                if hasattr(node, "original_file_path")
+                else "unknown"
+            )
+
+            raise DbtRuntimeError(
+                f'Snapshot "{snapshot_name}" ({file_path}) failed due to '
+                f"duplicate values in unique_key: {_format_unique_key(unique_key)}.\n\n"
+                f"The unique_key column(s) must uniquely identify each row in the "
+                f"source query. When duplicates exist, the snapshot MERGE statement "
+                f"cannot determine which source row to use for each target row.\n\n"
+                f"To fix this:\n"
+                f"  1. Check your source query for duplicate {_format_unique_key(unique_key)} values\n"
+                f"  2. Add a filter or deduplication step to ensure uniqueness\n"
+                f"  3. Consider using a composite unique_key if a single column is not sufficient\n\n"
+                f"Original error: {error_message}"
+            ) from e
+
+        # For all other errors, use default handling
+        return super().handle_exception(e, ctx)
 
 
 class SnapshotTask(RunTask):


### PR DESCRIPTION
## Summary

Improves the error message when a snapshot MERGE fails due to duplicate values in the `unique_key` column(s).

Closes #12775

## Problem

When running `dbt snapshot` with a `unique_key` that contains duplicate values, the error is:

> Duplicate row detected during DML action

This message doesn't indicate which snapshot, which column, or which values are duplicated. Debugging requires significant time because there's no indication of where to look.

## Fix

Overrides `handle_exception` in `SnapshotRunner` to detect common duplicate-key error patterns from various databases and re-raise with a descriptive message.

**Before:**
```
Duplicate row detected during DML action
```

**After:**
```
Snapshot "orders_snapshot" (snapshots/orders_snapshot.sql) failed due to
duplicate values in unique_key: order_id.

The unique_key column(s) must uniquely identify each row in the source
query. When duplicates exist, the snapshot MERGE statement cannot
determine which source row to use for each target row.

To fix this:
  1. Check your source query for duplicate order_id values
  2. Add a filter or deduplication step to ensure uniqueness
  3. Consider using a composite unique_key if a single column is not sufficient

Original error: Duplicate row detected during DML action
```

## Implementation Details

- Detects multiple database-specific error patterns: "duplicate row", "duplicate key", "unique constraint", "cardinality violation", "matched more than one", "merge keys are not unique"
- Handles both string and list forms of `unique_key`
- Falls through to default error handling for non-duplicate-key errors
- Includes changie changelog entry

## Checklist
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md)
- [x] This PR includes a changie changelog entry
- [x] No interface changes