### PR TITLE
Skip jsonschema_validation when adapter_type is empty

### DIFF
--- a/.changes/unreleased/Fixes-20260520-142206.yaml
+++ b/.changes/unreleased/Fixes-20260520-142206.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Skip jsonschema_validation if adapter_type is not available
+time: 2026-05-20T14:22:06.144757+05:30
+custom:
+    Author: ash2shukla
+    Issue: "12992"

--- a/core/dbt/jsonschemas/jsonschemas.py
+++ b/core/dbt/jsonschemas/jsonschemas.py
@@ -172,6 +172,10 @@ def _get_allowed_config_fields_from_error_path(
 
 def _can_run_validations() -> bool:
     invocation_context = get_invocation_context()
+    # for commands like dbt deps, we don't have adapter types set yet
+    if not invocation_context.adapter_types:
+        return False
+
     return invocation_context.adapter_types.issubset(_JSONSCHEMA_SUPPORTED_ADAPTERS)
 
 

--- a/core/dbt/jsonschemas/jsonschemas.py
+++ b/core/dbt/jsonschemas/jsonschemas.py
@@ -175,7 +175,6 @@ def _can_run_validations() -> bool:
     # for commands like dbt deps, we don't have adapter types set yet
     if not invocation_context.adapter_types:
         return False
-
     return invocation_context.adapter_types.issubset(_JSONSCHEMA_SUPPORTED_ADAPTERS)
 
 

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -1005,19 +1005,19 @@ class TestPropertyAliasesInConfig:
         return {"sources": {"test": {"+aliased_key": "value"}}}
 
     @mock.patch(
-        "dbt.jsonschemas.jsonschemas._get_allowed_config_key_aliases", return_value={"aliased_key"}
+        "dbt.jsonschemas.jsonschemas._ADAPTER_TO_CONFIG_ALIASES", {"postgres": ["aliased_key"]}
     )
     @mock.patch("dbt.jsonschemas.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
-    def test_property_aliases_in_config(self, mock_get_aliases, project):
+    def test_property_aliases_in_config(self, project):
         event_catcher = EventCatcher(CustomKeyInConfigDeprecation)
         run_dbt(["parse", "--no-partial-parse"], callbacks=[event_catcher.catch])
         assert len(event_catcher.caught_events) == 0
 
     @mock.patch(
-        "dbt.jsonschemas.jsonschemas._get_allowed_config_key_aliases", return_value={"aliased_key"}
+        "dbt.jsonschemas.jsonschemas._ADAPTER_TO_CONFIG_ALIASES", {"postgres": ["aliased_key"]}
     )
     @mock.patch("dbt.jsonschemas.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
-    def test_property_aliases_in_config_for_deps(self, mock_get_aliases, project):
+    def test_deps_command_property_aliases_in_config(self, project):
         event_catcher = EventCatcher(CustomKeyInConfigDeprecation)
         run_dbt(["deps"], callbacks=[event_catcher.catch])
         assert len(event_catcher.caught_events) == 0

--- a/tests/functional/deprecations/test_deprecations.py
+++ b/tests/functional/deprecations/test_deprecations.py
@@ -1012,3 +1012,12 @@ class TestPropertyAliasesInConfig:
         event_catcher = EventCatcher(CustomKeyInConfigDeprecation)
         run_dbt(["parse", "--no-partial-parse"], callbacks=[event_catcher.catch])
         assert len(event_catcher.caught_events) == 0
+
+    @mock.patch(
+        "dbt.jsonschemas.jsonschemas._get_allowed_config_key_aliases", return_value={"aliased_key"}
+    )
+    @mock.patch("dbt.jsonschemas.jsonschemas._JSONSCHEMA_SUPPORTED_ADAPTERS", {"postgres"})
+    def test_property_aliases_in_config_for_deps(self, mock_get_aliases, project):
+        event_catcher = EventCatcher(CustomKeyInConfigDeprecation)
+        run_dbt(["deps"], callbacks=[event_catcher.catch])
+        assert len(event_catcher.caught_events) == 0

--- a/tests/unit/config/test_project.py
+++ b/tests/unit/config/test_project.py
@@ -622,7 +622,8 @@ class TestGetRequiredVersion:
 
 class TestDeprecations:
 
-    def test_jsonschema_validate(self) -> None:
+    @mock.patch("dbt.jsonschemas.jsonschemas._can_run_validations", return_value=True)
+    def test_jsonschema_validate(self, mock_can_run) -> None:
         from dbt.jsonschemas.jsonschemas import jsonschema_validate
 
         project_dict: Dict[str, Any] = {}


### PR DESCRIPTION
Resolves #12992

### Problem
jsonchema_validation is called even when adapter_type is empty

### Solution
Skip calling jsonschema_validation if adapter_type is empty

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
