### PR TITLE
fix: bridge compile→materialization boundary for config.get_rendered

### DIFF
--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -623,6 +623,11 @@ class Compiler:
                 context,
                 node,
             )
+            # Stash rendered config values so materialization macros can access
+            # them via config.get_rendered() even though they run in a fresh context.
+            config_obj = context.get("config")
+            if config_obj is not None and hasattr(config_obj, "rendered_config_call_dict"):
+                node._rendered_config = config_obj.rendered_config_call_dict
 
         node.compiled = True
 

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -507,6 +507,24 @@ class Config(Protocol):
         return config
 
 
+def _make_parse_safe(value: Any) -> Any:
+    """Recursively convert non-msgpack-serializable values to strings.
+
+    parse-time ref() / source() calls return RelationProxy objects that cannot
+    be serialized to msgpack.  This helper converts them (and anything else not
+    representable as a primitive) to their string form so the manifest stays
+    serializable.  Callers that need the correctly-rendered runtime value should
+    use config.get_rendered() instead of config.get().
+    """
+    if isinstance(value, dict):
+        return {k: _make_parse_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_make_parse_safe(v) for v in value]
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    return str(value)
+
+
 # Implementation of "config(..)" calls in models
 class ParseConfigObject(Config):
     def __init__(self, model, context_config: Optional[ContextConfig]):
@@ -534,8 +552,13 @@ class ParseConfigObject(Config):
             if unrendered_config:
                 self.context_config.add_unrendered_config_call(unrendered_config)
 
-        # Use rendered opts to populate context_config
-        self.context_config.add_config_call(opts)
+        # Use rendered opts to populate context_config.
+        # At parse time, ref() returns the current model's own relation, not the
+        # referenced model's, so any RelationProxy values in opts are already
+        # semantically incorrect for the parsed config.  Stringify non-primitive
+        # values so the manifest stays msgpack-serializable; callers that need
+        # the correctly-rendered value must use config.get_rendered() instead.
+        self.context_config.add_config_call(_make_parse_safe(opts))
         return ""
 
     def set(self, name, value):
@@ -2000,7 +2023,13 @@ def generate_runtime_model_context(
     manifest: Manifest,
 ) -> Dict[str, Any]:
     ctx = ModelContext(model, config, manifest, RuntimeProvider(), None)
-    return ctx.to_dict()
+    ctx_dict = ctx.to_dict()
+    # Rehydrate rendered config captured during compilation so that
+    # materialization macros can call config.get_rendered() correctly.
+    rendered_config = getattr(model, "_rendered_config", None)
+    if rendered_config:
+        ctx_dict["config"].rendered_config_call_dict.update(rendered_config)
+    return ctx_dict
 
 
 def generate_runtime_macro_context(


### PR DESCRIPTION
## Summary

Builds on @MichelleArk's `exp-config-get-rendered` spike (PR #12365) to make `config.get_rendered()` actually usable from materialization macros — the primary use case that motivated the feature.

### The problem

The spike adds `config.get_rendered()` to `RuntimeConfigObject`, populated when the model SQL is rendered. But dbt calls `generate_runtime_model_context()` twice per model execution — once during compilation and once for the materialization macro — each time creating a **fresh** `RuntimeConfigObject`. The dict filled during compilation was silently discarded, so `config.get_rendered()` always returned `None` inside materializations.

There was a second problem at parse time: `ref()` inside `config(target_table=ref('x'))` returns a `RelationProxy` object, which `ParseConfigObject` stored verbatim in the parsed config. That object cannot be msgpack-serialised, crashing the manifest write.

### Three changes to close both gaps

**1. `_make_parse_safe()` in `providers.py`**
At parse time, `ref()` returns the *current* model's own `RelationProxy` (not the referenced model's) — so the value is already semantically wrong for the parsed config. Stringify non-primitive values before `add_config_call()` so the manifest stays serialisable. Callers that need the correct runtime value use `config.get_rendered()` instead of `config.get()`.

**2. Stash `rendered_config_call_dict` onto the node in `compilation.py`**
After `jinja.get_rendered()` finishes, copy the populated dict to `node._rendered_config` as a transient (non-serialised) attribute.

**3. Rehydrate in `generate_runtime_model_context()`**
When building the materialization context, pre-populate the new `RuntimeConfigObject.rendered_config_call_dict` from `node._rendered_config` so materialization macros see the values captured during compilation.

### Result

Adapter materializations can now use `config.get_rendered('target_table')` to access `ref()`-based config values **without requiring `| string`**:

```jinja
{{ config(
    materialized='materialized_view',
    target_table=ref('my_target')
) }}
```

Validated against ClickHouse with the dbt-clickhouse adapter — the MV materialization's explicit-target mode (previously requiring regex parsing of SQL comments) now works cleanly through `config.get_rendered('target_table')`.

## Test plan

- [ ] Existing `TestCompileRenderedConfig` test in `tests/functional/compile/test_compile.py` still passes
- [ ] New model with `config(target_table=ref('x'))` (no `| string`) works end-to-end in dbt-clickhouse
- [ ] `dbt run` does not crash with `can not serialize 'ClickHouseRelation' object`
- [ ] `config.get_rendered()` returns `None` (not the relation) when `target_table` is not set

🤖 Generated with [Claude Code](https://claude.ai/claude-code)