### PR TITLE
add dbt login fixes for post login flow

### DIFF
--- a/.changes/unreleased/Fixes-20260529-210815.yaml
+++ b/.changes/unreleased/Fixes-20260529-210815.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Write manage_state user_settings in all platform login flows unless explicitly disabled
+time: 2026-05-29T21:08:15.352105+05:30
+custom:
+    Author: ash2shukla
+    Issue: "13032"

--- a/core/dbt/auth/oauth/platform.py
+++ b/core/dbt/auth/oauth/platform.py
@@ -15,7 +15,7 @@ import requests
 from dbt.auth.credentials import OAuthSession, PlatformCredential
 from dbt.auth.secure_file import secure_open
 from dbt.auth.session_cache import DBT_HOME_DIR, DEFAULT_CACHE_PATH, upsert_session
-from dbt.config.user_settings import set_user_setting_flag
+from dbt.config.user_settings import get_user_setting_flag, set_user_setting_flag
 from dbt.exceptions import InteractiveAuthError
 from dbt_common.events.functions import fire_event
 from dbt_common.events.types import Note
@@ -205,8 +205,13 @@ def resolve_from_callback(
 
 
 def on_platform_login_success(credential: PlatformCredential) -> None:
-    # TODO: remove lazy import once dbt.cli.__init__ circular dep is resolved
-    # dbt.flags -> dbt.cli.main -> dbt.auth.oauth.platform
+    """Post-login steps after a successful platform OAuth login.
+
+    - manage_state already enabled (resolved flag): no change.
+    - manage_state explicitly false in user_settings.yml: prompts before overriding.
+    - manage_state not set: auto-enables without prompting.
+    """
+    # Lazy import: dbt.flags -> dbt.cli.main -> dbt.auth.oauth.platform
     from dbt.flags import get_flags
 
     client = DbtPlatformAPIClient(credential)
@@ -214,18 +219,41 @@ def on_platform_login_success(credential: PlatformCredential) -> None:
 
     fire_event(Note(msg="Congratulations! You are now signed in."))
 
-    state_enabled_locally = getattr(get_flags(), "MANAGE_STATE", False) or False
     configured = client.is_state_configured()
+    state_enabled_locally = getattr(get_flags(), "MANAGE_STATE", False) or False
 
-    if configured and not state_enabled_locally:
+    if state_enabled_locally:
+        if not configured:
+            fire_event(
+                Note(
+                    msg=(
+                        "Looks like dbt State is enabled on this machine but not in your "
+                        "dbt platform account. To enable State in your platform account, see docs: "
+                        "https://docs.getdbt.com/docs/deploy/dbt-state-setup"
+                    )
+                )
+            )
+    elif get_user_setting_flag("manage_state") is False:
         confirmed = click.confirm(
-            "Looks like dbt State is enabled for your dbt platform account. "
-            "Enable state on this machine by default, for faster and cheaper builds? "
-            "You can always change this configuration in ~/.dbt/user_settings.yml",
+            "dbt State is currently disabled in ~/.dbt/user_settings.yml. "
+            "Enable state on this machine by default, for faster and cheaper builds?",
             default=True,
         )
         if confirmed:
             set_user_setting_flag("manage_state", True)
+            fire_event(
+                Note(msg="dbt State enabled. Configuration written to ~/.dbt/user_settings.yml.")
+            )
+            if not configured:
+                fire_event(
+                    Note(
+                        msg=(
+                            "Looks like dbt State is enabled on this machine but not in your "
+                            "dbt platform account. To enable State in your platform account, see docs: "
+                            "https://docs.getdbt.com/docs/deploy/dbt-state-setup"
+                        )
+                    )
+                )
         else:
             fire_event(
                 Note(
@@ -233,13 +261,18 @@ def on_platform_login_success(credential: PlatformCredential) -> None:
                     "you can modify ~/.dbt/user_settings.yml"
                 )
             )
-    elif not configured and state_enabled_locally:
+    else:
+        set_user_setting_flag("manage_state", True)
         fire_event(
-            Note(
-                msg=(
-                    "Looks like dbt State is enabled on this machine but not in your "
-                    "dbt platform account. To enable State in your platform account, see docs: "
-                    "https://docs.getdbt.com/docs/deploy/dbt-state-setup"
+            Note(msg="dbt State enabled. Configuration written to ~/.dbt/user_settings.yml.")
+        )
+        if not configured:
+            fire_event(
+                Note(
+                    msg=(
+                        "Looks like dbt State is enabled on this machine but not in your "
+                        "dbt platform account. To enable State in your platform account, see docs: "
+                        "https://docs.getdbt.com/docs/deploy/dbt-state-setup"
+                    )
                 )
             )
-        )

--- a/core/dbt/auth/oauth/state.py
+++ b/core/dbt/auth/oauth/state.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 import os
 import secrets
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse, urlunparse
 
 import requests
 
@@ -15,8 +15,8 @@ from dbt.exceptions import InteractiveAuthError
 from dbt_common.events.functions import fire_event
 from dbt_common.events.types import Note
 
-STATE_OAUTH_AUTH_URL = "https://auth.runcache.com"
-STATE_OAUTH_TOKEN_URL = "https://auth.runcache.com/token"
+STATE_OAUTH_AUTH_URL = "https://auth.state.dbt.com"
+STATE_OAUTH_TOKEN_URL = "https://auth.state.dbt.com/token"
 STATE_OAUTH_CLIENT_ID = "2fd87cd5-69a6-4c5f-9097-747a58f0edf6"
 STATE_OAUTH_SCOPE = "runcache:scope:orgs"
 
@@ -41,9 +41,10 @@ def build_context(redirect_url: str) -> dict:
         "code_challenge": challenge,
         "code_challenge_method": "S256",
     }
-    authorize_url = f"{auth_url.rstrip('/')}?{urlencode(authorize_params)}"
+    parsed = urlparse(auth_url.rstrip("/"))
+    authorize_url = urlunparse(parsed._replace(query=urlencode(authorize_params)))
     return {
-        "encoded_param": base64.urlsafe_b64encode(authorize_url.encode()).decode(),
+        "encoded_param": base64.b64encode(authorize_url.encode()).decode(),
         "code_verifier": verifier,
         "client_id": client_id,
         "token_url": token_url,
@@ -97,6 +98,10 @@ def resolve_from_callback(result: dict, ctx: dict) -> StateCredential:
 
 
 def on_state_login_success(credential: StateCredential) -> None:
+    """Post-login steps after a successful dbt State OAuth login.
+
+    - Unconditionally sets manage_state: true in user_settings.yml (no prompt).
+    """
     set_user_setting_flag("manage_state", True)
     fire_event(
         Note(

--- a/core/dbt/auth/resolvers.py
+++ b/core/dbt/auth/resolvers.py
@@ -6,6 +6,7 @@ import webbrowser
 from enum import Enum
 from pathlib import Path
 from typing import Callable, Optional
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import requests
 import yaml
@@ -314,10 +315,11 @@ class OAuthInteractiveResolver:
         state_ctx = build_state_oauth_context(redirect_url)
         server.state_oauth_state = state_ctx["state"]
 
-        auth_url = (
-            platform_ctx["authorize_url"]
-            + f"&dbt_state_oauth={state_ctx['encoded_param']}&_dbtsrc=dbt-core"
-        )
+        parsed = urlparse(platform_ctx["authorize_url"])
+        params = parse_qsl(parsed.query)
+        params.append(("dbt_state_oauth", state_ctx["encoded_param"]))
+        params.append(("_dbtsrc", "dbt-core"))
+        auth_url = urlunparse(parsed._replace(query=urlencode(params)))
 
         server.timeout = self.timeout
 

--- a/core/dbt/config/user_settings.py
+++ b/core/dbt/config/user_settings.py
@@ -55,6 +55,10 @@ def get_user_setting_flags(path: Path | None = None) -> dict:
     return settings.flags
 
 
+def get_user_setting_flag(name: str, path: Path | None = None) -> bool | None:
+    return get_user_setting_flags(path).get(name)
+
+
 def set_user_setting_flag(name: str, value: bool, path: Path | None = None) -> None:
     settings = read_user_settings(path)
     settings.flags[name] = value

--- a/tests/functional/auth/test_login.py
+++ b/tests/functional/auth/test_login.py
@@ -13,7 +13,7 @@ from unittest import mock
 import pytest
 
 from dbt.auth.session_cache import read_session_cache
-from dbt.config.user_settings import get_user_setting_flags
+from dbt.config.user_settings import get_user_setting_flag, get_user_setting_flags
 from dbt.tests.util import run_dbt
 from dbt_common.events.event_catcher import EventCatcher
 from dbt_common.events.types import Note
@@ -77,39 +77,47 @@ class TestLoginInteractivePlatform:
         assert cache.sessions[0].access_token == fake_jwt
         assert cache.sessions[0].account_id == 42
 
+    def test_state_not_set_auto_enables(self, stub_confirm):
+        """manage_state not in user_settings.yml -> auto-enable without prompting."""
+        catcher = EventCatcher(Note)
+        run_dbt(["login"], callbacks=[catcher.catch])
+
+        stub_confirm.assert_not_called()
+        assert get_user_setting_flag("manage_state") is True
+        assert any("Configuration written" in e.info.msg for e in catcher.caught_events)
+
     @pytest.mark.parametrize("stub_platform_api", [True], indirect=True)
-    def test_state_configured_remotely_user_confirms(
-        self,
-        stub_platform_api,
-        stub_confirm,
-    ):
+    def test_explicitly_disabled_user_confirms(self, stub_platform_api, stub_confirm):
+        """manage_state explicitly false in user_settings.yml -> prompt, user confirms."""
+        from dbt.config.user_settings import set_user_setting_flag
+
+        set_user_setting_flag("manage_state", False)
+
         catcher = EventCatcher(Note)
         run_dbt(["login"], callbacks=[catcher.catch])
 
         stub_confirm.assert_called_once()
-        assert "Enable state on this machine" in stub_confirm.call_args[0][0]
-        assert get_user_setting_flags()["manage_state"] is True
+        assert "currently disabled" in stub_confirm.call_args[0][0]
+        assert get_user_setting_flag("manage_state") is True
 
     @pytest.mark.parametrize("stub_platform_api", [True], indirect=True)
     @pytest.mark.parametrize("stub_confirm", [False], indirect=True)
-    def test_state_configured_remotely_user_declines(
-        self,
-        stub_platform_api,
-        stub_confirm,
-    ):
+    def test_explicitly_disabled_user_declines(self, stub_platform_api, stub_confirm):
+        """manage_state explicitly false in user_settings.yml -> prompt, user declines."""
+        from dbt.config.user_settings import set_user_setting_flag
+
+        set_user_setting_flag("manage_state", False)
+
         catcher = EventCatcher(Note)
         run_dbt(["login"], callbacks=[catcher.catch])
 
         assert any(
             "you can modify ~/.dbt/user_settings.yml" in e.info.msg for e in catcher.caught_events
         )
-        assert not get_user_setting_flags().get("manage_state")
+        assert get_user_setting_flag("manage_state") is False
 
     @pytest.mark.parametrize("mock_flags", [True], indirect=True)
-    def test_state_enabled_locally_but_not_remotely_warns(
-        self,
-        mock_flags,
-    ):
+    def test_state_enabled_locally_but_not_remotely_warns(self, mock_flags):
         from dbt.config.user_settings import set_user_setting_flag
 
         set_user_setting_flag("manage_state", True)

--- a/tests/unit/auth/test_login_flow.py
+++ b/tests/unit/auth/test_login_flow.py
@@ -139,9 +139,21 @@ class TestPlatformLoginFlow:
 
 
 class TestPostPlatformLogin:
-    """All 4 cases of the configured/enabled matrix."""
+    """Post-login decision matrix: get_flags().MANAGE_STATE for resolved check,
+    get_user_setting_flag() to detect explicit disable, set_user_setting_flag to write."""
 
-    def _run_post_login(self, configured: bool, enabled: bool, confirm: bool = True):
+    def _run_post_login(
+        self,
+        configured: bool,
+        enabled: bool,
+        user_setting: object = None,
+        confirm: bool = True,
+    ):
+        """Run on_platform_login_success.
+
+        enabled: resolved MANAGE_STATE from get_flags() (CLI > env > project > user_settings)
+        user_setting: explicit value in user_settings.yml (True/False/None=not set)
+        """
         cred = PlatformCredential(
             token=FAKE_JWT,
             expires_at=time.time() + 3600,
@@ -156,6 +168,8 @@ class TestPostPlatformLogin:
                 fired_messages.append(event.msg)
 
         with mock.patch("dbt.flags.get_flags", return_value=flags), mock.patch(
+            "dbt.auth.oauth.platform.get_user_setting_flag", return_value=user_setting
+        ), mock.patch(
             "dbt.auth.oauth.platform.DbtPlatformAPIClient.is_state_configured",
             return_value=configured,
         ), mock.patch(
@@ -171,32 +185,60 @@ class TestPostPlatformLogin:
 
         return mock_set_flag, fired_messages
 
-    def test_configured_and_enabled_is_noop(self):
-        mock_set_flag, messages = self._run_post_login(configured=True, enabled=True)
+    def test_already_enabled_and_configured_is_noop(self):
+        mock_set_flag, messages = self._run_post_login(
+            configured=True, enabled=True, user_setting=True
+        )
         mock_set_flag.assert_not_called()
         assert any("Congratulations" in m for m in messages)
 
-    def test_configured_and_not_enabled_user_confirms(self):
+    def test_already_enabled_but_not_configured_warns(self):
         mock_set_flag, messages = self._run_post_login(
-            configured=True, enabled=False, confirm=True
+            configured=False, enabled=True, user_setting=True
+        )
+        mock_set_flag.assert_not_called()
+        assert any("not in your dbt platform" in m for m in messages)
+
+    def test_enabled_via_env_overrides_user_settings_false(self):
+        """MANAGE_STATE=True from env/CLI even though user_settings has false."""
+        mock_set_flag, messages = self._run_post_login(
+            configured=True, enabled=True, user_setting=False
+        )
+        mock_set_flag.assert_not_called()
+
+    def test_explicitly_disabled_user_confirms(self):
+        mock_set_flag, messages = self._run_post_login(
+            configured=True, enabled=False, user_setting=False, confirm=True
         )
         mock_set_flag.assert_called_once_with("manage_state", True)
+        assert any("Configuration written" in m for m in messages)
 
-    def test_configured_and_not_enabled_user_declines(self):
+    def test_explicitly_disabled_user_declines(self):
         mock_set_flag, messages = self._run_post_login(
-            configured=True, enabled=False, confirm=False
+            configured=True, enabled=False, user_setting=False, confirm=False
         )
         mock_set_flag.assert_not_called()
         assert any("you can modify ~/.dbt/user_settings.yml" in m for m in messages)
 
-    def test_not_configured_and_not_enabled_is_noop(self):
-        mock_set_flag, messages = self._run_post_login(configured=False, enabled=False)
-        mock_set_flag.assert_not_called()
-        assert any("Congratulations" in m for m in messages)
+    def test_explicitly_disabled_not_configured_user_confirms(self):
+        mock_set_flag, messages = self._run_post_login(
+            configured=False, enabled=False, user_setting=False, confirm=True
+        )
+        mock_set_flag.assert_called_once_with("manage_state", True)
+        assert any("not in your dbt platform" in m for m in messages)
 
-    def test_not_configured_but_enabled_fires_info(self):
-        mock_set_flag, messages = self._run_post_login(configured=False, enabled=True)
-        mock_set_flag.assert_not_called()
+    def test_not_set_auto_enables(self):
+        mock_set_flag, messages = self._run_post_login(
+            configured=True, enabled=False, user_setting=None
+        )
+        mock_set_flag.assert_called_once_with("manage_state", True)
+        assert any("Configuration written" in m for m in messages)
+
+    def test_not_set_not_configured_auto_enables_and_warns(self):
+        mock_set_flag, messages = self._run_post_login(
+            configured=False, enabled=False, user_setting=None
+        )
+        mock_set_flag.assert_called_once_with("manage_state", True)
         assert any("not in your dbt platform" in m for m in messages)
 
 

--- a/tests/unit/auth/test_login_flow.py
+++ b/tests/unit/auth/test_login_flow.py
@@ -11,11 +11,14 @@ import json
 import time
 from argparse import Namespace
 from unittest import mock
+from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse, urlunparse
 
 from dbt.auth.credentials import OAuthSession, PlatformCredential, StateCredential
+from dbt.auth.oauth.platform import build_context as build_platform_ctx
 from dbt.auth.oauth.platform import exchange_code as platform_exchange_code
 from dbt.auth.oauth.platform import on_platform_login_success
 from dbt.auth.oauth.platform import resolve_from_callback as platform_resolve
+from dbt.auth.oauth.state import build_context as build_state_ctx
 from dbt.auth.oauth.state import on_state_login_success
 from dbt.auth.oauth.state import resolve_from_callback as state_resolve
 from dbt.auth.resolvers import OAuthPassiveResolver
@@ -383,3 +386,73 @@ class TestStateLoginFlow:
         assert call_data["code"] == "the_code"
         assert call_data["client_id"] == "rc_client"
         assert call_data["state"] == "the_state"
+
+
+class TestStateOAuthUrlRoundTrip:
+    """The dbt_state_oauth param carries a base64-encoded state authorize URL
+    inside the platform authorize URL. A prior bug caused base64 '=' padding to
+    collide with URL query syntax when the domain changed to auth.state.dbt.com.
+    These tests prove the nested URL survives the round-trip."""
+
+    def _build_combined_url(self, state_auth_url: str = "https://auth.state.dbt.com"):
+        """Replicate the URL construction in OAuthInteractiveResolver.resolve()."""
+        redirect_url = "http://localhost:54321/"
+
+        platform_ctx = build_platform_ctx(
+            redirect_url=redirect_url,
+            client_id="test_client",
+            auth_server_url="https://us1.dbt.com/register",
+            scopes="identity:read offline_access",
+        )
+
+        with mock.patch.dict("os.environ", {"RUN_CACHE_AUTH_URL": state_auth_url}, clear=False):
+            state_ctx = build_state_ctx(redirect_url)
+
+        parsed = urlparse(platform_ctx["authorize_url"])
+        params = parse_qsl(parsed.query)
+        params.append(("dbt_state_oauth", state_ctx["encoded_param"]))
+        params.append(("_dbtsrc", "dbt-core"))
+        combined_url = urlunparse(parsed._replace(query=urlencode(params)))
+
+        return combined_url, state_ctx
+
+    def _extract_state_url(self, combined_url: str) -> str:
+        """Parse dbt_state_oauth from the combined URL and base64-decode it."""
+        qs = parse_qs(urlparse(combined_url).query)
+        assert "dbt_state_oauth" in qs, "dbt_state_oauth missing from combined URL"
+        encoded = qs["dbt_state_oauth"][0]
+        return base64.b64decode(encoded).decode()
+
+    def test_state_url_roundtrips_with_padding_domain(self):
+        """auth.state.dbt.com produces base64 output with '=' padding.
+        Verify the decoded state URL retains all expected query params."""
+        combined_url, state_ctx = self._build_combined_url("https://auth.state.dbt.com")
+        decoded_url = self._extract_state_url(combined_url)
+
+        decoded_qs = parse_qs(urlparse(decoded_url).query)
+        assert decoded_qs["client_id"][0] == state_ctx["client_id"]
+        assert decoded_qs["state"][0] == state_ctx["state"]
+        assert decoded_qs["redirect_uri"][0] == "http://localhost:54321/"
+        assert decoded_qs["scope"][0] == "runcache:scope:orgs"
+        assert decoded_qs["response_type"][0] == "code"
+        assert "code_challenge" in decoded_qs
+        assert decoded_qs["code_challenge_method"][0] == "S256"
+
+    def test_state_url_roundtrips_with_no_padding_domain(self):
+        """auth.runcache.com (no padding) should also round-trip cleanly."""
+        combined_url, state_ctx = self._build_combined_url("https://auth.runcache.com")
+        decoded_url = self._extract_state_url(combined_url)
+
+        decoded_qs = parse_qs(urlparse(decoded_url).query)
+        assert decoded_qs["client_id"][0] == state_ctx["client_id"]
+        assert decoded_qs["state"][0] == state_ctx["state"]
+        assert decoded_qs["redirect_uri"][0] == "http://localhost:54321/"
+
+    def test_encoded_param_contains_padding(self):
+        """Confirm that auth.state.dbt.com actually produces '=' padding,
+        which was the root cause of the original bug."""
+        _, state_ctx = self._build_combined_url("https://auth.state.dbt.com")
+        encoded = state_ctx["encoded_param"]
+        assert (
+            "=" in encoded
+        ), f"Expected base64 padding in encoded_param for auth.state.dbt.com, got: {encoded}"

--- a/tests/unit/plugins/test_manager.py
+++ b/tests/unit/plugins/test_manager.py
@@ -519,7 +519,8 @@ class TestManageStateClickIntegration:
         previous_global_flags = dbt.flags.get_flags()
         try:
             runner = CliRunner()
-            result = runner.invoke(probe, argv, env=env, catch_exceptions=False)
+            with mock.patch("dbt.cli.flags.get_user_setting_flags", return_value={}):
+                result = runner.invoke(probe, argv, env=env, catch_exceptions=False)
             assert result.exit_code == 0, result.output
         finally:
             dbt.flags.set_flags(previous_global_flags)


### PR DESCRIPTION
Resolves #13032 

### Problem
Post login flow for platform oauth login doesnt work as expected.

### Solution
- Only prompt user confirmation when he has explicitly set manage_state: false, else set manage_state: true
- Change auth.runcache.com url to auth.state.dbt.com
- Resolve url base64encoding issues

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
