### PR TITLE
Remove `version` from starter project's dbt_project.yml

### DIFF
--- a/.changes/unreleased/Under the Hood-20260507-120000.yaml
+++ b/.changes/unreleased/Under the Hood-20260507-120000.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove `version` from the starter project's `dbt_project.yml` to avoid user confusion, since it has been optional since #7060.
+time: 2026-05-07T12:00:00.000000-04:00
+custom:
+  Author: dave-connors-3
+  Issue: "9011"

--- a/core/dbt/include/starter_project/dbt_project.yml
+++ b/core/dbt/include/starter_project/dbt_project.yml
@@ -3,7 +3,6 @@
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: '{project_name}'
-version: '1.0.0'
 
 # This setting configures which "profile" dbt uses for this project.
 profile: '{profile_name}'

--- a/tests/functional/init/test_init.py
+++ b/tests/functional/init/test_init.py
@@ -567,7 +567,6 @@ test:
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: '{project_name}'
-version: '1.0.0'
 
 # This setting configures which "profile" dbt uses for this project.
 profile: '{project_name}'
@@ -685,7 +684,6 @@ class TestInitProvidedProjectNameAndSkipProfileSetup(TestInitOutsideOfProjectBas
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: '{project_name}'
-version: '1.0.0'
 
 # This setting configures which "profile" dbt uses for this project.
 profile: '{project_name}'
@@ -781,7 +779,6 @@ class TestInitOutsideOfProjectWithSpecifiedProfile(TestInitOutsideOfProjectBase)
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: '{project_name}'
-version: '1.0.0'
 
 # This setting configures which "profile" dbt uses for this project.
 profile: 'test'


### PR DESCRIPTION
## resolves #9011

### Problem

The starter project's `dbt_project.yml` ships with `version: '1.0.0'`, but `version` (and `config-version`) have been optional since #7060. The line is unused and creates undue confusion for new users — they don't know what it's for, and bumping it has no effect.

(`config-version` was already removed from the starter project at some point; only `version` remained.)

### Solution

Remove the `version: '1.0.0'` line from `core/dbt/include/starter_project/dbt_project.yml`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes type annotations for new and modified functions.
