### PR TITLE
Add optional CodeScene `cs delta` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,3 +90,13 @@ repos:
         files: ^core/dbt/
         types: [python]
         pass_filenames: true
+      # Optional: runs CodeScene `cs delta` on staged changes. The wrapper
+      # script silently exits 0 unless the `cs` CLI is installed AND CodeScene
+      # auth is configured, so this is a no-op for contributors who haven't
+      # opted in. See CONTRIBUTING.md.
+      - id: codescene-delta
+        name: codescene-delta
+        entry: python scripts/pre-commit-hooks/codescene_delta.py
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,6 +236,15 @@ hatch run +py=3.11 ci:unit-tests
 
 [`pre-commit`](https://pre-commit.com) takes care of running all code-checks for formatting and linting. Run `hatch run setup` to install `pre-commit` in your local environment (we recommend running this command with a python virtual environment active). This installs several pip executables including black, mypy, and flake8. Once installed, hooks will run automatically on `git commit`, or you can run them manually with `hatch run code-quality`.
 
+#### CodeScene (optional)
+
+The `codescene-delta` pre-commit hook runs [CodeScene](https://codescene.com/)'s delta analysis on staged Python changes via the [`cs` CLI](https://codescene.io/docs/cli/index.html). It blocks commits that introduce Code Health regressions. The hook is **opt-in** — it silently skips for any contributor who does not have both:
+
+1. The `cs` CLI installed and on `PATH` (see [install instructions](https://codescene.io/docs/cli/index.html)), and
+2. `CS_ACCESS_TOKEN` exported in the shell where you commit (or, for on-prem CodeScene: `CS_ONPREM_API_URL`, `CS_USERNAME`, `CS_PASSWORD`).
+
+Without both, no `cs` invocation occurs and no code leaves your machine. With both set, staged diffs are sent to CodeScene for delta analysis on every commit.
+
 #### `pytest`
 
 Finally, you can also run a specific test or group of tests using [`pytest`](https://docs.pytest.org/en/latest/) directly. After running `hatch run setup`, you can run pytest commands like:

--- a/scripts/pre-commit-hooks/codescene_delta.py
+++ b/scripts/pre-commit-hooks/codescene_delta.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Optional hook: skip silently unless `cs` is installed AND CodeScene auth is configured.
+# When active, `cs delta --git-hook` exits 1 on Code Health findings, blocking the commit.
+import os
+import shutil
+import subprocess
+import sys
+
+
+def _has_auth() -> bool:
+    if os.environ.get("CS_ACCESS_TOKEN"):
+        return True
+    return all(os.environ.get(var) for var in ("CS_ONPREM_API_URL", "CS_USERNAME", "CS_PASSWORD"))
+
+
+def main() -> int:
+    if shutil.which("cs") is None:
+        return 0
+    if not _has_auth():
+        return 0
+    return subprocess.run(["cs", "delta", "--git-hook", "--staged"]).returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Resolves #

> [!NOTE]
> No linked issue yet. The PR template says this is required for merge — happy to file one if needed; this is a small dev-tooling addition so flagging for reviewer judgment.

### Problem

CodeScene Code Health feedback only arrives after a PR is opened and CI has run. Contributors who care about Code Health (especially maintainers) have no built-in way to surface those findings locally before pushing.

### Solution

Adds a new `codescene-delta` pre-commit hook that runs [`cs delta --git-hook --staged`](https://codescene.io/docs/cli/index.html) on every commit, blocking commits that introduce Code Health regressions.

The hook is **opt-in** via a two-factor guard in a small Python wrapper:

1. The [`cs` CLI](https://codescene.io/docs/cli/index.html) must be on `PATH`, AND
2. CodeScene auth must be configured: `CS_ACCESS_TOKEN` for cloud, or the on-prem trio `CS_ONPREM_API_URL` + `CS_USERNAME` + `CS_PASSWORD`.

If either is missing, the wrapper exits 0 silently — no `cs` invocation, no network call, nothing for contributors who haven't opted in. CONTRIBUTING.md documents the opt-in steps and the data flow (staged diffs leave the contributor's machine when active).

**Alternatives / tradeoffs considered:**

- **Warn-only vs block-on-findings:** chose block-on-findings to match upstream's `--git-hook` design. Opting in (install + auth setup) is itself the signal that the contributor wants the safety net. Warn-only would require dropping `--git-hook` and either parsing JSON output or losing the upstream's silent-on-clean behavior.
- **`stages: [manual]` vs default stage:** chose default stage. The two-factor guard makes auto-skip robust enough that external contributors are unaffected. Manual stage would force opted-in contributors to remember to invoke the hook, defeating the shift-left value.
- **Improves on `cs docs pre-commit-hook-example`:** the upstream-published example guards only on `command -v cs` and would noisily fail for anyone who installs the CLI without configuring auth. Adding the env-var check closes that gap.
- **Python wrapper vs shell:** Python (matching the existing `no_versioned_artifact_resource_imports.py` hook) for Windows compatibility — the `cs` CLI ships for Windows and contributors there can't run a `#!/bin/sh` script.
- **`pass_filenames: false`:** `cs delta --staged` discovers staged files from git directly; pre-commit's filename plumbing isn't needed.
- **No `files:` regex:** unlike `mypy` / `no_versioned_artifact_resource_imports` (scoped to `^core/dbt/`), CodeScene heuristics apply usefully across tests and plugins too. `types: [python]` is the only scoping.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR. *(Hook behavior verified manually across the four guard states; the wrapper itself is ~20 lines of glue and the load-bearing logic is `cs`, which is upstream-tested.)*
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX. *(`.pre-commit-config.yaml` change is dev-tooling-internal, not a user-facing interface.)*
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

### Verification performed

- [x] Wrapper exits 0 silently when `cs` is not on PATH
- [x] Wrapper exits 0 silently when `cs` is installed but no auth env vars are set
- [x] `_has_auth()` returns the expected boolean across all four combinations (no auth / cloud token / on-prem partial / on-prem complete)
- [x] `pre-commit run codescene-delta --all-files` succeeds in the no-auth-skip path