### PR TITLE
Bundle dbt-state as an install dependency of dbt-core (opt-in via --m…

### DIFF
--- a/.changes/unreleased/Features-20260525-214500.yaml
+++ b/.changes/unreleased/Features-20260525-214500.yaml
@@ -1,0 +1,13 @@
+kind: Features
+body: >-
+    Bundle the dbt-state plugin (>=2.18,<3.0) as an install dependency of dbt-core.
+    The plugin is opt-in: PluginManager skips auto-discovery unless the user passes
+    `--manage-state` on the CLI, sets DBT_ENGINE_MANAGE_STATE=true, or sets
+    manage_state to true in the flags block of dbt_project.yml (equivalently in the
+    config block of profiles.yml). Discovery filters disabled modules before
+    importlib.import_module is called, so the default opt-in-off state incurs no
+    import cost.
+time: 2026-05-25T21:45:00.000000000Z
+custom:
+    Author: colin-rogers-dbt
+    Issue: "13014"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -127,6 +127,7 @@ def global_flags(func):
     @p.log_level_file
     @p.log_path
     @p.macro_debugging
+    @p.manage_state
     @p.partial_parse
     @p.partial_parse_file_path
     @p.partial_parse_file_diff

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -419,6 +419,18 @@ macro_debugging = _create_option_and_track_env_var(
 )
 
 
+manage_state = _create_option_and_track_env_var(
+    "--manage-state/--no-manage-state",
+    envvar="DBT_ENGINE_MANAGE_STATE",
+    help=(
+        "Opt in to loading the bundled dbt-state plugin (installed as a dependency "
+        "of dbt-core). Default false. Pass --manage-state to enable auto-discovery "
+        "and the plugin's runtime behavior."
+    ),
+    default=False,
+)
+
+
 sqlparse_options = _create_option_and_track_env_var(
     "--sqlparse",
     envvar="DBT_ENGINE_SQLPARSE",

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -345,6 +345,11 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     log_format_file: Optional[str] = None
     log_level: Optional[str] = None
     log_level_file: Optional[str] = None
+    # Opt-in for the bundled dbt-state plugin. Default None defers to the CLI/env-var
+    # default (False). Set true in dbt_project.yml's `flags:` block (or profiles.yml's
+    # `config:` block) to enable plugin auto-discovery. Also settable via
+    # `--manage-state/--no-manage-state` and `DBT_ENGINE_MANAGE_STATE`.
+    manage_state: Optional[bool] = None
     partial_parse: Optional[bool] = None
     populate_cache: Optional[bool] = None
     printer_width: Optional[int] = None

--- a/core/dbt/plugins/manager.py
+++ b/core/dbt/plugins/manager.py
@@ -1,8 +1,9 @@
 import functools
 import importlib
+import logging
 import pkgutil
-from types import ModuleType
-from typing import Callable, Dict, List, Mapping
+from types import MappingProxyType
+from typing import Callable, Dict, List, Mapping, NamedTuple, Sequence, Set, Tuple
 
 import dbt.tracking
 from dbt.contracts.graph.manifest import Manifest
@@ -10,6 +11,102 @@ from dbt.plugins.contracts import PluginArtifacts
 from dbt.plugins.manifest import PluginNodes
 from dbt_common.exceptions import DbtRuntimeError
 from dbt_common.tests import test_caching_enabled
+
+logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(maxsize=4)
+def _walk_prefixed_module_names(prefix: str) -> Tuple[str, ...]:
+    """Cached walk of `pkgutil.iter_modules()` returning the names matching `prefix`.
+
+    `pkgutil.iter_modules()` walks every entry on `sys.path`, which is slow in
+    environments with many site-packages directories. The candidate name list is
+    process-stable (the import path doesn't change between calls in a normal
+    invocation), so we cache it process-wide. Opt-in signals are still evaluated
+    per `get_prefixed_modules` call, so users who change env vars / flags between
+    calls (e.g. via dbtRunner) still see the right behavior.
+
+    Tests that mock `pkgutil.iter_modules` must clear this cache to avoid leaking
+    fake results across cases -- the autouse fixture in
+    tests/unit/plugins/test_manager.py does this."""
+    return tuple(name for _, name, _ in pkgutil.iter_modules() if name.startswith(prefix))
+
+
+class ManageSignal(NamedTuple):
+    """How a single bundled plugin's load behavior is controlled.
+
+    Read at PluginManager discovery time. The plugin is opt-in: it is only loaded
+    when the flag resolves to True. Default is False -- absent any explicit signal,
+    `importlib.import_module` is never called on the bundled module.
+
+    - `flag_attr`: attribute on `get_flags()` (UPPERCASE). True means load the
+      plugin; False (the default) means skip. Populated by the CLI parser from one
+      of three surfaces, in precedence order:
+        * explicit `--manage-state` / `--no-manage-state` on the command line
+        * `DBT_ENGINE_MANAGE_STATE` env var
+        * `manage_state` in dbt_project.yml's `flags:` block, or equivalently
+          `manage_state` in profiles.yml's `config:` block
+    - `cli_flag`: human-readable name of the corresponding CLI flag, used in log
+      messages so a curious user knows what to pass to opt in.
+    """
+
+    flag_attr: str
+    cli_flag: str
+
+
+# Track which (module_name, reason) combinations have already emitted a discovery
+# log message in this process, so we don't spam the user when PluginManager is
+# constructed multiple times (e.g. during test runs that reuse the dbtRunner).
+_DISCOVERY_NOTICES_EMITTED: Set[Tuple[str, str]] = set()
+
+
+def _plugin_is_managed(flag_attr: str) -> bool:
+    """Return True iff the user has explicitly opted in to loading this bundled plugin.
+
+    Reads `get_flags().<flag_attr>` lazily to avoid an import-time dependency between
+    PluginManager and the flags module. Defaults to False (skip) when flags haven't
+    been initialized yet -- absent an explicit opt-in, the bundled plugin stays off."""
+    try:
+        from dbt.flags import get_flags
+
+        return bool(getattr(get_flags(), flag_attr, False))
+    except Exception:
+        return False
+
+
+def _notify_bundled_plugin_skipped(module_name: str, cli_flag: str) -> None:
+    """Emit a one-time per-process DEBUG notice that a bundled plugin is installed
+    on the import path but not loaded because the user hasn't opted in. Emitted at
+    DEBUG (not INFO) because this is the default case -- every default invocation
+    hits this path and shouldn't log INFO-level noise."""
+    key = (module_name, "skipped")
+    if key in _DISCOVERY_NOTICES_EMITTED:
+        return
+    _DISCOVERY_NOTICES_EMITTED.add(key)
+    logger.debug(
+        "Bundled plugin %r is installed but not loaded (opt-in); pass %s to enable.",
+        module_name,
+        cli_flag,
+    )
+
+
+def _notify_bundled_plugin_conflict(preferred: str, skipped: str) -> None:
+    """Emit a one-time per-process warning when two modules from the same
+    conflict group are simultaneously installed. We prefer the canonical
+    (first-listed) module and skip the rest to avoid double monkey-patching."""
+    key = (skipped, "conflict")
+    if key in _DISCOVERY_NOTICES_EMITTED:
+        return
+    _DISCOVERY_NOTICES_EMITTED.add(key)
+    logger.warning(
+        "Both %r and %r are installed -- they are the same plugin under different "
+        "package names. Loading %r and skipping %r to avoid double monkey-patching of "
+        "core classes; uninstall the unused package to silence this warning.",
+        preferred,
+        skipped,
+        preferred,
+        skipped,
+    )
 
 
 def dbt_hook(func):
@@ -66,23 +163,78 @@ class dbtPlugin:
         raise NotImplementedError(f"get_manifest_artifacts hook not implemented for {self.name}")
 
 
-@functools.lru_cache(maxsize=None)
-def _get_dbt_modules() -> Mapping[str, ModuleType]:
-    # This is an expensive function, especially in the context of testing, when
-    # it is called repeatedly, so we break it out and cache the result globally.
-    return {
-        name: importlib.import_module(name)
-        for _, name, _ in pkgutil.iter_modules()
-        if name.startswith(PluginManager.PLUGIN_MODULE_PREFIX)
-    }
-
-
+# Module-level cache used by `from_modules` when test caching is enabled. The gate is
+# read at discovery time and the result is cached here; tests that toggle a gate env
+# var mid-process need to clear this cache to see the change.
 _MODULES_CACHE = None
 
 
 class PluginManager:
     PLUGIN_MODULE_PREFIX = "dbt_"
     PLUGIN_ATTR_NAME = "plugins"
+
+    # Bundled plugins that are installed as dependencies of dbt-core but are OPT-IN:
+    # PluginManager only loads them when the user explicitly enables them. Each entry
+    # maps a module name (as discovered by pkgutil) to a ManageSignal describing the
+    # flag the user can flip to opt in.
+    #
+    # Both `dbt_state` and `dbt_run_cache` refer to the same plugin -- the package was
+    # renamed from `run-cache` (module `dbt_run_cache`) to `dbt-state` (module
+    # `dbt_state`). Either may be present in a user's environment depending on which
+    # version they have installed, so both are listed here as first-class entries
+    # sharing the same `manage_state` flag. Pass `--manage-state` (or
+    # `DBT_ENGINE_MANAGE_STATE=true`, or `manage_state: true` in dbt_project.yml /
+    # profiles.yml `config:`) to enable either module name.
+    #
+    # Skipping happens at module-discovery time (before importlib.import_module), so a
+    # not-opted-in bundled plugin pays zero import cost and runs zero side effects --
+    # even if its __init__.py has eager imports or monkey-patching.
+    #
+    # Scope: this gate only suppresses auto-discovery via pkgutil. If a user's project
+    # code or another plugin explicitly `import dbt_state`s, the plugin's import-time
+    # side effects will still fire. The plugin itself should also self-gate as
+    # defense-in-depth; the registry here is the dbt-core-side contract.
+    #
+    # MappingProxyType makes the mapping read-only -- tampering raises TypeError rather
+    # than silently flipping activation for the rest of the process.
+    BUNDLED_PLUGIN_MODULES: Mapping[str, ManageSignal] = MappingProxyType(
+        {
+            "dbt_state": ManageSignal(flag_attr="MANAGE_STATE", cli_flag="--manage-state"),
+            "dbt_run_cache": ManageSignal(flag_attr="MANAGE_STATE", cli_flag="--manage-state"),
+        }
+    )
+
+    # Within a conflict group, if multiple modules are installed (e.g. both
+    # `dbt_state` and `dbt_run_cache` happen to be present during the rename
+    # transition), prefer the first listed and skip the rest with a warning. Avoids
+    # non-deterministic double monkey-patching of CompileRunner/ModelRunner/etc.
+    BUNDLED_PLUGIN_CONFLICT_GROUPS: Sequence[Sequence[str]] = (("dbt_state", "dbt_run_cache"),)
+
+    @classmethod
+    def _disabled_bundled_modules(cls) -> Set[str]:
+        """Names of bundled plugin modules whose `manage_*` flag resolves to False."""
+        return {
+            module_name
+            for module_name, signal in cls.BUNDLED_PLUGIN_MODULES.items()
+            if not _plugin_is_managed(signal.flag_attr)
+        }
+
+    @classmethod
+    def _resolve_bundled_plugin_conflicts(cls, candidate_names: Sequence[str]) -> Set[str]:
+        """Return the set of module names that should be skipped due to conflict-group
+        deduplication. Within each group, the first listed name that is present in
+        `candidate_names` wins and the rest are returned as "skip me"."""
+        candidates = set(candidate_names)
+        skip: Set[str] = set()
+        for group in cls.BUNDLED_PLUGIN_CONFLICT_GROUPS:
+            present = [name for name in group if name in candidates]
+            if len(present) <= 1:
+                continue
+            preferred, *rest = present
+            for losing in rest:
+                _notify_bundled_plugin_conflict(preferred, losing)
+                skip.add(losing)
+        return skip
 
     def __init__(self, plugins: List[dbtPlugin]) -> None:
         self._plugins = plugins
@@ -133,11 +285,31 @@ class PluginManager:
 
     @classmethod
     def get_prefixed_modules(cls):
-        return {
-            name: importlib.import_module(name)
-            for _, name, _ in pkgutil.iter_modules()
-            if name.startswith(cls.PLUGIN_MODULE_PREFIX)
-        }
+        # First pass: get the list of candidate module names without importing them.
+        # The walk is cached process-wide via `_walk_prefixed_module_names` so
+        # repeated PluginManager construction (e.g. multiple dbtRunner invocations
+        # in the same process) doesn't re-scan sys.path each time.
+        names_on_path = list(_walk_prefixed_module_names(cls.PLUGIN_MODULE_PREFIX))
+
+        # For each bundled plugin on disk, check whether the user has opted in via
+        # `--manage-state` / `DBT_ENGINE_MANAGE_STATE=true` / `manage_state: true`.
+        # If not opted in, the module is filtered out before any import.
+        disabled: Set[str] = set()
+        for name in names_on_path:
+            if name in cls.BUNDLED_PLUGIN_MODULES:
+                signal = cls.BUNDLED_PLUGIN_MODULES[name]
+                if not _plugin_is_managed(signal.flag_attr):
+                    _notify_bundled_plugin_skipped(name, signal.cli_flag)
+                    disabled.add(name)
+
+        # Second pass: dedupe within conflict groups so we don't load two copies of
+        # the same plugin under different package names. Only matters when both modules
+        # are opted in -- the disabled-by-default path has already filtered them out.
+        candidates = [n for n in names_on_path if n not in disabled]
+        conflict_skips = cls._resolve_bundled_plugin_conflicts(candidates)
+        to_import = [n for n in candidates if n not in conflict_skips]
+
+        return {name: importlib.import_module(name) for name in to_import}
 
     def get_manifest_artifacts(self, manifest: Manifest) -> PluginArtifacts:
         all_plugin_artifacts = {}

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -58,6 +58,12 @@ dependencies = [
     "dbt-common>=1.37.5,<2.0",
     "dbt-adapters>=1.24.1,<2.0",
     "dbt-protos>=1.0.498,<2.0",
+    # Bundled plugin: installed by default but opt-in. PluginManager skips loading
+    # unless the user passes `--manage-state` on the CLI, sets
+    # `DBT_ENGINE_MANAGE_STATE=true`, or sets `manage_state: true` in dbt_project.yml's
+    # `flags:` block (equivalently in profiles.yml's `config:` block). See
+    # core/dbt/plugins/manager.py (BUNDLED_PLUGIN_MODULES) for the gating contract.
+    "dbt-state>=2.18,<3.0",
     "pydantic<3",
     # ----
     # Expect compatibility with all new versions of these packages, so lower bounds only.

--- a/tests/functional/cli/test_requires.py
+++ b/tests/functional/cli/test_requires.py
@@ -136,6 +136,12 @@ class TestKnownEngineEnvVarsExplicit:
             "DBT_ENGINE_DEBUG",
             "DBT_ENGINE_PRINT",
             "DBT_ENGINE_SAMPLE",
+            "DBT_ENGINE_STATE_EMIT_REUSED_STATUS",
+            "DBT_ENGINE_STATE_OAUTH_CLIENT_ID",
+            "DBT_ENGINE_STATE_AUTH_URL",
+            "DBT_ENGINE_STATE_TOKEN_URL",
+            "DBT_ENGINE_STATE_API_URL",
+            "DBT_ENGINE_MANAGE_STATE",
         }
         from dbt.env_vars import _ALLOWED_ENV_VARS
 

--- a/tests/unit/plugins/test_manager.py
+++ b/tests/unit/plugins/test_manager.py
@@ -2,11 +2,46 @@ from unittest import mock
 
 import pytest
 
+import dbt.plugins.manager
 from dbt.exceptions import DbtRuntimeError
 from dbt.plugins import PluginManager, dbt_hook, dbtPlugin
 from dbt.plugins.contracts import PluginArtifact, PluginArtifacts
 from dbt.plugins.exceptions import dbtPluginError
+from dbt.plugins.manager import (
+    _DISCOVERY_NOTICES_EMITTED,
+    _plugin_is_managed,
+    _walk_prefixed_module_names,
+)
 from dbt.plugins.manifest import ModelNodeArgs, PluginNodes
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_manager_process_state():
+    """PluginManager has three pieces of process-global state that can leak between
+    tests if not cleared:
+
+    1. `_DISCOVERY_NOTICES_EMITTED` -- the de-dupe set for one-time log notices.
+       A test that asserts on log emission would be masked by an earlier test
+       that already emitted the notice.
+    2. `_MODULES_CACHE` -- the `from_modules` cache that's active when
+       `test_caching_enabled()` returns True. A test that mocks
+       `pkgutil.iter_modules` would silently see another test's cached dict
+       instead of its own mock results -- making assertions pass for the wrong
+       reason (or fail unpredictably depending on ordering).
+    3. The `_walk_prefixed_module_names` lru_cache -- caches the candidate name
+       list at process scope. Tests that mock `pkgutil.iter_modules` would see
+       the cached pre-mock walk on subsequent calls.
+
+    Clear all three before AND after each test so ordering doesn't matter."""
+
+    def _clear() -> None:
+        _DISCOVERY_NOTICES_EMITTED.clear()
+        dbt.plugins.manager._MODULES_CACHE = None
+        _walk_prefixed_module_names.cache_clear()
+
+    _clear()
+    yield
+    _clear()
 
 
 class ExceptionInitializePlugin(dbtPlugin):
@@ -126,3 +161,304 @@ class TestPluginManager:
         pm = PluginManager(plugins=get_artifacts_plugins)
         artifacts = pm.get_manifest_artifacts(None)
         assert len(artifacts) == 2
+
+
+class TestBundledPluginGating:
+    """Bundled plugins (e.g. dbt-state) are opt-in. The user enables them via the
+    `--manage-state` CLI flag, the DBT_ENGINE_MANAGE_STATE env var (handled by
+    Click), or the `manage_state: true` project/profile flag -- all three resolve
+    to `get_flags().MANAGE_STATE`. PluginManager skips the module at discovery time
+    BEFORE `importlib.import_module` is called, so a not-opted-in plugin pays zero
+    import cost."""
+
+    def test_plugin_is_managed_default_false(self):
+        """`_plugin_is_managed` defaults to False when the flag attribute is missing.
+
+        Opt-in default: absent an explicit opt-in via flags, the helper returns
+        False so PluginManager skips the bundled plugin."""
+        with mock.patch("dbt.flags.get_flags", return_value=mock.MagicMock(spec=[])):
+            assert _plugin_is_managed("MANAGE_STATE") is False
+
+    def test_plugin_is_managed_reads_flags(self):
+        fake_flags = mock.MagicMock()
+        fake_flags.MANAGE_STATE = False
+        with mock.patch("dbt.flags.get_flags", return_value=fake_flags):
+            assert _plugin_is_managed("MANAGE_STATE") is False
+
+        fake_flags.MANAGE_STATE = True
+        with mock.patch("dbt.flags.get_flags", return_value=fake_flags):
+            assert _plugin_is_managed("MANAGE_STATE") is True
+
+    def test_plugin_is_managed_returns_false_on_exception(self):
+        """If `get_flags()` itself raises (e.g. during very early startup), fall
+        back to False -- opt-in plugins stay off unless explicitly enabled."""
+        with mock.patch("dbt.flags.get_flags", side_effect=RuntimeError("flags not ready")):
+            assert _plugin_is_managed("MANAGE_STATE") is False
+
+    def test_bundled_registry_contains_both_module_names(self):
+        """dbt-state is bundled with dbt-core and loads by default. Both `dbt_state`
+        (new package name) and `dbt_run_cache` (legacy name from before the rename)
+        refer to the same plugin and share the same manage signal."""
+        signal_state = PluginManager.BUNDLED_PLUGIN_MODULES["dbt_state"]
+        assert signal_state.flag_attr == "MANAGE_STATE"
+        assert signal_state.cli_flag == "--manage-state"
+
+        signal_run_cache = PluginManager.BUNDLED_PLUGIN_MODULES["dbt_run_cache"]
+        assert signal_run_cache.flag_attr == "MANAGE_STATE"
+        assert signal_run_cache.cli_flag == "--manage-state"
+
+    def test_walk_prefixed_module_names_is_cached(self):
+        """`_walk_prefixed_module_names` must cache the `pkgutil.iter_modules()`
+        walk so repeated PluginManager construction doesn't re-scan sys.path.
+        Multiple calls with the same prefix should hit `iter_modules` exactly once."""
+        call_count = 0
+
+        def counting_iter():
+            nonlocal call_count
+            call_count += 1
+            return iter([(None, "dbt_state", False), (None, "dbt_other", False)])
+
+        with mock.patch("dbt.plugins.manager.pkgutil.iter_modules", side_effect=counting_iter):
+            r1 = _walk_prefixed_module_names("dbt_")
+            r2 = _walk_prefixed_module_names("dbt_")
+            r3 = _walk_prefixed_module_names("dbt_")
+
+        assert call_count == 1, "iter_modules should be invoked exactly once"
+        assert r1 == r2 == r3 == ("dbt_state", "dbt_other")
+
+    def test_bundled_registry_is_read_only(self):
+        # Wrapped in MappingProxyType so a buggy caller can't silently flip behavior
+        # for the rest of the process.
+        with pytest.raises(TypeError):
+            PluginManager.BUNDLED_PLUGIN_MODULES["dbt_state"] = None  # type: ignore[index]
+        with pytest.raises((TypeError, AttributeError)):
+            PluginManager.BUNDLED_PLUGIN_MODULES.pop("dbt_state")  # type: ignore[attr-defined]
+
+    def test_disabled_bundled_modules_empty_when_opted_in(self):
+        """When `manage_state` is True (user has opted in), nothing is disabled --
+        bundled plugins load."""
+        with mock.patch("dbt.plugins.manager._plugin_is_managed", return_value=True):
+            disabled = PluginManager._disabled_bundled_modules()
+        assert disabled == set()
+
+    def test_disabled_bundled_modules_when_not_opted_in(self):
+        """When `manage_state` is False (the default), both module names are
+        disabled."""
+        with mock.patch("dbt.plugins.manager._plugin_is_managed", return_value=False):
+            disabled = PluginManager._disabled_bundled_modules()
+        assert "dbt_state" in disabled
+        assert "dbt_run_cache" in disabled
+
+    # NOTE on patch ordering in the tests below: `mock.patch` resolves its target via
+    # `importlib.import_module`. If we patch `dbt.plugins.manager.importlib.import_module`
+    # FIRST, any subsequent patch on `dbt.plugins.manager.<attr>` in the same with-block
+    # silently fails -- mock.patch's own resolver hits the mocked import_module and gets a
+    # MagicMock back instead of the real module. So `logger` / `_notify_*` /
+    # `_plugin_is_managed` patches go first; `importlib.import_module` last.
+
+    def test_get_prefixed_modules_loads_when_opted_in(self):
+        """When manage_state is True, bundled plugin imports normally."""
+        fake_iter_result = [
+            (None, "dbt_state", False),
+            (None, "dbt_someother", False),
+            (None, "unrelated_pkg", False),
+        ]
+        imported = []
+
+        def fake_import(name):
+            imported.append(name)
+            return mock.MagicMock()
+
+        with mock.patch("dbt.plugins.manager._plugin_is_managed", return_value=True), mock.patch(
+            "dbt.plugins.manager.pkgutil.iter_modules", return_value=fake_iter_result
+        ), mock.patch("dbt.plugins.manager.importlib.import_module", side_effect=fake_import):
+            modules = PluginManager.get_prefixed_modules()
+
+        assert "dbt_state" in modules
+        assert "dbt_someother" in modules
+        assert "unrelated_pkg" not in modules
+        assert "dbt_state" in imported
+
+    def test_get_prefixed_modules_skips_by_default(self):
+        """When manage_state is False (the default), bundled plugin must be filtered
+        out BEFORE `importlib.import_module` is called."""
+        fake_iter_result = [
+            (None, "dbt_state", False),
+            (None, "dbt_someother", False),
+        ]
+        imported = []
+
+        def fake_import(name):
+            imported.append(name)
+            return mock.MagicMock()
+
+        with mock.patch("dbt.plugins.manager._plugin_is_managed", return_value=False), mock.patch(
+            "dbt.plugins.manager.pkgutil.iter_modules", return_value=fake_iter_result
+        ), mock.patch("dbt.plugins.manager.importlib.import_module", side_effect=fake_import):
+            modules = PluginManager.get_prefixed_modules()
+
+        assert "dbt_state" not in modules
+        assert "dbt_someother" in modules
+        # Zero-cost: the disabled plugin is never imported.
+        assert "dbt_state" not in imported
+
+    def test_discovery_logs_debug_when_not_opted_in(self):
+        """Skipping should emit a one-time DEBUG mentioning the CLI flag the user
+        can pass to opt in. DEBUG (not INFO) because the not-opted-in state is the
+        default and shouldn't log INFO-level noise on every default invocation."""
+        fake_iter_result = [(None, "dbt_state", False)]
+
+        with mock.patch("dbt.plugins.manager._plugin_is_managed", return_value=False), mock.patch(
+            "dbt.plugins.manager.logger"
+        ) as mock_logger, mock.patch(
+            "dbt.plugins.manager.pkgutil.iter_modules", return_value=fake_iter_result
+        ), mock.patch(
+            "dbt.plugins.manager.importlib.import_module"
+        ):
+            PluginManager.get_prefixed_modules()
+
+        mock_logger.debug.assert_called_once()
+        mock_logger.info.assert_not_called()
+        args = mock_logger.debug.call_args[0]
+        assert "dbt_state" in args
+        # The CLI flag name appears in the message so a curious user knows how to opt in.
+        assert any("--manage-state" in str(a) for a in args)
+
+    def test_discovery_notice_is_emitted_only_once_per_process(self):
+        fake_iter_result = [(None, "dbt_state", False)]
+
+        with mock.patch("dbt.plugins.manager._plugin_is_managed", return_value=False), mock.patch(
+            "dbt.plugins.manager.logger"
+        ) as mock_logger, mock.patch(
+            "dbt.plugins.manager.pkgutil.iter_modules", return_value=fake_iter_result
+        ), mock.patch(
+            "dbt.plugins.manager.importlib.import_module"
+        ):
+            PluginManager.get_prefixed_modules()
+            PluginManager.get_prefixed_modules()
+            PluginManager.get_prefixed_modules()
+
+        assert mock_logger.debug.call_count == 1
+
+    def test_conflict_resolution_prefers_dbt_state_over_dbt_run_cache(self):
+        """If both packages happen to be installed (mid-rename) and the user has
+        opted in, we must NOT load both -- double monkey-patching of
+        CompileRunner/ModelRunner is non-deterministic. Prefer the canonical name
+        and warn about the loser."""
+        fake_iter_result = [
+            (None, "dbt_state", False),
+            (None, "dbt_run_cache", False),
+        ]
+        imported = []
+
+        def fake_import(name):
+            imported.append(name)
+            return mock.MagicMock()
+
+        with mock.patch("dbt.plugins.manager._plugin_is_managed", return_value=True), mock.patch(
+            "dbt.plugins.manager.logger"
+        ) as mock_logger, mock.patch(
+            "dbt.plugins.manager.pkgutil.iter_modules", return_value=fake_iter_result
+        ), mock.patch(
+            "dbt.plugins.manager.importlib.import_module", side_effect=fake_import
+        ):
+            modules = PluginManager.get_prefixed_modules()
+
+        assert "dbt_state" in imported
+        assert "dbt_run_cache" not in imported
+        assert "dbt_state" in modules
+        assert "dbt_run_cache" not in modules
+        mock_logger.warning.assert_called_once()
+        warn_args = mock_logger.warning.call_args[0]
+        assert "dbt_state" in warn_args and "dbt_run_cache" in warn_args
+
+    def test_from_modules_instantiates_when_opted_in(self):
+        """End-to-end contract: with manage_state True, the bundled plugin is
+        instantiated."""
+        instantiated = []
+
+        class _FakeStatePlugin(dbtPlugin):
+            def initialize(self):
+                instantiated.append("dbt_state")
+
+        fake_state_module = mock.MagicMock()
+        fake_state_module.plugins = [_FakeStatePlugin]
+
+        def fake_import(name):
+            if name == "dbt_state":
+                return fake_state_module
+            raise ImportError(name)
+
+        fake_iter_result = [(None, "dbt_state", False)]
+
+        with mock.patch("dbt.plugins.manager._plugin_is_managed", return_value=True), mock.patch(
+            "dbt.plugins.manager.pkgutil.iter_modules", return_value=fake_iter_result
+        ), mock.patch("dbt.plugins.manager.importlib.import_module", side_effect=fake_import):
+            PluginManager.from_modules(project_name="test")
+
+        assert instantiated == ["dbt_state"]
+
+    def test_from_modules_does_not_instantiate_by_default(self):
+        """End-to-end contract: when manage_state is False (the default; user has
+        not opted in via CLI / env / project / profile), the plugin is never
+        instantiated."""
+        instantiated = []
+
+        class _FakeStatePlugin(dbtPlugin):
+            def initialize(self):
+                instantiated.append("dbt_state")
+
+        fake_state_module = mock.MagicMock()
+        fake_state_module.plugins = [_FakeStatePlugin]
+
+        def fake_import(name):
+            if name == "dbt_state":
+                return fake_state_module
+            raise ImportError(name)
+
+        fake_iter_result = [(None, "dbt_state", False)]
+
+        with mock.patch("dbt.plugins.manager._plugin_is_managed", return_value=False), mock.patch(
+            "dbt.plugins.manager.pkgutil.iter_modules", return_value=fake_iter_result
+        ), mock.patch("dbt.plugins.manager.importlib.import_module", side_effect=fake_import):
+            pm = PluginManager.from_modules(project_name="test")
+
+        assert instantiated == [], "opt-in plugin must not be instantiated by default"
+        assert pm.hooks == {}
+
+
+class TestProjectFlagsExposeManageState:
+    """The `manage_state` flag must be wired through ProjectFlags so that
+    dbt_project.yml's `flags:` block and profiles.yml's `config:` block both work
+    (they share the same parser via `read_project_flags`). Because manage_state is
+    also backed by the `--manage-state` CLI option, the field lives in the regular
+    ProjectFlags section (NOT in project_only_flags) -- cli/flags.py reads it via
+    `params_assigned_from_default` to override the CLI default when not explicitly
+    passed."""
+
+    def test_default_is_none(self):
+        """ProjectFlags' field default is None so the CLI option's default (False)
+        wins when nothing is set in dbt_project.yml / profiles.yml. Opt-in by
+        default means: absent any explicit signal, the plugin doesn't load."""
+        from dbt.contracts.project import ProjectFlags
+
+        assert ProjectFlags().manage_state is None
+
+    def test_can_be_set_from_dict(self):
+        from dbt.contracts.project import ProjectFlags
+
+        pf = ProjectFlags.from_dict({"manage_state": False})
+        assert pf.manage_state is False
+
+        pf = ProjectFlags.from_dict({"manage_state": True})
+        assert pf.manage_state is True
+
+    def test_is_not_in_project_only_flags(self):
+        """manage_state has a CLI option backing it, so it must NOT be in
+        project_only_flags -- otherwise it would be set both via the regular
+        CLI-default-override path AND the project-only path, and the two could
+        disagree."""
+        from dbt.contracts.project import ProjectFlags
+
+        pf = ProjectFlags(manage_state=False)
+        assert "manage_state" not in pf.project_only_flags


### PR DESCRIPTION
…anage-state / DBT_ENGINE_MANAGE_STATE / manage_state) (#13014)

* Bundle dbt-state as an opt-in dependency of dbt-core

Add dbt-state to core/pyproject.toml so it is installed alongside dbt-core, and teach PluginManager to skip discovery of bundled-but-opt-in plugins unless their gate env var is set. The skip happens before importlib.import_module, so a disabled opt-in plugin pays zero import cost and runs zero side effects -- important because the plugin monkey-patches core classes and registers signal handlers at initialize() time.

Why two module names: the package is mid-rename from `run-cache` (module `dbt_run_cache`) to `dbt-state` (module `dbt_state`). Both names are listed as first-class entries in OPT_IN_PLUGIN_MODULES gated by DBT_STATE_ENABLED so behavior is consistent regardless of which version a user has installed.

Note: the `dbt-state` PyPI release must land before this dependency line can resolve; this change and the upstream rename must ship together.



* Address review feedback on opt-in plugin gating

- Rename DBT_STATE_ENABLED -> DBT_ENGINE_STATE_ENABLED to match the DBT_ENGINE_STATE_* convention established in #13002, and add it to _ADDITIONAL_ENGINE_ENV_VARS plus the hard-coded allow-list test.
- Emit a discovery-time notice when an opt-in module is on the import path but the gate is off: INFO for the legacy `dbt_run_cache` (closes the silent-behavior-change gap reviewers flagged) and DEBUG for the new `dbt_state`. De-duplicated per process so PluginManager reconstruction doesn't spam the log.
- Detect and resolve the dbt_state + dbt_run_cache conflict at gate-on time: prefer the canonical `dbt_state`, skip `dbt_run_cache`, emit a WARNING. Prevents non-deterministic double monkey-patching when both packages happen to be installed during the rename transition.
- Wrap OPT_IN_PLUGIN_MODULES in MappingProxyType so it can't be silently mutated to flip activation for the rest of the process.
- Tighten return-type annotation to set[str] and document the canonical truthy values explicitly.
- Document scope (auto-discovery only; explicit imports still fire), cache contract (gate read at discovery time; tests toggling the env var must clear _MODULES_CACHE), and recommend plugin self-gating as defense-in-depth.
- Delete the unused _get_dbt_modules helper.
- Add end-to-end from_modules tests (gate on/off, plugin instantiated/not), conflict-resolution test, one-time-emission test, and MappingProxyType tampering test.

Note for reviewers/maintainers: when patching dbt.plugins.manager attrs in tests, patch `logger` / `_notify_*` BEFORE patching importlib.import_module in the same with-block -- mock.patch's own target resolver calls import_module internally, so a mocked import_module silently breaks subsequent patches.



* Update dbt-state dependency version range

* Flip dbt-state gating from opt-in to opt-out + add project-flag path

The plugin is now bundled (>=2.18) and loads by default. Users can opt out via either:

  - DBT_ENGINE_STATE_DISABLED env var (truthy = disable). Works pre-project-load.
  - state_plugin_disabled in the flags block of dbt_project.yml (equivalently in the config block of profiles.yml -- the existing read_project_flags loader handles both surfaces).

PluginManager checks both signals at module-discovery time, before importlib.import_module is called, so opting out costs zero imports and runs zero side effects. The conflict-group dedup (dbt_state + dbt_run_cache both installed) continues to apply on the default path.

Renames in this commit:
  - DBT_ENGINE_STATE_ENABLED -> DBT_ENGINE_STATE_DISABLED (env var)
  - OPT_IN_PLUGIN_MODULES    -> OPT_OUT_PLUGIN_MODULES (now maps to
                                an OptOutSignal namedtuple of
                                env_var + flag_attr)
  - OPT_IN_PLUGIN_CONFLICT_GROUPS -> OPT_OUT_PLUGIN_CONFLICT_GROUPS
  - _env_gate_is_on          -> _env_var_is_truthy
  - _notify_opt_in_*         -> _notify_opt_out_*

New ProjectFlags field state_plugin_disabled (default False) is included in project_only_flags so cli/flags.py setattrs it on the global Flags object as STATE_PLUGIN_DISABLED. _read_project_flag in manager.py lazy-imports dbt.flags to avoid hard import-time coupling.

Tests cover both opt-out paths (env-var and project-flag) at unit level and end-to-end via from_modules. Adds
TestProjectFlagsExposeStatePluginDisabled to assert the field is wired through project_only_flags -- if that mapping is removed, get_flags() never gets the attribute and the project-flag opt-out silently does nothing.

Updates the test_requires.py hard-coded engine env var allow-list and adds a changelog entry.



* Tidy docstring: empty string, not None, for env-var-only plugins



* Rename gate to manage_state, add --manage-state CLI flag

Three coordinated changes:

  - Env var:     DBT_ENGINE_STATE_DISABLED -> DBT_ENGINE_MANAGE_STATE
  - Project/profile flag: state_plugin_disabled -> manage_state
  - CLI flag (new): --manage-state / --no-manage-state

Semantics flip from "disabled" to "managed":

  - Old: truthy signal -> plugin OFF, default OFF means plugin ON
  - New: manage_state True -> plugin ON, default True means plugin ON; set to False (any surface) to skip the plugin

The CLI flag is registered via `_create_option_and_track_env_var` in params.py with envvar=DBT_MANAGE_STATE; the EngineEnvVar machinery auto-aliases that to DBT_ENGINE_MANAGE_STATE and Click reads either. Because the flag now has a CLI option, env_vars._ADDITIONAL_ENGINE_ENV_VARS no longer needs an explicit entry (params.KNOWN_ENV_VARS handles it).

ProjectFlags moves `manage_state: Optional[bool] = None` to the regular section (out of project_only_flags) so cli/flags.py's params_assigned_from_default override path handles it -- same pattern as partial_parse and other CLI-backed flags.

PluginManager renames:
  - OPT_OUT_PLUGIN_MODULES        -> BUNDLED_PLUGIN_MODULES
  - OPT_OUT_PLUGIN_CONFLICT_GROUPS -> BUNDLED_PLUGIN_CONFLICT_GROUPS
  - OptOutSignal(env_var, flag_attr) -> ManageSignal(flag_attr, cli_flag)
  - _disabled_opt_out_modules     -> _disabled_bundled_modules
  - _resolve_opt_out_conflicts    -> _resolve_bundled_plugin_conflicts
  - _env_var_is_truthy            -> dropped (Click handles env var)
  - _read_project_flag            -> _plugin_is_managed (and inverted)
  - _opt_out_reason               -> dropped (single signal source now)
  - _notify_opt_out_*             -> _notify_bundled_plugin_*

Discovery still happens at module-discovery time, before importlib.import_module is called, so a disabled bundled plugin pays zero import cost.

Tests rewritten to cover the new semantics: _plugin_is_managed default behavior, default-True on flag-init exception, registry contents, read-only mapping, conflict resolution, end-to-end from_modules with manage_state True/False. New test asserts manage_state is NOT in project_only_flags (it's CLI-backed; if it were in both paths they could disagree).



* Flip manage_state back to opt-in (default false)

Just a default-value flip plus comment/help-text/log-level updates; the wiring stays the same since manage_state still resolves through `get_flags().MANAGE_STATE` from any of the three surfaces (CLI flag, env var, project/profile config).

  - cli/params.py: --manage-state default changes from True to False. Help text reframed to "opt in".
  - plugins/manager.py: `_plugin_is_managed` defaults to False when the flag attribute is missing, and returns False on exception (was True in both cases). Comments/docstrings updated to reflect opt-in framing.
  - The discovery-skipped notice goes from logger.info to logger.debug, since with opt-in the not-loaded state is the default case and shouldn't log INFO-level noise on every default invocation.
  - contracts/project.py: docstring on `manage_state` field updated.
  - pyproject.toml: dependency comment updated.
  - Test names/assertions flipped to match: default_true ->
    default_false, returns_true_on_exception -> returns_false_on_exception, loads_by_default -> loads_when_opted_in, skips_when_unmanaged -> skips_by_default, logs_info_when_unmanaged -> logs_debug_when_not_opted_in, instantiates_by_default -> instantiates_when_opted_in, does_not_instantiate_when_unmanaged -> does_not_instantiate_by_default.
  - Changelog body rephrased ("opt-in: PluginManager skips unless...").

Conflict-resolution path is unchanged -- if both dbt_state and dbt_run_cache are installed AND the user has opted in, the dedup still fires.



* Restore process-wide cache of the pkgutil walk + reset between tests

Two fixes from Copilot's review on PR 13014:

1. Re-introduce a process-wide cache for the pkgutil.iter_modules() walk. The previous code had `@functools.lru_cache(maxsize=None)` on the (admittedly unused) `_get_dbt_modules` helper; deleting it removed the cache benefit too. `pkgutil.iter_modules()` walks sys.path and is slow in environments with many site-packages; repeated PluginManager constructions (notably programmatic dbtRunner usage) shouldn't re-scan.

   Introduce `_walk_prefixed_module_names(prefix)` decorated with `functools.lru_cache(maxsize=4)`. Cached at module scope, called from `get_prefixed_modules`. Opt-in signals are still re-evaluated per call (so env-var/flag changes between calls take effect); only the slow filesystem walk is cached.

2. Reset module-level cache state between tests. The new from_modules tests didn't clear `_MODULES_CACHE`, so if `test_caching_enabled()` returns True, the first test populates it with its mocked module dict and subsequent tests short-circuit using the stale cache -- the gate never runs, and assertions pass for the wrong reason (or fail non-deterministically depending on order).

   Extend the existing autouse fixture (rename to `_reset_plugin_manager_process_state`) to clear three pieces of process-global state before AND after each test: - `_DISCOVERY_NOTICES_EMITTED` - `_MODULES_CACHE` - the new `_walk_prefixed_module_names` lru_cache

   New test `test_walk_prefixed_module_names_is_cached` pins the caching behavior directly: three calls hit `pkgutil.iter_modules` exactly once.



* Register --manage-state with canonical DBT_ENGINE_ env var (no legacy alias)

tests/unit/test_env_vars.py::test_engine_env_vars_with_old_names_has_not_increased counts engine env vars that were registered with the legacy DBT_ prefix (EngineEnvVar then auto-aliases them with a DBT_ENGINE_ name and sets old_name to the legacy form). The test is a guard against adding NEW engine env vars in the legacy form.

I'd registered the new --manage-state option with envvar="DBT_MANAGE_STATE", which auto-aliased to DBT_ENGINE_MANAGE_STATE but counted as a legacy addition (incrementing the count from 65 to 66 and tripping the guard).

Fix: register with envvar="DBT_ENGINE_MANAGE_STATE" directly. EngineEnvVar sees the canonical prefix and sets old_name=None, so the count stays at
65. The user-facing env var is unchanged (still DBT_ENGINE_MANAGE_STATE); we just lose the implicit DBT_MANAGE_STATE alias, which has no users.

Also remove the stale "(or its non-engine-prefixed alias DBT_MANAGE_STATE)" note from the ManageSignal docstring in plugins/manager.py.



---------


(cherry picked from commit b6aae8c6f01430b531a347e4357b7404af2c841e)

Resolves #

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
