### PR TITLE
Allow-list DBT_ENGINE_STATE_EMIT_REUSED_STATUS and DBT_ENGINE_STATE_OAUTH_CLIENT_ID

### DIFF
--- a/.changes/unreleased/Under the Hood-20260521-120000.yaml
+++ b/.changes/unreleased/Under the Hood-20260521-120000.yaml
@@ -3,4 +3,4 @@ body: Allow-list additional DBT_ENGINE_STATE_* engine env vars (EMIT_REUSED_STAT
 time: 2026-05-21T12:00:00.000000000Z
 custom:
     Author: colin-rogers-dbt
-    Issue: 13002
+    Issue: "13002"

--- a/.changes/unreleased/Under the Hood-20260521-120000.yaml
+++ b/.changes/unreleased/Under the Hood-20260521-120000.yaml
@@ -3,4 +3,4 @@ body: Allow-list DBT_ENGINE_STATE_EMIT_REUSED_STATUS and DBT_ENGINE_STATE_OAUTH_
 time: 2026-05-21T12:00:00.000000000Z
 custom:
     Author: colin-rogers-dbt
-    Issue: N/A
+    Issue: 13002

--- a/.changes/unreleased/Under the Hood-20260521-120000.yaml
+++ b/.changes/unreleased/Under the Hood-20260521-120000.yaml
@@ -1,5 +1,5 @@
 kind: Under the Hood
-body: Allow-list DBT_ENGINE_STATE_EMIT_REUSED_STATUS and DBT_ENGINE_STATE_OAUTH_CLIENT_ID engine env vars
+body: Allow-list additional DBT_ENGINE_STATE_* engine env vars (EMIT_REUSED_STATUS, OAUTH_CLIENT_ID, AUTH_URL, TOKEN_URL, API_URL)
 time: 2026-05-21T12:00:00.000000000Z
 custom:
     Author: colin-rogers-dbt

--- a/.changes/unreleased/Under the Hood-20260521-120000.yaml
+++ b/.changes/unreleased/Under the Hood-20260521-120000.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Allow-list DBT_ENGINE_STATE_EMIT_REUSED_STATUS and DBT_ENGINE_STATE_OAUTH_CLIENT_ID engine env vars
+time: 2026-05-21T12:00:00.000000000Z
+custom:
+    Author: colin-rogers-dbt
+    Issue: N/A

--- a/core/dbt/env_vars.py
+++ b/core/dbt/env_vars.py
@@ -19,6 +19,9 @@ _ADDITIONAL_ENGINE_ENV_VARS: List[str] = [
     "DBT_PP_TEST",  # TODO: This is testing related, should we do this differently?
     "DBT_ENGINE_STATE_EMIT_REUSED_STATUS",
     "DBT_ENGINE_STATE_OAUTH_CLIENT_ID",
+    "DBT_ENGINE_STATE_AUTH_URL",
+    "DBT_ENGINE_STATE_TOKEN_URL",
+    "DBT_ENGINE_STATE_API_URL",
 ]
 
 

--- a/core/dbt/env_vars.py
+++ b/core/dbt/env_vars.py
@@ -17,6 +17,8 @@ _ADDITIONAL_ENGINE_ENV_VARS: List[str] = [
     "DBT_DOWNLOAD_DIR",
     "DBT_PP_FILE_DIFF_TEST",  # TODO: This is testing related, should we do this differently?
     "DBT_PP_TEST",  # TODO: This is testing related, should we do this differently?
+    "DBT_ENGINE_STATE_EMIT_REUSED_STATUS",
+    "DBT_ENGINE_STATE_OAUTH_CLIENT_ID",
 ]
 
 

--- a/tests/functional/cli/test_requires.py
+++ b/tests/functional/cli/test_requires.py
@@ -136,6 +136,11 @@ class TestKnownEngineEnvVarsExplicit:
             "DBT_ENGINE_DEBUG",
             "DBT_ENGINE_PRINT",
             "DBT_ENGINE_SAMPLE",
+            "DBT_ENGINE_STATE_EMIT_REUSED_STATUS",
+            "DBT_ENGINE_STATE_OAUTH_CLIENT_ID",
+            "DBT_ENGINE_STATE_AUTH_URL",
+            "DBT_ENGINE_STATE_TOKEN_URL",
+            "DBT_ENGINE_STATE_API_URL",
         }
         from dbt.env_vars import _ALLOWED_ENV_VARS
 


### PR DESCRIPTION
Resolves N/A

### Problem

`DBT_ENGINE_STATE_EMIT_REUSED_STATUS` and `DBT_ENGINE_STATE_OAUTH_CLIENT_ID` use the reserved `DBT_ENGINE_STATE_` prefix but were not in the engine env var allow list, so setting them triggered the `environment-variable-namespace-deprecation` warning from `validate_engine_env_vars`.

### Solution

Add both env vars to `_ADDITIONAL_ENGINE_ENV_VARS` in `core/dbt/env_vars.py` so they're recognized as known engine env vars and pass allow-list validation.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)