### PR TITLE
feature: add support for git package version ranges

### DIFF
--- a/.changes/unreleased/Features-20260430-162240.yaml
+++ b/.changes/unreleased/Features-20260430-162240.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Git packages version ranges support
+time: 2026-04-30T16:22:40.452962+02:00
+custom:
+    Author: kverburg
+    Issue: n/a

--- a/core/dbt/clients/git.py
+++ b/core/dbt/clients/git.py
@@ -77,6 +77,26 @@ def list_tags(cwd):
     return tags
 
 
+def list_remote_tags(repo, cwd):
+    out, err = run_cmd(cwd, ["git", "ls-remote", "--tags", repo], env={"LC_ALL": "C"})
+    tags = []
+    for line in out.decode("utf-8").splitlines():
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        ref = parts[1]
+        if not ref.startswith("refs/tags/"):
+            continue
+        tag = ref[len("refs/tags/") :]
+        if tag.endswith("^{}"):
+            tag = tag[:-3]
+        if tag not in tags:
+            tags.append(tag)
+    return tags
+
+
 def _checkout(cwd, repo, revision):
     fire_event(GitProgressCheckoutRevision(revision=revision))
 

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Dict, List, Optional, Union
 
@@ -63,6 +64,8 @@ class LocalPackage(Package):
 # `float` also allows `int`, according to PEP484 (and jsonschema!)
 RawVersion = Union[str, float]
 
+_REV_SPECIFIER_RE = re.compile(r"^(?P<op>>=|<=|>|<|=)")
+
 
 @dataclass
 class TarballPackage(Package):
@@ -74,17 +77,32 @@ class TarballPackage(Package):
 @dataclass
 class GitPackage(Package):
     git: str
-    revision: Optional[RawVersion] = None
+    revision: Optional[Union[RawVersion, List[RawVersion]]] = None
+    revision_range: Optional[List[RawVersion]] = None
     warn_unpinned: Optional[bool] = field(default=None, metadata={"alias": "warn-unpinned"})
     subdirectory: Optional[str] = None
     unrendered: Dict[str, Any] = field(default_factory=dict)
     name: Optional[str] = None
 
     def get_revisions(self) -> List[str]:
+        if self.revision is None or isinstance(self.revision, list):
+            return []
+        return [str(self.revision)]
+
+    def get_revision_ranges(self) -> List[str]:
+        if self.revision_range is not None:
+            return [str(v) for v in self.revision_range]
+
         if self.revision is None:
             return []
-        else:
-            return [str(self.revision)]
+
+        if isinstance(self.revision, list):
+            return [str(v) for v in self.revision]
+
+        revision_str = str(self.revision)
+        if _REV_SPECIFIER_RE.match(revision_str):
+            return [revision_str]
+        return []
 
 
 @dataclass
@@ -136,6 +154,20 @@ class PackageConfig(dbtClassMixin):
                 if package.get("git") == "":
                     raise ValidationError(
                         "A git package is missing the value. It is a required property."
+                    )
+                if (
+                    package.get("git")
+                    and package.get("revision") is not None
+                    and package.get("revision_range") is not None
+                ):
+                    raise ValidationError(
+                        "A git package may specify only one of revision or revision_range."
+                    )
+                if package.get("revision_range") is not None and not isinstance(
+                    package["revision_range"], list
+                ):
+                    raise ValidationError(
+                        "revision_range must be specified as a list of version specifiers."
                     )
             if isinstance(package, dict) and package.get("package"):
                 if not package["version"]:

--- a/core/dbt/deps/git.py
+++ b/core/dbt/deps/git.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import Dict, List, Optional
 
 from dbt.clients import git
@@ -7,15 +8,40 @@ from dbt.config.renderer import PackageRenderer
 from dbt.contracts.project import GitPackage, ProjectPackageMetadata
 from dbt.deps.base import PinnedPackage, UnpinnedPackage, get_downloads_path
 from dbt.events.types import DepsScrubbedPackageName, DepsUnpinned, EnsureGitInstalled
-from dbt.exceptions import MultipleVersionGitDepsError
+from dbt.exceptions import DependencyError, MultipleVersionGitDepsError
 from dbt.utils import md5
+from dbt_common import semver
 from dbt_common.clients import system
 from dbt_common.events.functions import env_secrets, fire_event, scrub_secrets
-from dbt_common.exceptions import ExecutableError
+from dbt_common.exceptions import (
+    ExecutableError,
+    SemverError,
+    VersionsNotCompatibleError,
+)
 
 
 def md5sum(s: str):
     return md5(s, "latin-1")
+
+
+_VERSION_SPECIFIER_RE = re.compile(r"^(?P<op>>=|<=|>|<|=)?(?P<version>.+)$")
+
+
+def _normalize_version_specifier(version_specifier: str) -> str:
+    match = _VERSION_SPECIFIER_RE.match(version_specifier)
+    if not match:
+        return version_specifier
+    op = match.group("op") or ""
+    version = match.group("version")
+    if version.startswith(("v", "V")):
+        version = version[1:]
+    return f"{op}{version}"
+
+
+def _normalize_tag_name(tag: str) -> str:
+    if tag.startswith(("v", "V")):
+        return tag[1:]
+    return tag
 
 
 class GitPackageMixin:
@@ -134,17 +160,20 @@ class GitUnpinnedPackage(GitPackageMixin, UnpinnedPackage[GitPinnedPackage]):
         git: str,
         git_unrendered: str,
         revisions: List[str],
+        revision_ranges: Optional[List[str]] = None,
         warn_unpinned: bool = True,
         subdirectory: Optional[str] = None,
     ) -> None:
         super().__init__(git, git_unrendered, subdirectory)
         self.revisions = revisions
+        self.revision_ranges = revision_ranges or []
         self.warn_unpinned = warn_unpinned
         self.subdirectory = subdirectory
 
     @classmethod
     def from_contract(cls, contract: GitPackage) -> "GitUnpinnedPackage":
         revisions = contract.get_revisions()
+        revision_ranges = contract.get_revision_ranges()
 
         # we want to map None -> True
         warn_unpinned = contract.warn_unpinned is not False
@@ -152,6 +181,7 @@ class GitUnpinnedPackage(GitPackageMixin, UnpinnedPackage[GitPinnedPackage]):
             git=contract.git,
             git_unrendered=(contract.unrendered.get("git") or contract.git),
             revisions=revisions,
+            revision_ranges=revision_ranges,
             warn_unpinned=warn_unpinned,
             subdirectory=contract.subdirectory,
         )
@@ -177,20 +207,98 @@ class GitUnpinnedPackage(GitPackageMixin, UnpinnedPackage[GitPinnedPackage]):
             git=self.git,
             git_unrendered=self.git_unrendered,
             revisions=self.revisions + other.revisions,
+            revision_ranges=self.revision_ranges + other.revision_ranges,
             warn_unpinned=warn_unpinned,
             subdirectory=self.subdirectory,
         )
 
+    def _parse_revision_ranges(self) -> List[semver.VersionSpecifier]:
+        try:
+            return [
+                semver.VersionSpecifier.from_version_string(_normalize_version_specifier(value))
+                for value in self.revision_ranges
+            ]
+        except SemverError as exc:
+            raise DependencyError(
+                f"Invalid revision_range for git package {self.name}: {exc}"
+            ) from exc
+
+    def _reduce_revision_ranges(self) -> semver.VersionRange:
+        parsed_ranges = self._parse_revision_ranges()
+        try:
+            return semver.reduce_versions(*parsed_ranges)
+        except VersionsNotCompatibleError as exc:
+            raise DependencyError(
+                f"Revision range error for git package {self.name}: {exc}"
+            ) from exc
+
+    def _resolve_revision_range(self) -> str:
+        range_spec = self._reduce_revision_ranges()
+        tags = git.list_remote_tags(self.git, os.getcwd())
+        candidates = {}
+        for tag in tags:
+            normalized = _normalize_tag_name(tag)
+            try:
+                semver.VersionSpecifier.from_version_string(normalized)
+            except SemverError:
+                continue
+            candidates[normalized] = tag
+
+        if not candidates:
+            raise DependencyError(f"No semantic tags found for git package {self.name}.")
+
+        target = semver.resolve_to_specific_version(range_spec, list(candidates.keys()))
+        if not target:
+            available = sorted(candidates.keys())
+            raise DependencyError(
+                f"Could not find a matching semantic tag for git package {self.name} "
+                f"within revision_range {self.revision_ranges}. Available tags: {available}"
+            )
+
+        return candidates[target]
+
+    def _exact_revision_matches_range(
+        self, revision: str, range_spec: semver.VersionRange
+    ) -> bool:
+        normalized = _normalize_tag_name(revision)
+        try:
+            semver.VersionSpecifier.from_version_string(normalized)
+        except SemverError:
+            return False
+        return bool(semver.find_possible_versions(range_spec, [normalized]))
+
     def resolved(self) -> GitPinnedPackage:
         requested = set(self.revisions)
-        if len(requested) == 0:
-            requested = {"HEAD"}
-        elif len(requested) > 1:
+        if len(requested) > 1:
             raise MultipleVersionGitDepsError(self.name, requested)
+
+        if requested and self.revision_ranges:
+            exact_revision = requested.pop()
+            range_spec = self._reduce_revision_ranges()
+            if not self._exact_revision_matches_range(exact_revision, range_spec):
+                raise DependencyError(
+                    f"Git package {self.name} revision '{exact_revision}' does not satisfy "
+                    f"revision_range {self.revision_ranges}."
+                )
+            return GitPinnedPackage(
+                git=self.git,
+                git_unrendered=self.git_unrendered,
+                revision=exact_revision,
+                warn_unpinned=self.warn_unpinned,
+                subdirectory=self.subdirectory,
+            )
+
+        if self.revision_ranges:
+            revision = self._resolve_revision_range()
+        elif len(requested) == 0:
+            revision = "HEAD"
+        else:
+            revision = requested.pop()
+
         return GitPinnedPackage(
             git=self.git,
             git_unrendered=self.git_unrendered,
-            revision=requested.pop(),
+            revision=revision,
             warn_unpinned=self.warn_unpinned,
             subdirectory=self.subdirectory,
         )

--- a/tests/unit/config/test_project.py
+++ b/tests/unit/config/test_project.py
@@ -22,6 +22,7 @@ from dbt.flags import set_from_args
 from dbt.jsonschemas.jsonschemas import project_schema
 from dbt.node_types import NodeType
 from dbt.tests.util import safe_set_invocation_context
+from dbt_common.dataclass_schema import ValidationError
 from dbt_common.events.event_catcher import EventCatcher
 from dbt_common.events.event_manager_client import get_event_manager
 from dbt_common.events.types import Note
@@ -275,6 +276,47 @@ class TestProjectInitialization(BaseConfigTest):
         )
         str(project)  # this does the equivalent of project.to_project_config(with_packages=True)
         json.dumps(project.to_project_config())
+
+    def test_git_package_revision_range(self):
+        packages = {
+            "packages": [
+                {
+                    "git": "git@example.com:dbt-labs/dbt-utils.git",
+                    "revision": [">=v0.0.1", "<v1.1.0"],
+                }
+            ]
+        }
+        project = project_from_config_norender(
+            self.default_project_data, project_root=self.project_dir, packages=packages
+        )
+        self.assertEqual(
+            project.packages,
+            PackageConfig(
+                packages=[
+                    GitPackage(
+                        git="git@example.com:dbt-labs/dbt-utils.git",
+                        revision=[">=v0.0.1", "<v1.1.0"],
+                        unrendered={
+                            "git": "git@example.com:dbt-labs/dbt-utils.git",
+                            "revision": [">=v0.0.1", "<v1.1.0"],
+                        },
+                    )
+                ]
+            ),
+        )
+
+    def test_invalid_git_package_revision_and_revision_range(self):
+        packages = {
+            "packages": [
+                {
+                    "git": "git@example.com:dbt-labs/dbt-utils.git",
+                    "revision": "0.0.1",
+                    "revision_range": [">=v0.0.1", "<v1.1.0"],
+                }
+            ]
+        }
+        with self.assertRaises(ValidationError):
+            PackageConfig.validate(packages)
 
     def test_string_run_hooks(self):
         self.default_project_data.update(

--- a/tests/unit/deps/test_deps.py
+++ b/tests/unit/deps/test_deps.py
@@ -200,6 +200,46 @@ class TestGitPackage(unittest.TestCase):
         a_pinned_dict = a_pinned.to_dict()
         self.assertEqual(a_pinned_dict, {"git": "http://example.com", "revision": "0.0.1"})
 
+    @mock.patch("dbt.deps.git.git.list_remote_tags")
+    def test_resolve_revision_range(self, mock_list_remote_tags):
+        mock_list_remote_tags.return_value = [
+            "v1.0.0",
+            "v1.0.1",
+            "v1.0.10",
+            "v1.0.11",
+            "v1.1.0",
+        ]
+
+        a_contract = GitPackage.from_dict(
+            {
+                "git": "http://example.com",
+                "revision": [">=v1.0.0", "<v1.1.0"],
+            }
+        )
+        a = GitUnpinnedPackage.from_contract(a_contract)
+
+        a_pinned = a.resolved()
+
+        self.assertEqual(a_pinned.revision, "v1.0.11")
+        self.assertEqual(a_pinned.name, "http://example.com")
+
+    @mock.patch("dbt.deps.git.git.list_remote_tags")
+    def test_resolve_revision_range_no_match(self, mock_list_remote_tags):
+        mock_list_remote_tags.return_value = ["v1.1.0"]
+
+        a_contract = GitPackage.from_dict(
+            {
+                "git": "http://example.com",
+                "revision": [">=v1.0.0", "<v1.1.0"],
+            }
+        )
+        a = GitUnpinnedPackage.from_contract(a_contract)
+
+        with self.assertRaises(dbt.exceptions.DependencyError) as exc:
+            a.resolved()
+
+        self.assertIn("Could not find a matching semantic tag", str(exc.exception))
+
     def test_init_with_unrendered(self):
         contract = GitPackage(
             git="http://example.com", revision="0.0.1", unrendered={"git": "git_unrendered"}


### PR DESCRIPTION
Resolves N/A

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

Git packages only accept a fixed version (or no version at all), but not a range like packages from dbt hub do. This mainly becomes a problem with cross package dependencies. 

Example:
We work with quite a number of internal packages as we need to deploy the same transformations across multiple data platforms.  Some for sources, 1 for a standard data model and then ideally multiple for use cases. Kinda like this diagram:
```mermaid
flowchart TD
  subgraph Project1[Office 1 Project]
    S1[Source A]
    S6[Source D]
    SP1[Source A Package]
    DM1[Standard Data Model Package]
    UC1[Use Case 1 Package]
    S1 --> SP1 --> DM1 --> UC1
    S6 --> DM1
  end

  subgraph Project2[Office 2 Project]
    S2[Source A]
    S3[Source B]
    SP2[Source A Package]
    SP3[Source B Package]
    DM2[Standard Data Model Package]
    UC2[Use Case 2 Package]
    UC1_2[Use Case 1 Package]
    S2 --> SP2 --> DM2 --> UC2
    S3 --> SP3 --> DM2
    DM2 --> UC1_2
  end

  subgraph Project3[Office 3 Project]
    S4[Source B]
    S5[Source C]
    SP4[Source B Package]
    SP5[Source C Package]
    DM3[Standard Data Model Package]
    UC3[Use Case 3 Package]
    S4 --> SP4 --> DM3 --> UC3
    S5 --> SP5 --> DM3
  end
```

Now, the use case packages would have a dependency on the standard data model, but with the current pinned version limitation this is not possible. If we do this now, we would lock versions between the package. 

Example scenario:
* Current version of Standard Data Model is 1.0.0
* Both Use Case 1 and Use Case 2 have this a dependency. 
* And Office 2 has all this installed and running.
* Now we update the Standard Data Model to 1.0.1
* We cannot update this in Office 2, as we then get a conflict with the Use Case packages.
* We would need to update both packages, before we then can update all 3 at once. 
With 3 moving parts, this is doable but annoying (we need to maintain 25 offices). But if this grows, this becomes unworkable.

Being able to give a range in the use cases, eg "This Use Case version works with Standard Data model version 1.2.0 and higher", would enable us to do our work way more structured. 

### Solution

The proposed solution adds support for ranges for private packages. It will work on proper semantic versioning, either with the v prefix (eg v1.7.223) or without (23.4.2).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
