### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260601-163048.yaml
+++ b/.changes/unreleased/Under the Hood-20260601-163048.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-06-01T16:30:48.133948586Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -2689,6 +2689,86 @@
         "application"
       ]
     },
+    "ExternalPartition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/ExternalPartitionConfig"
+        },
+        {
+          "type": "string",
+          "pattern": "^\\{.*\\}$"
+        }
+      ]
+    },
+    "ExternalPartitionConfig": {
+      "description": "Reference: https://github.com/dbt-labs/dbt-mantle/blob/da5abca4f829b167bd1b1d5c6666c12cd8c719c0/core/dbt/artifacts/resources/v1/source_definition.py#L36",
+      "type": "object",
+      "properties": {
+        "data_type": {
+          "default": "",
+          "type": "string"
+        },
+        "description": {
+          "default": "",
+          "type": "string"
+        },
+        "meta": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
+        "name": {
+          "default": "",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExternalTable": {
+      "description": "Reference: https://github.com/dbt-labs/dbt-mantle/blob/da5abca4f829b167bd1b1d5c6666c12cd8c719c0/core/dbt/artifacts/resources/v1/source_definition.py#L48 These always get serialized, even if none.",
+      "type": "object",
+      "properties": {
+        "file_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "location": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "partitions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ExternalPartition"
+          }
+        },
+        "row_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tbl_properties": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "FloatOrString": {
       "anyOf": [
         {
@@ -10487,7 +10567,7 @@
         "external": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AnyValue"
+              "$ref": "#/definitions/ExternalTable"
             },
             {
               "type": "null"


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`31c097df843e0429108ec013cd1c6da111fca3a5`](https://github.com/dbt-labs/fs/commit/31c097df843e0429108ec013cd1c6da111fca3a5)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/26766476101)