### PR TITLE
fix: remove exact version pin for libpq-dev in Dockerfile (#12808)

### DIFF
--- a/.changes/unreleased/Under the Hood-20260522-120000.yaml
+++ b/.changes/unreleased/Under the Hood-20260522-120000.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove exact version pin for libpq-dev in Dockerfile to prevent recurring build failures when Debian publishes PostgreSQL security updates.
+time: 2026-05-22T12:00:00.000000Z
+custom:
+  Author: OliverCostello1
+  Issue: "12808"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,9 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
     ca-certificates=20210119 \
-    libpq-dev=13.23-0+deb11u3 \
+    # libpq-dev is intentionally not pinned: Debian removes old patch versions when publishing
+    # security updates, which breaks builds. The apt-mark hold below prevents dist-upgrade drift.
+    libpq-dev \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \
@@ -85,7 +87,7 @@ FROM dbt-core AS dbt-third-party
 ARG dbt_third_party
 
 RUN if [ "$dbt_third_party" ]; then \
-        python -m pip install --no-cache-dir "${dbt_third_party}"; \
-    else \
-        echo "No third party adapter provided"; \
-    fi \
+    python -m pip install --no-cache-dir "${dbt_third_party}"; \
+  else \
+    echo "No third party adapter provided"; \
+  fi \


### PR DESCRIPTION
## Summary

Closes #12808

Removes the exact version pin on `libpq-dev` in `docker/Dockerfile`. This pin has required 5+ manual bumps in ~18 months because Debian removes old package versions from apt repos whenever it publishes a security update, breaking Docker builds until a maintainer notices and bumps the pin.

## What changed

`docker/Dockerfile`: `libpq-dev=13.23-0+deb11u3` → `libpq-dev` (unpinned), with an explanatory comment.

## Why this is safe

The `apt-mark hold libpq-dev` line that immediately follows already prevents `apt-get dist-upgrade` from changing the installed version during the build. The exact-version pin was providing no additional protection — it was only causing breakage when Debian published patch updates.

## Checklist
- [x] I have read the contributing guide and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required or relevant for this PR
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.)