### PR TITLE
fix: resolve source() references in UDF functions

### DIFF
--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1335,7 +1335,7 @@ class ManifestLoader:
             )
             _process_docs_for_saved_query(ctx, saved_query)
 
-    # Loops through all nodes and exposures, for each element in
+    # Loops through all nodes, exposures, and functions, for each element in
     # 'sources' array finds the source node and updates the
     # 'depends_on.nodes' array with the unique id
     def process_sources(self, current_project: str):

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -1350,6 +1350,10 @@ class ManifestLoader:
             if exposure.created_at < self.started_at:
                 continue
             _process_sources_for_exposure(self.manifest, current_project, exposure)
+        for function in self.manifest.functions.values():
+            if function.created_at < self.started_at:
+                continue
+            _process_sources_for_node(self.manifest, current_project, function)
 
     # Loops through all nodes, for each element in
     # 'unit_test' array finds the node and updates the

--- a/tests/functional/functions/test_udfs.py
+++ b/tests/functional/functions/test_udfs.py
@@ -7,7 +7,7 @@ from dbt.artifacts.resources import FunctionReturns
 from dbt.artifacts.resources.types import FunctionType, FunctionVolatility
 from dbt.contracts.graph.nodes import FunctionNode
 from dbt.exceptions import ParsingError
-from dbt.tests.util import run_dbt, write_file
+from dbt.tests.util import get_manifest, run_dbt, write_file
 
 double_it_sql = """
 SELECT value * 2
@@ -410,6 +410,14 @@ class TestCanUseSourceInUDF:
         assert isinstance(agate_table, agate.Table)
         assert agate_table.column_names == ("summed_numbers",)
         assert agate_table.rows == [(6,)]
+
+    def test_source_udf_depends_on_nodes(self, project):
+        run_dbt(["seed"])
+        run_dbt(["compile"])
+        manifest = get_manifest(project.project_root)
+        function_node = manifest.functions.get("function.test.sum_numbers_function")
+        assert function_node is not None
+        assert "source.test.test_source.numbers_seed" in function_node.depends_on.nodes
 
 
 class TestCanConfigFunctionsFromProjectConfig:


### PR DESCRIPTION
UDF function bodies containing `{{ source(...) }}` calls were not having those sources resolved into `depends_on.nodes`. This adds a loop over functions in `process_sources()`, mirroring how refs are already handled in `process_refs()`.

Fixes dbt-labs/dbt-core#12850