### PR TITLE
fix: initialize summary_message when profiles.yml is unreadable in _choose_profile_names

### DIFF
--- a/.changes/unreleased/Fixes-20260417-creazyfrog-9436.yaml
+++ b/.changes/unreleased/Fixes-20260417-creazyfrog-9436.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix UnboundLocalError when profiles.yml is missing or unreadable in _choose_profile_names
+time: 2026-04-17T09:00:00.000000+00:00
+custom:
+    Author: creazyfrog
+    Issue: "9436"

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -273,6 +273,8 @@ class DebugTask(BaseTask):
                 summary_message = MULTIPLE_PROFILE_MESSAGE.format(
                     "\n".join(" - {}".format(o) for o in profiles)
                 )
+        else:
+            summary_message = f"profile path <{self.profile_path}> not found\n"
         return profiles, summary_message
 
     def _read_adapter_version(self, module) -> str:

--- a/tests/unit/task/test_debug.py
+++ b/tests/unit/task/test_debug.py
@@ -1,0 +1,59 @@
+"""Unit tests for dbt/task/debug.py.
+
+Regression test for https://github.com/dbt-labs/dbt-core/issues/9436 —
+_choose_profile_names() raised UnboundLocalError when raw_profile_data was
+falsy (profiles.yml missing or unreadable).
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dbt.task.debug import DebugTask
+
+
+def _make_task(raw_profile_data=None, profile_path="/home/user/.dbt/profiles.yml"):
+    """Create a minimal DebugTask with mocked flags."""
+    args = MagicMock()
+    args.profile = None
+    args.VERSION_CHECK = False
+
+    with patch("dbt.task.debug.DebugTask.__init__", return_value=None):
+        task = DebugTask.__new__(DebugTask)
+
+    task.args = args
+    task.cli_vars = {}
+    task.raw_profile_data = raw_profile_data
+    task.profile_path = profile_path
+    task.project_path = "/nonexistent/dbt_project.yml"
+    return task
+
+
+class TestChooseProfileNames:
+    def test_no_raw_profile_data_returns_friendly_message(self):
+        """When raw_profile_data is None, return a message instead of raising UnboundLocalError."""
+        task = _make_task(raw_profile_data=None)
+        profiles, message = task._choose_profile_names()
+        assert profiles == []
+        assert "profiles.yml" in message or task.profile_path in message
+
+    def test_empty_raw_profile_data_returns_friendly_message(self):
+        """When raw_profile_data is an empty dict, return a message without error."""
+        task = _make_task(raw_profile_data={})
+        profiles, message = task._choose_profile_names()
+        assert profiles == []
+        assert isinstance(message, str)
+        assert len(message) > 0
+
+    def test_raw_profile_data_with_no_profiles_returns_empty_profiles_message(self):
+        """profiles.yml exists but has only a 'config' key — no usable profiles."""
+        task = _make_task(raw_profile_data={"config": {"send_anonymous_usage_stats": False}})
+        profiles, message = task._choose_profile_names()
+        assert profiles == []
+        assert "no profiles" in message.lower()
+
+    def test_raw_profile_data_with_one_profile(self):
+        """Single profile entry produces a populated list and a non-empty message."""
+        task = _make_task(raw_profile_data={"default": {"outputs": {}}})
+        profiles, message = task._choose_profile_names()
+        assert "default" in profiles
+        assert isinstance(message, str)


### PR DESCRIPTION
## Problem

Running `dbt debug` without a valid `profiles.yml` raises an `UnboundLocalError` instead of a helpful message:

```
UnboundLocalError: local variable 'summary_message' referenced before assignment
  File "dbt/task/debug.py", line 292, in _choose_profile_names
```

## Root Cause

In `_choose_profile_names()`, `summary_message` is only assigned inside the `if self.raw_profile_data:` block. When `raw_profile_data` is falsy (file missing or not a valid dict), the variable is never set but is still returned on the last line, causing the crash.

## Fix

Added an `else` branch that assigns a descriptive fallback message pointing to the missing profile path:

```python
else:
    summary_message = f"profile path <{self.profile_path}> not found\n"
```

This is consistent with the `MISSING_PROFILE_MESSAGE` pattern already used earlier in `_load_profile()`.

## Changes

- [`core/dbt/task/debug.py`](core/dbt/task/debug.py): Added `else` branch to initialize `summary_message` when `raw_profile_data` is falsy
- [`tests/unit/task/test_debug.py`](tests/unit/task/test_debug.py): New unit tests covering the fixed code path and related scenarios

## Test plan

- [ ] `pytest tests/unit/task/test_debug.py`
- [ ] Run `dbt debug` in a directory without a `profiles.yml` — verify a friendly message is shown instead of a traceback
- [ ] Run `dbt debug` normally — verify no regression

Fixes #9436
