### PR TITLE
Add User Settings Support

### DIFF
--- a/.changes/unreleased/Features-20260527-154416.yaml
+++ b/.changes/unreleased/Features-20260527-154416.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add support for user settings with flags reading writing
+time: 2026-05-27T15:44:16.231909+05:30
+custom:
+    Author: ash2shukla
+    Issue: "13031"

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -15,6 +15,7 @@ from dbt.cli.exceptions import DbtUsageException
 from dbt.cli.resolvers import default_log_path, default_project_dir
 from dbt.cli.types import Command as CliCommand
 from dbt.config.project import read_project_flags
+from dbt.config.user_settings import get_user_setting_flags
 from dbt.config.utils import normalize_warn_error_options
 from dbt.contracts.project import ProjectFlags
 from dbt.deprecations import fire_buffered_deprecations, renamed_env_var, warn
@@ -307,6 +308,18 @@ class Flags:
                 project_level_flag_value,
             ) in project_flags.project_only_flags.items():
                 object.__setattr__(self, project_level_flag_name.upper(), project_level_flag_value)
+
+        # Apply user settings (~/.dbt/user_settings.yml) as lowest precedence.
+        user_flags = get_user_setting_flags()
+        for param_name in list(params_assigned_from_default):
+            value = user_flags.get(param_name)
+            if value is not None:
+                object.__setattr__(
+                    self,
+                    param_name.upper(),
+                    convert_config(param_name, value),
+                )
+                params_assigned_from_default.remove(param_name)
 
         # Set hard coded flags.
         object.__setattr__(self, "WHICH", invoked_subcommand_name or ctx.info_name)

--- a/core/dbt/cli/resolvers.py
+++ b/core/dbt/cli/resolvers.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from dbt.config.project import PartialProject
+from dbt.constants import DBT_HOME_DIR_NAME
 from dbt.exceptions import DbtProjectError
 
 
@@ -11,8 +12,6 @@ def default_project_dir() -> Path:
 
 
 def default_dbt_home_dir() -> Path:
-    from dbt.constants import DBT_HOME_DIR_NAME
-
     return Path.home() / DBT_HOME_DIR_NAME
 
 

--- a/core/dbt/cli/resolvers.py
+++ b/core/dbt/cli/resolvers.py
@@ -10,8 +10,14 @@ def default_project_dir() -> Path:
     return next((x for x in paths if (x / "dbt_project.yml").exists()), Path.cwd())
 
 
+def default_dbt_home_dir() -> Path:
+    from dbt.constants import DBT_HOME_DIR_NAME
+
+    return Path.home() / DBT_HOME_DIR_NAME
+
+
 def default_profiles_dir() -> Path:
-    return Path.cwd() if (Path.cwd() / "profiles.yml").exists() else Path.home() / ".dbt"
+    return Path.cwd() if (Path.cwd() / "profiles.yml").exists() else default_dbt_home_dir()
 
 
 def default_log_path(project_dir: Path, verify_version: bool = False) -> Path:

--- a/core/dbt/config/user_settings.py
+++ b/core/dbt/config/user_settings.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import yaml
 
+from dbt.cli.resolvers import default_dbt_home_dir
 from dbt.clients.yaml_helper import load_yaml_text
 from dbt.constants import USER_SETTINGS_FILE_NAME
 from dbt.contracts.user_settings import UserSettings
@@ -13,8 +14,6 @@ from dbt_common.exceptions import DbtValidationError
 
 
 def _default_path() -> Path:
-    from dbt.cli.resolvers import default_dbt_home_dir
-
     return default_dbt_home_dir() / USER_SETTINGS_FILE_NAME
 
 

--- a/core/dbt/config/user_settings.py
+++ b/core/dbt/config/user_settings.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from dbt.constants import USER_SETTINGS_FILE_NAME
+from dbt.contracts.user_settings import UserSettings
+from dbt_common.dataclass_schema import ValidationError
+from dbt_common.exceptions import DbtValidationError
+
+
+def _default_path() -> Path:
+    from dbt.cli.resolvers import default_dbt_home_dir
+
+    return default_dbt_home_dir() / USER_SETTINGS_FILE_NAME
+
+
+def read_user_settings(path: Path | None = None) -> UserSettings:
+    if path is None:
+        path = _default_path()
+    try:
+        content = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return UserSettings()
+    except OSError as e:
+        raise DbtValidationError(f"cannot read {path}: {e}") from e
+
+    try:
+        parsed = yaml.safe_load(content)
+    except yaml.YAMLError as e:
+        raise DbtValidationError(f"invalid YAML in {path}: {e}") from e
+
+    if parsed is None:
+        return UserSettings()
+    if not isinstance(parsed, dict):
+        raise DbtValidationError(f"expected mapping in {path}, got {type(parsed).__name__}")
+
+    try:
+        return UserSettings.from_dict(parsed)
+    except ValidationError as e:
+        raise DbtValidationError(f"invalid user settings in {path}: {e}") from e
+
+
+def write_user_settings(settings: UserSettings, path: Path | None = None) -> None:
+    if path is None:
+        path = _default_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.dump(settings.to_dict(), default_flow_style=False), encoding="utf-8")
+
+
+def get_user_setting_flags(path: Path | None = None) -> dict:
+    try:
+        settings = read_user_settings(path)
+    except DbtValidationError:
+        return {}
+    return settings.flags
+
+
+def set_user_setting_flag(name: str, value: bool, path: Path | None = None) -> None:
+    settings = read_user_settings(path)
+    settings.flags[name] = value
+    write_user_settings(settings, path)

--- a/core/dbt/config/user_settings.py
+++ b/core/dbt/config/user_settings.py
@@ -16,13 +16,11 @@ def _default_path() -> Path:
     return default_dbt_home_dir() / USER_SETTINGS_FILE_NAME
 
 
-def read_user_settings(path: Path | None = None) -> UserSettings:
-    if path is None:
-        path = _default_path()
+def _load_yaml_mapping(path: Path) -> dict | None:
     try:
         content = path.read_text(encoding="utf-8")
     except FileNotFoundError:
-        return UserSettings()
+        return None
     except OSError as e:
         raise DbtValidationError(f"cannot read {path}: {e}") from e
 
@@ -32,10 +30,18 @@ def read_user_settings(path: Path | None = None) -> UserSettings:
         raise DbtValidationError(f"invalid YAML in {path}: {e}") from e
 
     if parsed is None:
-        return UserSettings()
+        return None
     if not isinstance(parsed, dict):
         raise DbtValidationError(f"expected mapping in {path}, got {type(parsed).__name__}")
+    return parsed
 
+
+def read_user_settings(path: Path | None = None) -> UserSettings:
+    if path is None:
+        path = _default_path()
+    parsed = _load_yaml_mapping(path)
+    if parsed is None:
+        return UserSettings()
     try:
         return UserSettings.from_dict(parsed)
     except ValidationError as e:

--- a/core/dbt/config/user_settings.py
+++ b/core/dbt/config/user_settings.py
@@ -4,8 +4,10 @@ from pathlib import Path
 
 import yaml
 
+from dbt.clients.yaml_helper import load_yaml_text
 from dbt.constants import USER_SETTINGS_FILE_NAME
 from dbt.contracts.user_settings import UserSettings
+from dbt_common.clients.system import load_file_contents
 from dbt_common.dataclass_schema import ValidationError
 from dbt_common.exceptions import DbtValidationError
 
@@ -17,18 +19,15 @@ def _default_path() -> Path:
 
 
 def _load_yaml_mapping(path: Path) -> dict | None:
-    try:
-        content = path.read_text(encoding="utf-8")
-    except FileNotFoundError:
+    if not path.is_file():
         return None
+
+    try:
+        contents = load_file_contents(str(path), strip=False)
     except OSError as e:
         raise DbtValidationError(f"cannot read {path}: {e}") from e
 
-    try:
-        parsed = yaml.safe_load(content)
-    except yaml.YAMLError as e:
-        raise DbtValidationError(f"invalid YAML in {path}: {e}") from e
-
+    parsed = load_yaml_text(contents)
     if parsed is None:
         return None
     if not isinstance(parsed, dict):
@@ -58,7 +57,8 @@ def write_user_settings(settings: UserSettings, path: Path | None = None) -> Non
 def get_user_setting_flags(path: Path | None = None) -> dict:
     try:
         settings = read_user_settings(path)
-    except DbtValidationError:
+    except (DbtValidationError, RuntimeError):
+        # RuntimeError: Path.home() fails when HOME/USERPROFILE env vars are absent.
         return {}
     return settings.flags
 

--- a/core/dbt/config/user_settings.py
+++ b/core/dbt/config/user_settings.py
@@ -17,33 +17,23 @@ def _default_path() -> Path:
     return default_dbt_home_dir() / USER_SETTINGS_FILE_NAME
 
 
-def _load_yaml_mapping(path: Path) -> dict | None:
-    if not path.is_file():
-        return None
-
-    try:
-        contents = load_file_contents(str(path), strip=False)
-    except OSError as e:
-        raise DbtValidationError(f"cannot read {path}: {e}") from e
-
-    parsed = load_yaml_text(contents)
-    if parsed is None:
-        return None
-    if not isinstance(parsed, dict):
-        raise DbtValidationError(f"expected mapping in {path}, got {type(parsed).__name__}")
-    return parsed
-
-
 def read_user_settings(path: Path | None = None) -> UserSettings:
     if path is None:
         path = _default_path()
-    parsed = _load_yaml_mapping(path)
-    if parsed is None:
-        return UserSettings()
-    try:
-        return UserSettings.from_dict(parsed)
-    except ValidationError as e:
-        raise DbtValidationError(f"invalid user settings in {path}: {e}") from e
+
+    if path.is_file():
+        try:
+            contents = load_file_contents(str(path), strip=False)
+            yaml_content = load_yaml_text(contents)
+
+            if not yaml_content:
+                return UserSettings()
+
+            return UserSettings.from_dict(yaml_content)
+        except (ValidationError, DbtValidationError, ValueError) as e:
+            raise DbtValidationError(f"invalid user settings in {path}: {e}") from e
+
+    return UserSettings()
 
 
 def write_user_settings(settings: UserSettings, path: Path | None = None) -> None:

--- a/core/dbt/constants.py
+++ b/core/dbt/constants.py
@@ -11,6 +11,8 @@ PIN_PACKAGE_URL = (
     "https://docs.getdbt.com/docs/package-management#section-specifying-package-versions"
 )
 
+DBT_HOME_DIR_NAME = ".dbt"
+USER_SETTINGS_FILE_NAME = "user_settings.yml"
 DBT_PROJECT_FILE_NAME = "dbt_project.yml"
 VARS_FILE_NAME = "vars.yml"
 PACKAGES_FILE_NAME = "packages.yml"

--- a/core/dbt/contracts/user_settings.py
+++ b/core/dbt/contracts/user_settings.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+from dbt_common.dataclass_schema import dbtClassMixin
+
+
+@dataclass
+class UserSettings(dbtClassMixin):
+    flags: Dict[str, Any] = field(default_factory=dict)

--- a/tests/functional/cli/test_user_settings_flags.py
+++ b/tests/functional/cli/test_user_settings_flags.py
@@ -1,0 +1,74 @@
+import os
+from unittest import mock
+
+import pytest
+
+from dbt.exceptions import DbtProjectError
+from dbt.tests.util import run_dbt, update_config_file
+
+
+class TestUserSettingsApplied:
+    """user_settings.yml flags override code defaults."""
+
+    def test_user_settings_override_default(self, project):
+        update_config_file({"require-dbt-version": "0.0.0"}, "dbt_project.yml")
+
+        # Default version_check is True, so parse should raise.
+        with pytest.raises(DbtProjectError):
+            run_dbt(["parse"])
+
+        # User settings set version_check to false — parse should succeed.
+        with mock.patch(
+            "dbt.cli.flags.get_user_setting_flags",
+            return_value={"version_check": False},
+        ):
+            run_dbt(["parse"])
+
+
+class TestCLIOverridesUserSettings:
+    """CLI flags take precedence over user_settings.yml."""
+
+    def test_cli_overrides_user_settings(self, project):
+        update_config_file({"require-dbt-version": "0.0.0"}, "dbt_project.yml")
+
+        # User settings disable version_check, but CLI re-enables it.
+        with mock.patch(
+            "dbt.cli.flags.get_user_setting_flags",
+            return_value={"version_check": False},
+        ):
+            with pytest.raises(DbtProjectError):
+                run_dbt(["parse", "--version-check"])
+
+
+class TestEnvVarOverridesUserSettings:
+    """Environment variables take precedence over user_settings.yml."""
+
+    def test_env_var_overrides_user_settings(self, project):
+        update_config_file({"require-dbt-version": "0.0.0"}, "dbt_project.yml")
+
+        # User settings disable version_check, but env var re-enables it.
+        with mock.patch(
+            "dbt.cli.flags.get_user_setting_flags",
+            return_value={"version_check": False},
+        ):
+            with mock.patch.dict(os.environ, {"DBT_VERSION_CHECK": "true"}):
+                with pytest.raises(DbtProjectError):
+                    run_dbt(["parse"])
+
+
+class TestProjectFlagsOverrideUserSettings:
+    """Project flags in dbt_project.yml take precedence over user_settings.yml."""
+
+    def test_project_flags_override_user_settings(self, project):
+        update_config_file(
+            {"require-dbt-version": "0.0.0", "flags": {"version_check": True}},
+            "dbt_project.yml",
+        )
+
+        # User settings disable version_check, but project flags re-enable it.
+        with mock.patch(
+            "dbt.cli.flags.get_user_setting_flags",
+            return_value={"version_check": False},
+        ):
+            with pytest.raises(DbtProjectError):
+                run_dbt(["parse"])

--- a/tests/unit/cli/test_flags.py
+++ b/tests/unit/cli/test_flags.py
@@ -150,6 +150,34 @@ class TestFlags:
         flags = Flags(context, project_flags)
         assert flags.USE_COLORS
 
+    def test_prefer_user_settings_to_default(self, monkeypatch):
+        monkeypatch.setattr(
+            "dbt.cli.flags.get_user_setting_flags",
+            lambda: {"use_colors": False},
+        )
+        context = self.make_dbt_context("run", ["run"])
+        flags = Flags(context)
+        assert flags.USE_COLORS is False
+
+    def test_prefer_project_flags_to_user_settings(self, monkeypatch, project_flags):
+        project_flags.use_colors = True
+        monkeypatch.setattr(
+            "dbt.cli.flags.get_user_setting_flags",
+            lambda: {"use_colors": False},
+        )
+        context = self.make_dbt_context("run", ["run"])
+        flags = Flags(context, project_flags)
+        assert flags.USE_COLORS is True
+
+    def test_prefer_cli_to_user_settings(self, monkeypatch):
+        monkeypatch.setattr(
+            "dbt.cli.flags.get_user_setting_flags",
+            lambda: {"use_colors": False},
+        )
+        context = self.make_dbt_context("run", ["--use-colors", "True", "run"])
+        flags = Flags(context)
+        assert flags.USE_COLORS is True
+
     def test_mutually_exclusive_options_passed_separately(self):
         """Assert options that are mutually exclusive can be passed separately without error"""
         warn_error_context = self.make_dbt_context("run", ["--warn-error", "run"])

--- a/tests/unit/config/test_user_settings.py
+++ b/tests/unit/config/test_user_settings.py
@@ -32,7 +32,7 @@ class TestReadUserSettings:
     def test_non_mapping_raises(self, tmp_path):
         p = tmp_path / "user_settings.yml"
         p.write_text("- a\n- b\n")
-        with pytest.raises(DbtValidationError, match="expected mapping"):
+        with pytest.raises(DbtValidationError, match="invalid user settings"):
             read_user_settings(p)
 
     def test_invalid_yaml_raises(self, tmp_path):

--- a/tests/unit/config/test_user_settings.py
+++ b/tests/unit/config/test_user_settings.py
@@ -1,0 +1,101 @@
+import pytest
+
+from dbt.config.user_settings import (
+    get_user_setting_flags,
+    read_user_settings,
+    set_user_setting_flag,
+    write_user_settings,
+)
+from dbt.contracts.user_settings import UserSettings
+from dbt_common.exceptions import DbtValidationError
+
+
+class TestReadUserSettings:
+    def test_missing_file_returns_defaults(self, tmp_path):
+        result = read_user_settings(tmp_path / "nonexistent.yml")
+        assert isinstance(result, UserSettings)
+        assert result.flags == {}
+
+    def test_empty_file_returns_defaults(self, tmp_path):
+        p = tmp_path / "user_settings.yml"
+        p.write_text("")
+        result = read_user_settings(p)
+        assert isinstance(result, UserSettings)
+        assert result.flags == {}
+
+    def test_valid_yaml(self, tmp_path):
+        p = tmp_path / "user_settings.yml"
+        p.write_text("flags:\n  send_anonymous_usage_stats: false\n")
+        result = read_user_settings(p)
+        assert result.flags == {"send_anonymous_usage_stats": False}
+
+    def test_non_mapping_raises(self, tmp_path):
+        p = tmp_path / "user_settings.yml"
+        p.write_text("- a\n- b\n")
+        with pytest.raises(DbtValidationError, match="expected mapping"):
+            read_user_settings(p)
+
+    def test_invalid_yaml_raises(self, tmp_path):
+        p = tmp_path / "user_settings.yml"
+        p.write_text(":\n  :\n bad: [")
+        with pytest.raises(DbtValidationError, match="invalid YAML"):
+            read_user_settings(p)
+
+
+class TestWriteUserSettings:
+    def test_roundtrip(self, tmp_path):
+        p = tmp_path / "user_settings.yml"
+        settings = UserSettings(flags={"fail_fast": True})
+        write_user_settings(settings, p)
+        result = read_user_settings(p)
+        assert result.flags["fail_fast"] is True
+
+    def test_creates_parent_dirs(self, tmp_path):
+        p = tmp_path / "nested" / "dir" / "user_settings.yml"
+        write_user_settings(UserSettings(), p)
+        assert p.exists()
+
+
+class TestGetUserSettingFlags:
+    def test_returns_flags_dict(self, tmp_path):
+        p = tmp_path / "user_settings.yml"
+        p.write_text("flags:\n  fail_fast: true\n")
+        assert get_user_setting_flags(p) == {"fail_fast": True}
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert get_user_setting_flags(tmp_path / "missing.yml") == {}
+
+    def test_empty_flags_returns_empty(self, tmp_path):
+        p = tmp_path / "user_settings.yml"
+        p.write_text("flags: {}\n")
+        assert get_user_setting_flags(p) == {}
+
+    def test_validation_error_returns_empty(self, tmp_path):
+        p = tmp_path / "user_settings.yml"
+        p.write_text("- list\n- not mapping\n")
+        assert get_user_setting_flags(p) == {}
+
+
+class TestSetUserSettingFlag:
+    def test_sets_new_flag(self, tmp_path):
+        p = tmp_path / "user_settings.yml"
+        p.write_text("flags: {}\n")
+        set_user_setting_flag("fail_fast", True, p)
+        assert get_user_setting_flags(p) == {"fail_fast": True}
+
+    def test_overwrites_existing_flag(self, tmp_path):
+        p = tmp_path / "user_settings.yml"
+        p.write_text("flags:\n  fail_fast: false\n")
+        set_user_setting_flag("fail_fast", True, p)
+        assert get_user_setting_flags(p) == {"fail_fast": True}
+
+    def test_creates_file_if_missing(self, tmp_path):
+        p = tmp_path / "user_settings.yml"
+        set_user_setting_flag("fail_fast", True, p)
+        assert get_user_setting_flags(p) == {"fail_fast": True}
+
+    def test_unknown_flag_preserved(self, tmp_path):
+        p = tmp_path / "user_settings.yml"
+        p.write_text("flags: {}\n")
+        set_user_setting_flag("custom_flag", True, p)
+        assert get_user_setting_flags(p)["custom_flag"] is True

--- a/tests/unit/config/test_user_settings.py
+++ b/tests/unit/config/test_user_settings.py
@@ -38,7 +38,7 @@ class TestReadUserSettings:
     def test_invalid_yaml_raises(self, tmp_path):
         p = tmp_path / "user_settings.yml"
         p.write_text(":\n  :\n bad: [")
-        with pytest.raises(DbtValidationError, match="invalid YAML"):
+        with pytest.raises(DbtValidationError, match="Syntax error"):
             read_user_settings(p)
 
 


### PR DESCRIPTION
Resolves #13031

### Problem
context: https://github.com/dbt-labs/dbt-core/issues/13031

### Solution
- Add support for user_settings.yml 
- The file exists at ~/.dbt
- Changes flag resolution to  cli -> env -> dbt_project -> user_settings -> code from cli -> env -> dbt_project -> code 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
