### PR TITLE
fix(#12947): handle float NodeVersion in version_to_str

### DIFF
--- a/.changes/unreleased/Fixes-20260513-120000.yaml
+++ b/.changes/unreleased/Fixes-20260513-120000.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: "Fix `version_to_str` returning empty string for float `NodeVersion` values,
+    causing unquoted YAML version scalars (e.g. `v: 4.5`) to be silently dropped
+    and mis-routed as non-versioned models"
+time: 2026-05-13T12:00:00.000000-05:00
+custom:
+    Author: tauhid621
+    Issue: "12947"

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -180,13 +180,12 @@ def extended_msgpack_decoder(code, data):
         return msgpack.ExtType(code, data)
 
 
-def version_to_str(version: Optional[Union[str, int]]) -> str:
-    if isinstance(version, int):
-        return str(version)
-    elif isinstance(version, str):
+def version_to_str(version: Optional[Union[str, int, float]]) -> str:
+    if version is None:
+        return ""
+    if isinstance(version, str):
         return version
-
-    return ""
+    return str(version)
 
 
 class ReparseReason(StrEnum):

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -180,7 +180,7 @@ def extended_msgpack_decoder(code, data):
         return msgpack.ExtType(code, data)
 
 
-def version_to_str(version: Optional[Union[str, int, float]]) -> str:
+def version_to_str(version: Optional[NodeVersion]) -> str:
     if version is None:
         return ""
     if isinstance(version, str):

--- a/tests/unit/parser/test_manifest.py
+++ b/tests/unit/parser/test_manifest.py
@@ -500,6 +500,11 @@ class TestCheckFunctionLanguageSupport:
 
 
 class TestVersionToStr:
+    # Regression test for #12947: PR #12828 widened NodeVersion to
+    # Union[int, float, str], and mashumaro deserializes union members in
+    # declaration order — so YAML scalars like `v: 4.5` now arrive as Python
+    # floats. The float case (4.5 -> "4.5") guards against a future Union
+    # reorder silently dropping float versions back to the "" sentinel.
     @pytest.mark.parametrize(
         "version,expected",
         [

--- a/tests/unit/parser/test_manifest.py
+++ b/tests/unit/parser/test_manifest.py
@@ -22,6 +22,7 @@ from dbt.parser.manifest import (
     _warn_for_unused_resource_config_paths,
     extended_mashumaro_encoder,
     extended_msgpack_encoder,
+    version_to_str,
 )
 from dbt.parser.read_files import FileDiff
 from dbt.tracking import User
@@ -496,3 +497,19 @@ class TestCheckFunctionLanguageSupport:
         }
         config = self._make_config("snowflake")
         _check_function_language_support(manifest, config)
+
+
+class TestVersionToStr:
+    @pytest.mark.parametrize(
+        "version,expected",
+        [
+            (None, ""),
+            (1, "1"),
+            ("1", "1"),
+            ("4.5", "4.5"),
+            (4.5, "4.5"),
+            ("test", "test"),
+        ],
+    )
+    def test_version_to_str(self, version, expected):
+        assert version_to_str(version) == expected


### PR DESCRIPTION
## Summary

Fixes #12947 — a regression introduced by #12828.

`version_to_str` in `core/dbt/parser/manifest.py` had no `float` branch and returned `""` for any float value, even though #12828 widened `NodeVersion` to `Union[int, float, str]`. YAML scalars like `v: 4.5` deserialize to Python `float` via mashumaro, so versioned models declared with unquoted YAML versions were silently mis-routed as non-versioned nodes (e.g. `model.<pkg>.versioned_v4.5`), breaking adapter version-selection tests:

- `tests/functional/graph_selection/test_version_selection.py::TestVersionSelection::test_select_none_versions`
- `tests/functional/graph_selection/test_version_selection.py::TestVersionSelection::test_select_prerelease_versions`

(both in `dbt-labs/dbt-adapters`, against current `main` of dbt-core)

## Changes

- **`core/dbt/parser/manifest.py`** — `version_to_str` now short-circuits on `None`, returns `str` unchanged, and uses `str(version)` for everything else. Type hint widened to `Optional[Union[str, int, float]]` to match `NodeVersion`.
- **`tests/unit/parser/test_manifest.py`** — New `TestVersionToStr` with parametrized regression coverage for `None`, `int`, `str`, and the regressing `float` case (`4.5`), with a comment referencing this issue so a future `Union` reorder cannot silently reintroduce the bug.
- **`.changes/unreleased/Fixes-20260513-120000.yaml`** — changelog entry.

## Verification

All 48 tests in `tests/unit/parser/test_manifest.py` pass, including the 6 new parametrized cases:

```
tests/unit/parser/test_manifest.py::TestVersionToStr::test_version_to_str[None-]   PASSED
tests/unit/parser/test_manifest.py::TestVersionToStr::test_version_to_str[1-1_0]   PASSED
tests/unit/parser/test_manifest.py::TestVersionToStr::test_version_to_str[1-1_1]   PASSED
tests/unit/parser/test_manifest.py::TestVersionToStr::test_version_to_str[4.5-4.5_0] PASSED
tests/unit/parser/test_manifest.py::TestVersionToStr::test_version_to_str[4.5-4.5_1] PASSED
tests/unit/parser/test_manifest.py::TestVersionToStr::test_version_to_str[test-test] PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)