### PR TITLE
Support overloaded UDFs with the same database function name

### DIFF
--- a/.changes/unreleased/Features-20260414-073900.yaml
+++ b/.changes/unreleased/Features-20260414-073900.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Support overloaded UDFs - multiple functions can share the same database name (alias) with different argument signatures
+body: Support overloaded UDFs - multiple functions can share the same database function name with different argument signatures
 time: 2026-04-14T07:39:00.000000-04:00
 custom:
     Author: aahel

--- a/.changes/unreleased/Features-20260414-073900.yaml
+++ b/.changes/unreleased/Features-20260414-073900.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support overloaded UDFs - multiple functions can share the same database name (alias) with different argument signatures
+time: 2026-04-14T07:39:00.000000-04:00
+custom:
+    Author: aahel
+    Issue: "12250"

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -189,13 +189,38 @@ class SourceLookup(dbtClassMixin):
 
 class FunctionLookup(dbtClassMixin):
     def __init__(self, manifest: "Manifest") -> None:
-        self.storage: Dict[str, Dict[PackageName, UniqueID]] = {}
+        # Maps a lookup key (name or alias) to {package_name: [unique_id, ...]}
+        self.storage: Dict[str, Dict[PackageName, List[UniqueID]]] = {}
         self.populate(manifest)
 
     def get_unique_id(
         self, search_name: str, package: Optional[PackageName]
     ) -> Optional[UniqueID]:
-        return find_unique_id_for_package(self.storage, search_name, package)
+        """Return the first matching unique_id for backward compatibility."""
+        ids = self._get_unique_ids(search_name, package)
+        return ids[0] if ids else None
+
+    def get_all_unique_ids(
+        self, search_name: str, package: Optional[PackageName]
+    ) -> List[UniqueID]:
+        """Return all matching unique_ids (supports overloaded functions)."""
+        return self._get_unique_ids(search_name, package)
+
+    def _get_unique_ids(self, search_name: str, package: Optional[PackageName]) -> List[UniqueID]:
+        if search_name not in self.storage:
+            return []
+
+        pkg_dct = self.storage[search_name]
+
+        if package is None:
+            result: List[UniqueID] = []
+            for ids in pkg_dct.values():
+                result.extend(ids)
+            return result
+        elif package in pkg_dct:
+            return list(pkg_dct[package])
+        else:
+            return []
 
     def find(
         self, search_name: str, package: Optional[PackageName], manifest: "Manifest"
@@ -205,11 +230,28 @@ class FunctionLookup(dbtClassMixin):
             return self.perform_lookup(unique_id, manifest)
         return None
 
-    def add_function(self, function: FunctionNode) -> None:
-        if function.search_name not in self.storage:
-            self.storage[function.search_name] = {}
+    def find_all(
+        self, search_name: str, package: Optional[PackageName], manifest: "Manifest"
+    ) -> List[FunctionNode]:
+        """Return all function nodes matching the search name (supports overloads)."""
+        unique_ids = self.get_all_unique_ids(search_name, package)
+        return [self.perform_lookup(uid, manifest) for uid in unique_ids]
 
-        self.storage[function.search_name][function.package_name] = function.unique_id
+    def add_function(self, function: FunctionNode) -> None:
+        self._add_to_storage(function.search_name, function.package_name, function.unique_id)
+
+        # Also index by alias (identifier) if different from name,
+        # so overloaded functions sharing an alias can be looked up by that alias.
+        if function.identifier != function.search_name:
+            self._add_to_storage(function.identifier, function.package_name, function.unique_id)
+
+    def _add_to_storage(self, key: str, package: PackageName, unique_id: UniqueID) -> None:
+        if key not in self.storage:
+            self.storage[key] = {}
+        if package not in self.storage[key]:
+            self.storage[key][package] = []
+        if unique_id not in self.storage[key][package]:
+            self.storage[key][package].append(unique_id)
 
     def populate(self, manifest: "Manifest") -> None:
         for function in manifest.functions.values():
@@ -1420,6 +1462,9 @@ class Manifest(MacroMethods, dbtClassMixin):
             self._function_lookup = FunctionLookup(self)
         return self._function_lookup
 
+    def rebuild_function_lookup(self) -> None:
+        self._function_lookup = FunctionLookup(self)
+
     @property
     def external_node_unique_ids(self) -> List[str]:
         return [node.unique_id for node in self.nodes.values() if node.is_external_node]
@@ -1511,6 +1556,29 @@ class Manifest(MacroMethods, dbtClassMixin):
         if disabled:
             return Disabled(disabled[0])
         return None
+
+    def resolve_all_functions(
+        self,
+        target_function_name: str,
+        target_function_package: Optional[str],
+        current_project: str,
+        node_package: str,
+    ) -> List[FunctionNode]:
+        """Resolve all overloads of a function by name or alias.
+
+        Returns all enabled function nodes matching the target name across
+        package candidates. This supports overloaded UDFs where multiple
+        functions share the same database name (alias) but have different
+        argument signatures.
+        """
+        package_candidates = _packages_to_search(
+            current_project, node_package, target_function_package
+        )
+        result: List[FunctionNode] = []
+        for package in package_candidates:
+            functions = self.function_lookup.find_all(target_function_name, package, self)
+            result.extend(f for f in functions if f.config.enabled)
+        return result
 
     def resolve_metric(
         self,

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -487,6 +487,9 @@ class ManifestLoader:
             self.process_metrics(self.root_project)
             self.process_saved_queries(self.root_project)
             self.process_model_inferred_primary_keys()
+            # Rebuild the function lookup to pick up aliases set during YAML
+            # patching (e.g. overloaded UDFs sharing the same alias).
+            self.manifest.rebuild_function_lookup()
             self.process_functions(self.root_project.project_name)
             self.check_valid_group_config()
             self.check_valid_access_property()
@@ -2345,27 +2348,40 @@ def _process_functions_for_node(
                 f"Functions should always be 1 or 2 arguments - got {len(function_args)}"
             )
 
-        target_function = manifest.resolve_function(
+        # Resolve all overloads of this function (supports overloaded UDFs).
+        # This ensures dependency edges are created to every overload so they
+        # are all materialized before the referencing node runs.
+        target_functions = manifest.resolve_all_functions(
             target_function_name,
             target_function_package,
             current_project,
             node.package_name,
         )
 
-        if target_function is None or isinstance(target_function, Disabled):
-            node.config.enabled = False
-            invalid_target_fail_unless_test(
-                node=node,
-                target_name=target_function_name,
-                target_kind="function",
-                target_package=target_function_package,
-                disabled=(isinstance(target_function, Disabled)),
-                should_warn_if_disabled=False,
+        if not target_functions:
+            # Fall back to single resolution for disabled-node handling
+            target_function = manifest.resolve_function(
+                target_function_name,
+                target_function_package,
+                current_project,
+                node.package_name,
             )
+
+            if target_function is None or isinstance(target_function, Disabled):
+                node.config.enabled = False
+                invalid_target_fail_unless_test(
+                    node=node,
+                    target_name=target_function_name,
+                    target_kind="function",
+                    target_package=target_function_package,
+                    disabled=(isinstance(target_function, Disabled)),
+                    should_warn_if_disabled=False,
+                )
 
             continue
 
-        node.depends_on.add_node(target_function.unique_id)
+        for target_function in target_functions:
+            node.depends_on.add_node(target_function.unique_id)
 
 
 # This is called in task.rpc.sql_commands when a "dynamic" node is

--- a/tests/functional/functions/test_overloaded_udfs.py
+++ b/tests/functional/functions/test_overloaded_udfs.py
@@ -1,0 +1,145 @@
+"""Functional tests for overloaded UDF support (dbt-labs/dbt-core#12250).
+
+Overloaded UDFs allow multiple functions to share the same database name
+(alias) while having different argument signatures. Each overload lives in
+its own SQL file with a unique filename but declares the same alias.
+"""
+
+from typing import Dict
+
+import pytest
+
+from dbt.contracts.graph.nodes import FunctionNode
+from dbt.tests.util import run_dbt
+
+# -- Fixtures: two SQL overloads with different argument types ----------------
+
+double_int_sql = """
+SELECT val * 2
+"""
+
+double_float_sql = """
+SELECT val * 2.0
+"""
+
+overloaded_functions_yml = """
+functions:
+  - name: double_int
+    description: "Doubles an integer value"
+    config:
+      alias: double_val
+    arguments:
+      - name: val
+        data_type: integer
+    returns:
+      data_type: integer
+  - name: double_float
+    description: "Doubles a float value"
+    config:
+      alias: double_val
+    arguments:
+      - name: val
+        data_type: float
+    returns:
+      data_type: float
+"""
+
+model_using_overloaded_function_sql = """
+SELECT {{ function('double_val') }}(1) as result
+"""
+
+
+class TestOverloadedUDFParsing:
+    """Parsing two functions with different names but the same alias."""
+
+    @pytest.fixture(scope="class")
+    def functions(self) -> Dict[str, str]:
+        return {
+            "double_int.sql": double_int_sql,
+            "double_float.sql": double_float_sql,
+            "schema.yml": overloaded_functions_yml,
+        }
+
+    def test_overloaded_functions_parsed_separately(self, project):
+        manifest = run_dbt(["parse"])
+
+        # Both overloads should exist as separate function nodes
+        assert len(manifest.functions) == 2
+        assert "function.test.double_int" in manifest.functions
+        assert "function.test.double_float" in manifest.functions
+
+        # Each should have its own arguments and alias
+        fn_int = manifest.functions["function.test.double_int"]
+        fn_float = manifest.functions["function.test.double_float"]
+
+        assert isinstance(fn_int, FunctionNode)
+        assert isinstance(fn_float, FunctionNode)
+
+        # Both share the same alias (database function name)
+        assert fn_int.alias == "double_val"
+        assert fn_float.alias == "double_val"
+
+        # But have different internal names
+        assert fn_int.name == "double_int"
+        assert fn_float.name == "double_float"
+
+        # And different argument types
+        assert fn_int.arguments[0].data_type == "integer"
+        assert fn_float.arguments[0].data_type == "float"
+
+
+class TestOverloadedUDFLookupByAlias:
+    """The function() Jinja method should resolve overloads by alias."""
+
+    @pytest.fixture(scope="class")
+    def functions(self) -> Dict[str, str]:
+        return {
+            "double_int.sql": double_int_sql,
+            "double_float.sql": double_float_sql,
+            "schema.yml": overloaded_functions_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self) -> Dict[str, str]:
+        return {
+            "model_using_overloaded_function.sql": model_using_overloaded_function_sql,
+        }
+
+    def test_model_depends_on_all_overloads(self, project):
+        manifest = run_dbt(["parse"])
+
+        # The model should depend on both overloads
+        model = manifest.nodes["model.test.model_using_overloaded_function"]
+        fn_deps = [dep for dep in model.depends_on.nodes if dep.startswith("function.")]
+        assert len(fn_deps) == 2
+        assert set(fn_deps) == {
+            "function.test.double_int",
+            "function.test.double_float",
+        }
+
+
+class TestOverloadedUDFBuild:
+    """Building overloaded functions should create all overloads."""
+
+    @pytest.fixture(scope="class")
+    def functions(self) -> Dict[str, str]:
+        return {
+            "double_int.sql": double_int_sql,
+            "double_float.sql": double_float_sql,
+            "schema.yml": overloaded_functions_yml,
+        }
+
+    def test_build_creates_all_overloads(self, project):
+        results = run_dbt(["build"])
+        assert len(results) == 2
+
+        # Both overloads should be built successfully
+        function_nodes = [r.node for r in results]
+        assert all(isinstance(n, FunctionNode) for n in function_nodes)
+
+        names = {n.name for n in function_nodes}
+        assert names == {"double_int", "double_float"}
+
+        # Both should use the same alias for the database function name
+        aliases = {n.alias for n in function_nodes}
+        assert aliases == {"double_val"}

--- a/tests/unit/contracts/graph/test_function_lookup.py
+++ b/tests/unit/contracts/graph/test_function_lookup.py
@@ -1,0 +1,198 @@
+"""Tests for FunctionLookup overloaded UDF support.
+
+FunctionLookup indexes functions by both their internal name (search_name)
+and their alias (identifier). When multiple functions share an alias
+(overloaded UDFs), find_all() returns all of them so that dependency
+edges are created to every overload.
+"""
+
+import pytest
+
+from dbt.artifacts.resources import FunctionArgument, FunctionReturns
+from dbt.contracts.files import FileHash
+from dbt.contracts.graph.manifest import FunctionLookup, Manifest
+from dbt.contracts.graph.nodes import FunctionNode, NodeType
+
+
+def _make_function_node(
+    name: str,
+    package_name: str = "test_project",
+    alias: str | None = None,
+    arguments: list[FunctionArgument] | None = None,
+    data_type: str = "int",
+) -> FunctionNode:
+    """Helper to create a FunctionNode for testing."""
+    return FunctionNode(
+        resource_type=NodeType.Function,
+        name=name,
+        returns=FunctionReturns(data_type=data_type),
+        database="db",
+        schema="public",
+        package_name=package_name,
+        path=f"functions/{name}.sql",
+        original_file_path=f"functions/{name}.sql",
+        unique_id=f"function.{package_name}.{name}",
+        fqn=[package_name, name],
+        alias=alias or name,
+        checksum=FileHash.from_contents(name),
+        arguments=arguments or [],
+    )
+
+
+class TestFunctionLookupBasic:
+    """Test basic FunctionLookup behavior (non-overloaded)."""
+
+    def test_find_by_name(self):
+        fn = _make_function_node("double_it")
+        manifest = Manifest(functions={fn.unique_id: fn})
+        lookup = FunctionLookup(manifest)
+
+        result = lookup.find("double_it", "test_project", manifest)
+        assert result is not None
+        assert result.unique_id == "function.test_project.double_it"
+
+    def test_find_missing_returns_none(self):
+        fn = _make_function_node("double_it")
+        manifest = Manifest(functions={fn.unique_id: fn})
+        lookup = FunctionLookup(manifest)
+
+        result = lookup.find("nonexistent", "test_project", manifest)
+        assert result is None
+
+    def test_find_all_single_function(self):
+        fn = _make_function_node("double_it")
+        manifest = Manifest(functions={fn.unique_id: fn})
+        lookup = FunctionLookup(manifest)
+
+        results = lookup.find_all("double_it", "test_project", manifest)
+        assert len(results) == 1
+        assert results[0].unique_id == "function.test_project.double_it"
+
+
+class TestFunctionLookupOverloaded:
+    """Test FunctionLookup with overloaded UDFs sharing the same alias."""
+
+    @pytest.fixture
+    def overloaded_functions(self):
+        """Create two functions with different names but the same alias."""
+        fn_varchar = _make_function_node(
+            name="null_if_empty_varchar",
+            alias="null_if_empty",
+            arguments=[FunctionArgument(name="val", data_type="varchar")],
+            data_type="varchar",
+        )
+        fn_array = _make_function_node(
+            name="null_if_empty_array",
+            alias="null_if_empty",
+            arguments=[FunctionArgument(name="val", data_type="array")],
+            data_type="array",
+        )
+        return fn_varchar, fn_array
+
+    def test_find_by_alias_returns_first_overload(self, overloaded_functions):
+        fn_varchar, fn_array = overloaded_functions
+        manifest = Manifest(
+            functions={fn_varchar.unique_id: fn_varchar, fn_array.unique_id: fn_array}
+        )
+        lookup = FunctionLookup(manifest)
+
+        # Looking up by alias should return at least one function
+        result = lookup.find("null_if_empty", "test_project", manifest)
+        assert result is not None
+        assert result.alias == "null_if_empty"
+
+    def test_find_all_by_alias_returns_all_overloads(self, overloaded_functions):
+        fn_varchar, fn_array = overloaded_functions
+        manifest = Manifest(
+            functions={fn_varchar.unique_id: fn_varchar, fn_array.unique_id: fn_array}
+        )
+        lookup = FunctionLookup(manifest)
+
+        results = lookup.find_all("null_if_empty", "test_project", manifest)
+        assert len(results) == 2
+        unique_ids = {r.unique_id for r in results}
+        assert unique_ids == {
+            "function.test_project.null_if_empty_varchar",
+            "function.test_project.null_if_empty_array",
+        }
+
+    def test_find_by_internal_name_returns_specific_overload(self, overloaded_functions):
+        fn_varchar, fn_array = overloaded_functions
+        manifest = Manifest(
+            functions={fn_varchar.unique_id: fn_varchar, fn_array.unique_id: fn_array}
+        )
+        lookup = FunctionLookup(manifest)
+
+        # Looking up by internal name should return that specific overload
+        result = lookup.find("null_if_empty_varchar", "test_project", manifest)
+        assert result is not None
+        assert result.unique_id == "function.test_project.null_if_empty_varchar"
+
+        result = lookup.find("null_if_empty_array", "test_project", manifest)
+        assert result is not None
+        assert result.unique_id == "function.test_project.null_if_empty_array"
+
+    def test_get_all_unique_ids_by_alias(self, overloaded_functions):
+        fn_varchar, fn_array = overloaded_functions
+        manifest = Manifest(
+            functions={fn_varchar.unique_id: fn_varchar, fn_array.unique_id: fn_array}
+        )
+        lookup = FunctionLookup(manifest)
+
+        ids = lookup.get_all_unique_ids("null_if_empty", "test_project")
+        assert len(ids) == 2
+        assert set(ids) == {
+            "function.test_project.null_if_empty_varchar",
+            "function.test_project.null_if_empty_array",
+        }
+
+    def test_no_alias_no_duplicate_indexing(self):
+        """When alias equals name, function should only be indexed once."""
+        fn = _make_function_node("double_it")
+        manifest = Manifest(functions={fn.unique_id: fn})
+        lookup = FunctionLookup(manifest)
+
+        # Should only find one entry, not a duplicate
+        ids = lookup.get_all_unique_ids("double_it", "test_project")
+        assert len(ids) == 1
+
+    def test_find_all_without_package_returns_all(self, overloaded_functions):
+        fn_varchar, fn_array = overloaded_functions
+        manifest = Manifest(
+            functions={fn_varchar.unique_id: fn_varchar, fn_array.unique_id: fn_array}
+        )
+        lookup = FunctionLookup(manifest)
+
+        # package=None should return all overloads across packages
+        results = lookup.find_all("null_if_empty", None, manifest)
+        assert len(results) == 2
+
+    def test_overloads_across_packages(self):
+        """Overloads in different packages should be independently resolvable."""
+        fn_pkg1 = _make_function_node(
+            name="my_func_int",
+            package_name="pkg1",
+            alias="my_func",
+            arguments=[FunctionArgument(name="val", data_type="int")],
+        )
+        fn_pkg2 = _make_function_node(
+            name="my_func_str",
+            package_name="pkg2",
+            alias="my_func",
+            arguments=[FunctionArgument(name="val", data_type="varchar")],
+        )
+        manifest = Manifest(functions={fn_pkg1.unique_id: fn_pkg1, fn_pkg2.unique_id: fn_pkg2})
+        lookup = FunctionLookup(manifest)
+
+        # By specific package
+        results_pkg1 = lookup.find_all("my_func", "pkg1", manifest)
+        assert len(results_pkg1) == 1
+        assert results_pkg1[0].package_name == "pkg1"
+
+        results_pkg2 = lookup.find_all("my_func", "pkg2", manifest)
+        assert len(results_pkg2) == 1
+        assert results_pkg2[0].package_name == "pkg2"
+
+        # Without package filter
+        results_all = lookup.find_all("my_func", None, manifest)
+        assert len(results_all) == 2


### PR DESCRIPTION
Resolves #12250

### Problem

dbt does not support overloaded UDFs — defining multiple functions with the same database name but different argument signatures. Databases like Snowflake and BigQuery natively support function overloading, but dbt's `FunctionLookup` only stores one function per (name, package) pair and doesn't index by alias, so there's no way to define or reference overloaded functions.

### Solution

Each overload lives in its own SQL file with a unique filename. Users set `config.alias` to the same database function name across overloads:

```yaml
functions:
  - name: double_int
    config:
      alias: double_val
    arguments:
      - name: val
        data_type: integer
    returns:
      data_type: integer
  - name: double_float
    config:
      alias: double_val
    arguments:
      - name: val
        data_type: float
    returns:
      data_type: float
```

Models reference the shared alias (`{{ function('double_val') }}`), and dbt creates dependency edges to all overloads. The database handles overload resolution at query time.

Key changes:
- **`FunctionLookup`** now stores `List[UniqueID]` per (name, package) and indexes by both internal name and alias. Added `find_all()` for multi-overload resolution.
- **`Manifest.resolve_all_functions()`** returns all enabled overloads matching a name/alias.
- **`_process_functions_for_node`** uses `resolve_all_functions()` to add dependency edges to every overload.
- **`rebuild_function_lookup()`** is called before `process_functions` to pick up aliases set during YAML patching.

Manually tested end-to-end on **BigQuery** and **Snowflake** — both `dbt build` and `dbt show` work correctly with overloaded functions.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.