### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260514-195334.yaml
+++ b/.changes/unreleased/Under the Hood-20260514-195334.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-05-14T19:53:34.117692557Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -5770,7 +5770,19 @@
             "null"
           ]
         },
+        "+external_location": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+file_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "+formatter": {
           "type": [
             "string",
             "null"

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -9380,6 +9380,12 @@
             "null"
           ]
         },
+        "external_location": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "external_volume": {
           "type": [
             "string",
@@ -9387,6 +9393,12 @@
           ]
         },
         "file_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "formatter": {
           "type": [
             "string",
             "null"
@@ -10251,6 +10263,18 @@
           ]
         },
         "event_time": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "external_location": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "formatter": {
           "type": [
             "string",
             "null"


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`b489baf8495d33f50111ff95f9ad135a6ff4050f`](https://github.com/dbt-labs/fs/commit/b489baf8495d33f50111ff95f9ad135a6ff4050f)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/25880889039)