### PR TITLE
fix: strip unknown keys from DependsOn during deserialization (#12900)

### DIFF
--- a/.changes/unreleased/Fixes-20260517-depends-on-fusion-extra-keys.yaml
+++ b/.changes/unreleased/Fixes-20260517-depends-on-fusion-extra-keys.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix loading Fusion-generated manifests that include extra keys in the `depends_on` block (e.g. `nodes_with_ref_location`)
+custom:
+  Author: afischh
+  Issue: "12900"
+time: 2026-05-17T00:00:00Z

--- a/core/dbt/artifacts/resources/v1/components.py
+++ b/core/dbt/artifacts/resources/v1/components.py
@@ -1,5 +1,5 @@
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields as dataclass_fields
 from datetime import timedelta
 from typing import Any, Dict, List, Optional, Union
 
@@ -52,6 +52,15 @@ class DependsOn(MacroDependsOn):
     def add_node(self, value: str):
         if value not in self.nodes:
             self.nodes.append(value)
+
+    @classmethod
+    def __pre_deserialize__(cls, data):
+        data = super().__pre_deserialize__(data)
+        # Fusion (dbt-fusion) adds extra keys such as `nodes_with_ref_location`
+        # to the depends_on block. Strip any keys not declared on this dataclass
+        # so mashumaro does not raise InvalidFieldValue on unknown fields.
+        known = {f.name for f in dataclass_fields(cls)}
+        return {k: v for k, v in data.items() if k in known}
 
 
 @dataclass

--- a/tests/unit/artifacts/test_depends_on.py
+++ b/tests/unit/artifacts/test_depends_on.py
@@ -1,0 +1,52 @@
+"""Regression tests for dbt-core#12900.
+
+Fusion (dbt-fusion) adds extra keys such as `nodes_with_ref_location` to the
+depends_on block of manifest nodes. DependsOn.__pre_deserialize__ must silently
+drop those unknown keys so that loading a Fusion-generated manifest does not
+raise InvalidFieldValue.
+"""
+
+import pytest
+
+from dbt.artifacts.resources.v1.components import DependsOn, MacroDependsOn
+
+
+class TestDependsOnFromDict:
+    def test_extra_keys_stripped(self):
+        data = {
+            "macros": ["macro.pkg.my_macro"],
+            "nodes": ["model.pkg.my_model"],
+            "nodes_with_ref_location": [
+                {"unique_id": "model.pkg.my_model", "ref_location": {"line": 1}}
+            ],
+        }
+        result = DependsOn.from_dict(data)
+        assert result.macros == ["macro.pkg.my_macro"]
+        assert result.nodes == ["model.pkg.my_model"]
+
+    def test_known_keys_preserved(self):
+        data = {"macros": ["macro.a.b"], "nodes": ["model.a.c"]}
+        result = DependsOn.from_dict(data)
+        assert result.macros == ["macro.a.b"]
+        assert result.nodes == ["model.a.c"]
+
+    def test_empty_depends_on(self):
+        result = DependsOn.from_dict({"macros": [], "nodes": []})
+        assert result.macros == []
+        assert result.nodes == []
+
+    def test_multiple_unknown_keys_stripped(self):
+        data = {
+            "macros": [],
+            "nodes": [],
+            "nodes_with_ref_location": [],
+            "future_unknown_field": "value",
+        }
+        result = DependsOn.from_dict(data)
+        assert result.macros == []
+        assert result.nodes == []
+
+    def test_macro_depends_on_unaffected(self):
+        # MacroDependsOn is the parent and should still work normally
+        result = MacroDependsOn.from_dict({"macros": ["macro.pkg.m"]})
+        assert result.macros == ["macro.pkg.m"]


### PR DESCRIPTION
## Summary

Fusion (`dbt-fusion`) generates manifest nodes with extra keys in the `depends_on` block — specifically `nodes_with_ref_location`. When loading such a manifest in dbt-core, mashumaro raises `InvalidFieldValue` because `DependsOn` only declares `macros` and `nodes`.

**Root cause:** `DependsOn` has no `__pre_deserialize__` hook. Mashumaro rejects unknown keys at deserialization time.

**Fix:** Add `__pre_deserialize__` to `DependsOn` that filters the incoming dict to only the fields declared on the dataclass, using `dataclasses.fields(cls)`. This follows the existing pattern used by `HasRelationMetadata` in the same file and is forward-safe — new fields added to `DependsOn` will be included automatically.

## Changes

- `core/dbt/artifacts/resources/v1/components.py`: `DependsOn.__pre_deserialize__` strips unknown keys before mashumaro processes them
- `tests/unit/artifacts/test_depends_on.py`: regression tests covering the Fusion `nodes_with_ref_location` case and edge cases

## Checklist

- [x] Added regression test
- [x] Added changie entry
- [x] Follows existing `__pre_deserialize__` pattern in codebase

Fixes #12900