### PR TITLE
allow skipping ddtrace in pytest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
       DBT_TEST_USER_1: dbt_test_user_1
       DBT_TEST_USER_2: dbt_test_user_2
       DBT_TEST_USER_3: dbt_test_user_3
-      DD_CIVISIBILITY_AGENTLESS_ENABLED: true
+      DD_CIVISIBILITY_AGENTLESS_ENABLED: ${{ secrets.DATADOG_API_KEY != '' }}
       DD_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       DD_SITE: datadoghq.com
       DD_ENV: ci
@@ -227,7 +227,7 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           shell: bash
-          command: cd core && hatch -v run ci:integration-tests -- --ddtrace --splits ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }} --group ${{ matrix.split-group }}
+          command: cd core && hatch -v run ci:integration-tests -- ${{ secrets.DATADOG_API_KEY != '' && '--ddtrace' || '' }} --splits ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }} --group ${{ matrix.split-group }}
 
       - name: Get current date
         if: always()
@@ -268,7 +268,7 @@ jobs:
       DBT_TEST_USER_1: dbt_test_user_1
       DBT_TEST_USER_2: dbt_test_user_2
       DBT_TEST_USER_3: dbt_test_user_3
-      DD_CIVISIBILITY_AGENTLESS_ENABLED: true
+      DD_CIVISIBILITY_AGENTLESS_ENABLED: ${{ secrets.DATADOG_API_KEY != '' }}
       DD_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       DD_SITE: datadoghq.com
       DD_ENV: ci
@@ -305,7 +305,7 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           shell: bash
-          command: cd core && hatch -v run ci:integration-tests -- --ddtrace --splits ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }} --group ${{ matrix.split-group }}
+          command: cd core && hatch -v run ci:integration-tests -- ${{ secrets.DATADOG_API_KEY != '' && '--ddtrace' || '' }} --splits ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }} --group ${{ matrix.split-group }}
 
       - name: Get current date
         if: always()


### PR DESCRIPTION
Resolves #


### Problem
Due to --ddtrace flag in pytest for integration tests we require datadog api key access for all PRs, this should not be mandatory for PRs from forked repos.

### Solution
Conditionally enable CI visibility.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
