### PR TITLE
fix(freshness): preserve sources in sources.json when warn-error raises during after_execute

### DIFF
--- a/.changes/unreleased/Fixes-20260415-120000.yaml
+++ b/.changes/unreleased/Fixes-20260415-120000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Preserve sources in sources.json when warn-error raises EventCompilationError during freshness after_execute
+time: 2026-04-15T12:00:00.000000-07:00
+custom:
+  Author: KamayaniR
+  Issue: "12812"

--- a/core/dbt/artifacts/schemas/freshness/v3/freshness.py
+++ b/core/dbt/artifacts/schemas/freshness/v3/freshness.py
@@ -114,7 +114,7 @@ class FreshnessExecutionResultArtifact(
         processed = [
             process_freshness_result(r)
             for r in base.results
-            if isinstance(r, SourceFreshnessResult)
+            if isinstance(r, (SourceFreshnessResult, PartialSourceFreshnessResult))
         ]
         return cls(
             metadata=base.metadata,

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -392,17 +392,23 @@ class GraphRunnableTask(ConfiguredTask):
             )
         )
 
-        return RunResult(
-            status=RunStatus.Error,  # type: ignore
-            timing=[],
-            thread_id="",
-            execution_time=0.0,
-            adapter_response={},
-            message=msg,
-            failures=None,
-            batch_results=None,
-            node=runner.node,
-        )
+        # Delegate to the runner's error_result so subclasses (e.g. FreshnessRunner)
+        # return a properly-typed result (e.g. PartialSourceFreshnessResult) that is
+        # correctly serialised into their artifact (e.g. sources.json).
+        try:
+            return runner.error_result(runner.node, msg, time.time(), [])  # type: ignore[return-value]
+        except Exception:
+            return RunResult(
+                status=RunStatus.Error,  # type: ignore
+                timing=[],
+                thread_id="",
+                execution_time=0.0,
+                adapter_response={},
+                message=msg,
+                failures=None,
+                batch_results=None,
+                node=runner.node,
+            )
 
     def _handle_result(self, result: NodeResult) -> None:
         """Mark the result as completed, insert the `CompileResultNode` into

--- a/tests/unit/task/test_freshness.py
+++ b/tests/unit/task/test_freshness.py
@@ -3,7 +3,15 @@ from unittest import mock
 
 import pytest
 
-from dbt.task.freshness import FreshnessResponse, FreshnessTask
+from dbt.artifacts.schemas.freshness import (
+    FreshnessExecutionResultArtifact,
+    FreshnessMetadata,
+    FreshnessResult,
+    PartialSourceFreshnessResult,
+    SourceFreshnessRuntimeError,
+)
+from dbt.artifacts.schemas.results import FreshnessStatus
+from dbt.task.freshness import FreshnessResponse, FreshnessRunner, FreshnessTask
 
 
 class TestFreshnessTaskMetadataCache:
@@ -153,3 +161,82 @@ class TestFreshnessTaskMetadataCache:
         task.populate_metadata_freshness_cache(adapter, {source_no_loaded_at_field.unique_id})
 
         assert task.get_freshness_metadata_cache() == {}
+
+
+class TestFreshnessExecutionResultArtifact:
+    """Tests for FreshnessExecutionResultArtifact.from_result.
+
+    Regression tests for https://github.com/dbt-labs/dbt-core/issues/12812:
+    sources with warn freshness status were missing from sources.json when
+    warn_error raised EventCompilationError during after_execute, causing
+    _handle_thread_exception to create a PartialSourceFreshnessResult that
+    was silently filtered out by the isinstance(r, SourceFreshnessResult) check.
+    """
+
+    def _make_partial_result(self, status=FreshnessStatus.RuntimeErr):
+        node = mock.Mock()
+        node.unique_id = "source.project.my_source.my_table"
+        return PartialSourceFreshnessResult(
+            status=status,
+            thread_id="Thread-1",
+            execution_time=0.1,
+            timing=[],
+            message="Exception on worker thread.",
+            node=node,
+            adapter_response={},
+            failures=None,
+        )
+
+    def _make_freshness_result(self, results):
+        return FreshnessResult(
+            metadata=FreshnessMetadata(),
+            results=results,
+            elapsed_time=1.0,
+        )
+
+    def test_partial_result_included_in_sources_json(self):
+        """PartialSourceFreshnessResult (RuntimeErr) must appear in sources.json."""
+        partial = self._make_partial_result(FreshnessStatus.RuntimeErr)
+        freshness_result = self._make_freshness_result([partial])
+
+        artifact = FreshnessExecutionResultArtifact.from_result(freshness_result)
+
+        assert len(artifact.results) == 1
+        assert isinstance(artifact.results[0], SourceFreshnessRuntimeError)
+        assert artifact.results[0].unique_id == partial.node.unique_id
+
+    def test_non_freshness_result_excluded_from_sources_json(self):
+        """Generic non-freshness results must still be excluded from sources.json."""
+        generic = mock.Mock()
+        generic.__class__ = object  # not a SourceFreshnessResult or PartialSourceFreshnessResult
+        freshness_result = self._make_freshness_result([generic])
+
+        artifact = FreshnessExecutionResultArtifact.from_result(freshness_result)
+
+        assert len(artifact.results) == 0
+
+
+class TestFreshnessRunnerErrorResult:
+    """Tests that FreshnessRunner.error_result returns PartialSourceFreshnessResult.
+
+    This is called by _handle_thread_exception so that thread-level failures
+    produce a properly-typed result that is included in sources.json.
+    """
+
+    def test_error_result_returns_partial_source_freshness_result(self):
+        node = mock.Mock()
+        node.unique_id = "source.project.my_source.my_table"
+
+        runner = FreshnessRunner(
+            config=mock.Mock(),
+            adapter=mock.Mock(),
+            node=node,
+            node_index=1,
+            num_nodes=1,
+        )
+
+        result = runner.error_result(node, "something went wrong", datetime.datetime.now().timestamp(), [])
+
+        assert isinstance(result, PartialSourceFreshnessResult)
+        assert result.status == FreshnessStatus.RuntimeErr
+        assert result.message == "something went wrong"


### PR DESCRIPTION
Fixes #12812

When `warn_error=True` (or `require_all_warnings_handled_by_warn_error` is set) and a source has a **warn** freshness status, `after_execute` fires `LogFreshnessResult` at WARN level which raises `EventCompilationError`. This caused the source to disappear from `sources.json`.

**Root cause chain:**
1. `FreshnessRunner.execute()` computes a valid `SourceFreshnessResult` with `status=Warn`
2. `after_execute()` fires `LogFreshnessResult` at `EventLevel.WARN` → raises `EventCompilationError`
3. Exception propagates out of `run_with_hooks` → `_handle_thread_exception` creates a **generic `RunResult`**
4. `FreshnessExecutionResultArtifact.from_result` filters with `isinstance(r, SourceFreshnessResult)` → generic `RunResult` is excluded → **source missing from sources.json**

## Fix

Two minimal changes:

1. **`core/dbt/task/runnable.py`** — `_handle_thread_exception` now calls `runner.error_result()` instead of constructing a bare `RunResult`. This lets `FreshnessRunner` return a `PartialSourceFreshnessResult` (a proper freshness-typed result).

2. **`core/dbt/artifacts/schemas/freshness/v3/freshness.py`** — `FreshnessExecutionResultArtifact.from_result` now includes `PartialSourceFreshnessResult` in its filter, so runtime-error results are written to `sources.json`.

## Tests

Added 3 unit tests to `tests/unit/task/test_freshness.py`:
- `test_partial_result_included_in_sources_json` — regression test for the bug
- `test_non_freshness_result_excluded_from_sources_json` — generic results still excluded
- `test_error_result_returns_partial_source_freshness_result` — `FreshnessRunner.error_result` returns the right type
