### PR TITLE
Bump libpq-dev to 13.23-0+deb11u3

### DIFF
--- a/.changes/unreleased/Dependencies-20260506-120000.yaml
+++ b/.changes/unreleased/Dependencies-20260506-120000.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump libpq-dev in Docker image from 13.23-0+deb11u2 to 13.23-0+deb11u3 to fix build failure due to superseded package version
+time: 2026-05-06T12:00:00.000000-04:00
+custom:
+  Author: tauhid621
+  Issue: NA

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
     ca-certificates=20210119 \
-    libpq-dev=13.23-0+deb11u2 \
+    libpq-dev=13.23-0+deb11u3 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \


### PR DESCRIPTION
## Summary
- Bump `libpq-dev` in Docker image from `13.23-0+deb11u2` to `13.23-0+deb11u3`
- The previous version was superseded by a Debian bullseye security update and is no longer available in the apt repos, causing Docker builds to fail
- Follow-up to #12806

## Test plan
- [ ] Verify Docker image builds successfully with `docker build --target dbt-core docker/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)