### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260508-224552.yaml
+++ b/.changes/unreleased/Under the Hood-20260508-224552.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-05-08T22:45:52.492026372Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -470,6 +470,38 @@
         }
       ]
     },
+    "ComputeArg": {
+      "oneOf": [
+        {
+          "description": "Execute on the remote warehouse (Snowflake, BigQuery, etc.)",
+          "type": "string",
+          "enum": [
+            "remote"
+          ]
+        },
+        {
+          "description": "Run computations in-process",
+          "type": "string",
+          "enum": [
+            "inline"
+          ]
+        },
+        {
+          "description": "Run computations in a separate, ephemeral worker process",
+          "type": "string",
+          "enum": [
+            "sidecar"
+          ]
+        },
+        {
+          "description": "Run via the remote compute service (persistent workers/cluster).",
+          "type": "string",
+          "enum": [
+            "service"
+          ]
+        }
+      ]
+    },
     "DataLakeObjectCategory": {
       "description": "See `category` from https://developer.salesforce.com/docs/data/connectapi/references/spec?meta=postDataLakeObject",
       "type": "string",
@@ -1370,6 +1402,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "+compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "+copy_grants": {
@@ -2616,6 +2658,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "+compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "+concurrent_batches": {
@@ -4797,6 +4849,16 @@
             "null"
           ]
         },
+        "+compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "+copy_grants": {
           "anyOf": [
             {
@@ -6275,6 +6337,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "+compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "+copy_grants": {

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -640,6 +640,38 @@
         "unique"
       ]
     },
+    "ComputeArg": {
+      "oneOf": [
+        {
+          "description": "Execute on the remote warehouse (Snowflake, BigQuery, etc.)",
+          "type": "string",
+          "enum": [
+            "remote"
+          ]
+        },
+        {
+          "description": "Run computations in-process",
+          "type": "string",
+          "enum": [
+            "inline"
+          ]
+        },
+        {
+          "description": "Run computations in a separate, ephemeral worker process",
+          "type": "string",
+          "enum": [
+            "sidecar"
+          ]
+        },
+        {
+          "description": "Run via the remote compute service (persistent workers/cluster).",
+          "type": "string",
+          "enum": [
+            "service"
+          ]
+        }
+      ]
+    },
     "ConstantProperty": {
       "type": "object",
       "required": [
@@ -1061,6 +1093,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "copy_grants": {
@@ -4837,6 +4879,16 @@
             "null"
           ]
         },
+        "compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "concurrent_batches": {
           "anyOf": [
             {
@@ -8018,6 +8070,16 @@
             "null"
           ]
         },
+        "compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "copy_grants": {
           "anyOf": [
             {
@@ -10479,6 +10541,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "copy_grants": {


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`3ed2a9fa9fb61e0c08bc600fdee14b35f21f339a`](https://github.com/dbt-labs/fs/commit/3ed2a9fa9fb61e0c08bc600fdee14b35f21f339a)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/25582331525)