### PR TITLE
cli: add `dbt.cli.__main__` so `python -m dbt.cli` works (#11013)

### DIFF
--- a/.changes/unreleased/Under-the-Hood-20260509-150001.yaml
+++ b/.changes/unreleased/Under-the-Hood-20260509-150001.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add core/dbt/cli/__main__.py so `python -m dbt.cli` works
+time: 2026-05-09T15:00:00.000000+02:00
+custom:
+    Author: jbbqqf
+    Issue: "11013"

--- a/core/dbt/cli/__main__.py
+++ b/core/dbt/cli/__main__.py
@@ -1,0 +1,4 @@
+from dbt.cli.main import cli
+
+if __name__ == "__main__":
+    cli()

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -59,3 +59,12 @@ class TestCLI:
                 continue
             cmd = Command.from_str(command.name)
             command_args(cmd)
+
+    def test_dunder_main_module_importable(self):
+        # Regression test for dbt-labs/dbt-core#11013:
+        # `python -m dbt.cli` must work, which requires dbt/cli/__main__.py
+        # to exist and be importable.
+        import importlib
+
+        module = importlib.import_module("dbt.cli.__main__")
+        assert module.cli is cli


### PR DESCRIPTION
Resolves dbt-labs/dbt-core#11013

### Problem

`python -m dbt.cli` fails with `No module named dbt.cli.__main__; 'dbt.cli' is a package and cannot be directly executed`. The `if __name__ == "__main__": cli()` guard at `core/dbt/cli/main.py:872` is fine for direct script invocation, but Python's `-m PACKAGE` form looks specifically for `PACKAGE/__main__.py`, which the `dbt.cli` package never shipped (only `__init__.py`, see `core/dbt/cli/__init__.py:1`).

### Solution

- `core/dbt/cli/__main__.py`: new 4-line module that imports `cli` from `dbt.cli.main` and calls it under the `__main__` guard. Same pattern stdlib uses for `pip`, `venv`, `http.server`.
- `tests/unit/cli/test_main.py`: regression test `test_dunder_main_module_importable` that imports `dbt.cli.__main__` via `importlib` and asserts it re-exports the same `cli` object.

### Reproduce BEFORE/AFTER yourself (copy-paste)

A reviewer can verify this fix end-to-end by pasting the block below.

```bash
# --- one-time setup ---
git clone https://github.com/dbt-labs/dbt-core.git /tmp/dbt-repro && cd /tmp/dbt-repro
python -m venv .venv && source .venv/bin/activate
pip install -e './core[test]'

# --- BEFORE (origin/main) ---
git checkout origin/main && pip install -e './core[test]' --quiet
python -m dbt.cli --version 2>&1 | head -3
# Expected: "Error while finding module specification for 'dbt.cli'" / "No module named dbt.cli.__main__"

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/dbt-core.git feat/11013-add-cli-main-module
git checkout FETCH_HEAD && pip install -e './core[test]' --quiet
python -m dbt.cli --version 2>&1 | head -3
# Expected: prints "Core: 1.x.x …"
```

### What I ran locally

- `pytest tests/unit/cli/test_main.py` -> 5 passed (4 existing + 1 new).
- Manual smoke: `python -m dbt.cli --version`, `dbt --version` (console-script), `python core/dbt/cli/main.py --version` -> all exit 0.

### Risk / blast radius

Strictly additive. The new module is only loaded when someone explicitly invokes `python -m dbt.cli`, which currently always errors. No existing import path, console-script entrypoint, or test pulls it in implicitly.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against `dbt-labs/dbt-core`'s source; the reproducer block above is the same one used during development.*
