### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260419-184827.yaml
+++ b/.changes/unreleased/Under the Hood-20260419-184827.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-04-19T18:48:27.814949845Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -1782,6 +1782,12 @@
             }
           ]
         },
+        "+scheduler": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+schema": {
           "type": [
             "string",
@@ -2832,6 +2838,23 @@
             "null"
           ]
         },
+        "+iceberg_version": {
+          "anyOf": [
+            {
+              "default": null,
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "+immutable_where": {
           "type": [
             "string",
@@ -3316,6 +3339,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "+scheduler": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "+schema": {
@@ -4270,6 +4299,12 @@
             }
           ]
         },
+        "+scheduler": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+schema": {
           "type": [
             "string",
@@ -5156,6 +5191,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "+scheduler": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "+schema": {
@@ -6627,6 +6668,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "+scheduler": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "+secure": {

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -1215,6 +1215,22 @@
             }
           ]
         },
+        "iceberg_version": {
+          "anyOf": [
+            {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "immutable_where": {
           "type": [
             "string",
@@ -1537,6 +1553,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "scheduler": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "schema": {
@@ -2995,6 +3017,22 @@
             }
           ]
         },
+        "iceberg_version": {
+          "anyOf": [
+            {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "immutable_where": {
           "type": [
             "string",
@@ -3314,6 +3352,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "scheduler": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "schema": {
@@ -4812,6 +4856,22 @@
             "null"
           ]
         },
+        "iceberg_version": {
+          "anyOf": [
+            {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "immutable_where": {
           "type": [
             "string",
@@ -5289,6 +5349,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "scheduler": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "schema": {
@@ -6727,6 +6793,22 @@
             }
           ]
         },
+        "iceberg_version": {
+          "anyOf": [
+            {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "immutable_where": {
           "type": [
             "string",
@@ -7079,6 +7161,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "scheduler": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "schema": {
@@ -7732,6 +7820,22 @@
             }
           ]
         },
+        "iceberg_version": {
+          "anyOf": [
+            {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "immutable_where": {
           "type": [
             "string",
@@ -8099,6 +8203,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "scheduler": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "schema": {
@@ -8760,6 +8870,22 @@
             }
           ]
         },
+        "iceberg_version": {
+          "anyOf": [
+            {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "immutable_where": {
           "type": [
             "string",
@@ -9069,6 +9195,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "scheduler": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "schema_origin": {
@@ -9927,6 +10059,22 @@
             }
           ]
         },
+        "iceberg_version": {
+          "anyOf": [
+            {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "immutable_where": {
           "type": [
             "string",
@@ -10214,6 +10362,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "scheduler": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "secure": {


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`fddec0b3d0f53b76af8ad89a634330f31c790dd8`](https://github.com/dbt-labs/fs/commit/fddec0b3d0f53b76af8ad89a634330f31c790dd8)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/24635991110)