### PR TITLE
Add `--sql` flag to `dbt run-operation`

### DIFF
--- a/.changes/unreleased/Features-20260413-120000.yaml
+++ b/.changes/unreleased/Features-20260413-120000.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Add --inline flag to dbt run-operation for executing ad-hoc SQL/Jinja statements
+body: Add --sql flag to dbt run-operation for executing ad-hoc SQL/Jinja statements
 time: 2026-04-13T12:00:00.000000+00:00
 custom:
     Author: aahel

--- a/.changes/unreleased/Features-20260413-120000.yaml
+++ b/.changes/unreleased/Features-20260413-120000.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add --inline flag to dbt run-operation for executing ad-hoc SQL/Jinja statements
+time: 2026-04-13T12:00:00.000000+00:00
+custom:
+    Author: aahel
+    Issue: "12478"

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -519,7 +519,9 @@ def command_params(command: CliCommand, args_dict: Dict[str, Any]) -> CommandPar
                 continue
 
         if k == "macro" and command == CliCommand.RUN_OPERATION:
-            add_fn(v)
+            if v is not None:
+                add_fn(v)
+            continue
         # None is a Singleton, False is a Flyweight, only one instance of each.
         elif (v is None or v is False) and k not in (
             # These are None by default but they do not support --no-{flag}

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -679,7 +679,7 @@ def clone(ctx, **kwargs):
 @global_flags
 @click.argument("macro", required=False, default=None)
 @p.args
-@p.inline
+@p.sql
 @p.profiles_dir
 @p.project_dir
 @p.target_path

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -677,8 +677,9 @@ def clone(ctx, **kwargs):
 @cli.command("run-operation")
 @click.pass_context
 @global_flags
-@click.argument("macro")
+@click.argument("macro", required=False, default=None)
 @p.args
+@p.inline
 @p.profiles_dir
 @p.project_dir
 @p.target_path

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -328,6 +328,12 @@ inline = _create_option_and_track_env_var(
     help="Pass SQL inline to dbt compile and show",
 )
 
+sql = _create_option_and_track_env_var(
+    "--sql",
+    envvar=None,
+    help="Execute ad-hoc SQL/Jinja directly via dbt run-operation, without requiring a macro definition.",
+)
+
 inline_direct = _create_option_and_track_env_var(
     "--inline-direct",
     envvar=None,

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -332,6 +332,8 @@ sql = _create_option_and_track_env_var(
     "--sql",
     envvar=None,
     help="Execute ad-hoc SQL/Jinja directly via dbt run-operation, without requiring a macro definition.",
+    type=click.STRING,
+    default=None,
 )
 
 inline_direct = _create_option_and_track_env_var(

--- a/core/dbt/clients/jinja_static.py
+++ b/core/dbt/clients/jinja_static.py
@@ -17,6 +17,17 @@ if typing.TYPE_CHECKING:
 _TESTING_MACRO_CACHE: Dict[str, Any] = {}
 
 
+def statically_check_has_jinja(source: Optional[str]) -> bool:
+    """Returns True if the source string contains Jinja delimiters (`{{` or `{%`).
+
+    Used as a fast-path check to skip Jinja parsing/compilation for plain SQL.
+    Safely handles None.
+    """
+    if not source:
+        return False
+    return "{{" in source or "{%" in source
+
+
 def statically_extract_has_name_this(source: str) -> bool:
     """Checks whether the raw jinja has any references to `this`"""
     env = get_environment(None, capture_macros=True)

--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -48,7 +48,43 @@ class RunOperationTask(ConfiguredTask):
 
         return res
 
+    def _run_inline_unsafe(self):
+        from dbt.parser.manifest import process_node
+        from dbt.parser.sql import SqlBlockParser
+
+        adapter = get_adapter(self.config)
+
+        block_parser = SqlBlockParser(
+            project=self.config, manifest=self.manifest, root_project=self.config
+        )
+        sql_node = block_parser.parse_remote(self.args.inline, "inline_query")
+        process_node(self.config, self.manifest, sql_node)
+
+        # Compile the node to resolve Jinja (ref, source, var, etc.)
+        compiled_node = self.compiler.compile_node(
+            sql_node, self.manifest, extra_context=None, write=False
+        )
+
+        with adapter.connection_named("inline_query"):
+            adapter.clear_transaction()
+            adapter.execute(compiled_node.compiled_code, auto_begin=True, fetch=False)
+
+    def _is_inline(self):
+        return bool(getattr(self.args, "inline", None))
+
     def run(self) -> RunResultsArtifact:
+        inline = self._is_inline()
+        macro_name = getattr(self.args, "macro", None)
+
+        if not inline and not macro_name:
+            raise dbt_common.exceptions.DbtRuntimeError(
+                "Either a macro name or --inline must be passed to run-operation"
+            )
+        if inline and macro_name:
+            raise dbt_common.exceptions.DbtRuntimeError(
+                "Cannot specify both a macro name and --inline for run-operation"
+            )
+
         timing: List[TimingInfo] = []
 
         with collect_timing_info("compile", timing.append):
@@ -58,11 +94,20 @@ class RunOperationTask(ConfiguredTask):
 
         success = True
         error_message = None
-        package_name, macro_name = self._get_macro_parts()
+
+        if inline:
+            operation_name = "inline_query"
+            unique_id = f"sqloperation.{self.config.project_name}.inline_query"
+            fqn = unique_id.split(".")
+        else:
+            package_name, operation_name = self._get_macro_parts()
 
         with collect_timing_info("execute", timing.append):
             try:
-                self._run_unsafe(package_name, macro_name)
+                if inline:
+                    self._run_inline_unsafe()
+                else:
+                    self._run_unsafe(package_name, operation_name)
             except dbt_common.exceptions.DbtBaseException as exc:
                 fire_event(RunningOperationCaughtError(exc=str(exc)))
                 fire_event(LogDebugStackTrace(exc_info=traceback.format_exc()))
@@ -76,19 +121,22 @@ class RunOperationTask(ConfiguredTask):
 
         end = timing[1].completed_at
 
-        macro = (
-            self.manifest.find_macro_by_name(macro_name, self.config.project_name, package_name)
-            if self.manifest
-            else None
-        )
-
-        if macro:
-            unique_id = macro.unique_id
-            fqn = unique_id.split(".")
-        else:
-            raise dbt_common.exceptions.UndefinedMacroError(
-                f"dbt could not find a macro with the name '{macro_name}' in any package"
+        if not inline:
+            macro = (
+                self.manifest.find_macro_by_name(
+                    operation_name, self.config.project_name, package_name
+                )
+                if self.manifest
+                else None
             )
+
+            if macro:
+                unique_id = macro.unique_id
+                fqn = unique_id.split(".")
+            else:
+                raise dbt_common.exceptions.UndefinedMacroError(
+                    f"dbt could not find a macro with the name '{operation_name}' in any package"
+                )
 
         execution_time = (end - start).total_seconds() if start and end else 0.0
 
@@ -99,15 +147,15 @@ class RunOperationTask(ConfiguredTask):
             failures=0 if success else 1,
             message=error_message,
             node=HookNode(
-                alias=macro_name,
+                alias=operation_name,
                 checksum=FileHash.from_contents(unique_id),
                 database=self.config.credentials.database,
                 schema=self.config.credentials.schema,
                 resource_type=NodeType.Operation,
                 fqn=fqn,
-                name=macro_name,
+                name=operation_name,
                 unique_id=unique_id,
-                package_name=package_name,
+                package_name=self.config.project_name if inline else package_name,
                 path="",
                 original_file_path="",
             ),

--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -183,7 +183,7 @@ class RunOperationTask(ConfiguredTask):
                 )
 
         if sql_mode:
-            unique_id = f"sqloperation.{package_name}.{operation_name}"
+            unique_id = f"{NodeType.SqlOperation}.{package_name}.{operation_name}"
             fqn = unique_id.split(".")
         else:
             macro = (

--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -25,6 +25,10 @@ if TYPE_CHECKING:
     import agate
 
 
+def _inline_has_jinja(sql: str) -> bool:
+    return "{{" in sql or "{%" in sql
+
+
 class RunOperationTask(ConfiguredTask):
     def _get_macro_parts(self):
         macro_name = self.args.macro
@@ -49,25 +53,28 @@ class RunOperationTask(ConfiguredTask):
         return res
 
     def _run_inline_unsafe(self):
-        from dbt.parser.manifest import process_node
-        from dbt.parser.sql import SqlBlockParser
-
         adapter = get_adapter(self.config)
 
-        block_parser = SqlBlockParser(
-            project=self.config, manifest=self.manifest, root_project=self.config
-        )
-        sql_node = block_parser.parse_remote(self.args.inline, "inline_query")
-        process_node(self.config, self.manifest, sql_node)
+        if _inline_has_jinja(self.args.inline):
+            from dbt.parser.manifest import process_node
+            from dbt.parser.sql import SqlBlockParser
 
-        # Compile the node to resolve Jinja (ref, source, var, etc.)
-        compiled_node = self.compiler.compile_node(
-            sql_node, self.manifest, extra_context=None, write=False
-        )
+            block_parser = SqlBlockParser(
+                project=self.config, manifest=self.manifest, root_project=self.config
+            )
+            sql_node = block_parser.parse_remote(self.args.inline, "inline_query")
+            process_node(self.config, self.manifest, sql_node)
+
+            compiled_node = self.compiler.compile_node(
+                sql_node, self.manifest, extra_context=None, write=False
+            )
+            sql = compiled_node.compiled_code
+        else:
+            sql = self.args.inline
 
         with adapter.connection_named("inline_query"):
             adapter.clear_transaction()
-            adapter.execute(compiled_node.compiled_code, auto_begin=True, fetch=False)
+            adapter.execute(sql, auto_begin=True, fetch=False)
 
     def _is_inline(self):
         return bool(getattr(self.args, "inline", None))
@@ -84,11 +91,20 @@ class RunOperationTask(ConfiguredTask):
             raise dbt_common.exceptions.DbtRuntimeError(
                 "Cannot specify both a macro name and --inline for run-operation"
             )
+        if inline and self.args.args:
+            raise dbt_common.exceptions.DbtRuntimeError(
+                "--args cannot be used with --inline; pass arguments directly in the SQL"
+            )
 
         timing: List[TimingInfo] = []
 
+        # Skip manifest graph compilation for Jinja-free inline SQL — the
+        # manifest is not needed to execute plain SQL directly.
+        needs_manifest = not inline or _inline_has_jinja(self.args.inline)
+
         with collect_timing_info("compile", timing.append):
-            self.compile_manifest()
+            if needs_manifest:
+                self.compile_manifest()
 
         start = timing[0].started_at
 

--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -8,6 +8,7 @@ import dbt_common.exceptions
 from dbt.adapters.factory import get_adapter
 from dbt.artifacts.schemas.results import RunStatus, TimingInfo, collect_timing_info
 from dbt.artifacts.schemas.run import RunResult, RunResultsArtifact
+from dbt.clients.jinja_static import statically_check_has_jinja
 from dbt.constants import RUN_RESULTS_FILE_NAME
 from dbt.contracts.files import FileHash
 from dbt.contracts.graph.nodes import HookNode
@@ -27,10 +28,6 @@ from dbt_common.ui import green, red
 
 if TYPE_CHECKING:
     import agate
-
-
-def _sql_has_jinja(sql: str) -> bool:
-    return "{{" in sql or "{%" in sql
 
 
 class RunOperationTask(ConfiguredTask):
@@ -56,10 +53,10 @@ class RunOperationTask(ConfiguredTask):
 
         return res
 
-    def _run_sql_unsafe(self):
+    def _run_unsafe_sql(self):
         adapter = get_adapter(self.config)
 
-        if _sql_has_jinja(self.args.sql):
+        if statically_check_has_jinja(self.args.sql):
             from dbt.parser.manifest import process_node
             from dbt.parser.sql import SqlBlockParser
 
@@ -117,7 +114,7 @@ class RunOperationTask(ConfiguredTask):
 
         # Skip manifest graph compilation for Jinja-free SQL — the
         # manifest is not needed to execute plain SQL directly.
-        needs_manifest = not sql_mode or _sql_has_jinja(self.args.sql)
+        needs_manifest = not sql_mode or statically_check_has_jinja(self.args.sql)
 
         with collect_timing_info("compile", timing.append):
             if needs_manifest:
@@ -130,16 +127,15 @@ class RunOperationTask(ConfiguredTask):
         adapter_response = {}
 
         if sql_mode:
+            package_name = self.config.project_name
             operation_name = "inline_query"
-            unique_id = f"sqloperation.{self.config.project_name}.inline_query"
-            fqn = unique_id.split(".")
         else:
             package_name, operation_name = self._get_macro_parts()
 
         with collect_timing_info("execute", timing.append):
             try:
                 if sql_mode:
-                    response = self._run_sql_unsafe()
+                    response = self._run_unsafe_sql()
                     adapter_response = response.to_dict() if response else {}
                 else:
                     self._run_unsafe(package_name, operation_name)
@@ -186,7 +182,10 @@ class RunOperationTask(ConfiguredTask):
                     level=EventLevel.ERROR,
                 )
 
-        if not sql_mode:
+        if sql_mode:
+            unique_id = f"sqloperation.{package_name}.{operation_name}"
+            fqn = unique_id.split(".")
+        else:
             macro = (
                 self.manifest.find_macro_by_name(
                     operation_name, self.config.project_name, package_name
@@ -218,7 +217,7 @@ class RunOperationTask(ConfiguredTask):
                 fqn=fqn,
                 name=operation_name,
                 unique_id=unique_id,
-                package_name=self.config.project_name if sql_mode else package_name,
+                package_name=package_name,
                 path="",
                 original_file_path="",
             ),

--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -19,13 +19,17 @@ from dbt.events.types import (
 )
 from dbt.node_types import NodeType
 from dbt.task.base import ConfiguredTask
+from dbt_common.events.base_types import EventLevel
+from dbt_common.events.format import format_fancy_output_line
 from dbt_common.events.functions import fire_event
+from dbt_common.events.types import Note
+from dbt_common.ui import green, red
 
 if TYPE_CHECKING:
     import agate
 
 
-def _inline_has_jinja(sql: str) -> bool:
+def _sql_has_jinja(sql: str) -> bool:
     return "{{" in sql or "{%" in sql
 
 
@@ -52,17 +56,17 @@ class RunOperationTask(ConfiguredTask):
 
         return res
 
-    def _run_inline_unsafe(self):
+    def _run_sql_unsafe(self):
         adapter = get_adapter(self.config)
 
-        if _inline_has_jinja(self.args.inline):
+        if _sql_has_jinja(self.args.sql):
             from dbt.parser.manifest import process_node
             from dbt.parser.sql import SqlBlockParser
 
             block_parser = SqlBlockParser(
                 project=self.config, manifest=self.manifest, root_project=self.config
             )
-            sql_node = block_parser.parse_remote(self.args.inline, "inline_query")
+            sql_node = block_parser.parse_remote(self.args.sql, "inline_query")
             process_node(self.config, self.manifest, sql_node)
 
             compiled_node = self.compiler.compile_node(
@@ -70,37 +74,50 @@ class RunOperationTask(ConfiguredTask):
             )
             sql = compiled_node.compiled_code
         else:
-            sql = self.args.inline
+            sql = self.args.sql
+
+        fire_event(
+            Note(
+                msg=format_fancy_output_line(
+                    msg="START executing inline_query",
+                    status="RUN",
+                    index=1,
+                    total=1,
+                )
+            )
+        )
 
         with adapter.connection_named("inline_query"):
             adapter.clear_transaction()
-            adapter.execute(sql, auto_begin=True, fetch=False)
+            response, _ = adapter.execute(sql, auto_begin=True, fetch=False)
 
-    def _is_inline(self):
-        return bool(getattr(self.args, "inline", None))
+        return response
+
+    def _is_sql(self):
+        return bool(getattr(self.args, "sql", None))
 
     def run(self) -> RunResultsArtifact:
-        inline = self._is_inline()
+        sql_mode = self._is_sql()
         macro_name = getattr(self.args, "macro", None)
 
-        if not inline and not macro_name:
+        if not sql_mode and not macro_name:
             raise dbt_common.exceptions.DbtRuntimeError(
-                "Either a macro name or --inline must be passed to run-operation"
+                "Either a macro name or --sql must be passed to run-operation"
             )
-        if inline and macro_name:
+        if sql_mode and macro_name:
             raise dbt_common.exceptions.DbtRuntimeError(
-                "Cannot specify both a macro name and --inline for run-operation"
+                "Cannot specify both a macro name and --sql for run-operation"
             )
-        if inline and self.args.args:
+        if sql_mode and self.args.args:
             raise dbt_common.exceptions.DbtRuntimeError(
-                "--args cannot be used with --inline; pass arguments directly in the SQL"
+                "--args cannot be used with --sql; pass arguments directly in the SQL"
             )
 
         timing: List[TimingInfo] = []
 
-        # Skip manifest graph compilation for Jinja-free inline SQL — the
+        # Skip manifest graph compilation for Jinja-free SQL — the
         # manifest is not needed to execute plain SQL directly.
-        needs_manifest = not inline or _inline_has_jinja(self.args.inline)
+        needs_manifest = not sql_mode or _sql_has_jinja(self.args.sql)
 
         with collect_timing_info("compile", timing.append):
             if needs_manifest:
@@ -110,8 +127,9 @@ class RunOperationTask(ConfiguredTask):
 
         success = True
         error_message = None
+        adapter_response = {}
 
-        if inline:
+        if sql_mode:
             operation_name = "inline_query"
             unique_id = f"sqloperation.{self.config.project_name}.inline_query"
             fqn = unique_id.split(".")
@@ -120,8 +138,9 @@ class RunOperationTask(ConfiguredTask):
 
         with collect_timing_info("execute", timing.append):
             try:
-                if inline:
-                    self._run_inline_unsafe()
+                if sql_mode:
+                    response = self._run_sql_unsafe()
+                    adapter_response = response.to_dict() if response else {}
                 else:
                     self._run_unsafe(package_name, operation_name)
             except dbt_common.exceptions.DbtBaseException as exc:
@@ -136,8 +155,38 @@ class RunOperationTask(ConfiguredTask):
                 error_message = str(exc)
 
         end = timing[1].completed_at
+        execution_time = (end - start).total_seconds() if start and end else 0.0
 
-        if not inline:
+        if sql_mode:
+            if success:
+                status_msg = adapter_response.get("_message") or "OK"
+                fire_event(
+                    Note(
+                        msg=format_fancy_output_line(
+                            msg="OK executed inline_query",
+                            status=green(status_msg),
+                            index=1,
+                            total=1,
+                            execution_time=execution_time,
+                        )
+                    ),
+                    level=EventLevel.INFO,
+                )
+            else:
+                fire_event(
+                    Note(
+                        msg=format_fancy_output_line(
+                            msg="ERROR executing inline_query",
+                            status=red("ERROR"),
+                            index=1,
+                            total=1,
+                            execution_time=execution_time,
+                        )
+                    ),
+                    level=EventLevel.ERROR,
+                )
+
+        if not sql_mode:
             macro = (
                 self.manifest.find_macro_by_name(
                     operation_name, self.config.project_name, package_name
@@ -154,10 +203,8 @@ class RunOperationTask(ConfiguredTask):
                     f"dbt could not find a macro with the name '{operation_name}' in any package"
                 )
 
-        execution_time = (end - start).total_seconds() if start and end else 0.0
-
         run_result = RunResult(
-            adapter_response={},
+            adapter_response=adapter_response,
             status=RunStatus.Success if success else RunStatus.Error,
             execution_time=execution_time,
             failures=0 if success else 1,
@@ -171,7 +218,7 @@ class RunOperationTask(ConfiguredTask):
                 fqn=fqn,
                 name=operation_name,
                 unique_id=unique_id,
-                package_name=self.config.project_name if inline else package_name,
+                package_name=self.config.project_name if sql_mode else package_name,
                 path="",
                 original_file_path="",
             ),

--- a/tests/functional/run_operations/test_run_operations.py
+++ b/tests/functional/run_operations/test_run_operations.py
@@ -165,6 +165,73 @@ name: 'pkg'
         rm_file("packages.yml")
 
 
+class TestRunOperationInline:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model.sql": model_sql}
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"happy_macros.sql": happy_macros_sql}
+
+    @pytest.fixture(scope="class")
+    def dbt_profile_data(self, unique_schema):
+        return {
+            "test": {
+                "outputs": {
+                    "default": {
+                        "type": "postgres",
+                        "threads": 4,
+                        "host": "localhost",
+                        "port": int(os.getenv("POSTGRES_TEST_PORT", 5432)),
+                        "user": os.getenv("POSTGRES_TEST_USER", "root"),
+                        "pass": os.getenv("POSTGRES_TEST_PASS", "password"),
+                        "dbname": os.getenv("POSTGRES_TEST_DATABASE", "dbt"),
+                        "schema": unique_schema,
+                    },
+                },
+                "target": "default",
+            },
+        }
+
+    def test_inline_simple_select(self, project):
+        results = run_dbt(["run-operation", "--inline", "select 1 as id"])
+        assert results.results[0].status == RunStatus.Success
+
+    def test_inline_create_table(self, project):
+        schema = project.test_schema
+        results = run_dbt(
+            ["run-operation", "--inline", f'create table "{schema}"."inline_table" (id int)']
+        )
+        assert results.results[0].status == RunStatus.Success
+        check_table_does_exist(project.adapter, "inline_table")
+
+    def test_inline_with_ref(self, project):
+        run_dbt(["run"])
+        results = run_dbt(["run-operation", "--inline", "select * from {{ ref('model') }}"])
+        assert results.results[0].status == RunStatus.Success
+
+    def test_inline_with_jinja(self, project):
+        results = run_dbt(
+            ["run-operation", "--inline", "select '{{ target.schema }}' as schema_name"]
+        )
+        assert results.results[0].status == RunStatus.Success
+
+    def test_inline_syntax_error(self, project):
+        results = run_dbt(
+            ["run-operation", "--inline", "select NOPE NOT A VALID QUERY"],
+            expect_pass=False,
+        )
+        assert results.results[0].status == RunStatus.Error
+
+    def test_inline_no_args_error(self, project):
+        with pytest.raises(
+            Exception,
+            match="Either a macro name or --inline must be passed",
+        ):
+            run_dbt(["run-operation"], expect_pass=False)
+
+
 class TestRunOperationRefPrivateModel:
     """Regression test for https://github.com/dbt-labs/dbt-core/issues/8248
 

--- a/tests/functional/run_operations/test_run_operations.py
+++ b/tests/functional/run_operations/test_run_operations.py
@@ -231,6 +231,24 @@ class TestRunOperationInline:
         ):
             run_dbt(["run-operation"], expect_pass=False)
 
+    def test_inline_args_conflict_error(self, project):
+        with pytest.raises(
+            Exception,
+            match="--args cannot be used with --inline",
+        ):
+            run_dbt(
+                ["run-operation", "--inline", "select 1", "--args", "{foo: bar}"],
+                expect_pass=False,
+            )
+
+    def test_inline_no_jinja_skips_compile(self, project):
+        # Plain SQL (no Jinja) should succeed without needing the manifest compiled.
+        # We verify this by checking timing: compile phase should complete near-instantly.
+        results = run_dbt(["run-operation", "--inline", "select 42 as answer"])
+        assert results.results[0].status == RunStatus.Success
+        timing_keys = [t.name for t in results.results[0].timing]
+        assert timing_keys == ["compile", "execute"]
+
 
 class TestRunOperationRefPrivateModel:
     """Regression test for https://github.com/dbt-labs/dbt-core/issues/8248

--- a/tests/functional/run_operations/test_run_operations.py
+++ b/tests/functional/run_operations/test_run_operations.py
@@ -165,7 +165,7 @@ name: 'pkg'
         rm_file("packages.yml")
 
 
-class TestRunOperationInline:
+class TestRunOperationSql:
     @pytest.fixture(scope="class")
     def models(self):
         return {"model.sql": model_sql}
@@ -194,60 +194,74 @@ class TestRunOperationInline:
             },
         }
 
-    def test_inline_simple_select(self, project):
-        results = run_dbt(["run-operation", "--inline", "select 1 as id"])
+    def test_sql_simple_select(self, project):
+        results = run_dbt(["run-operation", "--sql", "select 1 as id"])
         assert results.results[0].status == RunStatus.Success
 
-    def test_inline_create_table(self, project):
+    def test_sql_create_table(self, project):
         schema = project.test_schema
         results = run_dbt(
-            ["run-operation", "--inline", f'create table "{schema}"."inline_table" (id int)']
+            ["run-operation", "--sql", f'create table "{schema}"."inline_table" (id int)']
         )
         assert results.results[0].status == RunStatus.Success
         check_table_does_exist(project.adapter, "inline_table")
 
-    def test_inline_with_ref(self, project):
+    def test_sql_with_ref(self, project):
         run_dbt(["run"])
-        results = run_dbt(["run-operation", "--inline", "select * from {{ ref('model') }}"])
+        results = run_dbt(["run-operation", "--sql", "select * from {{ ref('model') }}"])
         assert results.results[0].status == RunStatus.Success
 
-    def test_inline_with_jinja(self, project):
+    def test_sql_with_jinja(self, project):
         results = run_dbt(
-            ["run-operation", "--inline", "select '{{ target.schema }}' as schema_name"]
+            ["run-operation", "--sql", "select '{{ target.schema }}' as schema_name"]
         )
         assert results.results[0].status == RunStatus.Success
 
-    def test_inline_syntax_error(self, project):
+    def test_sql_syntax_error(self, project):
         results = run_dbt(
-            ["run-operation", "--inline", "select NOPE NOT A VALID QUERY"],
+            ["run-operation", "--sql", "select NOPE NOT A VALID QUERY"],
             expect_pass=False,
         )
         assert results.results[0].status == RunStatus.Error
 
-    def test_inline_no_args_error(self, project):
+    def test_sql_no_args_error(self, project):
         with pytest.raises(
             Exception,
-            match="Either a macro name or --inline must be passed",
+            match="Either a macro name or --sql must be passed",
         ):
             run_dbt(["run-operation"], expect_pass=False)
 
-    def test_inline_args_conflict_error(self, project):
+    def test_sql_args_conflict_error(self, project):
         with pytest.raises(
             Exception,
-            match="--args cannot be used with --inline",
+            match=r"--args cannot be used with --sql",
         ):
             run_dbt(
-                ["run-operation", "--inline", "select 1", "--args", "{foo: bar}"],
+                ["run-operation", "--sql", "select 1", "--args", "{foo: bar}"],
                 expect_pass=False,
             )
 
-    def test_inline_no_jinja_skips_compile(self, project):
+    def test_sql_no_jinja_skips_compile(self, project):
         # Plain SQL (no Jinja) should succeed without needing the manifest compiled.
         # We verify this by checking timing: compile phase should complete near-instantly.
-        results = run_dbt(["run-operation", "--inline", "select 42 as answer"])
+        results = run_dbt(["run-operation", "--sql", "select 42 as answer"])
         assert results.results[0].status == RunStatus.Success
         timing_keys = [t.name for t in results.results[0].timing]
         assert timing_keys == ["compile", "execute"]
+
+    def test_sql_logs_execution_status(self, project):
+        results, log_output = run_dbt_and_capture(["run-operation", "--sql", "select 1 as id"])
+        assert results.results[0].status == RunStatus.Success
+        assert "START executing inline_query" in log_output
+        assert "OK executed inline_query" in log_output
+
+    def test_sql_logs_error_status(self, project):
+        results, log_output = run_dbt_and_capture(
+            ["run-operation", "--sql", "select NOPE NOT VALID"],
+            expect_pass=False,
+        )
+        assert results.results[0].status == RunStatus.Error
+        assert "ERROR executing inline_query" in log_output
 
 
 class TestRunOperationRefPrivateModel:


### PR DESCRIPTION
Resolves #12478

### Problem

`dbt run-operation` currently requires a named macro to execute any database statement. For ad-hoc or one-off operations (e.g., DDL, grants, data fixes), users must first create a macro file and then invoke it. This adds friction, especially for AI agents that need a lightweight way to execute arbitrary SQL through dbt's connection infrastructure without generating files on disk.

### Solution

Add a `--sql` flag to `dbt run-operation` that accepts a SQL/Jinja string and executes it directly against the target database. The statement goes through the full Jinja compilation pipeline, supporting `ref()`, `source()`, `var()`, `target`, and all other context variables.

**Implementation:**
- **CLI** (`main.py`, `params.py`): `macro` positional argument made optional, new `--sql` param added. Passing both or neither, or `--args` with `--sql`, produces clear errors.
- **Flags** (`flags.py`): Updated flag serialization to handle `None` macro when `--sql` is used.
- **Task** (`run_operation.py`): New `_run_sql_unsafe()` method that parses the SQL via `SqlBlockParser`, resolves `ref()`/`source()` via `process_node()`, compiles Jinja via `Compiler.compile_node()`, and executes via `adapter.execute()`. Reuses the same infrastructure as `dbt compile --inline` and `dbt show --inline`.
- **Logging**: Prints START/OK/ERROR status lines matching the `dbt run` pattern so users can see whether the operation succeeded:
  ```
  1 of 1 START executing inline_query ........... [RUN]
  1 of 1 OK executed inline_query ............... [SELECT 1 in 0.05s]
  ```
- **Optimization**: Skips manifest graph compilation entirely for Jinja-free SQL.

**Usage:**
```bash
dbt run-operation --sql "select 1"
dbt run-operation --sql "CREATE TABLE my_schema.t (id int)"
dbt run-operation --sql "select * from {{ ref('my_model') }}"
dbt run-operation --sql "GRANT SELECT ON {{ target.schema }} TO analyst"
```

**Artifact compatibility:**
The `run_results.json` schema is unchanged. Inline operations produce the same `RunResult` structure (`HookNode`, `resource_type: Operation`, both `compile`/`execute` timing entries) as macro-based operations. The `adapter_response` field is now populated with the execution response (rows affected, etc.). Field-value differences:

| Field | Macro path | --sql path |
|-------|-----------|-----------|
| `name` / `alias` | `"my_macro"` | `"inline_query"` |
| `unique_id` | `"macro.project.my_macro"` | `"sqloperation.project.inline_query"` |
| `package_name` | parsed from `pkg.macro` or `None` | project name |

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.