### PR TITLE
deps: restore dbt-adapters upper bound to <2.0 for 1.11.x

### DIFF
--- a/.changes/unreleased/Dependencies-20260519-214743.yaml
+++ b/.changes/unreleased/Dependencies-20260519-214743.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Restore dbt-adapters upper bound to <2.0 (reverting the temporary <1.24 cap) now that the breaking change in dbt-adapters 1.24.0 has been addressed.
+time: 2026-05-19T21:47:43.470896+05:30
+custom:
+    Author: sriramr98
+    Issue: NA

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "dbt-semantic-interfaces>=0.9.0,<0.10",
     # Minor versions for these are expected to be backwards-compatible
     "dbt-common>=1.37.3,<2.0",
-    "dbt-adapters>=1.15.5,<1.24",
+    "dbt-adapters>=1.15.5,<2.0",
     "dbt-protos>=1.0.405,<2.0",
     "pydantic<3",
     # ----


### PR DESCRIPTION
## Summary

- Reverts the temporary `dbt-adapters<1.24` cap on the 1.11.x line back to `<2.0`.
- The cap was introduced in #12957 and released in 1.11.10 to prevent users from silently resolving into a broken combo when dbt-adapters 1.24.0 added `javascript` to `supported_languages`.
- Now that the underlying breaking change in dbt-adapters has been addressed, the cap can be lifted. A new 1.11.x patch will follow.

## Test plan

- [ ] CI green
- [ ] Confirm `pip install "dbt-core==1.11.x"` resolves dbt-adapters in `[1.15.5, 2.0)` after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)