### PR TITLE
Fix AttributeError in write_osi_document_to_file

### DIFF
--- a/.changes/unreleased/Fixes-20260518-120000.yaml
+++ b/.changes/unreleased/Fixes-20260518-120000.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix `AttributeError` when writing the OSI document during manifest parsing
+    caused by a call to a non-existent `_get_pydantic_semantic_manifest` method.
+time: 2026-05-18T12:00:00.000000-05:00
+custom:
+    Author: colin-rogers-dbt
+    Issue: "0000"

--- a/core/dbt/contracts/graph/semantic_manifest.py
+++ b/core/dbt/contracts/graph/semantic_manifest.py
@@ -153,7 +153,7 @@ class SemanticManifest:
         from metricflow.converters.msi_to_osi import MSIToOSIConverter
 
         try:
-            result = MSIToOSIConverter().convert(self._get_pydantic_semantic_manifest())
+            result = MSIToOSIConverter().convert(self.get_pydantic_semantic_manifest())
         except RuntimeError as exc:
             fire_event(
                 SemanticValidationFailure(


### PR DESCRIPTION
## Summary
- `SemanticManifest.write_osi_document_to_file` calls `self._get_pydantic_semantic_manifest()` — a method that does not exist on the class. The actual method is `get_pydantic_semantic_manifest` (no leading underscore), as used correctly two lines below in `write_json_to_file`.
- This breaks every dbt invocation that parses a manifest: `write_osi_document_to_file` is called unconditionally from `write_semantic_manifest`, which is called from `write_manifest` at the end of `parse_manifest`. Result: `AttributeError: 'SemanticManifest' object has no attribute '_get_pydantic_semantic_manifest'`.

## Test plan
- [ ] CI green (functional tests that previously failed on parse should now pass)
- [ ] Local: dbt parse on a project with a semantic manifest no longer raises AttributeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)