### PR TITLE
fix: Correct FileHash.compare to compare FileHash objects

### DIFF
--- a/.changes/unreleased/Fixes-20260522-151716.yaml
+++ b/.changes/unreleased/Fixes-20260522-151716.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: corrects FileHash.compare to compare FileHash objects
+time: 2026-05-22T15:17:16.455827+01:00
+custom:
+    Author: andy-cave-nf
+    Issue: "8269"

--- a/core/dbt/artifacts/resources/base.py
+++ b/core/dbt/artifacts/resources/base.py
@@ -48,7 +48,7 @@ class FileHash(dbtClassMixin):
         if self.name == "none":
             return False
 
-        return self.from_contents(contents, name=self.name) == self.checksum
+        return self.from_contents(contents, name=self.name) == self
 
     @classmethod
     def from_contents(cls, contents: str, name="sha256") -> "FileHash":

--- a/tests/unit/artifacts/test_base_resource.py
+++ b/tests/unit/artifacts/test_base_resource.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from dbt.artifacts.resources.base import BaseResource
+from dbt.artifacts.resources.base import BaseResource, FileHash
 from dbt.artifacts.resources.types import NodeType
 
 
@@ -56,3 +56,53 @@ class TestMinorSchemaChange:
     ):
         # new code (using class without default field) can create an instance of itself given old data (class with old field)
         BaseResource.from_dict(base_resource_new_default_field.to_dict())
+
+
+class TestFileHashPath:
+    @pytest.fixture(scope="class")
+    def path(self):
+        return "test/path"
+
+    @pytest.fixture(scope="class")
+    def file_hash(self, path):
+        return FileHash.path(path)
+
+    def test_name_is_set(self, file_hash):
+        assert file_hash.name == "path"
+
+    def test_path_is_set(self, file_hash):
+        assert file_hash.checksum == "test/path"
+
+    def test_is_equal_to_equivalent_file_hash(self, file_hash, path):
+        assert file_hash == FileHash.path(path)
+
+
+class TestFileHashFromContents:
+    @pytest.fixture(scope="class")
+    def contents(self):
+        return "test"
+
+    @pytest.fixture(scope="class")
+    def file_hash(self, contents):
+        return FileHash.from_contents(contents)
+
+    def test_default_name_is_set(self, file_hash):
+        assert file_hash.name == "sha256"
+
+    def test_is_equal_to_equivalent_file_hash(self, contents, file_hash):
+        assert file_hash.compare(contents)
+
+    def test_is_unequal_to_different_file_hash(self, file_hash):
+        assert not file_hash.compare("different contents")
+
+
+class TestEmptyFileHash:
+    @pytest.fixture(scope="class")
+    def file_hash(self):
+        return FileHash.empty()
+
+    def test_empty_hash_is_not_equal_to_non_empty_hash(self, file_hash):
+        assert not file_hash.compare("test")
+
+    def test_empty_hash_is_not_equal_to_non_hash(self, file_hash):
+        assert not file_hash == "not a hash"


### PR DESCRIPTION
Contributes to #8269  

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

Hiya, first time contributing. I wanted to improve the unit test coverage and as I was adding to FileHash I noticed a bug in FileHash.compare. It compares FileHash objects with strings rather than other FileHash objects.

### Solution

I've correct the comparison to be against FileHash objects rather than against the checksum attribute, which is a string. 
I've also added extra tests to bring that file up to 100% coverage.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
