### PR TITLE
Fix/cut release branch hatch failure

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -206,7 +206,7 @@ jobs:
           cd core
           hatch version ${{ needs.cleanup_changelog.outputs.next-version }}
           hatch run dev-req
-          dbt --version
+          hatch run dbt --version
 
       - name: "Commit Version Bump to Branch"
         run: |
@@ -283,17 +283,19 @@ jobs:
       - name: "Determine PR Title"
         id: pr_title
         run: |
-          echo "pr_title=${{ env.PR_TITLE }}" >> $GITHUB_OUTPUT
-          if [${{ env.PR_TITLE }} == ""]; then
-            echo "pr_title='Clean up changelogs and bump to version ${{ needs.cleanup_changelog.outputs.next-version }}'" >> $GITHUB_OUTPUT
+          if [[ -z "$PR_TITLE" ]]; then
+            echo "pr_title=Clean up changelogs and bump to version ${{ needs.cleanup_changelog.outputs.next-version }}" >> $GITHUB_OUTPUT
+          else
+            echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
           fi
 
       - name: "Determine PR Body"
         id: pr_body
         run: |
-          echo "pr_body=${{ env.PR_BODY }}" >> $GITHUB_OUTPUT
-          if [${{ env.PR_BODY }} == ""]; then
-            echo "pr_body='Clean up changelogs and bump to version ${{ needs.cleanup_changelog.outputs.next-version }}'" >> $GITHUB_OUTPUT
+          if [[ -z "$PR_BODY" ]]; then
+            echo "pr_body=Clean up changelogs and bump to version ${{ needs.cleanup_changelog.outputs.next-version }}" >> $GITHUB_OUTPUT
+          else
+            echo "pr_body=$PR_BODY" >> $GITHUB_OUTPUT
           fi
 
       - name: "Add Branch Details"

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -123,7 +123,7 @@ jobs:
       - name: "Check Current Version In Code"
         id: determine_version
         run: |
-          current_version=$(grep '^version = ' core/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          current_version=$(sed -n 's/^version *= *"\(.*\)"/\1/p' core/dbt/__version__.py)
           echo "current_version=$current_version" >> $GITHUB_OUTPUT
 
       - name: "[Notification] Check Current Version In Code"


### PR DESCRIPTION
Resolves #

## Problem

After fixing the **Check Current Version In Code** step in #13005, the cut-release-branch workflow exposed a second pre-existing bug in the **Bump Version** step ([failed run](https://github.com/dbt-labs/dbt-core/actions/runs/26280095127/job/77354327584)):

```bash
cd core
hatch version ...
hatch run dev-req
dbt --version   # exit 127: "dbt: command not found"
```

`hatch run dev-req` installs `dbt-core` into hatch's managed virtualenv at `~/.local/share/hatch/...`, but that env is **not** activated in the surrounding shell — so the bare `dbt --version` on the next line can't find the binary. This has been broken since the hatch migration in #12192; it just never surfaced because the workflow is `workflow_dispatch`-only and hadn't been triggered since.

While auditing the rest of the workflow, I also noticed the **Determine PR Title / Determine PR Body** steps have a malformed empty-check:

```bash
echo "pr_title=${{ env.PR_TITLE }}" >> $GITHUB_OUTPUT
if [${{ env.PR_TITLE }} == ""]; then
  echo "pr_title='...'" >> $GITHUB_OUTPUT
fi
```

Three issues: missing spaces inside `[ ]`, template-interpolation directly into the test expression (breaks on any title containing spaces/quotes), and single quotes wrapped around the value would end up in the literal PR title since `$GITHUB_OUTPUT` doesn't strip them.

## Solution

1. Run the dbt sanity check inside the hatch env: `hatch run dbt --version`.
2. Rewrite the PR title/body conditionals to use `[[ -z "$VAR" ]]` against the workflow-level env var, and pick one branch instead of writing twice. Drop the literal single quotes from the fallback value.



### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
