### PR TITLE
Add v2-parser telemetry (invocation correlation + start/end events)

### DIFF
--- a/.changes/unreleased/Under the Hood-20260527-142247.yaml
+++ b/.changes/unreleased/Under the Hood-20260527-142247.yaml
@@ -1,5 +1,5 @@
 kind: Under the Hood
-body: Forward dbt-core's invocation_id and set DBT_INVOCATION_ENV=dbt-core-v2-parser on the fs subprocess when shelling out to the v2 parser, so embedded fs telemetry can be correlated with the host invocation and attributed to the v2-parser pathway.
+body: Add v2-parser telemetry — forward dbt-core's invocation_id and set DBT_INVOCATION_ENV=dbt-core-v2-parser on the parser subprocess so embedded telemetry correlates with the host invocation, and emit V2ParserStart/V2ParserEnd events around the handoff so pre-startup failures (missing binary, schema mismatch) are also captured. Bumps dbt-protos lower bound to 1.0.514 for the new event messages.
 time: 2026-05-27T14:22:47.358872-06:00
 custom:
     Author: aiguofer

--- a/.changes/unreleased/Under the Hood-20260527-142247.yaml
+++ b/.changes/unreleased/Under the Hood-20260527-142247.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Forward dbt-core's invocation_id and set DBT_INVOCATION_ENV=dbt-core-v2-parser on the fs subprocess when shelling out to the v2 parser, so embedded fs telemetry can be correlated with the host invocation and attributed to the v2-parser pathway.
+time: 2026-05-27T14:22:47.358872-06:00
+custom:
+    Author: aiguofer
+    Issue: "13029"

--- a/.changes/unreleased/Under the Hood-20260528-175200.yaml
+++ b/.changes/unreleased/Under the Hood-20260528-175200.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Emit V2ParserStart/V2ParserEnd telemetry events around the embedded fs parse subprocess so internal analytics can attribute v2-parser invocations and measure success rate. Bumps dbt-protos lower bound to 1.0.514 for the new event messages.
+time: 2026-05-28T17:52:00.460905-06:00
+custom:
+    Author: aiguofer
+    Issue: "13029"

--- a/.changes/unreleased/Under the Hood-20260528-175200.yaml
+++ b/.changes/unreleased/Under the Hood-20260528-175200.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Emit V2ParserStart/V2ParserEnd telemetry events around the embedded fs parse subprocess so internal analytics can attribute v2-parser invocations and measure success rate. Bumps dbt-protos lower bound to 1.0.514 for the new event messages.
-time: 2026-05-28T17:52:00.460905-06:00
-custom:
-    Author: aiguofer
-    Issue: "13029"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -2194,6 +2194,27 @@ class LogOverloadResult(DynamicLevel):
         return f"Overload {formatted}"
 
 
+class V2ParserStart(InfoLevel):
+    def code(self) -> str:
+        return "Q050"
+
+    def message(self) -> str:
+        return f"Delegating parse to v2 parser: {self.v2_parser_command}"
+
+
+class V2ParserEnd(DynamicLevel):
+    def code(self) -> str:
+        return "Q051"
+
+    def message(self) -> str:
+        if self.status == "success":
+            return f"v2 parser completed in {self.execution_time:.2f}s"
+        return (
+            f"v2 parser failed after {self.execution_time:.2f}s "
+            f"({self.error_class}, exit_code={self.exit_code})"
+        )
+
+
 # =======================================================
 # W - Node testing
 # =======================================================

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -90,6 +90,10 @@ class FusionParserError(DbtRuntimeError):
     CODE = 10025
     MESSAGE = "Fusion Parser Error"
 
+    def __init__(self, msg: str, returncode: int = -1, node=None) -> None:
+        super().__init__(msg, node=node)
+        self.returncode = returncode
+
 
 class FusionParserMissingError(FusionParserError):
     CODE = 10026

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -95,11 +95,6 @@ class FusionParserError(DbtRuntimeError):
         self.returncode = returncode
 
 
-class FusionParserMissingError(FusionParserError):
-    CODE = 10026
-    MESSAGE = "Fusion Parser Missing"
-
-
 class FusionParserSchemaError(FusionParserError):
     CODE = 10027
     MESSAGE = "Fusion Parser Schema Error"

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -30,6 +30,7 @@ from dbt.exceptions import (
     FusionParserVersionError,
 )
 from dbt.flags import get_flags
+from dbt_common.events.functions import get_invocation_id
 
 if TYPE_CHECKING:
     from dbt.config import RuntimeConfig
@@ -152,6 +153,11 @@ def _build_argv(flags, target_path_override: Optional[str] = None) -> List[str]:
     if cli_vars:
         forwarded += ["--vars", _serialize_vars(cli_vars)]
 
+    # Forward dbt-core's invocation_id so fs telemetry shares the same trace.
+    invocation_id = get_invocation_id()
+    if invocation_id:
+        forwarded += ["--invocation-id", str(invocation_id)]
+
     return base + forwarded
 
 
@@ -170,6 +176,21 @@ def _resolve_engine_command(command: str) -> str:
     if candidate.exists():
         return str(candidate)
     return command
+
+
+def _fusion_subprocess_env() -> dict:
+    """Return env for the fs subprocess, overriding DBT_INVOCATION_ENV.
+
+    Setting DBT_INVOCATION_ENV=dbt-core-v2-parser on the child only (not the
+    parent process env) tags every fs telemetry record from this run so the
+    internal-analytics warehouse can attribute it to the v2-parser pathway.
+    The host orchestrator's DBT_INVOCATION_ENV (set by dbt platform Orc/Sinter
+    or by CI) still applies to dbt-core's own telemetry — we only relabel the
+    embedded fs run.
+    """
+    env = os.environ.copy()
+    env["DBT_INVOCATION_ENV"] = "dbt-core-v2-parser"
+    return env
 
 
 def _run_fusion(argv: List[str]) -> None:
@@ -191,7 +212,7 @@ def _run_fusion(argv: List[str]) -> None:
     # Until then, capturing-then-printing-at-end would lose streaming (fusion
     # parsing can take minutes on large projects), so we inherit fds instead.
     try:
-        result = subprocess.run(argv, check=False)
+        result = subprocess.run(argv, check=False, env=_fusion_subprocess_env())
     except FileNotFoundError as e:
         raise FusionParserMissingError(
             f"Fusion parser command not found: {argv[0]!r}. "

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -27,7 +27,6 @@ from dbt.contracts.graph.manifest import Manifest
 from dbt.events.types import V2ParserEnd, V2ParserStart
 from dbt.exceptions import (
     FusionParserError,
-    FusionParserMissingError,
     FusionParserSchemaError,
     FusionParserVersionError,
 )
@@ -91,7 +90,6 @@ def parse_with_fusion(
                         semantic_manifest_path, project_target_path / "semantic_manifest.json"
                     )
     except (
-        FusionParserMissingError,
         FusionParserVersionError,
         FusionParserSchemaError,
         FusionParserError,
@@ -250,7 +248,7 @@ def _run_fusion(argv: List[str]) -> None:
     try:
         result = subprocess.run(argv, check=False, env=_fusion_subprocess_env())
     except FileNotFoundError as e:
-        raise FusionParserMissingError(
+        raise FusionParserError(
             f"Fusion parser command not found: {argv[0]!r}. "
             f"Reinstall dbt-core-experimental-parser, or set --v2-parser to "
             f"point to an alternate engine binary."

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -32,6 +32,7 @@ from dbt.exceptions import (
     FusionParserVersionError,
 )
 from dbt.flags import get_flags
+from dbt_common.events.base_types import EventLevel
 from dbt_common.events.functions import fire_event, get_invocation_id
 
 if TYPE_CHECKING:
@@ -102,7 +103,8 @@ def parse_with_fusion(
                 error_class=type(e).__name__,
                 exit_code=getattr(e, "returncode", -1),
                 project_name=project_name,
-            )
+            ),
+            level=EventLevel.ERROR,
         )
         raise
 
@@ -113,7 +115,8 @@ def parse_with_fusion(
             error_class="",
             exit_code=-1,
             project_name=project_name,
-        )
+        ),
+        level=EventLevel.INFO,
     )
 
     manifest = Manifest.from_writable_manifest(writable_manifest)

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -17,12 +17,14 @@ import shutil
 import subprocess
 import sysconfig
 import tempfile
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
 from dbt.artifacts.exceptions import IncompatibleSchemaError
 from dbt.artifacts.schemas.manifest import WritableManifest
 from dbt.contracts.graph.manifest import Manifest
+from dbt.events.types import V2ParserEnd, V2ParserStart
 from dbt.exceptions import (
     FusionParserError,
     FusionParserMissingError,
@@ -30,7 +32,7 @@ from dbt.exceptions import (
     FusionParserVersionError,
 )
 from dbt.flags import get_flags
-from dbt_common.events.functions import get_invocation_id
+from dbt_common.events.functions import fire_event, get_invocation_id
 
 if TYPE_CHECKING:
     from dbt.config import RuntimeConfig
@@ -57,31 +59,62 @@ def parse_with_fusion(
 
     flags = get_flags()
     project_target_path = Path(runtime_config.project_target_path)
+    v2_parser_command = getattr(flags, "V2_PARSER", "dbt-core-experimental-parser parse")
+    project_name = runtime_config.project_name
 
-    with tempfile.TemporaryDirectory(prefix="dbt-fusion-") as handoff_dir:
-        handoff = Path(handoff_dir)
-        argv = _build_argv(flags, target_path_override=str(handoff))
+    fire_event(V2ParserStart(v2_parser_command=v2_parser_command, project_name=project_name))
+    start_time = time.monotonic()
+    try:
+        with tempfile.TemporaryDirectory(prefix="dbt-fusion-") as handoff_dir:
+            handoff = Path(handoff_dir)
+            argv = _build_argv(flags, target_path_override=str(handoff))
 
-        _run_fusion(argv)
+            _run_fusion(argv)
 
-        manifest_path = handoff / "manifest.json"
-        if not manifest_path.exists():
-            raise FusionParserError(
-                f"Fusion parser exited successfully but did not produce {manifest_path.name} "
-                f"in the handoff directory."
-            )
-
-        writable_manifest = _load_writable_manifest(manifest_path)
-
-        if write and write_json:
-            # Copy v2 parser artifacts rather than re-serializing through write_manifest
-            project_target_path.mkdir(parents=True, exist_ok=True)
-            shutil.copyfile(manifest_path, project_target_path / "manifest.json")
-            semantic_manifest_path = handoff / "semantic_manifest.json"
-            if semantic_manifest_path.exists():
-                shutil.copyfile(
-                    semantic_manifest_path, project_target_path / "semantic_manifest.json"
+            manifest_path = handoff / "manifest.json"
+            if not manifest_path.exists():
+                raise FusionParserError(
+                    f"Fusion parser exited successfully but did not produce {manifest_path.name} "
+                    f"in the handoff directory."
                 )
+
+            writable_manifest = _load_writable_manifest(manifest_path)
+
+            if write and write_json:
+                # Copy v2 parser artifacts rather than re-serializing through write_manifest
+                project_target_path.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(manifest_path, project_target_path / "manifest.json")
+                semantic_manifest_path = handoff / "semantic_manifest.json"
+                if semantic_manifest_path.exists():
+                    shutil.copyfile(
+                        semantic_manifest_path, project_target_path / "semantic_manifest.json"
+                    )
+    except (
+        FusionParserMissingError,
+        FusionParserVersionError,
+        FusionParserSchemaError,
+        FusionParserError,
+    ) as e:
+        fire_event(
+            V2ParserEnd(
+                status="failure",
+                execution_time=time.monotonic() - start_time,
+                error_class=type(e).__name__,
+                exit_code=getattr(e, "returncode", -1),
+                project_name=project_name,
+            )
+        )
+        raise
+
+    fire_event(
+        V2ParserEnd(
+            status="success",
+            execution_time=time.monotonic() - start_time,
+            error_class="",
+            exit_code=-1,
+            project_name=project_name,
+        )
+    )
 
     manifest = Manifest.from_writable_manifest(writable_manifest)
     # build_flat_graph is normally called by ManifestLoader.get_full_manifest;
@@ -222,7 +255,8 @@ def _run_fusion(argv: List[str]) -> None:
 
     if result.returncode != 0:
         raise FusionParserError(
-            f"Fusion parser failed (exit {result.returncode}); see parser output above."
+            f"Fusion parser failed (exit {result.returncode}); see parser output above.",
+            returncode=result.returncode,
         )
 
 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     # Minor versions for these are expected to be backwards-compatible
     "dbt-common>=1.37.5,<2.0",
     "dbt-adapters>=1.24.1,<2.0",
-    "dbt-protos>=1.0.498,<2.0",
+    "dbt-protos>=1.0.514,<2.0",
     "dbt-core-experimental-parser>=2.0.0.dev0,<3",
     # Bundled plugin: installed by default but opt-in. PluginManager skips loading
     # unless the user passes `--manage-state` on the CLI, sets

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     "dbt-common>=1.37.5,<2.0",
     "dbt-adapters>=1.24.1,<2.0",
     "dbt-protos>=1.0.514,<2.0",
-    "dbt-core-experimental-parser>=2.0.0.dev0,<3",
+    "dbt-core-experimental-parser>=2.0.0.dev18,<3",
     # Bundled plugin: installed by default but opt-in. PluginManager skips loading
     # unless the user passes `--manage-state` on the CLI, sets
     # `DBT_ENGINE_MANAGE_STATE=true`, or sets `manage_state: true` in dbt_project.yml's

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -11,7 +11,6 @@ import pytest
 from dbt.events.types import V2ParserEnd, V2ParserStart
 from dbt.exceptions import (
     FusionParserError,
-    FusionParserMissingError,
     FusionParserSchemaError,
     FusionParserVersionError,
 )
@@ -166,7 +165,7 @@ class TestParseWithFusion:
             "dbt.parser.fusion.get_flags",
             return_value=_flags(V2_PARSER="definitely-not-a-real-binary-xyz"),
         ), mock.patch("dbt.parser.fusion.subprocess.run", side_effect=FileNotFoundError()):
-            with pytest.raises(FusionParserMissingError):
+            with pytest.raises(FusionParserError):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
 
     def test_sets_dbt_invocation_env_on_subprocess(self, tmp_path: Path, _patch_fusion_deps):
@@ -320,7 +319,7 @@ class TestParseWithFusionTelemetry:
     @pytest.mark.parametrize(
         "subprocess_side_effect, expected_error_class, expected_exit_code",
         [
-            (FileNotFoundError(), "FusionParserMissingError", -1),
+            (FileNotFoundError(), "FusionParserError", -1),
             # fs exits non-zero — exit code surfaced via FusionParserError.returncode
             (_fake_parser(manifest_text=None, returncode=2), "FusionParserError", 2),
             # fs exits 0 but writes no manifest — generic FusionParserError, no returncode

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -1,4 +1,5 @@
 import json
+import os
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -54,6 +55,13 @@ def _fake_parser(manifest_text: Optional[str], returncode: int = 0, stderr: str 
     return _run
 
 
+@pytest.fixture(autouse=True)
+def _no_invocation_id():
+    """Default to no invocation id so argv tests assert only the flags they set."""
+    with mock.patch("dbt.parser.fusion.get_invocation_id", return_value=None):
+        yield
+
+
 class TestBuildArgv:
     @pytest.fixture(autouse=True)
     def _identity_resolve(self):
@@ -102,6 +110,19 @@ class TestBuildArgv:
         assert argv[i + 1] == "/tmp/handoff"
         assert "user/target" not in argv
 
+    def test_forwards_invocation_id(self):
+        with mock.patch(
+            "dbt.parser.fusion.get_invocation_id",
+            return_value="11111111-1111-1111-1111-111111111111",
+        ):
+            argv = _build_argv(_flags())
+        i = argv.index("--invocation-id")
+        assert argv[i + 1] == "11111111-1111-1111-1111-111111111111"
+
+    def test_omits_invocation_id_when_unavailable(self):
+        argv = _build_argv(_flags())
+        assert "--invocation-id" not in argv
+
 
 class TestSerializeVars:
     def test_dict_to_yaml(self):
@@ -146,6 +167,33 @@ class TestParseWithFusion:
         ), mock.patch("dbt.parser.fusion.subprocess.run", side_effect=FileNotFoundError()):
             with pytest.raises(FusionParserMissingError):
                 parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
+
+    def test_sets_dbt_invocation_env_on_subprocess(self, tmp_path: Path, _patch_fusion_deps):
+        """fs must see DBT_INVOCATION_ENV=dbt-core-v2-parser regardless of the
+        parent process's value, so analytics can attribute the embedded fs run
+        to the v2-parser pathway without clobbering the host's own telemetry."""
+        captured = {}
+
+        def _capture(argv, *args, **kwargs):
+            captured["env"] = kwargs.get("env")
+            return _fake_fs(json.dumps({"metadata": {}}))(argv, *args, **kwargs)
+
+        with mock.patch.dict(
+            "os.environ", {"DBT_INVOCATION_ENV": "dbt-cloud-prod__host:cloud"}, clear=False
+        ), mock.patch(
+            "dbt.parser.fusion.subprocess.run", side_effect=_capture
+        ), mock.patch(
+            "dbt.parser.fusion._load_writable_manifest", return_value=mock.MagicMock()
+        ), mock.patch(
+            "dbt.parser.fusion.Manifest.from_writable_manifest", return_value=mock.MagicMock()
+        ):
+            parse_with_fusion(self._runtime_config(tmp_path), write=False, write_json=False)
+            # parent process env is untouched (asserted inside the patch.dict
+            # block so the original value is still in place to compare against)
+            assert os.environ["DBT_INVOCATION_ENV"] == "dbt-cloud-prod__host:cloud"
+
+        assert captured["env"] is not None
+        assert captured["env"]["DBT_INVOCATION_ENV"] == "dbt-core-v2-parser"
 
     def test_nonzero_exit_raises(self, tmp_path: Path, _patch_fusion_deps):
         # Passthrough mode: the parser's stderr streams directly to the user,

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -288,7 +288,11 @@ class TestParseWithFusionTelemetry:
 
     def _patch_fire_event(self):
         events: list = []
-        return events, mock.patch("dbt.parser.fusion.fire_event", side_effect=events.append)
+
+        def _capture(event, *args, **kwargs):
+            events.append(event)
+
+        return events, mock.patch("dbt.parser.fusion.fire_event", side_effect=_capture)
 
     def test_success_fires_start_and_end_success(self, tmp_path: Path, _patch_fusion_deps):
         events, patch_fire = self._patch_fire_event()

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -176,13 +176,11 @@ class TestParseWithFusion:
 
         def _capture(argv, *args, **kwargs):
             captured["env"] = kwargs.get("env")
-            return _fake_fs(json.dumps({"metadata": {}}))(argv, *args, **kwargs)
+            return _fake_parser(json.dumps({"metadata": {}}))(argv, *args, **kwargs)
 
         with mock.patch.dict(
             "os.environ", {"DBT_INVOCATION_ENV": "dbt-cloud-prod__host:cloud"}, clear=False
-        ), mock.patch(
-            "dbt.parser.fusion.subprocess.run", side_effect=_capture
-        ), mock.patch(
+        ), mock.patch("dbt.parser.fusion.subprocess.run", side_effect=_capture), mock.patch(
             "dbt.parser.fusion._load_writable_manifest", return_value=mock.MagicMock()
         ), mock.patch(
             "dbt.parser.fusion.Manifest.from_writable_manifest", return_value=mock.MagicMock()

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pytest
 
+from dbt.events.types import V2ParserEnd, V2ParserStart
 from dbt.exceptions import (
     FusionParserError,
     FusionParserMissingError,
@@ -272,3 +273,91 @@ class TestParseWithFusion:
         ):
             parse_with_fusion(self._runtime_config(target), write=True, write_json=True)
         assert (target / "manifest.json").exists()
+
+
+class TestParseWithFusionTelemetry:
+    """V2ParserStart/V2ParserEnd must fire around every v2-parser handoff so
+    internal analytics can attribute v2-parser invocations and measure success
+    rate end-to-end. Both events must fire on success; on each typed-exception
+    failure path the end event must carry status="failure" + the exception
+    class name. exit_code is -1 except for FusionParserError, which surfaces
+    fs's process exit code via FusionParserError.returncode."""
+
+    def _runtime_config(self, target_path: Path):
+        return SimpleNamespace(project_target_path=str(target_path), project_name="test")
+
+    def _patch_fire_event(self):
+        events: list = []
+        return events, mock.patch("dbt.parser.fusion.fire_event", side_effect=events.append)
+
+    def test_success_fires_start_and_end_success(self, tmp_path: Path, _patch_fusion_deps):
+        events, patch_fire = self._patch_fire_event()
+        with patch_fire, mock.patch(
+            "dbt.parser.fusion.subprocess.run",
+            side_effect=_fake_parser(json.dumps({"metadata": {}})),
+        ), mock.patch(
+            "dbt.parser.fusion._load_writable_manifest", return_value=mock.MagicMock()
+        ), mock.patch(
+            "dbt.parser.fusion.Manifest.from_writable_manifest", return_value=mock.MagicMock()
+        ):
+            parse_with_fusion(self._runtime_config(tmp_path), write=False, write_json=False)
+
+        types = [type(e).__name__ for e in events]
+        assert types == ["V2ParserStart", "V2ParserEnd"]
+        start, end = events
+        assert isinstance(start, V2ParserStart)
+        assert start.project_name == "test"
+        assert isinstance(end, V2ParserEnd)
+        assert end.status == "success"
+        assert end.error_class == ""
+        assert end.exit_code == -1
+        assert end.execution_time >= 0
+
+    @pytest.mark.parametrize(
+        "subprocess_side_effect, expected_error_class, expected_exit_code",
+        [
+            (FileNotFoundError(), "FusionParserMissingError", -1),
+            # fs exits non-zero — exit code surfaced via FusionParserError.returncode
+            (_fake_parser(manifest_text=None, returncode=2), "FusionParserError", 2),
+            # fs exits 0 but writes no manifest — generic FusionParserError, no returncode
+            (_fake_parser(manifest_text=None), "FusionParserError", -1),
+            (_fake_parser("{ not valid json"), "FusionParserSchemaError", -1),
+        ],
+    )
+    def test_failure_fires_end_failure(
+        self,
+        tmp_path: Path,
+        _patch_fusion_deps,
+        subprocess_side_effect,
+        expected_error_class,
+        expected_exit_code,
+    ):
+        events, patch_fire = self._patch_fire_event()
+        with patch_fire, mock.patch(
+            "dbt.parser.fusion.subprocess.run", side_effect=subprocess_side_effect
+        ):
+            with pytest.raises(FusionParserError):
+                parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
+
+        types = [type(e).__name__ for e in events]
+        assert types == ["V2ParserStart", "V2ParserEnd"]
+        end = events[1]
+        assert end.status == "failure"
+        assert end.error_class == expected_error_class
+        assert end.exit_code == expected_exit_code
+
+    def test_failure_version_error_fires_end_failure(self, tmp_path: Path, _patch_fusion_deps):
+        events, patch_fire = self._patch_fire_event()
+        bad_version = json.dumps(
+            {"metadata": {"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v1.json"}}
+        )
+        with patch_fire, mock.patch(
+            "dbt.parser.fusion.subprocess.run", side_effect=_fake_parser(bad_version)
+        ):
+            with pytest.raises(FusionParserVersionError):
+                parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
+
+        end = events[1]
+        assert end.status == "failure"
+        assert end.error_class == "FusionParserVersionError"
+        assert end.exit_code == -1

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -481,6 +481,14 @@ sample_values = [
         total_overloads=0,
         execution_time=0,
     ),
+    core_types.V2ParserStart(v2_parser_command="", project_name=""),
+    core_types.V2ParserEnd(
+        status="",
+        execution_time=0,
+        error_class="",
+        exit_code=0,
+        project_name="",
+    ),
     # W - Node testing ======================
     core_types.CatchableExceptionOnRun(exc=""),
     core_types.InternalErrorOnRun(build_path="", exc=""),


### PR DESCRIPTION
## Summary

Stacked on #13029. Adds telemetry for the v2-parser handoff so internal analytics can attribute v2-parser runs, correlate them with the host dbt-core invocation, and measure success rate end-to-end.

### Subprocess plumbing

- Forward dbt-core's `invocation_id` to the parser subprocess via `--invocation-id`, so parser telemetry records share the host's trace.
- Set `DBT_INVOCATION_ENV=dbt-core-v2-parser` on the parser subprocess env only (parent process env is untouched). This relabels the embedded invocation so the analytics warehouse can distinguish v2-parser runs from standalone runs, while dbt-core's own telemetry continues to see the host orchestrator's value.

### dbt-core-side telemetry events

Subprocess relabeling only fires once the parser binary actually starts and survives long enough to emit telemetry. Failures before that point — missing binary, incompatible manifest schema version, non-zero exit before the parser flushes — are invisible from the warehouse. These events close that gap:

- New `V2ParserStart` (Q050) / `V2ParserEnd` (Q051) event classes in `core/dbt/events/types.py`.
- `parse_with_fusion` fires `V2ParserStart` immediately after `assert_no_get_nodes_plugins`, then bookends the handoff with `V2ParserEnd(status, execution_time, error_class, exit_code, project_name)`.
- Narrow exception handling: only typed `FusionParser*` errors are caught for telemetry purposes; bare `Exception` is not swallowed.
- `FusionParserError` gains a `returncode: int` field so the parser's process exit code surfaces on `V2ParserEnd.exit_code` (defaults to `-1` when N/A).
- Bumps `dbt-protos>=1.0.514` for the new event messages (dbt-labs/proto#622).

## Notes

- IA team confirmed reusing `DBT_INVOCATION_ENV` for this purpose is the preferred approach (vs. adding a new field to the Invocation proto).
- `tests/unit/parser/test_fusion.py` covers all behaviors: `--invocation-id` is appended when available; the child process sees the overridden `DBT_INVOCATION_ENV` while the parent process env is preserved; `V2ParserStart`/`V2ParserEnd` fire on both the success path and each typed-exception failure path with the correct `error_class` and `exit_code`.