### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260511-184712.yaml
+++ b/.changes/unreleased/Under the Hood-20260511-184712.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-05-11T18:47:12.739588716Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -5777,6 +5777,7 @@
           ]
         },
         "+freshness": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/FreshnessDefinition"

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -382,6 +382,15 @@
             "$ref": "#/definitions/AnyValue"
           }
         },
+        "policy_tags": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "tags": {
           "anyOf": [
             {
@@ -9384,6 +9393,7 @@
           ]
         },
         "freshness": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/FreshnessDefinition"


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`333b7f7d512324eaf7376db91792021d67165194`](https://github.com/dbt-labs/fs/commit/333b7f7d512324eaf7376db91792021d67165194)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/25688978536)