### PR TITLE
unpin ci python version for ci envs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,8 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      HATCH_PYTHON: "3.10"
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+    env:
+      HATCH_PYTHON: ${{ matrix.python-version }}
 
     steps:
       - name: Check out the repository
@@ -168,6 +170,7 @@ jobs:
         os: ["ubuntu-latest"]
         split-group: ${{ fromJson(needs.integration-metadata.outputs.split-groups) }}
     env:
+      HATCH_PYTHON: ${{ matrix.python-version }}
       DBT_INVOCATION_ENV: github-actions
       DBT_TEST_USER_1: dbt_test_user_1
       DBT_TEST_USER_2: dbt_test_user_2
@@ -258,6 +261,7 @@ jobs:
         # already includes split group and runs mac + windows
         include: ${{ fromJson(needs.integration-metadata.outputs.include) }}
     env:
+      HATCH_PYTHON: ${{ matrix.python-version }}
       DBT_INVOCATION_ENV: github-actions
       DBT_TEST_USER_1: dbt_test_user_1
       DBT_TEST_USER_2: dbt_test_user_2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      HATCH_PYTHON: "3.10"
+      HATCH_PYTHON: "3.11"
 
     steps:
       - name: Check out the repository
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: "Install hatch"
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc # pypa/hatch@install
@@ -357,7 +357,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: "Install hatch"
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc # pypa/hatch@install

--- a/.github/workflows/structured-logging-schema-check.yml
+++ b/.github/workflows/structured-logging-schema-check.yml
@@ -56,6 +56,7 @@ jobs:
       matrix:
         split-group: ${{ fromJson(needs.integration-metadata.outputs.split-groups) }}
     env:
+      HATCH_PYTHON: "3.10"
       # turns warnings into errors
       RUSTFLAGS: "-D warnings"
       # points tests to the log file

--- a/.github/workflows/structured-logging-schema-check.yml
+++ b/.github/workflows/structured-logging-schema-check.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         split-group: ${{ fromJson(needs.integration-metadata.outputs.split-groups) }}
     env:
-      HATCH_PYTHON: "3.10"
+      HATCH_PYTHON: "3.11"
       # turns warnings into errors
       RUSTFLAGS: "-D warnings"
       # points tests to the log file
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: "Install hatch"
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc # pypa/hatch@install

--- a/core/hatch.toml
+++ b/core/hatch.toml
@@ -38,7 +38,6 @@ include = [
 [envs.default]
 # Python 3.10-3.11 required locally due to flake8==4.0.1 compatibility
 # CI uses [envs.ci] which doesn't set python, allowing matrix testing
-python = "3.11"
 dependencies = [
     # Git dependencies for development against main branches
     "dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-adapters",

--- a/core/hatch.toml
+++ b/core/hatch.toml
@@ -173,7 +173,6 @@ check-sdist = [
 
 # CI environment - isolated environment with test dependencies
 [envs.ci]
-detached=true
 dependencies = [
     # Git dependencies for development against main branches
     "dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-adapters",

--- a/core/hatch.toml
+++ b/core/hatch.toml
@@ -38,6 +38,7 @@ include = [
 [envs.default]
 # Python 3.10-3.11 required locally due to flake8==4.0.1 compatibility
 # CI uses [envs.ci] which doesn't set python, allowing matrix testing
+python = "3.11"
 dependencies = [
     # Git dependencies for development against main branches
     "dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-adapters",
@@ -172,6 +173,7 @@ check-sdist = [
 
 # CI environment - isolated environment with test dependencies
 [envs.ci]
+detached=true
 dependencies = [
     # Git dependencies for development against main branches
     "dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-adapters",

--- a/core/hatch.toml
+++ b/core/hatch.toml
@@ -36,8 +36,6 @@ include = [
 "dbt/task/docs/index.html" = "dbt/task/docs/index.html"
 
 [envs.default]
-# Python 3.10-3.11 required locally due to flake8==4.0.1 compatibility
-# CI uses [envs.ci] which doesn't set python, allowing matrix testing
 dependencies = [
     # Git dependencies for development against main branches
     "dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-adapters",

--- a/tests/functional/fixtures/happy_path_fixture.py
+++ b/tests/functional/fixtures/happy_path_fixture.py
@@ -1,5 +1,5 @@
 import os
-from distutils.dir_util import copy_tree
+import shutil
 
 import pytest
 
@@ -19,8 +19,10 @@ def delete_files_in_directory(directory_path):
 def happy_path_project_files(project_root):
     # copy fixture files to the project root
     delete_files_in_directory(project_root)
-    copy_tree(
-        os.path.dirname(os.path.realpath(__file__)) + "/happy_path_project", str(project_root)
+    shutil.copytree(
+        os.path.dirname(os.path.realpath(__file__)) + "/happy_path_project",
+        str(project_root),
+        dirs_exist_ok=True,
     )
 
 


### PR DESCRIPTION
Resolves #

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem
CI inherits python version from default env

### Solution
- Remove 3.11 pin from envs.default
- thread matrix python version to hatch through HATCH_PYTHON in gh workflows
- Remove distutils dependency as its removed in 3.12 and replace it with shutils

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
