### PR TITLE
warn or error for source & semantic model name with spaces

### DIFF
--- a/.changes/unreleased/Fixes-20260416-124251.yaml
+++ b/.changes/unreleased/Fixes-20260416-124251.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Sources and Semantic Model now raise a warning if name contains spaces. Use REQUIRE_SOURCE_AND_SEMANTIC_MODEL_NAMES_WITHOUT_SPACES to raise errors instead.
+time: 2026-04-16T12:42:51.4804+05:30
+custom:
+    Author: sriramr98
+    Issue: "12767"

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -372,6 +372,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     require_sql_header_in_test_configs: bool = False
     support_custom_ref_kwargs: bool = False
     require_corrected_analysis_fqns: bool = False
+    require_source_and_semantic_model_names_without_spaces: bool = False
 
     @property
     def project_only_flags(self) -> Dict[str, Any]:
@@ -394,6 +395,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
             "require_sql_header_in_test_configs": self.require_sql_header_in_test_configs,
             "support_custom_ref_kwargs": self.support_custom_ref_kwargs,
             "require_corrected_analysis_fqns": self.require_corrected_analysis_fqns,
+            "require_source_and_semantic_model_names_without_spaces": self.require_source_and_semantic_model_names_without_spaces,
         }
 
 

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -683,6 +683,68 @@ class ManifestLoader:
                     f"Resource names cannot contain spaces:\n{formatted_resources_with_spaces}\nPlease rename the invalid model(s) so that their name(s) do not contain any spaces."
                 )
 
+        self._check_for_spaces_in_source_and_semantic_model_names(flags)
+
+    def _check_for_spaces_in_source_and_semantic_model_names(self, flags):
+        """Validates that source and semantic model names do not contain spaces.
+
+        Controlled by the `REQUIRE_SOURCE_AND_SEMANTIC_MODEL_NAMES_WITHOUT_SPACES` flag.
+        """
+        error_on_invalid = getattr(
+            self.root_project.args,
+            "REQUIRE_SOURCE_AND_SEMANTIC_MODEL_NAMES_WITHOUT_SPACES",
+            False,
+        )
+        level = EventLevel.ERROR if error_on_invalid else EventLevel.WARN
+
+        improper_names: dict[str, str] = {}  # unique_id -> original_file_path
+
+        # Check source names (source_name is the source-level name).
+        # Deduplicate by source_name since multiple tables share the same source_name.
+        seen_source_names: set[str] = set()
+        for source in self.manifest.sources.values():
+            if " " in source.source_name and source.source_name not in seen_source_names:
+                seen_source_names.add(source.source_name)
+                source_id = f"source.{source.package_name}.{source.source_name}"
+                if (not improper_names and not error_on_invalid) or flags.DEBUG:
+                    fire_event(
+                        SpacesInResourceNameDeprecation(
+                            unique_id=source_id,
+                            level=level.value,
+                        ),
+                        level=level,
+                    )
+                improper_names[source_id] = source.original_file_path
+
+        # Check semantic model names.
+        for semantic_model in self.manifest.semantic_models.values():
+            if " " in semantic_model.name:
+                if (not improper_names and not error_on_invalid) or flags.DEBUG:
+                    fire_event(
+                        SpacesInResourceNameDeprecation(
+                            unique_id=semantic_model.unique_id,
+                            level=level.value,
+                        ),
+                        level=level,
+                    )
+                improper_names[semantic_model.unique_id] = semantic_model.original_file_path
+
+        if improper_names:
+            if level == EventLevel.WARN:
+                dbt.deprecations.warn(
+                    "resource-names-with-spaces",
+                    count_invalid_names=len(improper_names),
+                    show_debug_hint=(not flags.DEBUG),
+                )
+            else:
+                formatted = "\n".join(
+                    f"  * '{uid}' ({path})" for uid, path in improper_names.items()
+                )
+                raise DbtValidationError(
+                    f"Resource names cannot contain spaces:\n{formatted}\n"
+                    "Please rename the invalid resource(s) so that their name(s) do not contain any spaces."
+                )
+
     def check_for_microbatch_deprecations(self) -> None:
         if not get_flags().require_batched_execution_for_custom_microbatch_strategy:
             has_microbatch_model = False

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -690,11 +690,7 @@ class ManifestLoader:
 
         Controlled by the `REQUIRE_SOURCE_AND_SEMANTIC_MODEL_NAMES_WITHOUT_SPACES` flag.
         """
-        error_on_invalid = getattr(
-            self.root_project.args,
-            "REQUIRE_SOURCE_AND_SEMANTIC_MODEL_NAMES_WITHOUT_SPACES",
-            False,
-        )
+        error_on_invalid = get_flags().require_source_and_semantic_model_names_without_spaces
         level = EventLevel.ERROR if error_on_invalid else EventLevel.WARN
 
         improper_names: dict[str, str] = {}  # unique_id -> original_file_path

--- a/tests/functional/manifest_validations/test_check_for_spaces_in_source_and_semantic_model_names.py
+++ b/tests/functional/manifest_validations/test_check_for_spaces_in_source_and_semantic_model_names.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Any, Dict
 
 import pytest
 
@@ -86,8 +86,6 @@ class TestSpacesInSourceNameHappyPath:
         }
 
     def test_no_warnings_when_no_spaces_in_source_name(self, project) -> None:
-        config_patch = {"flags": {"require_source_and_semantic_model_names_without_spaces": False}}
-        update_config_file(config_patch, project.project_root, "dbt_project.yml")
         event_catcher = EventCatcher(SpacesInResourceNameDeprecation)
         runner = dbtRunner(callbacks=[event_catcher.catch])
         runner.invoke(["parse"])
@@ -104,8 +102,6 @@ class TestSpacesInSourceNameWarning:
         }
 
     def test_warning_when_spaces_in_source_name(self, project) -> None:
-        config_patch = {"flags": {"require_source_and_semantic_model_names_without_spaces": False}}
-        update_config_file(config_patch, project.project_root, "dbt_project.yml")
         deprecations.reset_deprecations()
         event_catcher = EventCatcher(SpacesInResourceNameDeprecation)
         total_catcher = EventCatcher(ResourceNamesWithSpacesDeprecation)
@@ -123,20 +119,23 @@ class TestSpacesInSourceNameError:
     """Error when source name has spaces and flag is True."""
 
     @pytest.fixture(scope="class")
+    def project_config_update(self) -> Dict[str, Any]:
+        return {"flags": {"require_source_and_semantic_model_names_without_spaces": True}}
+
+    @pytest.fixture(scope="class")
     def models(self) -> Dict[str, str]:
         return {
             "schema.yml": source_with_space_in_name_schema_yml,
         }
 
     def test_error_when_spaces_in_source_name_and_flag_true(self, project) -> None:
-        config_patch = {"flags": {"require_source_and_semantic_model_names_without_spaces": True}}
-        update_config_file(config_patch, project.project_root, "dbt_project.yml")
         event_catcher = EventCatcher(SpacesInResourceNameDeprecation)
         runner = dbtRunner(callbacks=[event_catcher.catch])
         result = runner.invoke(["parse"])
         assert not result.success
         assert "Resource names cannot contain spaces" in str(result.exception)
         assert "raw source" in str(result.exception)
+        assert len(event_catcher.caught_events) == 0
 
 
 class TestSpacesInSemanticModelNameWarning:
@@ -150,8 +149,6 @@ class TestSpacesInSemanticModelNameWarning:
         }
 
     def test_warning_when_spaces_in_semantic_model_name(self, project) -> None:
-        config_patch = {"flags": {"require_source_and_semantic_model_names_without_spaces": False}}
-        update_config_file(config_patch, project.project_root, "dbt_project.yml")
         deprecations.reset_deprecations()
         event_catcher = EventCatcher(SpacesInResourceNameDeprecation)
         total_catcher = EventCatcher(ResourceNamesWithSpacesDeprecation)
@@ -169,6 +166,10 @@ class TestSpacesInSemanticModelNameError:
     """Error when semantic model name has spaces and flag is True."""
 
     @pytest.fixture(scope="class")
+    def project_config_update(self) -> Dict[str, Any]:
+        return {"flags": {"require_source_and_semantic_model_names_without_spaces": True}}
+
+    @pytest.fixture(scope="class")
     def models(self) -> Dict[str, str]:
         return {
             "people.sql": people_model_sql,
@@ -176,14 +177,13 @@ class TestSpacesInSemanticModelNameError:
         }
 
     def test_error_when_spaces_in_semantic_model_name_and_flag_true(self, project) -> None:
-        config_patch = {"flags": {"require_source_and_semantic_model_names_without_spaces": True}}
-        update_config_file(config_patch, project.project_root, "dbt_project.yml")
         event_catcher = EventCatcher(SpacesInResourceNameDeprecation)
         runner = dbtRunner(callbacks=[event_catcher.catch])
         result = runner.invoke(["parse"])
         assert not result.success
         assert "Resource names cannot contain spaces" in str(result.exception)
         assert "semantic people" in str(result.exception)
+        assert len(event_catcher.caught_events) == 0
 
 
 class TestMultipleSourcesWithSpacesDebug:

--- a/tests/functional/manifest_validations/test_check_for_spaces_in_source_and_semantic_model_names.py
+++ b/tests/functional/manifest_validations/test_check_for_spaces_in_source_and_semantic_model_names.py
@@ -1,0 +1,226 @@
+from typing import Dict
+
+import pytest
+
+from dbt import deprecations
+from dbt.cli.main import dbtRunner
+from dbt.events.types import (
+    ResourceNamesWithSpacesDeprecation,
+    SpacesInResourceNameDeprecation,
+)
+from dbt.tests.util import update_config_file
+from dbt_common.events.base_types import EventLevel
+from dbt_common.events.event_catcher import EventCatcher
+
+source_with_space_in_name_schema_yml = """
+version: 2
+
+sources:
+  - name: raw source
+    schema: "{{ target.schema }}"
+    tables:
+      - name: my_table
+"""
+
+source_without_space_schema_yml = """
+version: 2
+
+sources:
+  - name: raw_source
+    schema: "{{ target.schema }}"
+    tables:
+      - name: my_table
+"""
+
+multiple_sources_with_spaces_schema_yml = """
+version: 2
+
+sources:
+  - name: raw source
+    schema: "{{ target.schema }}"
+    tables:
+      - name: my_table
+  - name: another source
+    schema: "{{ target.schema }}"
+    tables:
+      - name: other_table
+"""
+
+semantic_model_with_space_in_name_yml = """
+version: 2
+
+semantic_models:
+  - name: semantic people
+    label: "Semantic People"
+    model: ref('people')
+    dimensions:
+      - name: favorite_color
+        type: categorical
+      - name: created_at
+        type: TIME
+        type_params:
+          time_granularity: day
+    measures:
+      - name: people
+        agg: count
+        expr: id
+    entities:
+      - name: id
+        type: primary
+    defaults:
+      agg_time_dimension: created_at
+"""
+
+people_model_sql = """
+select 1 as id, 'Drew' as first_name, 'yellow' as favorite_color, 5 as tenure, current_timestamp as created_at
+"""
+
+
+class TestSpacesInSourceNameHappyPath:
+    """No warnings when source names have no spaces."""
+
+    @pytest.fixture(scope="class")
+    def models(self) -> Dict[str, str]:
+        return {
+            "schema.yml": source_without_space_schema_yml,
+        }
+
+    def test_no_warnings_when_no_spaces_in_source_name(self, project) -> None:
+        config_patch = {"flags": {"require_source_and_semantic_model_names_without_spaces": False}}
+        update_config_file(config_patch, project.project_root, "dbt_project.yml")
+        event_catcher = EventCatcher(SpacesInResourceNameDeprecation)
+        runner = dbtRunner(callbacks=[event_catcher.catch])
+        runner.invoke(["parse"])
+        assert len(event_catcher.caught_events) == 0
+
+
+class TestSpacesInSourceNameWarning:
+    """Deprecation warning when source name has spaces and flag is False."""
+
+    @pytest.fixture(scope="class")
+    def models(self) -> Dict[str, str]:
+        return {
+            "schema.yml": source_with_space_in_name_schema_yml,
+        }
+
+    def test_warning_when_spaces_in_source_name(self, project) -> None:
+        config_patch = {"flags": {"require_source_and_semantic_model_names_without_spaces": False}}
+        update_config_file(config_patch, project.project_root, "dbt_project.yml")
+        deprecations.reset_deprecations()
+        event_catcher = EventCatcher(SpacesInResourceNameDeprecation)
+        total_catcher = EventCatcher(ResourceNamesWithSpacesDeprecation)
+        runner = dbtRunner(callbacks=[event_catcher.catch, total_catcher.catch])
+        runner.invoke(["parse"])
+
+        assert len(event_catcher.caught_events) == 1
+        msg = event_catcher.caught_events[0].info.msg.replace("\n", " ")
+        assert "raw source" in msg
+        assert event_catcher.caught_events[0].info.level == EventLevel.WARN
+        assert len(total_catcher.caught_events) == 1
+
+
+class TestSpacesInSourceNameError:
+    """Error when source name has spaces and flag is True."""
+
+    @pytest.fixture(scope="class")
+    def models(self) -> Dict[str, str]:
+        return {
+            "schema.yml": source_with_space_in_name_schema_yml,
+        }
+
+    def test_error_when_spaces_in_source_name_and_flag_true(self, project) -> None:
+        config_patch = {"flags": {"require_source_and_semantic_model_names_without_spaces": True}}
+        update_config_file(config_patch, project.project_root, "dbt_project.yml")
+        event_catcher = EventCatcher(SpacesInResourceNameDeprecation)
+        runner = dbtRunner(callbacks=[event_catcher.catch])
+        result = runner.invoke(["parse"])
+        assert not result.success
+        assert "Resource names cannot contain spaces" in str(result.exception)
+        assert "raw source" in str(result.exception)
+
+
+class TestSpacesInSemanticModelNameWarning:
+    """Deprecation warning when semantic model name has spaces and flag is False."""
+
+    @pytest.fixture(scope="class")
+    def models(self) -> Dict[str, str]:
+        return {
+            "people.sql": people_model_sql,
+            "schema.yml": semantic_model_with_space_in_name_yml,
+        }
+
+    def test_warning_when_spaces_in_semantic_model_name(self, project) -> None:
+        config_patch = {"flags": {"require_source_and_semantic_model_names_without_spaces": False}}
+        update_config_file(config_patch, project.project_root, "dbt_project.yml")
+        deprecations.reset_deprecations()
+        event_catcher = EventCatcher(SpacesInResourceNameDeprecation)
+        total_catcher = EventCatcher(ResourceNamesWithSpacesDeprecation)
+        runner = dbtRunner(callbacks=[event_catcher.catch, total_catcher.catch])
+        runner.invoke(["parse"])
+
+        assert len(event_catcher.caught_events) == 1
+        msg = event_catcher.caught_events[0].info.msg.replace("\n", " ")
+        assert "semantic people" in msg
+        assert event_catcher.caught_events[0].info.level == EventLevel.WARN
+        assert len(total_catcher.caught_events) == 1
+
+
+class TestSpacesInSemanticModelNameError:
+    """Error when semantic model name has spaces and flag is True."""
+
+    @pytest.fixture(scope="class")
+    def models(self) -> Dict[str, str]:
+        return {
+            "people.sql": people_model_sql,
+            "schema.yml": semantic_model_with_space_in_name_yml,
+        }
+
+    def test_error_when_spaces_in_semantic_model_name_and_flag_true(self, project) -> None:
+        config_patch = {"flags": {"require_source_and_semantic_model_names_without_spaces": True}}
+        update_config_file(config_patch, project.project_root, "dbt_project.yml")
+        event_catcher = EventCatcher(SpacesInResourceNameDeprecation)
+        runner = dbtRunner(callbacks=[event_catcher.catch])
+        result = runner.invoke(["parse"])
+        assert not result.success
+        assert "Resource names cannot contain spaces" in str(result.exception)
+        assert "semantic people" in str(result.exception)
+
+
+class TestMultipleSourcesWithSpacesDebug:
+    """When multiple sources have spaces, debug mode shows all; non-debug shows first + count."""
+
+    @pytest.fixture(scope="class")
+    def models(self) -> Dict[str, str]:
+        return {
+            "schema.yml": multiple_sources_with_spaces_schema_yml,
+        }
+
+    def test_debug_shows_all_spaces_in_source_names(self, project) -> None:
+        config_patch = {"flags": {"require_source_and_semantic_model_names_without_spaces": False}}
+        update_config_file(config_patch, project.project_root, "dbt_project.yml")
+
+        # Without debug: only first source name shown, summary has count
+        deprecations.reset_deprecations()
+        spaces_catcher = EventCatcher(SpacesInResourceNameDeprecation)
+        total_catcher = EventCatcher(ResourceNamesWithSpacesDeprecation)
+        runner = dbtRunner(callbacks=[spaces_catcher.catch, total_catcher.catch])
+        runner.invoke(["parse"])
+        assert len(spaces_catcher.caught_events) == 1
+        assert len(total_catcher.caught_events) == 1
+        assert "Spaces found in 2 resource name(s)" in total_catcher.caught_events[0].info.msg
+        assert (
+            "Run again with `--debug` to see them all." in total_catcher.caught_events[0].info.msg
+        )
+
+        # With debug: all source names shown
+        deprecations.reset_deprecations()
+        spaces_catcher = EventCatcher(SpacesInResourceNameDeprecation)
+        total_catcher = EventCatcher(ResourceNamesWithSpacesDeprecation)
+        runner = dbtRunner(callbacks=[spaces_catcher.catch, total_catcher.catch])
+        runner.invoke(["parse", "--debug"])
+        assert len(spaces_catcher.caught_events) == 2
+        assert len(total_catcher.caught_events) == 1
+        assert (
+            "Run again with `--debug` to see them all."
+            not in total_catcher.caught_events[0].info.msg
+        )


### PR DESCRIPTION
Resolves #12767 

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

We introduced `require_resource_names_without_spaces` was 1.8 and “matured” (default flipped to true) in 1.10
But, we still allow users to use spaces in Source Names and Semantic Model Names

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Any source or semantic model that has a name with space will raise a warning. If `require_sources_and_semantic_model_names_without_spaces` is set, these warnings turn into errors.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
