### PR TITLE
Add V2ParserStart/V2ParserEnd telemetry for v2 parser handoff

### DIFF
--- a/.changes/unreleased/Under the Hood-20260528-175200.yaml
+++ b/.changes/unreleased/Under the Hood-20260528-175200.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Emit V2ParserStart/V2ParserEnd telemetry events around the embedded fs parse subprocess so internal analytics can attribute v2-parser invocations and measure success rate. Bumps dbt-protos lower bound to 1.0.514 for the new event messages.
+time: 2026-05-28T17:52:00.460905-06:00
+custom:
+    Author: aiguofer
+    Issue: "13029"

--- a/core/dbt/events/types.py
+++ b/core/dbt/events/types.py
@@ -2194,6 +2194,27 @@ class LogOverloadResult(DynamicLevel):
         return f"Overload {formatted}"
 
 
+class V2ParserStart(InfoLevel):
+    def code(self) -> str:
+        return "Q050"
+
+    def message(self) -> str:
+        return f"Delegating parse to v2 parser: {self.v2_parser_command}"
+
+
+class V2ParserEnd(DynamicLevel):
+    def code(self) -> str:
+        return "Q051"
+
+    def message(self) -> str:
+        if self.status == "success":
+            return f"v2 parser completed in {self.execution_time:.2f}s"
+        return (
+            f"v2 parser failed after {self.execution_time:.2f}s "
+            f"({self.error_class}, exit_code={self.exit_code})"
+        )
+
+
 # =======================================================
 # W - Node testing
 # =======================================================

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -90,6 +90,10 @@ class FusionParserError(DbtRuntimeError):
     CODE = 10025
     MESSAGE = "Fusion Parser Error"
 
+    def __init__(self, msg: str, returncode: int = -1, node=None) -> None:
+        super().__init__(msg, node=node)
+        self.returncode = returncode
+
 
 class FusionParserMissingError(FusionParserError):
     CODE = 10026

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -17,12 +17,14 @@ import shutil
 import subprocess
 import sysconfig
 import tempfile
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
 from dbt.artifacts.exceptions import IncompatibleSchemaError
 from dbt.artifacts.schemas.manifest import WritableManifest
 from dbt.contracts.graph.manifest import Manifest
+from dbt.events.types import V2ParserEnd, V2ParserStart
 from dbt.exceptions import (
     FusionParserError,
     FusionParserMissingError,
@@ -30,7 +32,7 @@ from dbt.exceptions import (
     FusionParserVersionError,
 )
 from dbt.flags import get_flags
-from dbt_common.events.functions import get_invocation_id
+from dbt_common.events.functions import fire_event, get_invocation_id
 
 if TYPE_CHECKING:
     from dbt.config import RuntimeConfig
@@ -57,31 +59,62 @@ def parse_with_fusion(
 
     flags = get_flags()
     project_target_path = Path(runtime_config.project_target_path)
+    v2_parser_command = getattr(flags, "V2_PARSER", "dbt-core-experimental-parser parse")
+    project_name = runtime_config.project_name
 
-    with tempfile.TemporaryDirectory(prefix="dbt-fusion-") as handoff_dir:
-        handoff = Path(handoff_dir)
-        argv = _build_argv(flags, target_path_override=str(handoff))
+    fire_event(V2ParserStart(v2_parser_command=v2_parser_command, project_name=project_name))
+    start_time = time.monotonic()
+    try:
+        with tempfile.TemporaryDirectory(prefix="dbt-fusion-") as handoff_dir:
+            handoff = Path(handoff_dir)
+            argv = _build_argv(flags, target_path_override=str(handoff))
 
-        _run_fusion(argv)
+            _run_fusion(argv)
 
-        manifest_path = handoff / "manifest.json"
-        if not manifest_path.exists():
-            raise FusionParserError(
-                f"Fusion parser exited successfully but did not produce {manifest_path.name} "
-                f"in the handoff directory."
-            )
-
-        writable_manifest = _load_writable_manifest(manifest_path)
-
-        if write and write_json:
-            # Copy v2 parser artifacts rather than re-serializing through write_manifest
-            project_target_path.mkdir(parents=True, exist_ok=True)
-            shutil.copyfile(manifest_path, project_target_path / "manifest.json")
-            semantic_manifest_path = handoff / "semantic_manifest.json"
-            if semantic_manifest_path.exists():
-                shutil.copyfile(
-                    semantic_manifest_path, project_target_path / "semantic_manifest.json"
+            manifest_path = handoff / "manifest.json"
+            if not manifest_path.exists():
+                raise FusionParserError(
+                    f"Fusion parser exited successfully but did not produce {manifest_path.name} "
+                    f"in the handoff directory."
                 )
+
+            writable_manifest = _load_writable_manifest(manifest_path)
+
+            if write and write_json:
+                # Copy v2 parser artifacts rather than re-serializing through write_manifest
+                project_target_path.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(manifest_path, project_target_path / "manifest.json")
+                semantic_manifest_path = handoff / "semantic_manifest.json"
+                if semantic_manifest_path.exists():
+                    shutil.copyfile(
+                        semantic_manifest_path, project_target_path / "semantic_manifest.json"
+                    )
+    except (
+        FusionParserMissingError,
+        FusionParserVersionError,
+        FusionParserSchemaError,
+        FusionParserError,
+    ) as e:
+        fire_event(
+            V2ParserEnd(
+                status="failure",
+                execution_time=time.monotonic() - start_time,
+                error_class=type(e).__name__,
+                exit_code=getattr(e, "returncode", -1),
+                project_name=project_name,
+            )
+        )
+        raise
+
+    fire_event(
+        V2ParserEnd(
+            status="success",
+            execution_time=time.monotonic() - start_time,
+            error_class="",
+            exit_code=-1,
+            project_name=project_name,
+        )
+    )
 
     manifest = Manifest.from_writable_manifest(writable_manifest)
     # build_flat_graph is normally called by ManifestLoader.get_full_manifest;
@@ -222,7 +255,8 @@ def _run_fusion(argv: List[str]) -> None:
 
     if result.returncode != 0:
         raise FusionParserError(
-            f"Fusion parser failed (exit {result.returncode}); see parser output above."
+            f"Fusion parser failed (exit {result.returncode}); see parser output above.",
+            returncode=result.returncode,
         )
 
 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     # Minor versions for these are expected to be backwards-compatible
     "dbt-common>=1.37.5,<2.0",
     "dbt-adapters>=1.24.1,<2.0",
-    "dbt-protos>=1.0.498,<2.0",
+    "dbt-protos>=1.0.514,<2.0",
     "dbt-core-experimental-parser>=2.0.0.dev0,<3",
     # Bundled plugin: installed by default but opt-in. PluginManager skips loading
     # unless the user passes `--manage-state` on the CLI, sets

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pytest
 
+from dbt.events.types import V2ParserEnd, V2ParserStart
 from dbt.exceptions import (
     FusionParserError,
     FusionParserMissingError,
@@ -272,3 +273,91 @@ class TestParseWithFusion:
         ):
             parse_with_fusion(self._runtime_config(target), write=True, write_json=True)
         assert (target / "manifest.json").exists()
+
+
+class TestParseWithFusionTelemetry:
+    """V2ParserStart/V2ParserEnd must fire around every v2-parser handoff so
+    internal analytics can attribute v2-parser invocations and measure success
+    rate end-to-end. Both events must fire on success; on each typed-exception
+    failure path the end event must carry status="failure" + the exception
+    class name. exit_code is -1 except for FusionParserError, which surfaces
+    fs's process exit code via FusionParserError.returncode."""
+
+    def _runtime_config(self, target_path: Path):
+        return SimpleNamespace(project_target_path=str(target_path), project_name="test")
+
+    def _patch_fire_event(self):
+        events: list = []
+        return events, mock.patch("dbt.parser.fusion.fire_event", side_effect=events.append)
+
+    def test_success_fires_start_and_end_success(self, tmp_path: Path, _patch_fusion_deps):
+        events, patch_fire = self._patch_fire_event()
+        with patch_fire, mock.patch(
+            "dbt.parser.fusion.subprocess.run",
+            side_effect=_fake_parser(json.dumps({"metadata": {}})),
+        ), mock.patch(
+            "dbt.parser.fusion._load_writable_manifest", return_value=mock.MagicMock()
+        ), mock.patch(
+            "dbt.parser.fusion.Manifest.from_writable_manifest", return_value=mock.MagicMock()
+        ):
+            parse_with_fusion(self._runtime_config(tmp_path), write=False, write_json=False)
+
+        types = [type(e).__name__ for e in events]
+        assert types == ["V2ParserStart", "V2ParserEnd"]
+        start, end = events
+        assert isinstance(start, V2ParserStart)
+        assert start.project_name == "test"
+        assert isinstance(end, V2ParserEnd)
+        assert end.status == "success"
+        assert end.error_class == ""
+        assert end.exit_code == -1
+        assert end.execution_time >= 0
+
+    @pytest.mark.parametrize(
+        "subprocess_side_effect, expected_error_class, expected_exit_code",
+        [
+            (FileNotFoundError(), "FusionParserMissingError", -1),
+            # fs exits non-zero — exit code surfaced via FusionParserError.returncode
+            (_fake_parser(manifest_text=None, returncode=2), "FusionParserError", 2),
+            # fs exits 0 but writes no manifest — generic FusionParserError, no returncode
+            (_fake_parser(manifest_text=None), "FusionParserError", -1),
+            (_fake_parser("{ not valid json"), "FusionParserSchemaError", -1),
+        ],
+    )
+    def test_failure_fires_end_failure(
+        self,
+        tmp_path: Path,
+        _patch_fusion_deps,
+        subprocess_side_effect,
+        expected_error_class,
+        expected_exit_code,
+    ):
+        events, patch_fire = self._patch_fire_event()
+        with patch_fire, mock.patch(
+            "dbt.parser.fusion.subprocess.run", side_effect=subprocess_side_effect
+        ):
+            with pytest.raises(FusionParserError):
+                parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
+
+        types = [type(e).__name__ for e in events]
+        assert types == ["V2ParserStart", "V2ParserEnd"]
+        end = events[1]
+        assert end.status == "failure"
+        assert end.error_class == expected_error_class
+        assert end.exit_code == expected_exit_code
+
+    def test_failure_version_error_fires_end_failure(self, tmp_path: Path, _patch_fusion_deps):
+        events, patch_fire = self._patch_fire_event()
+        bad_version = json.dumps(
+            {"metadata": {"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v1.json"}}
+        )
+        with patch_fire, mock.patch(
+            "dbt.parser.fusion.subprocess.run", side_effect=_fake_parser(bad_version)
+        ):
+            with pytest.raises(FusionParserVersionError):
+                parse_with_fusion(self._runtime_config(tmp_path), write=True, write_json=True)
+
+        end = events[1]
+        assert end.status == "failure"
+        assert end.error_class == "FusionParserVersionError"
+        assert end.exit_code == -1

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -481,6 +481,14 @@ sample_values = [
         total_overloads=0,
         execution_time=0,
     ),
+    core_types.V2ParserStart(v2_parser_command="", project_name=""),
+    core_types.V2ParserEnd(
+        status="",
+        execution_time=0,
+        error_class="",
+        exit_code=0,
+        project_name="",
+    ),
     # W - Node testing ======================
     core_types.CatchableExceptionOnRun(exc=""),
     core_types.InternalErrorOnRun(build_path="", exc=""),


### PR DESCRIPTION
## Summary

Stacked on #13041. Adds dbt-core-side telemetry around the v2-parser handoff so internal analytics can attribute v2-parser invocations and measure success rate end-to-end.

The fs-side `Invocation` event (relabeled via `DBT_INVOCATION_ENV=dbt-core-v2-parser` in #13041) only fires once `fs` actually starts and survives long enough to emit telemetry. Failures before that point — missing binary, incompatible manifest schema version, non-zero exit before fs flushes — are currently invisible. These events close that gap.

## Changes

- New `V2ParserStart` (Q050) / `V2ParserEnd` (Q051) event classes in `core/dbt/events/types.py`.
- `parse_with_fusion` now fires `V2ParserStart` immediately after `assert_no_get_nodes_plugins`, then bookends the handoff with `V2ParserEnd(status="success" | "failure", execution_time, error_class, exit_code, project_name)`.
- Narrow exception handling: only the typed `FusionParser*` errors are caught for telemetry purposes; bare `Exception` is not swallowed.
- `FusionParserError` gains a `returncode: int` field so fs's process exit code can be surfaced on `V2ParserEnd.exit_code` (defaults to `-1` when N/A).
- Bumps `dbt-protos>=1.0.514` for the new event messages (dbt-labs/proto#622).

## Test plan

- `core/dbt/events/types.py` covered by `tests/unit/test_events.py` `sample_values` list (already exercises every event class for `to_dict`/serialization parity).
- `tests/unit/parser/test_fusion.py::TestParseWithFusionTelemetry` covers:
  - Start + End fire on the happy path with `status="success"`.
  - Each typed failure path (`FusionParserMissingError`, non-zero exit `FusionParserError` with `returncode=2`, no-manifest `FusionParserError`, `FusionParserSchemaError`, `FusionParserVersionError`) fires End with the correct `error_class` and `exit_code`.