### PR TITLE
contracts: remove dead duplicate seed branch in ParsedNode._deserialize (#11040)

### DIFF
--- a/.changes/unreleased/Under-the-Hood-20260509-150002.yaml
+++ b/.changes/unreleased/Under-the-Hood-20260509-150002.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove unreachable duplicate `seed` branch in ParsedNode._deserialize
+time: 2026-05-09T15:00:00.000000+02:00
+custom:
+    Author: jbbqqf
+    Issue: "11040"

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -330,8 +330,6 @@ class ParsedNode(ParsedResource, NodeInfoMixin, ParsedNodeMandatory, Serializabl
                 return SingularTestNode.from_dict(dct)
         elif resource_type == "operation":
             return HookNode.from_dict(dct)
-        elif resource_type == "seed":
-            return SeedNode.from_dict(dct)
         elif resource_type == "snapshot":
             return SnapshotNode.from_dict(dct)
         else:

--- a/tests/unit/contracts/graph/test_nodes_parsed.py
+++ b/tests/unit/contracts/graph/test_nodes_parsed.py
@@ -47,6 +47,7 @@ from dbt.contracts.graph.nodes import (
     Macro,
     Metric,
     ModelNode,
+    ParsedNode,
     SeedNode,
     SemanticModel,
     SnapshotNode,
@@ -742,6 +743,15 @@ def test_seed_basic(basic_parsed_seed_dict, basic_parsed_seed_object, minimal_pa
 def test_seed_complex(complex_parsed_seed_dict, complex_parsed_seed_object):
     assert_symmetric(complex_parsed_seed_object, complex_parsed_seed_dict)
     assert complex_parsed_seed_object.get_materialization() == "seed"
+
+
+def test_parsed_node_deserialize_seed_returns_seed_node(basic_parsed_seed_dict):
+    # Regression test for dbt-labs/dbt-core#11040: ParsedNode._deserialize
+    # previously had two `elif resource_type == "seed":` branches; the second
+    # was unreachable. Ensure the single branch still produces a SeedNode.
+    node = ParsedNode._deserialize(basic_parsed_seed_dict)
+    assert isinstance(node, SeedNode)
+    assert node.resource_type == NodeType.Seed
 
 
 unchanged_seeds = [


### PR DESCRIPTION
Resolves dbt-labs/dbt-core#11040

### Problem

`ParsedNode._deserialize` in `core/dbt/contracts/graph/nodes.py` had two `elif resource_type == "seed":` branches in its dispatch chain. Python's `elif` short-circuits on the first match, so the second branch was unreachable dead code. The issue was labelled `tidy_first` by the maintainers.

### Solution

- `core/dbt/contracts/graph/nodes.py`: drop the duplicate (second) `elif resource_type == "seed":` branch. The first branch already dispatches to `SeedNode.from_dict(dct)`.
- `tests/unit/contracts/graph/test_nodes_parsed.py`: regression test `test_parsed_node_deserialize_seed_returns_seed_node` that calls `ParsedNode._deserialize` on a seed dict and asserts the result is a `SeedNode`. Pins the contract that the surviving branch covers.

### Reproduce BEFORE/AFTER yourself (copy-paste)

A reviewer can verify this fix end-to-end by pasting the block below.

```bash
# --- one-time setup ---
git clone https://github.com/dbt-labs/dbt-core.git /tmp/dbt-repro && cd /tmp/dbt-repro
python -m venv .venv && source .venv/bin/activate
pip install -e './core[test]'

git fetch https://github.com/jbbqqf/dbt-core.git feat/11040-dedupe-seed-deserialize-branch

# 1. The diff is purely subtractive (only deletions in nodes.py):
git diff origin/main..FETCH_HEAD -- core/dbt/contracts/graph/nodes.py

# 2. The new regression test passes on the fix:
git checkout FETCH_HEAD && pip install -e './core[test]' --quiet
pytest tests/unit/contracts/graph/test_nodes_parsed.py::test_parsed_node_deserialize_seed_returns_seed_node -v
# Expected: 1 passed — confirms ParsedNode._deserialize on a seed dict still returns SeedNode.
```

### What I ran locally

- `pytest tests/unit/contracts/graph/test_nodes_parsed.py` -> 114 passed (incl. new regression test).
- Existing `test_seed_basic` / `test_seed_complex` round-trip tests -> still green.

### Risk / blast radius

Zero. The deleted branch is unreachable: Python's `elif` chain short-circuits on the first match, and the first `seed` branch is identical to the second. No call site, no serialized artifact, and no manifest path can reach the deleted code.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against `dbt-labs/dbt-core`'s source; the reproducer block above is the same one used during development.*
