### PR TITLE
Strip core-only DBT_ENGINE_* env vars from v2 parser subprocess; expand ~ in --v2-parser

### DIFF
--- a/.changes/unreleased/Fixes-20260529-120000.yaml
+++ b/.changes/unreleased/Fixes-20260529-120000.yaml
@@ -1,0 +1,13 @@
+kind: Fixes
+body: >-
+    Strip dbt-core-only DBT_ENGINE_* env vars (e.g. DBT_ENGINE_USE_V2_PARSER,
+    DBT_ENGINE_V2_PARSER) from the v2-parser subprocess env, and expand `~` in
+    --v2-parser paths. Fusion hard-errors on unknown DBT_ENGINE_* vars, so
+    enabling the v2 parser via DBT_ENGINE_USE_V2_PARSER previously broke the
+    handoff. Stripping is keyed off click-bound options, so future core-only
+    DBT_ENGINE_* additions are handled automatically. Non-click vars
+    (DBT_ENGINE_STATE_*, recorder, deps) pass through unchanged.
+time: 2026-05-29T12:00:00.000000000Z
+custom:
+    Author: aiguofer
+    Issue: "13029"

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -152,8 +152,10 @@ def _build_argv(flags, target_path_override: Optional[str] = None) -> List[str]:
         getattr(flags, "V2_PARSER", "dbt-core-experimental-parser parse"),
         posix=(os.name != "nt"),
     )
+    # Expand `~` in the parser binary so users can point --v2-parser at e.g.
+    # `~/bin/my-parser`. shlex.split treats `~` as literal.
     if base:
-        base[0] = _resolve_engine_command(base[0])
+        base[0] = _resolve_engine_command(os.path.expanduser(base[0]))
     forwarded: List[str] = []
 
     project_dir = getattr(flags, "PROJECT_DIR", None)
@@ -221,8 +223,18 @@ def _fusion_subprocess_env() -> dict:
     The host orchestrator's DBT_INVOCATION_ENV (set by dbt platform Orc/Sinter
     or by CI) still applies to dbt-core's own telemetry — we only relabel the
     embedded fs run.
+
+    Also strips every DBT_ENGINE_* env var that maps to a dbt-core CLI option:
+    fs hard-errors on unknown DBT_ENGINE_* vars (its prefix is reserved), and
+    parsing-relevant flags are forwarded via argv by _build_argv. The
+    DBT_ENGINE_STATE_* / recorder / deps vars in _ADDITIONAL_ENGINE_ENV_VARS
+    are not click-bound and pass through unchanged — fs uses them natively.
     """
+    from dbt.cli import params
+
     env = os.environ.copy()
+    for engine_env_var in params.KNOWN_ENV_VARS:
+        env.pop(engine_env_var.name, None)
     env["DBT_INVOCATION_ENV"] = "dbt-core-v2-parser"
     return env
 

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -104,6 +104,13 @@ class TestBuildArgv:
         argv = _build_argv(_flags(V2_PARSER="uv run dbt-core-experimental-parser parse"))
         assert argv == ["uv", "run", "dbt-core-experimental-parser", "parse"]
 
+    def test_expands_tilde_in_v2_parser_path(self):
+        # shlex.split leaves ~ literal; users expect shell-style expansion when
+        # pointing --v2-parser at a binary under their home directory.
+        home = os.path.expanduser("~")
+        argv = _build_argv(_flags(V2_PARSER="~/bin/my-parser parse"))
+        assert argv == [f"{home}/bin/my-parser", "parse"]
+
     def test_target_path_override_replaces_user_value(self):
         argv = _build_argv(_flags(TARGET_PATH="user/target"), target_path_override="/tmp/handoff")
         i = argv.index("--target-path")
@@ -192,6 +199,47 @@ class TestParseWithFusion:
 
         assert captured["env"] is not None
         assert captured["env"]["DBT_INVOCATION_ENV"] == "dbt-core-v2-parser"
+
+    def test_strips_core_only_engine_env_vars_from_subprocess(
+        self, tmp_path: Path, _patch_fusion_deps
+    ):
+        """fs hard-errors on unknown DBT_ENGINE_* vars. Every DBT_ENGINE_* var
+        that maps to a dbt-core CLI option must be stripped from the child env;
+        non-click DBT_ENGINE_* vars (state/recorder/deps) must pass through."""
+        captured = {}
+
+        def _capture(argv, *args, **kwargs):
+            captured["env"] = kwargs.get("env")
+            return _fake_parser(json.dumps({"metadata": {}}))(argv, *args, **kwargs)
+
+        parent_env = {
+            # click-bound — must be stripped
+            "DBT_ENGINE_USE_V2_PARSER": "true",
+            "DBT_ENGINE_V2_PARSER": "dbt-core-experimental-parser parse",
+            "DBT_ENGINE_SKIP_BROWSER_AUTH": "true",
+            "DBT_ENGINE_SQLPARSE": '{"MAX_GROUPING_DEPTH": "10"}',
+            "DBT_ENGINE_DEBUG": "true",  # alias of DBT_DEBUG, click-bound
+            # not click-bound — must pass through (fs uses these natively)
+            "DBT_ENGINE_STATE_OAUTH_CLIENT_ID": "client-id",
+            "DBT_ENGINE_STATE_API_URL": "https://state.example.com",
+        }
+        with mock.patch.dict("os.environ", parent_env, clear=False), mock.patch(
+            "dbt.parser.fusion.subprocess.run", side_effect=_capture
+        ), mock.patch(
+            "dbt.parser.fusion._load_writable_manifest", return_value=mock.MagicMock()
+        ), mock.patch(
+            "dbt.parser.fusion.Manifest.from_writable_manifest", return_value=mock.MagicMock()
+        ):
+            parse_with_fusion(self._runtime_config(tmp_path), write=False, write_json=False)
+
+        child_env = captured["env"]
+        assert "DBT_ENGINE_USE_V2_PARSER" not in child_env
+        assert "DBT_ENGINE_V2_PARSER" not in child_env
+        assert "DBT_ENGINE_SKIP_BROWSER_AUTH" not in child_env
+        assert "DBT_ENGINE_SQLPARSE" not in child_env
+        assert "DBT_ENGINE_DEBUG" not in child_env
+        assert child_env["DBT_ENGINE_STATE_OAUTH_CLIENT_ID"] == "client-id"
+        assert child_env["DBT_ENGINE_STATE_API_URL"] == "https://state.example.com"
 
     def test_nonzero_exit_raises(self, tmp_path: Path, _patch_fusion_deps):
         # Passthrough mode: the parser's stderr streams directly to the user,


### PR DESCRIPTION
## Summary

Stacked on top of the v2-parser telemetry PR (base: `aiguofer/v2_parser_telemetry`). Fixes two issues with the v2-parser handoff that surfaced while validating the end-to-end flow.

### 1. Fusion rejects unknown `DBT_ENGINE_*` env vars

Fusion's `validate_engine_env_vars` (in `fs/fs/sa/crates/dbt-main/src/vars.rs`) hard-errors on any `DBT_ENGINE_*` var not in its known set:

> "The `DBT_ENGINE_` prefix is reserved for the dbt engine. The following environment variable(s) use this reserved prefix: ... Please rename them to avoid conflicts."

This is stricter than dbt-core, which only emits a deprecation warning. Today `_fusion_subprocess_env()` does `os.environ.copy()` and forwards everything, so setting `DBT_ENGINE_USE_V2_PARSER=true` (the documented way to enable the v2 parser) blows up the subprocess immediately. Same for `DBT_ENGINE_V2_PARSER`, `DBT_ENGINE_SKIP_BROWSER_AUTH`, and any future core-only `DBT_ENGINE_*` option.

**Fix:** strip every `DBT_ENGINE_*` env var that maps to a dbt-core click option (sourced from `params.KNOWN_ENV_VARS`). Safe because:
- Parsing-relevant flags (`project-dir`, `profiles-dir`, `profile`, `target`, `target-path`, `vars`, `packages-install-path`) are already forwarded as argv by `_build_argv`.
- Non-parsing flags (`debug`, `fail-fast`, `defer`, `warn-error`, ...) don't affect manifest output.
- Non-click `DBT_ENGINE_*` vars (`DBT_ENGINE_STATE_*`, recorder, deps in `_ADDITIONAL_ENGINE_ENV_VARS`) pass through unchanged — Fusion uses them natively.
- Self-healing for future additions: any new core-only `DBT_ENGINE_*` CLI option gets auto-tracked in `KNOWN_ENV_VARS` and auto-stripped.

### 2. `~` not expanded in `--v2-parser` path

`shlex.split` treats `~` as literal, so `--v2-parser '~/bin/my-parser parse'` was passed through verbatim and failed to execute. Now we `expanduser` the binary path before resolution.

## Cross-engine ask

Companion change recommended on the Fusion side: add `DBT_ENGINE_USE_V2_PARSER` and `DBT_ENGINE_V2_PARSER` to `KNOWN_UNUSED_ENGINE_ENV_VARS` in `fs/fs/sa/crates/dbt-main/src/vars.rs` so older dbt-core versions that lack this strip continue to interoperate with newer Fusion releases.
