### PR TITLE
fix: split intersection selectors in compile/show task_end_messages

### DIFF
--- a/.changes/unreleased/Fixes-20260515-201500.yaml
+++ b/.changes/unreleased/Fixes-20260515-201500.yaml
@@ -1,0 +1,9 @@
+kind: Fixes
+body: "Fix RuntimeError when using comma-separated intersection selectors (e.g.
+    `state:modified+,+state:modified`) with `dbt show` or `dbt compile` — the
+    task_end_messages filter now correctly splits on the intersection delimiter
+    before parsing each criterion"
+time: 2026-05-15T20:15:00.000000+05:30
+custom:
+    Author: aahelguha
+    Issue: "12937"

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -1,3 +1,4 @@
+import itertools
 import threading
 from typing import Optional, Set, Type, TypeVar
 
@@ -7,6 +8,7 @@ from dbt.contracts.graph.nodes import ManifestSQLNode
 from dbt.events.types import CompiledNode, ParseInlineNodeError
 from dbt.flags import get_flags
 from dbt.graph import ResourceTypeSelector
+from dbt.graph.cli import INTERSECTION_DELIMITER
 from dbt.graph.graph import UniqueId
 from dbt.graph.selector_spec import SelectionCriteria
 from dbt.node_types import EXECUTABLE_NODE_TYPES, NodeType
@@ -88,24 +90,27 @@ class CompileTask(GraphRunnableTask):
     def _get_directly_selected_unique_ids(self) -> Set[UniqueId]:
         """unique_ids matched by --select before graph operator (+/@) expansion.
 
-        Each entry in self.selection_arg is parsed as a single SelectionCriteria
-        — intersection tokens within one entry (e.g. ``tag:foo,tag:bar``) are
-        not split here and will resolve to nothing, matching the pre-existing
-        filter behavior for that grammar. The execution path still selects
-        nodes correctly via parse_difference; only end-of-task output filtering
-        is affected.
+        Mirrors the tokenization logic in ``parse_union``: space-splits each
+        entry into independent specs, then comma-splits each spec into an
+        intersection group.  Each criterion is resolved independently via
+        ``select_included`` (the no-operator-expansion path); intersection
+        groups are intersected, and the results are unioned.
         """
         if not self.selection_arg:
             return set()
         selector = self.get_node_selector()
         graph_nodes = selector.graph.nodes()
-        return {
-            uid
-            for raw in self.selection_arg
-            for uid in selector.select_included(
-                graph_nodes, SelectionCriteria.from_single_spec(raw)
-            )
-        }
+        result: Set[UniqueId] = set()
+        raw_specs = itertools.chain.from_iterable(r.split(" ") for r in self.selection_arg)
+        for raw_spec in raw_specs:
+            parts = raw_spec.split(INTERSECTION_DELIMITER)
+            part_sets = [
+                selector.select_included(graph_nodes, SelectionCriteria.from_single_spec(part))
+                for part in parts
+            ]
+            if part_sets:
+                result |= set.intersection(*part_sets)
+        return result
 
     def task_end_messages(self, results) -> None:
         is_inline = bool(getattr(self.args, "inline", None))

--- a/tests/functional/compile/test_compile.py
+++ b/tests/functional/compile/test_compile.py
@@ -1,11 +1,13 @@
 import json
+import os
 import pathlib
 import re
+import shutil
 
 import pytest
 import sqlparse
 
-from dbt.tests.util import read_file, run_dbt, run_dbt_and_capture
+from dbt.tests.util import read_file, run_dbt, run_dbt_and_capture, write_file
 from dbt_common.exceptions import DbtBaseException as DbtException
 from dbt_common.exceptions import DbtRuntimeError
 from tests.functional.assertions.test_runner import dbtTestRunner
@@ -378,3 +380,34 @@ class TestSqlParseOnlyDepthLeavesTokensNone:
     def test_only_depth_set_leaves_tokens_none(self, project):
         run_dbt(["compile", "--sqlparse", '{"MAX_GROUPING_DEPTH": "10000"}'])
         assert sqlparse.engine.grouping.MAX_GROUPING_TOKENS is None
+
+
+class TestCompileIntersectionStateSelector:
+    """Regression test: ``dbt compile --select 'state:modified+,+state:modified'``
+    must not raise a RuntimeError.  Before the fix, the comma-joined selector
+    was passed unsplit to from_single_spec, producing an invalid value that
+    StateSelectorMethod rejected."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_a.sql": "select 1 as id",
+            "model_b.sql": "select * from {{ ref('model_a') }}",
+        }
+
+    def test_compile_intersection_state_selector(self, project):
+        run_dbt(["run"])
+
+        state_dir = os.path.join(project.project_root, "state")
+        os.makedirs(state_dir, exist_ok=True)
+        shutil.copyfile(
+            os.path.join(project.project_root, "target", "manifest.json"),
+            os.path.join(state_dir, "manifest.json"),
+        )
+
+        write_file("select 1 as id, 'changed' as value", "models", "model_a.sql")
+
+        (results, log_output) = run_dbt_and_capture(
+            ["compile", "--select", "state:modified+,+state:modified", "--state", "./state"]
+        )
+        assert "Compiled node 'model_a' is:" in log_output

--- a/tests/unit/task/test_compile.py
+++ b/tests/unit/task/test_compile.py
@@ -116,3 +116,39 @@ class TestGetDirectlySelectedUniqueIds:
         selector = _selector_returning({})  # select_included returns set() for anything
         with patch.object(CompileTask, "get_node_selector", return_value=selector):
             assert task._get_directly_selected_unique_ids() == set()
+
+    def test_intersection_selector_comma_split(self):
+        """Comma-separated selectors like ``state:modified+,+state:modified``
+        must be split on the comma before being passed to from_single_spec.
+        Regression test for #12937 — without splitting, the raw string is
+        parsed as a single criterion with value='modified+,+state:modified'
+        which raises in StateSelectorMethod.search."""
+        task = _make_task(("state:modified+,+state:modified",))
+        selector = MagicMock()
+        selector.graph.nodes.return_value = {"model.test.a", "model.test.b", "model.test.c"}
+
+        def fake_select_included(nodes, criteria):
+            if criteria.value == "modified" and criteria.children:
+                return {"model.test.a", "model.test.b"}
+            elif criteria.value == "modified" and criteria.parents:
+                return {"model.test.b", "model.test.c"}
+            return set()
+
+        selector.select_included.side_effect = fake_select_included
+        with patch.object(CompileTask, "get_node_selector", return_value=selector):
+            result = task._get_directly_selected_unique_ids()
+
+        # Intersection of {a, b} and {b, c} = {b}
+        assert result == {"model.test.b"}
+        assert selector.select_included.call_count == 2
+
+    def test_space_separated_selectors_unioned(self):
+        """Space-separated tokens within a single --select entry are unioned,
+        mirroring parse_union semantics."""
+        task = _make_task(("model_a model_b",))
+        selector = _selector_returning(
+            {"model_a": ["model.test.a"], "model_b": ["model.test.b"]}
+        )
+        with patch.object(CompileTask, "get_node_selector", return_value=selector):
+            result = task._get_directly_selected_unique_ids()
+        assert result == {"model.test.a", "model.test.b"}

--- a/tests/unit/task/test_compile.py
+++ b/tests/unit/task/test_compile.py
@@ -146,9 +146,7 @@ class TestGetDirectlySelectedUniqueIds:
         """Space-separated tokens within a single --select entry are unioned,
         mirroring parse_union semantics."""
         task = _make_task(("model_a model_b",))
-        selector = _selector_returning(
-            {"model_a": ["model.test.a"], "model_b": ["model.test.b"]}
-        )
+        selector = _selector_returning({"model_a": ["model.test.a"], "model_b": ["model.test.b"]})
         with patch.object(CompileTask, "get_node_selector", return_value=selector):
             result = task._get_directly_selected_unique_ids()
         assert result == {"model.test.a", "model.test.b"}


### PR DESCRIPTION
## Summary

- Fixes a regression from #12937 where `_get_directly_selected_unique_ids` passed the raw `--select` string directly to `SelectionCriteria.from_single_spec` without splitting on the intersection delimiter (`,`).
- Selectors like `state:modified+,+state:modified` were parsed as a single criterion with an invalid value (`"modified,state:modified"`), causing a `RuntimeError` in `StateSelectorMethod.search`.
- The fix mirrors `parse_union`'s tokenization: space-split → comma-split → resolve each criterion independently → intersect within groups → union across groups.

## Repro

```
dbt show --select "state:modified+,+state:modified" --state ./target-old
```

Error on Latest (without fix):
```
Runtime Error
  Got an invalid selector "modified,state:modified", expected one of "['new', 'old', 'modified', ...]"
```

## Test plan

- [x] Added unit tests covering comma-separated intersection selectors and space-separated union selectors
- [x] Existing unit tests continue to pass (13/13)
- [ ] CI passes
- [ ] Manually verify `dbt show --select "state:modified+,+state:modified"` no longer raises