### PR TITLE
RC release workflow bug fix

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -123,7 +123,7 @@ jobs:
       - name: "Check Current Version In Code"
         id: determine_version
         run: |
-          current_version=$(grep '^version = ' core/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          current_version=$(sed -n 's/^version *= *"\(.*\)"/\1/p' core/dbt/__version__.py)
           echo "current_version=$current_version" >> $GITHUB_OUTPUT
 
       - name: "[Notification] Check Current Version In Code"


### PR DESCRIPTION

Resolves #

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

The Cut new release branch workflow (.github/workflows/cut-release-branch.yml) fails at the Check Current Version In Code step. The step runs:

`current_version=$(grep '^version = ' core/pyproject.toml | sed 's/version = "\(.*\)"/\1/')`

But `core/pyproject.toml` no longer contains a literal version = "..." line — it uses hatchling's dynamic versioning:

```toml
  [project]
  dynamic = ["version"]

  [tool.hatch.version]
  path = "dbt/__version__.py"
```

With no match, grep exits 1, pipefail aborts the step, and every downstream job (version bump, code-quality cleanup, PR creation, branch cut) is skipped. See failed run 26278051596.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Read the version from `core/dbt/__version__.py`. It is the source of truth that hatchling already points to:

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.