### PR TITLE
refactor: extract docs processing cluster to doc_processor.py

### DIFF
--- a/.changes/unreleased/Under the Hood-20260512-120105.yaml
+++ b/.changes/unreleased/Under the Hood-20260512-120105.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Move doc parsing into separate parsing submodule
+time: 2026-05-12T12:01:05.842159-05:00
+custom:
+  Author: QMalcolm
+  Issue: "12940"

--- a/core/dbt/parser/doc_processor.py
+++ b/core/dbt/parser/doc_processor.py
@@ -1,0 +1,132 @@
+from typing import Any, Dict, List
+
+from jinja2.nodes import Call, Const
+
+from dbt.clients.jinja import get_rendered
+from dbt.contracts.graph.manifest import Manifest
+from dbt.contracts.graph.nodes import (
+    Exposure,
+    Macro,
+    ManifestNode,
+    Metric,
+    SavedQuery,
+    SemanticModel,
+    SourceDefinition,
+)
+from dbt_common.clients.jinja import parse
+
+
+def _get_doc_blocks(description: str, manifest: Manifest, node_package: str) -> List[str]:
+    ast = parse(description)
+    doc_blocks: List[str] = []
+
+    if not hasattr(ast, "body"):
+        return doc_blocks
+
+    for statement in ast.body:
+        for node in statement.nodes:
+            if (
+                isinstance(node, Call)
+                and hasattr(node, "node")
+                and hasattr(node, "args")
+                and hasattr(node.node, "name")
+                and node.node.name == "doc"
+            ):
+                # Only Const is statically resolvable to a block name at parse time.
+                #    * It does have a "value" attribute but mypy is unconvinced so the hasattr is to make it extra happy.
+                # Filter out Const values to avoid raising an unhandled exception attempting
+                # to statically parseother jinja expression nodes (ie Concat, CondExpr)
+                doc_args = [
+                    arg.value
+                    for arg in node.args
+                    if isinstance(arg, Const) and hasattr(arg, "value")
+                ]
+
+                if len(doc_args) == 1:
+                    package, name = None, doc_args[0]
+                elif len(doc_args) == 2:
+                    package, name = doc_args
+                else:
+                    continue
+
+                if not manifest.metadata.project_name:
+                    continue
+
+                resolved_doc = manifest.resolve_doc(
+                    name, package, manifest.metadata.project_name, node_package
+                )
+
+                if resolved_doc:
+                    doc_blocks.append(resolved_doc.unique_id)
+
+    return doc_blocks
+
+
+# node and column descriptions
+def _process_docs_for_node(
+    context: Dict[str, Any],
+    node: ManifestNode,
+    manifest: Manifest,
+):
+    node.doc_blocks = _get_doc_blocks(node.description, manifest, node.package_name)
+    node.description = get_rendered(node.description, context)
+
+    for column_name, column in node.columns.items():
+        column.doc_blocks = _get_doc_blocks(column.description, manifest, node.package_name)
+        column.description = get_rendered(column.description, context)
+
+
+# source and table descriptions, column descriptions
+def _process_docs_for_source(
+    context: Dict[str, Any],
+    source: SourceDefinition,
+    manifest: Manifest,
+):
+    source.doc_blocks = _get_doc_blocks(source.description, manifest, source.package_name)
+    source.description = get_rendered(source.description, context)
+
+    source.source_description = get_rendered(source.source_description, context)
+
+    for column in source.columns.values():
+        column.doc_blocks = _get_doc_blocks(column.description, manifest, source.package_name)
+        column.description = get_rendered(column.description, context)
+
+
+# macro argument descriptions
+def _process_docs_for_macro(context: Dict[str, Any], macro: Macro) -> None:
+    macro.description = get_rendered(macro.description, context)
+    for arg in macro.arguments:
+        arg.description = get_rendered(arg.description, context)
+
+
+# exposure descriptions
+def _process_docs_for_exposure(context: Dict[str, Any], exposure: Exposure) -> None:
+    exposure.description = get_rendered(exposure.description, context)
+
+
+def _process_docs_for_metrics(context: Dict[str, Any], metric: Metric) -> None:
+    metric.description = get_rendered(metric.description, context)
+
+
+def _process_docs_for_semantic_model(
+    context: Dict[str, Any], semantic_model: SemanticModel
+) -> None:
+    if semantic_model.description:
+        semantic_model.description = get_rendered(semantic_model.description, context)
+
+    for dimension in semantic_model.dimensions:
+        if dimension.description:
+            dimension.description = get_rendered(dimension.description, context)
+
+    for measure in semantic_model.measures:
+        if measure.description:
+            measure.description = get_rendered(measure.description, context)
+
+    for entity in semantic_model.entities:
+        if entity.description:
+            entity.description = get_rendered(entity.description, context)
+
+
+def _process_docs_for_saved_query(context: Dict[str, Any], saved_query: SavedQuery) -> None:
+    if saved_query.description:
+        saved_query.description = get_rendered(saved_query.description, context)

--- a/core/dbt/parser/doc_processor.py
+++ b/core/dbt/parser/doc_processor.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 from jinja2.nodes import Call, Const
 
@@ -16,6 +16,39 @@ from dbt.contracts.graph.nodes import (
 from dbt_common.clients.jinja import parse
 
 
+def _is_doc_call(node: Any) -> bool:
+    return (
+        isinstance(node, Call)
+        and hasattr(node, "node")
+        and hasattr(node, "args")
+        and hasattr(node.node, "name")
+        and node.node.name == "doc"
+    )
+
+
+def _resolve_doc_unique_id(node: Any, manifest: Manifest, node_package: str) -> Optional[str]:
+    # Only Const is statically resolvable to a block name at parse time.
+    #    * It does have a "value" attribute but mypy is unconvinced so the hasattr is to make it extra happy.
+    # Filter out Const values to avoid raising an unhandled exception attempting
+    # to statically parse other jinja expression nodes (ie Concat, CondExpr)
+    doc_args = [arg.value for arg in node.args if isinstance(arg, Const) and hasattr(arg, "value")]
+
+    if len(doc_args) == 1:
+        package, name = None, doc_args[0]
+    elif len(doc_args) == 2:
+        package, name = doc_args
+    else:
+        return None
+
+    if not manifest.metadata.project_name:
+        return None
+
+    resolved_doc = manifest.resolve_doc(
+        name, package, manifest.metadata.project_name, node_package
+    )
+    return resolved_doc.unique_id if resolved_doc else None
+
+
 def _get_doc_blocks(description: str, manifest: Manifest, node_package: str) -> List[str]:
     ast = parse(description)
     doc_blocks: List[str] = []
@@ -25,41 +58,19 @@ def _get_doc_blocks(description: str, manifest: Manifest, node_package: str) -> 
 
     for statement in ast.body:
         for node in statement.nodes:
-            if (
-                isinstance(node, Call)
-                and hasattr(node, "node")
-                and hasattr(node, "args")
-                and hasattr(node.node, "name")
-                and node.node.name == "doc"
-            ):
-                # Only Const is statically resolvable to a block name at parse time.
-                #    * It does have a "value" attribute but mypy is unconvinced so the hasattr is to make it extra happy.
-                # Filter out Const values to avoid raising an unhandled exception attempting
-                # to statically parseother jinja expression nodes (ie Concat, CondExpr)
-                doc_args = [
-                    arg.value
-                    for arg in node.args
-                    if isinstance(arg, Const) and hasattr(arg, "value")
-                ]
-
-                if len(doc_args) == 1:
-                    package, name = None, doc_args[0]
-                elif len(doc_args) == 2:
-                    package, name = doc_args
-                else:
-                    continue
-
-                if not manifest.metadata.project_name:
-                    continue
-
-                resolved_doc = manifest.resolve_doc(
-                    name, package, manifest.metadata.project_name, node_package
-                )
-
-                if resolved_doc:
-                    doc_blocks.append(resolved_doc.unique_id)
+            if not _is_doc_call(node):
+                continue
+            unique_id = _resolve_doc_unique_id(node, manifest, node_package)
+            if unique_id:
+                doc_blocks.append(unique_id)
 
     return doc_blocks
+
+
+def _render_if_set(items: Iterable[Any], context: Dict[str, Any]) -> None:
+    for item in items:
+        if item.description:
+            item.description = get_rendered(item.description, context)
 
 
 def _render_description_and_columns(
@@ -114,18 +125,9 @@ def _process_docs_for_semantic_model(
 ) -> None:
     if semantic_model.description:
         semantic_model.description = get_rendered(semantic_model.description, context)
-
-    for dimension in semantic_model.dimensions:
-        if dimension.description:
-            dimension.description = get_rendered(dimension.description, context)
-
-    for measure in semantic_model.measures:
-        if measure.description:
-            measure.description = get_rendered(measure.description, context)
-
-    for entity in semantic_model.entities:
-        if entity.description:
-            entity.description = get_rendered(entity.description, context)
+    _render_if_set(semantic_model.dimensions, context)
+    _render_if_set(semantic_model.measures, context)
+    _render_if_set(semantic_model.entities, context)
 
 
 def _process_docs_for_saved_query(context: Dict[str, Any], saved_query: SavedQuery) -> None:

--- a/core/dbt/parser/doc_processor.py
+++ b/core/dbt/parser/doc_processor.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from jinja2.nodes import Call, Const
 
@@ -62,18 +62,25 @@ def _get_doc_blocks(description: str, manifest: Manifest, node_package: str) -> 
     return doc_blocks
 
 
+def _render_description_and_columns(
+    context: Dict[str, Any],
+    obj: Union[ManifestNode, SourceDefinition],
+    manifest: Manifest,
+) -> None:
+    obj.doc_blocks = _get_doc_blocks(obj.description, manifest, obj.package_name)
+    obj.description = get_rendered(obj.description, context)
+    for column in obj.columns.values():
+        column.doc_blocks = _get_doc_blocks(column.description, manifest, obj.package_name)
+        column.description = get_rendered(column.description, context)
+
+
 # node and column descriptions
 def _process_docs_for_node(
     context: Dict[str, Any],
     node: ManifestNode,
     manifest: Manifest,
-):
-    node.doc_blocks = _get_doc_blocks(node.description, manifest, node.package_name)
-    node.description = get_rendered(node.description, context)
-
-    for column_name, column in node.columns.items():
-        column.doc_blocks = _get_doc_blocks(column.description, manifest, node.package_name)
-        column.description = get_rendered(column.description, context)
+) -> None:
+    _render_description_and_columns(context, node, manifest)
 
 
 # source and table descriptions, column descriptions
@@ -81,15 +88,9 @@ def _process_docs_for_source(
     context: Dict[str, Any],
     source: SourceDefinition,
     manifest: Manifest,
-):
-    source.doc_blocks = _get_doc_blocks(source.description, manifest, source.package_name)
-    source.description = get_rendered(source.description, context)
-
+) -> None:
+    _render_description_and_columns(context, source, manifest)
     source.source_description = get_rendered(source.source_description, context)
-
-    for column in source.columns.values():
-        column.doc_blocks = _get_doc_blocks(column.description, manifest, source.package_name)
-        column.description = get_rendered(column.description, context)
 
 
 # macro argument descriptions

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -61,7 +61,6 @@ from dbt.contracts.graph.nodes import (
     ManifestNode,
     Metric,
     ModelNode,
-    ResultNode,
     SavedQuery,
     SeedNode,
     SemanticManifestNode,
@@ -1859,9 +1858,6 @@ def _check_manifest(manifest: Manifest, config: RuntimeConfig) -> None:
     _check_resource_uniqueness(manifest, config)
     _check_function_language_support(manifest, config)
     _warn_for_unused_resource_config_paths(manifest, config)
-
-
-DocsContextCallback = Callable[[ResultNode], Dict[str, Any]]
 
 
 def _process_refs(

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -11,7 +11,6 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Typ
 
 import jinja2
 import msgpack
-from jinja2.nodes import Call, Const
 
 import dbt.deprecations
 import dbt.exceptions
@@ -34,7 +33,7 @@ from dbt.artifacts.resources import (
 )
 from dbt.artifacts.resources.types import BatchSize, FunctionLanguage, FunctionType
 from dbt.artifacts.schemas.base import Writable
-from dbt.clients.jinja import MacroStack, get_rendered
+from dbt.clients.jinja import MacroStack
 from dbt.clients.jinja_static import statically_extract_macro_calls
 from dbt.config import Project, RuntimeConfig
 from dbt.constants import (
@@ -103,6 +102,15 @@ from dbt.mp_context import get_mp_context
 from dbt.node_types import AccessType, NodeType
 from dbt.parser.analysis import AnalysisParser
 from dbt.parser.base import Parser
+from dbt.parser.doc_processor import (
+    _process_docs_for_exposure,
+    _process_docs_for_macro,
+    _process_docs_for_metrics,
+    _process_docs_for_node,
+    _process_docs_for_saved_query,
+    _process_docs_for_semantic_model,
+    _process_docs_for_source,
+)
 from dbt.parser.docs import DocumentationParser
 from dbt.parser.fixtures import FixtureParser
 from dbt.parser.functions import FunctionParser
@@ -128,7 +136,6 @@ from dbt.parser.sources import SourcePatcher
 from dbt.parser.unit_tests import process_models_for_unit_test
 from dbt.utils.artifact_upload import add_artifact_produced
 from dbt.version import __version__
-from dbt_common.clients.jinja import parse
 from dbt_common.clients.system import make_directory, path_exists, read_json, write_file
 from dbt_common.constants import SECRET_ENV_PREFIX
 from dbt_common.dataclass_schema import StrEnum, dbtClassMixin
@@ -1855,122 +1862,6 @@ def _check_manifest(manifest: Manifest, config: RuntimeConfig) -> None:
 
 
 DocsContextCallback = Callable[[ResultNode], Dict[str, Any]]
-
-
-def _get_doc_blocks(description: str, manifest: Manifest, node_package: str) -> List[str]:
-    ast = parse(description)
-    doc_blocks: List[str] = []
-
-    if not hasattr(ast, "body"):
-        return doc_blocks
-
-    for statement in ast.body:
-        for node in statement.nodes:
-            if (
-                isinstance(node, Call)
-                and hasattr(node, "node")
-                and hasattr(node, "args")
-                and hasattr(node.node, "name")
-                and node.node.name == "doc"
-            ):
-                # Only Const is statically resolvable to a block name at parse time.
-                #    * It does have a "value" attribute but mypy is unconvinced so the hasattr is to make it extra happy.
-                # Filter out Const values to avoid raising an unhandled exception attempting
-                # to statically parseother jinja expression nodes (ie Concat, CondExpr)
-                doc_args = [
-                    arg.value
-                    for arg in node.args
-                    if isinstance(arg, Const) and hasattr(arg, "value")
-                ]
-
-                if len(doc_args) == 1:
-                    package, name = None, doc_args[0]
-                elif len(doc_args) == 2:
-                    package, name = doc_args
-                else:
-                    continue
-
-                if not manifest.metadata.project_name:
-                    continue
-
-                resolved_doc = manifest.resolve_doc(
-                    name, package, manifest.metadata.project_name, node_package
-                )
-
-                if resolved_doc:
-                    doc_blocks.append(resolved_doc.unique_id)
-
-    return doc_blocks
-
-
-# node and column descriptions
-def _process_docs_for_node(
-    context: Dict[str, Any],
-    node: ManifestNode,
-    manifest: Manifest,
-):
-    node.doc_blocks = _get_doc_blocks(node.description, manifest, node.package_name)
-    node.description = get_rendered(node.description, context)
-
-    for column_name, column in node.columns.items():
-        column.doc_blocks = _get_doc_blocks(column.description, manifest, node.package_name)
-        column.description = get_rendered(column.description, context)
-
-
-# source and table descriptions, column descriptions
-def _process_docs_for_source(
-    context: Dict[str, Any],
-    source: SourceDefinition,
-    manifest: Manifest,
-):
-    source.doc_blocks = _get_doc_blocks(source.description, manifest, source.package_name)
-    source.description = get_rendered(source.description, context)
-
-    source.source_description = get_rendered(source.source_description, context)
-
-    for column in source.columns.values():
-        column.doc_blocks = _get_doc_blocks(column.description, manifest, source.package_name)
-        column.description = get_rendered(column.description, context)
-
-
-# macro argument descriptions
-def _process_docs_for_macro(context: Dict[str, Any], macro: Macro) -> None:
-    macro.description = get_rendered(macro.description, context)
-    for arg in macro.arguments:
-        arg.description = get_rendered(arg.description, context)
-
-
-# exposure descriptions
-def _process_docs_for_exposure(context: Dict[str, Any], exposure: Exposure) -> None:
-    exposure.description = get_rendered(exposure.description, context)
-
-
-def _process_docs_for_metrics(context: Dict[str, Any], metric: Metric) -> None:
-    metric.description = get_rendered(metric.description, context)
-
-
-def _process_docs_for_semantic_model(
-    context: Dict[str, Any], semantic_model: SemanticModel
-) -> None:
-    if semantic_model.description:
-        semantic_model.description = get_rendered(semantic_model.description, context)
-
-    for dimension in semantic_model.dimensions:
-        if dimension.description:
-            dimension.description = get_rendered(dimension.description, context)
-
-    for measure in semantic_model.measures:
-        if measure.description:
-            measure.description = get_rendered(measure.description, context)
-
-    for entity in semantic_model.entities:
-        if entity.description:
-            entity.description = get_rendered(entity.description, context)
-
-
-def _process_docs_for_saved_query(context: Dict[str, Any], saved_query: SavedQuery) -> None:
-    if saved_query.description:
-        saved_query.description = get_rendered(saved_query.description, context)
 
 
 def _process_refs(

--- a/tests/unit/parser/test_get_doc_blocks.py
+++ b/tests/unit/parser/test_get_doc_blocks.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from dbt.parser.manifest import _get_doc_blocks
+from dbt.parser.doc_processor import _get_doc_blocks
 
 
 class TestGetDocBlocks:


### PR DESCRIPTION
## Summary

Follow-up to #12935. Continues the `manifest.py` code health improvement by extracting the 8-function docs processing cluster into a new `dbt/parser/doc_processor.py` sibling module.

- **Commit 1** (`ea05d1fd7`): Pure code move — 8 functions extracted verbatim; unused imports (`jinja2.nodes.Call/Const`, `dbt_common.clients.jinja.parse`, `dbt.clients.jinja.get_rendered`) removed from `manifest.py`; test import path updated
- **Commit 2** (`28938561c`): Consolidates duplication between `_process_docs_for_node` and `_process_docs_for_source` into a shared `_render_description_and_columns` helper; removes the unused `DocsContextCallback` type alias and orphaned `ResultNode` import from `manifest.py`

`manifest.py` drops from 76 → 68 functions.

## Test plan

- [ ] Existing unit tests in `tests/unit/parser/test_get_doc_blocks.py` and `tests/unit/parser/test_docs.py` pass (6/6)
- [ ] All pre-commit hooks pass clean (isort, black, flake8, mypy, CodeScene delta)