### PR TITLE
Remove unused enable arg from profiler context manager

### DIFF
--- a/.changes/unreleased/Under the Hood-20260524-124810.yaml
+++ b/.changes/unreleased/Under the Hood-20260524-124810.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Drop unused `enable` parameter from the `profiler` context manager; callers
+  already guard on `flags.RECORD_TIMING_INFO`.
+time: 2026-05-24T12:48:10.000000+00:00
+custom:
+    Author: Pawansingh3889
+    Issue: "5886"

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -125,7 +125,7 @@ def preflight(func):
 
         # Profiling
         if flags.RECORD_TIMING_INFO:
-            ctx.with_resource(profiler(enable=True, outfile=flags.RECORD_TIMING_INFO))
+            ctx.with_resource(profiler(outfile=flags.RECORD_TIMING_INFO))
 
         # Adapter management
         ctx.with_resource(adapter_management())

--- a/core/dbt/profiler.py
+++ b/core/dbt/profiler.py
@@ -5,16 +5,13 @@ from typing import Any, Generator
 
 
 @contextmanager
-def profiler(enable: bool, outfile: str) -> Generator[Any, None, None]:
+def profiler(outfile: str) -> Generator[Any, None, None]:
+    profiler = Profile()
+    profiler.enable()
     try:
-        if enable:
-            profiler = Profile()
-            profiler.enable()
-
         yield
     finally:
-        if enable:
-            profiler.disable()
-            stats = Stats(profiler)
-            stats.sort_stats("tottime")
-            stats.dump_stats(str(outfile))
+        profiler.disable()
+        stats = Stats(profiler)
+        stats.sort_stats("tottime")
+        stats.dump_stats(str(outfile))


### PR DESCRIPTION
### Description

`dbt.profiler.profiler` is a context manager that took an `enable: bool`
argument and wrapped its entire body in `if enable:`. Every call site
already guards the call behind `if flags.RECORD_TIMING_INFO:`, so
`enable` was always `True` when the context manager ran — the parameter
and the inner conditional were dead weight.

This removes the `enable` parameter, drops the now-redundant inner
`if`, and updates the single call site in `core/dbt/cli/requires.py`.

Before:

```python
with profiler(enable=flags.RECORD_TIMING_INFO, outfile=...):
    ...
```

After (the guard already existed, so the CM is just used conditionally
as the issue suggests):

```python
if flags.RECORD_TIMING_INFO:
    ctx.with_resource(profiler(outfile=flags.RECORD_TIMING_INFO))
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and confirm it tests cleanly.
- [x] I have signed the CLA.
- [x] I have added a changelog entry (`.changes/unreleased/`).

Resolves #5886
