### PR TITLE
Defensively cap recursion limit while resolving selector: references

### DIFF
--- a/.changes/unreleased/Fixes-20260525-225000.yaml
+++ b/.changes/unreleased/Fixes-20260525-225000.yaml
@@ -1,0 +1,14 @@
+kind: Fixes
+body: >-
+    Cap the Python recursion limit while resolving the `selector:` method so a
+    circular selector dependency raises a clean DbtRecursionError instead of
+    crashing the process. The previous code relied on Python's default recursion
+    limit (1000) tripping before the OS thread stack overflowed, but on platforms
+    with smaller default stacks (notably Windows, ~1 MB vs ~8 MB on Linux/macOS)
+    the margin can disappear once instrumentation (e.g. coverage) or stack-heavy
+    plugins join the call chain. Lower the limit locally (restored in finally)
+    so the catchable RecursionError fires first on every platform.
+time: 2026-05-25T22:50:00.000000000Z
+custom:
+    Author: colin-rogers-dbt
+    Issue: "13014"

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -1,4 +1,5 @@
 import abc
+import sys
 from fnmatch import fnmatch
 from itertools import chain
 from pathlib import Path
@@ -953,6 +954,19 @@ class VersionSelectorMethod(SelectorMethod):
 
 
 class SelectorSelectorMethod(SelectorMethod):
+    # Defensive recursion ceiling applied while resolving a `selector:` reference.
+    # `_search_for_matched_selector` can recurse arbitrarily deep when a user-defined
+    # selector references itself or another selector that references it. We rely on
+    # Python's RecursionError firing so we can re-raise it as DbtRecursionError and
+    # give the user a clear "circular dependency" message instead of a process
+    # crash. The default recursion limit (1000) leaves a thin margin on platforms
+    # with small OS thread stacks (notably Windows, ~1 MB default vs ~8 MB on Linux/
+    # macOS); add instrumentation (coverage) or stack-heavy plugins to the call chain
+    # and the OS stack can overflow before Python's check trips. Capping the limit
+    # locally to a value comfortably below any realistic OS-stack budget guarantees
+    # we hit the Python check first. Restored in `finally`.
+    _RECURSION_LIMIT_CEILING = 250
+
     def __init__(
         self,
         manifest: Manifest,
@@ -993,13 +1007,24 @@ class SelectorSelectorMethod(SelectorMethod):
                 f"Selector '{selector}' did not match any selector in selectors.yml"
             )
 
-        for matched_selector_dfn in matched_selector_dfns:
-            try:
-                yield from self._search_for_matched_selector(included_nodes, matched_selector_dfn)
-            except RecursionError as e:
-                raise DbtRecursionError(
-                    f"Circular dependency detected in selector: {matched_selector_dfn.raw}"
-                ) from e
+        # Temporarily lower the recursion limit so circular selectors trip a
+        # catchable RecursionError before the OS thread stack overflows. We only
+        # lower (never raise) the user's existing limit, and restore in `finally`.
+        original_limit = sys.getrecursionlimit()
+        effective_limit = min(original_limit, self._RECURSION_LIMIT_CEILING)
+        try:
+            sys.setrecursionlimit(effective_limit)
+            for matched_selector_dfn in matched_selector_dfns:
+                try:
+                    yield from self._search_for_matched_selector(
+                        included_nodes, matched_selector_dfn
+                    )
+                except RecursionError as e:
+                    raise DbtRecursionError(
+                        f"Circular dependency detected in selector: {matched_selector_dfn.raw}"
+                    ) from e
+        finally:
+            sys.setrecursionlimit(original_limit)
 
 
 class MethodManager:


### PR DESCRIPTION
Resolves #

### Problem

\`SelectorSelectorMethod.search\` resolves \`selector:\` references that may be circular. It relies on Python raising \`RecursionError\` so it can re-raise the more helpful \`DbtRecursionError\` ("Circular dependency detected in selector: ..."). That contract only holds if Python's recursion-limit check (default 1000) trips **before** the OS thread stack overflows.

On platforms with smaller default thread stacks — notably Windows at ~1 MB vs ~8 MB on Linux/macOS — the margin between recursion-limit and OS-stack can disappear once instrumentation (e.g. coverage) or stack-heavy plugins join the call chain. When that happens, the OS overflows first, the worker process dies, and the user sees a process crash instead of a clear error.

A concrete trigger: \`tests/functional/selectors/test_selector_selector_method.py::TestSelectorSelectorMethod::test_circular_dependency\` started crashing the xdist worker on Windows under coverage in PR #13014 (which bundles \`dbt-state\` by default; its monkey-patches add per-frame stack cost). The test is doing exactly what an end user with a circular selector would do; the regression is user-visible, not a test artifact.

### Solution

Wrap the recursive call in \`SelectorSelectorMethod.search\` with a temporary lower recursion ceiling (\`min(current_limit, 250)\`), restored in \`finally\`. Two properties:

1. **Never raises** the user's existing limit — only lowers it. If a user has already lowered it below 250, we respect that.
2. **\`finally\` always runs** before the caller resumes. \`select_included\` consumes via \`set(method.search(...))\` which eagerly exhausts the generator, so the cleanup is guaranteed before any caller frame returns.

250 is well above any realistic legitimate selector nesting (typically 2–3 levels deep) and well below any reasonable OS-stack budget, so circular selectors trip a \`RecursionError\` on every platform regardless of what else is on the stack.

### Test plan

- [x] Existing \`test_circular_dependency\` should continue to pass on Linux/macOS where it already does; expected to start passing on Windows.
- [ ] Confirm CI green on Windows after merge.
- [x] Lint / mypy clean on \`core/dbt/graph/selector_methods.py\`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR. _(Existing \`test_circular_dependency\` exercises the path; no new test needed.)_
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)