### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260528-182630.yaml
+++ b/.changes/unreleased/Under the Hood-20260528-182630.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-05-28T18:26:30.793748759Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -1949,6 +1949,12 @@
             "null"
           ]
         },
+        "+refresh_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+require_partition_filter": {
           "anyOf": [
             {
@@ -3594,6 +3600,12 @@
             "null"
           ]
         },
+        "+refresh_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+require_partition_filter": {
           "anyOf": [
             {
@@ -4620,6 +4632,12 @@
             "null"
           ]
         },
+        "+refresh_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+require_partition_filter": {
           "anyOf": [
             {
@@ -5534,6 +5552,12 @@
           ]
         },
         "+refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "+refresh_warehouse": {
           "type": [
             "string",
             "null"
@@ -6912,6 +6936,12 @@
           ]
         },
         "+refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "+refresh_warehouse": {
           "type": [
             "string",
             "null"

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -1629,6 +1629,12 @@
             "null"
           ]
         },
+        "refresh_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "require_partition_filter": {
           "anyOf": [
             {
@@ -3528,6 +3534,12 @@
           ]
         },
         "refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "refresh_warehouse": {
           "type": [
             "string",
             "null"
@@ -5733,6 +5745,12 @@
             "null"
           ]
         },
+        "refresh_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "require_partition_filter": {
           "anyOf": [
             {
@@ -7743,6 +7761,12 @@
             "null"
           ]
         },
+        "refresh_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "require_partition_filter": {
           "anyOf": [
             {
@@ -8888,6 +8912,12 @@
             "null"
           ]
         },
+        "refresh_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "require_partition_filter": {
           "anyOf": [
             {
@@ -9981,6 +10011,12 @@
           ]
         },
         "refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "refresh_warehouse": {
           "type": [
             "string",
             "null"
@@ -11271,6 +11307,12 @@
           ]
         },
         "refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "refresh_warehouse": {
           "type": [
             "string",
             "null"


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`6e3d8cb3ef2ef0b9f61235ccdb224a435a622e3c`](https://github.com/dbt-labs/fs/commit/6e3d8cb3ef2ef0b9f61235ccdb224a435a622e3c)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/26592564349)