### PR TITLE
Fix Python model ref detection in nested expressions

### DIFF
--- a/.changes/unreleased/Fixes-20260512-235427.yaml
+++ b/.changes/unreleased/Fixes-20260512-235427.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fixed Python model parsing so dbt detects refs nested inside chained subscripts and other Python expressions.
+time: 2026-05-12T23:54:27.479135+02:00
+custom:
+    Author: Sichej
+    Issue: "12939"

--- a/core/dbt/parser/models.py
+++ b/core/dbt/parser/models.py
@@ -109,46 +109,21 @@ class PythonParseVisitor(ast.NodeVisitor):
         return arg_literals, kwarg_literals
 
     def visit_Call(self, node: ast.Call) -> None:
-        # check weather the current call could be a dbt function call
+        # Check whether the current call is a dbt function call.
         if isinstance(node.func, ast.Attribute) and node.func.attr in dbt_function_key_words:
             func_name = self._flatten_attr(node.func)
-            # check weather the current call really is a dbt function call
+
+            # Check whether the current call really is a dbt function call.
             if func_name in dbt_function_full_names:
-                # drop the dot-dbt prefix
+                # Drop the dot-dbt prefix.
                 func_name = func_name.split(".")[-1]
                 args, kwargs = self._get_call_literals(node)
                 self.dbt_function_calls.append((func_name, args, kwargs))
 
-        # no matter what happened above, we should keep visiting the rest of the tree
-        # visit args and kwargs to see if there's call in it
-        for obj in node.args + [kwarg.value for kwarg in node.keywords]:
-            if isinstance(obj, ast.Call):
-                self.visit_Call(obj)
-            # support dbt.ref in list args, kwargs
-            elif isinstance(obj, ast.List) or isinstance(obj, ast.Tuple):
-                for el in obj.elts:
-                    if isinstance(el, ast.Call):
-                        self.visit_Call(el)
-            # support dbt.ref in dict args, kwargs
-            elif isinstance(obj, ast.Dict):
-                for value in obj.values:
-                    if isinstance(value, ast.Call):
-                        self.visit_Call(value)
-            # support dbt function calls in f-strings
-            elif isinstance(obj, ast.JoinedStr):
-                for value in obj.values:
-                    if isinstance(value, ast.FormattedValue) and isinstance(value.value, ast.Call):
-                        self.visit_Call(value.value)
-
-        # visit node.func.value if we are at an call attr
-        if isinstance(node.func, ast.Attribute):
-            self.attribute_helper(node.func)
-
-    def attribute_helper(self, node: ast.Attribute) -> None:
-        while isinstance(node, ast.Attribute):
-            node = node.value  # type: ignore
-        if isinstance(node, ast.Call):
-            self.visit_Call(node)
+        # Keep walking the full AST below this call. This handles dbt calls nested
+        # inside attributes, subscripts, conditionals, comprehensions, f-strings,
+        # args, kwargs, lists, dicts, tuples, and other Python expressions.
+        self.generic_visit(node)
 
     def visit_Import(self, node: ast.Import) -> None:
         for n in node.names:

--- a/tests/unit/parser/test_parser.py
+++ b/tests/unit/parser/test_parser.py
@@ -1308,11 +1308,55 @@ def model(dbt, session):
     return dbt.ref("some_model")
 """
 
+python_model_subscript_chained_ref = """
+def model(dbt, session):
+    spark_df = dbt.ref("some_model_dict_A")
+    pd_df_a = dbt.ref("some_model_dict_B").toPandas()[["colb","colc"]].reset_index()
+    result_df = spark_session.createDataFrame(pd_df_a).join(spark_df, on="id")
+    return result_df
+"""
+
 python_model_meta_get_too_many_args = """
 def model(dbt, session):
     dbt.config(materialized='table')
     value = dbt.config.meta_get('key', 'default', 'extra')
     return dbt.ref("some_model")
+"""
+
+python_model_conditional_chained_ref = """
+def model(dbt, session):
+    pd_df_a = (
+        dbt.ref("some_model_conditional_A")
+        if True
+        else dbt.ref("some_model_conditional_B")
+    ).toPandas()[["colb","colc"]].reset_index()
+    return pd_df_a
+"""
+
+python_model_call_arg_conditional_ref = """
+def model(dbt, session):
+    result_df = session.createDataFrame(
+        dbt.ref("some_model_arg_conditional_A")
+        if True
+        else dbt.ref("some_model_arg_conditional_B")
+    )
+    return result_df
+"""
+
+python_model_call_arg_subscript_comprehension_ref = """
+def model(dbt, session):
+    result_df = session.createDataFrame(
+        [dbt.ref("some_model_comprehension").limit(1) for _ in [1]][0]
+    )
+    return result_df
+"""
+
+python_model_nested_ref_not_duplicated = """
+def model(dbt, session):
+    result_df = session.createDataFrame(
+        dbt.ref("some_model_not_duplicated").toPandas()[["id"]]
+    )
+    return result_df
 """
 
 
@@ -1571,6 +1615,66 @@ class ModelParserTest(BaseParserTest):
         with self.assertRaises(ParsingError) as exc:
             self.parser.parse_file(block)
         self.assertIn("dbt.config.meta_get() takes at most 2 arguments", str(exc.exception))
+
+    def test_python_model_subscript_chained_ref(self):
+        """Refs chained through subscript access (e.g. ref(...)["col"].method()) must be detected."""
+        block = self.file_block_for(python_model_subscript_chained_ref, "nested/py_model.py")
+        self.parser.manifest.files[block.file.file_id] = block.file
+        self.parser.parse_file(block)
+        node = list(self.parser.manifest.nodes.values())[0]
+        self.assertEqual(
+            node.refs,
+            [
+                RefArgs(name="some_model_dict_A"),
+                RefArgs(name="some_model_dict_B"),
+            ],
+        )
+
+    def test_python_model_conditional_chained_ref(self):
+        """Refs inside conditional chained expressions must be detected."""
+        block = self.file_block_for(python_model_conditional_chained_ref, "nested/py_model.py")
+        self.parser.manifest.files[block.file.file_id] = block.file
+        self.parser.parse_file(block)
+        node = list(self.parser.manifest.nodes.values())[0]
+        self.assertEqual(
+            node.refs,
+            [
+                RefArgs(name="some_model_conditional_A"),
+                RefArgs(name="some_model_conditional_B"),
+            ],
+        )
+
+    def test_python_model_call_arg_conditional_ref(self):
+        """Refs inside conditional expressions used as call args must be detected."""
+        block = self.file_block_for(python_model_call_arg_conditional_ref, "nested/py_model.py")
+        self.parser.manifest.files[block.file.file_id] = block.file
+        self.parser.parse_file(block)
+        node = list(self.parser.manifest.nodes.values())[0]
+        self.assertEqual(
+            node.refs,
+            [
+                RefArgs(name="some_model_arg_conditional_A"),
+                RefArgs(name="some_model_arg_conditional_B"),
+            ],
+        )
+
+    def test_python_model_call_arg_subscript_comprehension_ref(self):
+        """Refs inside comprehensions nested below call args must be detected."""
+        block = self.file_block_for(
+            python_model_call_arg_subscript_comprehension_ref, "nested/py_model.py"
+        )
+        self.parser.manifest.files[block.file.file_id] = block.file
+        self.parser.parse_file(block)
+        node = list(self.parser.manifest.nodes.values())[0]
+        self.assertEqual(node.refs, [RefArgs(name="some_model_comprehension")])
+
+    def test_python_model_nested_ref_not_duplicated(self):
+        """Nested refs should be visited once when traversing the AST generically."""
+        block = self.file_block_for(python_model_nested_ref_not_duplicated, "nested/py_model.py")
+        self.parser.manifest.files[block.file.file_id] = block.file
+        self.parser.parse_file(block)
+        node = list(self.parser.manifest.nodes.values())[0]
+        self.assertEqual(node.refs, [RefArgs(name="some_model_not_duplicated")])
 
 
 class StaticModelParserTest(BaseParserTest):

--- a/tests/unit/parser/test_parser.py
+++ b/tests/unit/parser/test_parser.py
@@ -1905,9 +1905,7 @@ class SnapshotParserTest(BaseParserTest):
             select 1 as id, now() as last_update"""
         full_file = """
         {{% snapshot foo %}}{}{{% endsnapshot %}}
-        """.format(
-            raw_code
-        )
+        """.format(raw_code)
         block = self.file_block_for(full_file, "nested/snap_1.sql")
         self.parser.manifest.files[block.file.file_id] = block.file
         self.parser.parse_file(block)
@@ -1977,9 +1975,7 @@ class SnapshotParserTest(BaseParserTest):
         full_file = """
         {{% snapshot foo %}}{}{{% endsnapshot %}}
         {{% snapshot bar %}}{}{{% endsnapshot %}}
-        """.format(
-            raw_1, raw_2
-        )
+        """.format(raw_1, raw_2)
         block = self.file_block_for(full_file, "nested/snap_1.sql")
         self.parser.manifest.files[block.file.file_id] = block.file
         self.parser.parse_file(block)


### PR DESCRIPTION
Resolves #12939

### Problem

Python model parsing could miss `dbt.ref()` calls when they were nested inside certain Python AST expression shapes.
For example, refs chained through subscript access or other nested expressions were not always detected:
```python
dbt.ref("some_model").toPandas()[["col_a", "col_b"]].reset_index()
```
This could produce an incomplete manifest dependency graph for Python models.

### Solution
Update the Python model parser to use generic AST traversal after inspecting each call node. This allows dbt to continue walking through nested expressions such as chained attributes, subscripts, conditionals, comprehensions, call arguments, lists, dicts, tuples, and f-strings without manually handling each AST node shape.

Add unit coverage for:

- refs chained through subscript access
- refs inside conditional expressions
- refs inside conditional call arguments
- refs inside comprehensions nested below call arguments
- nested refs being collected only once

### Alternatives
The first possible fix was to explicitly handle ast.Subscript in the existing parser traversal. That would address the reported case, but it would still leave the parser vulnerable to similar misses for other valid Python expression shapes.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
