### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260518-112144.yaml
+++ b/.changes/unreleased/Under the Hood-20260518-112144.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-05-18T11:21:44.994449221Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -969,7 +969,7 @@
         "$ref": "#/definitions/PostgresIndex"
       }
     },
-    "LatestVersionView": {
+    "LatestVersionPointer": {
       "description": "Represents the latest version view configuration for versioned models. Supports shorthand (bool) and full form ({enabled: bool, alias: string}).",
       "type": "object",
       "properties": {
@@ -3113,10 +3113,10 @@
             }
           ]
         },
-        "+latest_version_view": {
+        "+latest_version_pointer": {
           "anyOf": [
             {
-              "$ref": "#/definitions/LatestVersionView"
+              "$ref": "#/definitions/LatestVersionPointer"
             },
             {
               "type": "null"

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -4127,7 +4127,7 @@
         "$ref": "#/definitions/PostgresIndex"
       }
     },
-    "LatestVersionView": {
+    "LatestVersionPointer": {
       "description": "Represents the latest version view configuration for versioned models. Supports shorthand (bool) and full form ({enabled: bool, alias: string}).",
       "type": "object",
       "properties": {
@@ -5330,10 +5330,10 @@
             }
           ]
         },
-        "latest_version_view": {
+        "latest_version_pointer": {
           "anyOf": [
             {
-              "$ref": "#/definitions/LatestVersionView"
+              "$ref": "#/definitions/LatestVersionPointer"
             },
             {
               "type": "null"


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`3d61f23b19a1f263f7e916d76c15a73e0ea72436`](https://github.com/dbt-labs/fs/commit/3d61f23b19a1f263f7e916d76c15a73e0ea72436)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/26029082855)