### PR TITLE
deps: cap dbt-adapters to <1.24 for 1.10.x line

### DIFF
--- a/.changes/unreleased/Dependencies-20260514-093001.yaml
+++ b/.changes/unreleased/Dependencies-20260514-093001.yaml
@@ -1,0 +1,7 @@
+kind: Dependencies
+body: Cap dbt-adapters to <1.24 to prevent KeyError on dbt parse when older dbt-core
+  encounters the JS UDF macro change shipped in dbt-adapters 1.24.0 (see dbt-labs/dbt-adapters#1926)
+time: 2026-05-14T09:30:01.000000-05:00
+custom:
+  Author: sriramk-dbt
+  Issue: "NA"

--- a/.changes/unreleased/Dependencies-20260514-093001.yaml
+++ b/.changes/unreleased/Dependencies-20260514-093001.yaml
@@ -3,5 +3,5 @@ body: Cap dbt-adapters to <1.24 to prevent KeyError on dbt parse when older dbt-
   encounters the JS UDF macro change shipped in dbt-adapters 1.24.0 (see dbt-labs/dbt-adapters#1926)
 time: 2026-05-14T09:30:01.000000-05:00
 custom:
-  Author: sriramk-dbt
+  Author: sriramr98
   Issue: "NA"

--- a/core/setup.py
+++ b/core/setup.py
@@ -73,7 +73,7 @@ setup(
         "dbt-semantic-interfaces>=0.9.0,<0.10",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.34.2,!=1.35.*,!=1.36.*,!=1.37.0,!=1.37.1,!=1.37.2,<2.0",
-        "dbt-adapters>=1.15.5,<2.0",
+        "dbt-adapters>=1.15.5,<1.24",
         "dbt-protos>=1.0.405,<2.0",
         "pydantic<3",
         # ----


### PR DESCRIPTION
See dbt-labs/dbt-adapters#1926.

Resolves #

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

dbt-adapters 1.24.0 added 'javascript' to supported_languages in the default function materialization. dbt-core <1.12.0b1 uses a strict enum lookup (ModelLanguage[item.value]) in get_supported_languages, which raises KeyError: 'javascript' during macro parsing.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Capping `dbt-adapters<1.24` ensures users on dbt-core `1.10.x` cannot silently resolve into the broken combo via `pip install -U`.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
