### PR TITLE
Migrate issue templates from dbt-fusion (dbt v2.x)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-v2.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-v2.yml
@@ -80,6 +80,7 @@ body:
         - postgres
         - redshift
         - duckdb
+        - clickhouse
         - other (describe in Additional Context)
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug-report-v2.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-v2.yml
@@ -1,0 +1,100 @@
+name: 🐞 Bug (dbt v2.x)
+description: Report a bug or issue you've found in dbt v2.x (Core or Fusion distributions)
+title: "[v2 Bug] <title>"
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+        This template is for bugs in dbt v2.x (either the Core or Fusion distribution). For bugs in dbt Core 1.x, use the "🐞 Bug" template instead.
+  - type: checkboxes
+    attributes:
+      label: Is this a new bug in dbt v2.x compared to the latest version of dbt 1.x?
+      description: >
+        In other words, is this an error, flaw, failure, or fault in our software?
+
+        If this is a regression (something that used to work in an older version), describe that in the steps to reproduce.
+
+        Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I believe this is a new bug in dbt v2.x
+          required: true
+        - label: I have searched the existing issues and could not find a duplicate
+          required: true
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: |
+        Steps to reproduce the behavior. The best way to help is a minimal reproducible example — a small dbt project or model snippet that triggers the issue.
+      placeholder: |
+        1. Create a model with...
+        2. Run `dbt run`
+        3. See error...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: |
+        If applicable, paste relevant log output. You can find logs in stdout, `logs/dbt.log`, or the VS Code Output pane under "dbt output" or "dbt Language Server".
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Environment
+      description: |
+        Please fill in your environment details.
+      value: |
+        - OS:
+        - CPU: (x86 or ARM)
+        - dbt distribution and version: (`dbt --version`)
+      render: markdown
+    validations:
+      required: false
+  - type: dropdown
+    id: adapter
+    attributes:
+      label: Which database adapter are you using?
+      description: Select all that apply. If adapter-specific, we'll apply the corresponding label automatically.
+      multiple: true
+      options:
+        - snowflake
+        - databricks
+        - bigquery
+        - postgres
+        - redshift
+        - duckdb
+        - other (describe in Additional Context)
+    validations:
+      required: false
+  - type: checkboxes
+    attributes:
+      label: Is this a discrepancy vs. dbt 1.x?
+      description: Does this behavior work correctly in dbt 1.x but not in dbt v2.x?
+      options:
+        - label: "Yes — this works in dbt 1.x but not in dbt v2.x"
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: |
+        Links, references, screenshots, or anything else that will give us more context.
+
+        Tip: You can attach images or log files by clicking this area and dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug-report-vsce.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-vsce.yml
@@ -1,0 +1,101 @@
+name: 🐞📟 VS Code Extension Bug
+description: Report a bug with the dbt VS Code extension
+title: "[VSCE] [Bug] <title>"
+labels: ["bug", "triage", "vsce"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+        **This template is for bugs in the dbt VS Code extension** (IntelliSense, go-to-definition, lineage, build menu, etc.).
+        For CLI/compiler bugs, please use the "🐞 Bug (dbt v2.x)" template instead.
+  - type: checkboxes
+    attributes:
+      label: Is this a new bug in the VS Code extension?
+      description: >
+        1. Is this an error in the VS Code extension, not the CLI? Use the dbt v2.x bug template for CLI issues.
+
+        2. Is this an error, flaw, or fault — not a regression, feature request, or confusing-but-working behavior?
+
+        3. Please search to see if an issue already exists.
+      options:
+        - label: I believe this is a new bug in the VS Code extension, not the dbt Fusion CLI
+          required: true
+        - label: I have searched the existing issues and could not find a duplicate
+          required: true
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Troubleshooting
+      description: Does the bug consistently occur? Does it go away after running `Developer: Reload Window`?
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: |
+        Steps to reproduce the behavior. A minimal dbt project or model snippet that triggers the issue is ideal.
+      placeholder: |
+        1. Open a dbt project in VS Code
+        2. Open model file...
+        3. See error / missing IntelliSense / etc.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: |
+        Paste relevant output from the VS Code Output pane. Use the dropdown to select "dbt output" or "dbt Language Server".
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Environment
+      description: |
+        Please fill in your environment details.
+      value: |
+        - OS:
+        - VS Code / Cursor: (Help → About, e.g. "VSCode: 1.96.2")
+        - dbt Fusion extension: (hover over "dbt" in the bottom taskbar)
+        - dbt Fusion CLI: (`dbt --version`)
+        - Adapter:
+      render: markdown
+    validations:
+      required: false
+  - type: dropdown
+    id: bug_area
+    attributes:
+      label: Which area of the extension is affected?
+      multiple: true
+      options:
+        - IntelliSense / SQL validation / go-to-definition / references
+        - Model lineage / DAG view
+        - Build menu / run commands / compiled SQL
+        - Preview models
+        - Initial setup / authentication
+        - other (describe in Additional Context)
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: |
+        Links, references, screenshots, or anything else that will give us more context.
+
+        Tip: You can attach images or log files by clicking this area and dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,9 @@ contact_links:
   - name: Documentation
     url: https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose
     about: Problems and issues with dbt product documentation hosted on docs.getdbt.com. Issues for markdown files within this repo, such as README, should be opened using the "Code docs" template.
+  - name: dbt v2.x docs
+    url: https://docs.getdbt.com/docs/fusion
+    about: Check the docs before filing — your answer may already be there.
   - name: Ask the community for help
     url: https://github.com/dbt-labs/docs.getdbt.com/discussions
     about: Need help troubleshooting? Check out our guide on how to ask
@@ -12,6 +15,6 @@ contact_links:
   - name: Participate in Discussions
     url: https://github.com/dbt-labs/dbt-core/discussions
     about: Do you have a Big Idea for dbt? Read open discussions, or start a new one
-  - name: Create an issue for adapters
+  - name: Create an issue for v1.x adapters
     url: https://github.com/dbt-labs/dbt-adapters/issues/new/choose
     about: Report a bug or request a feature for an adapter

--- a/.github/ISSUE_TEMPLATE/sql-understanding.yml
+++ b/.github/ISSUE_TEMPLATE/sql-understanding.yml
@@ -1,0 +1,86 @@
+name: 🧠 SQL understanding issue
+description: dbt Fusion doesn't recognize a function, flags valid SQL as an error, infers the wrong column type, or produces incorrect lineage
+title: "[SQL] <title>"
+labels: ["bug", "triage", "SQL_understanding"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for issues where dbt Fusion engine **fails to understand valid SQL** — things like unrecognized functions, incorrect type inference, unexpected parse errors, or wrong static analysis results.
+
+        For runtime errors or behavioral bugs unrelated to SQL analysis, use the "🐞 Bug (dbt v2.x)" template instead.
+  - type: checkboxes
+    attributes:
+      label: Before you submit
+      options:
+        - label: I have searched the existing issues and could not find a duplicate
+          required: true
+  - type: textarea
+    attributes:
+      label: SQL that dbt Fusion doesn't understand
+      description: Paste a minimal SQL snippet that reproduces the issue. Smaller is better.
+      render: sql
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What dbt Fusion does
+      description: What error, warning, or incorrect result does dbt Fusion produce?
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What you expected
+      description: What should dbt Fusion do with this SQL?
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: What kind of SQL understanding issue is this?
+      multiple: true
+      options:
+        - Unrecognized or unsupported function
+        - Incorrect type inference
+        - Parse error on valid SQL
+        - Wrong column lineage / ref resolution
+        - Macro or Jinja compilation
+        - Other (describe in Additional Context)
+    validations:
+      required: false
+  - type: dropdown
+    id: adapter
+    attributes:
+      label: Which database adapter are you using?
+      description: Dialect-specific SQL (e.g. Snowflake QUALIFY, BigQuery STRUCT) often requires adapter context.
+      multiple: true
+      options:
+        - snowflake
+        - databricks
+        - bigquery
+        - postgres
+        - redshift
+        - duckdb
+        - other (describe in Additional Context)
+    validations:
+      required: false
+  - type: checkboxes
+    attributes:
+      label: Does this SQL execute correctly with the `--static-analysis off` flag, or when run by dbt Core?
+      options:
+        - label: "Yes — this SQL is accepted by the warehouse"
+  - type: textarea
+    attributes:
+      label: Environment
+      value: |
+        - dbt Fusion version: (`dbt --version`)
+      render: markdown
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: Links, references, or anything else that will help us reproduce this.
+    validations:
+      required: false

--- a/.github/workflows/label-adapter.yml
+++ b/.github/workflows/label-adapter.yml
@@ -1,0 +1,44 @@
+name: Label Adapter from Issue Form
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label-adapter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply adapter label based on form selection
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+
+            // GitHub renders issue form multi-select dropdowns as a comma-separated
+            // string on a single line directly beneath the field's ### heading.
+            // If this regex stops matching after a GitHub rendering change, check:
+            // https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+            const match = body.match(/### Which database adapter are you using\?\n\n([^\n#]+)/);
+            if (!match) return;
+
+            const selected = match[1]
+              .split(',')
+              .map(s => s.trim().toLowerCase())
+              .filter(Boolean);
+
+            // "other (describe in additional context)" is intentionally excluded from
+            // validAdapters — it will be silently dropped, which is the desired behavior.
+            const validAdapters = ['snowflake', 'databricks', 'bigquery', 'postgres', 'redshift', 'duckdb'];
+            const labels = selected.filter(s => validAdapters.includes(s));
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels,
+              });
+            }

--- a/.github/workflows/label-adapter.yml
+++ b/.github/workflows/label-adapter.yml
@@ -31,7 +31,7 @@ jobs:
 
             // "other (describe in additional context)" is intentionally excluded from
             // validAdapters — it will be silently dropped, which is the desired behavior.
-            const validAdapters = ['snowflake', 'databricks', 'bigquery', 'postgres', 'redshift', 'duckdb'];
+            const validAdapters = ['snowflake', 'databricks', 'bigquery', 'postgres', 'redshift', 'duckdb', 'clickhouse'];
             const labels = selected.filter(s => validAdapters.includes(s));
 
             if (labels.length > 0) {


### PR DESCRIPTION
## What

Migrates issue tracking for the dbt Fusion engine into dbt-core (dbt-fusion repository is being archived). Adds **3** new templates alongside dbt-core's existing ones, and adds a docs contact link to `config.yml`.

New templates in `.github/ISSUE_TEMPLATE/`:

| File | Chooser name | Scope |
|---|---|---|
| `bug-report-v2.yml` | 🐞 Bug (dbt v2.x) | General v2.x bugs (Core or Fusion); has a built-in "discrepancy vs dbt 1.x" checkbox |
| `bug-report-vsce.yml` | 🐞📟 VS Code Extension Bug | Fusion VS Code extension / LSP (Fusion-only) |
| `sql-understanding.yml` | 🧠 SQL understanding issue | Fusion static analysis (Fusion-only) |

`config.yml` gains a Fusion docs contact link (existing links preserved). dbt-core's existing templates are unchanged.

## Decisions (from review with @joellabes)
- **One feature request form** — no separate v2 variant; dbt-core's existing feature template is the single form.
- **No `installation` template** — 0 install-labelled tickets to date, and installation support for v1 doesn't happen here currently either.
- **No standalone discrepancy template** — covered by the "discrepancy vs 1.x" checkbox on the main bug report.

Review companion (old→new wording diff): dbt-labs/dbt-fusion#2240.