### PR TITLE
emit osi_document.json at parse time alongside semantic_manifest.json

### DIFF
--- a/.changes/unreleased/Features-20260513-171849.yaml
+++ b/.changes/unreleased/Features-20260513-171849.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Begin writing OSI SL document at end of parsing
+time: 2026-05-13T17:18:49.359913-05:00
+custom:
+  Author: QMalcolm
+  Issue: "12786"

--- a/core/dbt/constants.py
+++ b/core/dbt/constants.py
@@ -18,6 +18,7 @@ DEPENDENCIES_FILE_NAME = "dependencies.yml"
 PACKAGE_LOCK_FILE_NAME = "package-lock.yml"
 MANIFEST_FILE_NAME = "manifest.json"
 SEMANTIC_MANIFEST_FILE_NAME = "semantic_manifest.json"
+OSI_DOCUMENT_FILE_NAME = "osi_document.json"
 LEGACY_TIME_SPINE_MODEL_NAME = "metricflow_time_spine"
 LEGACY_TIME_SPINE_GRANULARITY = TimeGranularity.DAY
 MINIMUM_REQUIRED_TIME_SPINE_GRANULARITY = TimeGranularity.DAY

--- a/core/dbt/contracts/graph/semantic_manifest.py
+++ b/core/dbt/contracts/graph/semantic_manifest.py
@@ -145,6 +145,13 @@ class SemanticManifest:
 
         return not validation_result_errors
 
+    def write_osi_document_to_file(self, file_path: str) -> None:
+        from metricflow.converters.msi_to_osi import MSIToOSIConverter
+
+        result = MSIToOSIConverter().convert(self._get_pydantic_semantic_manifest())
+        write_file(file_path, result.output.to_osi_json())
+        fire_event(ArtifactWritten(artifact_type="OsiDocument", artifact_path=file_path))
+
     def write_json_to_file(self, file_path: str):
         semantic_manifest = self._get_pydantic_semantic_manifest()
         json = semantic_manifest.json()

--- a/core/dbt/contracts/graph/semantic_manifest.py
+++ b/core/dbt/contracts/graph/semantic_manifest.py
@@ -42,7 +42,11 @@ from dbt.constants import (
 )
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.nodes import ModelNode
-from dbt.events.types import ArtifactWritten, SemanticValidationFailure
+from dbt.events.types import (
+    ArtifactWritten,
+    MFConverterIssue,
+    SemanticValidationFailure,
+)
 from dbt.exceptions import ParsingError
 from dbt.flags import get_flags
 from dbt_common.clients.system import write_file
@@ -149,6 +153,14 @@ class SemanticManifest:
         from metricflow.converters.msi_to_osi import MSIToOSIConverter
 
         result = MSIToOSIConverter().convert(self._get_pydantic_semantic_manifest())
+        for issue in result.issues:
+            fire_event(
+                MFConverterIssue(
+                    issue_type=issue.issue_type.value,
+                    element_name=issue.element_name,
+                    converter_name="MSIToOSIConverter",
+                )
+            )
         write_file(file_path, result.output.to_osi_json())
         fire_event(ArtifactWritten(artifact_type="OsiDocument", artifact_path=file_path))
 

--- a/core/dbt/contracts/graph/semantic_manifest.py
+++ b/core/dbt/contracts/graph/semantic_manifest.py
@@ -152,7 +152,17 @@ class SemanticManifest:
     def write_osi_document_to_file(self, file_path: str) -> None:
         from metricflow.converters.msi_to_osi import MSIToOSIConverter
 
-        result = MSIToOSIConverter().convert(self._get_pydantic_semantic_manifest())
+        try:
+            result = MSIToOSIConverter().convert(self._get_pydantic_semantic_manifest())
+        except RuntimeError as exc:
+            fire_event(
+                SemanticValidationFailure(
+                    msg=f"OSI document could not be generated: {exc}. "
+                    "The semantic manifest may contain metric types not yet supported "
+                    "by the MSI→OSI converter."
+                )
+            )
+            return
         for issue in result.issues:
             fire_event(
                 MFConverterIssue(

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -1307,6 +1307,24 @@ class PackageNodeDependsOnRootProjectNode(WarnLevel):
         return warning_tag(msg)
 
 
+class MFConverterIssue(WarnLevel):
+    def code(self) -> str:
+        return "I078"
+
+    def message(self) -> str:
+        if self.issue_type == "CONVERSION_METRIC_DROPPED":
+            msg = f"Metric '{self.element_name}' was excluded from the OSI document: conversion metrics cannot be represented in the OSI format."
+        elif self.issue_type == "PRIVATE_METRIC_DROPPED":
+            msg = f"Metric '{self.element_name}' was excluded from the OSI document: private metrics are not included in OSI output."
+        elif self.issue_type == "NATURAL_ENTITY_DROPPED":
+            msg = f"Entity '{self.element_name}' was excluded from the OSI document: natural entities have no equivalent in the OSI format."
+        elif self.issue_type == "CUMULATIVE_SEMANTICS_LOSS":
+            msg = f"Metric '{self.element_name}' was included in the OSI document, but its cumulative window and grain semantics cannot be represented."
+        else:
+            msg = f"'{self.element_name}' could not be fully represented in the OSI document ({self.issue_type})."
+        return warning_tag(msg)
+
+
 # =======================================================
 # M - Deps generation
 # =======================================================

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -42,6 +42,7 @@ from dbt.clients.jinja_static import statically_extract_macro_calls
 from dbt.config import Project, RuntimeConfig
 from dbt.constants import (
     MANIFEST_FILE_NAME,
+    OSI_DOCUMENT_FILE_NAME,
     PARTIAL_PARSE_FILE_NAME,
     SEMANTIC_MANIFEST_FILE_NAME,
 )
@@ -2489,9 +2490,9 @@ def process_node(config: RuntimeConfig, manifest: Manifest, node: ManifestNode):
 
 
 def write_semantic_manifest(manifest: Manifest, target_path: str) -> None:
-    path = os.path.join(target_path, SEMANTIC_MANIFEST_FILE_NAME)
     semantic_manifest = SemanticManifest(manifest)
-    semantic_manifest.write_json_to_file(path)
+    semantic_manifest.write_json_to_file(os.path.join(target_path, SEMANTIC_MANIFEST_FILE_NAME))
+    semantic_manifest.write_osi_document_to_file(os.path.join(target_path, OSI_DOCUMENT_FILE_NAME))
 
 
 def write_manifest(manifest: Manifest, target_path: str, which: Optional[str] = None):

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     # Minor versions for these are expected to be backwards-compatible
     "dbt-common>=1.37.5,<2.0",
     "dbt-adapters>=1.23.0,<2.0",
-    "dbt-protos>=1.0.491,<2.0",
+    "dbt-protos>=1.0.498,<2.0",
     "pydantic<3",
     # ----
     # Expect compatibility with all new versions of these packages, so lower bounds only.

--- a/tests/functional/artifacts/test_artifacts.py
+++ b/tests/functional/artifacts/test_artifacts.py
@@ -631,8 +631,8 @@ class TestVerifyArtifacts(BaseVerifyProject):
             manifest_schema_path,
         )
         verify_run_results(project, expected_run_results(), start_time, run_results_schema_path)
-        # manifest written twice, semantic manifest written twice, run results written once
-        assert len(catcher.caught_events) == 5
+        # manifest written twice, semantic manifest written twice, osi_document written twice, run results written once
+        assert len(catcher.caught_events) == 7
         assert (
             len(
                 [
@@ -649,6 +649,16 @@ class TestVerifyArtifacts(BaseVerifyProject):
                     event
                     for event in catcher.caught_events
                     if event.data.artifact_type == "SemanticManifest"
+                ]
+            )
+            > 0
+        )
+        assert (
+            len(
+                [
+                    event
+                    for event in catcher.caught_events
+                    if event.data.artifact_type == "OsiDocument"
                 ]
             )
             > 0

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -317,6 +317,7 @@ sample_values = [
     core_types.PackageNodeDependsOnRootProjectNode(
         node_name="", node_package="", root_project_unique_id=""
     ),
+    core_types.MFConverterIssue(issue_type="", element_name="", converter_name=""),
     # M - Deps generation ======================
     core_types.GitSparseCheckoutSubdirectory(subdir=""),
     core_types.GitProgressCheckoutRevision(revision=""),


### PR DESCRIPTION
resolves #12786 

## Summary

- Adds `osi_document.json` output to the dbt parse artifact directory alongside the existing `semantic_manifest.json`. The OSI (Open Semantic Interchange) document is generated by the `MSIToOSIConverter` from metricflow, converting the full `PydanticSemanticManifest` to the vendor-agnostic OSI format.
- Surfaces per-issue warnings when the converter drops or degrades elements (e.g. conversion metrics, private metrics, natural entities, cumulative semantics). Each warning fires a `MFConverterIssue` (I078) event with the issue type and affected element name so operators have actionable context about what was omitted.
- Bumps `dbt-protos` minimum to `1.0.498`, which introduces the `MFConverterIssue` event specifically for metricflow converter information-loss notifications.

## Test plan

- [ ] `hatch run default:pytest tests/unit/test_events.py` — covers the new `MFConverterIssue` event registration
- [ ] Manual: run `dbt parse` on a project with semantic models and confirm `target/osi_document.json` is written alongside `target/semantic_manifest.json`
- [ ] Manual: confirm `MFConverterIssue` warnings appear for projects with conversion metrics or private metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)