### PR TITLE
ci: point workflows at 1.latest ahead of main cutover

### DIFF
--- a/.changes/unreleased/Under the Hood-20260531-100800.yaml
+++ b/.changes/unreleased/Under the Hood-20260531-100800.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Point CI workflows at the `1.latest` branch in preparation for the `main` branch cutover to the Rust parser.
+time: 2026-05-31T10:08:00.000000000Z
+custom:
+    Author: tauhid621
+    Issue: ""

--- a/.changes/unreleased/Under the Hood-20260531-100800.yaml
+++ b/.changes/unreleased/Under the Hood-20260531-100800.yaml
@@ -3,4 +3,4 @@ body: Point CI workflows at the `1.latest` branch in preparation for the `main` 
 time: 2026-05-31T10:08:00.000000000Z
 custom:
     Author: tauhid621
-    Issue: ""
+    Issue: "13065"

--- a/.github/workflows/check-artifact-changes.yml
+++ b/.github/workflows/check-artifact-changes.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           echo "CI failure: Artifact changes checked in core/dbt/artifacts directory."
           echo "Files changed: ${{ steps.check_artifact_changes.outputs.artifacts_changed_files }}"
-          echo "To bypass this check, confirm that the change is not breaking (https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/artifacts/README.md#breaking-changes) and add the 'artifact_minor_upgrade' label to the PR. Modifications and additions to all fields require updates to https://github.com/dbt-labs/dbt-jsonschema."
+          echo "To bypass this check, confirm that the change is not breaking (https://github.com/dbt-labs/dbt-core/blob/1.latest/core/dbt/artifacts/README.md#breaking-changes) and add the 'artifact_minor_upgrade' label to the PR. Modifications and additions to all fields require updates to https://github.com/dbt-labs/dbt-jsonschema."
           exit 1
 
       - name: CI check passed

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -27,7 +27,7 @@ defaults:
     shell: bash
 
 env:
-  RELEASE_BRANCH: "main"
+  RELEASE_BRANCH: "1.latest"
 
 jobs:
   aggregate-release-data:

--- a/.github/workflows/release-branch-tests.yml
+++ b/.github/workflows/release-branch-tests.yml
@@ -28,4 +28,7 @@ jobs:
     uses: dbt-labs/actions/.github/workflows/release-branch-tests.yml@main
     with:
       workflows_to_run: '["main.yml"]'
+      # After cutover, `main` is the Rust branch and should not have Python CI run against it.
+      include_main: false
+      include_branches: '["1.latest"]'
     secrets: inherit

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -22,7 +22,7 @@ on:
       target_branch:
         description: "The branch to check against"
         type: string
-        default: "main"
+        default: "1.latest"
         required: true
 
 # no special access is needed

--- a/.github/workflows/test-repeater.yml
+++ b/.github/workflows/test-repeater.yml
@@ -17,7 +17,7 @@ on:
         description: "Branch to check out"
         type: string
         required: true
-        default: "main"
+        default: "1.latest"
       test_path:
         description: "Path to single test to run (ex: tests/functional/retry/test_retry.py::TestRetry::test_fail_fast)"
         type: string

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -91,6 +91,8 @@ jobs:
     steps:
       - name: "Check out the repository"
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # actions/checkout@v5
+        with:
+          ref: 1.latest
 
       - name: "Set up Python 3.11"
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # actions/setup-python@v6
@@ -142,6 +144,8 @@ jobs:
     steps:
       - name: "Check out the repository"
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # actions/checkout@v5
+        with:
+          ref: 1.latest
 
       - name: "Import build bot GPG key"
         id: import-gpg
@@ -232,6 +236,8 @@ jobs:
     steps:
       - name: "Check out the repository"
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # actions/checkout@v5
+        with:
+          ref: 1.latest
 
       - name: "Wait for CI to start"
         run: |
@@ -252,6 +258,8 @@ jobs:
     steps:
       - name: "Check out the repository"
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # actions/checkout@v5
+        with:
+          ref: 1.latest
 
       - name: "Merge PR"
         run: |


### PR DESCRIPTION
## Summary

Repoints CI/release workflows from `main` to the `1.latest` branch in preparation for the `main` branch cutover to the Rust parser, so Python CI/release automation continues to target the Python branch.

Changes:
- Default `target_branch`/checkout refs to `1.latest` (`schema-check`, `test-repeater`, `update-test-durations`).
- `nightly-release`: `RELEASE_BRANCH` -> `1.latest`.
- `release-branch-tests`: `include_main: false`, `include_branches: ["1.latest"]` (Python CI should not run against the Rust `main`).
- `check-artifact-changes`: README link points at `1.latest`.

## Test plan

- [ ] Workflow YAML parses / lints cleanly.
- [ ] Verify dispatched workflows default to and check out `1.latest`.

Made with [Cursor](https://cursor.com)