### PR TITLE
utils: remove dead add_ephemeral_model_prefix helper (#10471)

### DIFF
--- a/.changes/unreleased/Under-the-Hood-20260509-150004.yaml
+++ b/.changes/unreleased/Under-the-Hood-20260509-150004.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove unused add_ephemeral_model_prefix helper
+time: 2026-05-09T15:00:00.000000+02:00
+custom:
+    Author: jbbqqf
+    Issue: "10471"

--- a/core/dbt/utils/utils.py
+++ b/core/dbt/utils/utils.py
@@ -137,10 +137,6 @@ class memoized:
         return functools.partial(self.__call__, obj)
 
 
-def add_ephemeral_model_prefix(s: str) -> str:
-    return "__dbt__cte__{}".format(s)
-
-
 def timestring() -> str:
     """Get the current datetime as an RFC 3339-compliant string"""
     # isoformat doesn't include the mandatory trailing 'Z' for UTC.


### PR DESCRIPTION
Resolves dbt-labs/dbt-core#10471

### Problem

`add_ephemeral_model_prefix(s)` in `core/dbt/utils/utils.py:140` has zero callers across the repo — the only occurrence is the definition itself. The literal `__dbt__cte__` prefix it would produce is generated inline at the few sites that need it (`core/dbt/compilation.py`, lines 851/855/866-867, all in docstring examples — not runtime calls into this helper). The maintainer-filed tech-debt ticket asked to remove it.

### Solution

- `core/dbt/utils/utils.py`: delete the 2-line `add_ephemeral_model_prefix` function. No `__all__` to update; `core/dbt/utils/__init__.py` re-exports via `from .utils import *`, so the symbol simply disappears from the public surface.

### Reproduce BEFORE/AFTER yourself (copy-paste)

A reviewer can verify this fix end-to-end by pasting the block below.

```bash
# --- one-time setup ---
git clone https://github.com/dbt-labs/dbt-core.git /tmp/dbt-repro && cd /tmp/dbt-repro
python -m venv .venv && source .venv/bin/activate
pip install -e './core[test]'

git fetch https://github.com/jbbqqf/dbt-core.git feat/10471-remove-dead-add-ephemeral-model-prefix

# --- BEFORE: function exists, has zero callers ---
git checkout origin/main
grep -rn "add_ephemeral_model_prefix" core/ tests/
# Expected: exactly 1 match — the definition in core/dbt/utils/utils.py.

# --- AFTER: definition is gone, still zero references ---
git checkout FETCH_HEAD
grep -rn "add_ephemeral_model_prefix" core/ tests/ || echo "0 matches (expected)"
# Expected: "0 matches (expected)" — confirms it was unused.
```

### What I ran locally

- `pytest tests/unit/` -> 1668 passed, 8 skipped.
- `pytest tests/unit/test_compilation.py` -> 19 passed (the codepath that emits `__dbt__cte__*`).
- `python -c "from dbt.utils import utils; assert not hasattr(utils, 'add_ephemeral_model_prefix')"` -> exits 0.

### Risk / blast radius

Minimal. The helper had zero call sites; removing it cannot change runtime behavior. The only theoretical risk would be an external package importing `dbt.utils.utils.add_ephemeral_model_prefix` directly — the function is undocumented, has no public-API marker, and is trivially reproduced as a one-liner if needed.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against `dbt-labs/dbt-core`'s source; the reproducer block above is the same one used during development.*
