### PR TITLE
add fix for interoperable expires_at field

### DIFF
--- a/.changes/unreleased/Fixes-20260601-111946.yaml
+++ b/.changes/unreleased/Fixes-20260601-111946.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Make sure that expires_at in oauth_sessions is int so that its rust interoperable
+time: 2026-06-01T11:19:46.729977+05:30
+custom:
+    Author: ash2shukla
+    Issue: "13032"

--- a/core/dbt/auth/credentials.py
+++ b/core/dbt/auth/credentials.py
@@ -9,7 +9,7 @@ from typing import Optional
 class OAuthSession:
     access_token: str
     scopes: list[str]
-    expires_at: float  # unix timestamp
+    expires_at: int  # unix timestamp (seconds); integer for Rust u64 interop
     account_host: str
     account_id: int
     user_id: int

--- a/core/dbt/auth/oauth/platform.py
+++ b/core/dbt/auth/oauth/platform.py
@@ -189,7 +189,7 @@ def resolve_from_callback(
         refresh_token=token_data.get("refresh_token"),
         id_token=token_data.get("id_token"),
         scopes=scopes,
-        expires_at=time.time() + expires_in,
+        expires_at=int(time.time() + expires_in),
         account_host=account_host,
         account_id=account_id,
         user_id=user_id,

--- a/core/dbt/auth/resolvers.py
+++ b/core/dbt/auth/resolvers.py
@@ -158,7 +158,7 @@ class OAuthPassiveResolver:
             refresh_token=token_data.get("refresh_token"),
             id_token=token_data.get("id_token"),
             scopes=scopes,
-            expires_at=time.time() + expires_in,
+            expires_at=int(time.time() + expires_in),
             account_host=account_host,
             account_id=account_id,
             user_id=user_id,

--- a/core/dbt/auth/session_cache.py
+++ b/core/dbt/auth/session_cache.py
@@ -33,7 +33,12 @@ class OAuthSessionCache:
 
     @staticmethod
     def from_dict(data: dict) -> OAuthSessionCache:
-        sessions = [OAuthSession(**s) for s in data.get("sessions", [])]
+        sessions = []
+        for s in data.get("sessions", []):
+            # Coerce legacy float timestamps to int so rewrites stay u64-compatible
+            # for the Rust dbt-platform-auth crate, which deserializes expires_at as u64.
+            s = {**s, "expires_at": int(s["expires_at"])}
+            sessions.append(OAuthSession(**s))
         return OAuthSessionCache(
             version=data.get("version", 1),
             sessions=sessions,


### PR DESCRIPTION
Resolves #13032 

### Problem
When rust parser tries to load expires_at field written by python ( float ) it will fail as it expects u64

### Solution
Ensure expires_at is integer

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
