### PR TITLE
add back the removed descriptions render condition

### DIFF
--- a/.changes/unreleased/Fixes-20260422-190910.yaml
+++ b/.changes/unreleased/Fixes-20260422-190910.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add back the removed descriptions render condition
+time: 2026-04-22T19:09:10.684033+05:30
+custom:
+    Author: ash2shukla
+    Issue: "12865"

--- a/core/dbt/parser/schema_renderer.py
+++ b/core/dbt/parser/schema_renderer.py
@@ -62,6 +62,9 @@ class SchemaYamlRenderer(BaseRenderer):
         ):
             return True
 
+        if len(keypath) == 5 and keypath[4] == "description":
+            return True
+
         # versions: tests/data_tests, descriptions, and column tests/data_tests/descriptions
         # keypath looks like ("versions", <idx>, "tests" or "data_tests", ...) or
         # ("versions", <idx>, "columns", <idx>, "tests" or "data_tests", ...)


### PR DESCRIPTION
Resolves #12864 

### Problem
Keypath length 5 with description at index 4 raises Compilation error

### Solution
Restore description rendering behavior for keypath length 5 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
