### PR TITLE
ci(copybara): add reverse-sync dispatcher for dbt-core PRs

### DIFF
--- a/.github/workflows/auto-public-pr-copybara.yml
+++ b/.github/workflows/auto-public-pr-copybara.yml
@@ -1,0 +1,78 @@
+name: Copybara - Auto Public PR Migration
+
+# **what?**
+# When a PR is opened against dbt-core, trigger the reverse Copybara sync that
+# mirrors the change into a PR on the private dbt-labs/fs repo (the dbt_core_pr
+# profile, which moves the root Rust tree into fs/sa/).
+#
+# **why?**
+# dbt-core is the public, copybara-synced mirror of fs/sa. Contributions that
+# land here need to flow back into fs so the two stay in sync.
+#
+# **when?**
+# On every PR open/reopen/synchronize. PRs from public forks must carry the
+# `ci:approve-public-fork-ci` label (a maintainer adds it) before the
+# secret-bearing dispatch runs — the label is stripped on each new push so
+# updates require re-approval.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+    paths-ignore:
+      # Mirror the dbt_core_pr copybara profile's excludes: .github and the
+      # private-anchored .rs files that cannot safely round-trip back to fs.
+      - '.github/**'
+      - 'crates/dbt-parser/src/resolver.rs'
+      - 'crates/dbt-deps/src/private_package.rs'
+      - 'crates/dbt-loader/src/load_packages.rs'
+      - 'crates/dbt-loader/src/loader.rs'
+      - 'crates/dbt-loader/src/mod.rs'
+
+# only run this once per PR at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+env:
+  CI_LABEL: "ci:approve-public-fork-ci"
+
+jobs:
+  check_run_approval:
+    permissions:
+      pull-requests: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: "If the event is to synchronize, remove the label from the PR"
+        if: ${{ github.event_name == 'pull_request_target' && (github.event.action == 'synchronize' || github.event.action == 'reopened') && github.event.pull_request.head.repo.full_name != github.repository && contains(github.event.pull_request.labels.*.name, env.CI_LABEL) }}
+        run: |
+          echo "Synchronizing PR, removing '${{ env.CI_LABEL }}' label"
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label ${{ env.CI_LABEL }} --repo ${{ github.repository }}
+          msg="All pull request updates require re-approval of CI. No CI will be run."
+          echo "::error::$msg"
+          exit 1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Check that forks have the '${{ env.CI_LABEL }}' label"
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository && !contains(github.event.pull_request.labels.*.name, env.CI_LABEL) }}
+        run: |
+          msg="Pull request is from a public fork but does not have the '${{ env.CI_LABEL }}' label. No CI will be run."
+          echo "::error::$msg"
+          exit 1
+
+  copybara:
+    needs: check_run_approval
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger dbt-core PR Copybara sync in fs
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.FS_SERVICE_PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/dbt-labs/fs/dispatches \
+            -d "{\"event_type\": \"dbt-core-pr-copybara-trigger\", \"client_payload\": {\"copybara_pr\": \"${{ github.event.number }}\"}}"


### PR DESCRIPTION
## What

Adds `.github/workflows/auto-public-pr-copybara.yml` — the dbt-core side of the **dbt-core → fs reverse sync**.

On every PR against dbt-core, it dispatches a `dbt-core-pr-copybara-trigger` `repository_dispatch` event to `dbt-labs/fs`, which runs the `dbt_core_pr` copybara profile to mirror the change into a PR on the private `fs` repo (root Rust tree → `fs/sa/`).

## Why

dbt-core is the public, copybara-synced mirror of `fs/sa`. Contributions landing here need to flow back into `fs` so the two stay in sync. This is the dispatcher half; the fs-side receiver is enabled in dbt-labs/fs#10733.

## How it works

1. Trigger: `pull_request_target` (opened / reopened / synchronize), with `paths-ignore` mirroring the `dbt_core_pr` profile's excludes.
2. **Fork-safety gate** (`check_run_approval`): a PR from a public fork must carry the `ci:approve-public-fork-ci` label before the secret-bearing dispatch runs. The label is auto-removed on every `synchronize`, so each new push requires maintainer re-approval. (`pull_request_target` runs with repo secrets, so this gate is the trust boundary.)
3. **Dispatch** (`copybara`): `curl` POST to `/repos/dbt-labs/fs/dispatches` with the PR number, authed via `FS_SERVICE_PAT`.

Mirrors the proven `dbt-core-staging` dispatcher, retargeted at `fs` (instead of `fs-staging`) with root-layout paths (instead of `kernel/...`).

## Prerequisites — already in place

- [x] `ci:approve-public-fork-ci` label created on dbt-core.
- [x] `FS_SERVICE_PAT` secret added on dbt-core (scoped to POST `/repos/dbt-labs/fs/dispatches`).
- [x] fs-side receiver trigger enabled — dbt-labs/fs#10733.

## Note for reviewers

The `dbt_core_pr` copybara profile excludes `**/dbt-fusion-adapter/src/load_catalogs.rs`, but dbt-core has no `dbt-fusion-adapter` crate or `load_catalogs.rs` (its adapter crate is `dbt-adapter`). That exclude is inert here, so it's omitted from `paths-ignore`. Reconciling the profile's exclude list with actual dbt-core crate names is a worthwhile follow-up but out of scope for this PR.