### PR TITLE
[Backport 1.11 ]fix: state:modified does not detect .yml property changes for resourc…

### DIFF
--- a/.changes/unreleased/Fixes-20260304-140229.yaml
+++ b/.changes/unreleased/Fixes-20260304-140229.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix state:modified not detecting .yml property changes for resource_type:function
+time: 2026-03-04T14:02:29.38595+01:00
+custom:
+    Author: Thrasi
+    Issue: "12547"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -1594,6 +1594,19 @@ class FunctionNode(CompiledNode, FunctionResource):
     def resource_class(cls) -> Type[FunctionResource]:
         return FunctionResource
 
+    def same_arguments(self, old: "FunctionNode") -> bool:
+        return self.arguments == old.arguments
+
+    def same_returns(self, old: "FunctionNode") -> bool:
+        return self.returns == old.returns
+
+    def same_contents(self, old, adapter_type) -> bool:
+        return (
+            super().same_contents(old, adapter_type)
+            and self.same_arguments(old)
+            and self.same_returns(old)
+        )
+
 
 # ====================================
 # SemanticModel node

--- a/tests/unit/contracts/graph/test_nodes.py
+++ b/tests/unit/contracts/graph/test_nodes.py
@@ -5,11 +5,19 @@ from dataclasses import replace
 
 import pytest
 
-from dbt.artifacts.resources import ColumnInfo, TestConfig, TestMetadata
+from dbt.artifacts.resources import (
+    ColumnInfo,
+    FunctionArgument,
+    FunctionConfig,
+    FunctionReturns,
+    TestConfig,
+    TestMetadata,
+)
 from dbt.compilation import inject_ctes_into_sql
 from dbt.contracts.files import FileHash
 from dbt.contracts.graph.nodes import (
     DependsOn,
+    FunctionNode,
     GenericTestNode,
     InjectedCTE,
     ModelConfig,
@@ -821,3 +829,89 @@ def test_inject_ctes_with_recursive():
     """
     generated_sql = inject_ctes_into_sql(starting_sql, ctes)
     assert norm_whitespace(generated_sql) == norm_whitespace(expected_sql)
+
+
+# ====================================
+# FunctionNode.same_contents tests
+# ====================================
+
+
+@pytest.fixture
+def basic_function_node():
+    return FunctionNode(
+        package_name="test",
+        path="functions/my_func.sql",
+        original_file_path="functions/my_func.sql",
+        language="sql",
+        raw_code="a_string + 1",
+        name="my_func",
+        resource_type=NodeType.Function,
+        unique_id="function.test.my_func",
+        fqn=["test", "my_func"],
+        database="test_db",
+        schema="test_schema",
+        alias="my_func",
+        checksum=FileHash.from_contents("a_string + 1"),
+        config=FunctionConfig(),
+        returns=FunctionReturns(data_type="integer"),
+        arguments=[FunctionArgument(name="a_string", data_type="string")],
+    )
+
+
+unchanged_function_nodes = [
+    # description, tags, meta are not tracked
+    lambda u: (u, replace(u, description="a description")),
+    lambda u: (u, replace(u, tags=["mytag"])),
+    lambda u: (u, replace(u, meta={"cool_key": "cool value"})),
+    # direct field-level database/schema/alias changes are not tracked
+    # (only config-level changes via unrendered_config matter)
+    lambda u: (u, replace(u, database="nope")),
+    lambda u: (u, replace(u, schema="nope")),
+    lambda u: (u, replace(u, alias="nope")),
+]
+
+changed_function_nodes = [
+    # old is None means the node is new
+    lambda u: (u, None),
+    # SQL body change
+    lambda u: (u, replace(u, raw_code="a_string + 2")),
+    # FQN change
+    lambda u: (
+        u,
+        replace(
+            u,
+            fqn=["test", "functions", "subdir", "my_func"],
+            original_file_path="functions/subdir/my_func.sql",
+            path="functions/subdir/my_func.sql",
+        ),
+    ),
+    # Regression: returns.data_type change must be detected (issue #12547)
+    lambda u: (u, replace(u, returns=FunctionReturns(data_type="boolean"))),
+    # Regression: argument data_type change must be detected (issue #12547)
+    lambda u: (u, replace(u, arguments=[FunctionArgument(name="a_string", data_type="boolean")])),
+    # argument added
+    lambda u: (
+        u,
+        replace(
+            u,
+            arguments=[
+                FunctionArgument(name="a_string", data_type="string"),
+                FunctionArgument(name="b_string", data_type="integer"),
+            ],
+        ),
+    ),
+    # argument removed
+    lambda u: (u, replace(u, arguments=[])),
+]
+
+
+@pytest.mark.parametrize("func", unchanged_function_nodes)
+def test_compare_unchanged_function(func, basic_function_node):
+    node, compare = func(basic_function_node)
+    assert node.same_contents(compare, "bigquery")
+
+
+@pytest.mark.parametrize("func", changed_function_nodes)
+def test_compare_changed_function(func, basic_function_node):
+    node, compare = func(basic_function_node)
+    assert not node.same_contents(compare, "bigquery")


### PR DESCRIPTION
Resolves #

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

Backporting `state:modified` UDF bug to `1.11`
Original PR - https://github.com/dbt-labs/dbt-core/pull/12548

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
