### PR TITLE
Fix config-level loaded_at_field handling in freshness runtime

### DIFF
--- a/core/dbt/task/freshness.py
+++ b/core/dbt/task/freshness.py
@@ -132,12 +132,17 @@ class FreshnessRunner(BaseRunner[SourceDefinition, FreshnessNodeResult]):
                     macro_resolver=manifest,
                 )
                 status = compiled_node.freshness.status(freshness["age"])
-            elif compiled_node.loaded_at_field is not None:
-                adapter_response, freshness = self.adapter.calculate_freshness(
+                loaded_at_field = (
+                    compiled_node.loaded_at_field
+                    or compiled_node.config.loaded_at_field
+                )
+
+            elif loaded_at_field is not None:
+                adapter_response,freshness = self.adapter.calculate_freshness(
                     relation,
-                    compiled_node.loaded_at_field,
+                    loaded_at_field,
                     compiled_node.freshness.filter,
-                    macro_resolver=manifest,
+                    macro_resolver = manifest,
                 )
 
                 status = compiled_node.freshness.status(freshness["age"])

--- a/tests/functional/sources/test_source_loaded_at_field.py
+++ b/tests/functional/sources/test_source_loaded_at_field.py
@@ -81,6 +81,18 @@ sources:
       - name: table1
         loaded_at_field: ""
 """
+loaded_at_field_config_schema_yml = """
+sources:
+  - name: test_source
+    config:
+      loaded_at_field: created_at
+    freshness:
+      warn_after:
+        count: 1
+        period: day
+    tables:
+      - name: table1
+"""
 
 
 class TestParsingLoadedAtField:
@@ -134,3 +146,21 @@ class TestParsingLoadedAtField:
         )
         with pytest.raises(YamlParseDictError):
             run_dbt(["parse"])
+        
+                # test config-level loaded_at_field
+        write_file(
+            loaded_at_field_config_schema_yml,
+            project.project_root,
+            "models",
+            "schema.yml",
+        )
+
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+
+        assert "source.test.test_source.table1" in manifest.sources
+
+        assert (
+            manifest.sources.get("source.test.test_source.table1").loaded_at_field
+            == "created_at"
+        )

--- a/tests/unit/parser/test_parser.py
+++ b/tests/unit/parser/test_parser.py
@@ -476,6 +476,14 @@ sources:
       - name: my_table
         loaded_at_query: "select 1 as id"
 """
+SOURCE_CONFIG_LOADED_AT_FIELD = """
+sources:
+  - name: my_source
+    config:
+      loaded_at_field: created_at
+    tables:
+      - name: my_table
+"""
 
 SOURCE_FRESHNESS_AT_TABLE_AND_CONFIG = """
 sources:
@@ -607,6 +615,24 @@ class SchemaParserSourceTest(SchemaParserTest):
         unpatched_src_default = self.parser.manifest.sources["source.snowplow.my_source.my_table"]
         src_default = self.source_patcher.parse_source(unpatched_src_default)
         assert src_default.loaded_at_query == "select 1 as id"
+
+    @mock.patch("dbt.parser.sources.get_adapter")
+    def test_parse_source_config_loaded_at_field(self, mock_get_adapter):
+     block = self.file_block_for(
+      SOURCE_CONFIG_LOADED_AT_FIELD,
+        "test_one.yml",
+    )
+
+     dct = yaml_from_file(block.file, validate=True)
+     self.parser.parse_file(block, dct)
+
+     unpatched_src_default = self.parser.manifest.sources[
+        "source.snowplow.my_source.my_table"
+    ]
+
+     src_default = self.source_patcher.parse_source(unpatched_src_default)
+
+     assert src_default.loaded_at_field == "created_at"
 
     @mock.patch("dbt.parser.sources.get_adapter")
     def test_parse_source_field_at_custom_freshness_both_at_table_fails(self, _):

--- a/tests/unit/task/test_freshness.py
+++ b/tests/unit/task/test_freshness.py
@@ -38,6 +38,19 @@ class TestFreshnessTaskMetadataCache:
         mock_source = mock.Mock()
         mock_source.unique_id = "source_no_loaded_at_field"
         return mock_source
+    
+    @pytest.fixture(scope="class")
+    def source_config_loaded_at_field(self):
+     mock_source = mock.Mock()
+     mock_source.unique_id = "source_config_loaded_at_field"
+     mock_source.loaded_at_field = None
+
+     mock_config = mock.Mock()
+     mock_config.loaded_at_field = "created_at"
+
+     mock_source.config = mock_config
+
+     return mock_source
 
     @pytest.fixture(scope="class")
     def source_no_loaded_at_field2(self):


### PR DESCRIPTION
Resolves #12945

### Problem

When `loaded_at_field` was defined under `config` for a source table, parser-level handling correctly propagated the value, but runtime freshness execution only checked `compiled_node.loaded_at_field`.

As a result, dbt incorrectly fell back to metadata-based freshness checks (`INFORMATION_SCHEMA`) instead of using the configured `loaded_at_field`.

Example:

```yaml
sources:
  - name: test_source
    tables:
      - name: table1
        config:
          loaded_at_field: created_at
```

### Solution

Updated freshness runtime execution to also respect `compiled_node.config.loaded_at_field` when determining whether to run freshness checks using a loaded-at field.

Added regression coverage for:

* parser handling of config-level `loaded_at_field`
* runtime freshness handling
* functional source freshness behavior

### Checklist

* [x] I have read [[the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md)](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
* [x] I have run this code in development, and it appears to resolve the stated issue.
* [x] This PR includes tests, or tests are not required or relevant for this PR.
* [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
* [x] This PR includes [[type annotations](https://docs.python.org/3/library/typing.html)](https://docs.python.org/3/library/typing.html) for new and modified functions.
