### PR TITLE
context: add `indent` kwarg to tojson and toyaml (#11210)

### DIFF
--- a/.changes/unreleased/Features-20260509-120000.yaml
+++ b/.changes/unreleased/Features-20260509-120000.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add `indent` kwarg to `tojson` and `toyaml` Jinja context methods to allow pretty-printed structured output
+time: 2026-05-09T12:00:00.000000-05:00
+custom:
+  Author: jbbqqf
+  Issue: "11210"

--- a/.changes/unreleased/Features-20260509-150010.yaml
+++ b/.changes/unreleased/Features-20260509-150010.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add an `indent` kwarg to the `tojson` and `toyaml` Jinja helpers
+time: 2026-05-09T15:00:00.000000+02:00
+custom:
+    Author: jbbqqf
+    Issue: "11210"

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -423,7 +423,12 @@ class BaseContext(metaclass=ContextMeta):
 
     @contextmember()
     @staticmethod
-    def tojson(value: Any, default: Any = None, sort_keys: bool = False) -> Any:
+    def tojson(
+        value: Any,
+        default: Any = None,
+        sort_keys: bool = False,
+        indent: Optional[int] = None,
+    ) -> Any:
         """The `tojson` context method can be used to serialize a Python
         object primitive, eg. a `dict` or `list` to a json string.
 
@@ -431,6 +436,9 @@ class BaseContext(metaclass=ContextMeta):
         :param default: A default value to return if the `value` argument
             cannot be serialized
         :param sort_keys: If True, sort the keys.
+        :param indent: If a non-negative integer, pretty-print the output
+            with that indent level. If None (default), the output is a
+            single line.
 
 
         Usage:
@@ -440,7 +448,7 @@ class BaseContext(metaclass=ContextMeta):
             {% do log(my_json_string) %}
         """
         try:
-            return json.dumps(value, sort_keys=sort_keys)
+            return json.dumps(value, sort_keys=sort_keys, indent=indent)
         except ValueError:
             return default
 
@@ -478,7 +486,10 @@ class BaseContext(metaclass=ContextMeta):
     @contextmember()
     @staticmethod
     def toyaml(
-        value: Any, default: Optional[str] = None, sort_keys: bool = False
+        value: Any,
+        default: Optional[str] = None,
+        sort_keys: bool = False,
+        indent: Optional[int] = None,
     ) -> Optional[str]:
         """The `tojson` context method can be used to serialize a Python
         object primitive, eg. a `dict` or `list` to a yaml string.
@@ -487,6 +498,9 @@ class BaseContext(metaclass=ContextMeta):
         :param default: A default value to return if the `value` argument
             cannot be serialized
         :param sort_keys: If True, sort the keys.
+        :param indent: If a positive integer, indent nested blocks by that
+            number of spaces. If None (default), `yaml.safe_dump`'s default
+            indentation is used.
 
 
         Usage:
@@ -496,7 +510,7 @@ class BaseContext(metaclass=ContextMeta):
             {% do log(my_yaml_string) %}
         """
         try:
-            return yaml.safe_dump(data=value, sort_keys=sort_keys)
+            return yaml.safe_dump(data=value, sort_keys=sort_keys, indent=indent)
         except (ValueError, yaml.YAMLError):
             return default
 

--- a/tests/unit/context/test_base.py
+++ b/tests/unit/context/test_base.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from jinja2.runtime import Undefined
@@ -52,3 +53,29 @@ class TestBaseContext:
         flags = BaseContext(cli_vars={}).flags
         for expected_flag in expected_context_flags:
             assert hasattr(flags, expected_flag.upper())
+
+    def test_tojson_default_is_compact(self):
+        result = BaseContext.tojson({"a": 1, "b": [2, 3]})
+        # default: single line, no indent
+        assert "\n" not in result
+        assert json.loads(result) == {"a": 1, "b": [2, 3]}
+
+    def test_tojson_with_indent(self):
+        result = BaseContext.tojson({"a": 1}, indent=2)
+        # indented: multi-line and starts with '{\n  '
+        assert result == '{\n  "a": 1\n}'
+        assert json.loads(result) == {"a": 1}
+
+    def test_tojson_with_indent_and_sort_keys(self):
+        result = BaseContext.tojson({"b": 2, "a": 1}, sort_keys=True, indent=4)
+        assert result == '{\n    "a": 1,\n    "b": 2\n}'
+
+    def test_toyaml_default(self):
+        result = BaseContext.toyaml({"a": 1})
+        # default safe_dump produces "a: 1\n"
+        assert result == "a: 1\n"
+
+    def test_toyaml_with_indent(self):
+        result = BaseContext.toyaml({"a": {"b": 1}}, indent=4)
+        # nested mapping should be indented by 4 spaces
+        assert "\n    b: 1" in result


### PR DESCRIPTION
Resolves dbt-labs/dbt-core#11210

### Problem

`tojson` and `toyaml` in `core/dbt/context/base.py` did not expose an `indent` kwarg, so users could not pretty-print structured output rendered from Jinja. The standard library / PyYAML already support `indent`; it just wasn't plumbed through the `BaseContext` wrappers. Pretty-printed JSON/YAML is useful when emitting docs, debug logs, or generating config snippets from Jinja.

### Solution

- `core/dbt/context/base.py`: `BaseContext.tojson(value, default=None, sort_keys=False, indent=None)` now passes `indent=indent` to `json.dumps`. `BaseContext.toyaml(value, default=None, sort_keys=False, indent=None)` now passes `indent=indent` to `yaml.safe_dump`. Docstrings updated to describe the new kwarg.
- `tests/unit/context/test_base.py`: 5 new unit tests (compact default, `tojson` indent=2, `tojson` sort_keys+indent, `toyaml` default unchanged, `toyaml` indent=4 nested mapping).

### Reproduce BEFORE/AFTER yourself (copy-paste)

A reviewer can verify this fix end-to-end by pasting the block below.

```bash
# --- one-time setup ---
git clone https://github.com/dbt-labs/dbt-core.git /tmp/dbt-repro && cd /tmp/dbt-repro
python -m venv .venv && source .venv/bin/activate
pip install -e './core[test]'

git fetch https://github.com/jbbqqf/dbt-core.git feat/11210-tojson-toyaml-indent

# --- BEFORE (origin/main): kwarg rejected ---
git checkout origin/main && pip install -e './core[test]' --quiet
python -c "
from dbt.context.base import BaseContext
ctx = BaseContext.__new__(BaseContext)
try:
    print(ctx.tojson({'a': 1, 'b': [2, 3]}, indent=2))
except TypeError as e:
    print(f'BEFORE → TypeError: {e}')
"
# Expected: BEFORE → TypeError: tojson() got an unexpected keyword argument 'indent'

# --- AFTER: indented output ---
git checkout FETCH_HEAD && pip install -e './core[test]' --quiet
python -c "
from dbt.context.base import BaseContext
ctx = BaseContext.__new__(BaseContext)
print('--- tojson indent=2 ---')
print(ctx.tojson({'a': 1, 'b': [2, 3]}, indent=2))
print('--- toyaml indent=4 ---')
print(ctx.toyaml({'a': 1, 'b': [2, 3]}, indent=4))
"
# Expected: indented JSON followed by indented YAML.
```

### What I ran locally

- `pytest tests/unit/context/test_base.py` -> 8 passed (3 existing + 5 new).
- Verified default behaviour unchanged: `tojson({"a": 1, "b": [2, 3]})` is compact (no newline); `toyaml({"a": 1}) == "a: 1\n"`.

### Risk / blast radius

Strictly additive. The new `indent` kwarg defaults to `None`, so existing call sites and rendered output are bit-for-bit identical. **Interface note:** new optional kwarg on two Jinja-exposed helpers (`tojson`, `toyaml`). Flagging for Product/DX awareness since this expands the documented Jinja surface.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against `dbt-labs/dbt-core`'s source; the reproducer block above is the same one used during development.*
