### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260415-030144.yaml
+++ b/.changes/unreleased/Under the Hood-20260415-030144.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-04-15T03:01:44.175566756Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -1506,6 +1506,12 @@
             }
           ]
         },
+        "+immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+include_full_name_in_path": {
           "anyOf": [
             {
@@ -2826,6 +2832,12 @@
             "null"
           ]
         },
+        "+immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+imports": {
           "anyOf": [
             {
@@ -3960,6 +3972,12 @@
             }
           ]
         },
+        "+immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+include_full_name_in_path": {
           "anyOf": [
             {
@@ -4807,6 +4825,12 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "+immutable_where": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "+include_full_name_in_path": {
@@ -5964,12 +5988,6 @@
             }
           ]
         },
-        "+snowflake_initialization_warehouse": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "+snowflake_warehouse": {
           "type": [
             "string",
@@ -6358,6 +6376,12 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "+immutable_where": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "+include_full_name_in_path": {

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -1215,6 +1215,12 @@
             }
           ]
         },
+        "immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "include_full_name_in_path": {
           "anyOf": [
             {
@@ -2987,6 +2993,12 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "immutable_where": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "include_full_name_in_path": {
@@ -4795,6 +4807,12 @@
           ]
         },
         "http_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "immutable_where": {
           "type": [
             "string",
             "null"
@@ -6709,6 +6727,12 @@
             }
           ]
         },
+        "immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "include_full_name_in_path": {
           "anyOf": [
             {
@@ -7706,6 +7730,12 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "immutable_where": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "include_full_name_in_path": {
@@ -8728,6 +8758,12 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "immutable_where": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "include_full_name_in_path": {
@@ -9889,6 +9925,12 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "immutable_where": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "include_full_name_in_path": {


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`c262e06b02d655d6746afffa952136b03fe597f1`](https://github.com/dbt-labs/fs/commit/c262e06b02d655d6746afffa952136b03fe597f1)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/24433542689)