### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260422-222026.yaml
+++ b/.changes/unreleased/Under the Hood-20260422-222026.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-04-22T22:20:26.722183883Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -1007,6 +1007,13 @@
         "unknown"
       ]
     },
+    "OnError": {
+      "type": "string",
+      "enum": [
+        "skip_children",
+        "continue"
+      ]
+    },
     "OnSchemaChange": {
       "type": "string",
       "enum": [
@@ -3135,6 +3142,16 @@
           "anyOf": [
             {
               "$ref": "#/definitions/OnConfigurationChange"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "+on_error": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OnError"
             },
             {
               "type": "null"

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -5154,6 +5154,16 @@
             }
           ]
         },
+        "on_error": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OnError"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "on_schema_change": {
           "anyOf": [
             {
@@ -5973,6 +5983,13 @@
         "continue",
         "fail",
         "unknown"
+      ]
+    },
+    "OnError": {
+      "type": "string",
+      "enum": [
+        "skip_children",
+        "continue"
       ]
     },
     "OnSchemaChange": {


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`bc5a10c6d3871ee6bd291a7fde22a30560bdf366`](https://github.com/dbt-labs/fs/commit/bc5a10c6d3871ee6bd291a7fde22a30560bdf366)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/24804716414)