### PR TITLE
Fix #12975: fail parse when generic tests reference missing nodes

### DIFF
--- a/.changes/unreleased/Fixes-20260517-115903.yaml
+++ b/.changes/unreleased/Fixes-20260517-115903.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: 'Fail parse when generic tests reference missing nodes (Fixes #12975)'
+time: 2026-05-17T11:59:03.833668-04:00
+custom:
+    Author: omarfarooq908
+    Issue: "12975"

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -81,7 +81,6 @@ from dbt.events.types import (
     InvalidConcurrentBatchesConfig,
     InvalidDisabledTargetInTestNode,
     MicrobatchModelNoEventTimeInputs,
-    NodeNotFoundOrDisabled,
     PackageNodeDependsOnRootProjectNode,
     ParsedFileLoadFailed,
     ParsePerfInfoPath,
@@ -1702,18 +1701,13 @@ def invalid_target_fail_unless_test(
 
             fire_event(event, EventLevel.WARN if should_warn_if_disabled else None)
         else:
-            fire_or_defer_event(
-                NodeNotFoundOrDisabled(
-                    original_file_path=node.original_file_path,
-                    unique_id=node.unique_id,
-                    resource_type_title=node.resource_type.title(),
-                    target_name=target_name,
-                    target_kind=target_kind,
-                    target_package=target_package if target_package else "",
-                    disabled=str(disabled),
-                ),
-                force_warn_or_error_handling=True,
-                event_group_type=EventGroupType.PARSE,
+            raise TargetNotFoundError(
+                node=node,
+                target_name=target_name,
+                target_kind=target_kind,
+                target_package=target_package,
+                target_version=target_version,
+                disabled=disabled,
             )
     else:
         raise TargetNotFoundError(

--- a/tests/functional/schema_tests/test_invalid_generic_test_ref.py
+++ b/tests/functional/schema_tests/test_invalid_generic_test_ref.py
@@ -1,0 +1,42 @@
+import pytest
+
+from dbt.exceptions import CompilationError
+from dbt.tests.util import run_dbt
+
+# Minimal repro for dbt-core #12975: relationships test with invalid to: ref() in arguments.
+
+models__my_model_sql = "select 1 as pk_line_item"
+
+models__valid_parent_sql = "select 1 as pk_line_item"
+
+schema_yml = """
+version: 2
+
+models:
+  - name: my_model
+    columns:
+      - name: fk_line_item
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                field: pk_line_item
+                to: ref('missing_parent_model')
+"""
+
+
+class TestInvalidRefInGenericTestArguments:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": models__my_model_sql,
+            "valid_parent.sql": models__valid_parent_sql,
+            "schema.yml": schema_yml,
+        }
+
+    def test_parse_fails_on_missing_ref_in_generic_test(self, project):
+        with pytest.raises(CompilationError) as excinfo:
+            run_dbt(["parse"])
+
+        assert "missing_parent_model" in str(excinfo.value)
+        assert "which was not found" in str(excinfo.value)


### PR DESCRIPTION
Raise TargetNotFoundError for tests with missing refs during process_refs instead of warning and disabling. Add functional test.

Resolves #12975

### Problem

Generic tests with a missing `ref` or `source` (e.g. `relationships` with `arguments.to: ref('missing_model')`) only produced a parse warning, set `enabled: false`, and were omitted from `dbt ls` — easy to miss. Fusion fails parse ([#12975](https://github.com/dbt-labs/dbt-core/issues/12975)).

### Solution

Raise `TargetNotFoundError` in `invalid_target_fail_unless_test` when a test depends on a missing node, matching models and other resources. Tests referencing **disabled** nodes still warn only.

Added `tests/functional/schema_tests/test_invalid_generic_test_ref.py`.

**Behavior change:** Projects with invalid generic-test refs that previously parsed with a warning will now fail parse until fixed.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.