### PR TITLE
test: trigger copybara reverse sync (DO NOT MERGE)

### DIFF
--- a/COPYBARA_REVERSE_SYNC_TEST.md
+++ b/COPYBARA_REVERSE_SYNC_TEST.md
@@ -1,0 +1,5 @@
+# Copybara reverse-sync trigger test
+
+Throwaway file to verify the `auto-public-pr-copybara.yml` dispatcher fires on
+a dbt-core PR and dispatches the `dbt-core-pr-copybara-trigger` event to
+dbt-labs/fs. Safe to delete — carries no functional meaning.


### PR DESCRIPTION
**DO NOT MERGE** — test PR to verify the `auto-public-pr-copybara.yml` reverse-sync dispatcher fires and dispatches `dbt-core-pr-copybara-trigger` to dbt-labs/fs.

Adds a throwaway markdown file. Will be closed once the dispatch + fs-side receiver are confirmed working.