### PR TITLE
Fix package version validation to handle missing property

### DIFF
--- a/.changes/unreleased/Fixes-20260317-133144.yaml
+++ b/.changes/unreleased/Fixes-20260317-133144.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix error message for missing `version` property in `packages.yml`
+time: 2026-03-17T13:31:44.7469465-07:00
+custom:
+    Author: benlevycmp
+    Issue: "12649"

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -138,7 +138,7 @@ class PackageConfig(dbtClassMixin):
                         "A git package is missing the value. It is a required property."
                     )
             if isinstance(package, dict) and package.get("package"):
-                if not package["version"]:
+                if not package.get("version"):
                     raise ValidationError(
                         f"{package['package']} is missing the version. When installing from the Hub "
                         "package index, version is a required property"

--- a/tests/functional/dependencies/test_simple_dependency.py
+++ b/tests/functional/dependencies/test_simple_dependency.py
@@ -472,3 +472,15 @@ class TestEmptyDependency:
         write_config_file(empty_local_package, "packages.yml")
         with pytest.raises(DbtProjectError, match="A local package is missing the value"):
             run_dbt(["deps"])
+
+    def test_versionless_package(self, project):
+        no_version_hub_package = {
+            "packages": [
+                {
+                    "package": "dbt-labs/dbt_utils",
+                }
+            ]
+        }
+        write_config_file(no_version_hub_package, "packages.yml")
+        with pytest.raises(DbtProjectError, match="is missing the version"):
+            run_dbt(["deps"])


### PR DESCRIPTION


Resolves #12649

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

Previously, the custom error would not be raised if the `version` property was missing entirely, rather than simply falsy, and only a cryptic `KeyError` would be raised.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
Replaces direct key access with the safer `get()` method.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
