### PR TITLE
[Fix] allow rendering tests in versioned models

### DIFF
--- a/.changes/unreleased/Fixes-20260413-134208.yaml
+++ b/.changes/unreleased/Fixes-20260413-134208.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Allows rendering of data_tests in versioned models
+time: 2026-04-13T13:42:08.054974+05:30
+custom:
+    Author: ash2shukla
+    Issue: "12805"

--- a/.changes/unreleased/Fixes-20260413-134208.yaml
+++ b/.changes/unreleased/Fixes-20260413-134208.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: Allows rendering of data_tests in versioned models
+body: Skip schema-time rendering of version-level data_tests so they can be rendered later with full context
 time: 2026-04-13T13:42:08.054974+05:30
 custom:
     Author: ash2shukla

--- a/core/dbt/parser/schema_renderer.py
+++ b/core/dbt/parser/schema_renderer.py
@@ -62,9 +62,9 @@ class SchemaYamlRenderer(BaseRenderer):
         ):
             return True
 
-        # versions: data_tests, descriptions, and column data_tests/descriptions
-        # keypath looks like ("versions", <idx>, "data_tests", ...) or
-        # ("versions", <idx>, "columns", <idx>, "data_tests", ...)
+        # versions: tests/data_tests, descriptions, and column tests/data_tests/descriptions
+        # keypath looks like ("versions", <idx>, "tests" or "data_tests", ...) or
+        # ("versions", <idx>, "columns", <idx>, "tests" or "data_tests", ...)
         if (
             len(keypath) >= 3
             and keypath[0] == "versions"

--- a/core/dbt/parser/schema_renderer.py
+++ b/core/dbt/parser/schema_renderer.py
@@ -62,8 +62,27 @@ class SchemaYamlRenderer(BaseRenderer):
         ):
             return True
 
-        # versions
-        if len(keypath) == 5 and keypath[4] == "description":
+        # versions: data_tests, descriptions, and column data_tests/descriptions
+        # keypath looks like ("versions", <idx>, "data_tests", ...) or
+        # ("versions", <idx>, "columns", <idx>, "data_tests", ...)
+        if (
+            len(keypath) >= 3
+            and keypath[0] == "versions"
+            and keypath[2]
+            in (
+                "tests",
+                "data_tests",
+                "description",
+            )
+        ):
+            return True
+
+        if (
+            len(keypath) >= 5
+            and keypath[0] == "versions"
+            and keypath[2] == "columns"
+            and keypath[4] in ("tests", "data_tests", "description")
+        ):
             return True
 
         if (

--- a/tests/unit/parser/test_schema_renderer.py
+++ b/tests/unit/parser/test_schema_renderer.py
@@ -353,6 +353,87 @@ class TestYamlRendering(unittest.TestCase):
             ["{{ Dimension('my_entity__is_fraud') }} = false"],
         )
 
+    def test__versioned_model_data_tests(self):
+        """Test that data_tests inside version blocks are not rendered.
+
+        Version-level data_tests may contain Jinja expressions like {{ ref() }}
+        that are not available in the schema rendering context. These must be
+        skipped and rendered later in the test compilation phase.
+        """
+        context = {"test_var": "1234"}
+        renderer = SchemaYamlRenderer(context, "models")
+
+        # Version-level data_tests should not be rendered
+        dct = {
+            "name": "my_model",
+            "attribute": "{{ test_var }}",
+            "versions": [
+                {
+                    "v": 1,
+                    "data_tests": [
+                        {
+                            "compare_datasets": {
+                                "source_query": "select * from {{ ref('other_model') }}",
+                                "target_query": "select * from {{ ref('my_model') }}",
+                            }
+                        }
+                    ],
+                }
+            ],
+        }
+        expected = {
+            "name": "my_model",
+            "attribute": "1234",
+            "versions": [
+                {
+                    "v": 1,
+                    "data_tests": [
+                        {
+                            "compare_datasets": {
+                                "source_query": "select * from {{ ref('other_model') }}",
+                                "target_query": "select * from {{ ref('my_model') }}",
+                            }
+                        }
+                    ],
+                }
+            ],
+        }
+        dct = renderer.render_data(dct)
+        self.assertEqual(expected, dct)
+
+        # Version-level descriptions should not be rendered
+        dct = {
+            "name": "my_model",
+            "versions": [
+                {
+                    "v": 1,
+                    "description": "{{ test_var }}",
+                }
+            ],
+        }
+        rendered = renderer.render_data(dct)
+        self.assertEqual(rendered["versions"][0]["description"], "{{ test_var }}")
+
+        # Version-level column data_tests and descriptions should not be rendered
+        dct = {
+            "name": "my_model",
+            "versions": [
+                {
+                    "v": 1,
+                    "columns": [
+                        {
+                            "name": "id",
+                            "description": "{{ test_var }}",
+                            "data_tests": [{"not_null": {}}],
+                        }
+                    ],
+                }
+            ],
+        }
+        rendered = renderer.render_data(dct)
+        self.assertEqual(rendered["versions"][0]["columns"][0]["description"], "{{ test_var }}")
+        self.assertEqual(rendered["versions"][0]["columns"][0]["data_tests"], [{"not_null": {}}])
+
     def test__derived_semantics_descriptions(self):
         context = {
             "test_var": "1234",


### PR DESCRIPTION
Resolves #12805 

### Problem
`_is_no_renderer_key` did not exclude tests and data_tests for versioned models which resulted in missing context that is only available in later phases ( eg. missing ref ).

### Solution
Allow initial no render by including `versions: -> data_tests / tests` and `versions: -> columns -> data_tests/tests` so that they can be rendered later with sufficient context in `parse_generic_test`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
