### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260506-182341.yaml
+++ b/.changes/unreleased/Under the Hood-20260506-182341.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-05-06T18:23:41.50237338Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -11324,6 +11324,15 @@
             "null"
           ]
         },
+        "tests": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataTests"
+          }
+        },
         "v": {
           "$ref": "#/definitions/AnyValue"
         }


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`a98aa9789c73e5d54291de699b659b508e10e862`](https://github.com/dbt-labs/fs/commit/a98aa9789c73e5d54291de699b659b508e10e862)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/25452159322)