### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260413-144017.yaml
+++ b/.changes/unreleased/Under the Hood-20260413-144017.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-04-13T14:40:17.050472259Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -1837,6 +1837,12 @@
             }
           ]
         },
+        "+snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+snowflake_warehouse": {
           "type": [
             "string",
@@ -3361,6 +3367,12 @@
             }
           ]
         },
+        "+snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+snowflake_warehouse": {
           "type": [
             "string",
@@ -4288,6 +4300,12 @@
             }
           ]
         },
+        "+snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+snowflake_warehouse": {
           "type": [
             "string",
@@ -5177,6 +5195,12 @@
             }
           ]
         },
+        "+snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+snowflake_warehouse": {
           "type": [
             "string",
@@ -5940,6 +5964,12 @@
             }
           ]
         },
+        "+snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+snowflake_warehouse": {
           "type": [
             "string",
@@ -6618,6 +6648,12 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "+snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "+snowflake_warehouse": {

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -1591,6 +1591,12 @@
             }
           ]
         },
+        "snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "snowflake_warehouse": {
           "type": [
             "string",
@@ -3344,6 +3350,12 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "snowflake_warehouse": {
@@ -5318,6 +5330,12 @@
             }
           ]
         },
+        "snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "snowflake_warehouse": {
           "type": [
             "string",
@@ -7087,6 +7105,12 @@
             }
           ]
         },
+        "snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "snowflake_warehouse": {
           "type": [
             "string",
@@ -8105,6 +8129,12 @@
             }
           ]
         },
+        "snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "snowflake_warehouse": {
           "type": [
             "string",
@@ -9056,6 +9086,12 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "snowflake_warehouse": {
@@ -10178,6 +10214,12 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "snowflake_warehouse": {


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`ae9d6eda570147e4a3700e8945e79a4391f9bdc7`](https://github.com/dbt-labs/fs/commit/ae9d6eda570147e4a3700e8945e79a4391f9bdc7)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/24348278543)