### PR TITLE
Bump minimum dbt-core-experimental-parser to 2.0.0a1

### DIFF
--- a/.changes/unreleased/Dependencies-20260601-120000.yaml
+++ b/.changes/unreleased/Dependencies-20260601-120000.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump the minimum `dbt-core-experimental-parser` to `2.0.0a1`
+time: 2026-06-01T12:00:00.000000000Z
+custom:
+    Author: tauhid621
+    Issue: "13065"

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     "dbt-common>=1.37.5,<2.0",
     "dbt-adapters>=1.24.1,<2.0",
     "dbt-protos>=1.0.514,<2.0",
-    "dbt-core-experimental-parser>=2.0.0.dev18,<3",
+    "dbt-core-experimental-parser>=2.0.0a1,<3",
     # Bundled plugin: installed by default but opt-in. PluginManager skips loading
     # unless the user passes `--manage-state` on the CLI, sets
     # `DBT_ENGINE_MANAGE_STATE=true`, or sets `manage_state: true` in dbt_project.yml's


### PR DESCRIPTION
## What

Bump the minimum `dbt-core-experimental-parser` from `2.0.0.dev18` to `2.0.0a1` in `core/pyproject.toml`. The upper bound (`<3`) is unchanged.

## Why

Move off the dev pre-release onto the `2.0.0a1` alpha.

## Checklist

- [x] Added a changelog entry (`Dependencies`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)