### PR TITLE
Support newline-delimited JSON (.jsonl/.ndjson) seed files

### DIFF
--- a/.changes/unreleased/Features-20260520-103000.yaml
+++ b/.changes/unreleased/Features-20260520-103000.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support newline-delimited JSON (.jsonl/.ndjson) seed files alongside CSV seeds
+time: 2026-05-20T10:30:00.000000-05:00
+custom:
+    Author: jmmaloney4
+    Issue: "2365"

--- a/JSONL-SEEDS.md
+++ b/JSONL-SEEDS.md
@@ -1,0 +1,283 @@
+# JSONL Object Seeds for dbt-core
+
+Design for dbt-core issue #2365: support newline-delimited JSON seed files
+alongside CSV seeds.
+
+## Goal
+
+Add support for seed files with extensions `.jsonl` and `.ndjson`. Each
+non-empty line must be a valid JSON **object**. The loader converts top-level
+object keys into agate columns and values into agate cell values, so the
+existing seed execution path continues to receive an `agate.Table` unchanged.
+
+## Non-goals
+
+- Top-level JSON arrays.
+- Multi-line JSON records.
+- Adapter-native bulk JSONL loading (BigQuery, etc.).
+- Schema inference for nested fields.
+- Flattening nested objects into dotted columns.
+- Streaming huge files with constant memory. Seeds are for small,
+  version-controlled datasets.
+
+## User-facing behavior
+
+Given `seeds/users.jsonl`:
+
+```jsonl
+{"id": 1, "name": "alpha", "metadata": {"source": "manual", "rank": 1}}
+{"id": 2, "name": "beta", "metadata": {"source": "api", "flags": ["x", "y"]}, "active": true}
+```
+
+dbt builds an agate table equivalent to:
+
+```
+id | name  | metadata                                  | active
+1  | alpha | {"rank":1,"source":"manual"}              | null
+2  | beta  | {"flags":["x","y"],"source":"api"}        | true
+```
+
+Top-level keys become columns. Missing keys become `null`. Nested objects and
+arrays are preserved as compact canonical JSON strings in the cell.
+
+Users can set `column_types` to map JSON columns to native warehouse types:
+
+```yaml
+seeds:
+  my_project:
+    users:
+      +column_types:
+        metadata: json
+```
+
+## File discovery
+
+`core/dbt/parser/read_files.py` — `get_file_types_for_project()` currently
+maps `ParseFileType.Seed` to extension `.csv` only. Add `.jsonl` and
+`.ndjson`:
+
+```python
+ParseFileType.Seed: {
+    "paths": project.seed_paths,
+    "extensions": [".csv", ".jsonl", ".ndjson"],
+    "parser": "SeedParser",
+}
+```
+
+The `read_files_for_parser()` function already iterates over extensions, so
+this is sufficient for both full-parse and partial-parse (`ReadFilesFromDiff`)
+paths. The diff path builds its extension lookup from the same
+`get_file_types_for_project()` return value, so `.jsonl`/`.ndjson` will map
+to `ParseFileType.Seed` automatically.
+
+`load_seed_source_file()` already reads file contents for checksum and sets
+`contents = ""` for non-large seeds — same behavior for JSONL.
+
+Node naming uses `os.path.splitext`, so `users.jsonl` produces node name
+`users`. Having both `users.csv` and `users.jsonl` in the same directory will
+produce a naming collision (same as having two CSV files with the same stem
+in the same directory).
+
+## Integration point: `load_agate_table()`
+
+The critical integration point is `load_agate_table()` in
+`core/dbt/context/providers.py:1285`. This is a `@contextmember()` on the
+Jinja context, called from the seed materialization macro as
+`{{ load_agate_table() }}`.
+
+Current flow:
+
+1. `load_agate_table()` resolves the seed file path from the node's
+   `original_file_path`.
+2. Reads `column_types` and `delimiter` from `self.model.config`.
+3. Validates `column_types` keys against CSV header via `_read_csv_header()`.
+4. Calls `agate_helper.from_csv(path, text_cols=..., delimiter=...)`.
+5. Returns the `agate.Table`. The macro stores it via
+   `store_result("agate_table", ...)`.
+
+The change: after path resolution, dispatch by file extension:
+
+```python
+ext = os.path.splitext(path)[1].lower()
+if ext == ".csv":
+    # existing CSV path (unchanged)
+    table = agate_helper.from_csv(path, text_cols=filtered_column_types, delimiter=delimiter)
+elif ext in {".jsonl", ".ndjson"}:
+    table = load_jsonl_seed_agate_table(path, column_types=filtered_column_types)
+else:
+    raise DbtInternalError(f"Unsupported seed extension: {ext}")
+```
+
+The JSONL branch skips `delimiter` (CSV-only config) and uses a different
+column-type validation approach (see below).
+
+## New module: `core/dbt/task/seed_readers.py`
+
+The JSONL parsing and agate construction logic lives here. Execution-time
+ownership is correct — parse-time code only discovers files and computes
+checksums; actual data loading happens at run time.
+
+### Public API
+
+```python
+from pathlib import Path
+import agate
+
+def load_jsonl_seed_agate_table(
+    path: str,
+    column_types: dict[str, str] | None = None,
+) -> agate.Table:
+    ...
+```
+
+### JSONL parsing rules
+
+Valid records: each non-empty line must parse as a JSON object.
+
+Whitespace-only lines are ignored.
+
+Invalid records raise an error with filename and line number:
+
+```
+Invalid JSONL seed at seeds/users.jsonl:17.
+Expected each non-empty line to be a JSON object; got list.
+```
+
+For JSON decode failures:
+
+```
+Invalid JSONL seed at seeds/users.jsonl:17.
+Could not parse JSON: Expecting ',' delimiter.
+```
+
+Empty files (no valid JSON objects) raise:
+
+```
+JSONL seed file 'seeds/users.jsonl' is empty or contains no valid JSON objects.
+```
+
+### Column discovery
+
+Deterministic first-seen ordering:
+
+1. Iterate records in file order.
+2. For each object, iterate keys in JSON object order.
+3. Append a key to `column_names` the first time it appears.
+4. Missing keys become `None`.
+
+### Duplicate keys inside one object
+
+Use Python's standard `json.loads` behavior: last duplicate key wins. No
+duplicate-key detection in the MVP.
+
+### Value conversion
+
+```python
+def _normalize_jsonl_value(value):
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    raise DbtInternalError(f"Unexpected JSON value type: {type(value)}")
+```
+
+- `dict` and `list` are encoded as compact JSON strings.
+- `sort_keys=True` gives stable, reproducible values.
+- `ensure_ascii=False` preserves Unicode naturally.
+- Top-level list records are rejected; nested arrays inside object fields are
+  allowed and preserved as JSON strings.
+
+### Agate table construction
+
+After collecting all rows:
+
+1. Identify columns that ever contain a nested JSON value (serialized
+   `dict`/`list`). Force these to `agate.Text` so agate doesn't try to infer
+   weird types from JSON-looking strings.
+2. For purely scalar columns, allow agate to infer types (number, boolean,
+   date, text).
+3. Explicitly pass `column_types` to `agate.Table()` to avoid relying on
+   agate's default inference across heterogeneous data.
+
+### Column type validation
+
+CSV validation reads the header row to check `column_types` keys. JSONL has
+no header row. Instead, validate after constructing the table:
+
+1. Build the agate table from the JSONL file.
+2. Compare `column_types` keys against the table's column names.
+3. Log a warning for any `column_types` keys that don't appear as columns
+   (same warning text as CSV path).
+4. Filter `column_types` to valid columns only.
+
+## Config interaction
+
+- `column_types`: continues to control database column type. Works for both
+  CSV and JSONL seeds.
+- `delimiter`: CSV-only. Ignored for JSONL seeds.
+- `quote_columns`: CSV-only. Ignored for JSONL seeds.
+
+## What is NOT changed
+
+- Seed selection semantics.
+- `ref()` behavior.
+- Seed node naming (beyond the extension in `original_file_path`).
+- Existing CSV parsing or materialization macros.
+- `SeedParser`, `SeedConfig`, or `SeedNode` data model.
+
+## Tests
+
+Functional tests in `tests/functional/seeds/`:
+
+- `.jsonl` seed is discovered.
+- `.ndjson` seed is discovered.
+- `dbt seed --select my_seed` loads a JSONL seed.
+- Downstream model can `ref("my_seed")`.
+- Missing keys become null.
+- New columns discovered after row 1 are included.
+- Nested object becomes compact JSON string.
+- Nested array inside an object field becomes compact JSON string.
+- Top-level array errors with filename and line number.
+- Top-level scalar errors with filename and line number.
+- Malformed JSON errors with filename and line number.
+- Empty lines are ignored.
+- Empty file errors with clear message.
+- Existing `.csv` seed tests still pass unchanged.
+- `column_types` works for at least one JSONL column.
+- `column_types` for non-existent JSONL columns produces warning.
+
+Test fixture:
+
+```jsonl
+{"id":1,"name":"alpha","metadata":{"source":"manual","rank":1}}
+{"id":2,"active":true,"metadata":{"source":"api","flags":["x","y"]}}
+{"id":3,"name":null}
+```
+
+Expected columns: `id, name, metadata, active`
+
+Expected metadata values:
+- `{"rank":1,"source":"manual"}`
+- `{"flags":["x","y"],"source":"api"}`
+- `null`
+
+## Open questions for maintainers
+
+1. Extension-based detection is sufficient (consistent with `.sql`/`.py` for
+   models). No `+seed_format` config needed.
+2. Nested arrays inside object fields: allowed, serialized as compact JSON.
+3. `sort_keys=True` for deterministic nested JSON output: yes.
+4. Empty files: clear error message, not agate's generic error.
+5. Duplicate keys: punt, use `json.loads` default behavior.
+
+## MVP PR shape
+
+- Add `.jsonl` and `.ndjson` to seed file discovery.
+- Add `core/dbt/task/seed_readers.py` with JSONL-to-agate loader.
+- Modify `load_agate_table()` in `providers.py` to dispatch by extension.
+- Preserve all existing CSV behavior.
+- Serialize nested JSON to compact strings.
+- Add functional tests.
+- Do not add adapter-native BigQuery loading.

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1283,8 +1283,6 @@ class ProviderContext(ManifestContext):
 
     @contextmember()
     def load_agate_table(self) -> "agate.Table":
-        from dbt_common.clients import agate_helper
-
         if not isinstance(self.model, SeedNode):
             raise LoadAgateTableNotSeedError(self.model.resource_type, node=self.model)
 
@@ -1300,6 +1298,22 @@ class ProviderContext(ManifestContext):
             path = os.path.join(self.model.root_path, self.model.original_file_path)
 
         column_types = self.model.config.column_types or {}
+        ext = os.path.splitext(path)[1].lower()
+
+        if ext == ".csv":
+            table = self._load_csv_agate_table(path, column_types)
+        elif ext in {".jsonl", ".ndjson"}:
+            table = self._load_jsonl_agate_table(path, column_types)
+        else:
+            raise DbtInternalError(f"Unsupported seed extension: {ext}")
+
+        # this is used by some adapters
+        table.original_abspath = os.path.abspath(path)  # type: ignore
+        return table
+
+    def _load_csv_agate_table(self, path: str, column_types: Dict[str, str]) -> "agate.Table":
+        from dbt_common.clients import agate_helper
+
         delimiter = self.model.config.delimiter
 
         # Validate that column_types keys exist in the file header
@@ -1330,8 +1344,29 @@ class ProviderContext(ManifestContext):
                 table = table.limit(0)
         except ValueError as e:
             raise LoadAgateTableValueError(e, node=self.model)
-        # this is used by some adapters
-        table.original_abspath = os.path.abspath(path)  # type: ignore
+        return table
+
+    def _load_jsonl_agate_table(self, path: str, column_types: Dict[str, str]) -> "agate.Table":
+        from dbt.task.seed_readers import JSONLSeedError, load_jsonl_seed_agate_table
+
+        try:
+            table = load_jsonl_seed_agate_table(path, column_types=column_types)
+        except JSONLSeedError as exc:
+            raise CompilationError(msg=str(exc), node=self.model) from exc
+
+        if column_types:
+            table_columns = {col.name for col in table.columns}
+            invalid_column_names = set(column_types) - table_columns
+            if invalid_column_names:
+                invalid_column_names_str = ", ".join(sorted(invalid_column_names))
+                msg = (
+                    f"Column types specified for non-existent columns in seed '{self.model.name}' (file: {path}): "
+                    f"{invalid_column_names_str}. These column type overrides will be ignored."
+                )
+                fire_event(JinjaLogWarning(msg=msg))
+
+        if getattr(get_flags(), "EMPTY", False):
+            table = table.limit(0)
         return table
 
     @contextproperty()

--- a/core/dbt/parser/read_files.py
+++ b/core/dbt/parser/read_files.py
@@ -463,7 +463,7 @@ def get_file_types_for_project(project):
         },
         ParseFileType.Seed: {
             "paths": project.seed_paths,
-            "extensions": [".csv"],
+            "extensions": [".csv", ".jsonl", ".ndjson"],
             "parser": "SeedParser",
         },
         ParseFileType.Documentation: {

--- a/core/dbt/task/seed_readers.py
+++ b/core/dbt/task/seed_readers.py
@@ -1,0 +1,148 @@
+"""Loaders that convert seed files into agate tables.
+
+The CSV path delegates to dbt_common.clients.agate_helper. The JSONL path
+implements object-per-line parsing with nested-value preservation.
+"""
+
+import json
+import os
+from typing import Dict, List, Optional, Sequence
+
+import agate
+
+from dbt_common.exceptions import DbtInternalError
+
+
+# ---------------------------------------------------------------------------
+# JSONL loader
+# ---------------------------------------------------------------------------
+
+_JSONL_EXTENSIONS = frozenset({".jsonl", ".ndjson"})
+
+
+class JSONLSeedError(Exception):
+    """Raised when a JSONL seed file contains invalid content."""
+
+    def __init__(self, path: str, line_number: int, message: str) -> None:
+        self.path = path
+        self.line_number = line_number
+        self.message = message
+        super().__init__(f"Invalid JSONL seed at {path}:{line_number}. {message}")
+
+
+def load_jsonl_seed_agate_table(
+    path: str,
+    column_types: Optional[Dict[str, str]] = None,
+) -> agate.Table:
+    """Parse a JSONL seed file into an agate table.
+
+    Each non-empty line must be a JSON object. Top-level keys across all
+    records become columns (first-seen ordering). Nested dicts and lists are
+    serialised as compact JSON strings. Missing keys become None.
+    """
+    column_names: List[str] = []
+    column_names_set: set = set()
+    rows: List[tuple] = []
+
+    with open(path, "r", encoding="utf-8-sig") as f:
+        for line_number, raw_line in enumerate(f, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise JSONLSeedError(
+                    path,
+                    line_number,
+                    f"Could not parse JSON: {exc.msg}.",
+                ) from exc
+
+            if not isinstance(value, dict):
+                type_name = type(value).__name__
+                if isinstance(value, list):
+                    type_name = "list"
+                raise JSONLSeedError(
+                    path,
+                    line_number,
+                    f"Expected each non-empty line to be a JSON object; got {type_name}.",
+                )
+
+            # Discover new columns in first-seen order.
+            for key in value:
+                if key not in column_names_set:
+                    column_names.append(key)
+                    column_names_set.add(key)
+
+            # Build a row tuple in column_names order.
+            row = tuple(_normalize_jsonl_value(value.get(col)) for col in column_names)
+            rows.append(row)
+
+    if not column_names:
+        raise JSONLSeedError(
+            path,
+            0,
+            "JSONL seed file is empty or contains no valid JSON objects.",
+        )
+
+    # Determine which columns ever held a nested JSON value so we can force
+    # them to agate.Text. Scan the normalised rows rather than re-reading.
+    nested_columns = _detect_nested_columns(rows, column_names)
+
+    # Build explicit column types.
+    agate_column_types = _build_agate_column_types(rows, column_names, nested_columns)
+
+    return agate.Table(rows, column_names, column_types=agate_column_types)
+
+
+def _normalize_jsonl_value(value):
+    """Convert a JSON value to a Python value suitable for an agate cell."""
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    raise DbtInternalError(f"Unexpected JSON value type: {type(value)}")
+
+
+def _detect_nested_columns(
+    rows: Sequence[tuple],
+    column_names: List[str],
+) -> set:
+    """Return the set of column indices that contain serialised JSON strings."""
+    nested = set()
+    for row in rows:
+        for i, val in enumerate(row):
+            if i in nested:
+                continue
+            if isinstance(val, str) and _looks_like_json(val):
+                nested.add(i)
+    return nested
+
+
+def _looks_like_json(value: str) -> bool:
+    """Quick check whether a string starts with a JSON object or array."""
+    return len(value) > 0 and value[0] in ("{", "[")
+
+
+def _build_agate_column_types(
+    rows: Sequence[tuple],
+    column_names: List[str],
+    nested_column_indices: set,
+) -> List:
+    """Build an explicit list of agate column types.
+
+    Columns containing nested JSON are forced to Text. Other columns get a
+    TypeTester that will infer number, boolean, date, or text.
+    """
+    from dbt_common.clients.agate_helper import DEFAULT_TYPE_TESTER
+
+    types: List = []
+    for i, name in enumerate(column_names):
+        if i in nested_column_indices:
+            types.append(agate.Text())
+        else:
+            types.append(DEFAULT_TYPE_TESTER)
+    return types

--- a/tests/functional/seeds/test_jsonl_seeds.py
+++ b/tests/functional/seeds/test_jsonl_seeds.py
@@ -1,0 +1,400 @@
+import pytest
+
+from dbt.tests.util import run_dbt, run_dbt_and_capture
+
+
+# ---------------------------------------------------------------------------
+# Shared seed content
+# ---------------------------------------------------------------------------
+
+seeds__basic_jsonl = """\
+{"id":1,"name":"alpha","metadata":{"source":"manual","rank":1}}
+{"id":2,"active":true,"metadata":{"source":"api","flags":["x","y"]}}
+{"id":3,"name":null}
+"""
+
+seeds__basic_ndjson = """\
+{"id":1,"name":"alpha"}
+{"id":2,"name":"beta"}
+"""
+
+seeds__simple_csv = """\
+id,name
+1,alice
+2,bob
+"""
+
+models__query_jsonl_sql = """
+select * from {{ ref('basic') }}
+"""
+
+models__query_ndjson_sql = """
+select * from {{ ref('basic_ndjson') }}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Discovery and basic loading
+# ---------------------------------------------------------------------------
+
+
+class TestJSONLSeedDiscovery:
+    """JSONL and NDJSON seeds are discovered and loaded."""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "basic.jsonl": seeds__basic_jsonl,
+        }
+
+    def test_jsonl_seed_discovered(self, project):
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        assert results[0].node.name == "basic"
+
+    def test_jsonl_seed_columns(self, project):
+        results = run_dbt(["seed"])
+        table = results[0].agate_table
+        column_names = [col.name for col in table.columns]
+        assert "id" in column_names
+        assert "name" in column_names
+        assert "metadata" in column_names
+        assert "active" in column_names
+
+    def test_jsonl_seed_row_count(self, project):
+        results = run_dbt(["seed"])
+        table = results[0].agate_table
+        assert len(table.rows) == 3
+
+
+class TestNDJSONSeedDiscovery:
+    """NDJSON extension is also supported."""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "basic_ndjson.ndjson": seeds__basic_ndjson,
+        }
+
+    def test_ndjson_seed_discovered(self, project):
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        assert results[0].node.name == "basic_ndjson"
+
+
+# ---------------------------------------------------------------------------
+# Selective seed loading
+# ---------------------------------------------------------------------------
+
+
+class TestJSONLSeedSelect:
+    """dbt seed --select works for JSONL seeds."""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "basic.jsonl": seeds__basic_jsonl,
+            "other.csv": seeds__simple_csv,
+        }
+
+    def test_select_jsonl_seed(self, project):
+        results = run_dbt(["seed", "--select", "basic"])
+        assert len(results) == 1
+        assert results[0].node.name == "basic"
+
+
+# ---------------------------------------------------------------------------
+# Downstream ref()
+# ---------------------------------------------------------------------------
+
+
+class TestJSONLSeedRef:
+    """Downstream models can ref() a JSONL seed."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "query_jsonl.sql": models__query_jsonl_sql,
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "basic.jsonl": seeds__basic_jsonl,
+        }
+
+    def test_ref_jsonl_seed(self, project):
+        run_dbt(["seed"])
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+
+# ---------------------------------------------------------------------------
+# Missing keys become null
+# ---------------------------------------------------------------------------
+
+
+class TestJSONLMissingKeys:
+    """Keys missing from some rows become null."""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "missing.jsonl": seeds__basic_jsonl,
+        }
+
+    def test_missing_keys_null(self, project):
+        results = run_dbt(["seed"])
+        table = results[0].agate_table
+        # Row 0 (id=1) should have active=None since row 1 introduces it
+        # Row 2 (id=3) should have metadata=None and active=None
+        rows = list(table.rows)
+        # Row with id=3 is the third row
+        assert rows[2]["active"] is None
+
+
+# ---------------------------------------------------------------------------
+# New columns discovered after row 1
+# ---------------------------------------------------------------------------
+
+
+class TestJSONLNewColumnsAfterFirstRow:
+    """Columns that first appear in later rows are included."""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "new_cols.jsonl": seeds__basic_jsonl,
+        }
+
+    def test_new_columns_included(self, project):
+        results = run_dbt(["seed"])
+        table = results[0].agate_table
+        column_names = [col.name for col in table.columns]
+        # "active" first appears on row 2 — should still be a column
+        assert "active" in column_names
+        # Row 1 should have active=None
+        rows = list(table.rows)
+        assert rows[0]["active"] is None
+
+
+# ---------------------------------------------------------------------------
+# Nested objects and arrays become compact JSON strings
+# ---------------------------------------------------------------------------
+
+
+class TestJSONLNestedValues:
+    """Nested objects and arrays are preserved as compact JSON strings."""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "nested.jsonl": seeds__basic_jsonl,
+        }
+
+    def test_nested_object_compact_json(self, project):
+        results = run_dbt(["seed"])
+        table = results[0].agate_table
+        rows = list(table.rows)
+        # Row 0: metadata should be a sorted compact JSON string
+        metadata_0 = rows[0]["metadata"]
+        assert isinstance(metadata_0, str)
+        assert '"rank":1' in metadata_0
+        assert '"source":"manual"' in metadata_0
+
+    def test_nested_array_compact_json(self, project):
+        results = run_dbt(["seed"])
+        table = results[0].agate_table
+        rows = list(table.rows)
+        # Row 1: metadata contains "flags": ["x", "y"]
+        metadata_1 = rows[1]["metadata"]
+        assert isinstance(metadata_1, str)
+        assert '"flags":["x","y"]' in metadata_1
+
+    def test_null_nested_value(self, project):
+        results = run_dbt(["seed"])
+        table = results[0].agate_table
+        rows = list(table.rows)
+        # Row 2: metadata is null
+        assert rows[2]["metadata"] is None
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+class TestJSONLTopLevelArrayError:
+    """A top-level JSON array should produce a clear error."""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "bad_array.jsonl": '[{"id": 1}]\n',
+        }
+
+    def test_top_level_array_error(self, project):
+        results = run_dbt(["seed"], expect_pass=False)
+        assert len(results) == 1
+        assert results[0].status == "error"
+        msg = results[0].message
+        assert "JSON object" in msg
+        assert "list" in msg.lower() or "array" in msg.lower() or "got list" in msg
+
+
+class TestJSONLTopLevelScalarError:
+    """A top-level JSON scalar should produce a clear error."""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "bad_scalar.jsonl": '"hello"\n',
+        }
+
+    def test_top_level_scalar_error(self, project):
+        results = run_dbt(["seed"], expect_pass=False)
+        assert len(results) == 1
+        assert results[0].status == "error"
+        msg = results[0].message
+        assert "JSON object" in msg
+
+
+class TestJSONLMalformedError:
+    """Malformed JSON should produce a clear error with line number."""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "bad_malformed.jsonl": '{"id": 1}\n{"bad": true\n',
+        }
+
+    def test_malformed_json_error(self, project):
+        results = run_dbt(["seed"], expect_pass=False)
+        assert len(results) == 1
+        assert results[0].status == "error"
+        msg = results[0].message
+        assert "Could not parse JSON" in msg
+
+
+class TestJSONLEmptyFile:
+    """An empty JSONL file should produce a clear error."""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "empty.jsonl": "",
+        }
+
+    def test_empty_file_error(self, project):
+        results = run_dbt(["seed"], expect_pass=False)
+        assert len(results) == 1
+        assert results[0].status == "error"
+
+
+class TestJSONLEmptyLinesIgnored:
+    """Empty and whitespace-only lines are ignored."""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "empty_lines.jsonl": '{"id":1}\n\n  \n{"id":2}\n',
+        }
+
+    def test_empty_lines_ignored(self, project):
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        table = results[0].agate_table
+        assert len(table.rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# CSV seeds still work alongside JSONL
+# ---------------------------------------------------------------------------
+
+
+class TestCSVStillWorks:
+    """Existing CSV seed behavior is unchanged."""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "basic.jsonl": seeds__basic_jsonl,
+            "simple.csv": seeds__simple_csv,
+        }
+
+    def test_csv_seed_loaded(self, project):
+        results = run_dbt(["seed"])
+        assert len(results) == 2
+        csv_result = next(r for r in results if r.node.name == "simple")
+        table = csv_result.agate_table
+        rows = list(table.rows)
+        assert len(rows) == 2
+
+    def test_jsonl_seed_loaded_alongside_csv(self, project):
+        results = run_dbt(["seed"])
+        jsonl_result = next(r for r in results if r.node.name == "basic")
+        assert jsonl_result.agate_table is not None
+
+
+# ---------------------------------------------------------------------------
+# column_types for JSONL seeds
+# ---------------------------------------------------------------------------
+
+
+class TestJSONLColumnTypes:
+    """column_types config works for JSONL seeds."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": """
+version: 2
+seeds:
+  - name: typed
+    config:
+      column_types:
+        id: integer
+        name: text
+""",
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "typed.jsonl": '{"id":1,"name":"alice"}\n{"id":2,"name":"bob"}\n',
+        }
+
+    def test_column_types_jsonl(self, project):
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        assert results[0].agate_table is not None
+
+
+class TestJSONLColumnTypesNonExistent:
+    """column_types for non-existent JSONL columns produces a warning."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": """
+version: 2
+seeds:
+  - name: typed_warn
+    config:
+      column_types:
+        id: integer
+        nonexistent_column: text
+""",
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "typed_warn.jsonl": '{"id":1,"name":"alice"}\n',
+        }
+
+    def test_nonexistent_column_warning(self, project):
+        results, log_output = run_dbt_and_capture(["seed"])
+        assert len(results) == 1
+        assert "nonexistent_column" in log_output


### PR DESCRIPTION
## Summary

Adds support for seed files with `.jsonl` and `.ndjson` extensions, where each non-empty line is a JSON object. This addresses issue #2365.

Top-level keys across all records become agate columns (first-seen ordering). Nested objects and arrays are preserved as compact JSON strings. Missing keys become `null`.

### Example

```jsonl
{"id": 1, "name": "alpha", "metadata": {"source": "manual", "rank": 1}}
{"id": 2, "name": "beta", "metadata": {"source": "api", "flags": ["x", "y"]}, "active": true}
```

Produces:

```
id | name  | metadata                              | active
1  | alpha | {"rank":1,"source":"manual"}           | null
2  | beta  | {"flags":["x","y"],"source":"api"}     | true
```

## Changes

- **`core/dbt/parser/read_files.py`**: Added `.jsonl` and `.ndjson` to seed file discovery extensions.
- **`core/dbt/task/seed_readers.py`** (new): JSONL-to-agate loader with:
  - Per-line JSON object parsing with line-number error reporting
  - First-seen column ordering
  - Nested value serialization (compact, sorted keys)
  - Agate type inference (Text for nested columns, inference for scalar columns)
- **`core/dbt/context/providers.py`**: Refactored `load_agate_table()` to dispatch by file extension (`.csv`, `.jsonl`, `.ndjson`). CSV path unchanged. JSONL path gets its own column-type validation.
- **`tests/functional/seeds/test_jsonl_seeds.py`** (new): 13 test classes covering discovery, loading, ref(), missing keys, nested values, error cases, column_types, and CSV coexistence.
- **`.changes/unreleased/Features-20260520-103000.yaml`**: Changie entry.
- **`JSONL-SEEDS.md`**: Design document.

## What is NOT changed

- Existing CSV seed parsing (completely unchanged path).
- Seed selection, `ref()`, node naming, or materialization macros.
- Adapter code (no adapter-specific JSON loading).
- `SeedConfig` data model (no new config fields).

## Test plan

Functional tests in `tests/functional/seeds/test_jsonl_seeds.py` cover:

- [x] `.jsonl` seed is discovered and loaded
- [x] `.ndjson` seed is discovered and loaded
- [x] `dbt seed --select` works for JSONL seeds
- [x] Downstream model can `ref()` a JSONL seed
- [x] Missing keys become null
- [x] New columns discovered after row 1
- [x] Nested object → compact JSON string
- [x] Nested array inside object field → compact JSON string
- [x] Top-level array → error with filename and line number
- [x] Top-level scalar → error
- [x] Malformed JSON → error with line number
- [x] Empty file → clear error
- [x] Empty lines are ignored
- [x] CSV seeds still work alongside JSONL
- [x] `column_types` config works for JSONL columns
- [x] `column_types` for non-existent columns produces warning

These tests require a running Postgres instance (`hatch run integration-tests`). I was unable to run them in my local environment (no hatch/PYTHON_VERSION match) — CI validation is needed.

## Risks

- **Partial parsing regression**: The `ReadFilesFromDiff` path builds its extension lookup from `get_file_types_for_project()`, so `.jsonl`/`.ndjson` should map to `ParseFileType.Seed` automatically. This needs CI verification.
- **Node name collision**: `users.csv` and `users.jsonl` in the same directory would both produce node name `users`. This is the same collision behavior that already exists for same-stem files.
- **Agate type inference**: Columns with mixed scalar and nested JSON values are forced to `agate.Text`. This is correct but worth noting.

## Design doc

See `JSONL-SEEDS.md` in the repo root for the full design document.

Closes #2365