### PR TITLE
Add per-overload start/result log events for overloaded UDFs

### DIFF
--- a/.changes/unreleased/Features-20260508-161204.yaml
+++ b/.changes/unreleased/Features-20260508-161204.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add per-overload start and result log events for overloaded UDFs (LogStartOverload, LogOverloadResult)
+time: 2026-05-08T16:12:04.299545+05:30
+custom:
+    Author: aahel
+    Issue: "12250"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -2135,6 +2135,47 @@ class LogFunctionResult(DynamicLevel):
         )
 
 
+class LogStartOverload(InfoLevel):
+    def code(self) -> str:
+        return "Q048"
+
+    def message(self) -> str:
+        msg = f"START {self.description}"
+        formatted = format_fancy_output_line(
+            msg=msg,
+            status="RUN",
+            index=self.overload_index,
+            total=self.total_overloads,
+        )
+        return f"Overload {formatted}"
+
+
+class LogOverloadResult(DynamicLevel):
+    def code(self) -> str:
+        return "Q049"
+
+    def message(self) -> str:
+        if self.status == "error":
+            info = "ERROR creating"
+            status = red(self.status.upper())
+        elif self.status == "skipped":
+            info = "SKIP"
+            status = yellow(self.status.upper())
+        else:
+            info = "OK created"
+            status = green(self.status.upper())
+
+        msg = f"{info} {self.description}"
+        formatted = format_fancy_output_line(
+            msg=msg,
+            status=status,
+            index=self.overload_index,
+            total=self.total_overloads,
+            execution_time=self.execution_time,
+        )
+        return f"Overload {formatted}"
+
+
 # =======================================================
 # W - Node testing
 # =======================================================

--- a/core/dbt/task/function.py
+++ b/core/dbt/task/function.py
@@ -1,4 +1,5 @@
 import threading
+import time
 from dataclasses import replace
 from typing import Any, Dict
 
@@ -10,7 +11,12 @@ from dbt.clients.jinja import MacroGenerator
 from dbt.context.providers import generate_runtime_function_context
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.nodes import FunctionNode
-from dbt.events.types import LogFunctionResult, LogStartLine
+from dbt.events.types import (
+    LogFunctionResult,
+    LogOverloadResult,
+    LogStartLine,
+    LogStartOverload,
+)
 from dbt.task import group_lookup
 from dbt.task.compile import CompileRunner
 from dbt_common.clients.jinja import MacroProtocol
@@ -99,11 +105,35 @@ class FunctionRunner(CompileRunner[FunctionNode]):
         # earlier failures; the order in which overloads are created does not
         # affect database-side dispatch.
         overload_results = OverloadResults()
-        overload_errors: list[str] = []
-        for overload in compiled_node.overloads:
+        total_overloads = len(compiled_node.overloads)
+        group = group_lookup.get(compiled_node.unique_id)
+        for idx, overload in enumerate(compiled_node.overloads, start=1):
+            overload_desc = f"function {compiled_node.name} overload {overload.defined_in}"
+
             if overload.defined_in in already_successful:
                 overload_results.successful.append(overload.defined_in)
+                fire_event(
+                    LogOverloadResult(
+                        description=overload_desc,
+                        status="skipped",
+                        overload_index=idx,
+                        total_overloads=total_overloads,
+                        execution_time=0.0,
+                        node_info=self.node.node_info,
+                        group=group,
+                    ),
+                    level=EventLevel.INFO,
+                )
                 continue
+
+            fire_event(
+                LogStartOverload(
+                    description=overload_desc,
+                    overload_index=idx,
+                    total_overloads=total_overloads,
+                    node_info=self.node.node_info,
+                )
+            )
 
             overload_node = replace(
                 compiled_node,
@@ -112,12 +142,36 @@ class FunctionRunner(CompileRunner[FunctionNode]):
                 compiled_code=overload.compiled_body or "",
             )
             overload_ctx = generate_runtime_function_context(overload_node, self.config, manifest)
+            overload_started_at = time.time()
             try:
                 MacroGenerator(materialization_macro, context=overload_ctx)()
                 overload_results.successful.append(overload.defined_in)
+                fire_event(
+                    LogOverloadResult(
+                        description=overload_desc,
+                        status=str(RunStatus.Success),
+                        overload_index=idx,
+                        total_overloads=total_overloads,
+                        execution_time=time.time() - overload_started_at,
+                        node_info=self.node.node_info,
+                        group=group,
+                    ),
+                    level=EventLevel.INFO,
+                )
             except Exception as e:
                 overload_results.failed.append(overload.defined_in)
-                overload_errors.append(f"{overload.defined_in}: {e}")
+                fire_event(
+                    LogOverloadResult(
+                        description=f"{overload_desc}: {e}",
+                        status=str(RunStatus.Error),
+                        overload_index=idx,
+                        total_overloads=total_overloads,
+                        execution_time=time.time() - overload_started_at,
+                        node_info=self.node.node_info,
+                        group=group,
+                    ),
+                    level=EventLevel.ERROR,
+                )
 
         result = self.build_result(compiled_node, context)
         result.overload_results = overload_results
@@ -125,20 +179,6 @@ class FunctionRunner(CompileRunner[FunctionNode]):
         if overload_results.failed:
             result.status = RunStatus.PartialSuccess
             result.message = f"PARTIAL SUCCESS {compiled_node.name}"
-            # Surface the per-overload errors so users see what failed.
-            for err in overload_errors:
-                fire_event(
-                    LogFunctionResult(
-                        description=f"function {compiled_node.name} overload {err}",
-                        status=str(RunStatus.Error),
-                        index=self.node_index,
-                        total=self.num_nodes,
-                        execution_time=0.0,
-                        node_info=self.node.node_info,
-                        group=group_lookup.get(compiled_node.unique_id),
-                    ),
-                    level=EventLevel.ERROR,
-                )
 
         return result
 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     # Minor versions for these are expected to be backwards-compatible
     "dbt-common>=1.37.5,<2.0",
     "dbt-adapters>=1.22.8,<2.0",
-    "dbt-protos>=1.0.419,<2.0",
+    "dbt-protos>=1.0.491,<2.0",
     "pydantic<3",
     # ----
     # Expect compatibility with all new versions of these packages, so lower bounds only.

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -472,6 +472,14 @@ sample_values = [
         total=0,
         execution_time=0,
     ),
+    core_types.LogStartOverload(description="", overload_index=0, total_overloads=0),
+    core_types.LogOverloadResult(
+        description="",
+        status="",
+        overload_index=0,
+        total_overloads=0,
+        execution_time=0,
+    ),
     # W - Node testing ======================
     core_types.CatchableExceptionOnRun(exc=""),
     core_types.InternalErrorOnRun(build_path="", exc=""),


### PR DESCRIPTION
Resolves #12250

### Problem

When dbt creates an overloaded UDF (#12871), failure errors are surfaced via `LogFunctionResult` events but there are no per-overload start events and no per-overload success events. This is inconsistent with microbatch, which fires structured `LogStartBatch` / `LogBatchResult` events per batch. The result is that users can't see which overload is being attempted, only which ones failed — and even those are emitted as a post-hoc hack using the generic `LogFunctionResult` with a freeform description string.

### Solution

Replaces the ad-hoc failure logging with proper `LogStartOverload` (Q048) and `LogOverloadResult` (Q049) events, mirroring `LogStartBatch` (Q045) and `LogBatchResult` (Q046) from microbatch. `FunctionRunner.execute()` now fires:

- `LogStartOverload` before attempting each overload
- `LogOverloadResult` after each overload — `Success`, `Error`, or `skipped` status
  - `Error` results carry the underlying database error inline
  - `skipped` is fired on `dbt retry` for overloads that already succeeded on the previous attempt

Output now looks like:

```
1 of 2 START function overload_test.double_int [RUN]
Overload 1 of 2 START function double_int overload double_float [RUN]
Overload 1 of 2 OK created function double_int overload double_float [SUCCESS in 0.00s]
Overload 2 of 2 START function double_int overload double_text [RUN]
Overload 2 of 2 ERROR creating function double_int overload double_text: column "bad_col" does not exist [ERROR in 0.00s]
1 of 2 OK created function overload_test.double_int [PARTIAL SUCCESS in 0.04s]
```

### Implementation

- Bump `dbt-protos` dep to `>=1.0.491` (first release containing Q048/Q049 proto messages — see dbt-labs/proto#599)
- Add Python event wrappers in `core/dbt/events/types.py`
- Wire `fire_event` calls into `FunctionRunner.execute()`
- All proto changes are additive — no breaking changes to existing event consumers

### Manually tested

- Multi-overload build with one failing overload — both START events fire, success and error RESULT events surface correctly
- `dbt retry` after partial failure — previously-successful overloads emit `SKIP` events, only failed ones re-attempted

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.