### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260428-033558.yaml
+++ b/.changes/unreleased/Under the Hood-20260428-033558.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-04-28T03:35:58.489382084Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -800,6 +800,7 @@
         "count": {
           "anyOf": [
             {
+              "default": null,
               "type": [
                 "integer",
                 "null"
@@ -813,6 +814,7 @@
           ]
         },
         "period": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/FreshnessPeriod"

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -2689,6 +2689,7 @@
         "count": {
           "anyOf": [
             {
+              "default": null,
               "type": [
                 "integer",
                 "null"
@@ -2702,6 +2703,7 @@
           ]
         },
         "period": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/FreshnessPeriod"


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`e1a20a266fa47c56d7d80fa2cc6219cb156982fb`](https://github.com/dbt-labs/fs/commit/e1a20a266fa47c56d7d80fa2cc6219cb156982fb)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/25031782410)