### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260415-011929.yaml
+++ b/.changes/unreleased/Under the Hood-20260415-011929.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-04-15T01:19:29.457918598Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -5964,12 +5964,6 @@
             }
           ]
         },
-        "+snowflake_initialization_warehouse": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "+snowflake_warehouse": {
           "type": [
             "string",


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`a4d69f5acd38d5c24355ad6fac375156a33b7089`](https://github.com/dbt-labs/fs/commit/a4d69f5acd38d5c24355ad6fac375156a33b7089)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/24430680047)