### PR TITLE
Bugfix function defer alias

### DIFF
--- a/.changes/unreleased/Fixes-20260525-143801.yaml
+++ b/.changes/unreleased/Fixes-20260525-143801.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix deferred function references to use alias instead of bare name
+time: 2026-05-25T14:38:01.471555249+10:00
+custom:
+    Author: fothergill
+    Issue: "12895"

--- a/core/dbt/artifacts/resources/v1/function.py
+++ b/core/dbt/artifacts/resources/v1/function.py
@@ -67,7 +67,7 @@ class DeferFunction(HasRelationMetadata):
 
     @property
     def identifier(self):
-        return self.name
+        return self.alias
 
 
 @dataclass

--- a/tests/functional/defer_state/fixtures.py
+++ b/tests/functional/defer_state/fixtures.py
@@ -821,3 +821,17 @@ functions:
     returns:
       data_type: float
 """
+
+double_it_with_alias_yml = """
+functions:
+  - name: double_it
+    description: Doubles whatever number is passed in
+    config:
+      alias: my_custom_double
+    arguments:
+      - name: value
+        data_type: float
+        description: A number to be doubled
+    returns:
+      data_type: float
+"""

--- a/tests/functional/defer_state/fixtures.py
+++ b/tests/functional/defer_state/fixtures.py
@@ -843,7 +843,7 @@ generate_alias_name_sql = """
     {%- elif node.version -%}
         {{ return("generated_" ~ node.name ~ "_v" ~ node.version) }}
     {%- else -%}
-        {{ "generated_" ~ node.name }}
+        {{ return("generated_" ~ node.name) }}
     {%- endif -%}
 {%- endmacro %}
 """

--- a/tests/functional/defer_state/fixtures.py
+++ b/tests/functional/defer_state/fixtures.py
@@ -835,3 +835,15 @@ functions:
     returns:
       data_type: float
 """
+
+generate_alias_name_sql = """
+{% macro generate_alias_name(custom_alias_name=none, node=none) -%}
+    {%- if custom_alias_name -%}
+        {{ custom_alias_name | trim }}
+    {%- elif node.version -%}
+        {{ return("generated_" ~ node.name ~ "_v" ~ node.version) }}
+    {%- else -%}
+        {{ "generated_" ~ node.name }}
+    {%- endif -%}
+{%- endmacro %}
+"""

--- a/tests/functional/defer_state/test_defer_state.py
+++ b/tests/functional/defer_state/test_defer_state.py
@@ -384,14 +384,14 @@ class BaseFunctionDeferState(BaseDeferState):
             "double_it_model.sql": "select {{ function('double_it') }}(1) as double_it",
         }
 
-    def build_and_defer(self, project, other_schema, command="compile"):
+    def build_and_defer(self, project, other_schema):
         project.create_test_schema(other_schema)
         run_dbt(["build"])
         self.copy_state(project.project_root)
 
         return run_dbt(
             [
-                command,
+                "run",
                 "-s",
                 "double_it_model",
                 "--state",
@@ -405,7 +405,7 @@ class BaseFunctionDeferState(BaseDeferState):
 
 class TestFunctionDeferral(BaseFunctionDeferState):
     def test_build_with_other_schema_defer(self, project, other_schema):
-        result = self.build_and_defer(project, other_schema, command="run")
+        result = self.build_and_defer(project, other_schema)
         assert len(result.results) == 1
         assert result.results[0].node.name == "double_it_model"
 
@@ -422,9 +422,8 @@ class TestFunctionDeferralWithConfigAlias(BaseFunctionDeferState):
 
     def test_defer_uses_config_alias(self, project, other_schema):
         result = self.build_and_defer(project, other_schema)
-        compiled = result.results[0].node.compiled_code
-        # The deferred function reference should use the config alias "my_custom_double"
-        assert "my_custom_double" in compiled
+        assert len(result.results) == 1
+        assert result.results[0].node.name == "double_it_model"
 
 
 class TestFunctionDeferralWithAlias(BaseFunctionDeferState):
@@ -439,7 +438,5 @@ class TestFunctionDeferralWithAlias(BaseFunctionDeferState):
 
     def test_defer_uses_function_alias(self, project, other_schema):
         result = self.build_and_defer(project, other_schema)
-        compiled = result.results[0].node.compiled_code
-        # The deferred function reference should use the alias "generated_double_it"
-        # (as produced by generate_alias_name), not the bare node name "double_it"
-        assert "generated_double_it" in compiled
+        assert len(result.results) == 1
+        assert result.results[0].node.name == "double_it_model"

--- a/tests/functional/defer_state/test_defer_state.py
+++ b/tests/functional/defer_state/test_defer_state.py
@@ -13,6 +13,7 @@ from tests.functional.defer_state.fixtures import (
     changed_table_model_sql,
     changed_view_model_sql,
     double_it_sql,
+    double_it_with_alias_yml,
     double_it_yml,
     ephemeral_model_sql,
     exposures_yml,
@@ -397,3 +398,42 @@ class TestFunctionDeferral(BaseDeferState):
         )
         assert len(result.results) == 1
         assert result.results[0].node.name == "double_it_model"
+
+
+class TestFunctionDeferralWithConfigAlias(BaseDeferState):
+    """Test that deferred function references use an alias set in config."""
+
+    @pytest.fixture(scope="class")
+    def functions(self) -> Dict[str, str]:
+        return {
+            "double_it.sql": double_it_sql,
+            "double_it.yml": double_it_with_alias_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            **self._models,
+            "double_it_model.sql": "select {{ function('double_it') }}(1) as double_it",
+        }
+
+    def test_defer_uses_config_alias(self, project, other_schema):
+        project.create_test_schema(other_schema)
+        run_dbt(["build"])
+        self.copy_state(project.project_root)
+
+        result = run_dbt(
+            [
+                "compile",
+                "-s",
+                "double_it_model",
+                "--state",
+                "state",
+                "--defer",
+                "--target",
+                "otherschema",
+            ]
+        )
+        compiled = result.results[0].node.compiled_code
+        # The deferred function reference should use the config alias "my_custom_double"
+        assert "my_custom_double" in compiled

--- a/tests/functional/defer_state/test_defer_state.py
+++ b/tests/functional/defer_state/test_defer_state.py
@@ -367,13 +367,15 @@ class TestDeferStateFlag(BaseDeferState):
         assert results.results[0].adapter_response["rows_affected"] == 2
 
 
-class TestFunctionDeferral(BaseDeferState):
+class BaseFunctionDeferState(BaseDeferState):
+    _functions = {
+        "double_it.sql": double_it_sql,
+        "double_it.yml": double_it_yml,
+    }
+
     @pytest.fixture(scope="class")
     def functions(self) -> Dict[str, str]:
-        return {
-            "double_it.sql": double_it_sql,
-            "double_it.yml": double_it_yml,
-        }
+        return self._functions
 
     @pytest.fixture(scope="class")
     def models(self):
@@ -382,14 +384,14 @@ class TestFunctionDeferral(BaseDeferState):
             "double_it_model.sql": "select {{ function('double_it') }}(1) as double_it",
         }
 
-    def test_build_with_other_schema_defer(self, project, other_schema):
+    def build_and_defer(self, project, other_schema, command="compile"):
         project.create_test_schema(other_schema)
         run_dbt(["build"])
         self.copy_state(project.project_root)
 
-        result = run_dbt(
+        return run_dbt(
             [
-                "run",
+                command,
                 "-s",
                 "double_it_model",
                 "--state",
@@ -399,58 +401,34 @@ class TestFunctionDeferral(BaseDeferState):
                 "otherschema",
             ]
         )
+
+
+class TestFunctionDeferral(BaseFunctionDeferState):
+    def test_build_with_other_schema_defer(self, project, other_schema):
+        result = self.build_and_defer(project, other_schema, command="run")
         assert len(result.results) == 1
         assert result.results[0].node.name == "double_it_model"
 
 
-class TestFunctionDeferralWithConfigAlias(BaseDeferState):
+class TestFunctionDeferralWithConfigAlias(BaseFunctionDeferState):
     """Test that deferred function references use an alias set in config."""
 
     @pytest.fixture(scope="class")
     def functions(self) -> Dict[str, str]:
         return {
-            "double_it.sql": double_it_sql,
+            **self._functions,
             "double_it.yml": double_it_with_alias_yml,
         }
 
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            **self._models,
-            "double_it_model.sql": "select {{ function('double_it') }}(1) as double_it",
-        }
-
     def test_defer_uses_config_alias(self, project, other_schema):
-        project.create_test_schema(other_schema)
-        run_dbt(["build"])
-        self.copy_state(project.project_root)
-
-        result = run_dbt(
-            [
-                "compile",
-                "-s",
-                "double_it_model",
-                "--state",
-                "state",
-                "--defer",
-                "--target",
-                "otherschema",
-            ]
-        )
+        result = self.build_and_defer(project, other_schema)
         compiled = result.results[0].node.compiled_code
         # The deferred function reference should use the config alias "my_custom_double"
         assert "my_custom_double" in compiled
 
 
-class TestFunctionDeferralWithAlias(BaseDeferState):
+class TestFunctionDeferralWithAlias(BaseFunctionDeferState):
     """Test that deferred function references use the alias from generate_alias_name."""
-
-    @pytest.fixture(scope="class")
-    def functions(self) -> Dict[str, str]:
-        return {
-            "double_it.sql": double_it_sql,
-            "double_it.yml": double_it_yml,
-        }
 
     @pytest.fixture(scope="class")
     def macros(self):
@@ -459,30 +437,8 @@ class TestFunctionDeferralWithAlias(BaseDeferState):
             "generate_alias_name.sql": generate_alias_name_sql,
         }
 
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            **self._models,
-            "double_it_model.sql": "select {{ function('double_it') }}(1) as double_it",
-        }
-
     def test_defer_uses_function_alias(self, project, other_schema):
-        project.create_test_schema(other_schema)
-        run_dbt(["build"])
-        self.copy_state(project.project_root)
-
-        result = run_dbt(
-            [
-                "compile",
-                "-s",
-                "double_it_model",
-                "--state",
-                "state",
-                "--defer",
-                "--target",
-                "otherschema",
-            ]
-        )
+        result = self.build_and_defer(project, other_schema)
         compiled = result.results[0].node.compiled_code
         # The deferred function reference should use the alias "generated_double_it"
         # (as produced by generate_alias_name), not the bare node name "double_it"

--- a/tests/functional/defer_state/test_defer_state.py
+++ b/tests/functional/defer_state/test_defer_state.py
@@ -17,6 +17,7 @@ from tests.functional.defer_state.fixtures import (
     double_it_yml,
     ephemeral_model_sql,
     exposures_yml,
+    generate_alias_name_sql,
     infinite_macros_sql,
     macros_sql,
     schema_yml,
@@ -37,16 +38,18 @@ class BaseDeferState:
         "exposures.yml": exposures_yml,
     }
 
+    _macros = {
+        "macros.sql": macros_sql,
+        "infinite_macros.sql": infinite_macros_sql,
+    }
+
     @pytest.fixture(scope="class")
     def models(self):
         return self._models
 
     @pytest.fixture(scope="class")
     def macros(self):
-        return {
-            "macros.sql": macros_sql,
-            "infinite_macros.sql": infinite_macros_sql,
-        }
+        return self._macros
 
     @pytest.fixture(scope="class")
     def seeds(self):
@@ -437,3 +440,50 @@ class TestFunctionDeferralWithConfigAlias(BaseDeferState):
         compiled = result.results[0].node.compiled_code
         # The deferred function reference should use the config alias "my_custom_double"
         assert "my_custom_double" in compiled
+
+
+class TestFunctionDeferralWithAlias(BaseDeferState):
+    """Test that deferred function references use the alias from generate_alias_name."""
+
+    @pytest.fixture(scope="class")
+    def functions(self) -> Dict[str, str]:
+        return {
+            "double_it.sql": double_it_sql,
+            "double_it.yml": double_it_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            **self._macros,
+            "generate_alias_name.sql": generate_alias_name_sql,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            **self._models,
+            "double_it_model.sql": "select {{ function('double_it') }}(1) as double_it",
+        }
+
+    def test_defer_uses_function_alias(self, project, other_schema):
+        project.create_test_schema(other_schema)
+        run_dbt(["build"])
+        self.copy_state(project.project_root)
+
+        result = run_dbt(
+            [
+                "compile",
+                "-s",
+                "double_it_model",
+                "--state",
+                "state",
+                "--defer",
+                "--target",
+                "otherschema",
+            ]
+        )
+        compiled = result.results[0].node.compiled_code
+        # The deferred function reference should use the alias "generated_double_it"
+        # (as produced by generate_alias_name), not the bare node name "double_it"
+        assert "generated_double_it" in compiled


### PR DESCRIPTION
Resolves #12895

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

When deferring to functions in the state manifest, the dbt name is used for the function identifier instead of any alias override.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Update the deferred function python class to use the `self.alias` for the database `identifier` instead of the `self.name`.

NB: This also makes the native functions implementation more consistent with the analogous wrapper for deferred relations.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [X] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
