### PR TITLE
deps: bump dbt-adapters lower bound to 1.24.1

### DIFF
--- a/.changes/unreleased/Dependencies-20260519-125430.yaml
+++ b/.changes/unreleased/Dependencies-20260519-125430.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump dbt-adapters lower bound to >=1.24.1
+time: 2026-05-19T12:54:30.70035+05:30
+custom:
+    Author: aahel
+    Issue: "12985"

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "metricflow>=0.211.0,<1.0",
     # Minor versions for these are expected to be backwards-compatible
     "dbt-common>=1.37.5,<2.0",
-    "dbt-adapters>=1.23.0,<2.0",
+    "dbt-adapters>=1.24.1,<2.0",
     "dbt-protos>=1.0.498,<2.0",
     "pydantic<3",
     # ----


### PR DESCRIPTION
## Summary

- Bumps the `dbt-adapters` lower bound from `>=1.23.0` to `>=1.24.1` in `core/pyproject.toml`

## Test plan

- [ ] CI passes (no code changes, dependency constraint update only)