### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260511-155325.yaml
+++ b/.changes/unreleased/Under the Hood-20260511-155325.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-05-11T15:53:25.590262105Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -5777,6 +5777,7 @@
           ]
         },
         "+freshness": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/FreshnessDefinition"

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -382,6 +382,15 @@
             "$ref": "#/definitions/AnyValue"
           }
         },
+        "policy_tags": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "tags": {
           "anyOf": [
             {
@@ -9384,6 +9393,7 @@
           ]
         },
         "freshness": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/FreshnessDefinition"


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`ae7a8b09d5d140bcc85a6c65c8234e8fac839687`](https://github.com/dbt-labs/fs/commit/ae7a8b09d5d140bcc85a6c65c8234e8fac839687)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/25679743403)