### PR TITLE
fix(DI-4133): make column-level entity name optional in V2 semantic spec

### DIFF
--- a/.changes/unreleased/Fixes-20260512-150000.yaml
+++ b/.changes/unreleased/Fixes-20260512-150000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Allow column-level entity definitions in V2 semantic YAML to omit `name`, falling back to the column name to match the existing dimension behavior
+time: 2026-05-12T15:00:00.000000000Z
+custom:
+    Author: theyostalservice
+    Issue: "DI-4133"

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -203,17 +203,18 @@ class UnparsedDerivedDimensionV2(UnparsedDimensionV2):
 
 @dataclass
 class UnparsedEntityBase(dbtClassMixin):
-    name: str
     type: str  # EntityType enum
+    name: Optional[str] = None
     description: Optional[str] = None
     label: Optional[str] = None
     config: Dict[str, Any] = field(default_factory=dict)
 
 
-@dataclass
+@dataclass(kw_only=True)
 class UnparsedEntity(UnparsedEntityBase):
     """Used for dbt Semantic Layer entities (v1 YAML only)."""
 
+    name: str
     role: Optional[str] = None
     expr: Optional[str] = None
 
@@ -230,6 +231,7 @@ class UnparsedColumnEntityV2(UnparsedEntityBase):
 class UnparsedDerivedEntityV2(UnparsedEntityBase):
     """Used for dbt Semantic Layer derived entities (v2 YAML)."""
 
+    name: str
     expr: str
 
 

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -231,7 +231,6 @@ class UnparsedColumnEntityV2(UnparsedEntityBase):
 class UnparsedDerivedEntityV2(UnparsedEntityBase):
     """Used for dbt Semantic Layer derived entities (v2 YAML)."""
 
-    name: str
     expr: str
 
 

--- a/core/dbt/parser/common.py
+++ b/core/dbt/parser/common.py
@@ -254,7 +254,7 @@ class ParserRef:
 
             if isinstance(column.entity, UnparsedColumnEntityV2):
                 entity = ColumnEntity(
-                    name=column.entity.name,
+                    name=column.entity.name or column.name,
                     type=EntityType(column.entity.type),
                     description=column.entity.description or column.description,
                     label=column.entity.label,

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -1026,6 +1026,8 @@ class SemanticModelParser(YamlReader):
     ) -> List[Entity]:
         entities: List[Entity] = []
         for unparsed_entity in derived_semantics.entities:
+            if unparsed_entity.name is None:
+                raise ValidationError("Derived entity is missing a required 'name' field.")
             entities.append(
                 Entity(
                     name=unparsed_entity.name,

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -1102,3 +1102,20 @@ derived_semantics_with_doc_jinja_yml = """
           type: categorical
           expr: id
 """
+
+semantic_model_schema_yml_v2_entity_without_name = """models:
+  - name: fct_revenue
+    description: This is the model fct_revenue.
+    semantic_model: true
+    columns:
+      - name: id
+        entity:
+          type: primary
+      - name: second_col
+        granularity: day
+        dimension:
+          type: time
+      - name: foreign_key
+        entity:
+          type: foreign
+"""

--- a/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
@@ -34,10 +34,10 @@ from tests.functional.semantic_models.fixtures import (
     semantic_model_schema_yml_v2,
     semantic_model_schema_yml_v2_default_values,
     semantic_model_schema_yml_v2_disabled,
+    semantic_model_schema_yml_v2_entity_without_name,
     semantic_model_schema_yml_v2_false_config,
     semantic_model_schema_yml_v2_primary_entity_only_on_model,
     semantic_model_schema_yml_v2_renamed,
-    semantic_model_schema_yml_v2_entity_without_name,
     semantic_model_schema_yml_v2_with_primary_entity_only_on_column,
     semantic_model_test_groups_yml,
 )

--- a/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
@@ -37,6 +37,7 @@ from tests.functional.semantic_models.fixtures import (
     semantic_model_schema_yml_v2_false_config,
     semantic_model_schema_yml_v2_primary_entity_only_on_model,
     semantic_model_schema_yml_v2_renamed,
+    semantic_model_schema_yml_v2_entity_without_name,
     semantic_model_schema_yml_v2_with_primary_entity_only_on_column,
     semantic_model_test_groups_yml,
 )
@@ -1059,6 +1060,38 @@ class TestV2SemanticModelPartialParsingDisabled:
         result = runner.invoke(["parse"])
         assert result.success, result.exception
         assert len(result.result.semantic_models) == 0
+
+
+class TestSemanticModelEntityWithoutName:
+    """Regression test for DI-4133: entity: {type: foreign} without an explicit 'name'
+    must parse successfully and default the entity name to the column name."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": semantic_model_schema_yml_v2_entity_without_name,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
+
+    def test_entity_without_name_defaults_to_column_name(self, project):
+        runner = dbtTestRunner()
+        result = runner.invoke(["parse"])
+        assert result.success, result.exception
+        manifest = result.result
+        assert len(manifest.semantic_models) == 1
+        semantic_model = list(manifest.semantic_models.values())[0]
+        entities = {entity.name: entity for entity in semantic_model.entities}
+
+        # Column "id" with entity: {type: primary} — name should default to "id"
+        assert "id" in entities
+        assert entities["id"].type == EntityType.PRIMARY
+        assert entities["id"].expr is None  # name matches column, no expr needed
+
+        # Column "foreign_key" with entity: {type: foreign} — name should default to "foreign_key"
+        assert "foreign_key" in entities
+        assert entities["foreign_key"].type == EntityType.FOREIGN
+        assert entities["foreign_key"].expr is None  # name matches column, no expr needed
 
 
 # TODO DI-4603: add enforcement and a test for a TIME type dimension and a column that has no granularity set

--- a/tests/unit/parser/test_v2_column_semantic_parsing.py
+++ b/tests/unit/parser/test_v2_column_semantic_parsing.py
@@ -11,6 +11,8 @@ from collections import OrderedDict
 from metricflow_semantic_interfaces.type_enums import DimensionType, EntityType
 
 from dbt.artifacts.resources import ColumnDimension, ColumnEntity, ColumnInfo
+from dbt.contracts.graph.unparsed import UnparsedColumn, UnparsedColumnEntityV2
+from dbt.parser.common import ParserRef
 from dbt.parser.schema_yaml_readers import SemanticModelParser
 
 
@@ -147,3 +149,51 @@ class TestParseV2ColumnEntitiesExpr:
         assert len(entities) == 1
         assert entities[0].name == "foreign_id_col"
         assert entities[0].expr is None
+
+
+class TestParserRefEntityAdd:
+    """Test that ParserRef._add handles column-level entities without an explicit name.
+
+    Before the fix, UnparsedColumnEntityV2 required a name — so entity: {type: foreign}
+    (no name) failed JSON-schema validation. These tests verify the full
+    UnparsedColumn → ColumnInfo path introduced by making the name optional.
+    """
+
+    def _add_column(self, name, entity):
+        """Run ParserRef._add on an UnparsedColumn and return the resulting ColumnInfo."""
+        col = UnparsedColumn(name=name, entity=entity)
+        refs = ParserRef()
+        refs._add(col)
+        return refs.column_info[name]
+
+    def test_entity_dict_without_name_falls_back_to_column_name(self):
+        """entity: {type: foreign} with no name must parse and default name to the column name."""
+        col_info = self._add_column(
+            name="property_id",
+            entity=UnparsedColumnEntityV2(type="foreign"),
+        )
+        assert isinstance(col_info.entity, ColumnEntity)
+        assert col_info.entity.name == "property_id"
+        assert col_info.entity.type == EntityType.FOREIGN
+
+    def test_entity_dict_without_name_expr_is_none_when_names_match(self):
+        """When the entity name falls back to the column name, _parse_v2_column_entities
+        should produce no expr (names are equal)."""
+        col = _make_column(
+            name="property_id",
+            entity=ColumnEntity(name="property_id", type=EntityType.FOREIGN),
+        )
+        entities = SemanticModelParser._parse_v2_column_entities(None, _make_columns_dict(col))
+        assert len(entities) == 1
+        assert entities[0].name == "property_id"
+        assert entities[0].expr is None
+
+    def test_entity_dict_without_name_with_description(self):
+        """entity: {type: foreign, description: ...} with no name — description flows through."""
+        col_info = self._add_column(
+            name="org_id",
+            entity=UnparsedColumnEntityV2(type="foreign", description="Foreign key to orgs"),
+        )
+        assert isinstance(col_info.entity, ColumnEntity)
+        assert col_info.entity.name == "org_id"
+        assert col_info.entity.description == "Foreign key to orgs"


### PR DESCRIPTION
# Why

Customers using the V2 in-model semantic layer spec get a parse error on dbt Cloud Latest (Mantle) when specifying a column-level entity without an explicit \`name\`:

\`\`\`yaml
columns:
  - name: property_id
    entity:
      type: foreign   # no 'name' — valid per V2 spec, but rejected by core
\`\`\`

Error: \`at path ['columns'][0]['entity']: {'type': 'foreign'} is not valid under any of the given schemas\`

The V2 spec is expected to be backward-compatible on Latest. This is a bug — Fusion parses this correctly and the fix should land in Mantle promptly.

Root cause: \`UnparsedEntityBase.name\` was a required field (\`name: str\`), while the equivalent \`UnparsedDimensionBase.name\` is already \`Optional[str] = None\`. Additionally, \`ParserRef._add\` had a column-name fallback for dimensions (\`name=column.dimension.name or column.name\`) but not for entities.

# What

- \`core/dbt/contracts/graph/unparsed.py\`: Make \`UnparsedEntityBase.name\` optional (\`Optional[str] = None\`), mirroring \`UnparsedDimensionBase\`. Re-declare \`name: str\` on \`UnparsedEntity\` (v1 top-level) via \`kw_only=True\` so that caller still requires an explicit name (no column to fall back to). \`UnparsedColumnEntityV2\` and \`UnparsedDerivedEntityV2\` inherit the now-optional name.
- \`core/dbt/parser/common.py\`: Add column-name fallback for entities in \`ParserRef._add\`: \`name=column.entity.name or column.name\` (mirrors the existing dimension branch).
- \`tests/unit/parser/test_v2_column_semantic_parsing.py\`: Add 3 new tests in \`TestParserRefEntityAdd\` covering the full \`UnparsedColumn → ColumnInfo\` path for the no-name case.
- \`tests/functional/semantic_models/test_semantic_model_v2_parsing.py\`: Add \`TestSemanticModelEntityWithoutName\` — a full parse integration test using a model with \`entity: {type: primary/foreign}\` (no name) confirming entity names default to column names end-to-end.
- \`.changes/unreleased/Fixes-20260512-150000.yaml\`: Changelog entry.

# Refs

- Jira: [DI-4133](https://dbtlabs.atlassian.net/browse/DI-4133)
- Slack thread: https://dbt-labs.slack.com/archives/C03KHQRQUBX/p1778605608941209?thread_ts=1778184317.073059&cid=C03KHQRQUBX
- Zendesk: 121457 (Bilt Rewards)
- Related: #12513, #12763

Drafted by claude-opus-4-7 under the direction of @theyostalservice

[DI-4133]: https://dbtlabs.atlassian.net/browse/DI-4133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ