### PR TITLE
fix: resolve --select via selector API in show/compile task_end_messages

### DIFF
--- a/.changes/unreleased/Fixes-20260512-035505.yaml
+++ b/.changes/unreleased/Fixes-20260512-035505.yaml
@@ -1,0 +1,14 @@
+kind: Fixes
+body: >-
+  Fix regression from #12562 where `dbt show` and `dbt compile` filtered out
+  every result when `--select` used a graph operator (`+model`, `model+`,
+  `@model`) or a method selector (e.g. `tag:foo`, `state:modified`,
+  `fqn:model`). The membership check ran against the raw `--select` strings,
+  so any non-bare selector matched nothing. Filter the streamed `ShowNode` /
+  `CompiledNode` events by the resolved set of directly-selected `unique_id`s
+  instead, using the same selector parser dbt already uses for execution. The
+  substring fix from #12562 (originally #12539) is preserved structurally.
+time: 2026-05-12T03:55:05.0000000Z
+custom:
+    Author: tauhidanjum
+    Issue: "12562"

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -7,6 +7,7 @@ from dbt.contracts.graph.nodes import ManifestSQLNode
 from dbt.events.types import CompiledNode, ParseInlineNodeError
 from dbt.flags import get_flags
 from dbt.graph import ResourceTypeSelector
+from dbt.graph.graph import UniqueId
 from dbt.graph.selector_spec import SelectionCriteria
 from dbt.node_types import EXECUTABLE_NODE_TYPES, NodeType
 from dbt.parser.manifest import process_node
@@ -84,8 +85,16 @@ class CompileTask(GraphRunnableTask):
     def get_runner_type(self, _) -> Optional[Type[BaseRunner]]:
         return CompileRunner
 
-    def _get_directly_selected_unique_ids(self) -> Set[str]:
-        """unique_ids matched by --select before graph operator (+/@) expansion."""
+    def _get_directly_selected_unique_ids(self) -> Set[UniqueId]:
+        """unique_ids matched by --select before graph operator (+/@) expansion.
+
+        Each entry in self.selection_arg is parsed as a single SelectionCriteria
+        — intersection tokens within one entry (e.g. ``tag:foo,tag:bar``) are
+        not split here and will resolve to nothing, matching the pre-existing
+        filter behavior for that grammar. The execution path still selects
+        nodes correctly via parse_difference; only end-of-task output filtering
+        is affected.
+        """
         if not self.selection_arg:
             return set()
         selector = self.get_node_selector()

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Optional, Type, TypeVar
+from typing import Optional, Set, Type, TypeVar
 
 from dbt.artifacts.schemas.run import RunResult, RunStatus
 from dbt.contracts.graph.manifest import Manifest
@@ -7,6 +7,7 @@ from dbt.contracts.graph.nodes import ManifestSQLNode
 from dbt.events.types import CompiledNode, ParseInlineNodeError
 from dbt.flags import get_flags
 from dbt.graph import ResourceTypeSelector
+from dbt.graph.selector_spec import SelectionCriteria
 from dbt.node_types import EXECUTABLE_NODE_TYPES, NodeType
 from dbt.parser.manifest import process_node
 from dbt.parser.sql import SqlBlockParser
@@ -83,6 +84,20 @@ class CompileTask(GraphRunnableTask):
     def get_runner_type(self, _) -> Optional[Type[BaseRunner]]:
         return CompileRunner
 
+    def _get_directly_selected_unique_ids(self) -> Set[str]:
+        """unique_ids matched by --select before graph operator (+/@) expansion."""
+        if not self.selection_arg:
+            return set()
+        selector = self.get_node_selector()
+        graph_nodes = selector.graph.nodes()
+        return {
+            uid
+            for raw in self.selection_arg
+            for uid in selector.select_included(
+                graph_nodes, SelectionCriteria.from_single_spec(raw)
+            )
+        }
+
     def task_end_messages(self, results) -> None:
         is_inline = bool(getattr(self.args, "inline", None))
         output_format = getattr(self.args, "output", "text")
@@ -90,17 +105,10 @@ class CompileTask(GraphRunnableTask):
         if is_inline:
             matched_results = [result for result in results if result.node.name == "inline_query"]
         elif self.selection_arg:
+            directly_selected = self._get_directly_selected_unique_ids()
             matched_results = []
             for result in results:
-                node_name = result.node.name
-                versioned_name = (
-                    f"{node_name}.v{result.node.version}"
-                    if hasattr(result.node, "version") and result.node.version
-                    else None
-                )
-                if node_name in self.selection_arg or (
-                    versioned_name and versioned_name in self.selection_arg
-                ):
+                if result.node.unique_id in directly_selected:
                     matched_results.append(result)
                 else:
                     fire_event(

--- a/core/dbt/task/show.py
+++ b/core/dbt/task/show.py
@@ -77,17 +77,10 @@ class ShowTask(CompileTask):
         if is_inline:
             matched_results = [result for result in results if result.node.name == "inline_query"]
         else:
+            directly_selected = self._get_directly_selected_unique_ids()
             matched_results = []
             for result in results:
-                node_name = result.node.name
-                versioned_name = (
-                    f"{node_name}.v{result.node.version}"
-                    if hasattr(result.node, "version") and result.node.version
-                    else None
-                )
-                if node_name in self.selection_arg or (
-                    versioned_name and versioned_name in self.selection_arg
-                ):
+                if result.node.unique_id in directly_selected:
                     matched_results.append(result)
                 else:
                     fire_event(

--- a/tests/functional/compile/test_compile.py
+++ b/tests/functional/compile/test_compile.py
@@ -292,6 +292,36 @@ class TestCompile:
             assert "linked" in summary
 
 
+class TestCompileGraphOperatorSelectors:
+    """`--select` accepts graph operators (`+m`, `m+`, `@m`) and method
+    selectors (`tag:`, `fqn:`…). Operator-expanded neighbors are compiled,
+    but the streamed `CompiledNode` output should only include the anchors
+    the user named — never the ancestors/descendants pulled in by the
+    operator, and never unrelated nodes."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "first_model.sql": first_model_sql,
+            "second_model.sql": second_model_sql,
+            "unrelated_model.sql": "select 1 as id",
+            "schema.yml": schema_yml,
+        }
+
+    @pytest.mark.parametrize("selector", ["+second_model", "@second_model", "fqn:second_model"])
+    def test_compile_anchor_selectors(self, project, selector):
+        (_, log_output) = run_dbt_and_capture(["compile", "--select", selector])
+        assert "Compiled node 'second_model' is:" in log_output
+        assert "Compiled node 'first_model' is:" not in log_output
+        assert "Compiled node 'unrelated_model' is:" not in log_output
+
+    def test_compile_descendants_operator(self, project):
+        (_, log_output) = run_dbt_and_capture(["compile", "--select", "first_model+"])
+        assert "Compiled node 'first_model' is:" in log_output
+        assert "Compiled node 'second_model' is:" not in log_output
+        assert "Compiled node 'unrelated_model' is:" not in log_output
+
+
 class TestSqlParseGroupingTokenLimit:
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/functional/show/test_show.py
+++ b/tests/functional/show/test_show.py
@@ -302,3 +302,26 @@ class TestShowSubstringBug:
         )
         assert "Previewing node 'my_show_model'" in log_output
         assert "Previewing node 'second_model'" not in log_output
+
+
+class TestShowGraphOperatorSelectors(ShowBase):
+    """`--select` accepts graph operators (`+m`, `m+`, `@m`) and method
+    selectors (`tag:`, `fqn:`…). Operator-expanded neighbors execute, but
+    the streamed `ShowNode` preview should only include the anchors the
+    user named — never the ancestors/descendants pulled in by the operator,
+    and never unrelated nodes."""
+
+    @pytest.mark.parametrize("selector", ["+second_model", "@second_model", "fqn:second_model"])
+    def test_show_anchor_selectors(self, project, selector):
+        run_dbt(["build"])
+        (_, log_output) = run_dbt_and_capture(["show", "--select", selector])
+        assert "Previewing node 'second_model'" in log_output
+        assert "Previewing node 'sample_model'" not in log_output
+        assert "Previewing node 'sample_number_model'" not in log_output
+
+    def test_show_descendants_operator(self, project):
+        run_dbt(["build"])
+        (_, log_output) = run_dbt_and_capture(["show", "--select", "sample_model+"])
+        assert "Previewing node 'sample_model'" in log_output
+        assert "Previewing node 'second_model'" not in log_output
+        assert "Previewing node 'sample_number_model'" not in log_output

--- a/tests/unit/task/test_compile.py
+++ b/tests/unit/task/test_compile.py
@@ -1,0 +1,118 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dbt.graph.selector_spec import SelectionCriteria
+from dbt.task.compile import CompileTask
+
+
+def _make_task(select):
+    """Build a CompileTask with just enough attached to drive
+    _get_directly_selected_unique_ids without going through __init__."""
+    task = CompileTask.__new__(CompileTask)
+    task.args = MagicMock(select=select, exclude=None)
+    return task
+
+
+def _selector_returning(per_value):
+    """A fake NodeSelector whose select_included returns the unique_ids
+    pre-configured per criterion value. graph.nodes() returns a sentinel
+    we assert is forwarded unchanged."""
+    selector = MagicMock()
+    selector.graph.nodes.return_value = {"sentinel"}
+
+    def fake_select_included(nodes, criteria):
+        assert nodes == {"sentinel"}, "graph.nodes() result must be forwarded"
+        return set(per_value.get(criteria.value, ()))
+
+    selector.select_included.side_effect = fake_select_included
+    return selector
+
+
+class TestGetDirectlySelectedUniqueIds:
+    """The helper resolves `--select` to the set of `unique_id`s the user
+    anchored on, without applying graph operator (+/@) expansion. It must
+    use `select_included` (the no-expansion path), not
+    `get_nodes_from_criteria` (which re-expands and would defeat the point)."""
+
+    @pytest.mark.parametrize("select", [None, (), []])
+    def test_empty_selection_returns_empty_set(self, select):
+        task = _make_task(select)
+        with patch.object(CompileTask, "get_node_selector") as get_selector:
+            assert task._get_directly_selected_unique_ids() == set()
+            # No selector work should happen when there's nothing to resolve.
+            get_selector.assert_not_called()
+
+    def test_bare_name_selector(self):
+        task = _make_task(("my_model",))
+        selector = _selector_returning({"my_model": ["model.test.my_model"]})
+        with patch.object(CompileTask, "get_node_selector", return_value=selector):
+            assert task._get_directly_selected_unique_ids() == {"model.test.my_model"}
+        # select_included is the no-operator-expansion path the helper uses.
+        selector.select_included.assert_called_once()
+        selector.get_nodes_from_criteria.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "raw,flag",
+        [
+            ("+my_model", "parents"),
+            ("my_model+", "children"),
+            ("@my_model", "childrens_parents"),
+        ],
+    )
+    def test_graph_operator_is_parsed_but_not_applied(self, raw, flag):
+        """Each graph operator parses into its own flag on SelectionCriteria,
+        but select_included ignores those flags — so the helper returns only
+        the anchor, never the operator-expanded neighbors."""
+        task = _make_task((raw,))
+        selector = _selector_returning({"my_model": ["model.test.my_model"]})
+        with patch.object(CompileTask, "get_node_selector", return_value=selector):
+            result = task._get_directly_selected_unique_ids()
+
+        assert result == {"model.test.my_model"}
+        passed_criteria = selector.select_included.call_args.args[1]
+        assert isinstance(passed_criteria, SelectionCriteria)
+        assert passed_criteria.value == "my_model"
+        assert getattr(passed_criteria, flag) is True  # operator parsed
+        # …but never expanded — get_nodes_from_criteria is the expansion path.
+        selector.get_nodes_from_criteria.assert_not_called()
+
+    def test_multiple_selectors_unioned(self):
+        task = _make_task(("a", "b"))
+        selector = _selector_returning(
+            {"a": ["model.test.a"], "b": ["model.test.b1", "model.test.b2"]}
+        )
+        with patch.object(CompileTask, "get_node_selector", return_value=selector):
+            assert task._get_directly_selected_unique_ids() == {
+                "model.test.a",
+                "model.test.b1",
+                "model.test.b2",
+            }
+        assert selector.select_included.call_count == 2
+
+    def test_method_selector_can_match_multiple(self):
+        """`tag:foo` resolves to every tagged node — all of them are anchors.
+        Verifies the method prefix survives parsing (the dropped-method case
+        is what made `dbt show --select tag:foo` filter out every result)."""
+        task = _make_task(("tag:foo",))
+        selector = _selector_returning({"foo": ["model.test.a", "model.test.b"]})
+        with patch.object(CompileTask, "get_node_selector", return_value=selector):
+            assert task._get_directly_selected_unique_ids() == {
+                "model.test.a",
+                "model.test.b",
+            }
+        passed_criteria = selector.select_included.call_args.args[1]
+        assert passed_criteria.method == "tag"
+        assert passed_criteria.value == "foo"
+
+    def test_versioned_model_passed_through(self):
+        task = _make_task(("my_model.v1",))
+        selector = _selector_returning({"my_model.v1": ["model.test.my_model.v1"]})
+        with patch.object(CompileTask, "get_node_selector", return_value=selector):
+            assert task._get_directly_selected_unique_ids() == {"model.test.my_model.v1"}
+
+    def test_no_match_returns_empty(self):
+        task = _make_task(("nonexistent",))
+        selector = _selector_returning({})  # select_included returns set() for anything
+        with patch.object(CompileTask, "get_node_selector", return_value=selector):
+            assert task._get_directly_selected_unique_ids() == set()


### PR DESCRIPTION
Resolves #12562 (regression from that PR — see below)

### Problem

After [#12562](https://github.com/dbt-labs/dbt-core/pull/12562) (which fixed the substring-match bug from #12539 by switching to tuple membership), `dbt show` and `dbt compile` filtered out every result whenever `--select` used anything other than a bare model name. Concretely:

| `--select` | Pre-#12562 | #12562 | This PR |
|---|---|---|---|
| `my_model` | ✅ shows (but substring-matches by accident) | ✅ shows | ✅ shows |
| `+my_model` / `my_model+` / `@my_model` | ✅ shows | ❌ filtered out | ✅ shows anchor only |
| `tag:foo` / `fqn:foo` / `state:modified` | ✅ shows | ❌ filtered out | ✅ shows matched anchors |
| `my_model.v1` | ✅ shows | ✅ shows (via special case) | ✅ shows |

The membership check ran against the raw `--select` strings — so `"my_model" in ("+my_model",)` was always `False`, and `dbt show`/`dbt compile` in the IDE appeared to hang waiting for output that never streamed.

### Solution

Replace the string-level filter with a proper resolution through dbt's existing selector API:

1. New helper [`CompileTask._get_directly_selected_unique_ids`](https://github.com/dbt-labs/dbt-core/blob/fix/show-compile-select-graph-operators/core/dbt/task/compile.py) parses each raw `--select` token with `SelectionCriteria.from_single_spec`, then resolves it via `select_included` — the **no-operator-expansion** path. This returns only the anchors the user named, never the ancestors/descendants pulled in by `+`/`@`.
2. `task_end_messages` in both `CompileTask` and `ShowTask` filters streamed events by `unique_id` membership in that resolved set.
3. The versioned-name special case (`f"{name}.v{version}"`) is removed — `unique_id` already encodes the version (`model.test.my_model.v1`), so equality does the right thing.

**Why `select_included` over `get_nodes_from_criteria`:** the latter re-applies the graph operator and would put us right back where we were pre-#12562 (showing ancestors for `+my_model`). `select_included` is the architectural invariant — it must stay this way.

**Substring fix preserved structurally:** `unique_id` equality can never substring-match, so the #12539 regression cannot recur without rewriting the helper.

### Test coverage

Three layers:

- **Unit tests** ([`tests/unit/task/test_compile.py`](tests/unit/task/test_compile.py)) — 11 tests covering the helper in isolation:
  - Empty / `None` / `()` selection short-circuits without building a selector
  - Bare names resolve via `select_included`, not `get_nodes_from_criteria`
  - Parametrized over `+m` / `m+` / `@m`: asserts each operator's flag (`parents` / `children` / `childrens_parents`) is parsed on the criteria **and** that the expansion path is never called
  - `tag:foo` asserts `criteria.method == "tag"` survives parsing (the failure mode that broke method selectors)
  - Multiple selectors union; versioned models pass through; unknown selectors resolve to empty
- **Functional tests** ([`tests/functional/compile/test_compile.py`](tests/functional/compile/test_compile.py), [`tests/functional/show/test_show.py`](tests/functional/show/test_show.py)) — parametrized over `+m`, `@m`, `fqn:m`, plus a descendants case. Each fixture includes an **unrelated** node and asserts it's also absent — catches a "filter regressed to show everything" failure mode the original two-model fixture couldn't.
- **Pre-existing regression tests** (`TestShowSubstringBug`, `TestShowSelectText`, `TestShowMultiple`) traced through the new code path and pass — the #12539 substring fix is preserved.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes type annotations for new and modified functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)