### PR TITLE
Drop usage of deprecated `warn_or_error` handler method

### DIFF
--- a/.changes/unreleased/Under the Hood-20260423-130357.yaml
+++ b/.changes/unreleased/Under the Hood-20260423-130357.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Drop usage of deprecated `warn_or_error` handler method
+time: 2026-04-23T13:03:57.945255-05:00
+custom:
+  Author: QMalcolm
+  Issue: "8133"

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -41,7 +41,7 @@ from dbt.exceptions import (
 )
 from dbt.flags import get_flags
 from dbt_common.dataclass_schema import ValidationError
-from dbt_common.events.functions import warn_or_error
+from dbt_common.events.functions import fire_event
 from dbt_common.helper_types import DictDefaultEmptyStr, FQNPath, PathSet
 
 from .profile import Profile
@@ -410,7 +410,10 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
         if len(unused_resource_config_paths) == 0:
             return
 
-        warn_or_error(UnusedResourceConfigPath(unused_config_paths=unused_resource_config_paths))
+        fire_event(
+            UnusedResourceConfigPath(unused_config_paths=unused_resource_config_paths),
+            force_warn_or_error_handling=True,
+        )
 
     def load_dependencies(self, base_only=False) -> Mapping[str, "RuntimeConfig"]:
         if self.dependencies is None:

--- a/core/dbt/context/exceptions_jinja.py
+++ b/core/dbt/context/exceptions_jinja.py
@@ -24,7 +24,7 @@ from dbt.exceptions import (
     env_secrets,
     scrub_secrets,
 )
-from dbt_common.events.functions import warn_or_error
+from dbt_common.events.functions import fire_event
 from dbt_common.exceptions import (
     DataclassNotDictError,
     DbtDatabaseError,
@@ -34,7 +34,7 @@ from dbt_common.exceptions import (
 
 
 def warn(msg, node=None):
-    warn_or_error(JinjaLogWarning(msg=msg), node=node)
+    fire_event(JinjaLogWarning(msg=msg), node=node, force_warn_or_error_handling=True)
     return ""
 
 
@@ -119,11 +119,12 @@ def raise_fail_fast_error(msg, node=None) -> NoReturn:
 def warn_snapshot_timestamp_data_types(
     snapshot_time_data_type: str, updated_at_data_type: str
 ) -> None:
-    warn_or_error(
+    fire_event(
         SnapshotTimestampWarning(
             snapshot_time_data_type=snapshot_time_data_type,
             updated_at_data_type=updated_at_data_type,
-        )
+        ),
+        force_warn_or_error_handling=True,
     )
 
 

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -110,7 +110,7 @@ from dbt_common.contracts.constraints import (
 )
 from dbt_common.dataclass_schema import dbtClassMixin
 from dbt_common.events.contextvars import set_log_contextvars
-from dbt_common.events.functions import warn_or_error
+from dbt_common.events.functions import fire_event
 
 # =====================================================================
 # This contains the classes for all of the nodes and node-like objects
@@ -718,13 +718,14 @@ class ModelNode(ModelResource, CompiledNode):
             breaking_change = f"Contracted model '{self.unique_id}' was deleted or renamed."
 
         if self.version is None:
-            warn_or_error(
+            fire_event(
                 UnversionedBreakingChange(
                     breaking_changes=[breaking_change],
                     model_name=self.name,
                     model_file_path=self.original_file_path,
                 ),
                 node=self,
+                force_warn_or_error_handling=True,
             )
             return False
         else:
@@ -935,7 +936,7 @@ class ModelNode(ModelResource, CompiledNode):
                 )
 
             if self.version is None:
-                warn_or_error(
+                fire_event(
                     UnversionedBreakingChange(
                         contract_enforced_disabled=contract_enforced_disabled,
                         columns_removed=columns_removed,
@@ -947,6 +948,7 @@ class ModelNode(ModelResource, CompiledNode):
                         model_file_path=self.original_file_path,
                     ),
                     node=self,
+                    force_warn_or_error_handling=True,
                 )
             else:
                 raise (
@@ -988,27 +990,32 @@ class SeedNode(SeedResource, ParsedNode):  # No SQLDefaults!
         if self.checksum.name == "path":
             msg: str
             if other.checksum.name != "path":
-                warn_or_error(
-                    SeedIncreased(package_name=self.package_name, name=self.name), node=self
+                fire_event(
+                    SeedIncreased(package_name=self.package_name, name=self.name),
+                    node=self,
+                    force_warn_or_error_handling=True,
                 )
             elif result:
-                warn_or_error(
+                fire_event(
                     SeedExceedsLimitSamePath(package_name=self.package_name, name=self.name),
                     node=self,
+                    force_warn_or_error_handling=True,
                 )
             elif not result:
-                warn_or_error(
+                fire_event(
                     SeedExceedsLimitAndPathChanged(package_name=self.package_name, name=self.name),
                     node=self,
+                    force_warn_or_error_handling=True,
                 )
             else:
-                warn_or_error(
+                fire_event(
                     SeedExceedsLimitChecksumChanged(
                         package_name=self.package_name,
                         name=self.name,
                         checksum_name=other.checksum.name,
                     ),
                     node=self,
+                    force_warn_or_error_handling=True,
                 )
 
         return result

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -7,7 +7,7 @@ import dbt.tracking
 from dbt.events import types as core_types
 from dbt.flags import get_flags
 from dbt_common.dataclass_schema import dbtClassMixin
-from dbt_common.events.functions import fire_event, warn_or_error
+from dbt_common.events.functions import fire_event
 from dbt_common.events.types import Note
 from dbt_common.exceptions import DbtInternalError
 
@@ -52,7 +52,7 @@ class DBTDeprecation:
             flags = get_flags()
             if self.name not in active_deprecations or flags.show_all_deprecations:
                 event = self.event(**kwargs)
-                warn_or_error(event)
+                fire_event(event, force_warn_or_error_handling=True)
                 self.track_deprecation_warn()
 
             active_deprecations[self.name] += 1
@@ -295,8 +295,9 @@ def show_deprecations_summary() -> None:
 
     if len(summaries) > 0:
         show_all_hint = not get_flags().show_all_deprecations
-        warn_or_error(
-            core_types.DeprecationsSummary(summaries=summaries, show_all_hint=show_all_hint)
+        fire_event(
+            core_types.DeprecationsSummary(summaries=summaries, show_all_hint=show_all_hint),
+            force_warn_or_error_handling=True,
         )
 
 

--- a/core/dbt/deps/git.py
+++ b/core/dbt/deps/git.py
@@ -10,12 +10,7 @@ from dbt.events.types import DepsScrubbedPackageName, DepsUnpinned, EnsureGitIns
 from dbt.exceptions import MultipleVersionGitDepsError
 from dbt.utils import md5
 from dbt_common.clients import system
-from dbt_common.events.functions import (
-    env_secrets,
-    fire_event,
-    scrub_secrets,
-    warn_or_error,
-)
+from dbt_common.events.functions import env_secrets, fire_event, scrub_secrets
 from dbt_common.exceptions import ExecutableError
 
 
@@ -61,7 +56,10 @@ class GitPinnedPackage(GitPackageMixin, PinnedPackage):
     def to_dict(self) -> Dict[str, str]:
         git_scrubbed = scrub_secrets(self.git_unrendered, env_secrets())
         if self.git_unrendered != git_scrubbed:
-            warn_or_error(DepsScrubbedPackageName(package_name=git_scrubbed))
+            fire_event(
+                DepsScrubbedPackageName(package_name=git_scrubbed),
+                force_warn_or_error_handling=True,
+            )
         ret = {
             "git": git_scrubbed,
             "revision": self.revision,
@@ -108,7 +106,10 @@ class GitPinnedPackage(GitPackageMixin, PinnedPackage):
 
         # raise warning (or error) if this package is not pinned
         if (self.revision == "HEAD" or self.revision in ("main", "master")) and self.warn_unpinned:
-            warn_or_error(DepsUnpinned(revision=self.revision, git=self.git))
+            fire_event(
+                DepsUnpinned(revision=self.revision, git=self.git),
+                force_warn_or_error_handling=True,
+            )
 
         # now overwrite 'revision' with actual commit SHA
         self.revision = git.get_current_sha(path)

--- a/core/dbt/deps/tarball.py
+++ b/core/dbt/deps/tarball.py
@@ -9,7 +9,7 @@ from dbt.deps.base import PinnedPackage, UnpinnedPackage, get_downloads_path
 from dbt.events.types import DepsScrubbedPackageName
 from dbt.exceptions import DependencyError, env_secrets, scrub_secrets
 from dbt_common.clients import system
-from dbt_common.events.functions import warn_or_error
+from dbt_common.events.functions import fire_event
 from dbt_common.utils.connection import connection_exception_retry
 
 
@@ -42,7 +42,10 @@ class TarballPinnedPackage(TarballPackageMixin, PinnedPackage):
     def to_dict(self) -> Dict[str, str]:
         tarball_scrubbed = scrub_secrets(self.tarball_unrendered, env_secrets())
         if self.tarball_unrendered != tarball_scrubbed:
-            warn_or_error(DepsScrubbedPackageName(package_name=tarball_scrubbed))
+            fire_event(
+                DepsScrubbedPackageName(package_name=tarball_scrubbed),
+                force_warn_or_error_handling=True,
+            )
         return {
             "tarball": tarball_scrubbed,
             "name": self.package,

--- a/core/dbt/graph/selector.py
+++ b/core/dbt/graph/selector.py
@@ -7,7 +7,7 @@ from dbt.contracts.state import PreviousState
 from dbt.events.types import NoNodesForSelectionCriteria, SelectorReportInvalidSelector
 from dbt.exceptions import DbtInternalError, InvalidSelectorError
 from dbt.node_types import NodeType
-from dbt_common.events.functions import fire_event, warn_or_error
+from dbt_common.events.functions import fire_event
 
 from .graph import Graph, UniqueId
 from .queue import GraphQueue
@@ -172,7 +172,10 @@ class NodeSelector(MethodManager):
             )
 
             if spec.expect_exists and len(direct_nodes) == 0 and warn_on_no_nodes:
-                warn_or_error(NoNodesForSelectionCriteria(spec_raw=str(spec.raw)))
+                fire_event(
+                    NoNodesForSelectionCriteria(spec_raw=str(spec.raw)),
+                    force_warn_or_error_handling=True,
+                )
 
         return direct_nodes, indirect_nodes
 

--- a/core/dbt/internal_deprecations.py
+++ b/core/dbt/internal_deprecations.py
@@ -2,7 +2,7 @@ import functools
 from typing import Optional
 
 from dbt.events.types import InternalDeprecation
-from dbt_common.events.functions import warn_or_error
+from dbt_common.events.functions import fire_event
 
 
 def deprecated(suggested_action: str, version: str, reason: Optional[str]):
@@ -11,13 +11,14 @@ def deprecated(suggested_action: str, version: str, reason: Optional[str]):
         def wrapped(*args, **kwargs):
             name = func.__name__
 
-            warn_or_error(
+            fire_event(
                 InternalDeprecation(
                     name=name,
                     suggested_action=suggested_action,
                     version=version,
                     reason=reason,
-                )
+                ),
+                force_warn_or_error_handling=True,
             )  # TODO: pass in event?
             return func(*args, **kwargs)
 

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -133,7 +133,7 @@ from dbt_common.clients.system import make_directory, path_exists, read_json, wr
 from dbt_common.constants import SECRET_ENV_PREFIX
 from dbt_common.dataclass_schema import StrEnum, dbtClassMixin
 from dbt_common.events.base_types import EventLevel
-from dbt_common.events.functions import fire_event, get_invocation_id, warn_or_error
+from dbt_common.events.functions import fire_event, get_invocation_id
 from dbt_common.events.types import Note
 from dbt_common.exceptions.base import DbtValidationError
 from dbt_common.helper_types import PathSet
@@ -608,12 +608,13 @@ class ManifestLoader:
         for node in self.manifest.nodes.values():
             if isinstance(node, ModelNode) and node.deprecation_date:
                 if node.is_past_deprecation_date:
-                    warn_or_error(
+                    fire_event(
                         DeprecatedModel(
                             model_name=node.name,
                             model_version=version_to_str(node.version),
                             deprecation_date=node.deprecation_date.isoformat(),
-                        )
+                        ),
+                        force_warn_or_error_handling=True,
                     )
                 # At this point _process_refs should already have been called, and
                 # we just rebuilt the parent and child maps.
@@ -628,7 +629,7 @@ class ManifestLoader:
                     else:
                         event_cls = UpcomingReferenceDeprecation
 
-                    warn_or_error(
+                    fire_event(
                         event_cls(
                             model_name=child_node.name,
                             ref_model_package=node.package_name,
@@ -636,7 +637,8 @@ class ManifestLoader:
                             ref_model_version=version_to_str(node.version),
                             ref_model_latest_version=str(node.latest_version),
                             ref_model_deprecation_date=node.deprecation_date.isoformat(),
-                        )
+                        ),
+                        force_warn_or_error_handling=True,
                     )
 
     def check_for_spaces_in_resource_names(self):
@@ -1597,11 +1599,12 @@ class ManifestLoader:
                         models_forcing_concurrent_batches += 1
 
                 if models_forcing_concurrent_batches > 0:
-                    warn_or_error(
+                    fire_event(
                         InvalidConcurrentBatchesConfig(
                             num_models=models_forcing_concurrent_batches,
                             adapter_type=adapter.type(),
-                        )
+                        ),
+                        force_warn_or_error_handling=True,
                     )
 
     def check_microbatch_model_has_a_filtered_input(self):
@@ -1681,7 +1684,7 @@ def invalid_target_fail_unless_test(
 
             fire_event(event, EventLevel.WARN if should_warn_if_disabled else None)
         else:
-            warn_or_error(
+            fire_event(
                 NodeNotFoundOrDisabled(
                     original_file_path=node.original_file_path,
                     unique_id=node.unique_id,
@@ -1690,7 +1693,8 @@ def invalid_target_fail_unless_test(
                     target_kind=target_kind,
                     target_package=target_package if target_package else "",
                     disabled=str(disabled),
-                )
+                ),
+                force_warn_or_error_handling=True,
             )
     else:
         raise TargetNotFoundError(
@@ -1721,12 +1725,13 @@ def warn_if_package_node_depends_on_root_project_node(
         and target_model.package_name == current_project
         and ref_package_name != current_project
     ):
-        warn_or_error(
+        fire_event(
             PackageNodeDependsOnRootProjectNode(
                 node_name=node.name,
                 package_name=node.package_name,
                 root_project_unique_id=target_model.unique_id,
-            )
+            ),
+            force_warn_or_error_handling=True,
         )
 
 

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -89,7 +89,7 @@ from dbt.utils import coerce_dict_str
 from dbt_common.contracts.constraints import ConstraintType, ModelLevelConstraint
 from dbt_common.dataclass_schema import ValidationError, dbtClassMixin
 from dbt_common.events import EventLevel
-from dbt_common.events.functions import fire_event, warn_or_error
+from dbt_common.events.functions import fire_event
 from dbt_common.events.types import Note
 from dbt_common.exceptions import DbtValidationError
 from dbt_common.utils import deep_merge
@@ -843,14 +843,15 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
             if unique_id:
                 resource_type = NodeType(unique_id.split(".")[0])
                 if resource_type.pluralize() != patch.yaml_key:
-                    warn_or_error(
+                    fire_event(
                         WrongResourceSchemaFile(
                             patch_name=patch.name,
                             resource_type=resource_type,
                             plural_resource_type=resource_type.pluralize(),
                             yaml_key=patch.yaml_key,
                             file_path=patch.original_file_path,
-                        )
+                        ),
+                        force_warn_or_error_handling=True,
                     )
                     return
         elif patch.yaml_key == "functions":
@@ -894,12 +895,13 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
 
                     self.patch_node_properties(node, patch)
             else:
-                warn_or_error(
+                fire_event(
                     NoNodeForYamlKey(
                         patch_name=patch.name,
                         yaml_key=patch.yaml_key,
                         file_path=source_file.path.original_file_path,
-                    )
+                    ),
+                    force_warn_or_error_handling=True,
                 )
                 return  # we only return early if no disabled early nodes are found. Why don't we return after patching the disabled nodes?
 
@@ -937,12 +939,13 @@ class NodePatchParser(PatchParser[NodeTarget, ParsedNodePatch], Generic[NodeTarg
         if not isinstance(node, ModelNode):
             for attr in ["latest_version", "access", "version", "constraints"]:
                 if getattr(patch, attr):
-                    warn_or_error(
+                    fire_event(
                         ValidationWarning(
                             field_name=attr,
                             resource_type=node.resource_type.value,
                             node_name=patch.name,
-                        )
+                        ),
+                        force_warn_or_error_handling=True,
                     )
 
 
@@ -964,14 +967,15 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
     def parse_patch(self, block: TargetBlock[UnparsedModelUpdate], refs: ParserRef) -> None:
         target = block.target
         if NodeType.Model.pluralize() != target.yaml_key:
-            warn_or_error(
+            fire_event(
                 WrongResourceSchemaFile(
                     patch_name=target.name,
                     resource_type=NodeType.Model,
                     plural_resource_type=NodeType.Model.pluralize(),
                     yaml_key=target.yaml_key,
                     file_path=target.original_file_path,
-                )
+                ),
+                force_warn_or_error_handling=True,
             )
             return
 
@@ -1033,12 +1037,13 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
                     add_node_nofile_fn = self.manifest.add_node_nofile
 
                 if versioned_model_node is None:
-                    warn_or_error(
+                    fire_event(
                         NoNodeForYamlKey(
                             patch_name=versioned_model_name,
                             yaml_key=target.yaml_key,
                             file_path=source_file.path.original_file_path,
-                        )
+                        ),
+                        force_warn_or_error_handling=True,
                     )
                     continue
 
@@ -1236,9 +1241,10 @@ class ModelPatchParser(NodePatchParser[UnparsedModelUpdate]):
 
         # if any constraint has `warn_unsupported` as True then send the warning
         if any(warn_unsupported) and not model_node.materialization_enforces_constraints:
-            warn_or_error(
+            fire_event(
                 UnsupportedConstraintMaterialization(materialized=model_node.config.materialized),
                 node=model_node,
+                force_warn_or_error_handling=True,
             )
 
         errors = []
@@ -1291,12 +1297,13 @@ class SingularTestPatchParser(PatchParser[UnparsedSingularTestUpdate, ParsedSing
             block.name, block.target.package_name
         )
         if not unique_id:
-            warn_or_error(
+            fire_event(
                 NoNodeForYamlKey(
                     patch_name=patch.name,
                     yaml_key=patch.yaml_key,
                     file_path=source_file.path.original_file_path,
-                )
+                ),
+                force_warn_or_error_handling=True,
             )
             return
 
@@ -1378,7 +1385,9 @@ class MacroPatchParser(PatchParser[UnparsedMacroUpdate, ParsedMacroPatch]):
         unique_id = f"macro.{patch.package_name}.{patch.name}"
         macro = self.manifest.macros.get(unique_id)
         if not macro:
-            warn_or_error(MacroNotFoundForPatch(patch_name=patch.name))
+            fire_event(
+                MacroNotFoundForPatch(patch_name=patch.name), force_warn_or_error_handling=True
+            )
             return
         if macro.patch_path:
             package_name, existing_file_path = macro.patch_path.split("://")
@@ -1428,10 +1437,11 @@ class MacroPatchParser(PatchParser[UnparsedMacroUpdate, ParsedMacroPatch]):
                 self._fire_macro_arg_warning(msg, macro)
 
     def _fire_macro_arg_warning(self, msg: str, macro: Macro) -> None:
-        warn_or_error(
+        fire_event(
             InvalidMacroAnnotation(
                 msg=msg, macro_unique_id=macro.unique_id, macro_file_path=macro.original_file_path
-            )
+            ),
+            force_warn_or_error_handling=True,
         )
 
 

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -30,7 +30,7 @@ from dbt.exceptions import ParsingError
 from dbt.node_types import NodeType
 from dbt.parser.common import ParserRef
 from dbt.parser.schema_generic_tests import SchemaGenericTestParser
-from dbt_common.events.functions import fire_event, warn_or_error
+from dbt_common.events.functions import fire_event
 from dbt_common.exceptions import DbtInternalError
 
 
@@ -354,7 +354,10 @@ class SourcePatcher:
 
         if unused_tables:
             unused_tables_formatted = self.get_unused_msg(unused_tables)
-            warn_or_error(UnusedTables(unused_tables=unused_tables_formatted))
+            fire_event(
+                UnusedTables(unused_tables=unused_tables_formatted),
+                force_warn_or_error_handling=True,
+            )
 
         self.manifest.source_patches = {}
 
@@ -495,12 +498,13 @@ class SourcePatcher:
         config_tags_valid: List[str] = []
         for tag in config_tags:
             if not isinstance(tag, str):
-                warn_or_error(
+                fire_event(
                     ValidationWarning(
                         field_name=f"`config.tags`: {tags}",
                         resource_type=NodeType.Source.value,
                         node_name=source_name,
-                    )
+                    ),
+                    force_warn_or_error_handling=True,
                 )
             else:
                 config_tags_valid.append(tag)

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -20,7 +20,7 @@ from dbt.task.base import resource_types_from_args
 from dbt.task.runnable import GraphRunnableTask
 from dbt.utils import JSONEncoder
 from dbt_common.events.contextvars import task_contextvars
-from dbt_common.events.functions import fire_event, warn_or_error
+from dbt_common.events.functions import fire_event
 from dbt_common.events.types import PrintEvent
 from dbt_common.exceptions import DbtInternalError, DbtRuntimeError
 
@@ -78,7 +78,7 @@ class ListTask(GraphRunnableTask):
         spec = self.get_selection_spec()
         unique_ids = sorted(selector.get_selected(spec))
         if not unique_ids:
-            warn_or_error(NoNodesSelected())
+            fire_event(NoNodesSelected(), force_warn_or_error_handling=True)
             return
         if self.manifest is None:
             raise DbtInternalError("manifest is None in _iterate_selected_nodes")

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -71,7 +71,7 @@ from dbt.utils.artifact_upload import add_artifact_produced
 from dbt_common.context import _INVOCATION_CONTEXT_VAR, get_invocation_context
 from dbt_common.dataclass_schema import StrEnum
 from dbt_common.events.contextvars import log_contextvars, task_contextvars
-from dbt_common.events.functions import fire_event, warn_or_error
+from dbt_common.events.functions import fire_event
 from dbt_common.events.types import Formatting
 from dbt_common.exceptions import NotImplementedError
 
@@ -632,7 +632,7 @@ class GraphRunnableTask(ConfiguredTask):
                 )
 
             if len(self._flattened_nodes) == 0:
-                warn_or_error(NothingToDo())
+                fire_event(NothingToDo(), force_warn_or_error_handling=True)
                 result = self.get_result(
                     results=[],
                     generated_at=datetime.now(timezone.utc).replace(tzinfo=None),

--- a/tests/unit/graph/test_selector_methods.py
+++ b/tests/unit/graph/test_selector_methods.py
@@ -824,23 +824,23 @@ def test_select_state_changed_seed_checksum_path_to_path(manifest, previous_stat
         manifest, replace(seed, checksum=FileHash(name="path", checksum=seed.original_file_path))
     )
     method = statemethod(manifest, previous_state)
-    with mock.patch("dbt.contracts.graph.nodes.warn_or_error") as warn_or_error_patch:
+    with mock.patch("dbt.contracts.graph.nodes.fire_event") as fire_event_patch:
         assert not search_manifest_using_method(manifest, method, "modified")
-        warn_or_error_patch.assert_called_once()
-        event = warn_or_error_patch.call_args[0][0]
+        fire_event_patch.assert_called_once()
+        event = fire_event_patch.call_args[0][0]
         assert type(event).__name__ == "SeedExceedsLimitSamePath"
         msg = event.message()
         assert msg.startswith(warning_tag("Found a seed (pkg.seed) >1MB in size"))
-    with mock.patch("dbt.contracts.graph.nodes.warn_or_error") as warn_or_error_patch:
+    with mock.patch("dbt.contracts.graph.nodes.fire_event") as fire_event_patch:
         assert not search_manifest_using_method(manifest, method, "new")
-        warn_or_error_patch.assert_not_called()
-    with mock.patch("dbt.contracts.graph.nodes.warn_or_error") as warn_or_error_patch:
+        fire_event_patch.assert_not_called()
+    with mock.patch("dbt.contracts.graph.nodes.fire_event") as fire_event_patch:
         assert search_manifest_using_method(manifest, method, "old")
-        warn_or_error_patch.assert_not_called()
-    with mock.patch("dbt.contracts.graph.nodes.warn_or_error") as warn_or_error_patch:
+        fire_event_patch.assert_not_called()
+    with mock.patch("dbt.contracts.graph.nodes.fire_event") as fire_event_patch:
         assert search_manifest_using_method(manifest, method, "unmodified")
-        warn_or_error_patch.assert_called_once()
-        event = warn_or_error_patch.call_args[0][0]
+        fire_event_patch.assert_called_once()
+        event = fire_event_patch.call_args[0][0]
         assert type(event).__name__ == "SeedExceedsLimitSamePath"
         msg = event.message()
         assert msg.startswith(warning_tag("Found a seed (pkg.seed) >1MB in size"))
@@ -851,23 +851,23 @@ def test_select_state_changed_seed_checksum_sha_to_path(manifest, previous_state
         manifest, replace(seed, checksum=FileHash(name="path", checksum=seed.original_file_path))
     )
     method = statemethod(manifest, previous_state)
-    with mock.patch("dbt.contracts.graph.nodes.warn_or_error") as warn_or_error_patch:
+    with mock.patch("dbt.contracts.graph.nodes.fire_event") as fire_event_patch:
         assert search_manifest_using_method(manifest, method, "modified") == {"seed"}
-        warn_or_error_patch.assert_called_once()
-        event = warn_or_error_patch.call_args[0][0]
+        fire_event_patch.assert_called_once()
+        event = fire_event_patch.call_args[0][0]
         assert type(event).__name__ == "SeedIncreased"
         msg = event.message()
         assert msg.startswith(warning_tag("Found a seed (pkg.seed) >1MB in size"))
-    with mock.patch("dbt.contracts.graph.nodes.warn_or_error") as warn_or_error_patch:
+    with mock.patch("dbt.contracts.graph.nodes.fire_event") as fire_event_patch:
         assert not search_manifest_using_method(manifest, method, "new")
-        warn_or_error_patch.assert_not_called()
-    with mock.patch("dbt.contracts.graph.nodes.warn_or_error") as warn_or_error_patch:
+        fire_event_patch.assert_not_called()
+    with mock.patch("dbt.contracts.graph.nodes.fire_event") as fire_event_patch:
         assert search_manifest_using_method(manifest, method, "old")
-        warn_or_error_patch.assert_not_called()
-    with mock.patch("dbt.contracts.graph.nodes.warn_or_error") as warn_or_error_patch:
+        fire_event_patch.assert_not_called()
+    with mock.patch("dbt.contracts.graph.nodes.fire_event") as fire_event_patch:
         assert search_manifest_using_method(manifest, method, "unmodified")
-        warn_or_error_patch.assert_called_once()
-        event = warn_or_error_patch.call_args[0][0]
+        fire_event_patch.assert_called_once()
+        event = fire_event_patch.call_args[0][0]
         assert type(event).__name__ == "SeedIncreased"
         msg = event.message()
         assert msg.startswith(warning_tag("Found a seed (pkg.seed) >1MB in size"))
@@ -879,18 +879,18 @@ def test_select_state_changed_seed_checksum_path_to_sha(manifest, previous_state
         replace(seed, checksum=FileHash(name="path", checksum=seed.original_file_path)),
     )
     method = statemethod(manifest, previous_state)
-    with mock.patch("dbt.contracts.graph.nodes.warn_or_error") as warn_or_error_patch:
+    with mock.patch("dbt.contracts.graph.nodes.fire_event") as fire_event_patch:
         assert search_manifest_using_method(manifest, method, "modified") == {"seed"}
-        warn_or_error_patch.assert_not_called()
-    with mock.patch("dbt.contracts.graph.nodes.warn_or_error") as warn_or_error_patch:
+        fire_event_patch.assert_not_called()
+    with mock.patch("dbt.contracts.graph.nodes.fire_event") as fire_event_patch:
         assert not search_manifest_using_method(manifest, method, "new")
-        warn_or_error_patch.assert_not_called()
-    with mock.patch("dbt.contracts.graph.nodes.warn_or_error") as warn_or_error_patch:
+        fire_event_patch.assert_not_called()
+    with mock.patch("dbt.contracts.graph.nodes.fire_event") as fire_event_patch:
         assert "seed" not in search_manifest_using_method(manifest, method, "unmodified")
-        warn_or_error_patch.assert_not_called()
-    with mock.patch("dbt.contracts.graph.nodes.warn_or_error") as warn_or_error_patch:
+        fire_event_patch.assert_not_called()
+    with mock.patch("dbt.contracts.graph.nodes.fire_event") as fire_event_patch:
         assert "seed" in search_manifest_using_method(manifest, method, "old")
-        warn_or_error_patch.assert_not_called()
+        fire_event_patch.assert_not_called()
 
 
 def test_select_state_changed_seed_fqn(manifest, previous_state, seed):

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -5,7 +5,7 @@ import pytest
 import dbt.flags as flags
 from dbt.adapters.events.types import AdapterDeprecationWarning
 from dbt.events.types import NoNodesForSelectionCriteria
-from dbt_common.events.functions import msg_to_dict, warn_or_error
+from dbt_common.events.functions import fire_event, msg_to_dict
 from dbt_common.events.types import InfoLevel, RetryExternalCall
 from dbt_common.exceptions import EventCompilationError
 
@@ -26,9 +26,9 @@ def test_warn_or_error_warn_error_options(warn_error_options, expect_compilation
     flags.set_from_args(args, {})
     if expect_compilation_exception:
         with pytest.raises(EventCompilationError):
-            warn_or_error(NoNodesForSelectionCriteria())
+            fire_event(NoNodesForSelectionCriteria(), force_warn_or_error_handling=True)
     else:
-        warn_or_error(NoNodesForSelectionCriteria())
+        fire_event(NoNodesForSelectionCriteria(), force_warn_or_error_handling=True)
 
 
 @pytest.mark.parametrize(
@@ -43,11 +43,11 @@ def test_warn_error_options_captures_all_events(error_cls):
     args = Namespace(warn_error_options={"error": [error_cls.__name__]})
     flags.set_from_args(args, {})
     with pytest.raises(EventCompilationError):
-        warn_or_error(error_cls())
+        fire_event(error_cls(), force_warn_or_error_handling=True)
 
     args = Namespace(warn_error_options={"error": "*", "warn": [error_cls.__name__]})
     flags.set_from_args(args, {})
-    warn_or_error(error_cls())
+    fire_event(error_cls(), force_warn_or_error_handling=True)
 
 
 @pytest.mark.parametrize(
@@ -62,9 +62,9 @@ def test_warn_or_error_warn_error(warn_error, expect_compilation_exception):
     flags.set_from_args(args, {})
     if expect_compilation_exception:
         with pytest.raises(EventCompilationError):
-            warn_or_error(NoNodesForSelectionCriteria())
+            fire_event(NoNodesForSelectionCriteria(), force_warn_or_error_handling=True)
     else:
-        warn_or_error(NoNodesForSelectionCriteria())
+        fire_event(NoNodesForSelectionCriteria(), force_warn_or_error_handling=True)
 
 
 def test_msg_to_dict_handles_exceptions_gracefully():


### PR DESCRIPTION
## Summary

- `dbt-common#259` deprecated `warn_or_error()` in favour of calling `fire_event()` directly with `force_warn_or_error_handling=True`
- `warn_or_error()` is a one-liner wrapper that forwards to `fire_event` with that flag, so every call site is a mechanical no-op substitution
- Sweeps all 15 affected files (13 source, 2 test); mock patches in `test_selector_methods.py` updated to target `fire_event` instead of the now-removed `warn_or_error` import

## Test plan

- [ ] All existing unit tests pass (`tests/unit/test_functions.py`, `tests/unit/graph/test_selector_methods.py`)
- [x] No functional behaviour change — this is a pure mechanical substitution of a deprecated wrapper