### PR TITLE
Remove enabled arg from profiler

### DIFF
--- a/.changes/unreleased/Under the Hood-20260522-231500.yaml
+++ b/.changes/unreleased/Under the Hood-20260522-231500.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove the unused `enable` argument from `dbt.profiler` and update the CLI call site accordingly.
+time: 2026-05-22T23:15:00.000000000Z
+custom:
+    Author: RaghunandanKumar
+    Issue: "5886"

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -125,7 +125,7 @@ def preflight(func):
 
         # Profiling
         if flags.RECORD_TIMING_INFO:
-            ctx.with_resource(profiler(enable=True, outfile=flags.RECORD_TIMING_INFO))
+            ctx.with_resource(profiler(outfile=flags.RECORD_TIMING_INFO))
 
         # Adapter management
         ctx.with_resource(adapter_management())

--- a/core/dbt/profiler.py
+++ b/core/dbt/profiler.py
@@ -5,16 +5,14 @@ from typing import Any, Generator
 
 
 @contextmanager
-def profiler(enable: bool, outfile: str) -> Generator[Any, None, None]:
+def profiler(outfile: str) -> Generator[Any, None, None]:
     try:
-        if enable:
-            profiler = Profile()
-            profiler.enable()
+        profile = Profile()
+        profile.enable()
 
         yield
     finally:
-        if enable:
-            profiler.disable()
-            stats = Stats(profiler)
-            stats.sort_stats("tottime")
-            stats.dump_stats(str(outfile))
+        profile.disable()
+        stats = Stats(profile)
+        stats.sort_stats("tottime")
+        stats.dump_stats(str(outfile))

--- a/tests/unit/test_profiler.py
+++ b/tests/unit/test_profiler.py
@@ -1,0 +1,20 @@
+from unittest.mock import Mock, patch
+
+from dbt.profiler import profiler
+
+
+def test_profiler_records_stats_to_requested_outfile():
+    profile = Mock()
+    stats = Mock()
+
+    with (
+        patch("dbt.profiler.Profile", return_value=profile),
+        patch("dbt.profiler.Stats", return_value=stats),
+    ):
+        with profiler("timing.prof"):
+            pass
+
+    profile.enable.assert_called_once_with()
+    profile.disable.assert_called_once_with()
+    stats.sort_stats.assert_called_once_with("tottime")
+    stats.dump_stats.assert_called_once_with("timing.prof")


### PR DESCRIPTION
Resolves #5886

### Problem

`dbt.profiler` accepted an `enable` argument even though it is only used inside an `if flags.RECORD_TIMING_INFO` branch. That made the context manager API more complicated than it needed to be and required callers to pass a value that was already known at the call site.

### Solution

Remove the `enable` argument from `dbt.profiler`, always profile when the context manager is constructed, and update the CLI call site accordingly. Add a focused unit test covering stats emission to the requested output path.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

### Verification

- Attempted: `python3 -m pytest tests/unit/test_profiler.py -q`
- Blocked locally because the host pytest environment is missing repo test dependencies (`yaml` import failure from dbt test plugins)