### PR TITLE
Fix fill_nulls_with not propagated to MetricTypeParams in manifest (Fixes #13037)

### DIFF
--- a/.changes/unreleased/Fixes-20260528-203500.yaml
+++ b/.changes/unreleased/Fixes-20260528-203500.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: >-
+  Propagate fill_nulls_with from metric YAML into type_params.fill_nulls_with in
+  the manifest for v1 measure-level and v2 top-level metric configs.
+time: 2026-05-28T20:35:00.000000000Z
+custom:
+  Issue: "13037"

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -456,8 +456,9 @@ class MetricParser(YamlReader):
                 # `cumulative_type_params.grain_to_date`
                 grain_to_date = TimeGranularity(type_params.grain_to_date)
 
+            measure = self._get_optional_input_measure(type_params.measure)
             return MetricTypeParams(
-                measure=self._get_optional_input_measure(type_params.measure),
+                measure=measure,
                 numerator=self._get_optional_metric_input(type_params.numerator),
                 denominator=self._get_optional_metric_input(type_params.denominator),
                 expr=str(type_params.expr) if type_params.expr is not None else None,
@@ -470,6 +471,7 @@ class MetricParser(YamlReader):
                 cumulative_type_params=self._get_optional_v1_cumulative_type_params(
                     unparsed_metric=unparsed_metric,
                 ),
+                fill_nulls_with=measure.fill_nulls_with if measure else None,
                 # input measures are calculated via metric processing post parsing
                 # input_measures=?,
             )
@@ -514,6 +516,7 @@ class MetricParser(YamlReader):
                 ),
                 metric_aggregation_params=metric_aggregation_params,
                 join_to_timespine=unparsed_metric.join_to_timespine or False,
+                fill_nulls_with=unparsed_metric.fill_nulls_with,
                 is_private=unparsed_metric.hidden,
             )
         else:

--- a/tests/functional/metrics/test_metrics.py
+++ b/tests/functional/metrics/test_metrics.py
@@ -90,6 +90,10 @@ class TestSimpleMetrics:
         )
         assert manifest.metrics["metric.test.collective_tenure"].time_granularity is None
 
+        collective_tenure = manifest.metrics["metric.test.collective_tenure"]
+        assert collective_tenure.type_params.measure.fill_nulls_with == 0
+        assert collective_tenure.type_params.fill_nulls_with == 0
+
 
 class TestInvalidRefMetrics:
     @pytest.fixture(scope="class")

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -846,6 +846,8 @@ schema_yml_v2_simple_metric_on_model_1 = """
         type: simple
         agg: count
         expr: id
+        fill_nulls_with: 0
+        join_to_timespine: true
       - name: simple_metric_2
         description: This is our second simple metric.
         agg_time_dimension: ds

--- a/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
@@ -303,6 +303,8 @@ class TestMetricOnModelParsingWorks:
         assert (
             simple_metric.type_params.metric_aggregation_params.agg_time_dimension == "second_dim"
         )
+        assert simple_metric.type_params.fill_nulls_with == 0
+        assert simple_metric.type_params.join_to_timespine is True
 
         simple_metric_pydantic = semantic_manifest_metrics["simple_metric"]
         assert simple_metric_pydantic.name == "simple_metric"

--- a/tests/unit/parser/test_metric_type_params.py
+++ b/tests/unit/parser/test_metric_type_params.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock
+
+from dbt.contracts.graph.unparsed import (
+    UnparsedMetric,
+    UnparsedMetricInputMeasure,
+    UnparsedMetricTypeParams,
+    UnparsedMetricV2,
+)
+from dbt.parser.schema_yaml_readers import MetricParser
+
+
+def _metric_parser() -> MetricParser:
+    return MetricParser(MagicMock(), MagicMock())
+
+
+def test_get_metric_type_params_v1_fill_nulls_with():
+    unparsed = UnparsedMetric(
+        name="orders",
+        label="Orders",
+        type="simple",
+        type_params=UnparsedMetricTypeParams(
+            measure=UnparsedMetricInputMeasure(name="order_count", fill_nulls_with=0),
+        ),
+    )
+    type_params = _metric_parser()._get_metric_type_params(unparsed)
+    assert type_params.measure.fill_nulls_with == 0
+    assert type_params.fill_nulls_with == 0
+
+
+def test_get_metric_type_params_v2_fill_nulls_with():
+    unparsed = UnparsedMetricV2(
+        name="orders",
+        label="Orders",
+        type="simple",
+        agg="count",
+        fill_nulls_with=0,
+        join_to_timespine=True,
+    )
+    type_params = _metric_parser()._get_metric_type_params(
+        unparsed,
+        generated_from="fct_orders",
+        default_agg_time_dimension="order_date",
+    )
+    assert type_params.fill_nulls_with == 0
+    assert type_params.join_to_timespine is True


### PR DESCRIPTION
# Fixes #13037

## Problem

When `fill_nulls_with` is set on a metric in YAML, `type_params.fill_nulls_with` in the manifest was always `null`, even though the value was correctly configured. The value would appear on `type_params.measure.fill_nulls_with` (v1 metrics) or be parsed into `UnparsedMetricV2` (v2 metrics), but `MetricParser._get_metric_type_params()` never copied it onto `MetricTypeParams`.

MetricFlow query behavior was unaffected for the common v1 measure-level case, but this created a manifest shape inconsistency for downstream tools that read the manifest directly.

## Solution

Wire `fill_nulls_with` through in `MetricParser._get_metric_type_params()`:

- **V2 path**: Pass `fill_nulls_with=unparsed_metric.fill_nulls_with` (following the same pattern as `join_to_timespine`)
- **V1 path**: Mirror `measure.fill_nulls_with` onto `MetricTypeParams.fill_nulls_with`

No schema changes or MetricFlow logic changes required.

## Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

## Test plan

**Unit tests** (no database required):
```bash
cd core && hatch run python3 -m pytest ../tests/unit/parser/test_metric_type_params.py -q
```
**Result:** 2 passed

**Functional tests** (Postgres):
```bash
docker compose up -d database
cd core && hatch run setup-db
hatch run python3 -m pytest \
  ../tests/functional/metrics/test_metrics.py::TestSimpleMetrics::test_simple_metric \
  ../tests/functional/semantic_models/test_semantic_model_v2_parsing.py::TestMetricOnModelParsingWorks::test_metric_on_model_parsing \
  -q
```
**Result:** 2 passed