### PR TITLE
Improve dbt debug

### DIFF
--- a/.changes/unreleased/Fixes-20260526-203133.yaml
+++ b/.changes/unreleased/Fixes-20260526-203133.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Improve `dbt debug` output when `git --help` fails by surfacing the underlying command output and installation guidance
+time: 2026-05-26T20:31:33.900000000Z
+custom:
+    Author: desusaiteja
+    Issue: "9537"

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -387,12 +387,26 @@ class DebugTask(BaseTask):
     def test_git(self) -> SubtaskStatus:
         try:
             dbt_common.clients.system.run_cmd(os.getcwd(), ["git", "--help"])
-        except dbt_common.exceptions.ExecutableError as exc:
+        except (
+            dbt_common.exceptions.CommandResultError,
+            dbt_common.exceptions.ExecutableError,
+        ) as exc:
+            extra_message = ""
+            if isinstance(exc, dbt_common.exceptions.CommandResultError):
+                command_output = exc.stderr.strip() or exc.stdout.strip()
+                if command_output:
+                    extra_message = f"\nError from git --help: {command_output}"
+
             return SubtaskStatus(
                 log_msg=red("ERROR"),
                 run_status=RunStatus.Error,
                 details="git error",
-                summary_message="Error from git --help: {!s}".format(exc),
+                summary_message=(
+                    f"{exc!s}"
+                    f"{extra_message}\n\n"
+                    "Make sure that `git` is installed in your shell and that "
+                    "`git --help` can execute successfully."
+                ),
             )
         else:
             return SubtaskStatus(

--- a/tests/unit/task/test_debug.py
+++ b/tests/unit/task/test_debug.py
@@ -1,0 +1,45 @@
+from unittest import mock
+
+import dbt_common.exceptions
+from dbt.artifacts.schemas.results import RunStatus
+from dbt.task.debug import DebugTask
+
+
+def test_test_git_includes_command_output_for_nonzero_return_codes():
+    task = object.__new__(DebugTask)
+    error = dbt_common.exceptions.CommandResultError(
+        cwd="/tmp",
+        cmd=["/usr/bin/git", "--help"],
+        returncode=1,
+        stdout=b"",
+        stderr=(
+            b"xcrun: error: invalid active developer path "
+            b"(/Library/Developer/CommandLineTools)"
+        ),
+    )
+
+    with mock.patch("dbt.task.debug.dbt_common.clients.system.run_cmd", side_effect=error):
+        result = task.test_git()
+
+    assert result.run_status == RunStatus.Error
+    assert "Got a non-zero returncode running" in result.summary_message
+    assert "Error from git --help: xcrun: error: invalid active developer path" in (
+        result.summary_message
+    )
+    assert "Make sure that `git` is installed in your shell" in result.summary_message
+
+
+def test_test_git_handles_missing_executable_errors():
+    task = object.__new__(DebugTask)
+    error = dbt_common.exceptions.ExecutableError(
+        cwd="/tmp",
+        cmd=["git", "--help"],
+        msg="No such file or directory",
+    )
+
+    with mock.patch("dbt.task.debug.dbt_common.clients.system.run_cmd", side_effect=error):
+        result = task.test_git()
+
+    assert result.run_status == RunStatus.Error
+    assert 'No such file or directory: "git"' in result.summary_message
+    assert "Make sure that `git` is installed in your shell" in result.summary_message


### PR DESCRIPTION
Resolves #9537

### Problem

When `dbt debug` checks for `git`, a failing `git --help` can raise a non-zero return code with useful stderr output, but `DebugTask.test_git()` only handled missing-executable errors. In practice that meant users only saw the wrapper message and not the underlying cause.

### Solution

- catch `CommandResultError` in addition to `ExecutableError`
- include stderr/stdout from `git --help` when available
- add a follow-up hint telling users to verify that `git` is installed and runnable in their shell
- add unit tests covering both non-zero-return-code and missing-executable paths

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
