### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260515-112741.yaml
+++ b/.changes/unreleased/Under the Hood-20260515-112741.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-05-15T11:27:41.200470932Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -969,6 +969,33 @@
         "$ref": "#/definitions/PostgresIndex"
       }
     },
+    "LatestVersionView": {
+      "description": "Represents the latest version view configuration for versioned models. Supports shorthand (bool) and full form ({enabled: bool, alias: string}).",
+      "type": "object",
+      "properties": {
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enabled": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "LogPath": {
       "type": "string",
       "enum": [
@@ -3083,6 +3110,16 @@
             {
               "type": "string",
               "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "+latest_version_view": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LatestVersionView"
+            },
+            {
+              "type": "null"
             }
           ]
         },

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -4127,6 +4127,33 @@
         "$ref": "#/definitions/PostgresIndex"
       }
     },
+    "LatestVersionView": {
+      "description": "Represents the latest version view configuration for versioned models. Supports shorthand (bool) and full form ({enabled: bool, alias: string}).",
+      "type": "object",
+      "properties": {
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enabled": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "MacrosArguments": {
       "type": "object",
       "required": [
@@ -5300,6 +5327,16 @@
             {
               "type": "string",
               "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "latest_version_view": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LatestVersionView"
+            },
+            {
+              "type": "null"
             }
           ]
         },


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`a1993e8726f43f9bcf5d791d54b38c7c6fe5eef9`](https://github.com/dbt-labs/fs/commit/a1993e8726f43f9bcf5d791d54b38c7c6fe5eef9)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/25914363201)