### PR TITLE
exceptions: stop hardcoding "model" in ambiguous-relation error (#12629)

### DIFF
--- a/.changes/unreleased/Fixes-20260509-150006.yaml
+++ b/.changes/unreleased/Fixes-20260509-150006.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Stop hardcoding "model" in the ambiguous-relation error; derive the resource type from the node's unique_id
+time: 2026-05-09T15:00:00.000000+02:00
+custom:
+    Author: jbbqqf
+    Issue: "12629"

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -1214,9 +1214,14 @@ class AmbiguousCatalogMatchError(CompilationError):
         return f"{match_schema}.{match_name}"
 
     def get_message(self) -> str:
+        # The unique_id prefix encodes the resource type (e.g. "source", "seed",
+        # "snapshot", "model"). Use it instead of hardcoding "model", which is
+        # misleading when the offending node is a source/seed/snapshot.
+        # See: https://github.com/dbt-labs/dbt-core/issues/12629
+        resource_type = self.unique_id.split(".")[0] if "." in self.unique_id else "node"
         msg = (
             "dbt found two relations in your warehouse with similar database identifiers. "
-            "dbt\nis unable to determine which of these relations was created by the model "
+            f"dbt\nis unable to determine which of these relations was created by the {resource_type} "
             f'"{self.unique_id}".\nIn order for dbt to correctly generate the catalog, one '
             "of the following relations must be deleted or renamed:\n\n - "
             f"{self.get_match_string(self.match_1)}\n - {self.get_match_string(self.match_2)}"

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,0 +1,66 @@
+"""Unit tests for exception classes in dbt.exceptions.
+
+These cover user-facing message rendering — small enough that we want them
+fast and adapter-free.
+"""
+import pytest
+
+from dbt.exceptions import AmbiguousCatalogMatchError
+
+
+def _make_match(schema: str, name: str) -> dict:
+    return {"metadata": {"schema": schema, "name": name}}
+
+
+class TestAmbiguousCatalogMatchError:
+    """Regression coverage for issue #12629.
+
+    The error fires for any node type whose alias collides — sources, seeds,
+    snapshots, models. The original wording hardcoded "model" which was
+    misleading when the node was, e.g., a source.
+    """
+
+    def test_message_uses_source_label_for_source_unique_id(self):
+        err = AmbiguousCatalogMatchError(
+            unique_id="source.dbt_pipeline.raw_dcrm.subject",
+            match_1=_make_match("raw_dcrm", "subject"),
+            match_2=_make_match("raw_dcrm_other", "subject"),
+        )
+        msg = str(err)
+        # Must NOT mislead the user by calling a source a "model".
+        assert "created by the model" not in msg
+        # Should call out the actual resource type.
+        assert "created by the source" in msg
+        assert "source.dbt_pipeline.raw_dcrm.subject" in msg
+
+    def test_message_uses_seed_label_for_seed_unique_id(self):
+        err = AmbiguousCatalogMatchError(
+            unique_id="seed.proj.my_seed",
+            match_1=_make_match("public", "my_seed"),
+            match_2=_make_match("staging", "my_seed"),
+        )
+        msg = str(err)
+        assert "created by the seed" in msg
+        assert "created by the model" not in msg
+
+    def test_message_keeps_model_label_for_model_unique_id(self):
+        err = AmbiguousCatalogMatchError(
+            unique_id="model.proj.my_model",
+            match_1=_make_match("public", "my_model"),
+            match_2=_make_match("staging", "my_model"),
+        )
+        msg = str(err)
+        assert "created by the model" in msg
+
+    def test_message_falls_back_to_node_when_unique_id_lacks_prefix(self):
+        err = AmbiguousCatalogMatchError(
+            unique_id="bare_id_no_prefix",
+            match_1=_make_match("public", "x"),
+            match_2=_make_match("staging", "x"),
+        )
+        msg = str(err)
+        assert "created by the node" in msg
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Resolves dbt-labs/dbt-core#12629

### Problem

`AmbiguousCatalogMatchError.get_message` in `core/dbt/exceptions.py` hardcoded the resource type as "model" in its user-facing message ("…was created by the model …"), even though the same exception is raised for sources, seeds, snapshots, etc. The reporter hit this with `unique_id="source.dbt_pipeline.raw_dcrm.subject"` and saw misleading "model" wording. `unique_id` already encodes the resource type as its first dotted segment — the prefix-parsing idiom is used elsewhere in the codebase (`core/dbt/parser/schemas.py:845`, `core/dbt/artifacts/schemas/upgrades/upgrade_manifest.py:120`).

### Solution

- `core/dbt/exceptions.py`: in `AmbiguousCatalogMatchError.get_message`, derive `resource_type` from `self.unique_id.split(".")[0]`; fall back to `"node"` if the unique_id has no dotted prefix. The rest of the message is unchanged.
- `tests/unit/test_exceptions.py`: new file. Four cases covering source / seed / model / no-prefix unique_ids and asserting the message no longer says "model" when the node is a source.

### Reproduce BEFORE/AFTER yourself (copy-paste)

A reviewer can verify this fix end-to-end by pasting the block below.

```bash
# --- one-time setup ---
git clone https://github.com/dbt-labs/dbt-core.git /tmp/dbt-repro && cd /tmp/dbt-repro
python -m venv .venv && source .venv/bin/activate
pip install -e './core[test]'

git fetch https://github.com/jbbqqf/dbt-core.git feat/12629-generic-resource-error-wording

# --- BEFORE: borrow the AFTER branch's regression test, run it on origin/main → fails ---
git checkout origin/main && pip install -e './core[test]' --quiet
git checkout feat/12629-generic-resource-error-wording -- tests/unit/test_exceptions.py
pytest tests/unit/test_exceptions.py -v 2>&1 | tail -25
# Expected: failures on the source / seed / no-prefix cases — message hardcodes "created by the model".

# --- AFTER: same test passes on the fix ---
git checkout feat/12629-generic-resource-error-wording && pip install -e './core[test]' --quiet
pytest tests/unit/test_exceptions.py -v 2>&1 | tail -25
# Expected: 4/4 passed — message is now resource-type-aware (source/seed/model/no-prefix).
```

### What I ran locally

- `pytest tests/unit/test_exceptions.py` -> 4 passed (source / seed / model / no-prefix).

### Risk / blast radius

User-facing message change. Any tooling that grepped for the literal substring `"was created by the model"` to detect this specific failure mode will still match for model nodes (unchanged) but stop matching for source/seed/snapshot nodes. Such tooling was previously fragile because the message was already misleading for those node types — this is a strict improvement. No control-flow changes; no new code paths.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against `dbt-labs/dbt-core`'s source; the reproducer block above is the same one used during development.*
