### PR TITLE
deps: restore dbt-adapters upper bound to <2.0 for 1.10.x

### DIFF
--- a/.changes/unreleased/Dependencies-20260519-214655.yaml
+++ b/.changes/unreleased/Dependencies-20260519-214655.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Restore dbt-adapters upper bound to <2.0 (reverting the temporary <1.24 cap) now that the breaking change in dbt-adapters 1.24.0 has been addressed.
+time: 2026-05-19T21:46:55.030968+05:30
+custom:
+    Author: sriramr98
+    Issue: NA

--- a/core/setup.py
+++ b/core/setup.py
@@ -73,7 +73,7 @@ setup(
         "dbt-semantic-interfaces>=0.9.0,<0.10",
         # Minor versions for these are expected to be backwards-compatible
         "dbt-common>=1.34.2,!=1.35.*,!=1.36.*,!=1.37.0,!=1.37.1,!=1.37.2,<2.0",
-        "dbt-adapters>=1.15.5,<1.24",
+        "dbt-adapters>=1.15.5,<2.0",
         "dbt-protos>=1.0.405,<2.0",
         "pydantic<3",
         # ----


### PR DESCRIPTION
## Summary

- Reverts the temporary `dbt-adapters<1.24` cap on the 1.10.x line back to `<2.0`.
- The cap was introduced in #12958 and released in 1.10.21 to prevent users from silently resolving into a broken combo when dbt-adapters 1.24.0 added `javascript` to `supported_languages`.
- Now that the underlying breaking change in dbt-adapters has been addressed, the cap can be lifted. A new 1.10.x patch will follow.

## Test plan

- [ ] CI green
- [ ] Confirm `pip install "dbt-core==1.10.x"` resolves dbt-adapters in `[1.15.5, 2.0)` after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)