### PR TITLE
profiler: drop dead `enable` parameter (#5886)

### DIFF
--- a/.changes/unreleased/Under-the-Hood-20260509-150003.yaml
+++ b/.changes/unreleased/Under-the-Hood-20260509-150003.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Drop dead `enable` parameter from dbt.profiler.profiler
+time: 2026-05-09T15:00:00.000000+02:00
+custom:
+    Author: jbbqqf
+    Issue: "5886"

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -119,7 +119,7 @@ def preflight(func):
 
         # Profiling
         if flags.RECORD_TIMING_INFO:
-            ctx.with_resource(profiler(enable=True, outfile=flags.RECORD_TIMING_INFO))
+            ctx.with_resource(profiler(outfile=flags.RECORD_TIMING_INFO))
 
         # Adapter management
         ctx.with_resource(adapter_management())

--- a/core/dbt/profiler.py
+++ b/core/dbt/profiler.py
@@ -5,16 +5,13 @@ from typing import Any, Generator
 
 
 @contextmanager
-def profiler(enable: bool, outfile: str) -> Generator[Any, None, None]:
+def profiler(outfile: str) -> Generator[Any, None, None]:
+    profiler = Profile()
+    profiler.enable()
     try:
-        if enable:
-            profiler = Profile()
-            profiler.enable()
-
         yield
     finally:
-        if enable:
-            profiler.disable()
-            stats = Stats(profiler)
-            stats.sort_stats("tottime")
-            stats.dump_stats(str(outfile))
+        profiler.disable()
+        stats = Stats(profiler)
+        stats.sort_stats("tottime")
+        stats.dump_stats(str(outfile))

--- a/tests/unit/test_profiler.py
+++ b/tests/unit/test_profiler.py
@@ -1,0 +1,23 @@
+import os
+import tempfile
+
+from dbt.profiler import profiler
+
+
+def test_profiler_writes_stats_file():
+    """profiler() context manager should always profile and dump stats."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        outfile = os.path.join(tmpdir, "stats.prof")
+        with profiler(outfile=outfile):
+            # do a tiny bit of work to populate stats
+            sum(range(1000))
+        assert os.path.isfile(outfile)
+        assert os.path.getsize(outfile) > 0
+
+
+def test_profiler_accepts_positional_outfile():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        outfile = os.path.join(tmpdir, "stats.prof")
+        with profiler(outfile):
+            pass
+        assert os.path.isfile(outfile)


### PR DESCRIPTION
Resolves dbt-labs/dbt-core#5886

### Problem

`dbt.profiler.profiler` takes an `enable: bool` parameter and wraps its entry/exit logic in `if enable:` guards. The single caller at `core/dbt/cli/requires.py:122` always passes `enable=True`, and the call itself sits inside an `if flags.RECORD_TIMING_INFO:` branch — so the inner guards are unreachable when `enable=False` and redundant when `enable=True`. The maintainers labelled this `good_first_issue`.

### Solution

- `core/dbt/profiler.py`: drop the `enable: bool` parameter and the two `if enable:` branches. The body of the context manager is now unconditional: enable, yield, disable, dump stats.
- `core/dbt/cli/requires.py`: drop `enable=True` from the single call site.
- `tests/unit/test_profiler.py`: new minimal unit test covering the refactored signature (keyword and positional `outfile` forms both produce a non-empty stats file).

### Reproduce BEFORE/AFTER yourself (copy-paste)

A reviewer can verify this fix end-to-end by pasting the block below.

```bash
# --- one-time setup ---
git clone https://github.com/dbt-labs/dbt-core.git /tmp/dbt-repro && cd /tmp/dbt-repro
python -m venv .venv && source .venv/bin/activate
pip install -e './core[test]'

git fetch https://github.com/jbbqqf/dbt-core.git feat/5886-drop-dead-profiler-enable

# 1. Diff: enable= argument and conditional removed from profiler.py; caller in cli/requires.py no longer passes enable=True.
git diff origin/main..FETCH_HEAD -- core/dbt/profiler.py core/dbt/cli/requires.py

# 2. New regression tests pass on the fix:
git checkout FETCH_HEAD && pip install -e './core[test]' --quiet
pytest tests/unit/test_profiler.py -v
# Expected: 2 passed (keyword + positional outfile both work).
```

### What I ran locally

- `pytest tests/unit/test_profiler.py` -> 2 passed.
- `from dbt.cli.requires import preflight` imports cleanly.
- `rg "profiler\(" core/` confirms a single call site.

### Risk / blast radius

Minimal. `profiler` is only called from one site in the codebase and prior behavior with `enable=True` is preserved bit-for-bit. The public function signature does change (drops a parameter), so any out-of-tree caller passing `enable=...` would need to drop the kwarg. `dbt.profiler` is an internal utility, not part of the documented public API.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against `dbt-labs/dbt-core`'s source; the reproducer block above is the same one used during development.*
