### PR TITLE
fix: annotate PARAM_TYPE_MAP to satisfy mypy with click 8.4.0

### DIFF
--- a/.changes/unreleased/Under the Hood-20260518-160000.yaml
+++ b/.changes/unreleased/Under the Hood-20260518-160000.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Annotate PARAM_TYPE_MAP to fix mypy failure with click 8.4.0
+time: 2026-05-18T16:00:00.000000000Z
+custom:
+    Author: colin-rogers-dbt
+    Issue: N/A

--- a/core/dbt/docs/source/_ext/dbt_click.py
+++ b/core/dbt/docs/source/_ext/dbt_click.py
@@ -8,7 +8,7 @@ from docutils.parsers.rst import Directive
 
 import dbt.cli.option_types as dbt_t
 
-PARAM_TYPE_MAP = {
+PARAM_TYPE_MAP: t.Dict[type, t.Callable[[t.Any], str]] = {
     click_t.BoolParamType: lambda _: "boolean",
     click_t.Choice: lambda c: f"choice: {c.choices}",
     click_t.IntParamType: lambda _: "int",


### PR DESCRIPTION
## Summary
- `code-quality` has been failing on `main` and every PR since 2026-05-17, when click 8.4.0 was released. click 8.4.0 changed the metaclass of its `ParamType` subclasses, causing mypy to infer `PARAM_TYPE_MAP`'s keys as `ABCMeta` and reject the `type(param.type)` lookup in [core/dbt/docs/source/_ext/dbt_click.py:44](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/docs/source/_ext/dbt_click.py#L44).
- Annotating the dict as `Dict[type, Callable[[Any], str]]` restores the broader key type and unblocks CI without pinning click.

The exact error:
```
core/dbt/docs/source/_ext/dbt_click.py:44: error: No overload variant of "get" of "dict"
  matches argument types "type[Any]", "Callable[[Any], str]"  [call-overload]
```

## Test plan
- [ ] `code-quality` job passes in CI
- [ ] No other mypy regressions introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)