### PR TITLE
Roadmaps -> `main`

### DIFF
--- a/docs/roadmap/2022-05-dbt-a-core-story.md
+++ b/docs/roadmap/2022-05-dbt-a-core-story.md
@@ -1,0 +1,225 @@
+# Let's talk about dbt
+
+Any writer, any artist, who finds themselves doing work that invites [thoughtful, clear, forward-looking](https://thecreativeindependent.com/people/doreen-st-felix-on-entering-the-world-of-criticism) criticism should be counted lucky. As a person who builds dbt Core for a living, I feel lucky to have [Pedram](https://pedram.substack.com/p/we-need-to-talk-about-dbt). He's a person who understands exactly what dbt is, and who cares deeply about its future.
+
+It's possible that we're not building the right things. It's certain that we're not doing a good enough job of communicating what we're building. How can we expect to know the former without doing the latter? In the end, [transparency always wins](https://www.getdbt.com/dbt-labs/values/#:~:text=Transparency%20always%20wins.).
+
+### What is this doc?
+
+This is my story of dbt Core in 2022: everything we're trying to build, and why.
+
+This Markdown table is your `tl;dr`. The rest is commentary.
+
+| Version | When | Stuff | Confidence* |
+|-----|----------|----------------------------------------------------------------------------------|------------|
+| 1.1 ✅ | April | Testing framework for dbt-core + adapters. Tools and processes for sustainable OSS maintenance tools. | 100% |
+| 1.2 | July | Refactoring core materializations (especially incremental). Built-in support for grants. "Cross-db" macros in dbt-core + plugins. Python-language models (beta). | 95% |
+| 1.3 | October | Python-language models. Built-in support for UDFs. Exposures / external nodes. | 80% |
+| 1.4 | Jan 2023 | Mechanisms for cross-project lineage (namespacing). Performance tune-up. Start incorporating SQL grammar (linting & lineage). | 50% |
+
+`updated_at: 2022-04-12`
+
+**\*Confidence?** I mean the certainty of which things we build for which release. dbt Core is relied on by many. The most important things stay the same, but some of the details vary. When looking 6+ months into the future, I expect us to do ~half of the things I've listed above and below, and shuffle ~half of them out in favor of the things that you will be telling us we need to build.
+
+### Why this doc?
+
+A product philosophy of dbt, taking inspiration [from Perl](https://www.amazon.com/gp/feature.html?ie=UTF8&docId=7137#:~:text=%22Easy%20things%20should%20be%20easy%2C%20and%20hard%20things%20should%20be%20possible.%22): **"Make the easy things easy, and the hard things possible."**
+
+The analyst in you probably has some questions:
+- Which things? The entire analytics engineering workflow?
+- What ought to be easy? What deserves to be hard?
+- Who's making them, and when?
+
+I haven't been doing a good enough job of answering those questions, in a single easy-to-bookmark place. I don't do my long-form writing in a personal blog, I do it [in a GitHub repo](https://github.com/dbt-labs/dbt-core/issues?q=is%3Aissue+is%3Aopen+commenter%3Ajtcohen6+), and trawling through issues is a leisure activity enjoyed by precious few.
+
+dbt Core is a product, sort of; a CLI tool, for many; a software project, for sure; an open source project, definitively; but above all it's a guide, a set of opinionated practices about how you should do this work of data transformation, testing, documentation. We believe these are many (not all) of the essential components of the thing we call analytics engineering, which maybe you just call getting your job done. If you're reading this, even if you don't pay to use dbt, you've more than likely invested in it a meaningful quantity of your time, care, and attention—not to mention, your business logic. It matters a lot to me that you know how we're thinking about dbt's ongoing development. (That also means that the story I can tell in this document is necessarily incomplete: I can tell you what dbt Core can do for you, but just as important is [what you and other skilled practitioners can do with dbt Core](https://docs.getdbt.com/blog).)
+
+That is to say, _mea culpa_. The best time to have written this document was a few months ago; the second best time, I hope, is right now.
+
+### Where are we now?
+
+dbt is a workflow tool. It was originally built by a team of full-time analytics consultants (us). We built it because there were jobs to be done, literally, and dbt made us unreasonably effective at doing them. As a fresh-faced Data Analyst, with a seat in the engine room (the only room there was), I was able to deliver high-quality work to clients ahead of schedule, [and go home early](https://www.getdbt.com/dbt-labs/values/#:~:text=We%20work%20hard%20and%20go%20home.) (or to the beach).
+
+The people who built dbt had the same names, faces, and hand gestures as the people who used it every day. That was our blessing and our curse. Each time we found a new idiosyncrasy in analytical databases, we coded it into dbt. Late-bound views on Redshift? Always. Quoted identifiers on Snowflake? Never. These turned into magic incantations, whose full meaning could only be revealed, slowly, through immersion in our shared ritual practice. To the uninitiated, the curly-braced characters of the incremental materialization may more resemble cuneiform than Python.
+
+As an end user, `dbt-core` felt like a magical experience, even as it grew to be an indecipherable mess of a codebase. Logging was random. Metadata was at once invaluable and totally undocumented. Our automated testing and release processes were "prayers up" undertakings. This makes sense for where our priorities were. It also meant that, at the start of 2021, two things were true:
+1. `dbt parse` was really, really freaking slow for any project with more than 500 models in it.
+2. dbt Core was major-version-zero software, a fundamentally unstable substratum, used in production by thousands of people.
+
+Those were our two top priorities in 2021. Speed up dbt-core parsing, especially in development. Work up to v1.0, and release it. We made steady progress on both of those, not without some public pains along the way. There were moments when I, like Phoebe, wondered if we'd make it through December. We did. [Read all about it, featuring a dorky picture of me, and my genuine gratitude to all the colleagues and community members who made it happen](https://www.getdbt.com/blog/dbt-core-v1-is-here/).
+
+Those were two big accomplishments. (We also grew the team of people working full-time on dbt Core from three to eight.) That doesn't mean we're done developing Core, though—not even close. I reprised the exercise. At the start of 2022, three things were true:
+1. **There are easy things we need to make easy, and one hard thing we need to make possible.** Users of dbt are still totally constrained to what they can write in SQL (or Jinja-SQL). At the same time, there's still too many things that, while doable, require lots of insider knowledge, custom code, or magic incantations. dbt Core needs some **new constructs,** a mix of totally-new and just-plain-easier things.
+2. **dbt-core is still missing the right modular interfaces for long-term development.** This is a codebase that grew organically over time. Its layout today is _much_ more sensible than it was a year ago, but we're not all the way there. The tight couplings, of tasks with configs with CLI initialization, tax our ability to build next-level capabilities with confidence, including all the stuff in (1). Not just that: it prevents community members and technology partners from building truly next-level integrations. dbt Core needs some **new interfaces.**
+3. **And yet: dbt Core is major-version-one software.** There are commitments to backwards compatibility and ease of upgrade that we take incredibly seriously. This is a necessary constraint that's always top-of-mind for us when building the new (1) and refactoring the old (2).
+
+I believe those three concerns are and remain relevant for every user of dbt. There are going to be specific things we build along the way that might be less relevant for you as an individual—support for other databases, if you happily use Redshift/Snowflake/BigQuery; support for large projects, if you're at a happy medium; better programmatic interfaces, if you need only to invoke dbt from the CLI—but they all weave together into the larger story we're telling this year.
+
+There's inevitably some "inside dbt-ball" in this document. It can't just be a list of user-facing features we're shipping, or I wouldn't be doing the story justice. We're here to take big swings, the kinds of things I get excited about demo'ing at Staging and Coalesce—but we're also here to maintain critical infrastructure, to grow a roster of talented position players who can put in a solid nine innings day after day. So this will also discuss some behind-the-scenes work we're doing, and the people who rely on it.
+
+It's true that many of the people now building dbt aren't themselves users of it—they're talented software engineers who know the things we need to do to scale large, performant, maintainable codebases. It's my job, and the job of my long-time colleagues, to ensure that dbt continues to feel dbtonic along the way.
+
+# Program for the 2022 season
+
+Welcome to the official program for "dbt: A Core Story," the devised theatre piece where everyone has a part to play. First, a few housekeeping items.
+
+We'll be releasing a new minor version of dbt Core every 3 months: April, July, August, January (2023). We put out our new [adapter](https://docs.getdbt.com/docs/available-adapters) versions at the same time. Adapters maintained by other people might be available for upgrade a few weeks later. For each new minor version, we put up a ["migration guide"](https://docs.getdbt.com/docs/guides/migration-guide) in the docs.
+
+Everything we work on is public on GitHub. I attach issues to [milestones](https://github.com/dbt-labs/dbt-core/milestones) for upcoming releases. We're using [discussions](https://github.com/dbt-labs/dbt-core/discussions) now for bigger-picture conversations—stuff we're thinking about, even if we can't write the code for it right away. If the dbt Community Slack feels overwhelming, discussions still feel, for now, like a slower-paced forum for dreaming up ideas, talking through caveats and rough edges. I really welcome your voices there.
+
+As for this document: Each quarter, I'll swing back and update it, with the edits preserved in git. If you see something you don't like, you'll know whom to `blame`.
+
+## Act I: Sharpening our tools (January–April)
+
+### Scene 1: Rewrite the way we test dbt-core and adapters
+
+This probably isn't news to you: dbt-Jinja code is pretty hard to test. I'm not talking about tests for data quality, but tests of "application code," in the sense of making sure that the incremental materialization is doing the right thing in the right circumstances. We've been feeling the pain here, too—it's really hurt our ability to onboard new engineers to the team, and ship features quickly and confidently. It's also hurt our ability to help the people who, whether for their job or with the generosity of their free time, maintain the adapter plugins that let dbt talk to dozens of databases. As core maintainers, we owed them a lot more than we could give them.
+
+So, we wrote a new testing framework, based in `pytest`, that's much easier to extend and debug. Who benefits? Concretely, these automated tests offer us a way to stamp our approval on adapter plugins developed and maintained outside dbt Labs, while ensuring a consistent baseline experience, whichever adapter you use. I think everyone who wants healthy competition between database vendors, and to know that you can have the same magical experience of using dbt across them. Ask your neighborhood adapter maintainer if the new testing framework is working well for them.
+
+Is the new `pytest`-based framework actually the dbt feature called "unit testing" in disguise? Funny you asked—no, but I do think it's a step on the way there. It's possible to use this functional testing framework to quickly spin up "projects," with fixture inputs and outputs, that check the behavior of a macro. We can test that macro for consistency across many databases. (Check this out in that most complex project of them all, [`dbt_utils`](https://github.com/dbt-labs/dbt-utils/pull/588).) The dream is indeed to expose a dbt-code-only version of this workflow, along the lines of what people have been cooking up in https://github.com/dbt-labs/dbt-core/discussions/4455.
+
+(We also intentionally built this in a way that avoids locking us into Jinja-y code forever. Jinja is a tool, just like Python. It gets us a lot right now. There will come a time when it's no longer the right fit, and we'll need to be ready to move away from it.)
+
+### Scene 2: Sustainable maintainership
+
+Since December, we've added three new folks to the team. There's 10 of us now! You may have seen some newer names, if you're used to hanging around our GitHub: @leahwicz @gshank @nathaniel-may @iknox-fa @emmyoop @McKnight-42 @VersusFacit @ChenyuLInx @stu-k
+
+That growth was in parallel to the growth of `dbt-core` active users, and the growth of issues in the `dbt-core` repo. We get 2 or 3 new open source issues every calendar day. When it was just me responding, I would take a week of vacation, and come back to a stack of a dozen or more.
+
+At the same time, I was learning a **ton** about dbt—what it is today, what it should be—by reading and responding to all your issues. That's invaluable stuff for the people building dbt, and it's stuff that was all living in my head only.
+
+So, for both reasons, I've been sharing the load with the engineering team building dbt Core. This requires more time, and process, but it also requires a level of rigor and organization that I didn't have when it was just me. Bugs don't get lost in the shuffle, and get resolved more quickly.
+
+Is this groundbreaking stuff? No, but it is major-version-one stuff. Is every one of these issues game-changing? No, but they matter a lot to the person who opens them—and I believe it matters a lot to you, a person who has invested meaningfully in standardizing on dbt Core. You should want to know that that core dbt functionality is well maintained, to know that when you run into a bug or have an idea there will be a human on the other end to receive and respond to it. To that end, I want to share a new doc we put together over the past few months: [Expectations for OSS Contributors](https://docs.getdbt.com/docs/contributing/oss-expectations).
+
+It took some doing, but we now live in a world where:
+- every issue gets a timely response
+- every community PR gets code review (with easier code checks! and conflict-free changlog entries!)
+- they're not all (or even mostly) from Drew or me
+
+I care about making contribution accessible, and making dbt a thing we can keep building together. I care a lot about what you have to say and think about feel about dbt. I still read every new issue, even if it's not me who responds. Maybe I'll stop, someday. But for now I read them all.
+
+### Scene 3: v1.1 (Gloria Casarez)
+
+At the end of April, [we released v1.1](https://github.com/dbt-labs/dbt-core/releases/tag/v1.1.0), named for Gloria Casarez, the activist and advocate for the rights of LGBTQ+ people in Philadelphia. This release had [some good stuff in it](https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-v1.1), including a few boundary-pushing community contributions—but I'll be the first to admit that it was a lighter release than others in recent memory. The biggest work was sharpening our tools, and sharpening the team. We'd rather do this work upfront, so we can build and ship the bigger stuff, with alacrity and assurance.
+
+## Act II: Ergonomic interfaces (May–July)
+
+This is where we are now. There are three big focus areas for the Core team in these three months. Two of them are user-facing, and one of them is software-facing. This is work we've just kicked off, and if you choose to look closely, you can see the full flurry of issues and PRs flying around.
+
+### Scene 1: "Adapter ergonomics"
+
+For the full story, and to leave your thoughts, check out the discussion: https://github.com/dbt-labs/dbt-core/discussions/5091. Meanwhile, I'll give the quick & dirty version.
+
+**First, grants.** These have been, [in Tristan's words](https://roundup.getdbt.com/p/the-response-you-deserve), "super-budget literally forever." Database permissions matter; they're an easy thing, and yet dbt makes them hard. I've lost track of the number of issues (but linked to many of them in https://github.com/dbt-labs/dbt-core/issues/5090) where users have run into bad experiences with `pre-hook` and `post-hook`, which are [rendered a little bit differently](https://docs.getdbt.com/docs/building-a-dbt-project/dont-nest-your-curlies), in ways that can be very useful and very confusing. Honestly, we want to move hooks into the category of "advanced functionality"—use only if you must!—but we can't do that while `grants` remain hooked on hooks.
+
+There's another reason to do this work now: BigQuery added support for DCL statements [last summer](https://cloud.google.com/bigquery/docs/release-notes#June_28_2021). Databricks has built a [brand-new unity catalog](https://databricks.com/product/unity-catalog). Many warehouses are adding more-complex permissions—dynamic data masking, role-based access policies on rows and columns. If dbt can be a forcing function for baseline consistency among data warehouse vendors—make the easy stuff easy—it provides a foundation, and clears human brain space, for the trickier case-dependent capabilities.
+
+**Second, materializations:** specifically, the 'incremental' materialization, and the sorta-real thing that is "incremental strategy" on a handful of adapters. These are powerful, complex, misunderstood. We need more sensible code, more sensible docs. Lots of people (adapters, users) want to customize or contribute to materialization logic. It's really tricky to write today, in ways that go beyond the standard (fair) complaints about macros. Our functional testing framework helps here, by giving us the ability to define the superset of behaviors in `dbt-core`, and to let each adapter or user opt into and fine-tune the ones they wish to support.
+
+**Third, `dbt-utils`**, which is getting unsustainably big. As part of [the work of splitting it up](https://github.com/dbt-labs/dbt-utils/discussions/487), we decided that its lowest-level building blocks—the "cross-db" macros so useful to authors of other packages—really belong in `dbt-core` and plugins. This is an opportunity for us to continue expanding the "dbt-SQL" language, such as it exists today, for the benefit of the package maintainers who contribute so much to our ecosystem.
+
+**The v1.2 release** will include all of the above, with a beta prerelease in June, and a final releaes to arrive in mid-July. What else? v1.2 will also to include [support for ratio metrics](https://github.com/dbt-labs/dbt-core/issues/4884), to power dbt's rapidly iterating semantic layer. Last and never least, it will include the dozen or so capabilities for which community members have taken the initiative to contribute. (Fun fact: thanks to our new `changie`-powered changelog, you can always catch a glimpse of [upcoming changes](https://github.com/dbt-labs/dbt-core/tree/main/.changes/unreleased), merged but not yet released.)
+
+### Scene 2: Modular programmatic interfaces
+
+If you've hung around the `dbt-core` GitHub repo lately, you may have seen that we've started tagging a lot of issues with `tech_debt`, as well as with `Team:Language`, `Team:Execution`, `Team:Adapters`.
+
+Not long ago, we had one team (one person), one codebase, one tightly coupled application that did all of the things, from beginning to end, without clear stopping points in the middle. Now, I'm truly lucky to work with a team of talented software engineers, as we try to make the experience of developing and interfacing with `dbt-core` as no-bs as it is to use. We believe the highest-leverage way to do this is by splitting up the team into specialties, and the codebase into modular interfaces.
+
+For too long now, the [docs for dbt's "Python API"](https://docs.getdbt.com/docs/running-a-dbt-project/dbt-api) have cautioned:
+
+> It _is_ possible to import and invoke dbt as a Python module. This API is still not contracted or documented, and it is liable to change in future versions of `dbt-core` without warning. Please use caution when upgrading across versions of dbt if you choose to run dbt in this manner!
+
+There are two big parts of this initiative that I'm hoping to tackle in July, after we've readied v1.2 for prerelease testing:
+1. Decouple the CLI from the `dbt-core` "library." Support actual programmatic interfaces into initialization and tasks. Unbundle the massive blobs of config that get passed around during initialization today.
+2. **Structured logging**, as the future of (real time) dbt metadata. In v1.0, we replaced all our "legacy" logging with a real event system and structured interface. We need to extend that system to handle errors/exceptions, too—a pain to debug when dbt spits back no or little information—and we need to add much more logging than we have today. There's so much more valuable information that dbt collects _while_ it runs, which we want to expose for you and everyone else. (Think: model table statistics _during_ `dbt run`, not just after `docs generate`.) Eventually, we see these logs eclipsing `manifest.json`—which doesn't go away, exactly, but is no longer the one (giant) file that answers every question about a dbt project.
+
+These things don't pay dividends as quickly as user-facing functionality, but we believe they more than pay for themselves in the long run. Here are the three ways I can think of:
+1. Better interfaces makes us faster at onboarding new engineers to the Core team, and building new features in dbt Core.
+2. External contributors (you!) can contribute code to `dbt-core` more easily: to find the right module, the right interfaces to extend, and fewer pitfalls that sap enthusiasm while doing it.
+3. It's easier to build other tools on top of dbt Core. That includes dbt Cloud—which, candidly, has been hamstrung in its ability to develop differentiated experiences by the lack of reliable interfaces in Core. But it also includes way-cool tools, such as [`sqlfluff`](https://github.com/sqlfluff/sqlfluff) and [`fal`](https://github.com/fal-ai/fal), that already hook into `dbt-core`'s officially undocumented Python interface. Let's make that the practice, not the anti-pattern.
+
+### Scene 3: Python-language dbt models
+
+(!!)
+
+Sorry to bury the lede for this one. This is shaping up to be the groundbreaking new entrant in the Core roadmap in 2022. If do our job well, we'll have made a hard thing possible; if we do it very well, we might just manage to make it feel easy.
+
+Over the past few weeks, I've been drafting thoughts for a forthcoming discussion, and Core engineers have been playing around with a little bit of experimental code. We're hoping to have something that's beta-ready by July. I'll have more to say about this next week, including my personal take on le grand débat of SQL ~versus~ and Python.
+
+For now, here's a taste:
+
+```python
+def model(dbt):
+
+    # look familiar?
+    dbt.config(
+        materialized='table',
+    )
+
+    # this knows about the DAG
+    upstream_model = dbt.ref("upstream_model")
+    upstream_source = dbt.source("upstream", "source")
+
+    # dataframe-style transformations
+    sample = upstream_model.where(col("city")=="Philly")
+    ...
+
+    # this too
+    import numpy as np
+    ...
+    
+    # your final 'select' statement
+    df = ...
+
+    # return a dataset, just like SQL — dbt takes care of the rest
+    return df
+```
+
+Once the beta is available, we'll want to hear everyone's thoughts. Our plan is to incorporate your thoughts, ideas, and feedback, as well as some complementary features we have in mind, as we build toward...
+
+## Act III: Unified Lineage (August–October)
+
+v1.3 takes us to Coalesce, where I might just manage to meet (some of) you in person for the very first time.
+
+The theme of this release will be **unifying lineage.** We're pulling some new pieces of transformation logic into dbt's execution model, and offering more ways to push the rich metadata from your project out into the world.
+
+Things like:
+- Python-language dbt models, ready for production
+- Native support for UDFs (https://github.com/dbt-labs/dbt-core/issues/136: an oldie, a goodie, and newly relevant!)
+- Improvements to exposures, and external nodes, and maybe those are actually the same thing? (https://github.com/dbt-labs/dbt-core/discussions/5073)
+
+What else? 'Tis not so sweet now as it was before? I think there will be lots to discuss, some to debate, things to try out, a few to throw away, and maybe just maybe we'll find ourselves with an expanded standard, a thing we're proud to still call dbt Core.
+
+Thoughts? For my part, I think **unit testing** model code becomes an even more pressing question when:
+- dbt models can be written in Python, a language that _wants_ to be unit-tested even more than SQL
+- dbt nodes (models?) can return _functions_, with testable inputs and outputs
+- dbt can be interacting with external services that live outside the database
+
+I rest well knowing we'll be better equipped to solve that problem, using all that we learn about Python-language models, and the components of the `pytest` framework that we put together in the first few months of the year.
+
+Of course, all of that will be in addition to the ongoing work that we're doing around metrics and the semantic layer, first previewed at last year's Coalesce. It's not my place to spoil any of the surprises there.
+
+## Act IV: Reflect and reinvest (November–January)
+
+v1.3 takes us through Coalesce, which is always a bit of an event horizon for the Product team at dbt Labs. Looking further than six months away, I'm only ~50% certain about which initiatives we'll be tackling into the new year. For now, I can share the ones that feel most important to me:
+
+**Better mechanisms for cross-project lineage** (https://github.com/dbt-labs/dbt-core/discussions/5244), to support large projects that should really be multiple projects. That would include support for namespaced models, at least in different packages. This is an initiative I care about a lot, and I'm trying to push up earlier if possible.
+
+**Building a SQL grammar**, or build compelling features on top of another open source one. Catch syntax errors at parse time, lint code, auto-format. Also, detect column-level lineage. This gets complicated, because of how some dbt models are templated dynamically, but I trust that we'll be able to find reasonable compromises when people are doing more-complex things to template model SQL.
+
+**Revisiting performance.** It will have been 2 years since we first began performance work in earnest, in November 2020. Then, we had the goal of speeding up dbt startup by 100x. Now, we should see where the bottlenecks are—I sense they're around database caching and cataloging. Then, we chose to write some low-lying parts of dbt-core in Rust, instead of Python. Now, with more clearly defined interfaces, it might make sense to rewrite some parts again.
+
+## Epilogue: What's missing?
+
+It's not all accounted for above. There are many important things we won't be able to build. I can name a few; I'm sure you have more than these, and I want to hear them.
+
+**Meaningfully rebuilding, rewriting, or reinvesting in the `dbt-docs` site.** We're going to keep this up & running, and we'll review community PRs—but we haven't built a team of Angular (!) engineers. The fact that `dbt-core` ships with an auto-generated documentation site is essential; the next-level version of this thing needs to be built on a more powerful engine than a static site reading JSON files.
+
+**DRYer configuration.** YAML reuse. Macros in `.yml` files. Vars of vars, and docs blocks on docs blocks. Why not solve it sooner? I think column-level lineage has a part to play here; anything we build before then risks emphasizing the wrong details. But I appreciate the real frustrations around config duplication and code generation in the meantime. dbt can be verbose, not unlike yours truly.
+
+**Native plugins for VS Code, PyCharm, Vim, ...**—I know. I want these things _very_ badly. I think the role of the Core team, first and foremost, is to solidify and harden the programmatic interfaces that I mentioned above. There's no sense building a thing on a rocky (let alone undocumented) foundation. This is also the best way for us to expand our reach: by enabling our colleagues, yes, and also partners, and also every member of the community with a hack day, to build better and cooler stuff, and build it with confidence. It's the kindness of strangers, and then some—it's open source.
+
+**What about `<issue that's been open since ...>`?** Tell me which one, and I'll give it another read. I'm `@jerco` in dbt Community Slack.

--- a/docs/roadmap/2022-08-back-for-more.md
+++ b/docs/roadmap/2022-08-back-for-more.md
@@ -1,0 +1,117 @@
+# dbt Core: Back for more (August 2022)
+
+Me again! As promised, three months later. Since I wrote to you in May, a few things have happened:
+
+- We released a new final version of dbt Core (v1.2)
+- We put out a beta of the next version (v1.3)
+- Two new colleagues on the Product team, Cody and Florian, joined me in imagining the future of dbt Core
+
+This update is going to be a touch shorter, as we have many fewer surprises to share. That's a good thing. We've been talking more in public about what we're building: on [the blog](https://www.getdbt.com/blog/), on [the other (cooler) blog](https://docs.getdbt.com/blog), at [Staging](https://www.getdbt.com/blog/staging-highlights-the-latest-from-dbt-labs/), and in [GitHub discussions](https://github.com/dbt-labs/dbt-core/discussions). And, while the meta conceit was good once ("welcome to my mind, it's an improvised play in four acts, how's that for stream[-of-consciousness] transformation"), I don't want to risk overdoing it.
+
+Here's what you came for:
+
+| Version | When          | Namesake<sup>a</sup>      | Stuff | Confidence<sup>b</sup>  |
+| ------- | ------------- | -------------- | ----- | ------------ |
+| 1.1 ✅   | April        | Gloria Casarez | Testing framework for dbt-core + adapters. Tools and processes for sustainable OSS maintenance. | 100% |
+| 1.2 ✅   | July         | Henry George   | Built-in support for grants. Migrate cross-db macros into dbt-core / adapters. Improvements to metrics. | 100% |
+| 1.3 🌀   | October      |                | Python models in dbt. More improvements to metrics. (Other things, too—but those are the main events.) | 95% |
+| 1.4 ⚒️    | Jan 2023     |                | Behind-the-scenes improvements to technical interfaces. A real, documented Python API/library, with an improved CLI to wrap it. Further investments in structured logging. | 80% |
+| 1.5+ 💡  | Next year<sup>c</sup> |                | Multi-project deployments: split up the monolith. The same DAG, more active: external orchestration. Python in dbt: next steps. Start imagining dbt Core v2. | 50% |
+
+`updated_at: 2022-08-31`
+
+<sup>a</sup>Always a [phamous Philadelphian](https://en.wikipedia.org/wiki/List_of_people_from_Philadelphia), true to our roots. If you have ideas or recommendations for future version namesakes, my DMs are open :)
+
+<sup>b</sup>dbt Core is, increasingly, a standard-bearer and direction-setter. We need to tell you about the things we're thinking about, long in advance of actually building them, because it has real impacts for the plans of data teams and the roadmaps of other tools in the ecosystem. We also know that we don't know now everything we will know a year from now. As new things come up, as you tell us which ones are important to you, we reserve the right to pivot. So we'll keep sharing our future plans, on an ongoing basis, wrapped in a confidence interval.
+
+<sup>c</sup>We're sticking with one minor version release per quarter, for the foreseeable. I haven't split those out here because, 6+ months into the future, we care more about the _what_ and the _why_ than the _when_. As we get closer, we'll be able to detail the more-specific functionality that might land in specific releases. Note too that these ideas, though we're already devoting meaningful time and effort to thinking through them, are not definite commitments.
+
+# Introducing…
+
+Two new Product Managers dedicated to thinking about dbt Core full time!
+
+Cody, Florian, could you say a few words of introduction? What brought you to dbt Labs? What are some things you're excited about doing here?
+
+> Cody: Hello! My name is Cody, or [@lostmygithubaccount](https://github.com/lostmygithubaccount). The first programming language I learned was Python, my background is in electrical engineering and data science, and my previous experience as a product manager centered around operationalizing machine learning systems (MLOps). I'm excited about empowering you to build intelligent systems, the role dbt Labs has to play in converging the data & AI stacks while breaking down organizational silos, and to work on open-source software with an awesome community supporting! 
+
+> Florian: Bonjour friends! You can find me around here under [@fleid](https://github.com/fleid). I started a long time ago as a SQL developer, writing monstrous queries to feed complex reports on top of operational databases. Version control was adding a version number in the filename of each report. No logic was shared across reports. Performance was horrendous. Overall data quality was… abysmal. Since then, by engaging in various communities I was able to learn a couple of neat tricks, like modern software engineering practices and dimensional modeling. So now I'm delighted to be able to contribute back to a community that supports a tool and a workflow that make these pitfalls obsolete. I only wish dbt existed all of these years ago! As for the future, I'm ramping up to help on the adapters, starting with a big backlog of issues and PRs that needs attention and love. I hope we can get to a better place, more reactive and ideally proactive, by end of the year. Please reach out if you've feelings or opinions to share about that space!
+
+(Jeremy again.) It's been a lot of fun to bring both of you into the fold over the past few months. The music does slow down when we add new chairs—there are processes that have become muscle memory for me, and turning those into collective endeavors takes time—but it's a thing worth doing. I can already say that our conversations have given me a huge boost of energy and excitement, in terms of what we can build together. We're grappling with some big questions—the biggest question being, what is dbt, *really?*—that I realize I've been taking for granted. I hadn't appreciated the risk that my old instinctive answers had calcified into constrained visions, or a GitHub issue comment from 2019 into binding precedent. Now that dbt Core is safely stable, it's the right time to ask those questions again. To start developing answers, always from the same principled viewpoint; to refine and critique them together; and to follow the logic where it leads.
+
+# Commentary
+
+Hopefully, you're already well aware of, and happily making use of, the capabilities that shipped in dbt Core v1.1 and v1.2 earlier this year. If you're not, the [upgrade guides](https://docs.getdbt.com/guides/migration/versions) are a good place to get up to speed.
+
+## v1.3 (October): Coalesce
+
+I got to see a very small number of you a few months ago at a London dbt meetup, where I presented May's edition of roadmap. I'm looking forward—we're all (!) looking forward—to seeing and talking with many more of you in October for [Coalesce](https://coalesce.getdbt.com/). For those who are able and comfortable to make the trip to New Orleans, London, or Sydney—and for all the many more who are planning on a "classic Coalesce" experience, from the comfort of your laptop—we're very excited to have you.
+
+The big thing coming in dbt Core v1.3 is support for Python models. You already knew that. All the details are in [the beta docs](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/python-models), so give 'em a read now if you haven't yet.
+
+There are a couple of FAQs (Frequently Associated Qualms) that I want to address, here and now, in case you're thinking one of them:
+
+**Will I need to know Python to start using dbt?** Not at all. At the same time, if you don't know it, and want to learn, that's great! The open source Python-for-data ecosystem is powerful, and often also overwhelming. We'll be creating resources to help light the way, plus highlighting guides, walkthroughs, and recommendations made by members of the community.
+
+**Is now the time to start experimenting with advanced statistical processing, predictive analytics, …?** Maybe! Or maybe not. Developing a solid, foundational set of data models should always come first. Deeply understand your data. Use it to power reliable analytical reporting. Whether you're ready to take the next step now or later, dbt is here to make it possible.
+
+**Does adding Python fundamentally change the nature of dbt Core?** Honestly, yes and no.
+
+- **No:** For all the SQL you're already writing and running successfully, we think you should keep it that way. SQL remains the most expedient and accessible way to write most forms of data transformation. We are *not* going to stop investing in dbt's support for SQL—and in Jinja as its templating engine, for the foreseeable future. (dbt-core v1.3 also includes a long-awaited upgrade to Jinja3, which should help folks installing alongside other Jinja-powered tools.)
+- **Yes:** Adding support for Python has clarified our thinking on multilingual dbt. It's helped us realize that the real value of dbt is not in Jinja-templated SQL. (Anyone can build that in a weekend; many have.) It's the framework, the environment-aware workflow, the DAG, the integrated testing and documentation—more things than I can name here. That's more language-agnostic than you might expect. At the same time, each language brings its strengths; there will be things you can do in Python that you cannot do in Jinja-SQL, and vice versa.
+
+Note that, while Python is the main event, it's not the only new thing coming in v1.3. Every release includes a bunch of exciting community contributions, and this one's got [something long awaited](https://docs.getdbt.com/reference/resource-configs/docs#custom-node-colors?version=1.3). We're also making improvements to metrics to support the launch of the **dbt Semantic Layer**. That's been a *huge* initiative, long in the works, and a long time coming. It's not my place to offer spoilers. I recommend you check out [Drew's blog](https://www.getdbt.com/blog/dbt-semantic-layer/), if you haven't already, and [join us for the show](https://coalesce.getdbt.com/).
+
+## v1.4 (January): For us, for you, for Core
+
+After Coalesce, we'll be taking stock of all that we built this year, and all we're looking to build next year. We are dedicating the months of November through January to dbt Core's technical foundations. (Plus: taking some well-deserved vacation over the holidays.)
+
+This work is comprised of two big initiatives:
+
+1. **API + CLI:** Improving and documenting dbt-core's internal Python APIs. Creating a new and better-constructed CLI to wrap around it. To be clear, this CLI will support all the same commands, flags, and arguments as it does today.
+2. **Event + logging interface.** Supporting type-safe, language-agnostic ways to ingest structured logs produced by dbt-core. This will enable other tools (ours and yours) to provide reliable observability around dbt runs, as well as more-digestible and realer-time metadata. Over a longer term, providing more information in log events where it's missing today.
+
+This is work that largely happens behind the scenes. If we do it well, the average dbt user should not notice any immediate differences. So why are we doing it?
+
+**If you use dbt Core's CLI,** this will make it easier to manage the growing number and complexity of command line options. To make sure all the right flags and options are supported on all the right commands; to add and update help text; and to automatically coordinate updated documentation that's been, to date, hand crafted by resident artisans.
+
+**If you build tools that wrap around dbt-core,** the appeal of a stable and documented API to its internals should be obvious. This is a long initiative, and we won't get to all of it right away, but the right idea is there. (And apologies, in advance, for the undocumented internal methods we'll be breaking in the process.)
+
+**If you use dbt Cloud,** Core's ability to provide stable and sensible interfaces is a big part of what enables differentiated capabilities in dbt Cloud in the future. It's not the coolest stuff in its own right, but a necessary precondition for that cool stuff to exist.
+
+**If you use dbt at all,** you should care about this work, insofar as it will make it easier for us to build more features faster next year. We want more people to join us in building dbt Core, and a welcoming codebase to greet them.
+
+## v1.5+ (Next year)
+
+If you've been following our GitHub discussions, or the Analytics Engineering roundup, none of these topics should come as too much of a surprise. They're neither definite commitments, nor the full set of things we expect to do next year. There's a lot of linear improvement to existing functionality that's always on our minds, and in our issues. But I want to start with the pair of ideas that we've been talking about nonstop, for which we're already dreaming up some code:
+
+1. **Multi-project deployments.** `ref` a final model from someone else's project, wherever they've put it, without the need to run it first. Split up monolithic projects of 5000 models into 10 projects of 500, grouped by team and domain. This is more than just "namespacing": to really solve for this, we also need to solve for versioning and contracts, and support a variety of deployment mechanisms. The discussion for this has been in [#5244](https://github.com/dbt-labs/dbt-core/discussions/5244); I'll have more to share over the next few months.
+
+2. **External orchestration.** The same dbt DAG, playing a more active role. We've been developing this idea internally, and have arrived at a few strong opinions. This would not be a new node type, but an upgrade to the ones we already have: sources, models, and exposures. Sources that can trigger their own ingest. Exposures that can trigger downstream data consumers (syncs, sinks, etc). Models that can define and run transformations in dedicated execution environments, reading from and writing back to centralized data storage. For each of those external integrations, a simple request where possible, and a dedicated plugin where justified. If you're someone who followed along the original "external nodes" discussion ([#5073](https://github.com/dbt-labs/dbt-core/discussions/5073))—especially if you've got a tool you'd be excited to integrate into dbt's DAG—let's talk.
+
+---
+
+We also intend to keep pushing on existing capabilities in dbt Core. Again, a non-exhaustive list:
+
+**Python models, only just beginning.** What's the right DataFrame API to standardize on? Should dbt have a role in managing packages, model training, artifacts? Eventually, a full "MLOps" workflow? v1.3 in October will be our first foray, not the final story. Cody just opened some GitHub discussions, starting with [#5742](https://github.com/dbt-labs/dbt-core/discussions/5742). See what we're thinking, and weigh in.
+
+**Adapters, adapters, adapters.** We want to make it easier to build, test, and validate support for dbt on a new database, query engine, or runtime environment. We want to support more than one adapter for use in a single dbt-core invocation. We want to keep honing the performance of caching, cataloging, and incremental processing at scale, across data platforms. We want to offer more adapters in dbt Cloud.
+
+**Imagining dbt Core v2.** Last December, when announcing the v1.0 release, I predicted (wildly guessed) that dbt v2.0 would take 2-4 years to reach us (2023-2025). Then I put some things on a slide, asking everyone to imagine:
+- *dbt-SQL: The same capabilities. No Jinja.*<sup>1</sup>
+- *The docs are always ready.*<sup>2</sup>
+- *One dbt run across many databases and query engines.*<sup>3</sup>
+- *Define your own tasks for the dbt DAG.*<sup>4</sup>
+
+Most of that still feels about right. I don't see us ending next year with a v2.0 final release, but I do see us having a clear picture of what v2 will look like. In a sense, we've already started the work to get there, by combing our way through the rougher edges of v1.
+
+I'm excited for the next few months. I hope you are too.
+
+---
+
+<sup>1</sup>Now, I wonder if the answer is: Jinja-SQL and Python are just two of many supported languages for dbt Core. Some languages will make it dead-easy to unit test, to transpile across different databases, to infer column-level lineage. Others make it possible to run introspective queries that dynamically template transformation logic. It's an exciting future to consider. The challenge is to be clear and opinionated about what each one brings to the table, and when each one shines.
+
+<sup>2</sup>Real-time metadata; see above.
+
+<sup>3</sup>External orchestration; see above.
+
+<sup>4</sup>This one, I'm not so sure! The task before us is the same as it ever was: build the DAG, as fast as possible, just what's needed, when it's needed. Still, I keep  more advanced use cases that want to programmatically create, manipulate, and invoking the dbt DAG—and they may well be more plausible in a future where dbt-core has a documented, contracted set of internal APIs. That would be advanced-level stuff, guardrails not included. You probably don't need (or want) it, and if you do, you know it.

--- a/docs/roadmap/2023-02-back-to-basics.md
+++ b/docs/roadmap/2023-02-back-to-basics.md
@@ -1,0 +1,110 @@
+# dbt: Back to basics (February 2023)
+
+We're back, and there's a lot to say—so much that if we're not mindful, we risk writing a(nother) novella. We're going to try for concision this time; it's a year of focus. Of course, a lot more has already been written, so we'll also link to those issues & discussions, where we encourage you to weigh in with thoughts.
+
+Since last August, we've released two new versions of dbt Core:
+- v1.3 unleashed Python models onto the world. This is very new functionality, and we are still gathering feedback on where to go next. Read & comment on [the big ideas](https://github.com/dbt-labs/dbt-core/discussions/categories/ideas?discussions_q=label%3Apython_models+category%3AIdeas).
+- v1.4 reworked some internals, paid down some tech debt, and paved the way for better APIs going forward.
+
+| Version | When | Namesake | Stuff |
+| ------- | ------------- | -------------- | ----- |
+| 1.3 ✅ | Oct 2022 | Edgar Allen Poe | Python models in dbt. More improvements to metrics. |
+| 1.4 ✅ | Jan 2023 | Alain LeRoy Locke | Behind-the-scenes improvements to technical interfaces, especially structured logging. |
+
+This year, we're returning to our fundamentals. This means fewer big surprises—fewer new answers to the question, "What is dbt?"—and more of the things that dbt needs—the dbt that you know, the dbt that you & your teams have come to rely on for getting your job done.
+
+There are four big themes we want to tackle, reflected in the questions below. We will aim to provide compelling answers, sometimes with new functionality, sometimes with polish on top of existing capabilities. These aren't the only questions that interest us, but they are the ones we're prioritizing this year.
+
+1. **Our APIs.** How can we enable the thousands of people who want to use dbt today, ? Can we enable community members to build more powerful extensions of dbt's framework, by exposing more & more of its functionality as a stable Python library? Can we provide an experience as delightful as dbt-core's CLI, via a reliable `dbt-server`, and RESTful APIs in dbt Cloud?
+2. **Your models, as APIs.** Can dbt as a framework scale to complex deployments, across multiple teams, entering their third or fourth year of project maturity? Can it scale to some of the largest organizations who have adopted it as a standard pattern? What can we learn from the scaling challenges that software teams have encountered and surmounted over the last decade?
+3. **Streaming.** How must dbt's essential building blocks—models, tests, sources, materializations—change (or not) to finally leverage data platforms' capabilities around streaming transformation?
+4. **Semantic Layer.** How can we combine the existing power of dbt metrics, defined as an extension of your dbt DAG, with the depth of MetricFlow (!) as a framework for defining richer metrics and generating optimized queries?
+
+In a sentence: **The same dbt, for more people.** More community members who might build plugins and extensions, without having to read `dbt-core` source code and hack together undocumented internal methods. More embedded analysts who can confidently contribute the right change to the right model in the right project, without having to first navigate through thousands of preexisting models with unclear ownership. More use cases that can be solved in "the dbt way," for batch as well as streaming. More downstream queriers who can benefit from asking questions on top of a dbt Semantic Layer.
+
+We're sticking with one minor version release every three months. There won't be a version dedicated to _just_ API improvements, multi-project deployments, streaming, or semantic layer. Rather, we expect to make incremental progress as we go along. With that, here's our near-sighted lay of the land:
+
+| Version | When          | Stuff          | Confidence |
+| ------- | ------------- | -------------- | ---------- |
+| 1.5 ⚒️ | April | An initial Python API for programmatic invocations, and a cleaner CLI to match. The beginning of multi-project deployments ("Models as APIs"), and of support for streaming (materialized views). | 95% |
+| 1.6 🌀 | July | Next steps for multi-project deployments (cross-project `ref`, project-level namespacing, patterns for development & deployment). Continue the story around stream processing (materialized tests, managed sources). Integrating dbt metrics and MetricFlow. | 75% |
+| 1.7 | October | More on the same themes. The details will be based on velocity, feedback, and emergent discoveries. | 50% |
+| 1.8+ 💡 | 2024 | dbt-core as a library. A sketch of dbt v2. | 25% |
+
+
+`updated_at: 2023-02-28`
+
+As always, to keep track of what's happening between these roadmap updates:
+- [Milestones](https://github.com/dbt-labs/dbt-core/milestones)
+- [GitHub discussions](https://github.com/dbt-labs/dbt-core/discussions)
+- [Company blog](https://blog.getdbt.com/) & [dev blog](https://docs.getdbt.com/blog)
+
+Don't forget to ~~like and subscribe~~ [upgrade](https://docs.getdbt.com/guides/migration/versions)!
+
+# Commentary
+
+Let's keep it brief!
+
+## A Python API for dbt-core
+
+dbt Core v1.5 will include:
+- A new CLI, based on `click`, with improved help text & documentation
+- Support for programmatic invocations, via a Python API, at parity with CLI functionality
+
+Is this it? I don't think so. We have a longer-term vision of dbt-core as a mature software library, with clear interfaces and plugin points.
+
+We aren't going to get all the way there by April. We will have a subset of capabilities that will enable a number of cool things for many. I believe we will be able to get there, over the next year, with carefully scoped initiatives tied to clear outcomes. We've been developing & sharing our visions as a team, and we'll have more to share over the coming months.
+
+_Read more: ["dbt-core as a library: first steps"](https://github.com/dbt-labs/dbt-core/issues/6356)_
+
+## Multi-project deployments (v1.5+)
+
+Here are three guiding principles:
+1. Each team owns its data, and how that data is shared with other teams.
+2. Organizations can maintain central governance, coordinating rules across teams.
+3. All models are in one DAG.
+
+These are not necessarily the doctrine of "dbt mesh," but we are using them to describe the end state we're hoping to achieve, the core capabilities we need to unlock it, and the user flows (person-to-person, team-to-team, person-to-dbt) we want to facilitate along the way.
+
+Each person interacts with the subset(s) of the DAG relevant to them. Developing and deploying dbt should feel the same.
+
+The first step here is giving teams maintaining dbt projects the tools to start serving models as "APIs." The coup de grâce is being able to `ref` another team's stable, public, contracted model as the starting point for your own.
+
+_Read more: ["Multi-project deployments"](https://github.com/dbt-labs/dbt-core/discussions/6725) & linked discussions_
+
+## Support for streaming
+
+Back in 2020, one of Jeremy's very first projects, as newly designated Associate Product Manager, was investigating the implementation of Materialized Views across our most popular data platforms. The findings: while the dream of MVs was a happy one, every real MV was unhappy in its own way, motivated by different use cases and beset by subtle limitations.
+
+A few years later, the major data platform vendors are taking another swing at first-class support for streaming transformation. We're also lucky to have Florian, who talked & thought streaming databases for a living. Our vision is a dbt DAG that can combine batch & streaming, without distorting the core framework that's gotten dbt where it is.
+
+_Read more: ["Let's add Materialized View as a materialization, finally"](https://github.com/dbt-labs/dbt-core/issues/6911)_
+
+## dbt Semantic Layer
+
+We've officially welcomed many new colleagues from Transform. We're going to be spending time over the next several weeks talking about how to integrate dbt Core's existing metrics spec with MetricFlow's.
+
+We expect to be writing much more about this in public. Until then, you can read our previous thinking. The specifics are liable to change, but the foundational concept still holds: ["dbt should know more semantic information"](https://github.com/dbt-labs/dbt-core/discussions/6644)
+
+## What's **not** here?
+
+In 2023, we need to be focused & disciplined. There's a lot we wish we could be making progress on, but we can only guarantee that progress in a precious few areas, by devoting our attention & energy to them.
+
+Each of the topics below has appeared in the lower-confidence portions of previous roadmaps, and they continue to interest us greatly. We have all been guilty of saying, "Let's just take a day—just one day!—and try to hack together a working demo." You might even see some proof-of-concept code appear, here or there. We won't turn down opportunities to take small steps, to make incremental forward progress. But none of these is something we expect us to be launching at Coalesce in October.
+
+- **External orchestration.** Can dbt trigger external APIs to ingest `sources`, and sync `exposures`? To run `models` that require tools outside the data platform? I'd like the answer here to be "yes," but it isn't a priority for this year.
+- **Next steps for Python models.** It's worth restating: This is very new functionality, and we're still very early. We have some ideas of what could be compelling and ergonomic, and there are some small usability improvements we'll try to make over the year—but we need to learn more about how you all are using, and want to be using, Python models, before we once again tackle these as a top priority.
+- **More modeling languages**, or "Bring Your Own SQL transpiler / Python framework / ???". This is one of the more boundary-pushing ideas we've had, for continuing to expand dbt's reach as a framework for (language-agnostic!) data transformation. It's not one of the foundational reinvestments that we must make sooner rather than later. We've also [discussed this pattern](https://github.com/dbt-labs/dbt-core/discussions/4458#discussioncomment-4176217) as one potential path toward unlocking **column-level lineage,** which—while always present in our hearts & among our [most popular discussions](https://github.com/dbt-labs/dbt-core/discussions?discussions_q=sort%3Atop+)—also doesn't appear on this year's list of top priorities.
+- **Unit testing.** ~Let's just take a day—just one day!—and try to hack together a working demo.~ (We might, though.)
+
+## What we'll keep doing
+
+This covers the big rocks. The pebbles and the sand, we already have our ~~mouths~~ hands full. Most of the time, it's even fun.
+
+We'll keep releasing patches with fixes for bugs and any regressions that crop up in new versions of dbt-core.
+
+We'll keep a swimlane open for developer ergonomics. Not fundamental changes to the dbt framework, but quality-of-life improvements for those who use it every day. We've created [a new label to track these "paper cuts"](https://github.com/dbt-labs/dbt-core/issues?q=is%3Aissue+is%3Aopen+label%3Apaper_cut+sort%3Areactions-%2B1-desc)—often among the most upvoted issues!—and we're very interested in supporting community members who want to help us refine & contribute these improvements.
+
+We'll keep reading & responding to your issues, bug reports, feature requests, ideas. We can't respond to every comment everywhere, but we read them all. You come to dbt, and so we build it & keep building it—with ambition & with vision, with discipline & with focus.
+
+Yours truly - Jeremy, Florian, Doug, & the entire Core team

--- a/docs/roadmap/2023-11-dbt-tng.md
+++ b/docs/roadmap/2023-11-dbt-tng.md
@@ -1,0 +1,107 @@
+# dbt: The Next Generation (November 2023)
+
+To everyone we saw at [Coalesce](https://coalesce.getdbt.com/) last month: thank you for joining us! We got up on stage and shared the next chapters from this year’s featured stories: about [collaborating across multiple teams and projects at scale](https://www.youtube.com/watch?v=NIseH-Gd-U4); about [relaunching the dbt Semantic Layer](https://www.youtube.com/watch?v=2Qo5_CIsSH4); about [more flexibility in development](https://www.youtube.com/watch?v=UfraDWKsSvU); and about [more mature CI/CD](https://www.youtube.com/watch?v=3sp6tmYykVc). To anyone who missed us live, [catch us on the replays](https://www.youtube.com/@dbt-labs)!
+
+These are stories that span both dbt Core and dbt Cloud. Our aim is to push forward the open source standard for analytics engineering, and also the platform that makes it possible for more teams to adopt & deploy dbt at scale.
+
+In [his keynote presentation](https://youtu.be/lNZLcsHAdco?si=FdtTOOIokvm1pT8D&t=637), Tristan talked about these two priorities for dbt Labs. We remain committed to dbt Core, as a standard for the industry, and an open source project under an Apache 2 license. We are also committed to creating a business around dbt Cloud that is sustainable over the long term, to enable us to continue to invest in driving dbt forward.
+
+Those two goals are inseparable. To make them both happen, we need to strike an important balance. What has it looked like over the last six months, and what will it look like for the six months ahead?
+
+_[JC](https://github.com/jtcohen6) & [GG](https://github.com/graciegoheen)*_
+
+> *Also, hi! I’m Grace Goheen, or [@graciegoheen](https://github.com/graciegoheen). Long time dbt user, new to the dbt Core product team. I joined the Professional Services team at dbt Labs back in 2021, where I’ve since had the opportunity to work hands-on in dozens of dbt projects - leading legacy migrations, consulting on architecture, optimizing project performance, and more. I lived through the joy (lineage! testing! documentation!) and pain (spaghetti DAGs! model bottlenecks! debugging code!) of being an analytics engineer, and realized I wanted to be a part of shaping the tool at the center of it all. So here I am, the newest Product Manager of dbt Core! I am so grateful to be building this industry-defining tool with all of you.
+> 
+
+# The last six months: scale
+
+| Version | When | Namesake | Stuff |
+| --- | --- | --- | --- |
+| [v1.5](https://docs.getdbt.com/guides/migration/versions/upgrading-to-v1.5) | April | [Dawn Staley](https://github.com/dbt-labs/dbt-core/releases/tag/v1.5.0#:~:text=Dawn%20Staley%20(b.%201970)) | Revamped CLI. Programmatic invocations. Model governance features (contracts, access, groups, versions). |
+| [v1.6](https://docs.getdbt.com/guides/migration/versions/upgrading-to-v1.6) | July | [Quiara Alegría Hudes](https://github.com/dbt-labs/dbt-core/releases/tag/v1.6.0#:~:text=Quiara%20Alegr%C3%ADa%20Hudes%20(b.%201977)) | New Semantic Layer spec. More on model governance (deprecations). Saving time and $$ with retry + clone. Initial rollout of materialized views. |
+| [v1.7](https://docs.getdbt.com/guides/migration/versions/upgrading-to-v1.7) | November | <a href="https://github.com/dbt-labs/dbt-core/releases/tag/v1.7.0#:~:text=%238692)-,Questlove%20(b.%201971),-Thanks%20to%20%40dave">Questlove</a> | More flexible access to "applied state" in docs generate and source freshness. Improvements to model governance & semantic layer features (driven by user feedback). |
+
+We added a **lot** of stuff this year! Over the past three dbt Core minor versions, we’ve managed to knock out a litany of the most popular issues and discussions gathered over the past several years:
+
+- [CLI preview](https://github.com/dbt-labs/dbt-core/discussions/5418) (1.5)
+- [Invoking dbt as a Python module](https://github.com/dbt-labs/dbt-core/issues/2013) (1.5)
+- [Materialized views](https://github.com/dbt-labs/dbt-core/issues/1162) (1.6)
+- [Namespacing for dbt resources](https://github.com/dbt-labs/dbt-core/issues/1269) (1.6), in support of [multi-project collaboration](https://github.com/dbt-labs/dbt-core/discussions/6725)
+- [`docs generate --select` for slimmer catalog queries](https://github.com/dbt-labs/dbt-core/issues/6014) (1.7)
+- And… we’re finally taking aim at [unit testing for dbt-SQL models](https://github.com/dbt-labs/dbt-core/discussions/8275) (!), coming in 1.8, which you should read more about in the section below.
+
+Thank you for providing your upvotes, comments, and feedback. One of the best things about building dbt Core in the open is that we are all pushing forward the analytics engineering standard together. We’re able to prioritize these features and paper cuts because of your participation. 
+
+We’ve got lots more to build - there are some highly upvoted issues and discussions that remain, and gaps in the analytics engineering workflow that we want to close. But before we keep building, we must ensure our foundation is a **stable** one.
+
+# The next six months: stability (& unit testing!)
+
+| Version | When | Stuff | Confidence |
+| --- | --- | --- | --- |
+| 1.8 | Spring 2024 | Stable interfaces for adapters & artifacts. Built-in support for unit testing dbt models. | 80% |
+
+Since the v1.0 release of dbt Core (almost two years ago), we’ve released a minor version of dbt Core every three months. The January release (post-Coalesce, post-holidays) tends to be an understated affair: tech debt, bug fixes, support for Python 3-dot-new.
+
+We’ve been measuring the rate of adoption for new versions, and we’ve seen that it takes more than 3 months for the wider user base to really adopt them. The plurality of dbt projects in the world are using a dbt Core version released between 6 and 12 months ago. We think this speaks to two things: It’s harder to upgrade than it should be.; and we can afford to take more time baking new releases.
+
+Between now and next April (2024), we plan to instead prepare **one** minor release that prioritizes **all-around interface stability**. We want to make it easier for _everyone_ to upgrade with confidence, regardless of their adapter or other integrated tooling. There is a _lot_ of value locked up in the features we’ve already released in 2023, and we want to lower the barrier for *tens of thousands* of existing projects who are still on older versions. That work is important, it takes time, and it has long-lasting implications.
+
+### Adapters & artifacts
+
+With the v1.0 release, [we committed](https://www.getdbt.com/blog/getting-ready-for-v1-0) to minimizing breaking changes to project code, so that end users would be able to upgrade more easily. We haven’t perfected this, including earlier this year when we did a full relaunch of the metrics spec for the Semantic Layer. We are committed to getting better here.
+
+Even in v1.0, though, we intentionally carved out two less-stable interfaces, which would continue to evolve in minor releases: **adapter plugins** and **metadata artifacts**. At the time, these interfaces were newer and rapidly changing. Almost every minor version upgrade, from v1.0 through v1.7, has required some fast-follow compatibility changes for adapters and for tools that parse dbt manifests.
+
+This has been particularly difficult for adapter maintainers. As of this writing, while [the majority of third-party adapters support v1.4](https://github.com/dbt-labs/dbt-core/discussions/6624#discussioncomment-5663823) (released in January), [just over a third support v1.5](https://github.com/dbt-labs/dbt-core/discussions/7213#discussioncomment-5663790) (April), and [only a handful support v1.6](https://github.com/dbt-labs/dbt-core/discussions/7958#discussioncomment-6310276) (July). It isn’t fair of us to keep releasing in a way that *requires* this reactive compatibility work every 3 months. Instead, we will be defining a stable interface for adapters, in a separate codebase and versioned separately from dbt Core. Starting in v1.8, it will be forward-compatible for future versions. If you want to use `dbt-core` v1.X with `dbt-duckdb` v1.Y, you will be able to.
+
+For most people, we don’t want you to have to think about versions _at all_: just use latest & greatest dbt Core. For customers and users of dbt Cloud, this is the experience we want to provide: delivering dbt Core and dbt Cloud together, as one integrated and continuously delivered SaaS application — an experience where you don’t need to think about versions or upgrading, and where you get access to Cloud-enhanced & Cloud-only features as a matter of course.
+
+**An aside:** This was the first year in which we delivered [some functionality like that](https://github.com/dbt-labs/dbt-core/discussions/6725): built it in such a way that it _feels like Core_ while being actually powered by (and exclusive to) dbt Cloud. This has long been our pattern: Core defines the spec, and Cloud the scalable implementation, especially for Enterprise-geared functionality. 
+
+I (Jeremy) wish I had communicated this delineation more clearly, and from the start. We are going to continue telling unified stories, across mature capabilities in Core and newer ones in Cloud, and we want all of you — open source community members, Cloud customers, longtime data practitioners and more-recent arrivals — to know that you are along for this journey with us.
+
+### Summary: continuous & stable delivery
+
+Over the next 6-12 months, we will be spending less time on totally new constructs in dbt Core, and more time on the fundamentals that are already there: stabilizing, maintaining, iterating, improving.
+
+dbt Cloud customers will see enhancements and under-the-hood improvements delivered continuously, as we move towards this model of increased stability. Features that fit inside dbt Core’s traditional scope will also land in a subsequent minor version of dbt Core.
+
+This is an important part of our evolving story: a compelling commercial offering that makes it possible for us to keep developing, maintaining, and distributing dbt Core as Apache 2 software.
+
+## Onwards
+
+dbt Core is as it has always been: an open source standard. It’s a framework, a coherent set of ideas, and a fully functional standalone tool that anyone can take for a spin — adopt, extend, integrate, imitate — without ever needing to ask us for permission. Adapters will keep moving at the pace of innovation for their respective data warehouse. dbt Docs remains a great "single-player" experience for getting hooked on data documentation. (The aesthetic isn’t dated, it’s *[retro](https://github.com/lightdash/dbt-docs-95).*) dbt Core remains the industry-defining way to author analytical models and ensure their quality in production.
+
+But wait!
+
+As many of you have voiced, there’s been no good way to ensure your SQL logic is correct without running expensive queries against your full production data. dbt does not have native unit testing functionality… yet. This gap in the standard is one we have been eager to work on, and we’re planning to land it in the next minor release of dbt Core.
+
+### What is unit testing in dbt?
+
+For many years, dbt has supported "data" tests — testing your *data outputs* (dbt models, snapshots, seeds, etc.) based on that environment’s actual *inputs* (dbt sources in your warehouse), and ensure the resulting datasets match your defined expectations.
+
+Soon, we’re introducing "unit" tests — testing your modeling *logic,* using a small set of static inputs, to validate that your code is working as expected, faster and cheaper.
+
+### What’s the plan?
+
+Thank you to everyone who has already provided feedback and thoughts on our [unit testing discussion](https://github.com/dbt-labs/dbt-core/discussions/8275) — or, we should say our _new_ unit testing discussion, since Michelle opened the [original one](https://github.com/dbt-labs/dbt-core/discussions/4455) back in 2020, before she joined dbt Labs :)
+
+We truly appreciate the amount of insights and energy y’all have already poured into helping us make sure we build the right thing.
+
+We are actively working on this feature and expect it to be ready for you all in our `1.8` release next year! If you have thoughts or opinions, please keep commenting in the discussion. We’re also planning a community feedback session for unit testing once we’ve released an initial beta of `1.8`, so keep an eye out.
+
+### Bugs, regressions, paper cuts, ...
+
+We will continue to respond to your issues and review your PRs. We will continue to resolve regressions and high-priority bugs, fast as we’re able, and include those fixes in regular patch releases.
+
+Along with fixing bugs and regressions, we’d also like to keep tackling some of the highly requested "paper cuts”. Thank you to all those who have expressed their interest by upvoting and commenting.
+
+We’re unlikely to tackle all of these things in v1.8 — they’re lower-priority than the interface stability work, which we must do — they are all legitimate opportunities to solidify the existing, well-established Core functionality:
+
+- [Allow data tests to be documented](https://github.com/dbt-labs/dbt-core/issues/2578)
+- [Snapshot paper cuts](https://github.com/dbt-labs/dbt-core/discussions/7018)
+- [Making external tables native to dbt-core](https://github.com/dbt-labs/dbt-core/discussions/8617)
+- [Defining vars, folder-level configs outside `dbt_project.yml`](https://github.com/dbt-labs/dbt-core/issues/2955)
+- [Supporting additional formats for seeds](https://github.com/dbt-labs/dbt-core/issues/2365) (JSON)
+
+Let us know which ones speak to you — in that list, not in that list, the ideas in your head — on GitHub, on Slack, or wherever you may find us.

--- a/docs/roadmap/2024-12-play-on.md
+++ b/docs/roadmap/2024-12-play-on.md
@@ -1,0 +1,207 @@
+# dbt: Play On (December 2024)
+
+Oh hi there :)
+
+We’ve had the opportunity to talk a lot about our investments in open source over the past few months:
+
+- [I [Grace] renewed my vows with the dbt Community in a Vegas wedding ceremony officiated by Elvis](https://youtu.be/DC9sbZBYzpI?si=uK9Aie6Jl-FIHggm) (aka [@jtcohen6](https://github.com/jtcohen6)).
+- [We spoke about dbt Labs’ continued commitment to Open Source in the Coalesce Keynote](https://youtu.be/I72yUtrmhbY?si=Iu6s9WXdHnFtyCvi).
+- [We wrote about the importance of extensibility for how we build features in dbt Core.](https://www.getdbt.com/blog/dbt-core-v1-9-is-ga#:~:text=Extensibility%20is%20what%20powers%20the%20community)
+
+All of these points and themes remain incredibly relevant to our team and are fueling our vision as we prepare for the new year:
+
+- we're committed to defending dbt Core as the open source standard for data transformation, which will remain licensed under Apache 2.0
+- the dbt framework will continue to be shaped by a collaborative effort between you (the community) and us (the maintainers)
+- when we add something new to the standard, we are committing to the long term, which means we are intentional about *how* and *when* we expand its breadth - in the meantime, lean into dbt's extensibility (and show us how you're doing it!)
+
+Now that we’ve gotten into our new rhythm…
+
+Now that last year’s focus on stability has earned us the right to ship awesome new additions to the dbt framework…
+
+Now that we’re actually seeing a *much* higher % of projects running the latest & greatest dbt…
+
+…the next 6-12 months will feel similar to the last. dbt will keep getting better at doing what it does - being a mission-critical piece of your data stack, and a delightful part of your work. To that end, stability always comes first. And, we will be shipping some exciting new features to dbt Core. 
+
+# Oh What A Year It’s Been!
+
+This year, we released two new minor versions of dbt Core.
+
+| **Version** | **When** | **Namesake** | **Stuff** |
+| --- | --- | --- | --- |
+| [v1.8](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v1.8) | May | [Julian Abele](https://github.com/dbt-labs/dbt-core/releases/tag/v1.8.0) | Unit testing. Decoupling of dbt-core and adapters. Flags for managing changes to legacy behaviors. |
+| [v1.9](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v1.9) | December | [Dr. Susan La Flesche Picotte](https://github.com/dbt-labs/dbt-core/releases/tag/v1.9.0) | Microbatch incremental strategy. New configurations and spec for snapshots. Standardizing support for Iceberg. |
+
+In the [last roadmap post](https://github.com/dbt-labs/dbt-core/blob/main/docs/roadmap/2023-11-dbt-tng.md), we committed to prioritizing all-around interface stability. This included decoupling dbt-core and adapters, introducing [behavior change flags](https://docs.getdbt.com/reference/global-configs/behavior-changes) to give you time to adjust to ~~breaking~~ changes, and improving the stability of metadata artifacts. You can read more about those efforts [here](https://docs.getdbt.com/blog/latest-dbt-stability).
+
+Stability means you can upgrade with confidence. 
+
+Stability means less disruptions for our adapters and integrations in the dbt ecosystem.
+
+Stability means we’ve earned the right to **ship some big new features**.
+
+This past year, we were able to ship some long-awaited additions and enhancements to the dbt Core framework:
+
+- [**Unit tests**](https://github.com/dbt-labs/dbt-core/discussions/8275) allow you to validate your SQL modeling logic on a small set of static inputs before you materialize your full model in production.
+- [**Snapshots**](https://github.com/dbt-labs/dbt-core/discussions/7018) got the glow up they deserved - with new configurations and spec to make capturing your data changes easier to configure, run, and customize.
+- [**Microbatch**](https://github.com/dbt-labs/dbt-core/discussions/10672) incremental models enable you to optimize your largest datasets, by transforming your timeseries data in discrete periods with their own SQL queries, rather than all at once.
+- [**Iceberg**](https://docs.getdbt.com/blog/icebeg-is-an-implementation-detail) table format (an open standard for storing data and accessing metadata) is standardized across adapters, enabling you to store your data in a way that promises interoperability with multiple compute engines.
+
+We also were able to close out some highly-upvoted “paper cuts”:
+
+- `--empty` flag limits the `ref`s and `source`s to zero rows, which you can use for schema-only dry runs that validate your model SQL and run unit tests
+- dbt now issues a single (batch) query when calculating source freshness through metadata, instead of executing a query per source
+- improvements to `state:modified` help reduce the risk of false positives due to environment-aware logic
+- you can now document your data tests with `description`s
+
+A lot of these features are things that you (the community) have been discussing and experimenting with for years. To everyone who opened an issue, commented on a discussion, joined us for a feedback session, developed a package, or contributed to our code base… however you made your voice heard this year, **thank you** for continuing to care, for continuing to lean in, for continuing to help shape dbt. 
+
+# New Year’s Resolutions
+
+To start off the new year, we’re focusing on three major areas of development to the dbt framework:
+
+- **typed macros** - configure Python type annotations for better macro validation
+- **catalogs** - first-class support for materializing dbt models into external catalogs, providing a warehouse-agnostic interface for managing data in object storage
+- **sample mode** - limit your data to smaller, time-based samples for faster development and CI testing
+
+## Typed Macros
+
+In the simplest terms, [macros](https://docs.getdbt.com/docs/build/jinja-macros#macros) are are pieces of code, written in Jinja, that can be reused throughout your project – they are similar to "functions" in other programming languages. 
+
+In practice, you can reference a macro in a model’s SQL (or config block, or hook) to:
+
+- make your SQL code more DRY by abstracting snippets of SQL into reusable “functions”
+- use the results of one query to generate a set of logic
+- change the way your project builds based on the current environment
+
+Or, if you really need to, run arbitrary SQL in your warehouse via `dbt run-operation`.
+
+Macros can depend on inputs, vars, `env_vars`, or even other macros — *and* there are “special” macros for defining custom generic tests and materializations.
+
+This immense flexibility is one of the great benefits of macros — you can use them to solve **a lot** of different problems.
+
+However, on the flip side, this flexibility — where macros can be whatever you want them to be — makes it challenging to validate that your macros are doing what you expect. 
+
+Without a way to define expected types for the inputs and outputs of macros, our adapter maintainers struggle to validate that a built-in macro override will produce the correct output. Furthermore, *any* analytics engineer writing a macro in dbt should be able to validate the expected behavior. 
+
+One of the things we aim to work on in the coming months is an interface for **typed macros.** 
+
+Imagine being able to codify the expected types* for the inputs and outputs for your macros:
+
+```sql
+{% macro cents_to_dollars(column_name: str, scale: int = 2 -> str) %}
+	({{ column_name }} / 100)::numeric(16, {{ scale }})
+{% endmacro %}
+```
+
+**Note: These are a subset of Python types (internal to dbt), not the data types within the data warehouse.*
+
+Then, we could issue warnings at parse time when usage of a macro violates these types. By adding the ability to configure type expectations, user-created macros become more predicable, and [built-in macros become easier to override](https://github.com/dbt-labs/dbt-core/issues/9164). 
+
+Should this type checking be on by default, or something you opt into? Should we also support dbt-specific types, such as `Relation`? Head over to the [github discussion](https://github.com/dbt-labs/dbt-core/discussions/11158) to participate in the conversation!
+
+## Catalogs
+
+In `v1.9`, we shipped a set of standard configs to materialize dbt models in Iceberg table format:
+
+```sql
+{{
+  config(
+    materialized = "table",
+    table_format = "iceberg",
+    external_volume = "s3_iceberg_snow"
+  )
+}}
+
+...
+```
+
+Supporting the Iceberg table format was our first step towards empowering users to adopt Iceberg as a standard storage format for their critical datasets.
+
+In the coming months, we want to add first-class support for “catalogs” in dbt. “Catalogs,” including Glue or Iceberg REST, operate at a level of abstraction above specific Iceberg tables — and they can provide a warehouse-agnostic interface for managing a large number of datasets in object storage. 
+
+Imagine a new top-level `catalogs.yml` that tells dbt about the catalog integrations you want to write to:
+
+```yaml
+catalogs:
+  - catalog_name: my_first_catalog
+    write_integrations:  
+      - integration_name: prod_glue_write_integration
+        external_volume: my_prod_external_volume
+        table_format: iceberg
+        catalog_type: glue	    
+```
+
+Then, in your model’s configuration, simply specify the `catalog` field:
+
+```sql
+{{
+  config(
+    catalog = "my_first_catalog"
+  )
+}}
+
+...
+```
+
+These new configurations will enable dbt to template the correct DDL statements for the platform (`CREATE GLUE ICEBERG TABLE` vs. `CREATE ICEBERG TABLE`, etc.). Now, when you run the above model, it will be materialized as an Iceberg table in s3 registered in the AWS Glue catalog. 
+
+We believe the approach of writing datasets to a platform-agnostic storage layer, and registering those datasets with a similarly agnostic *catalog service,* will become important to the technical foundations of the dbt workflow — the [Analytics Development Lifecycle (ADLC)](https://www.getdbt.com/resources/guides/the-analytics-development-lifecycle) — moving forward. Support for materializing Iceberg tables in external catalogs is another step down this path.
+
+To read more about catalogs and participate in shaping this feature, head over to the [discussion on GitHub](https://github.com/dbt-labs/dbt-core/discussions/11171)!
+
+## Sample Mode
+
+We began our [“event_time” journey](https://github.com/dbt-labs/dbt-core/discussions/10672) with microbatch incremental models. Next up is [sample mode](https://github.com/dbt-labs/dbt-core/discussions/10672#:~:text=%F0%9F%8C%80%5BNext%5D%20%E2%80%9CSample%E2%80%9D%20mode%20for%20dev%20%26%20CI%20runs) - we want to support a pattern for speeding up development and CI testing by filtering your dataset to a *time-limited sample.* 
+
+Imagine your model contains a `ref` statements like so:
+
+```sql
+select * from {{ ref('fct_orders') }}
+```
+
+During standard runs, this compiles to:
+
+```sql
+select * from my_db.my_schema.fct_orders
+```
+
+But during a *sample* run, dbt could automatically filter down large tables to the last X days of data using the same `event_time` column used for microbatch. The exact syntax here is TBD, but imagine you run something like `dbt run --sample 3`, which then compiles your code to:
+
+```sql
+select * from my_db.my_schema.fct_orders
+-- the event_time column in fct_orders is 'order_at'
+where order_at > dateadd(-3, day, current_date)
+```
+
+No more [overriding the `source` or `ref` macro](https://discourse.getdbt.com/t/limiting-dev-runs-with-a-dynamic-date-range/508) to hack together this functionality.
+
+Built-in support for “sample mode” — filtering to a consistent time-based “slice” across all models — means faster development and faster testing because you’re running on *less* data. This could be configured for a specific dbt invocation, a CI environment, or as a set-it-and-forget-it default for everyone who’s developing on your team’s project.
+
+[#11200 Sample Mode (for faster Development and CI 🚀)](https://github.com/dbt-labs/dbt-core/discussions/11200) is the place to think in public with us.
+
+## and who could forget, paper cuts!
+
+Those are the big things we plan to tackle in the coming months. As always, we want to tackle some smaller `paper_cut`s as well. Your upvotes and comments help us prioritize these, so please make some noise if there’s something you care a whole lot about. Some that are top of mind for me already:
+
+- **DRY-er YML**, including:
+    - [Defining vars configs outside dbt_project.yml](https://github.com/dbt-labs/dbt-core/issues/2955)
+    - [Add ability to import/include YAML from other files](https://github.com/dbt-labs/dbt-core/issues/9695)
+- **Enhancements to model versions and contracts**, including:
+    - [Automatically create view/clone of latest version](https://github.com/dbt-labs/dbt-core/issues/7442)
+    - [Support constraints independently from enforcing a full model contract](https://github.com/dbt-labs/dbt-core/issues/10195)
+- and [warnings when configs are misspelled](https://github.com/dbt-labs/dbt-core/issues/8942) :)
+
+# [**Call me**, **beep me** if you wanna reach me](https://www.youtube.com/watch?v=GIgLqN_rAXU)
+
+If one of *your* New Year’s resolutions is to be more involved in the dbt community, here are some of the many ways you can contribute:
+
+- open, upvote, and comment on GitHub [issues](https://docs.getdbt.com/community/resources/oss-expectations#issues)
+- start a [discussion](https://docs.getdbt.com/community/resources/oss-expectations#discussions) or discourse post when you’ve got a Big Idea
+- engage in conversations in the [dbt Community Slack](https://www.getdbt.com/community/join-the-community)
+- [contribute code](https://docs.getdbt.com/community/resources/oss-expectations#pull-requests) back to one of our open source repos, for one of our issues tagged `help_wanted` or `good_first_issue`, and our engineering team will work with you to get it over the finish line
+- join us on zoom for feedback sessions (which we’ll post about in slack and in the relevant GitHub discussion)
+- share your creative solutions in a blog post, at a dbt meetup, or by talking at Coalesce
+
+Your feedback and thoughts are incredibly valuable to us, so make yourself heard this year. We’re excited to build some awesome new features together. 
+
+[Your loving wife](https://youtu.be/DC9sbZBYzpI?si=xCGWoQDK-w13Fz6U&t=1594), Grace

--- a/docs/roadmap/2025-05-new-engine-same-language.md
+++ b/docs/roadmap/2025-05-new-engine-same-language.md
@@ -1,0 +1,187 @@
+# dbt: New Engine, Same Language (May 2025)
+
+Hello! Today was one of our biggest launches in dbt Labs history. We announced a bunch of new experiences for the dbt platform, which you can read about in [the roundup](https://www.getdbt.com/blog/dbt-launch-showcase-2025-recap).
+
+And we finally got to announce one big thing that we’ve been working on with [the team that joined us from SDF](https://www.getdbt.com/blog/dbt-labs-acquires-sdf-labs) — the **dbt Fusion engine**, written in Rust and optimized for speed and scale.
+
+Since [last December](https://github.com/dbt-labs/dbt-core/blob/main/docs/roadmap/2024-12-play-on.md), the Core team at dbt Labs has been busy developing new features for the [dbt Core v1.10 release](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v1.10) (`rc1` available now!) …
+
+| **Version** | **When** | **Namesake** | **Stuff** |
+| --- | --- | --- | --- |
+| v1.10 | May (beta) | Florence Earle Coates | `--sample` mode. Catalogs. Macro argument validation. Calculate source freshness via a custom `loaded_at_query`. Deprecation warnings using new and improved jsonschemas. |
+
+… and **we’ve been building a [whole new dbt engine](https://github.com/dbt-labs/dbt-fusion) from the ground up**.
+
+First thing’s first:
+
+- We’re committed to maintaining dbt Core **indefinitely**, under the Apache 2.0 license.
+- Fusion will be available under ELv2. That means you can use Fusion internally in your own business, for free and without restriction, forever. A bunch of its components (dbt-jinja, adapters, grammars, specs) will also be available under Apache 2.0.
+- You can read all the fine print in the [Licensing FAQs](https://www.getdbt.com/licenses-faq).
+
+Let’s talk about what’s changing, and what’s staying the same.
+
+## What’s the difference between dbt Core and the new dbt Fusion engine?
+
+The new dbt Fusion **engine** is brand-new code. It’s built for speed and SQL comprehension, meaning it already has some underlying capabilities that dbt Core doesn’t.
+
+The **language** is the same: it’s dbt. It’s the language you’ve learned to do your job, and learned to love because it’s how you get your job done.
+
+```
+    .--------------.
+   / dbt language   \
+  |    .--------.    |
+  |   /          \   |
+  |  | dbt engine |  |  
+  |   \          /   |
+  |    '--------'    |
+   \                /
+    '--------------'
+
+caption: the dbt framework
+```
+
+We’ve written about this difference between “language” and the “engine” in the FAQs (linked above), and we’re going to give some more specific examples below. The really important message is this one:
+
+Together, the **language** and the **engine** create **the dbt framework.**
+
+### What is the dbt language?
+
+The “language” of dbt includes anything you can write in your dbt project. Some of us like to call this the “authoring layer” — what we mean is, *the code you can put in your project.* Every data test configuration, every unit test property, the `+` before configs in `dbt_project.yml`, everything you can put between `{% macro %}` and `{% endmacro %}` ([just one, though](https://github.com/dbt-labs/dbt-core/issues/11393)). The language also includes important abstractions, like the idea that one `.sql` file in the `models/` directory == one dbt model == one data warehouse object ([or none](https://docs.getdbt.com/docs/build/materializations#ephemeral)).
+
+This language is really important. You’ve invested years into learning it, and you’ve used it to define your organization’s critical business logic. That’s why we’re committed to supporting, improving, and expanding the language across both dbt Core and Fusion.
+
+Recently, that has included important work to *tighten up* the language with stricter validation of your project code, as discussed in [dbt-core#11493](https://github.com/dbt-labs/dbt-core/discussions/11493). We want dbt to give more-helpful feedback when you misspell a config or write bad code in your project — a longtime paper-cut we are thrilled to at last be solving (see: [#2606,](https://github.com/dbt-labs/dbt-core/issues/2606) [#4280, #5605](https://github.com/dbt-labs/dbt-core/issues/5605), [#8942](https://github.com/dbt-labs/dbt-core/issues/8942)). dbt Core v1.10 is firing deprecation warnings, and Fusion will raise errors — and both engines are using the *same strongly-typed schemas* do it. Those schemas are live in the [dbt-jsonschema](https://github.com/dbt-labs/dbt-jsonschema/tree/main/schemas/latest_fusion) repo (under an Apache 2.0 license), and they’ll keep getting better as we work through prerelease feedback for dbt Core v1.10 and Fusion.
+
+We also want to keep adding language features across both Core and Fusion. Because Fusion is newer technology and has additional capabilities, such as built-in SQL comprehension, some language features will be better or exclusively available on Fusion. Think: an _enhancement_ to `--sample` and `--empty` modes where the engine intelligently add filters and limits, [without the associated issues of subqueries](https://github.com/dbt-labs/dbt-adapters/issues/199).
+
+### What is the dbt engine?
+
+The “engine” of dbt is the foundational technology for turning **the code in your dbt project into data platform reality*.* The engine:
+
+- takes your project code, validates it (against the dbt language spec), and turns it into a DAG
+- connects to remote data warehouse using **adapters**
+- executes that DAG in order — creating, updating, or queries data in the warehouse — based on the commands/flags/arguments you pass in
+- produces logs and metadata from that DAG execution
+
+These things may differ across the dbt Core and Fusion engines. To ease the upgrade path, Fusion supports most of the same CLI commands/flags/arguments as dbt Core, and Fusion adapters support the same authentication methods as Core adapters. But we’re not planning for exact conformance on logs, metadata, and every single runtime behavior. 
+
+Two examples from [the upgrade guide](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-fusion):
+
+- Fusion can run unit tests first before building *any* models, because it can infer column schemas from SQL understanding.
+- There’s no `--partial-parse` flag for Fusion, because its project parsing is *just that much faster. (And it will manage the cache itself)*
+
+If there are things you think are great about the dbt Core engine, and you want Fusion to meet the same need — let us know! We’ve got some tips at the end about how to engage with the next few months of Fusion development.
+
+## What’s next for dbt-the-language?
+
+We’ve been building the new dbt Fusion engine since January, and we’ve still got plenty more to go. Our biggest focus area for the next few months is stabilizing and enhancing Fusion to support more of dbt's existing features, and more existing dbt projects. ([Joel and Jeremy wrote about Fusion’s path to GA](https://docs.getdbt.com/blog/dbt-fusion-engine-path-to-ga).)
+
+At the same time, we know there’s appetite for new capabilities in the dbt language — including some ideas we’ve been talking about for a long time.
+
+Importantly, our goal isn’t just parity with dbt as it exists today. We intend to keep expanding the language, across both the Core and Fusion engines. In many cases, we will be able to deliver an even-better experience in Fusion, thanks to its speed and SQL awareness.
+
+The exact specs here are TBD, but here are some features we’ve been thinking about adding:
+
+- **Out-of-the-box support for UDFs**
+- **Sources from external catalogs**
+- **Model freshness checks**
+- **…along with Bugs, Polish Work, and Paper Cuts**
+
+To be clear, we’re not committing to building precisely these things on any specific timeline — our top priority is parity for the new engine, to support existing users and customers in upgrading to Fusion — but we’re including these ideas as an illustration of what the same-framework, multi-engine future could look like. We’d love your thoughts on these ideas — what would be most interesting/useful to you?
+
+### **Out-of-the-box support for UDFs**
+
+The idea to manage user-defined functions (UDFs) with dbt is almost [as old as dbt](https://github.com/dbt-labs/dbt-core/issues/136) — and it’s one that has [come up](https://github.com/dbt-labs/dbt-core/discussions/5099) [every few](https://github.com/dbt-labs/dbt-core/discussions/5741) [years since](https://github.com/dbt-labs/dbt-core/discussions/10395).
+
+UDFs enable users to define and register custom functions within the warehouse. Like dbt macros, they enable DRY reuse of code; unlike macros, UDFs can be defined in languages other than SQL (Python, Java, Scala, …) and they can be used by queries outside of dbt.
+
+There are two direct benefits to dbt-managed UDFs:
+
+1. dbt will manage (create, update, rename) UDFs as part of DAG execution. If you want to update a UDF *and* a model that calls it, you can test the changes together in a development environment; propose those changes in a single pull request that goes through CI; and deploy them together into your production environment. dbt will ensure that the UDF is created before attempting to build the model that references it. And we could even imagine supporting *unit tests* on UDFs — which are functions, after all!
+2. Fusion’s SQL comprehension is dialect-aware, but it is not yet *UDF-aware.* Today, if you call UDFs within a dbt model, you need to turn off Fusion’s static analysis for that model’s SQL. By supporting UDFs in the dbt framework, Fusion can also support them in its static analysis. We’re taking inspiration from Fusion’s antecedent, SDF, which supported UDFs for exactly this reason: https://docs.sdf.com/guide/advanced/udf
+
+Imagine if the dbt framework knew about user-defined functions. The Core engine could manage the creation of UDFs as data warehouse objects. The Fusion engine could take it one step further, by *also* validating your UDFs’ SQL and statically analyzing the SQL of dbt models that call those UDFs. 
+
+### **Sources from external catalogs**
+
+Back in December, we discussed ([dbt-core#11171](https://github.com/dbt-labs/dbt-core/discussions/11171)) our plans for integrating catalogs: Glue, Iceberg, Snowflake Managed, Unity, …
+
+Our goal was to centralize the configuration for materializing Iceberg tables, try to abstract over the minute differences between catalog providers (where possible), and teach dbt about a new top-level construct (`catalogs`).
+
+You can check out [the docs on Iceberg catalogs](https://docs.getdbt.com/docs/mesh/iceberg/about-catalogs), new in dbt Core v1.10.
+
+The first supported use case for external catalogs is around materializing dbt models *as Iceberg tables* by *writing them to catalogs* — but we know that another popular use case is reading from source tables that have been ingested to Iceberg catalogs, a.k.a. bringing the functionality of [read-external-iceberg from the dbt-labs-experimental-features](https://github.com/dbt-labs/dbt-labs-experimental-features/tree/main/read-external-iceberg) repository [into the dbt framework](https://github.com/dbt-labs/dbt-core/discussions/11265):
+
+```sql
+select * from {{ source('my_catalog', 'my_iceberg_table') }}
+```
+
+You can already hack this with the [experimental code](https://github.com/dbt-labs/dbt-labs-experimental-features/tree/main/read-external-iceberg) today — but we see an opportunity to build it into dbt out-of-the-box, and to standardize the configurations for everyone interacting with Iceberg tables, for both use cases (sources and models) in their dbt projects.
+
+### **Model freshness checks**
+
+dbt Core has supported `source freshness` checks since the [v0.13 release in 2019](https://github.com/dbt-labs/dbt-core/releases/tag/v0.13.0) (!). The idea, then and now, is: for tables that are updated by processes outside of dbt, the least dbt can do is ask, “How fresh is in the data in this table?”
+
+By contrast, it should be simple for dbt to know the freshness in the models *that dbt is building*… right?
+
+In practice, this can be trickier than you’d think! Multiple dbt invocations, split across different jobs/tasks/DAGs/schedules/orchestrators/projects/…, can result in confusion about when a model actually last built. Users have closed the gap with generic tests in popular packages, such as [dbt_utils.recency](https://github.com/dbt-labs/dbt-utils?tab=readme-ov-file#recency-source) and [dbt_expectations.expect_row_values_to_have_recent_data](https://github.com/metaplane/dbt-expectations?tab=readme-ov-file#expect_row_values_to_have_recent_data) — but the idea that [*dbt should know about model freshness*](https://github.com/dbt-labs/dbt-core/discussions/5103) is one we’ve tossed around a few times.
+
+This is a case where we think we might be able to introduce a new language concept that powers a capability in both engines, and unlock something additional in Fusion. Imagine:
+
+- The dbt language introduces `freshness` as an optional config for models.
+- dbt Core, which is stateless, could execute `freshness` checks on models — using a configured column, or metadata from the data warehouse. Fusion could support this check, too.
+- And: When the dbt Fusion engine is connected to the dbt platform, [it can run with *state awareness*](https://docs.getdbt.com/docs/deploy/state-aware-about). Fusion checks the freshness of upstream data inputs, and users can configure `freshness.build_after` — to reduce overbuilding models when there’s no new data, or when users want to save costs by placing an upper limit on build frequency.
+
+```yaml
+models:
+  - name: stg_orders
+    config:
+      freshness:
+        # Fusion-powered state-aware orchestration: build this model after 4 hours, as long as it has new data
+        build_after: {count: 4, period: hour}
+        
+        # Future: check that model has successfully updated within expected SLA, warn/error owner otherwise
+        warn_after: {count: 24, period: hour}
+        error_after: {count: 48, period: hour}
+```
+
+### **Bugs, Polish Work, and Paper Cuts**
+
+And then, there’s everything else.
+
+While our team has been focused on the v1.10 release of dbt Core, and building the new dbt Fusion engine, we’ve had less capacity to triage every new issue and externally contributed PR. Thank you for your patience over the past five months — and thank you to the community members who gave us the feedback that we need to ensure maintenance even while working on the exciting new stuff.
+
+Over the coming months, alongside our work ensuring Fusion framework parity, we will be tracking our backlog of:
+
+- externally-contributed PRs
+- [polishing on microbatch](https://github.com/dbt-labs/dbt-core/issues/11292)
+- polishing on jsonschemas (the long-tail of adapter-specific configs)
+- `paper_cut`s
+
+## How can you, a community member, contribute?
+
+Mostly, in all the same ways as before: [https://docs.getdbt.com/community/resources/contributor-expectations](https://docs.getdbt.com/community/resources/contributor-expectations)
+
+In the next few weeks, we’d really like your help — trying out the new engine, mettle-testing the new jsonschemas against your project code, and opening up bug issues when you run into problems — as we get Fusion (and the stricter dbt language spec) ready for prime-time. 
+
+You can contribute your ideas by opening GitHub discussions or feature requests. While we’re focused on getting dbt Fusion to GA, we're going to keep the `dbt-fusion` repo focused on engine bugs and framework parity, so we’ll keep net-new feature requests in the `dbt-core` repo for the foreseeable future. Be on the lookout for GitHub discussions about new framework features, once we’re ready to start building.
+
+You can contribute your code by opening pull requests against *any* of our repos — whether you’ve written Rust before, or you’re looking for an excuse to get started :)
+
+## Let’s get to work
+
+Maintaining a common framework across two codebases, written in entirely different languages, will be challenging. We’ve got some ideas for how to make this easier:
+
+- Core and Fusion are already sharing a set of strongly-typed jsonschemas defining the spec of acceptable project code inputs
+- Core adapters and Fusion adapters could share the same “packages” of macros and materializations
+- *… and more to come …*
+
+No lie — it’s going to be tricky, any way we slice it. We’re going to keep figuring it out over the coming months, and we ask for your patience while we do.
+
+After all, [our commitment](https://www.youtube.com/watch?v=DC9sbZBYzpI) is to you, the community, not to any one codebase. We’re excited to welcome in some new codebases, and some new contributors, to this thing we’re all building together.
+
+(╭☞ ͡° ͜ʖ ͡°)╭☞
+
+**J**erco
+**E**lias
+**G**race

--- a/docs/roadmap/2025-12-magic-to-do.md
+++ b/docs/roadmap/2025-12-magic-to-do.md
@@ -1,0 +1,116 @@
+# dbt: Magic to Do (December 2025)
+
+dbt Core will turn in 10 in March 🥳. That’s almost a decade of `select`-ing, data-testing, and docs-generating.
+
+ICYMI - [we threw a birthday bash for the dbt Community at Coalesce this year](https://www.youtube.com/watch?v=aMUAQjqTKtc), and we used the occasion to reflect on all the ways dbt has grown up:
+
+There are now 2 engines: dbt Core (which will remain Apache 2.0 forever) and dbt Fusion (which uses a [mix of licenses](https://www.getdbt.com/blog/new-code-new-license-understanding-the-new-license-for-the-dbt-fusion-engine))...
+
+...And lots more Open Source code: [MetricFlow](https://www.getdbt.com/blog/open-source-metricflow-governed-metrics) (now Apache 2.0!), [Fusion adapters](https://github.com/dbt-labs/dbt-fusion), [dbt-jinja](https://github.com/dbt-labs/dbt-fusion/tree/main/crates/dbt-jinja), [jsonschemas](https://github.com/dbt-labs/dbt-jsonschema/tree/main/schemas/latest_fusion), and [dbt-autofix](https://github.com/dbt-labs/dbt-autofix).
+
+The language is codified: `dbt-jinja` for the Jinja you can use in dbt, `jsonschemas` for yaml...
+
+...And will continue to grow, [with new features across Core and Fusion](https://www.youtube.com/watch?v=6lI9d-gPKW8).
+
+As always, there is more ~~work~~ magic to do.
+
+# 2025 Wrapped
+
+In 2025, we had: 
+
+- **>90k** weekly active projects
+- **>10k** comments across over **>5k** issues from over **>1k** people across our open source and source available repos
+- **4** new product-led discussions:
+    - [Sample Mode (for faster Development and CI 🚀)](https://github.com/dbt-labs/dbt-core/discussions/11200)
+    - [Out-of-the-box support for UDFs](https://github.com/dbt-labs/dbt-core/discussions/11851)
+    - [UX Feedback on Logging and stdout](https://github.com/dbt-labs/dbt-fusion/discussions/584)
+    - [Source schemas should be first-class, versioned artifacts](https://github.com/dbt-labs/dbt-fusion/discussions/1042)
+- **10** [Community Awards](https://www.youtube.com/watch?v=I-DgySJ0Syg)
+- **1** [demo on roller skates](https://youtu.be/aMUAQjqTKtc?si=9ZCmz30wZ118HeHI&t=1116)
+
+    <img width="512" height="341.5" alt="picture of demo on roller skates" src="https://github.com/user-attachments/assets/c3857e83-eca7-4b9d-a144-4638b05af564" />
+    
+- **2** minor dbt Core releases
+    
+    
+    | **Version** | **When** | **Namesake** | **Stuff** |
+    | --- | --- | --- | --- |
+    | [v1.10](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v1.10) | June | [Florence Earle Coates](https://github.com/dbt-labs/dbt-core/releases/tag/v1.10.0) | `--sample` mode. Catalogs. Macro argument validation. Calculate source freshness via a custom `loaded_at_query`. YAML `anchors:`. |
+    | [v1.11](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v1.11) | December | [Juan R. Torruella](https://github.com/dbt-labs/dbt-core/releases/tag/v1.11.0) | User-defined functions. `cluster_by` for dynamic tables. Deprecation warnings using new and improved jsonschemas, enabled by default.  |
+- and **1** dbt community <3
+
+### New language features
+
+This past year we added three big new language features to the dbt framework:
+
+- **[sample mode](https://docs.getdbt.com/docs/build/sample-flag)** renders filtered `ref`s and `source`s using time-based sampling, allowing developers to validate outputs without building entire historical datasets.
+- **[catalogs](https://docs.getdbt.com/docs/mesh/iceberg/about-catalogs)** abstraction for materializing dbt models as Iceberg tables, with a consistent set of configs (more on this below).
+- **[user-defined functions](https://docs.getdbt.com/docs/build/udfs)** as a new dbt resource type - allowing you to define custom functions in your project, call them in models, and register them in your warehouse as part of building your DAG.
+
+All of these are supported now across BOTH engines - dbt Core and dbt Fusion.
+
+The language is also now **codified** - **[new and improved jsonschemas](https://github.com/dbt-labs/dbt-jsonschema/tree/main/schemas/latest_fusion)** power warnings in Core (and errors in Fusion) to help you proactively identify and update deprecated configurations (such as misspelled config keys, old properties, or incorrect data types). 
+
+This stricter spec creates clearer separation between the built-in configurations of the dbt language (or flags/options of the dbt engine) and your custom code (nested under `meta`), reducing the risk of collisions as we continue to add new capabilities and configurations to the dbt framework in the future.
+
+Because we plan to keep building dbt for a long time to come, and for that we need…
+
+### Stability
+
+[Two years ago](https://github.com/dbt-labs/dbt-core/blob/main/docs/roadmap/2023-11-dbt-tng.md), we saw that lots of projects were still running older versions of dbt Core, even as we pushed ahead with newer ones. Our top priority was making it easier to upgrade. To that end, we’ve made significant investments in interface stability, and updated the release cadence to 1 new minor version every 6 months.
+
+All of that work has paid off: **Today, the majority of active dbt Core projects run on the latest minor version.** On December 1, >50% of projects were running on dbt Core `v1.10`, which we released in June. We just released `v1.11` this week, and we expect that the majority of projects will upgrade in the next 6 months.
+
+This means that when we fix bugs in patch releases, or release exciting language features in new minor versions — such as UDFs in `v1.11` — more users can get *immediate* access to those fixes and features than ever before. It also means that more users can benefit from strongly-typed schemas for dbt’s properties and configurations. **And if those users want to try out the new Fusion engine while it’s in preview, they can.**
+
+In order for the Fusion engine to work on your project, your dbt code will need to be compatible with the very latest language spec — which means resolving any deprecation warnings that you would have started seeing in dbt Core `v1.10` and `v1.11`. We have a tool that can help: [**`dbt-autofix`**](https://github.com/dbt-labs/dbt-autofix) scans your dbt project for deprecations, and automatically updates your code to align with the latest spec. 
+
+We closed out this year with "De*bug*-cember" - a month-long bug bash where we squashed 35 long-standing issues across parsing, execution, logging, error messages, and more in the lead up to the final `v1.11` release. (To see the full list, head over to #dbt-core-development in the community Slack.)
+
+<img width="604" height="292" alt="screenshot of slack post" src="https://github.com/user-attachments/assets/e2ed08a4-7eef-4adc-a540-47a45d8e5e5a" />
+
+# What’s in the Queue for 2026?
+
+Over the next six months, we’re adding a bunch of new team members (say hi to new faces as they pop up in slack and github). With their help, we’re eager to tackle the backlog of bugs and "paper cuts". You can upvote and comment on issues to help us prioritize!
+
+As for bigger features…
+
+In our roadmap post from May, we proposed three possibilities for "[What’s next for dbt-the-language?](https://github.com/dbt-labs/dbt-core/blob/main/docs/roadmap/2025-05-new-engine-same-language.md#whats-next-for-dbt-the-language)": 
+
+1. Out-of-the-box support for UDFs
+2. Sources from external catalogs
+3. Model freshness checks
+
+We tackled #1 in the `v1.11` release. 
+
+We intend to work on #3 next (github discussion coming soon).
+
+As for #2… [Jeremy says "it’s complicated"](https://www.youtube.com/watch?v=bRJJkeJkUsE&t=1s):
+
+> We are always building dbt within the context of the larger data ecosystem. In summer 2024, Databricks and Snowflake acclaimed Iceberg as the most promising standard for interoperable data storage. Following the flurry of new Iceberg catalogs, we [proposed a spec](https://github.com/dbt-labs/dbt-core/discussions/11171), implemented in dbt Core `v1.10`, to configure those `catalogs` as a place to materialize dbt models.
+> 
+> Over the past year, the major data warehouses have added support for writing tables to *external* Iceberg catalogs — and even for *synchronizing* metadata from those catalogs (e.g. with a Snowflake [catalog-linked database](https://docs.snowflake.com/en/user-guide/tables-iceberg-catalog-linked-database)) so that you can treat their contents like any other table. This makes it substantially easier to treat Iceberg as [just another implementation detail](https://docs.getdbt.com/blog/icebeg-is-an-implementation-detail), and as the interchange layer for [cross-platform workflows](https://www.getdbt.com/blog/introducing-cross-platform-dbt-mesh).
+> 
+> It also means that other features of dbt "just work." Earlier this year, we added an [experimental feature](https://github.com/dbt-labs/dbt-labs-experimental-features/tree/main/read-external-iceberg) for registering and refreshing Iceberg tables (à la `dbt-external-sources`), and in our May roadmap we proposed "sources from external catalogs" as a potential new feature of the dbt language. But if the underlying data warehouse can synchronize tables with an external Iceberg catalog automatically, then `sources` pointing to tables in an external Iceberg catalog already work, without any changes to the dbt language. That’s not the full end of the story — Iceberg requires a lot of setup (could dbt help here?) and careful optimization (might it be faster/cheaper to batch-calculate `freshness` by integrating with an Iceberg REST catalog directly, rather than querying the data warehouse?) — it warrants more time and testing. The plan is to keep evolving dbt along with the Iceberg ecosystem in 2026.
+
+Last-but-not-least, we will continue to invest in improving the stability of dbt Core. There’s much more we can improve about:
+
+- the interfaces shared between Core and Fusion
+- the integration between dbt Core and MetricFlow, [now that the latter is Apache 2.0 too](https://www.getdbt.com/blog/open-source-metricflow-governed-metrics)
+- the ease of contributing to our open source and source-available codebases
+
+# [Join us, leave your fields to flower](https://www.youtube.com/watch?v=AqbYa-NXFOg)
+
+Looking for ways to get involved in the dbt community? 
+
+- give or get help in the [community slack](https://www.getdbt.com/community/join-the-community)
+- open up bug reports, feature requests, or discussions in our repos: [dbt-core](https://github.com/dbt-labs/dbt-core), [dbt-adapters](https://github.com/dbt-labs/dbt-adapters) (our new Core adapters monorepo), and [dbt-fusion](https://github.com/dbt-labs/dbt-fusion) are great places to start
+- join zoom feedback sessions to help shape new features coming to dbt
+- follow along with Fusion progress by [reading our diaries](https://github.com/dbt-labs/dbt-fusion/discussions/categories/announcements) and [subscribing to our linkedin newsletter](https://www.linkedin.com/newsletters/fusion-diaries-7366935294090084360/)
+- find community in-person at our [dbt meetups](https://www.meetup.com/pro/dbt/) and [roadshows](https://www.getdbt.com/events), all around the world
+
+See you in the new year,
+
+your neighborhood theater kids (Jerco & Grace)
+
+<img width="512" height="341.5" alt="picture of jerco and grace running away" src="https://github.com/user-attachments/assets/425221e9-aac0-4e5a-a115-0f8dba4cd2e7" />


### PR DESCRIPTION
The `main` branch of `dbt-core` has a bunch of brand-new code (!), but we want to keep some history on the default branch, specifically our roadmap posts from the last four years :)