### PR TITLE
pinned dbt-adapters to < 1.24 as there are breaking changes in 1.24 w…

### DIFF
--- a/.changes/unreleased/Dependencies-20260514-135848.yaml
+++ b/.changes/unreleased/Dependencies-20260514-135848.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Pinned dbt-adapters<1.24 to avoid breaking changes in 1.24 JS UDFs. Ref https://github.com/dbt-labs/dbt-adapters/issues/1926
+time: 2026-05-14T13:58:48.288009+05:30
+custom:
+    Author: sriramr98
+    Issue: "12960"

--- a/core/hatch.toml
+++ b/core/hatch.toml
@@ -40,11 +40,10 @@ include = [
 # CI uses [envs.ci] which doesn't set python, allowing matrix testing
 python = "3.11"
 dependencies = [
-    # Git dependencies for development against main branches
-    "dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-adapters",
-    "dbt-tests-adapter @ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-tests-adapter",
-    "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git@main",
-    "dbt-postgres @ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-postgres",
+    "dbt-adapters<1.24",
+    "dbt-tests-adapter",
+    "dbt-common",
+    "dbt-postgres",
     # Code quality
     "pre-commit~=3.7.0",
     "black>=24.3,<25.0",
@@ -174,11 +173,10 @@ check-sdist = [
 # CI environment - isolated environment with test dependencies
 [envs.ci]
 dependencies = [
-    # Git dependencies for development against main branches
-    "dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-adapters",
-    "dbt-tests-adapter @ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-tests-adapter",
-    "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git@main",
-    "dbt-postgres @ git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-postgres",
+    "dbt-adapters<1.24",
+    "dbt-tests-adapter",
+    "dbt-common",
+    "dbt-postgres",
     # Testing
     "pre-commit~=3.7.0",
     "pytest>=7.0,<8.0",


### PR DESCRIPTION
### Problem

The hatch `default` and `ci` environments on the `1.11.latest` line install `dbt-adapters`, `dbt-tests-adapter`, `dbt-common`, and `dbt-postgres` from `git+...@main`. `dbt-adapters` main is now `1.24.0`, which introduces a breaking change for dbt-core <1.12 (see dbt-labs/dbt-adapters#1926: `'javascript'` added to supported_languages causes `KeyError` against dbt-core's strict `ModelLanguage` enum lookup).

As a result, CI on the 1.11.x line pulls a version of `dbt-adapters` that is incompatible with `dbt-core` 1.11.x, and once #12957 lands the cap in `pyproject.toml`, the same envs additionally fail with `ResolutionImpossible`.

Resolves #12960

### Solution

Switch the adapter dev/CI dependencies in `core/hatch.toml` from `git@main` installs to PyPI version specs:

- `dbt-adapters<1.24` — avoid the breaking change
- `dbt-tests-adapter`, `dbt-common`, `dbt-postgres` — latest from PyPI; pip selects versions compatible with the adapters cap

### Checklist
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

