### PR TITLE
Drop dbt-semantic-interfaces, migrate to metricflow-semantic-interfaces

### DIFF
--- a/.changes/unreleased/Dependencies-20260430-162835.yaml
+++ b/.changes/unreleased/Dependencies-20260430-162835.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Begin depending on MetricFlow instead of dbt-semantic-interfaces
+time: 2026-04-30T16:28:35.97023-05:00
+custom:
+  Author: QMalcolm
+  Issue: "12893"

--- a/core/dbt/artifacts/resources/v1/components.py
+++ b/core/dbt/artifacts/resources/v1/components.py
@@ -3,6 +3,12 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any, Dict, List, Optional, Union
 
+from metricflow_semantic_interfaces.type_enums import (
+    DimensionType,
+    EntityType,
+    TimeGranularity,
+)
+
 from dbt.artifacts.resources.base import Docs, FileHash, GraphResource
 from dbt.artifacts.resources.types import NodeType, TimePeriod
 from dbt.artifacts.resources.v1.config import NodeConfig
@@ -11,11 +17,6 @@ from dbt_common.contracts.config.properties import AdditionalPropertiesMixin
 from dbt_common.contracts.constraints import ColumnLevelConstraint
 from dbt_common.contracts.util import Mergeable
 from dbt_common.dataclass_schema import ExtensibleDbtClassMixin, dbtClassMixin
-from dbt_semantic_interfaces.type_enums import (
-    DimensionType,
-    EntityType,
-    TimeGranularity,
-)
 
 NodeVersion = Union[str, float]
 

--- a/core/dbt/artifacts/resources/v1/metric.py
+++ b/core/dbt/artifacts/resources/v1/metric.py
@@ -2,6 +2,15 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Literal, Optional
 
+from metricflow_semantic_interfaces.references import MeasureReference, MetricReference
+from metricflow_semantic_interfaces.type_enums import (
+    AggregationType,
+    ConversionCalculationType,
+    MetricType,
+    PeriodAggregation,
+    TimeGranularity,
+)
+
 from dbt.artifacts.resources.base import GraphResource
 from dbt.artifacts.resources.types import NodeType
 from dbt.artifacts.resources.v1.components import DependsOn, RefArgs
@@ -13,21 +22,13 @@ from dbt.artifacts.resources.v1.semantic_layer_components import (
 )
 from dbt_common.contracts.config.base import BaseConfig, CompareBehavior, MergeBehavior
 from dbt_common.dataclass_schema import dbtClassMixin
-from dbt_semantic_interfaces.references import MeasureReference, MetricReference
-from dbt_semantic_interfaces.type_enums import (
-    AggregationType,
-    ConversionCalculationType,
-    MetricType,
-    PeriodAggregation,
-    TimeGranularity,
-)
 
 """
 The following classes are dataclasses which are used to construct the Metric
 node in dbt-core. Additionally, these classes need to at a minimum support
 what is specified in their protocol definitions in dbt-semantic-interfaces.
 Their protocol definitions can be found here:
-https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/dbt_semantic_interfaces/protocols/metric.py
+https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/metricflow_semantic_interfaces/protocols/metric.py
 """
 
 

--- a/core/dbt/artifacts/resources/v1/saved_query.py
+++ b/core/dbt/artifacts/resources/v1/saved_query.py
@@ -4,6 +4,10 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Literal, Optional, Union
 
+from metricflow_semantic_interfaces.type_enums.export_destination_type import (
+    ExportDestinationType,
+)
+
 from dbt.artifacts.resources.base import GraphResource
 from dbt.artifacts.resources.types import NodeType
 from dbt.artifacts.resources.v1.components import DependsOn, RefArgs
@@ -15,9 +19,6 @@ from dbt.artifacts.resources.v1.semantic_layer_components import (
 from dbt_common.contracts.config.base import BaseConfig, CompareBehavior, MergeBehavior
 from dbt_common.contracts.config.metadata import ShowBehavior
 from dbt_common.dataclass_schema import dbtClassMixin
-from dbt_semantic_interfaces.type_enums.export_destination_type import (
-    ExportDestinationType,
-)
 
 
 @dataclass

--- a/core/dbt/artifacts/resources/v1/semantic_layer_components.py
+++ b/core/dbt/artifacts/resources/v1/semantic_layer_components.py
@@ -1,13 +1,14 @@
 from dataclasses import dataclass
 from typing import List, Optional, Sequence, Tuple
 
-from dbt_common.dataclass_schema import dbtClassMixin
-from dbt_semantic_interfaces.call_parameter_sets import JinjaCallParameterSets
-from dbt_semantic_interfaces.parsing.where_filter.jinja_object_parser import (
+from metricflow_semantic_interfaces.call_parameter_sets import JinjaCallParameterSets
+from metricflow_semantic_interfaces.parsing.where_filter.jinja_object_parser import (
     JinjaObjectParser,
     QueryItemLocation,
 )
-from dbt_semantic_interfaces.type_enums import AggregationType
+from metricflow_semantic_interfaces.type_enums import AggregationType
+
+from dbt_common.dataclass_schema import dbtClassMixin
 
 
 @dataclass

--- a/core/dbt/artifacts/resources/v1/semantic_model.py
+++ b/core/dbt/artifacts/resources/v1/semantic_model.py
@@ -2,6 +2,22 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Sequence
 
+from metricflow_semantic_interfaces.references import (
+    DimensionReference,
+    EntityReference,
+    LinkableElementReference,
+    MeasureReference,
+    SemanticModelReference,
+    TimeDimensionReference,
+)
+from metricflow_semantic_interfaces.type_enums import (
+    AggregationType,
+    DimensionType,
+    EntityType,
+    MetricType,
+    TimeGranularity,
+)
+
 from dbt.artifacts.resources import SourceFileMetadata
 from dbt.artifacts.resources.base import GraphResource
 from dbt.artifacts.resources.v1.components import DependsOn, RefArgs
@@ -12,28 +28,13 @@ from dbt.artifacts.resources.v1.semantic_layer_components import (
 )
 from dbt_common.contracts.config.base import BaseConfig, CompareBehavior, MergeBehavior
 from dbt_common.dataclass_schema import dbtClassMixin
-from dbt_semantic_interfaces.references import (
-    DimensionReference,
-    EntityReference,
-    LinkableElementReference,
-    MeasureReference,
-    SemanticModelReference,
-    TimeDimensionReference,
-)
-from dbt_semantic_interfaces.type_enums import (
-    AggregationType,
-    DimensionType,
-    EntityType,
-    MetricType,
-    TimeGranularity,
-)
 
 """
 The classes in this file are dataclasses which are used to construct the Semantic
 Model node in dbt-core. Additionally, these classes need to at a minimum support
 what is specified in their protocol definitions in dbt-semantic-interfaces.
 Their protocol definitions can be found here:
-https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/dbt_semantic_interfaces/protocols/semantic_model.py
+https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/metricflow_semantic_interfaces/protocols/semantic_model.py
 """
 
 
@@ -60,7 +61,7 @@ class NodeRelation(dbtClassMixin):
 
 # ====================================
 # Dimension objects
-# Dimension protocols: https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/dbt_semantic_interfaces/protocols/dimension.py
+# Dimension protocols: https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/metricflow_semantic_interfaces/protocols/dimension.py
 # ====================================
 
 
@@ -109,7 +110,7 @@ class Dimension(dbtClassMixin):
 
 # ====================================
 # Entity objects
-# Entity protocols: https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/dbt_semantic_interfaces/protocols/entity.py
+# Entity protocols: https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/metricflow_semantic_interfaces/protocols/entity.py
 # ====================================
 
 
@@ -134,7 +135,7 @@ class Entity(dbtClassMixin):
 
 # ====================================
 # Measure object
-# Measure protocols: https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/dbt_semantic_interfaces/protocols/measure.py
+# Measure protocols: https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/metricflow_semantic_interfaces/protocols/measure.py
 # ====================================
 
 

--- a/core/dbt/artifacts/resources/v1/semantic_model.py
+++ b/core/dbt/artifacts/resources/v1/semantic_model.py
@@ -32,9 +32,9 @@ from dbt_common.dataclass_schema import dbtClassMixin
 """
 The classes in this file are dataclasses which are used to construct the Semantic
 Model node in dbt-core. Additionally, these classes need to at a minimum support
-what is specified in their protocol definitions in dbt-semantic-interfaces.
+what is specified in their protocol definitions in metricflow-semantic-interfaces.
 Their protocol definitions can be found here:
-https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/metricflow_semantic_interfaces/protocols/semantic_model.py
+https://github.com/dbt-labs/metricflow/blob/main/metricflow_semantic_interfaces/protocols/semantic_model.py
 """
 
 
@@ -61,7 +61,7 @@ class NodeRelation(dbtClassMixin):
 
 # ====================================
 # Dimension objects
-# Dimension protocols: https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/metricflow_semantic_interfaces/protocols/dimension.py
+# Dimension protocols: https://github.com/dbt-labs/metricflow/blob/main/metricflow_semantic_interfaces/protocols/dimension.py
 # ====================================
 
 
@@ -110,7 +110,7 @@ class Dimension(dbtClassMixin):
 
 # ====================================
 # Entity objects
-# Entity protocols: https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/metricflow_semantic_interfaces/protocols/entity.py
+# Entity protocols: https://github.com/dbt-labs/metricflow/blob/main/metricflow_semantic_interfaces/protocols/entity.py
 # ====================================
 
 
@@ -135,7 +135,7 @@ class Entity(dbtClassMixin):
 
 # ====================================
 # Measure object
-# Measure protocols: https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/metricflow_semantic_interfaces/protocols/measure.py
+# Measure protocols: https://github.com/dbt-labs/metricflow/blob/main/metricflow_semantic_interfaces/protocols/measure.py
 # ====================================
 
 

--- a/core/dbt/constants.py
+++ b/core/dbt/constants.py
@@ -1,4 +1,4 @@
-from dbt_semantic_interfaces.type_enums import TimeGranularity
+from metricflow_semantic_interfaces.type_enums import TimeGranularity
 
 DEFAULT_ENV_PLACEHOLDER = "DBT_DEFAULT_PLACEHOLDER"
 

--- a/core/dbt/contracts/graph/metrics.py
+++ b/core/dbt/contracts/graph/metrics.py
@@ -1,7 +1,8 @@
 from typing import Any, Dict, Iterator, List
 
+from metricflow_semantic_interfaces.type_enums import MetricType
+
 from dbt.contracts.graph.manifest import Manifest, Metric
-from dbt_semantic_interfaces.type_enums import MetricType
 
 DERIVED_METRICS = [MetricType.DERIVED, MetricType.RATIO]
 BASE_METRICS = [MetricType.SIMPLE, MetricType.CUMULATIVE, MetricType.CONVERSION]

--- a/core/dbt/contracts/graph/semantic_manifest.py
+++ b/core/dbt/contracts/graph/semantic_manifest.py
@@ -1,5 +1,39 @@
 from typing import List, Optional, Set
 
+from metricflow_semantic_interfaces.implementations.metric import PydanticMetric
+from metricflow_semantic_interfaces.implementations.node_relation import (
+    PydanticNodeRelation,
+)
+from metricflow_semantic_interfaces.implementations.project_configuration import (
+    PydanticProjectConfiguration,
+)
+from metricflow_semantic_interfaces.implementations.saved_query import (
+    PydanticSavedQuery,
+)
+from metricflow_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
+from metricflow_semantic_interfaces.implementations.semantic_model import (
+    PydanticSemanticModel,
+)
+from metricflow_semantic_interfaces.implementations.time_spine import (
+    PydanticTimeSpine,
+    PydanticTimeSpineCustomGranularityColumn,
+    PydanticTimeSpinePrimaryColumn,
+)
+from metricflow_semantic_interfaces.implementations.time_spine_table_configuration import (
+    PydanticTimeSpineTableConfiguration as LegacyTimeSpine,
+)
+from metricflow_semantic_interfaces.type_enums import TimeGranularity
+from metricflow_semantic_interfaces.validations.semantic_manifest_validator import (
+    SemanticManifestValidator,
+)
+from metricflow_semantic_interfaces.validations.validator_helpers import (
+    FileContext,
+    ValidationError,
+    ValidationIssueContext,
+)
+
 from dbt import deprecations
 from dbt.constants import (
     LEGACY_TIME_SPINE_GRANULARITY,
@@ -14,33 +48,6 @@ from dbt.flags import get_flags
 from dbt_common.clients.system import write_file
 from dbt_common.events.base_types import EventLevel
 from dbt_common.events.functions import fire_event
-from dbt_semantic_interfaces.implementations.metric import PydanticMetric
-from dbt_semantic_interfaces.implementations.node_relation import PydanticNodeRelation
-from dbt_semantic_interfaces.implementations.project_configuration import (
-    PydanticProjectConfiguration,
-)
-from dbt_semantic_interfaces.implementations.saved_query import PydanticSavedQuery
-from dbt_semantic_interfaces.implementations.semantic_manifest import (
-    PydanticSemanticManifest,
-)
-from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
-from dbt_semantic_interfaces.implementations.time_spine import (
-    PydanticTimeSpine,
-    PydanticTimeSpineCustomGranularityColumn,
-    PydanticTimeSpinePrimaryColumn,
-)
-from dbt_semantic_interfaces.implementations.time_spine_table_configuration import (
-    PydanticTimeSpineTableConfiguration as LegacyTimeSpine,
-)
-from dbt_semantic_interfaces.type_enums import TimeGranularity
-from dbt_semantic_interfaces.validations.semantic_manifest_validator import (
-    SemanticManifestValidator,
-)
-from dbt_semantic_interfaces.validations.validator_helpers import (
-    FileContext,
-    ValidationError,
-    ValidationIssueContext,
-)
 
 
 class SemanticManifest:

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -5,6 +5,11 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Sequence, Union
 
+from metricflow_semantic_interfaces.type_enums import (
+    ConversionCalculationType,
+    DimensionType,
+    PeriodAggregation,
+)
 from typing_extensions import override
 
 # trigger the PathEncoder
@@ -47,11 +52,6 @@ from dbt_common.dataclass_schema import (
     dbtClassMixin,
 )
 from dbt_common.exceptions import DbtInternalError
-from dbt_semantic_interfaces.type_enums import (
-    ConversionCalculationType,
-    DimensionType,
-    PeriodAggregation,
-)
 
 
 @dataclass

--- a/core/dbt/parser/common.py
+++ b/core/dbt/parser/common.py
@@ -1,6 +1,12 @@
 from dataclasses import dataclass
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
 
+from metricflow_semantic_interfaces.type_enums import (
+    DimensionType,
+    EntityType,
+    TimeGranularity,
+)
+
 from dbt.artifacts.resources import (
     ColumnConfig,
     ColumnDimension,
@@ -29,11 +35,6 @@ from dbt.node_types import NodeType
 from dbt.parser.search import FileBlock
 from dbt_common.contracts.constraints import ColumnLevelConstraint, ConstraintType
 from dbt_common.exceptions import DbtInternalError
-from dbt_semantic_interfaces.type_enums import (
-    DimensionType,
-    EntityType,
-    TimeGranularity,
-)
 
 schema_file_keys_to_resource_types = {
     "models": NodeType.Model,

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -12,6 +12,8 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Typ
 import jinja2
 import msgpack
 from jinja2.nodes import Call, Const
+from metricflow_semantic_interfaces.enum_extension import assert_values_exhausted
+from metricflow_semantic_interfaces.type_enums import MetricType
 
 import dbt.deprecations
 import dbt.exceptions
@@ -138,8 +140,6 @@ from dbt_common.events.types import Note
 from dbt_common.exceptions.base import DbtValidationError
 from dbt_common.helper_types import PathSet
 from dbt_common.ui import error_tag
-from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
-from dbt_semantic_interfaces.type_enums import MetricType
 
 PERF_INFO_FILE_NAME = "perf_info.json"
 

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -1,6 +1,16 @@
 from collections.abc import Sequence
 from typing import Any, Dict, List, Optional, Union
 
+from metricflow_semantic_interfaces.type_enums import (
+    AggregationType,
+    ConversionCalculationType,
+    DimensionType,
+    EntityType,
+    MetricType,
+    PeriodAggregation,
+    TimeGranularity,
+)
+
 from dbt.artifacts.resources import (
     ColumnDimension,
     ColumnEntity,
@@ -83,15 +93,6 @@ from dbt.parser.common import YamlBlock
 from dbt.parser.schemas import ParseResult, SchemaParser, YamlReader
 from dbt_common.dataclass_schema import ValidationError
 from dbt_common.exceptions import DbtInternalError
-from dbt_semantic_interfaces.type_enums import (
-    AggregationType,
-    ConversionCalculationType,
-    DimensionType,
-    EntityType,
-    MetricType,
-    PeriodAggregation,
-    TimeGranularity,
-)
 
 
 def parse_where_filter(

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     # These are major-version-0 packages also maintained by dbt-labs.
     # Accept patches but avoid automatically updating past a set minor version range.
     "dbt-extractor>=0.5.0,<=0.6",
-    "dbt-semantic-interfaces>=0.10.2,<0.11",
+    "metricflow @ git+https://github.com/dbt-labs/metricflow@main",
     # Minor versions for these are expected to be backwards-compatible
     "dbt-common>=1.37.3,<2.0",
     "dbt-adapters>=1.22.8,<2.0",
@@ -76,6 +76,9 @@ Changelog = "https://github.com/dbt-labs/dbt-core/blob/main/CHANGELOG.md"
 
 [project.scripts]
 dbt = "dbt.cli.main:cli"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 path = "dbt/__version__.py"

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     # These are major-version-0 packages also maintained by dbt-labs.
     # Accept patches but avoid automatically updating past a set minor version range.
     "dbt-extractor>=0.5.0,<=0.6",
-    "metricflow @ git+https://github.com/dbt-labs/metricflow@main",
+    "metricflow>=0.210.0,<1.0",
     # Minor versions for these are expected to be backwards-compatible
     "dbt-common>=1.37.3,<2.0",
     "dbt-adapters>=1.22.8,<2.0",
@@ -76,9 +76,6 @@ Changelog = "https://github.com/dbt-labs/dbt-core/blob/main/CHANGELOG.md"
 
 [project.scripts]
 dbt = "dbt.cli.main:cli"
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.version]
 path = "dbt/__version__.py"

--- a/tests/functional/metrics/test_metrics.py
+++ b/tests/functional/metrics/test_metrics.py
@@ -1,12 +1,12 @@
 import pytest
+from metricflow_semantic_interfaces.type_enums.period_agg import PeriodAggregation
+from metricflow_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
 from dbt.artifacts.resources.v1.metric import CumulativeTypeParams, MetricTimeWindow
 from dbt.cli.main import dbtRunner
 from dbt.contracts.graph.manifest import Manifest
 from dbt.exceptions import ParsingError
 from dbt.tests.util import get_manifest, run_dbt
-from dbt_semantic_interfaces.type_enums.period_agg import PeriodAggregation
-from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from tests.functional.metrics.fixtures import (
     basic_metrics_yml,
     conversion_metric_yml,

--- a/tests/functional/saved_queries/test_configs.py
+++ b/tests/functional/saved_queries/test_configs.py
@@ -1,10 +1,10 @@
 import pytest
+from metricflow_semantic_interfaces.type_enums.export_destination_type import (
+    ExportDestinationType,
+)
 
 from dbt.contracts.graph.manifest import Manifest
 from dbt.tests.util import update_config_file
-from dbt_semantic_interfaces.type_enums.export_destination_type import (
-    ExportDestinationType,
-)
 from tests.functional.assertions.test_runner import dbtTestRunner
 from tests.functional.configs.fixtures import BaseConfigProject
 from tests.functional.saved_queries.fixtures import (

--- a/tests/functional/saved_queries/test_saved_query_parsing.py
+++ b/tests/functional/saved_queries/test_saved_query_parsing.py
@@ -4,13 +4,13 @@ from copy import deepcopy
 from typing import List
 
 import pytest
+from metricflow_semantic_interfaces.type_enums.export_destination_type import (
+    ExportDestinationType,
+)
 
 from dbt.contracts.graph.manifest import Manifest
 from dbt.tests.util import run_dbt, write_file
 from dbt_common.events.base_types import BaseEvent
-from dbt_semantic_interfaces.type_enums.export_destination_type import (
-    ExportDestinationType,
-)
 from tests.functional.assertions.test_runner import dbtTestRunner
 from tests.functional.saved_queries.fixtures import (
     saved_queries_with_defaults_yml,

--- a/tests/functional/semantic_models/test_semantic_model_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_parsing.py
@@ -1,17 +1,17 @@
 from typing import List
 
 import pytest
+from metricflow_semantic_interfaces.type_enums.conversion_calculation_type import (
+    ConversionCalculationType,
+)
+from metricflow_semantic_interfaces.type_enums.period_agg import PeriodAggregation
+from metricflow_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
 from dbt.artifacts.resources.v1.semantic_model import MetricType
 from dbt.contracts.graph.manifest import Manifest
 from dbt.exceptions import CompilationError
 from dbt.tests.util import run_dbt, write_file
 from dbt_common.events.base_types import BaseEvent
-from dbt_semantic_interfaces.type_enums.conversion_calculation_type import (
-    ConversionCalculationType,
-)
-from dbt_semantic_interfaces.type_enums.period_agg import PeriodAggregation
-from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from tests.functional.assertions.test_runner import dbtTestRunner
 from tests.functional.semantic_models.fixtures import (
     base_schema_yml,

--- a/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
@@ -1,8 +1,5 @@
 import pytest
-
-from core.dbt.contracts.graph.semantic_manifest import SemanticManifest
-from dbt.contracts.graph.manifest import Manifest
-from dbt_semantic_interfaces.type_enums import (
+from metricflow_semantic_interfaces.type_enums import (
     AggregationType,
     ConversionCalculationType,
     DimensionType,
@@ -10,6 +7,9 @@ from dbt_semantic_interfaces.type_enums import (
     MetricType,
     PeriodAggregation,
 )
+
+from core.dbt.contracts.graph.semantic_manifest import SemanticManifest
+from dbt.contracts.graph.manifest import Manifest
 from tests.functional.assertions.test_runner import dbtTestRunner
 from tests.functional.semantic_models.fixtures import (
     base_schema_yml_v2,

--- a/tests/functional/time_spines/test_time_spines.py
+++ b/tests/functional/time_spines/test_time_spines.py
@@ -1,13 +1,13 @@
 from typing import Set
 
 import pytest
+from metricflow_semantic_interfaces.type_enums import TimeGranularity
 
 from dbt.cli.main import dbtRunner
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.semantic_manifest import SemanticManifest
 from dbt.exceptions import ParsingError
 from dbt.tests.util import get_manifest
-from dbt_semantic_interfaces.type_enums import TimeGranularity
 from tests.functional.time_spines.fixtures import (
     metricflow_time_spine_second_sql,
     metricflow_time_spine_sql,

--- a/tests/unit/contracts/graph/test_manifest.py
+++ b/tests/unit/contracts/graph/test_manifest.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 import freezegun
 import pytest
+from metricflow_semantic_interfaces.type_enums import MetricType
 
 import dbt.version
 import dbt_common.invocation
@@ -42,7 +43,6 @@ from dbt.exceptions import AmbiguousResourceNameRefError, ParsingError
 from dbt.flags import set_from_args
 from dbt.node_types import NodeType
 from dbt_common.events.functions import reset_metadata_vars
-from dbt_semantic_interfaces.type_enums import MetricType
 from tests.unit.utils import (
     MockDocumentation,
     MockGenerateMacro,

--- a/tests/unit/contracts/graph/test_nodes_parsed.py
+++ b/tests/unit/contracts/graph/test_nodes_parsed.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 import pytest
 from hypothesis import given
 from hypothesis.strategies import builds, lists
+from metricflow_semantic_interfaces.type_enums import MetricType
 
 from dbt.artifacts.resources import (
     ColumnInfo,
@@ -53,7 +54,6 @@ from dbt.contracts.graph.nodes import (
 )
 from dbt.node_types import AccessType, NodeType
 from dbt_common.dataclass_schema import ValidationError
-from dbt_semantic_interfaces.type_enums import MetricType
 from tests.unit.utils import (
     ContractTestCase,
     assert_fails_validation,

--- a/tests/unit/contracts/graph/test_semantic_manifest.py
+++ b/tests/unit/contracts/graph/test_semantic_manifest.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
 
 import pytest
+from metricflow_semantic_interfaces.type_enums import TimeGranularity
+from metricflow_semantic_interfaces.type_enums.metric_type import MetricType
 
 from core.dbt.contracts.graph.manifest import Manifest
 from dbt.artifacts.resources.types import NodeType
@@ -24,8 +26,6 @@ from dbt.contracts.graph.semantic_manifest import SemanticManifest
 from dbt.events.types import TimeDimensionsRequireGranularityDeprecation
 from dbt_common.events.event_catcher import EventCatcher
 from dbt_common.events.event_manager_client import add_callback_to_manager
-from dbt_semantic_interfaces.type_enums import TimeGranularity
-from dbt_semantic_interfaces.type_enums.metric_type import MetricType
 
 
 # Overwrite the default nods to construct the manifest

--- a/tests/unit/contracts/graph/test_unparsed.py
+++ b/tests/unit/contracts/graph/test_unparsed.py
@@ -4,6 +4,9 @@ from datetime import timedelta
 from typing import Any, Dict
 
 import pytest
+from metricflow_semantic_interfaces.type_enums.conversion_calculation_type import (
+    ConversionCalculationType,
+)
 from typing_extensions import override
 
 from dbt.artifacts.resources import (
@@ -41,9 +44,6 @@ from dbt.contracts.graph.unparsed import (
 from dbt.exceptions import ParsingError
 from dbt.node_types import NodeType
 from dbt.parser.schemas import ParserRef
-from dbt_semantic_interfaces.type_enums.conversion_calculation_type import (
-    ConversionCalculationType,
-)
 from tests.unit.utils import ContractTestCase
 
 

--- a/tests/unit/graph/test_nodes.py
+++ b/tests/unit/graph/test_nodes.py
@@ -4,6 +4,16 @@ from typing import List
 
 import pytest
 from freezegun import freeze_time
+from metricflow_semantic_interfaces.references import (
+    MeasureReference,
+    TimeDimensionReference,
+)
+from metricflow_semantic_interfaces.type_enums import (
+    AggregationType,
+    DimensionType,
+    EntityType,
+    MetricType,
+)
 
 from dbt.artifacts.resources import (
     Defaults,
@@ -24,13 +34,6 @@ from dbt_common.contracts.constraints import (
     ColumnLevelConstraint,
     ConstraintType,
     ModelLevelConstraint,
-)
-from dbt_semantic_interfaces.references import MeasureReference, TimeDimensionReference
-from dbt_semantic_interfaces.type_enums import (
-    AggregationType,
-    DimensionType,
-    EntityType,
-    MetricType,
 )
 from tests.unit.fixtures import generic_test_node, model_node
 

--- a/tests/unit/parser/test_v2_column_semantic_parsing.py
+++ b/tests/unit/parser/test_v2_column_semantic_parsing.py
@@ -8,9 +8,10 @@ column name so that MetricFlow generates SQL against the correct warehouse colum
 
 from collections import OrderedDict
 
+from metricflow_semantic_interfaces.type_enums import DimensionType, EntityType
+
 from dbt.artifacts.resources import ColumnDimension, ColumnEntity, ColumnInfo
 from dbt.parser.schema_yaml_readers import SemanticModelParser
-from dbt_semantic_interfaces.type_enums import DimensionType, EntityType
 
 
 def _make_column(name, description="", dimension=None, entity=None, granularity=None, config=None):

--- a/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
+++ b/tests/unit/test_semantic_layer_nodes_satisfy_protocols.py
@@ -4,6 +4,23 @@ from typing import Protocol, runtime_checkable
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis.strategies import builds, none, text
+from metricflow_semantic_interfaces.protocols import WhereFilter as WhereFilterProtocol
+from metricflow_semantic_interfaces.protocols import dimension as DimensionProtocols
+from metricflow_semantic_interfaces.protocols import entity as EntityProtocols
+from metricflow_semantic_interfaces.protocols import measure as MeasureProtocols
+from metricflow_semantic_interfaces.protocols import metadata as MetadataProtocols
+from metricflow_semantic_interfaces.protocols import metric as MetricProtocols
+from metricflow_semantic_interfaces.protocols import saved_query as SavedQueryProtocols
+from metricflow_semantic_interfaces.protocols import (
+    semantic_model as SemanticModelProtocols,
+)
+from metricflow_semantic_interfaces.type_enums import (
+    AggregationType,
+    DimensionType,
+    EntityType,
+    MetricType,
+    TimeGranularity,
+)
 
 from dbt.artifacts.resources import (
     ConstantPropertyInput,
@@ -28,21 +45,6 @@ from dbt.artifacts.resources import (
 )
 from dbt.contracts.graph.nodes import Metric, SavedQuery, SemanticModel
 from dbt.node_types import NodeType
-from dbt_semantic_interfaces.protocols import WhereFilter as WhereFilterProtocol
-from dbt_semantic_interfaces.protocols import dimension as DimensionProtocols
-from dbt_semantic_interfaces.protocols import entity as EntityProtocols
-from dbt_semantic_interfaces.protocols import measure as MeasureProtocols
-from dbt_semantic_interfaces.protocols import metadata as MetadataProtocols
-from dbt_semantic_interfaces.protocols import metric as MetricProtocols
-from dbt_semantic_interfaces.protocols import saved_query as SavedQueryProtocols
-from dbt_semantic_interfaces.protocols import semantic_model as SemanticModelProtocols
-from dbt_semantic_interfaces.type_enums import (
-    AggregationType,
-    DimensionType,
-    EntityType,
-    MetricType,
-    TimeGranularity,
-)
 
 
 @runtime_checkable

--- a/tests/unit/utils/manifest.py
+++ b/tests/unit/utils/manifest.py
@@ -1,6 +1,12 @@
 from typing import Any, Dict, List
 
 import pytest
+from metricflow_semantic_interfaces.type_enums import (
+    AggregationType,
+    DimensionType,
+    MetricType,
+    TimeGranularity,
+)
 
 from dbt.artifacts.resources import (
     ExposureType,
@@ -50,12 +56,6 @@ from dbt.contracts.graph.nodes import (
 )
 from dbt.contracts.graph.unparsed import UnitTestInputFixture, UnitTestOutputFixture
 from dbt.node_types import NodeType
-from dbt_semantic_interfaces.type_enums import (
-    AggregationType,
-    DimensionType,
-    MetricType,
-    TimeGranularity,
-)
 
 
 def make_model(


### PR DESCRIPTION
## Summary

- Replaces `dbt-semantic-interfaces` with `metricflow-semantic-interfaces` (now distributed as part of the `metricflow` PyPI package) throughout the codebase
- Updates all import sites from `dbt_semantic_interfaces` to `metricflow_semantic_interfaces`
- Switches the `metricflow` dependency from a `git+https` reference to the published PyPI version (`>=0.210.0,<1.0`), and removes the now-unnecessary `allow-direct-references = true` hatch metadata setting

## Test plan

- [x] Run the semantic layer / metrics test suite to confirm no import errors
- [x] Verify `hatch env create` resolves cleanly against PyPI (no git source fetch)