### PR TITLE
feat(duckdb): catalogs.yml v2 support (Iceberg / Unity / Horizon)

### DIFF
--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -61,7 +61,7 @@ use dbt_schemas::schemas::common::DbtIncrementalStrategy;
 use dbt_schemas::schemas::common::DbtMaterialization;
 use dbt_schemas::schemas::common::ResolvedQuoting;
 use dbt_schemas::schemas::common::{ClusterConfig, Constraint, ConstraintSupport, PartitionConfig};
-use dbt_schemas::schemas::dbt_catalogs_v2::V2CatalogType;
+use dbt_schemas::schemas::dbt_catalogs_v2::{DbtCatalogsV2View, V2CatalogType, V2TableFormat};
 use dbt_schemas::schemas::dbt_column::{DbtColumn, DbtColumnRef};
 use dbt_schemas::schemas::manifest::BigqueryPartitionConfig;
 use dbt_schemas::schemas::profiles::DuckDBPathInfo;
@@ -430,22 +430,10 @@ impl AdapterImpl {
         // return the appropriate table format so that macros can skip CASCADE / ALTER TABLE RENAME.
         if load_catalogs::fetch_use_catalogs_v2() {
             if let Some(catalogs) = load_catalogs::fetch_catalogs() {
-                if let Ok(view) = catalogs.view_v2() {
-                    for catalog in &view.catalogs {
-                        if let Some(duckdb_block) = catalog.config_block("duckdb") {
-                            let alias = duckdb_block
-                                .get(dbt_yaml::Value::from("attach_as"))
-                                .and_then(|v| v.as_str())
-                                .unwrap_or(catalog.name);
-                            let alias = crate::catalog_relation::sanitize_duckdb_identifier(alias);
-                            if alias.eq_ignore_ascii_case(database) {
-                                return match catalog.catalog_type {
-                                    V2CatalogType::DuckLake => TableFormat::DuckLake,
-                                    _ => TableFormat::Iceberg,
-                                };
-                            }
-                        }
-                    }
+                if let Ok(view) = catalogs.view_v2()
+                    && let Some(format) = table_format_for_database_from_v2(database, &view)
+                {
+                    return format;
                 }
             }
         }
@@ -4333,6 +4321,34 @@ impl AdapterImpl {
     }
 }
 
+fn table_format_for_database_from_v2(
+    database: &str,
+    view: &DbtCatalogsV2View<'_>,
+) -> Option<TableFormat> {
+    // Used by adapter.table_format(relation) when a Jinja relation only gives
+    // us its database/catalog. The attached DuckDB alias is the bridge back to
+    // catalogs.yml, which tells macros whether DuckDB needs Iceberg/DuckLake
+    // DDL behavior for that relation.
+    for catalog in &view.catalogs {
+        let Some(duckdb_block) = catalog.config_block("duckdb") else {
+            continue;
+        };
+        let alias = duckdb_block
+            .get(dbt_yaml::Value::from("attach_as"))
+            .and_then(|v| v.as_str())
+            .unwrap_or(catalog.name);
+        let alias = crate::catalog_relation::sanitize_duckdb_identifier(alias);
+        if alias.eq_ignore_ascii_case(database) {
+            return Some(match catalog.catalog_type {
+                V2CatalogType::DuckLake => TableFormat::DuckLake,
+                _ if matches!(catalog.table_format, V2TableFormat::Iceberg) => TableFormat::Iceberg,
+                _ => TableFormat::Default,
+            });
+        }
+    }
+    None
+}
+
 /// Reads `job_execution_timeout_seconds` from the BigQuery adapter attr of the current
 /// model or snapshot in the Jinja state. Returns `None` if the state has no model or the
 /// model has no BigQuery timeout configured.
@@ -4828,12 +4844,23 @@ mod tests {
     use dbt_adapter_core::AdapterType;
     use dbt_auth::auth_for_backend;
     use dbt_common::AdapterResult;
+    use dbt_schemas::schemas::dbt_catalogs::DbtCatalogs;
     use dbt_schemas::schemas::dbt_column::{DbtColumn, DbtColumnRef};
     use dbt_schemas::schemas::relations::base::ComponentName;
     use dbt_schemas::schemas::relations::{DEFAULT_RESOLVED_QUOTING, SNOWFLAKE_RESOLVED_QUOTING};
     use dbt_yaml::Mapping;
 
     use minijinja::{Environment, State, Value};
+
+    fn with_catalogs_v2_view(yaml: &str, test: impl FnOnce(&DbtCatalogsV2View<'_>)) {
+        let parsed: dbt_yaml::Value = dbt_yaml::from_str(yaml).expect("valid YAML");
+        let dbt_yaml::Value::Mapping(repr, span) = parsed else {
+            panic!("expected YAML mapping");
+        };
+        let catalogs = DbtCatalogs::new(repr, span);
+        let view = catalogs.view_v2().expect("valid catalogs v2 view");
+        test(&view);
+    }
 
     fn engine(adapter_type: AdapterType) -> Arc<dyn AdapterEngine> {
         let config = match adapter_type {
@@ -5011,6 +5038,40 @@ mod tests {
         assert_eq!(
             adapter.table_format_for_database("demo"),
             TableFormat::Default
+        );
+    }
+
+    #[test]
+    fn test_table_format_v2_uses_catalog_table_format() {
+        with_catalogs_v2_view(
+            r#"
+catalogs:
+  - name: horizon_demo
+    type: horizon
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint: https://snowflake.example.com/polaris/api/catalog
+        warehouse: HORIZON_CATALOG
+  - name: remote_catalog
+    type: local_filesystem
+    table_format: default
+    config:
+      duckdb:
+        root_path: /tmp/remote
+        attach_as: remote_db
+"#,
+            |view| {
+                assert_eq!(
+                    table_format_for_database_from_v2("horizon_demo", view),
+                    Some(TableFormat::Iceberg)
+                );
+                assert_eq!(
+                    table_format_for_database_from_v2("remote_db", view),
+                    Some(TableFormat::Default)
+                );
+                assert_eq!(table_format_for_database_from_v2("missing", view), None);
+            },
         );
     }
 

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -464,12 +464,18 @@ impl AdapterImpl {
             let Some(path) = map.get("path").and_then(|v| v.as_str()) else {
                 continue;
             };
+            let explicit_type = map
+                .get("type")
+                .and_then(|v| v.as_str())
+                .map(str::to_ascii_lowercase);
             let attach_info = DuckDBPathInfo::parse_path(Some(path));
             let explicit_ducklake = map
                 .get("is_ducklake")
                 .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-            if !explicit_ducklake && !attach_info.is_ducklake {
+                .unwrap_or(false)
+                || explicit_type.as_deref() == Some("ducklake");
+            let explicit_iceberg = explicit_type.as_deref() == Some("iceberg");
+            if !explicit_ducklake && !attach_info.is_ducklake && !explicit_iceberg {
                 continue;
             }
 
@@ -479,6 +485,9 @@ impl AdapterImpl {
                 .map(ToOwned::to_owned)
                 .unwrap_or_else(|| attach_info.database.to_owned());
             if attachment_db.eq_ignore_ascii_case(database) {
+                if explicit_iceberg {
+                    return TableFormat::Iceberg;
+                }
                 return TableFormat::DuckLake;
             }
         }
@@ -4972,6 +4981,35 @@ mod tests {
         );
         assert_eq!(
             adapter.table_format_for_database("main"),
+            TableFormat::Default
+        );
+    }
+
+    #[test]
+    fn test_table_format_profile_level_iceberg_attachment() {
+        let attach = YmlValue::Sequence(
+            vec![YmlValue::Mapping(
+                Mapping::from_iter([
+                    ("path".into(), "demo".into()),
+                    ("alias".into(), "iceberg_demo".into()),
+                    ("type".into(), "iceberg".into()),
+                ]),
+                Default::default(),
+            )],
+            Default::default(),
+        );
+        let config = Mapping::from_iter([
+            ("path".into(), "demo.duckdb".into()),
+            ("attach".into(), attach),
+        ]);
+        let adapter = AdapterImpl::new(build_engine(DuckDB, config), None);
+
+        assert_eq!(
+            adapter.table_format_for_database("iceberg_demo"),
+            TableFormat::Iceberg
+        );
+        assert_eq!(
+            adapter.table_format_for_database("demo"),
             TableFormat::Default
         );
     }

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -16,7 +16,7 @@ use crate::sql_types::TypeOps;
 use crate::stmt_splitter::DefaultStmtSplitter;
 use crate::time_machine::TimeMachine;
 use crate::value::*;
-use crate::{AdapterResponse, AdapterResult};
+use crate::{AdapterResponse, AdapterResult, connection};
 
 use dbt_adapter_core::AdapterType;
 use dbt_agate::AgateTable;
@@ -240,7 +240,11 @@ impl Adapter {
     /// def commit(self) -> None
     /// ```
     pub fn commit(&self) -> Result<Value, minijinja::Error> {
-        Ok(Value::from(true))
+        if self.adapter_type() == AdapterType::DuckDB && matches!(self.inner, Typed { .. }) {
+            connection::commit_thread_local_connection_if_present()
+                .map_err(minijinja::Error::from)?;
+        }
+        Ok(none_value())
     }
 
     /// Execute a statement, expect no results.

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -240,6 +240,9 @@ impl Adapter {
     /// def commit(self) -> None
     /// ```
     pub fn commit(&self) -> Result<Value, minijinja::Error> {
+        // DuckDB Iceberg writes need an explicit transaction boundary before
+        // some follow-up DDL. Other adapters either manage commits elsewhere or
+        // do not expose a thread-local ADBC connection through this Jinja hook.
         if self.adapter_type() == AdapterType::DuckDB && matches!(self.inner, Typed { .. }) {
             connection::commit_thread_local_connection_if_present()
                 .map_err(minijinja::Error::from)?;
@@ -1302,8 +1305,21 @@ impl Adapter {
                             temp_relation.schema_as_resolved_str().unwrap_or_default();
                         let has_schema =
                             !resolved_catalog.is_empty() || !resolved_schema.is_empty();
+                        // Schema-wide listing is only unreliable for external
+                        // Iceberg REST catalogs (their information_schema coverage
+                        // is incomplete), so skip warming the cache only when the
+                        // *target* catalog is one of them. For a regular DuckDB
+                        // catalog we still warm once per schema — otherwise every
+                        // per-relation existence check falls back to a query over
+                        // the unqualified `information_schema.tables`, which unions
+                        // every attached database and fans out across all remote
+                        // catalogs on each call.
+                        let skip_schema_listing = adapter.adapter_type() == AdapterType::DuckDB
+                            && duckdb::is_duckdb_v2_external_iceberg_catalog_database(
+                                &resolved_catalog,
+                            );
 
-                        if has_schema {
+                        if has_schema && !skip_schema_listing {
                             let mut conn = adapter
                                 .borrow_tlocal_connection(Some(state), node_id_from_state(state))?;
                             let db_schema = CatalogAndSchema::from(temp_relation.as_ref());

--- a/crates/dbt-adapter/src/catalog_relation.rs
+++ b/crates/dbt-adapter/src/catalog_relation.rs
@@ -21,7 +21,7 @@ mod catalog_relation_v2;
 /// Keep only ASCII alphanumeric and underscore characters (SQL identifier safety).
 /// Used for DuckDB ATTACH aliases so that the routing database name matches the
 /// attached alias exactly.
-pub(crate) fn sanitize_duckdb_identifier(name: &str) -> String {
+pub fn sanitize_duckdb_identifier(name: &str) -> String {
     name.chars()
         .filter(|c| c.is_ascii_alphanumeric() || *c == '_')
         .collect()

--- a/crates/dbt-adapter/src/catalog_relation.rs
+++ b/crates/dbt-adapter/src/catalog_relation.rs
@@ -1431,6 +1431,33 @@ impl CatalogRelation {
             Value::from(())
         }
     }
+
+    pub fn supports_stage_create(&self) -> bool {
+        // Adapter-generic Jinja surface for materializations. DuckDB catalogs
+        // can opt out when the underlying catalog cannot create directly from
+        // SELECT and needs create-then-insert writes instead.
+        if let Some(support_stage_create) = self.adapter_properties.get("support_stage_create") {
+            return support_stage_create.eq_ignore_ascii_case("true");
+        }
+
+        if self.adapter_type == AdapterType::DuckDB {
+            if self
+                .catalog_type
+                .eq_ignore_ascii_case(V2CatalogType::Horizon.as_str())
+            {
+                return false;
+            }
+
+            if let Some(endpoint_type) = self.adapter_properties.get("endpoint_type")
+                && (endpoint_type.eq_ignore_ascii_case("GLUE")
+                    || endpoint_type.eq_ignore_ascii_case("S3_TABLES"))
+            {
+                return false;
+            }
+        }
+
+        true
+    }
 }
 
 #[inline]
@@ -1469,6 +1496,10 @@ impl Object for CatalogRelation {
 
             "catalog_type" => Self::map_str_val(self.catalog_type.as_str()),
             "table_format" => Self::map_str_val(self.table_format.as_str()),
+            "supports_stage_create" => Value::from(self.supports_stage_create()),
+            // ATTACH/YAML use the singular option name, while macro code reads this
+            // as a catalog capability predicate.
+            "support_stage_create" => Value::from(self.supports_stage_create()),
 
             // common optional
             "base_location" => Self::map_opt_str(self.base_location.clone()),

--- a/crates/dbt-adapter/src/catalog_relation.rs
+++ b/crates/dbt-adapter/src/catalog_relation.rs
@@ -1436,8 +1436,8 @@ impl CatalogRelation {
         // Adapter-generic Jinja surface for materializations. DuckDB catalogs
         // can opt out when the underlying catalog cannot create directly from
         // SELECT and needs create-then-insert writes instead.
-        if let Some(support_stage_create) = self.adapter_properties.get("support_stage_create") {
-            return support_stage_create.eq_ignore_ascii_case("true");
+        if let Some(stage_create_tables) = self.adapter_properties.get("stage_create_tables") {
+            return stage_create_tables.eq_ignore_ascii_case("true");
         }
 
         if self.adapter_type == AdapterType::DuckDB {
@@ -1497,9 +1497,9 @@ impl Object for CatalogRelation {
             "catalog_type" => Self::map_str_val(self.catalog_type.as_str()),
             "table_format" => Self::map_str_val(self.table_format.as_str()),
             "supports_stage_create" => Value::from(self.supports_stage_create()),
-            // ATTACH/YAML use the singular option name, while macro code reads this
-            // as a catalog capability predicate.
-            "support_stage_create" => Value::from(self.supports_stage_create()),
+            // ATTACH/YAML use the duckdb-iceberg option name, while macro code reads
+            // this as a catalog capability predicate.
+            "stage_create_tables" => Value::from(self.supports_stage_create()),
 
             // common optional
             "base_location" => Self::map_opt_str(self.base_location.clone()),

--- a/crates/dbt-adapter/src/catalog_relation/catalog_relation_v2.rs
+++ b/crates/dbt-adapter/src/catalog_relation/catalog_relation_v2.rs
@@ -171,7 +171,8 @@ pub(super) fn from_model_config_and_catalogs_v2(
             CatalogRelation::build_bigquery_biglake_with_catalogs_v2(model, catalog, &catalog_name)
         }
         (AdapterType::DuckDB, V2CatalogType::Glue)
-        | (AdapterType::DuckDB, V2CatalogType::IcebergRest) => {
+        | (AdapterType::DuckDB, V2CatalogType::IcebergRest)
+        | (AdapterType::DuckDB, V2CatalogType::Horizon) => {
             CatalogRelation::build_duckdb_with_catalogs_v2(model, catalog, &catalog_name)
         }
         (AdapterType::DuckDB, V2CatalogType::DuckLake) => {
@@ -187,7 +188,7 @@ pub(super) fn from_model_config_and_catalogs_v2(
         (AdapterType::DuckDB, other) => Err(AdapterError::new(
             AdapterErrorKind::Configuration,
             format!(
-                "Catalog '{catalog_name}' has type '{}'; DuckDB v2 mapping supports only 'glue', 'iceberg_rest', 'ducklake', and 'local_filesystem'",
+                "Catalog '{catalog_name}' has type '{}'; DuckDB v2 mapping supports only 'horizon', 'glue', 'iceberg_rest', 'ducklake', and 'local_filesystem'",
                 other.as_str()
             ),
         )),
@@ -796,6 +797,7 @@ impl CatalogRelation {
         let warehouse = get_yaml_str(duckdb, "warehouse").map(|s| s.to_string());
         let secret = get_yaml_str(duckdb, "secret").map(|s| s.to_string());
         let attach_as = get_yaml_str(duckdb, "attach_as").map(|s| s.to_string());
+        let support_stage_create = get_yaml_bool(duckdb, "support_stage_create");
         // Use same sanitization as ATTACH SQL generation so routing and attachment stay in sync
         let alias = sanitize_duckdb_identifier(attach_as.as_deref().unwrap_or(catalog_name));
 
@@ -820,6 +822,12 @@ impl CatalogRelation {
         }
         if let Some(ref secret) = secret {
             adapter_properties.insert("secret".to_string(), secret.clone());
+        }
+        if let Some(support_stage_create) = support_stage_create {
+            adapter_properties.insert(
+                "support_stage_create".to_string(),
+                support_stage_create.to_string(),
+            );
         }
         adapter_properties.insert("attached_database".to_string(), alias);
 
@@ -1655,19 +1663,107 @@ catalogs:
     }
 
     #[test]
+    fn duckdb_v2_horizon_catalog_builds_relation() {
+        let catalogs = load_catalogs_yaml(
+            r#"
+catalogs:
+  - name: horizon_demo
+    type: horizon
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint: "https://snowflake.example.com/polaris/api/catalog"
+        warehouse: "HORIZON_CATALOG"
+        secret: "horizon_secret"
+        attach_as: "horizon_db"
+"#,
+        );
+        let conf = json!({ "catalog_name": "horizon_demo" });
+        let m = model(AdapterType::DuckDB, conf);
+
+        let r =
+            from_model_config_and_catalogs_v2(AdapterType::DuckDB, &m, Arc::new(catalogs)).unwrap();
+
+        assert_eq!(r.catalog_type, "horizon");
+        assert_eq!(r.table_format, ICEBERG_TABLE_FORMAT);
+        assert_eq!(
+            r.adapter_properties.get("endpoint").map(|s| s.as_str()),
+            Some("https://snowflake.example.com/polaris/api/catalog")
+        );
+        assert_eq!(
+            r.adapter_properties.get("warehouse").map(|s| s.as_str()),
+            Some("HORIZON_CATALOG")
+        );
+        assert_eq!(
+            r.adapter_properties
+                .get("attached_database")
+                .map(|s| s.as_str()),
+            Some("horizon_db")
+        );
+        assert!(!r.supports_stage_create());
+    }
+
+    #[test]
+    fn duckdb_v2_horizon_support_stage_create_override_true() {
+        let catalogs = load_catalogs_yaml(
+            r#"
+catalogs:
+  - name: horizon_demo
+    type: horizon
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint: "https://snowflake.example.com/polaris/api/catalog"
+        warehouse: "HORIZON_CATALOG"
+        support_stage_create: true
+"#,
+        );
+        let conf = json!({ "catalog_name": "horizon_demo" });
+        let m = model(AdapterType::DuckDB, conf);
+
+        let r =
+            from_model_config_and_catalogs_v2(AdapterType::DuckDB, &m, Arc::new(catalogs)).unwrap();
+
+        assert!(r.supports_stage_create());
+    }
+
+    #[test]
+    fn duckdb_v2_iceberg_rest_support_stage_create_override_false() {
+        let catalogs = load_catalogs_yaml(
+            r#"
+catalogs:
+  - name: rest_demo
+    type: iceberg_rest
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint: "https://rest.example.com"
+        support_stage_create: false
+"#,
+        );
+        let conf = json!({ "catalog_name": "rest_demo" });
+        let m = model(AdapterType::DuckDB, conf);
+
+        let r =
+            from_model_config_and_catalogs_v2(AdapterType::DuckDB, &m, Arc::new(catalogs)).unwrap();
+
+        assert!(!r.supports_stage_create());
+    }
+
+    #[test]
     fn duckdb_v2_unsupported_catalog_type_errors() {
         let catalogs = load_catalogs_yaml(
             r#"
 catalogs:
-  - name: my_horizon
-    type: horizon
+  - name: my_unity
+    type: unity
     table_format: iceberg
     config:
       snowflake:
-        external_volume: "EV"
+        catalog_database: "UC_DB"
 "#,
         );
-        let conf = json!({ "catalog_name": "my_horizon" });
+        let conf = json!({ "catalog_name": "my_unity" });
         let m = model(AdapterType::DuckDB, conf);
 
         let err = from_model_config_and_catalogs_v2(AdapterType::DuckDB, &m, Arc::new(catalogs))
@@ -1675,7 +1771,7 @@ catalogs:
 
         assert!(
             format!("{err}").contains(
-                "DuckDB v2 mapping supports only 'glue', 'iceberg_rest', 'ducklake', and 'local_filesystem'"
+                "DuckDB v2 mapping supports only 'horizon', 'glue', 'iceberg_rest', 'ducklake', and 'local_filesystem'"
             )
         );
     }

--- a/crates/dbt-adapter/src/catalog_relation/catalog_relation_v2.rs
+++ b/crates/dbt-adapter/src/catalog_relation/catalog_relation_v2.rs
@@ -6,6 +6,7 @@ use dbt_schemas::schemas::dbt_catalogs_v2::{
 use dbt_yaml as yml;
 
 const FIELD_CATALOG_NAME: &str = "catalog_name";
+const FIELD_CATALOG: &str = "catalog";
 const FIELD_CATALOG_TYPE: &str = "catalog_type";
 const FIELD_TABLE_FORMAT: &str = "table_format";
 const FIELD_EXTERNAL_VOLUME: &str = "external_volume";
@@ -39,6 +40,7 @@ const ADAPTER_PROP_TARGET_FILE_SIZE: &str = "target_file_size";
 const ADAPTER_PROP_EXTERNAL_ROOT: &str = "external_root";
 
 const MODEL_NONE_SENTINEL: &str = "none";
+const MODEL_BUILTIN_SENTINEL: &str = "builtin";
 
 pub(super) fn from_model_config_and_catalogs_v2(
     adapter_type: AdapterType,
@@ -172,7 +174,8 @@ pub(super) fn from_model_config_and_catalogs_v2(
         }
         (AdapterType::DuckDB, V2CatalogType::Glue)
         | (AdapterType::DuckDB, V2CatalogType::IcebergRest)
-        | (AdapterType::DuckDB, V2CatalogType::Horizon) => {
+        | (AdapterType::DuckDB, V2CatalogType::Horizon)
+        | (AdapterType::DuckDB, V2CatalogType::Unity) => {
             CatalogRelation::build_duckdb_with_catalogs_v2(model, catalog, &catalog_name)
         }
         (AdapterType::DuckDB, V2CatalogType::DuckLake) => {
@@ -188,7 +191,7 @@ pub(super) fn from_model_config_and_catalogs_v2(
         (AdapterType::DuckDB, other) => Err(AdapterError::new(
             AdapterErrorKind::Configuration,
             format!(
-                "Catalog '{catalog_name}' has type '{}'; DuckDB v2 mapping supports only 'horizon', 'glue', 'iceberg_rest', 'ducklake', and 'local_filesystem'",
+                "Catalog '{catalog_name}' has type '{}'; DuckDB v2 mapping supports only 'horizon', 'glue', 'iceberg_rest', 'unity', 'ducklake', and 'local_filesystem'",
                 other.as_str()
             ),
         )),
@@ -254,14 +257,18 @@ fn parse_model_u32(
 }
 
 fn model_catalog_name(model: &Value, adapter_type: AdapterType) -> Option<String> {
-    CatalogRelation::get_model_config_value(model, FIELD_CATALOG_NAME, adapter_type).and_then(|s| {
-        let t = s.trim();
-        if t.eq_ignore_ascii_case(MODEL_NONE_SENTINEL) {
-            None
-        } else {
-            Some(t.to_string())
-        }
-    })
+    CatalogRelation::get_model_config_value(model, FIELD_CATALOG_NAME, adapter_type)
+        .or_else(|| CatalogRelation::get_model_config_value(model, FIELD_CATALOG, adapter_type))
+        .and_then(|s| {
+            let t = s.trim();
+            if t.eq_ignore_ascii_case(MODEL_NONE_SENTINEL)
+                || t.eq_ignore_ascii_case(MODEL_BUILTIN_SENTINEL)
+            {
+                None
+            } else {
+                Some(t.to_string())
+            }
+        })
 }
 
 fn get_yaml_str<'a>(map: &'a yml::Mapping, key: &str) -> Option<&'a str> {
@@ -797,7 +804,7 @@ impl CatalogRelation {
         let warehouse = get_yaml_str(duckdb, "warehouse").map(|s| s.to_string());
         let secret = get_yaml_str(duckdb, "secret").map(|s| s.to_string());
         let attach_as = get_yaml_str(duckdb, "attach_as").map(|s| s.to_string());
-        let support_stage_create = get_yaml_bool(duckdb, "support_stage_create");
+        let stage_create_tables = get_yaml_bool(duckdb, "stage_create_tables");
         // Use same sanitization as ATTACH SQL generation so routing and attachment stay in sync
         let alias = sanitize_duckdb_identifier(attach_as.as_deref().unwrap_or(catalog_name));
 
@@ -823,10 +830,10 @@ impl CatalogRelation {
         if let Some(ref secret) = secret {
             adapter_properties.insert("secret".to_string(), secret.clone());
         }
-        if let Some(support_stage_create) = support_stage_create {
+        if let Some(stage_create_tables) = stage_create_tables {
             adapter_properties.insert(
-                "support_stage_create".to_string(),
-                support_stage_create.to_string(),
+                "stage_create_tables".to_string(),
+                stage_create_tables.to_string(),
             );
         }
         adapter_properties.insert("attached_database".to_string(), alias);
@@ -1623,6 +1630,47 @@ catalogs:
     }
 
     #[test]
+    fn duckdb_v2_unity_catalog_builds_relation() {
+        let catalogs = load_catalogs_yaml(
+            r#"
+catalogs:
+  - name: my_uc
+    type: unity
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint: "https://dbc.example.com/api/2.1/unity-catalog/iceberg-rest"
+        warehouse: "main"
+        secret: "databricks_pat"
+        attach_as: "uc"
+"#,
+        );
+        let conf = json!({ "catalog_name": "my_uc" });
+        let m = model(AdapterType::DuckDB, conf);
+
+        let r =
+            from_model_config_and_catalogs_v2(AdapterType::DuckDB, &m, Arc::new(catalogs)).unwrap();
+
+        assert_eq!(r.catalog_name.as_deref(), Some("my_uc"));
+        assert_eq!(r.catalog_type, "unity");
+        assert_eq!(r.table_format, ICEBERG_TABLE_FORMAT);
+        assert_eq!(
+            r.adapter_properties.get("endpoint").map(|s| s.as_str()),
+            Some("https://dbc.example.com/api/2.1/unity-catalog/iceberg-rest")
+        );
+        assert_eq!(
+            r.adapter_properties.get("warehouse").map(|s| s.as_str()),
+            Some("main")
+        );
+        assert_eq!(
+            r.adapter_properties
+                .get("attached_database")
+                .map(|s| s.as_str()),
+            Some("uc")
+        );
+    }
+
+    #[test]
     fn duckdb_v2_glue_catalog_builds_relation_with_endpoint_type() {
         let catalogs = load_catalogs_yaml(
             r#"
@@ -1704,7 +1752,7 @@ catalogs:
     }
 
     #[test]
-    fn duckdb_v2_horizon_support_stage_create_override_true() {
+    fn duckdb_v2_horizon_stage_create_tables_override_true() {
         let catalogs = load_catalogs_yaml(
             r#"
 catalogs:
@@ -1715,7 +1763,7 @@ catalogs:
       duckdb:
         endpoint: "https://snowflake.example.com/polaris/api/catalog"
         warehouse: "HORIZON_CATALOG"
-        support_stage_create: true
+        stage_create_tables: true
 "#,
         );
         let conf = json!({ "catalog_name": "horizon_demo" });
@@ -1728,7 +1776,7 @@ catalogs:
     }
 
     #[test]
-    fn duckdb_v2_iceberg_rest_support_stage_create_override_false() {
+    fn duckdb_v2_iceberg_rest_stage_create_tables_override_false() {
         let catalogs = load_catalogs_yaml(
             r#"
 catalogs:
@@ -1738,7 +1786,7 @@ catalogs:
     config:
       duckdb:
         endpoint: "https://rest.example.com"
-        support_stage_create: false
+        stage_create_tables: false
 "#,
         );
         let conf = json!({ "catalog_name": "rest_demo" });
@@ -1751,7 +1799,7 @@ catalogs:
     }
 
     #[test]
-    fn duckdb_v2_unsupported_catalog_type_errors() {
+    fn duckdb_v2_unity_missing_duckdb_config_errors() {
         let catalogs = load_catalogs_yaml(
             r#"
 catalogs:
@@ -1769,11 +1817,7 @@ catalogs:
         let err = from_model_config_and_catalogs_v2(AdapterType::DuckDB, &m, Arc::new(catalogs))
             .unwrap_err();
 
-        assert!(
-            format!("{err}").contains(
-                "DuckDB v2 mapping supports only 'horizon', 'glue', 'iceberg_rest', 'ducklake', and 'local_filesystem'"
-            )
-        );
+        assert!(format!("{err}").contains("Catalog 'my_unity' is missing config.duckdb"));
     }
 
     #[test]
@@ -1809,8 +1853,7 @@ catalogs:
     }
 
     #[test]
-    fn duckdb_v2_catalog_name_none_returns_default() {
-        // DuckDB with catalog_name = "none" should return default
+    fn duckdb_v2_catalog_name_sentinel_returns_default() {
         let catalogs = load_catalogs_yaml(
             r#"
 catalogs:
@@ -1822,15 +1865,44 @@ catalogs:
         endpoint: "https://rest.example.com"
 "#,
         );
-        let conf = json!({ "catalog_name": "none" });
+        for sentinel in ["none", "builtin"] {
+            let conf = json!({ "catalog_name": sentinel });
+            let m = model(AdapterType::DuckDB, conf);
+
+            let r = from_model_config_and_catalogs_v2(
+                AdapterType::DuckDB,
+                &m,
+                Arc::new(catalogs.clone()),
+            )
+            .unwrap();
+
+            assert!(r.catalog_name.is_none());
+            assert_eq!(r.catalog_type, "duckdb");
+            assert_eq!(r.table_format, "default");
+        }
+    }
+
+    #[test]
+    fn duckdb_v2_catalog_alias_builds_relation() {
+        let catalogs = load_catalogs_yaml(
+            r#"
+catalogs:
+  - name: my_lake
+    type: ducklake
+    table_format: default
+    config:
+      duckdb:
+        metadata_path: "metadata.ducklake"
+"#,
+        );
+        let conf = json!({ "catalog": "my_lake" });
         let m = model(AdapterType::DuckDB, conf);
 
         let r =
             from_model_config_and_catalogs_v2(AdapterType::DuckDB, &m, Arc::new(catalogs)).unwrap();
 
-        assert!(r.catalog_name.is_none());
-        assert_eq!(r.catalog_type, "duckdb");
-        assert_eq!(r.table_format, "default");
+        assert_eq!(r.catalog_name.as_deref(), Some("my_lake"));
+        assert_eq!(r.catalog_type, "ducklake");
     }
 
     // ===== DuckLake v2 tests =====

--- a/crates/dbt-adapter/src/connection.rs
+++ b/crates/dbt-adapter/src/connection.rs
@@ -22,7 +22,7 @@ use crossbeam_utils::CachePadded;
 use tracing::Span;
 
 use crate::AdapterEngine;
-use crate::errors::AdapterError;
+use crate::errors::{AdapterError, adbc_error_to_adapter_error};
 
 /// Global atomic for generating unique connection IDs.
 static CONN_SEQ_NUM: AtomicU64 = AtomicU64::new(0);
@@ -112,6 +112,19 @@ pub fn recycle_thread_local_connection() {
     if let Some(conn) = conn {
         sort_for_recycling(conn)
     }
+}
+
+pub(crate) fn commit_thread_local_connection_if_present() -> AdapterResult<bool> {
+    // The DuckDB adapter stores the active blocking-task connection in a
+    // thread-local slot, so Jinja `adapter.commit()` has to temporarily take it
+    // out, commit, then put it back for the rest of the materialization.
+    let Some(mut conn) = CONNECTION.with(|c| c.take()) else {
+        return Ok(false);
+    };
+
+    let result = conn.commit().map_err(adbc_error_to_adapter_error);
+    CONNECTION.with(|c| c.replace(Some(conn)));
+    result.map(|_| true)
 }
 
 /// Drop guard that recycles this thread's cached adapter connection.

--- a/crates/dbt-adapter/src/engine/xdbc.rs
+++ b/crates/dbt-adapter/src/engine/xdbc.rs
@@ -513,6 +513,12 @@ fn build_duckdb_catalog_attach_stmt(
     for (key, sql_key) in [
         ("support_nested_namespaces", "SUPPORT_NESTED_NAMESPACES"),
         ("support_stage_create", "SUPPORT_STAGE_CREATE"),
+        ("use_transaction_commit", "USE_TRANSACTION_COMMIT"),
+        (
+            "skip_create_table_metadata_updates",
+            "SKIP_CREATE_TABLE_METADATA_UPDATES",
+        ),
+        ("allow_deletes", "ALLOW_DELETES"),
         ("purge_requested", "PURGE_REQUESTED"),
     ] {
         if let Some(val) = duckdb_get_bool(duckdb, key) {

--- a/crates/dbt-adapter/src/engine/xdbc.rs
+++ b/crates/dbt-adapter/src/engine/xdbc.rs
@@ -328,7 +328,7 @@ impl XdbcEngine {
     }
 
     /// Build v2 catalog-driven `ATTACH IF NOT EXISTS` statements for DuckDB
-    /// Glue, Iceberg REST, and DuckLake catalogs.
+    /// Horizon, Glue, Iceberg REST, Unity Catalog, and DuckLake catalogs.
     ///
     /// Reads the global catalogs v2 state, extracts every catalog that has a
     /// `config.duckdb` block, and emits one ATTACH per catalog. Duplicate
@@ -373,6 +373,7 @@ fn compose_v2_catalog_attach_stmts(view: &DbtCatalogsV2View<'_>) -> AdapterResul
                 V2CatalogType::Horizon
                     | V2CatalogType::Glue
                     | V2CatalogType::IcebergRest
+                    | V2CatalogType::Unity
                     | V2CatalogType::DuckLake
             )
         })
@@ -467,6 +468,49 @@ fn build_duckdb_ducklake_attach_stmt(
     Ok((alias, stmt))
 }
 
+/// DuckDB Iceberg `ATTACH` option defaults per catalog type, encoding dbt's
+/// maintainer knowledge of each backend so common catalogs work out of the box.
+///
+/// Each entry is `(config.duckdb key, full SQL option clause)`. The clause is
+/// emitted only when the user has not set that key in `config.duckdb`, so
+/// explicit user values always win. Generic `iceberg_rest` (and `glue`) catalogs
+/// get no opinionated defaults — callers opt in to any of these options
+/// explicitly.
+fn catalog_attach_defaults(catalog_type: V2CatalogType) -> &'static [(&'static str, &'static str)] {
+    match catalog_type {
+        // Snowflake Horizon (Polaris) Iceberg REST: OAuth2 + vended credentials,
+        // and a write path that supports neither staged creates nor multi-table
+        // commits.
+        V2CatalogType::Horizon => &[
+            ("authorization_type", "AUTHORIZATION_TYPE 'OAUTH2'"),
+            (
+                "access_delegation_mode",
+                "ACCESS_DELEGATION_MODE 'VENDED_CREDENTIALS'",
+            ),
+            ("stage_create_tables", "STAGE_CREATE_TABLES false"),
+            (
+                "disable_multi_table_commit",
+                "DISABLE_MULTI_TABLE_COMMIT true",
+            ),
+            (
+                "skip_create_table_metadata_updates",
+                "SKIP_CREATE_TABLE_METADATA_UPDATES true",
+            ),
+            ("remove_files_on_delete", "REMOVE_FILES_ON_DELETE false"),
+        ],
+        // Databricks Unity Catalog's Iceberg REST endpoint does not support the
+        // REST multi-table commit, so default it off; single-table commits work.
+        // (Other write-path options are left to DuckDB's defaults pending
+        // confirmation against a live Unity catalog.)
+        V2CatalogType::Unity => &[(
+            "disable_multi_table_commit",
+            "DISABLE_MULTI_TABLE_COMMIT true",
+        )],
+        // Generic iceberg_rest / glue: no opinionated defaults.
+        _ => &[],
+    }
+}
+
 fn build_duckdb_catalog_attach_stmt(
     catalog: &CatalogSpecV2View<'_>,
     duckdb: &dbt_yaml::Mapping,
@@ -513,43 +557,29 @@ fn build_duckdb_catalog_attach_stmt(
             opts.push(format!("{sql_key} '{}'", escape_duckdb_single_quotes(val)));
         }
     }
-    if catalog.catalog_type == V2CatalogType::Horizon {
-        if duckdb_get_str(duckdb, "authorization_type").is_none() {
-            opts.push("AUTHORIZATION_TYPE 'OAUTH2'".to_string());
-        }
-        if duckdb_get_str(duckdb, "access_delegation_mode").is_none() {
-            opts.push("ACCESS_DELEGATION_MODE 'VENDED_CREDENTIALS'".to_string());
-        }
-    }
     for (key, sql_key) in [
         ("support_nested_namespaces", "SUPPORT_NESTED_NAMESPACES"),
-        ("support_stage_create", "SUPPORT_STAGE_CREATE"),
-        ("use_transaction_commit", "USE_TRANSACTION_COMMIT"),
+        ("stage_create_tables", "STAGE_CREATE_TABLES"),
+        ("disable_multi_table_commit", "DISABLE_MULTI_TABLE_COMMIT"),
         (
             "skip_create_table_metadata_updates",
             "SKIP_CREATE_TABLE_METADATA_UPDATES",
         ),
-        ("allow_deletes", "ALLOW_DELETES"),
+        ("remove_files_on_delete", "REMOVE_FILES_ON_DELETE"),
         ("purge_requested", "PURGE_REQUESTED"),
     ] {
         if let Some(val) = duckdb_get_bool(duckdb, key) {
             opts.push(format!("{sql_key} {val}"));
         }
     }
-    if catalog.catalog_type == V2CatalogType::Horizon {
-        for (key, sql_key, default) in [
-            ("support_stage_create", "SUPPORT_STAGE_CREATE", false),
-            ("use_transaction_commit", "USE_TRANSACTION_COMMIT", false),
-            (
-                "skip_create_table_metadata_updates",
-                "SKIP_CREATE_TABLE_METADATA_UPDATES",
-                true,
-            ),
-            ("allow_deletes", "ALLOW_DELETES", false),
-        ] {
-            if duckdb_get_bool(duckdb, key).is_none() {
-                opts.push(format!("{sql_key} {default}"));
-            }
+    // Apply catalog-type preset defaults for any option the user did not set in
+    // config.duckdb. Explicit user values (emitted above) always win, and
+    // generic iceberg_rest / glue catalogs get no opinionated defaults.
+    for (config_key, default_clause) in catalog_attach_defaults(catalog.catalog_type) {
+        let user_set = duckdb_get_str(duckdb, config_key).is_some()
+            || duckdb_get_bool(duckdb, config_key).is_some();
+        if !user_set {
+            opts.push((*default_clause).to_string());
         }
     }
     if duckdb_get_bool(duckdb, "encode_entire_prefix").unwrap_or(false) {

--- a/crates/dbt-adapter/src/engine/xdbc.rs
+++ b/crates/dbt-adapter/src/engine/xdbc.rs
@@ -370,7 +370,10 @@ fn compose_v2_catalog_attach_stmts(view: &DbtCatalogsV2View<'_>) -> AdapterResul
         .filter(|catalog| {
             matches!(
                 catalog.catalog_type,
-                V2CatalogType::Glue | V2CatalogType::IcebergRest | V2CatalogType::DuckLake
+                V2CatalogType::Horizon
+                    | V2CatalogType::Glue
+                    | V2CatalogType::IcebergRest
+                    | V2CatalogType::DuckLake
             )
         })
         .filter_map(|catalog| {
@@ -510,6 +513,14 @@ fn build_duckdb_catalog_attach_stmt(
             opts.push(format!("{sql_key} '{}'", escape_duckdb_single_quotes(val)));
         }
     }
+    if catalog.catalog_type == V2CatalogType::Horizon {
+        if duckdb_get_str(duckdb, "authorization_type").is_none() {
+            opts.push("AUTHORIZATION_TYPE 'OAUTH2'".to_string());
+        }
+        if duckdb_get_str(duckdb, "access_delegation_mode").is_none() {
+            opts.push("ACCESS_DELEGATION_MODE 'VENDED_CREDENTIALS'".to_string());
+        }
+    }
     for (key, sql_key) in [
         ("support_nested_namespaces", "SUPPORT_NESTED_NAMESPACES"),
         ("support_stage_create", "SUPPORT_STAGE_CREATE"),
@@ -523,6 +534,22 @@ fn build_duckdb_catalog_attach_stmt(
     ] {
         if let Some(val) = duckdb_get_bool(duckdb, key) {
             opts.push(format!("{sql_key} {val}"));
+        }
+    }
+    if catalog.catalog_type == V2CatalogType::Horizon {
+        for (key, sql_key, default) in [
+            ("support_stage_create", "SUPPORT_STAGE_CREATE", false),
+            ("use_transaction_commit", "USE_TRANSACTION_COMMIT", false),
+            (
+                "skip_create_table_metadata_updates",
+                "SKIP_CREATE_TABLE_METADATA_UPDATES",
+                true,
+            ),
+            ("allow_deletes", "ALLOW_DELETES", false),
+        ] {
+            if duckdb_get_bool(duckdb, key).is_none() {
+                opts.push(format!("{sql_key} {default}"));
+            }
         }
     }
     if duckdb_get_bool(duckdb, "encode_entire_prefix").unwrap_or(false) {

--- a/crates/dbt-adapter/src/engine/xdbc/fixtures/horizon_duckdb/catalogs.yml
+++ b/crates/dbt-adapter/src/engine/xdbc/fixtures/horizon_duckdb/catalogs.yml
@@ -1,0 +1,13 @@
+# Scenario: Snowflake Horizon catalog attached from DuckDB.
+# Exercises: Horizon-specific DuckDB REST options are inferred from type=horizon.
+catalogs:
+  - name: horizon_demo
+    type: horizon
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint: "https://snowflake.example.com/polaris/api/catalog"
+        warehouse: "HORIZON_CATALOG"
+        secret: "horizon_secret"
+        attach_as: "horizon_db"
+        default_schema: "demo"

--- a/crates/dbt-adapter/src/engine/xdbc/fixtures/horizon_duckdb/output.snap
+++ b/crates/dbt-adapter/src/engine/xdbc/fixtures/horizon_duckdb/output.snap
@@ -1,0 +1,5 @@
+---
+source: fs/sa/crates/dbt-adapter/src/engine/xdbc/duckdb_attach_snapshot_tests.rs
+input_file: fs/sa/crates/dbt-adapter/src/engine/xdbc/fixtures/horizon_duckdb/catalogs.yml
+---
+ATTACH IF NOT EXISTS 'HORIZON_CATALOG' AS horizon_db (TYPE ICEBERG, SECRET horizon_secret, ENDPOINT 'https://snowflake.example.com/polaris/api/catalog', DEFAULT_SCHEMA 'demo', AUTHORIZATION_TYPE 'OAUTH2', ACCESS_DELEGATION_MODE 'VENDED_CREDENTIALS', SUPPORT_STAGE_CREATE false, USE_TRANSACTION_COMMIT false, SKIP_CREATE_TABLE_METADATA_UPDATES true, ALLOW_DELETES false)

--- a/crates/dbt-adapter/src/engine/xdbc/fixtures/horizon_duckdb/output.snap
+++ b/crates/dbt-adapter/src/engine/xdbc/fixtures/horizon_duckdb/output.snap
@@ -2,4 +2,4 @@
 source: fs/sa/crates/dbt-adapter/src/engine/xdbc/duckdb_attach_snapshot_tests.rs
 input_file: fs/sa/crates/dbt-adapter/src/engine/xdbc/fixtures/horizon_duckdb/catalogs.yml
 ---
-ATTACH IF NOT EXISTS 'HORIZON_CATALOG' AS horizon_db (TYPE ICEBERG, SECRET horizon_secret, ENDPOINT 'https://snowflake.example.com/polaris/api/catalog', DEFAULT_SCHEMA 'demo', AUTHORIZATION_TYPE 'OAUTH2', ACCESS_DELEGATION_MODE 'VENDED_CREDENTIALS', SUPPORT_STAGE_CREATE false, USE_TRANSACTION_COMMIT false, SKIP_CREATE_TABLE_METADATA_UPDATES true, ALLOW_DELETES false)
+ATTACH IF NOT EXISTS 'HORIZON_CATALOG' AS horizon_db (TYPE ICEBERG, SECRET horizon_secret, ENDPOINT 'https://snowflake.example.com/polaris/api/catalog', DEFAULT_SCHEMA 'demo', AUTHORIZATION_TYPE 'OAUTH2', ACCESS_DELEGATION_MODE 'VENDED_CREDENTIALS', STAGE_CREATE_TABLES false, DISABLE_MULTI_TABLE_COMMIT true, SKIP_CREATE_TABLE_METADATA_UPDATES true, REMOVE_FILES_ON_DELETE false)

--- a/crates/dbt-adapter/src/engine/xdbc/fixtures/horizon_overrides_defaults/catalogs.yml
+++ b/crates/dbt-adapter/src/engine/xdbc/fixtures/horizon_overrides_defaults/catalogs.yml
@@ -1,0 +1,17 @@
+# Scenario: Horizon catalog where the user overrides preset defaults.
+# Exercises: explicit config.duckdb values win over the type=horizon presets
+# (e.g. disable_multi_table_commit:false and stage_create_tables:true are
+# emitted as set, not as the Horizon defaults of true/false).
+catalogs:
+  - name: horizon_override
+    type: horizon
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint: "https://snowflake.example.com/polaris/api/catalog"
+        warehouse: "HORIZON_CATALOG"
+        secret: "horizon_secret"
+        attach_as: "horizon_db"
+        default_schema: "demo"
+        disable_multi_table_commit: false
+        stage_create_tables: true

--- a/crates/dbt-adapter/src/engine/xdbc/fixtures/horizon_overrides_defaults/output.snap
+++ b/crates/dbt-adapter/src/engine/xdbc/fixtures/horizon_overrides_defaults/output.snap
@@ -1,0 +1,5 @@
+---
+source: fs/sa/crates/dbt-adapter/src/engine/xdbc.rs
+input_file: fs/sa/crates/dbt-adapter/src/engine/xdbc/fixtures/horizon_overrides_defaults/catalogs.yml
+---
+ATTACH IF NOT EXISTS 'HORIZON_CATALOG' AS horizon_db (TYPE ICEBERG, SECRET horizon_secret, ENDPOINT 'https://snowflake.example.com/polaris/api/catalog', DEFAULT_SCHEMA 'demo', STAGE_CREATE_TABLES true, DISABLE_MULTI_TABLE_COMMIT false, AUTHORIZATION_TYPE 'OAUTH2', ACCESS_DELEGATION_MODE 'VENDED_CREDENTIALS', SKIP_CREATE_TABLE_METADATA_UPDATES true, REMOVE_FILES_ON_DELETE false)

--- a/crates/dbt-adapter/src/engine/xdbc/fixtures/iceberg_rest_full_options/catalogs.yml
+++ b/crates/dbt-adapter/src/engine/xdbc/fixtures/iceberg_rest_full_options/catalogs.yml
@@ -1,8 +1,8 @@
 # Scenario: iceberg_rest catalog exercising every supported option.
 # Exercises: SECRET, ENDPOINT, DEFAULT_REGION, DEFAULT_SCHEMA,
 # MAX_TABLE_STALENESS, AUTHORIZATION_TYPE, ACCESS_DELEGATION_MODE,
-# SUPPORT_NESTED_NAMESPACES, SUPPORT_STAGE_CREATE, PURGE_REQUESTED,
-# ENCODE_ENTIRE_PREFIX.
+# SUPPORT_NESTED_NAMESPACES, SUPPORT_STAGE_CREATE, USE_TRANSACTION_COMMIT,
+# SKIP_CREATE_TABLE_METADATA_UPDATES, ALLOW_DELETES, PURGE_REQUESTED, ENCODE_ENTIRE_PREFIX.
 catalogs:
   - name: rest_full
     type: iceberg_rest
@@ -20,5 +20,8 @@ catalogs:
         access_delegation_mode: "VENDED_CREDENTIALS"
         support_nested_namespaces: false
         support_stage_create: true
+        use_transaction_commit: false
+        skip_create_table_metadata_updates: true
+        allow_deletes: false
         purge_requested: false
         encode_entire_prefix: true

--- a/crates/dbt-adapter/src/engine/xdbc/fixtures/iceberg_rest_full_options/catalogs.yml
+++ b/crates/dbt-adapter/src/engine/xdbc/fixtures/iceberg_rest_full_options/catalogs.yml
@@ -1,8 +1,8 @@
 # Scenario: iceberg_rest catalog exercising every supported option.
 # Exercises: SECRET, ENDPOINT, DEFAULT_REGION, DEFAULT_SCHEMA,
 # MAX_TABLE_STALENESS, AUTHORIZATION_TYPE, ACCESS_DELEGATION_MODE,
-# SUPPORT_NESTED_NAMESPACES, SUPPORT_STAGE_CREATE, USE_TRANSACTION_COMMIT,
-# SKIP_CREATE_TABLE_METADATA_UPDATES, ALLOW_DELETES, PURGE_REQUESTED, ENCODE_ENTIRE_PREFIX.
+# SUPPORT_NESTED_NAMESPACES, STAGE_CREATE_TABLES, DISABLE_MULTI_TABLE_COMMIT,
+# SKIP_CREATE_TABLE_METADATA_UPDATES, REMOVE_FILES_ON_DELETE, PURGE_REQUESTED, ENCODE_ENTIRE_PREFIX.
 catalogs:
   - name: rest_full
     type: iceberg_rest
@@ -19,9 +19,9 @@ catalogs:
         authorization_type: "OAUTH2"
         access_delegation_mode: "VENDED_CREDENTIALS"
         support_nested_namespaces: false
-        support_stage_create: true
-        use_transaction_commit: false
+        stage_create_tables: true
+        disable_multi_table_commit: true
         skip_create_table_metadata_updates: true
-        allow_deletes: false
+        remove_files_on_delete: false
         purge_requested: false
         encode_entire_prefix: true

--- a/crates/dbt-adapter/src/engine/xdbc/fixtures/iceberg_rest_full_options/output.snap
+++ b/crates/dbt-adapter/src/engine/xdbc/fixtures/iceberg_rest_full_options/output.snap
@@ -2,4 +2,4 @@
 source: fs/sa/crates/dbt-adapter/src/engine/xdbc/duckdb_attach_snapshot_tests.rs
 input_file: fs/sa/crates/dbt-adapter/src/engine/xdbc/fixtures/iceberg_rest_full_options/catalogs.yml
 ---
-ATTACH IF NOT EXISTS 'warehouse_name' AS iceberg_db (TYPE ICEBERG, SECRET iceberg_secret, ENDPOINT 'https://rest.example.com', DEFAULT_REGION 'us-east-1', DEFAULT_SCHEMA 'demo', MAX_TABLE_STALENESS '10 minutes', AUTHORIZATION_TYPE 'OAUTH2', ACCESS_DELEGATION_MODE 'VENDED_CREDENTIALS', SUPPORT_NESTED_NAMESPACES false, SUPPORT_STAGE_CREATE true, USE_TRANSACTION_COMMIT false, SKIP_CREATE_TABLE_METADATA_UPDATES true, ALLOW_DELETES false, PURGE_REQUESTED false, ENCODE_ENTIRE_PREFIX true)
+ATTACH IF NOT EXISTS 'warehouse_name' AS iceberg_db (TYPE ICEBERG, SECRET iceberg_secret, ENDPOINT 'https://rest.example.com', DEFAULT_REGION 'us-east-1', DEFAULT_SCHEMA 'demo', MAX_TABLE_STALENESS '10 minutes', AUTHORIZATION_TYPE 'OAUTH2', ACCESS_DELEGATION_MODE 'VENDED_CREDENTIALS', SUPPORT_NESTED_NAMESPACES false, STAGE_CREATE_TABLES true, DISABLE_MULTI_TABLE_COMMIT true, SKIP_CREATE_TABLE_METADATA_UPDATES true, REMOVE_FILES_ON_DELETE false, PURGE_REQUESTED false, ENCODE_ENTIRE_PREFIX true)

--- a/crates/dbt-adapter/src/engine/xdbc/fixtures/iceberg_rest_full_options/output.snap
+++ b/crates/dbt-adapter/src/engine/xdbc/fixtures/iceberg_rest_full_options/output.snap
@@ -2,4 +2,4 @@
 source: fs/sa/crates/dbt-adapter/src/engine/xdbc/duckdb_attach_snapshot_tests.rs
 input_file: fs/sa/crates/dbt-adapter/src/engine/xdbc/fixtures/iceberg_rest_full_options/catalogs.yml
 ---
-ATTACH IF NOT EXISTS 'warehouse_name' AS iceberg_db (TYPE ICEBERG, SECRET iceberg_secret, ENDPOINT 'https://rest.example.com', DEFAULT_REGION 'us-east-1', DEFAULT_SCHEMA 'demo', MAX_TABLE_STALENESS '10 minutes', AUTHORIZATION_TYPE 'OAUTH2', ACCESS_DELEGATION_MODE 'VENDED_CREDENTIALS', SUPPORT_NESTED_NAMESPACES false, SUPPORT_STAGE_CREATE true, PURGE_REQUESTED false, ENCODE_ENTIRE_PREFIX true)
+ATTACH IF NOT EXISTS 'warehouse_name' AS iceberg_db (TYPE ICEBERG, SECRET iceberg_secret, ENDPOINT 'https://rest.example.com', DEFAULT_REGION 'us-east-1', DEFAULT_SCHEMA 'demo', MAX_TABLE_STALENESS '10 minutes', AUTHORIZATION_TYPE 'OAUTH2', ACCESS_DELEGATION_MODE 'VENDED_CREDENTIALS', SUPPORT_NESTED_NAMESPACES false, SUPPORT_STAGE_CREATE true, USE_TRANSACTION_COMMIT false, SKIP_CREATE_TABLE_METADATA_UPDATES true, ALLOW_DELETES false, PURGE_REQUESTED false, ENCODE_ENTIRE_PREFIX true)

--- a/crates/dbt-adapter/src/engine/xdbc/fixtures/unity_catalog_databricks/catalogs.yml
+++ b/crates/dbt-adapter/src/engine/xdbc/fixtures/unity_catalog_databricks/catalogs.yml
@@ -1,0 +1,17 @@
+# Scenario: Unity Catalog through DuckDB's Iceberg REST ATTACH surface.
+# Exercises: Databricks UC endpoint, warehouse/catalog name, secret, alias,
+# OAUTH2 auth, and vended credentials. Managed reads and Java-compatible writes
+# still depend on duckdb-iceberg fixes.
+catalogs:
+  - name: uc_managed
+    type: unity
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint: "https://dbc.example.com/api/2.1/unity-catalog/iceberg-rest"
+        warehouse: "main"
+        secret: "databricks_pat"
+        attach_as: "uc"
+        default_schema: "analytics"
+        authorization_type: "OAUTH2"
+        access_delegation_mode: "VENDED_CREDENTIALS"

--- a/crates/dbt-adapter/src/engine/xdbc/fixtures/unity_catalog_databricks/output.snap
+++ b/crates/dbt-adapter/src/engine/xdbc/fixtures/unity_catalog_databricks/output.snap
@@ -1,0 +1,5 @@
+---
+source: fs/sa/crates/dbt-adapter/src/engine/xdbc.rs
+input_file: fs/sa/crates/dbt-adapter/src/engine/xdbc/fixtures/unity_catalog_databricks/catalogs.yml
+---
+ATTACH IF NOT EXISTS 'main' AS uc (TYPE ICEBERG, SECRET databricks_pat, ENDPOINT 'https://dbc.example.com/api/2.1/unity-catalog/iceberg-rest', DEFAULT_SCHEMA 'analytics', AUTHORIZATION_TYPE 'OAUTH2', ACCESS_DELEGATION_MODE 'VENDED_CREDENTIALS', DISABLE_MULTI_TABLE_COMMIT true)

--- a/crates/dbt-adapter/src/metadata/duckdb/mod.rs
+++ b/crates/dbt-adapter/src/metadata/duckdb/mod.rs
@@ -1,6 +1,7 @@
 use crate::AdapterEngine;
 use crate::adapter::adapter_impl::AdapterImpl;
 use crate::connection::AdapterConnectionFactory;
+use crate::load_catalogs;
 use crate::relation::do_create_relation;
 use crate::sql_types::{TypeOps, make_arrow_field_v2};
 use crate::{AdapterResult, errors::AsyncAdapterResult, metadata::*, record_batch::RecordBatchExt};
@@ -12,7 +13,11 @@ use dbt_adapter_core::ExecutionPhase;
 use dbt_common::cancellation::Cancellable;
 use dbt_common::cancellation::CancellationToken;
 use dbt_schemas::dbt_types::RelationType;
+use dbt_schemas::schemas::dbt_catalogs_v2::{
+    CatalogSpecV2View, DbtCatalogsV2View, V2CatalogType, V2TableFormat,
+};
 use dbt_schemas::schemas::{
+    common::ResolvedQuoting,
     legacy_catalog::{CatalogNodeStats, CatalogTable, ColumnMetadata, TableMetadata},
     relations::base::{BaseRelation, RelationPattern},
 };
@@ -289,6 +294,44 @@ impl MetadataAdapter for DuckDBMetadataAdapter {
     }
 }
 
+/// Build the `information_schema.tables` query used to list relations in a
+/// schema.
+///
+/// `information_schema.tables` unions every attached database, so the query is
+/// constrained to the target catalog. This keeps the result correct (no rows
+/// leak in from other attached catalogs, including misreported Iceberg REST
+/// ones) and matches the per-catalog scope dbt expects when warming the relation
+/// cache. When the catalog is unknown (empty), the catalog predicate is omitted.
+fn list_relations_sql(quoting: ResolvedQuoting, db_schema: &CatalogAndSchema) -> String {
+    let query_schema = if quoting.schema {
+        db_schema.resolved_schema.clone()
+    } else {
+        db_schema.resolved_schema.to_lowercase()
+    };
+
+    let catalog_predicate = if db_schema.resolved_catalog.is_empty() {
+        String::new()
+    } else {
+        let query_catalog = if quoting.database {
+            db_schema.resolved_catalog.clone()
+        } else {
+            db_schema.resolved_catalog.to_lowercase()
+        };
+        format!(
+            " AND lower(table_catalog) = lower('{}')",
+            query_catalog.replace('\'', "''"),
+        )
+    };
+
+    format!(
+        "SELECT table_catalog, table_schema, table_name, table_type \
+         FROM information_schema.tables \
+         WHERE table_schema = '{}'{}",
+        query_schema.replace('\'', "''"),
+        catalog_predicate,
+    )
+}
+
 /// List all relations (tables, views) in a given schema.
 ///
 /// Queries DuckDB's `information_schema.tables` and maps the results to
@@ -300,17 +343,22 @@ pub fn list_relations(
     db_schema: &CatalogAndSchema,
     token: CancellationToken,
 ) -> AdapterResult<Vec<Arc<dyn BaseRelation>>> {
-    let query_schema = if engine.quoting().schema {
-        db_schema.resolved_schema.clone()
-    } else {
-        db_schema.resolved_schema.to_lowercase()
-    };
+    // Schema-wide listing is only unreliable for external Iceberg REST catalogs
+    // (their information_schema coverage is incomplete), so bail to the targeted
+    // DESCRIBE-based get_relation path only when the *target* catalog is one of
+    // them. A regular DuckDB catalog is still listed even while Iceberg catalogs
+    // are attached — see the catalog scoping below.
+    if is_duckdb_v2_external_iceberg_catalog_database(&db_schema.resolved_catalog) {
+        return Err(AdapterError::new(
+            AdapterErrorKind::NotSupported,
+            format!(
+                "DuckDB schema-wide relation listing is disabled while v2 Iceberg REST catalogs are attached; use targeted get_relation introspection instead for '{}'",
+                db_schema.resolved_catalog
+            ),
+        ));
+    }
 
-    let sql = format!(
-        "SELECT table_catalog, table_schema, table_name, table_type \
-         FROM information_schema.tables \
-         WHERE table_schema = '{query_schema}'"
-    );
+    let sql = list_relations_sql(engine.quoting(), db_schema);
 
     let batch = engine.execute(None, conn, ctx, &sql, token)?;
 
@@ -352,6 +400,76 @@ pub fn list_relations(
     Ok(relations)
 }
 
+pub(crate) fn is_duckdb_v2_external_iceberg_catalog_database(database: &str) -> bool {
+    if database.is_empty() {
+        return false;
+    }
+
+    with_duckdb_v2_external_iceberg_catalogs(|view| {
+        is_duckdb_v2_external_iceberg_catalog_database_in_view(database, view)
+    })
+}
+
+fn with_duckdb_v2_external_iceberg_catalogs(
+    f: impl FnOnce(&DbtCatalogsV2View<'_>) -> bool,
+) -> bool {
+    if !load_catalogs::fetch_use_catalogs_v2() {
+        return false;
+    }
+
+    let Some(catalogs) = load_catalogs::fetch_catalogs() else {
+        return false;
+    };
+    let Ok(view) = catalogs.view_v2() else {
+        return false;
+    };
+
+    f(&view)
+}
+
+#[cfg(test)]
+fn has_duckdb_v2_external_iceberg_catalogs_in_view(view: &DbtCatalogsV2View<'_>) -> bool {
+    view.catalogs
+        .iter()
+        .any(is_duckdb_v2_external_iceberg_catalog)
+}
+
+fn is_duckdb_v2_external_iceberg_catalog_database_in_view(
+    database: &str,
+    view: &DbtCatalogsV2View<'_>,
+) -> bool {
+    if database.is_empty() {
+        return false;
+    }
+
+    view.catalogs.iter().any(|catalog| {
+        if !is_duckdb_v2_external_iceberg_catalog(catalog) {
+            return false;
+        }
+        let Some(duckdb_block) = catalog.config_block("duckdb") else {
+            return false;
+        };
+
+        let alias = duckdb_block
+            .get(dbt_yaml::Value::from("attach_as"))
+            .and_then(|value| value.as_str())
+            .unwrap_or(catalog.name);
+        let alias = crate::catalog_relation::sanitize_duckdb_identifier(alias);
+        alias.eq_ignore_ascii_case(database)
+    })
+}
+
+fn is_duckdb_v2_external_iceberg_catalog(catalog: &CatalogSpecV2View<'_>) -> bool {
+    // DuckDB exposes these catalogs through Iceberg REST-style attachments.
+    // Their information_schema coverage is incomplete, so schema-wide listing
+    // is avoided while targeted DESCRIBE-based get_relation remains available.
+    matches!(
+        catalog.catalog_type,
+        V2CatalogType::Horizon | V2CatalogType::Glue | V2CatalogType::IcebergRest
+    ) && matches!(catalog.table_format, V2TableFormat::Iceberg)
+        && catalog.config_block("duckdb").is_some()
+}
+
 /// Build an Arrow Schema from DuckDB's DESCRIBE output.
 ///
 /// DuckDB's DESCRIBE returns columns: column_name, column_type, null, key, default, extra
@@ -382,4 +500,117 @@ fn build_schema_from_duckdb_describe(
 
     let schema = Schema::new(fields);
     Ok(Arc::new(schema))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dbt_schemas::schemas::dbt_catalogs::DbtCatalogs;
+
+    fn catalog_and_schema(catalog: &str, schema: &str) -> CatalogAndSchema {
+        CatalogAndSchema {
+            rendered_catalog: catalog.to_string(),
+            rendered_schema: schema.to_string(),
+            resolved_catalog: catalog.to_string(),
+            resolved_schema: schema.to_string(),
+        }
+    }
+
+    #[test]
+    fn list_relations_sql_scopes_to_target_catalog() {
+        // With a catalog present the listing must be constrained to it, so rows
+        // from other attached databases (e.g. remote Iceberg REST catalogs that
+        // `information_schema.tables` would otherwise union in) cannot leak.
+        let sql = list_relations_sql(
+            ResolvedQuoting::trues(),
+            &catalog_and_schema("aws_cloud_cost_demo", "aws_cloud_cost"),
+        );
+        assert_eq!(
+            sql,
+            "SELECT table_catalog, table_schema, table_name, table_type \
+             FROM information_schema.tables \
+             WHERE table_schema = 'aws_cloud_cost' \
+             AND lower(table_catalog) = lower('aws_cloud_cost_demo')",
+        );
+    }
+
+    #[test]
+    fn list_relations_sql_lowercases_unquoted_identifiers() {
+        // Unquoted identifiers fold to lowercase in DuckDB, so the predicates
+        // must be lowercased to match.
+        let sql = list_relations_sql(
+            ResolvedQuoting::falses(),
+            &catalog_and_schema("My_Catalog", "My_Schema"),
+        );
+        assert!(sql.contains("table_schema = 'my_schema'"));
+        assert!(sql.contains("lower(table_catalog) = lower('my_catalog')"));
+    }
+
+    #[test]
+    fn list_relations_sql_omits_catalog_predicate_when_unknown() {
+        // No catalog means we cannot scope; fall back to the schema-only filter
+        // rather than emitting an empty/incorrect catalog predicate.
+        let sql = list_relations_sql(ResolvedQuoting::trues(), &catalog_and_schema("", "main"));
+        assert!(sql.ends_with("WHERE table_schema = 'main'"));
+        assert!(!sql.contains("lower(table_catalog)"));
+        assert!(!sql.contains(" AND "));
+    }
+
+    fn with_v2_view(yaml: &str, test: impl FnOnce(&DbtCatalogsV2View<'_>)) {
+        let parsed: dbt_yaml::Value = dbt_yaml::from_str(yaml).expect("valid YAML");
+        let dbt_yaml::Value::Mapping(repr, span) = parsed else {
+            panic!("expected YAML mapping");
+        };
+        let catalogs = DbtCatalogs::new(repr, span);
+        let view = catalogs.view_v2().expect("valid catalogs v2 view");
+        test(&view);
+    }
+
+    #[test]
+    fn duckdb_v2_external_iceberg_catalogs_disable_schema_listing() {
+        with_v2_view(
+            r#"
+catalogs:
+  - name: lakekeeper
+    type: iceberg_rest
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint: http://localhost:8181/catalog
+        warehouse: demo
+        attach_as: iceberg_demo
+  - name: horizon
+    type: horizon
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint: https://snowflake.example.com/polaris/api/catalog
+        warehouse: HORIZON_CATALOG
+  - name: files
+    type: local_filesystem
+    table_format: default
+    config:
+      duckdb:
+        root_path: local_files
+        file_format: csv
+"#,
+            |view| {
+                assert!(has_duckdb_v2_external_iceberg_catalogs_in_view(view));
+                assert!(is_duckdb_v2_external_iceberg_catalog_database_in_view(
+                    "iceberg_demo",
+                    view
+                ));
+                assert!(is_duckdb_v2_external_iceberg_catalog_database_in_view(
+                    "horizon", view
+                ));
+                assert!(!is_duckdb_v2_external_iceberg_catalog_database_in_view(
+                    "local_files",
+                    view
+                ));
+                assert!(!is_duckdb_v2_external_iceberg_catalog_database_in_view(
+                    "", view
+                ));
+            },
+        );
+    }
 }

--- a/crates/dbt-adapter/src/metadata/get_relation.rs
+++ b/crates/dbt-adapter/src/metadata/get_relation.rs
@@ -762,15 +762,53 @@ fn duckdb_get_relation(
         identifier.to_lowercase()
     };
 
+    if !schema.is_empty()
+        && !identifier.is_empty()
+        && crate::metadata::duckdb::is_duckdb_v2_external_iceberg_catalog_database(database)
+    {
+        // DuckDB's information_schema can omit or misreport Iceberg REST
+        // attached-catalog tables. A targeted DESCRIBE is the narrow fallback:
+        // it reuses the normal relation construction after proving the table
+        // exists, without enabling broad schema listing for these catalogs.
+        let relation_name = format!(
+            "{}.{}.{}",
+            quote_duckdb_identifier(database),
+            quote_duckdb_identifier(&query_schema),
+            quote_duckdb_identifier(&query_identifier),
+        );
+        let sql = format!("DESCRIBE {relation_name}");
+        let result = adapter
+            .engine()
+            .execute(Some(state), conn, ctx, &sql, token);
+
+        match result {
+            Ok(_) => {
+                let relation = do_create_relation(
+                    adapter.adapter_type(),
+                    database.to_string(),
+                    schema.to_string(),
+                    Some(identifier.to_string()),
+                    Some(RelationType::Table),
+                    adapter.quoting(),
+                )?;
+                return Ok(Some(relation));
+            }
+            Err(err) if is_duckdb_missing_relation_error(&err, identifier) => return Ok(None),
+            Err(err) => return Err(err),
+        }
+    }
+
     // Query INFORMATION_SCHEMA.TABLES for relation metadata
     // DuckDB's table_type values: BASE TABLE, VIEW, LOCAL TEMPORARY
     let sql = format!(
         r#"
             SELECT table_type as type
             FROM information_schema.tables
-            WHERE table_schema = '{query_schema}'
-              AND table_name = '{query_identifier}'
+            WHERE table_schema = '{}'
+              AND table_name = '{}'
         "#,
+        query_schema.replace('\'', "''"),
+        query_identifier.replace('\'', "''"),
     );
 
     let batch = adapter
@@ -810,6 +848,18 @@ fn duckdb_get_relation(
         adapter.quoting(),
     )?;
     Ok(Some(relation))
+}
+
+fn is_duckdb_missing_relation_error(err: &AdapterError, identifier: &str) -> bool {
+    let msg = err.to_string().to_lowercase();
+    let identifier = identifier.to_lowercase();
+    (msg.contains("does not exist") || msg.contains("not found"))
+        && (msg.contains("table") || msg.contains("view"))
+        && msg.contains(&identifier)
+}
+
+fn quote_duckdb_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/dbt-auth/src/duckdb/init.rs
+++ b/crates/dbt-auth/src/duckdb/init.rs
@@ -305,8 +305,8 @@ fn generate_setting_sql(config: &AdapterConfig, stmts: &mut Vec<String>) {
     if let YmlValue::Mapping(map, _) = val {
         for (k, v) in map.iter() {
             if let Some(key_str) = k.as_str() {
-                // motherduck_token must be set at database init, not via SET
-                if key_str == "motherduck_token" {
+                // These settings must be applied at database init, not via SET.
+                if key_str == "motherduck_token" || key_str == "allow_unsigned_extensions" {
                     continue;
                 }
                 let key = sanitize_identifier(key_str);
@@ -752,6 +752,19 @@ settings:
         assert_eq!(stmts.len(), 2);
         assert!(stmts.contains(&"SET memory_limit = '4GB'".to_owned()));
         assert!(stmts.contains(&"SET threads = 8".to_owned()));
+    }
+
+    #[test]
+    fn test_allow_unsigned_extensions_not_emitted_as_sql_setting() {
+        let config = config_from_yaml(
+            r#"
+settings:
+  allow_unsigned_extensions: true
+  memory_limit: "4GB"
+"#,
+        );
+        let stmts = generate_duckdb_init_sql(&config);
+        assert_eq!(stmts, vec!["SET memory_limit = '4GB'"]);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/dbt-auth/src/duckdb/mod.rs
+++ b/crates/dbt-auth/src/duckdb/mod.rs
@@ -1,8 +1,16 @@
 pub mod init;
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::config::YmlValue;
 use crate::{AdapterConfig, Auth, AuthError, AuthOutcome};
 
 use dbt_xdbc::{Backend, database};
+
+/// Tracks whether the `allow_unsigned_extensions` warning has already been
+/// emitted in this process. `configure` runs once per connection/model, so this
+/// guard keeps the warning to a single emission instead of one per model.
+static ALLOW_UNSIGNED_EXTENSIONS_WARNED: AtomicBool = AtomicBool::new(false);
 
 pub struct DuckDbAuth {
     backend: Backend,
@@ -38,10 +46,47 @@ impl Auth for DuckDbAuth {
                 .map_err(|e| AuthError::Config(e.to_string()))?;
         }
 
-        Ok(AuthOutcome {
-            builder,
-            warnings: vec![],
-        })
+        let mut warnings = Vec::new();
+        // `allow_unsigned_extensions` lets DuckDB load extensions that are not
+        // signed by dbt Labs. It is an explicit, opt-in escape hatch for local
+        // development against custom/unsigned extension builds; surface a warning
+        // so it is never enabled silently against production data.
+        if let Some(value) = duckdb_startup_setting(config, "allow_unsigned_extensions") {
+            builder
+                .with_named_option("allow_unsigned_extensions", value)
+                .map_err(|e| AuthError::Config(e.to_string()))?;
+            // Warn only once per process: `configure` runs once per
+            // connection/model, so without this guard the warning is repeated
+            // for every model in the run.
+            if !ALLOW_UNSIGNED_EXTENSIONS_WARNED.swap(true, Ordering::Relaxed) {
+                warnings.push(
+                    "DuckDB `allow_unsigned_extensions` is enabled: this connection will load \
+                     unsigned extensions. This is intended for local development only — do not \
+                     enable it against production data."
+                        .to_string(),
+                );
+            }
+        }
+
+        Ok(AuthOutcome { builder, warnings })
+    }
+}
+
+fn duckdb_startup_setting(config: &AdapterConfig, key: &str) -> Option<String> {
+    let settings = config.get("settings")?;
+    let YmlValue::Mapping(map, _) = settings else {
+        return None;
+    };
+    map.get(key).and_then(yml_value_to_duckdb_option)
+}
+
+fn yml_value_to_duckdb_option(value: &YmlValue) -> Option<String> {
+    match value {
+        YmlValue::Bool(value, _) => Some(value.to_string()),
+        YmlValue::Number(value, _) => Some(value.to_string()),
+        YmlValue::String(value, _) => Some(value.clone()),
+        YmlValue::Tagged(tagged, _) => yml_value_to_duckdb_option(&tagged.value),
+        YmlValue::Null(_) | YmlValue::Sequence(_, _) | YmlValue::Mapping(_, _) => None,
     }
 }
 
@@ -119,5 +164,40 @@ path: "/tmp/local.duckdb"
                 ) if option_name == "path" && option_value == "/tmp/local.duckdb"
             )
         }));
+    }
+
+    #[test]
+    fn configure_passes_allow_unsigned_extensions_as_database_option() {
+        // The warning is gated by a process-wide latch; reset it so this test
+        // observes the first (and only) emission regardless of test ordering.
+        ALLOW_UNSIGNED_EXTENSIONS_WARNED.store(false, Ordering::Relaxed);
+        let auth = DuckDbAuth::new(Backend::DuckDBExtended);
+        let config = config_from_yaml(
+            r#"
+path: "/tmp/local.duckdb"
+settings:
+  allow_unsigned_extensions: true
+"#,
+        );
+
+        let outcome = auth.configure(&config).unwrap();
+        assert!(outcome.builder.other.iter().any(|(name, value)| {
+            matches!(
+                (name, value),
+                (
+                    OptionDatabase::Other(option_name),
+                    OptionValue::String(option_value)
+                ) if option_name == "allow_unsigned_extensions" && option_value == "true"
+            )
+        }));
+        // Enabling the escape hatch must surface a warning so it is never silent.
+        assert!(
+            outcome
+                .warnings
+                .iter()
+                .any(|w| w.contains("allow_unsigned_extensions")),
+            "expected an allow_unsigned_extensions warning, got: {:?}",
+            outcome.warnings
+        );
     }
 }

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-duckdb/macros/adapters.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-duckdb/macros/adapters.sql
@@ -59,8 +59,11 @@
 
 
 {% macro duckdb__create_table_as(temporary, relation, compiled_code, language='sql') -%}
-  {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
-  {%- set supports_stage_create = catalog_relation.supports_stage_create -%}
+  {# DIVERGENCE: adapter.build_catalog_relation / adapter.table_format are Fusion-only
+     (see issue #10659). Under dbt-core (1.x) there is no catalog routing, so treat as a
+     stage-create-capable, non-iceberg target and use the plain CTAS path below. #}
+  {%- set supports_stage_create = adapter.build_catalog_relation(config.model).supports_stage_create if dbt_version.startswith('2.') else true -%}
+  {%- set table_format = adapter.table_format(relation) if dbt_version.startswith('2.') else none -%}
   {%- if language == 'sql' -%}
     {% set contract_config = config.get('contract') %}
     {% if contract_config.enforced %}
@@ -70,7 +73,7 @@
 
     {{ sql_header if sql_header is not none }}
 
-    {%- if not temporary and not supports_stage_create %}
+    {%- if not temporary and (table_format == 'iceberg' or not supports_stage_create) %}
       {% if contract_config.enforced %}
         {#-- DuckDB doesnt support constraints on temp tables --#}
         create table
@@ -113,8 +116,8 @@
   {% endif %}
     {% endif %}
   {%- elif language == 'python' -%}
-    {% if not temporary and not supports_stage_create %}
-      {% do exceptions.raise_compiler_error("DuckDB Python models cannot materialize to a catalog that does not support Iceberg REST staged create. Use a SQL model or a catalog with support_stage_create: true.") %}
+    {% if not temporary and (table_format == 'iceberg' or not supports_stage_create) %}
+      {% do exceptions.raise_compiler_error("DuckDB Python models cannot materialize to an Iceberg catalog that requires create-then-insert writes. Use a SQL model.") %}
     {% endif %}
     {{ py_write_table(temporary=temporary, relation=relation, compiled_code=compiled_code) }}
   {%- else -%}
@@ -155,10 +158,12 @@ def materialize(df, con):
 {% endmacro %}
 
 {% macro duckdb__get_columns_in_relation(relation) -%}
-  {% set fmt = adapter.table_format(relation) %}
+  {# DIVERGENCE: adapter.table_format is Fusion-only (see issue #10659). Under dbt-core
+     (1.x) fmt is none, so we use the standard information_schema.columns query. #}
+  {% set fmt = adapter.table_format(relation) if dbt_version.startswith('2.') else none %}
   {% if fmt == 'iceberg' %}
     {# information_schema.columns returns incorrect metadata for Iceberg REST catalog tables. #}
-    {% call statement('get_columns_in_relation', fetch_result=True) %}
+    {% set get_columns_sql %}
       select
           column_name,
           column_type                as data_type,
@@ -166,9 +171,9 @@ def materialize(df, con):
           null::integer              as numeric_precision,
           null::integer              as numeric_scale
       from (describe {{ relation }})
-    {% endcall %}
+    {% endset %}
   {% else %}
-    {% call statement('get_columns_in_relation', fetch_result=True) %}
+    {% set get_columns_sql %}
       select
           column_name,
           data_type,
@@ -186,8 +191,11 @@ def materialize(df, con):
       {% endif %}
       order by ordinal_position
 
-    {% endcall %}
+    {% endset %}
   {% endif %}
+  {% call statement('get_columns_in_relation', fetch_result=True) %}
+    {{ get_columns_sql }}
+  {% endcall %}
   {% set table = load_result('get_columns_in_relation').table %}
   {{ return(sql_convert_columns_in_relation(table)) }}
 {% endmacro %}
@@ -224,11 +232,8 @@ def materialize(df, con):
 {% endmacro %}
 
 {% macro duckdb__rename_relation(from_relation, to_relation) -%}
-  {# DIVERGENCE: adapter.table_format is Fusion-only (see issue #10659). Under dbt-core
-     (1.x) treat as non-iceberg and use the plain ALTER TABLE RENAME path. #}
-  {% set fmt = adapter.table_format(from_relation) if dbt_version.startswith('2.') else none %}
   {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}
-  {% if fmt == 'iceberg' %}
+  {% if adapter.table_format(from_relation) == 'iceberg' %}
     {# Iceberg REST: CTAS and ALTER...RENAME cannot share a transaction. #}
     {{ adapter.commit() }}
   {% endif %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-duckdb/macros/adapters.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-duckdb/macros/adapters.sql
@@ -232,8 +232,11 @@ def materialize(df, con):
 {% endmacro %}
 
 {% macro duckdb__rename_relation(from_relation, to_relation) -%}
+  {# DIVERGENCE: adapter.table_format is Fusion-only (see issue #10659). Under dbt-core
+     (1.x) fmt is none, so we skip the iceberg-specific commit and just ALTER RENAME. #}
+  {% set fmt = adapter.table_format(from_relation) if dbt_version.startswith('2.') else none %}
   {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}
-  {% if adapter.table_format(from_relation) == 'iceberg' %}
+  {% if fmt == 'iceberg' %}
     {# Iceberg REST: CTAS and ALTER...RENAME cannot share a transaction. #}
     {{ adapter.commit() }}
   {% endif %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-duckdb/macros/adapters.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-duckdb/macros/adapters.sql
@@ -59,6 +59,8 @@
 
 
 {% macro duckdb__create_table_as(temporary, relation, compiled_code, language='sql') -%}
+  {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
+  {%- set supports_stage_create = catalog_relation.supports_stage_create -%}
   {%- if language == 'sql' -%}
     {% set contract_config = config.get('contract') %}
     {% if contract_config.enforced %}
@@ -68,6 +70,33 @@
 
     {{ sql_header if sql_header is not none }}
 
+    {%- if not temporary and not supports_stage_create %}
+      {% if contract_config.enforced %}
+        {#-- DuckDB doesnt support constraints on temp tables --#}
+        create table
+          {{ relation.include(database=True, schema=True) }}
+        {{ get_table_columns_and_constraints() }} ;
+        insert into {{ relation }} {{ get_column_names() }} (
+          {{ get_select_subquery(compiled_code) }}
+        );
+      {% else %}
+        {%- set columns = get_column_schema_from_query(compiled_code, sql_header) -%}
+        create table
+          {{ relation.include(database=True, schema=True) }}
+        (
+          {% for col in columns -%}
+            {{ col.quoted }} {{ col.dtype }}{{ "," if not loop.last }}
+          {% endfor -%}
+        );
+        insert into {{ relation }} (
+          {% for col in columns -%}
+            {{ col.quoted }}{{ "," if not loop.last }}
+          {% endfor -%}
+        ) (
+          {{ compiled_code }}
+        );
+      {% endif %}
+    {%- else %}
     create {% if temporary: -%}temporary{%- endif %} table
       {{ relation.include(database=(not temporary), schema=(not temporary)) }}
   {% if contract_config.enforced and not temporary %}
@@ -77,11 +106,16 @@
       {{ get_select_subquery(compiled_code) }}
     );
   {% else %}
+
     as (
       {{ compiled_code }}
     );
   {% endif %}
+    {% endif %}
   {%- elif language == 'python' -%}
+    {% if not temporary and not supports_stage_create %}
+      {% do exceptions.raise_compiler_error("DuckDB Python models cannot materialize to a catalog that does not support Iceberg REST staged create. Use a SQL model or a catalog with support_stage_create: true.") %}
+    {% endif %}
     {{ py_write_table(temporary=temporary, relation=relation, compiled_code=compiled_code) }}
   {%- else -%}
       {% do exceptions.raise_compiler_error("duckdb__create_table_as macro didn't get supported language, it got %s" % language) %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-duckdb/macros/adapters.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-duckdb/macros/adapters.sql
@@ -121,7 +121,20 @@ def materialize(df, con):
 {% endmacro %}
 
 {% macro duckdb__get_columns_in_relation(relation) -%}
-  {% call statement('get_columns_in_relation', fetch_result=True) %}
+  {% set fmt = adapter.table_format(relation) %}
+  {% if fmt == 'iceberg' %}
+    {# information_schema.columns returns incorrect metadata for Iceberg REST catalog tables. #}
+    {% call statement('get_columns_in_relation', fetch_result=True) %}
+      select
+          column_name,
+          column_type                as data_type,
+          null::integer              as character_maximum_length,
+          null::integer              as numeric_precision,
+          null::integer              as numeric_scale
+      from (describe {{ relation }})
+    {% endcall %}
+  {% else %}
+    {% call statement('get_columns_in_relation', fetch_result=True) %}
       select
           column_name,
           data_type,
@@ -139,7 +152,8 @@ def materialize(df, con):
       {% endif %}
       order by ordinal_position
 
-  {% endcall %}
+    {% endcall %}
+  {% endif %}
   {% set table = load_result('get_columns_in_relation').table %}
   {{ return(sql_convert_columns_in_relation(table)) }}
 {% endmacro %}
@@ -180,16 +194,12 @@ def materialize(df, con):
      (1.x) treat as non-iceberg and use the plain ALTER TABLE RENAME path. #}
   {% set fmt = adapter.table_format(from_relation) if dbt_version.startswith('2.') else none %}
   {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}
+  {% if fmt == 'iceberg' %}
+    {# Iceberg REST: CTAS and ALTER...RENAME cannot share a transaction. #}
+    {{ adapter.commit() }}
+  {% endif %}
   {% call statement('rename_relation') -%}
-    {% if fmt == 'iceberg' %}
-      {# DuckDB Iceberg REST does not support ALTER TABLE RENAME.
-         Use DROP + CREATE AS SELECT instead. #}
-      drop table if exists {{ to_relation }};
-      create table {{ to_relation }} as select * from {{ from_relation }};
-      drop table if exists {{ from_relation }}
-    {% else %}
-      alter {{ to_relation.type }} {{ from_relation }} rename to {{ target_name }}
-    {% endif %}
+    alter {{ to_relation.type }} {{ from_relation }} rename to {{ target_name }}
   {%- endcall %}
 {% endmacro %}
 

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-duckdb/macros/materializations/table.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-duckdb/macros/materializations/table.sql
@@ -19,6 +19,30 @@
   -- grab current tables grants config for comparision later on
   {% set grant_config = config.get('grants') %}
 
+  {% if adapter.table_format(target_relation) == 'iceberg' %}
+    {{ drop_relation_if_exists(existing_relation) }}
+
+    {{ run_hooks(pre_hooks, inside_transaction=False) }}
+    {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+    {% call statement('main', language=language) -%}
+      {{- create_table_as(False, target_relation, compiled_code, language) }}
+    {%- endcall %}
+
+    {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+    {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
+    {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+    {% do persist_docs(target_relation, model) %}
+
+    {{ adapter.commit() }}
+
+    {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+    {{ return({'relations': [target_relation]}) }}
+  {% else %}
+
   -- drop the temp relations if they exist already in the database
   {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
   {{ drop_relation_if_exists(preexisting_backup_relation) }}
@@ -60,4 +84,5 @@
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
   {{ return({'relations': [target_relation]}) }}
+  {% endif %}
 {% endmaterialization %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-duckdb/macros/materializations/table.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-duckdb/macros/materializations/table.sql
@@ -2,50 +2,35 @@
 
   {%- set language = model['language'] -%}
 
-  {%- set existing_relation = load_cached_relation(this) -%}
   {%- set target_relation = this.incorporate(type='table') %}
-  {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}
-  -- the intermediate_relation should not already exist in the database; get_relation
-  -- will return None in that case. Otherwise, we get a relation that we can drop
-  -- later, before we try to use this name for the current operation
-  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
+  -- grab current tables grants config for comparision later on
+  {% set grant_config = config.get('grants') %}
+
+  {# DIVERGENCE: adapter.table_format is Fusion-only (see issue #10659). Under dbt-core
+     (1.x) there is no iceberg table-format routing, so use the standard temp+rename flow. #}
+  {% set use_direct_create = (adapter.table_format(target_relation) == 'iceberg') if dbt_version.startswith('2.') else false %}
+  {%- set existing_relation = none if use_direct_create else load_cached_relation(this) -%}
+  {%- set intermediate_relation = target_relation if use_direct_create else make_intermediate_relation(target_relation) -%}
+  {%- set preexisting_intermediate_relation = none if use_direct_create else load_cached_relation(intermediate_relation) -%}
   /*
       See ../view/view.sql for more information about this relation.
   */
   {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}
-  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
-  -- as above, the backup_relation should not already exist
-  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
-  -- grab current tables grants config for comparision later on
-  {% set grant_config = config.get('grants') %}
+  {%- set backup_relation = none if use_direct_create else make_backup_relation(target_relation, backup_relation_type) -%}
+  {%- set preexisting_backup_relation = none if use_direct_create else load_cached_relation(backup_relation) -%}
 
-  {% if adapter.table_format(target_relation) == 'iceberg' %}
-    {{ drop_relation_if_exists(existing_relation) }}
-
-    {{ run_hooks(pre_hooks, inside_transaction=False) }}
-    {{ run_hooks(pre_hooks, inside_transaction=True) }}
-
-    {% call statement('main', language=language) -%}
-      {{- create_table_as(False, target_relation, compiled_code, language) }}
-    {%- endcall %}
-
-    {{ run_hooks(post_hooks, inside_transaction=True) }}
-
-    {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
-    {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
-
-    {% do persist_docs(target_relation, model) %}
-
-    {{ adapter.commit() }}
-
-    {{ run_hooks(post_hooks, inside_transaction=False) }}
-
-    {{ return({'relations': [target_relation]}) }}
+  {% if use_direct_create %}
+    {# Iceberg REST catalogs do not support the temp-table + rename flow. #}
+    {{ adapter.drop_relation(target_relation) }}
   {% else %}
-
-  -- drop the temp relations if they exist already in the database
-  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
-  {{ drop_relation_if_exists(preexisting_backup_relation) }}
+    -- the intermediate_relation should not already exist in the database; get_relation
+    -- will return None in that case. Otherwise, we get a relation that we can drop
+    -- later, before we try to use this name for the current operation
+    -- as above, the backup_relation should not already exist
+    -- drop the temp relations if they exist already in the database
+    {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
+    {{ drop_relation_if_exists(preexisting_backup_relation) }}
+  {% endif %}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
@@ -57,16 +42,19 @@
     {{- create_table_as(False, intermediate_relation, compiled_code, language) }}
   {%- endcall %}
 
-  -- cleanup
-  {% if existing_relation is not none %}
+  {% if not use_direct_create and existing_relation is not none %}
       {#-- Drop indexes before renaming to avoid dependency errors --#}
       {% do drop_indexes_on_relation(existing_relation) %}
       {{ adapter.rename_relation(existing_relation, backup_relation) }}
   {% endif %}
 
-  {{ adapter.rename_relation(intermediate_relation, target_relation) }}
+  {% if not use_direct_create %}
+    {{ adapter.rename_relation(intermediate_relation, target_relation) }}
+  {% endif %}
 
-  {% do create_indexes(target_relation) %}
+  {% if not use_direct_create %}
+    {% do create_indexes(target_relation) %}
+  {% endif %}
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
@@ -78,11 +66,12 @@
   -- `COMMIT` happens here
   {{ adapter.commit() }}
 
-  -- finally, drop the existing/backup relation after the commit
-  {{ drop_relation_if_exists(backup_relation) }}
+  {% if not use_direct_create %}
+    -- finally, drop the existing/backup relation after the commit
+    {{ drop_relation_if_exists(backup_relation) }}
+  {% endif %}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
   {{ return({'relations': [target_relation]}) }}
-  {% endif %}
 {% endmaterialization %}

--- a/crates/dbt-loader/tests/macros/duckdb.rs
+++ b/crates/dbt-loader/tests/macros/duckdb.rs
@@ -178,6 +178,7 @@ fn table_materialization_writes_iceberg_target_directly() {
         .mock()
         .on("table_format", |_| Ok(Value::from("iceberg")));
     harness.mock().on("get_relation", |_| Ok(Value::from(())));
+    harness.mock().on("drop_relation", |_| Ok(Value::UNDEFINED));
     harness
         .mock()
         .on("rename_relation", |_| Ok(Value::UNDEFINED));
@@ -226,11 +227,26 @@ fn table_materialization_writes_iceberg_target_directly() {
         .mock()
         .observed_calls()
         .assert_not_called("rename_relation");
-    assert_executed_contains(harness.mock(), "create  table");
+    harness
+        .mock()
+        .observed_calls()
+        .assert_not_called("get_relation");
     let executed = executed_sql(harness.mock()).join("\n");
+    assert!(
+        executed.contains("create table"),
+        "Iceberg table materialization should create the target relation, got: {executed}"
+    );
     assert!(
         !executed.contains("__dbt_tmp"),
         "Iceberg table materialization should not use an intermediate relation, got: {executed}"
+    );
+    assert!(
+        executed.contains("insert into"),
+        "Iceberg table materialization should create then insert, got: {executed}"
+    );
+    assert!(
+        !executed.contains(" as ("),
+        "Iceberg table materialization should not use CTAS, got: {executed}"
     );
 }
 
@@ -244,6 +260,7 @@ fn table_materialization_uses_create_insert_when_stage_create_is_unsupported() {
         .mock()
         .on("build_catalog_relation", |_| Ok(catalog_relation(false)));
     harness.mock().on("get_relation", |_| Ok(Value::from(())));
+    harness.mock().on("drop_relation", |_| Ok(Value::UNDEFINED));
     harness
         .mock()
         .on("rename_relation", |_| Ok(Value::UNDEFINED));
@@ -271,6 +288,10 @@ fn table_materialization_uses_create_insert_when_stage_create_is_unsupported() {
         .render("{{ materialization_table_duckdb() }}", ctx)
         .expect("render should succeed");
 
+    harness
+        .mock()
+        .observed_calls()
+        .assert_not_called("get_relation");
     let executed = executed_sql(harness.mock()).join("\n").to_lowercase();
     assert!(
         executed.contains("create table"),

--- a/crates/dbt-loader/tests/macros/duckdb.rs
+++ b/crates/dbt-loader/tests/macros/duckdb.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use dbt_adapter::relation::RelationObject;
 use dbt_adapter_core::AdapterType;
+use dbt_jinja_utils::mock_object::MockJinjaObject;
 use dbt_schemas::dbt_types::RelationType;
 use minijinja::Value;
 
@@ -153,5 +155,67 @@ fn rename_relation_commits_before_iceberg_rename() {
     assert!(
         !executed.contains("create table") && !executed.contains("drop table"),
         "rename should not use DROP/CREATE fallback, got: {executed}"
+    );
+}
+
+#[test]
+fn table_materialization_writes_iceberg_target_directly() {
+    let harness = build_harness("iceberg_demo", "ducklake_demo");
+    harness
+        .mock()
+        .on("table_format", |_| Ok(Value::from("iceberg")));
+    harness.mock().on("get_relation", |_| Ok(Value::from(())));
+    harness
+        .mock()
+        .on("rename_relation", |_| Ok(Value::UNDEFINED));
+    harness
+        .mock()
+        .on("drop_indexes_on_relation", |_| Ok(Value::UNDEFINED));
+
+    let model = Value::from_serialize(BTreeMap::from([
+        ("alias", Value::from("orders")),
+        ("unique_id", Value::from("model.test_project.orders")),
+        ("columns", Value::from(BTreeMap::<String, Value>::new())),
+        ("language", Value::from("sql")),
+        ("compiled_code", Value::from("select 1 as id")),
+    ]));
+    let config = Arc::new(MockJinjaObject::new());
+    config.on("get", |args| {
+        let key = args.first().and_then(|v| v.as_str());
+        let default = args.get(1).cloned().unwrap_or(Value::UNDEFINED);
+        match key {
+            Some("contract") => Ok(Value::from_serialize(BTreeMap::from([(
+                "enforced".to_string(),
+                Value::from(false),
+            )]))),
+            Some("indexes") => Ok(Value::from(Vec::<Value>::new())),
+            _ => Ok(default),
+        }
+    });
+    config.on("persist_column_docs", |_| Ok(Value::from(false)));
+    config.on("persist_relation_docs", |_| Ok(Value::from(false)));
+
+    let ctx = harness
+        .materialization_context("orders", "select 1 as id")
+        .database("iceberg_demo")
+        .schema("main")
+        .relation_type(RelationType::Table)
+        .config(Value::from_dyn_object(config))
+        .with("model", model)
+        .build();
+
+    harness
+        .render("{{ materialization_table_duckdb() }}", ctx)
+        .expect("render should succeed");
+
+    harness
+        .mock()
+        .observed_calls()
+        .assert_not_called("rename_relation");
+    assert_executed_contains(harness.mock(), "create  table");
+    let executed = executed_sql(harness.mock()).join("\n");
+    assert!(
+        !executed.contains("__dbt_tmp"),
+        "Iceberg table materialization should not use an intermediate relation, got: {executed}"
     );
 }

--- a/crates/dbt-loader/tests/macros/duckdb.rs
+++ b/crates/dbt-loader/tests/macros/duckdb.rs
@@ -9,6 +9,12 @@ use minijinja::Value;
 
 use crate::macro_test_harness::{MacroTestHarness, assert_executed_contains, executed_sql};
 
+fn catalog_relation(supports_stage_create: bool) -> Value {
+    let catalog_relation = Arc::new(MockJinjaObject::new());
+    catalog_relation.set_attr("supports_stage_create", Value::from(supports_stage_create));
+    Value::from_dyn_object(catalog_relation)
+}
+
 fn relation_database(arg: Option<&Value>) -> Option<String> {
     arg.and_then(|v| v.get_attr("database").ok())
         .and_then(|v| v.as_str().map(str::to_string))
@@ -37,6 +43,13 @@ fn build_harness(
     mock.on("commit", |_| Ok(Value::UNDEFINED));
     mock.on("quote_as_configured", |args| {
         Ok(args.first().cloned().unwrap_or(Value::UNDEFINED))
+    });
+    mock.on("build_catalog_relation", |_| Ok(catalog_relation(true)));
+    mock.on("get_column_schema_from_query", |_| {
+        Ok(Value::from_serialize(vec![BTreeMap::from([
+            ("quoted", Value::from("id")),
+            ("dtype", Value::from("integer")),
+        ])]))
     });
     harness
         .env_mut()
@@ -194,6 +207,7 @@ fn table_materialization_writes_iceberg_target_directly() {
     });
     config.on("persist_column_docs", |_| Ok(Value::from(false)));
     config.on("persist_relation_docs", |_| Ok(Value::from(false)));
+    config.set_attr("model", model.clone());
 
     let ctx = harness
         .materialization_context("orders", "select 1 as id")
@@ -217,5 +231,57 @@ fn table_materialization_writes_iceberg_target_directly() {
     assert!(
         !executed.contains("__dbt_tmp"),
         "Iceberg table materialization should not use an intermediate relation, got: {executed}"
+    );
+}
+
+#[test]
+fn table_materialization_uses_create_insert_when_stage_create_is_unsupported() {
+    let harness = build_harness("horizon_demo", "ducklake_demo");
+    harness
+        .mock()
+        .on("table_format", |_| Ok(Value::from("iceberg")));
+    harness
+        .mock()
+        .on("build_catalog_relation", |_| Ok(catalog_relation(false)));
+    harness.mock().on("get_relation", |_| Ok(Value::from(())));
+    harness
+        .mock()
+        .on("rename_relation", |_| Ok(Value::UNDEFINED));
+    harness
+        .mock()
+        .on("drop_indexes_on_relation", |_| Ok(Value::UNDEFINED));
+
+    let model = Value::from_serialize(BTreeMap::from([
+        ("alias", Value::from("orders")),
+        ("unique_id", Value::from("model.test_project.orders")),
+        ("columns", Value::from(BTreeMap::<String, Value>::new())),
+        ("language", Value::from("sql")),
+        ("compiled_code", Value::from("select 1 as id")),
+    ]));
+
+    let ctx = harness
+        .materialization_context("orders", "select 1 as id")
+        .database("horizon_demo")
+        .schema("main")
+        .relation_type(RelationType::Table)
+        .with("model", model)
+        .build();
+
+    harness
+        .render("{{ materialization_table_duckdb() }}", ctx)
+        .expect("render should succeed");
+
+    let executed = executed_sql(harness.mock()).join("\n").to_lowercase();
+    assert!(
+        executed.contains("create table"),
+        "Horizon materialization should create the table first, got: {executed}"
+    );
+    assert!(
+        executed.contains("insert into"),
+        "Horizon materialization should insert after create, got: {executed}"
+    );
+    assert!(
+        !executed.contains(" as ("),
+        "Horizon materialization should not use CTAS, got: {executed}"
     );
 }

--- a/crates/dbt-loader/tests/macros/duckdb.rs
+++ b/crates/dbt-loader/tests/macros/duckdb.rs
@@ -1,0 +1,157 @@
+use std::collections::BTreeMap;
+
+use dbt_adapter::relation::RelationObject;
+use dbt_adapter_core::AdapterType;
+use dbt_schemas::dbt_types::RelationType;
+use minijinja::Value;
+
+use crate::macro_test_harness::{MacroTestHarness, assert_executed_contains, executed_sql};
+
+fn relation_database(arg: Option<&Value>) -> Option<String> {
+    arg.and_then(|v| v.get_attr("database").ok())
+        .and_then(|v| v.as_str().map(str::to_string))
+}
+
+fn build_harness(
+    iceberg_database: &'static str,
+    ducklake_database: &'static str,
+) -> MacroTestHarness {
+    let mut harness = MacroTestHarness::for_adapter(AdapterType::DuckDB)
+        .load_all_macros()
+        .with_stub_functions()
+        .build()
+        .expect("harness should build");
+
+    let mock = harness.mock().clone();
+    mock.on("table_format", move |args| {
+        let database = relation_database(args.first());
+        let table_format = match database.as_deref() {
+            Some(database) if database == iceberg_database => "iceberg",
+            Some(database) if database == ducklake_database => "ducklake",
+            _ => "default",
+        };
+        Ok(Value::from(table_format))
+    });
+    mock.on("commit", |_| Ok(Value::UNDEFINED));
+    mock.on("quote_as_configured", |args| {
+        Ok(args.first().cloned().unwrap_or(Value::UNDEFINED))
+    });
+    harness
+        .env_mut()
+        .env
+        .add_function("load_result", |_name: Value| {
+            Ok(Value::from_serialize(BTreeMap::from([(
+                "table",
+                Vec::<Vec<Value>>::new(),
+            )])))
+        });
+    harness
+        .env_mut()
+        .env
+        .add_global("execute", Value::from(true));
+    harness
+        .env_mut()
+        .env
+        .add_global("adapter", Value::from_dyn_object(mock));
+
+    harness
+}
+
+#[test]
+fn get_columns_in_relation_uses_describe_for_iceberg_relations() {
+    let harness = build_harness("iceberg_demo", "ducklake_demo");
+    let relation = harness.relation("iceberg_demo", "main", "orders", Some(RelationType::Table));
+    let ctx = BTreeMap::from([(
+        "relation".to_string(),
+        RelationObject::new(relation).into_value(),
+    )]);
+
+    harness
+        .render("{{ duckdb__get_columns_in_relation(relation) }}", ctx)
+        .expect("render should succeed");
+
+    let executed = executed_sql(harness.mock()).join("\n");
+    assert!(
+        executed.contains("from (describe"),
+        "Iceberg relations should use DESCRIBE, got: {executed}"
+    );
+    assert!(
+        !executed.contains("information_schema.columns"),
+        "Iceberg relations should not use information_schema.columns, got: {executed}"
+    );
+}
+
+#[test]
+fn drop_relation_omits_cascade_for_iceberg_relations() {
+    let harness = build_harness("iceberg_demo", "ducklake_demo");
+    let relation = harness.relation("iceberg_demo", "main", "orders", Some(RelationType::Table));
+    let ctx = BTreeMap::from([(
+        "relation".to_string(),
+        RelationObject::new(relation).into_value(),
+    )]);
+
+    harness
+        .render("{{ duckdb__drop_relation(relation) }}", ctx)
+        .expect("render should succeed");
+
+    assert_executed_contains(harness.mock(), "drop table if exists");
+    let executed = executed_sql(harness.mock()).join("\n");
+    assert!(
+        !executed.contains("cascade"),
+        "Iceberg drop should omit CASCADE, got: {executed}"
+    );
+}
+
+#[test]
+fn rename_relation_commits_before_iceberg_rename() {
+    let harness = build_harness("iceberg_demo", "ducklake_demo");
+    let from_relation = harness.relation(
+        "iceberg_demo",
+        "main",
+        "orders__dbt_tmp",
+        Some(RelationType::Table),
+    );
+    let to_relation = harness.relation("regular_demo", "main", "orders", Some(RelationType::Table));
+    let ctx = BTreeMap::from([
+        (
+            "from_relation".to_string(),
+            RelationObject::new(from_relation).into_value(),
+        ),
+        (
+            "to_relation".to_string(),
+            RelationObject::new(to_relation).into_value(),
+        ),
+    ]);
+
+    harness
+        .render(
+            "{{ duckdb__rename_relation(from_relation, to_relation) }}",
+            ctx,
+        )
+        .expect("render should succeed");
+
+    let calls = harness.mock().observed_calls();
+    let commit_idx = calls
+        .iter()
+        .position(|call| call.method == "commit")
+        .expect("Iceberg rename should commit before ALTER TABLE RENAME");
+    let execute_idx = calls
+        .iter()
+        .position(|call| call.method == "execute")
+        .expect("rename should execute ALTER TABLE RENAME");
+    assert!(
+        commit_idx < execute_idx,
+        "commit should be rendered before rename SQL: {calls:?}"
+    );
+    drop(calls);
+
+    let executed = executed_sql(harness.mock()).join("\n");
+    assert!(
+        executed.contains("alter table"),
+        "rename should use ALTER TABLE RENAME, got: {executed}"
+    );
+    assert!(
+        !executed.contains("create table") && !executed.contains("drop table"),
+        "rename should not use DROP/CREATE fallback, got: {executed}"
+    );
+}

--- a/crates/dbt-loader/tests/macros/mod.rs
+++ b/crates/dbt-loader/tests/macros/mod.rs
@@ -1,2 +1,3 @@
+mod duckdb;
 mod persist_docs;
 mod relations;

--- a/crates/dbt-schemas/src/schemas/dbt_catalogs_v2.rs
+++ b/crates/dbt-schemas/src/schemas/dbt_catalogs_v2.rs
@@ -741,9 +741,11 @@ fn validate_platform_support(catalog: &CatalogSpecV2View<'_>) -> FsResult<()> {
             return err!(
                 code => ErrorCode::InvalidConfig,
                 hacky_yml_loc => catalog.field_span("type").cloned(),
-                "dbt does not support {} on the {} 'type'",
+                "Catalog '{}' (type '{}') does not support a '{}' config block; valid config blocks are: {}",
+                catalog.name,
+                catalog.catalog_type.as_str(),
                 platform,
-                catalog.catalog_type.as_str()
+                catalog_platforms.join(", ")
             );
         }
         has_supported_config = true;
@@ -1717,7 +1719,8 @@ catalogs:
         let res = parse_and_validate(yaml);
         assert!(res.is_err(), "expected error");
         assert!(
-            format!("{res:?}").contains("does not support databricks on the iceberg_rest"),
+            format!("{res:?}")
+                .contains("(type 'iceberg_rest') does not support a 'databricks' config block"),
             "unexpected error: {res:?}"
         );
     }
@@ -1823,7 +1826,7 @@ catalogs:
         let msg = format!("{res:?}");
         assert!(res.is_err(), "expected error but got Ok");
         assert!(
-            msg.contains("does not support bigquery on the unity"),
+            msg.contains("(type 'unity') does not support a 'bigquery' config block"),
             "unexpected error: {msg}"
         );
     }
@@ -1844,7 +1847,7 @@ catalogs:
         let msg = format!("{res:?}");
         assert!(res.is_err(), "expected error but got Ok");
         assert!(
-            msg.contains("does not support bigquery on the horizon"),
+            msg.contains("(type 'horizon') does not support a 'bigquery' config block"),
             "unexpected error: {msg}"
         );
     }
@@ -2647,7 +2650,7 @@ catalogs:
         let msg = format!("{res:?}");
         assert!(res.is_err(), "expected error but got Ok");
         assert!(
-            msg.contains("does not support snowflake on the ducklake"),
+            msg.contains("(type 'ducklake') does not support a 'snowflake' config block"),
             "unexpected error: {msg}"
         );
     }

--- a/crates/dbt-schemas/src/schemas/dbt_catalogs_v2.rs
+++ b/crates/dbt-schemas/src/schemas/dbt_catalogs_v2.rs
@@ -47,15 +47,15 @@
 //!         authorization_type: OAUTH2|SIGV4|NONE                   # optional
 //!         access_delegation_mode: VENDED_CREDENTIALS|NONE         # optional
 //!         support_nested_namespaces: <boolean>                    # optional
-//!         support_stage_create: <boolean>                         # optional
-//!         use_transaction_commit: <boolean>                        # optional
+//!         stage_create_tables: <boolean>                          # optional
+//!         disable_multi_table_commit: <boolean>                   # optional
 //!         skip_create_table_metadata_updates: <boolean>            # optional
-//!         allow_deletes: <boolean>                                 # optional
+//!         remove_files_on_delete: <boolean>                       # optional
 //!         purge_requested: <boolean>                              # optional
 //!         encode_entire_prefix: <boolean>                         # optional
 //!
 //!   # type: unity
-//!   # supported platforms: snowflake, databricks
+//!   # supported platforms: snowflake, databricks, duckdb
 //!   # at least one supported platform block is required
 //!   - name: unity_catalog
 //!     type: unity
@@ -71,7 +71,17 @@
 //!         file_format: delta                                      # required if databricks block exists
 //!         location_root: <path string>                            # optional, non-empty if present
 //!         use_uniform: <boolean>                                  # optional, defaults to false
-//!         # Both managed and UniForm paths currently use delta.
+//!         # Managed external paths use parquet; UniForm paths use delta.
+//!       duckdb:
+//!         endpoint: https://<workspace>/api/2.1/unity-catalog/iceberg-rest
+//!         warehouse: <unity catalog name>                         # optional, non-empty if present
+//!         secret: <string>                                        # optional DuckDB secret name from profiles.yml
+//!         attach_as: <string>                                     # optional, non-empty if present
+//!         default_schema: <string>                                # optional, non-empty if present
+//!         authorization_type: OAUTH2|NONE                         # optional
+//!         access_delegation_mode: VENDED_CREDENTIALS|NONE         # optional
+//!         # DuckDB UC support uses the Iceberg REST ATTACH surface; managed reads
+//!         # and Java Iceberg-compatible writes depend on duckdb-iceberg fixes.
 //!
 //!   # type: hive_metastore
 //!   # supported platforms: databricks
@@ -118,10 +128,10 @@
 //!         authorization_type: OAUTH2|SIGV4|NONE                   # optional
 //!         access_delegation_mode: VENDED_CREDENTIALS|NONE         # optional
 //!         support_nested_namespaces: <boolean>                    # optional
-//!         support_stage_create: <boolean>                         # optional
-//!         use_transaction_commit: <boolean>                        # optional
+//!         stage_create_tables: <boolean>                          # optional
+//!         disable_multi_table_commit: <boolean>                   # optional
 //!         skip_create_table_metadata_updates: <boolean>            # optional
-//!         allow_deletes: <boolean>                                 # optional
+//!         remove_files_on_delete: <boolean>                       # optional
 //!         purge_requested: <boolean>                              # optional
 //!         encode_entire_prefix: <boolean>                         # optional
 //!
@@ -702,10 +712,10 @@ const DUCKDB_KEYS: &[&str] = &[
     "authorization_type",
     "access_delegation_mode",
     "support_nested_namespaces",
-    "support_stage_create",
-    "use_transaction_commit",
+    "stage_create_tables",
+    "disable_multi_table_commit",
     "skip_create_table_metadata_updates",
-    "allow_deletes",
+    "remove_files_on_delete",
     "purge_requested",
     "encode_entire_prefix",
 ];
@@ -715,15 +725,19 @@ fn validate_platform_support(catalog: &CatalogSpecV2View<'_>) -> FsResult<()> {
         V2CatalogType::Horizon => &["snowflake", "duckdb"][..],
         V2CatalogType::Glue => &["snowflake", "duckdb"],
         V2CatalogType::IcebergRest => &["snowflake", "duckdb"],
-        V2CatalogType::Unity => &["snowflake", "databricks"],
+        V2CatalogType::Unity => &["snowflake", "databricks", "duckdb"],
         V2CatalogType::HiveMetastore => &["databricks"],
         V2CatalogType::BiglakeMetastore => &["bigquery"],
         V2CatalogType::DuckLake => &["duckdb"],
         V2CatalogType::LocalFilesystem => &["duckdb"],
     };
 
+    let mut has_supported_config = false;
     for &platform in ALL_V2_PLATFORMS {
-        if catalog.config_block(platform).is_some() && !catalog_platforms.contains(&platform) {
+        if catalog.config_block(platform).is_none() {
+            continue;
+        }
+        if !catalog_platforms.contains(&platform) {
             return err!(
                 code => ErrorCode::InvalidConfig,
                 hacky_yml_loc => catalog.field_span("type").cloned(),
@@ -732,8 +746,33 @@ fn validate_platform_support(catalog: &CatalogSpecV2View<'_>) -> FsResult<()> {
                 catalog.catalog_type.as_str()
             );
         }
+        has_supported_config = true;
+    }
+    if !has_supported_config {
+        return err!(
+            code => ErrorCode::InvalidConfig,
+            hacky_yml_loc => catalog.field_span("type").cloned(),
+            "Catalog '{}' of type '{}' requires at least one config block: {}",
+            catalog.name,
+            catalog.catalog_type.as_str(),
+            format_config_block_choices(catalog_platforms)
+        );
     }
     Ok(())
+}
+
+fn format_config_block_choices(platforms: &[&str]) -> String {
+    match platforms {
+        [] => String::new(),
+        [only] => (*only).to_string(),
+        [first, second] => format!("{first} or {second}"),
+        _ => {
+            let mut choices = platforms[..platforms.len() - 1].join(", ");
+            choices.push_str(", or ");
+            choices.push_str(platforms[platforms.len() - 1]);
+            choices
+        }
+    }
 }
 
 fn validate_u32_range(map: &yml::Mapping, field: &str, max: u32) -> FsResult<()> {
@@ -763,14 +802,6 @@ fn parse_horizon_catalog(catalog: &CatalogSpecV2View<'_>) -> FsResult<()> {
     }
     let snowflake = catalog.config_block("snowflake");
     let duckdb = catalog.config_block("duckdb");
-    if snowflake.is_none() && duckdb.is_none() {
-        return err!(
-            code => ErrorCode::InvalidConfig,
-            hacky_yml_loc => catalog.field_span("type").cloned(),
-            "Catalog '{}' type 'horizon' requires at least one config block: snowflake or duckdb",
-            catalog.name
-        );
-    };
 
     if let Some(snowflake) = snowflake {
         if field_span(snowflake, "base_location_subpath").is_some() {
@@ -1002,10 +1033,10 @@ fn validate_duckdb_config(
 
     for key in [
         "support_nested_namespaces",
-        "support_stage_create",
-        "use_transaction_commit",
+        "stage_create_tables",
+        "disable_multi_table_commit",
         "skip_create_table_metadata_updates",
-        "allow_deletes",
+        "remove_files_on_delete",
         "purge_requested",
         "encode_entire_prefix",
     ] {
@@ -1022,15 +1053,6 @@ fn parse_glue_catalog(catalog: &CatalogSpecV2View<'_>) -> FsResult<()> {
             code => ErrorCode::InvalidConfig,
             hacky_yml_loc => catalog.field_span("table_format").cloned(),
             "Catalog '{}' type 'glue' requires table_format='iceberg'",
-            catalog.name
-        );
-    }
-
-    if catalog.config_block("snowflake").is_none() && catalog.config_block("duckdb").is_none() {
-        return err!(
-            code => ErrorCode::InvalidConfig,
-            hacky_yml_loc => catalog.field_span("type").cloned(),
-            "Catalog '{}' of type 'glue' requires at least one config block: snowflake or duckdb",
             catalog.name
         );
     }
@@ -1086,15 +1108,6 @@ fn parse_linked_catalog(catalog: &CatalogSpecV2View<'_>, type_name: &str) -> FsR
             code => ErrorCode::InvalidConfig,
             hacky_yml_loc => catalog.field_span("table_format").cloned(),
             "Catalog '{}' type '{}' requires table_format='iceberg'",
-            catalog.name,
-            type_name
-        );
-    }
-    if catalog.config_block("snowflake").is_none() && catalog.config_block("databricks").is_none() {
-        return err!(
-            code => ErrorCode::InvalidConfig,
-            hacky_yml_loc => catalog.field_span("type").cloned(),
-            "Catalog '{}' of type '{}' requires at least one config block: snowflake or databricks",
             catalog.name,
             type_name
         );
@@ -1195,6 +1208,10 @@ fn parse_linked_catalog(catalog: &CatalogSpecV2View<'_>, type_name: &str) -> FsR
                 type_name
             );
         }
+    }
+
+    if let Some(duckdb) = catalog.config_block("duckdb") {
+        validate_duckdb_config(duckdb, catalog, "unity")?;
     }
 
     Ok(())
@@ -1341,15 +1358,6 @@ fn parse_iceberg_rest_catalog(catalog: &CatalogSpecV2View<'_>) -> FsResult<()> {
             code => ErrorCode::InvalidConfig,
             hacky_yml_loc => catalog.field_span("table_format").cloned(),
             "Catalog '{}' type 'iceberg_rest' requires table_format='iceberg'",
-            catalog.name
-        );
-    }
-
-    if catalog.config_block("snowflake").is_none() && catalog.config_block("duckdb").is_none() {
-        return err!(
-            code => ErrorCode::InvalidConfig,
-            hacky_yml_loc => catalog.field_span("type").cloned(),
-            "Catalog '{}' of type 'iceberg_rest' requires at least one config block: snowflake or duckdb",
             catalog.name
         );
     }
@@ -1780,6 +1788,24 @@ iceberg_catalogs:
     }
 
     #[test]
+    fn v2_rejects_missing_supported_platform_block() {
+        let yaml = r#"
+catalogs:
+  - name: linked_catalog
+    type: unity
+    table_format: iceberg
+    config: {}
+"#;
+        let res = parse_and_validate(yaml);
+        let msg = format!("{res:?}");
+        assert!(res.is_err(), "expected error but got Ok");
+        assert!(
+            msg.contains("requires at least one config block: snowflake, databricks, or duckdb"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
     fn unity_rejects_bigquery_block_in_config() {
         let yaml = r#"
 catalogs:
@@ -2175,15 +2201,35 @@ catalogs:
     table_format: iceberg
     config:
       duckdb:
-        endpoint: "https://example.com"
+        endpoint: ""
 "#;
         let res = parse_and_validate(yaml);
         let msg = format!("{res:?}");
         assert!(res.is_err(), "expected error but got Ok");
         assert!(
-            msg.contains("does not support duckdb on the unity"),
+            msg.contains("'endpoint' must be non-empty"),
             "unexpected error: {msg}"
         );
+    }
+
+    #[test]
+    fn unity_duckdb_v2_valid() {
+        let yaml = r#"
+catalogs:
+  - name: unity_duck
+    type: unity
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint: "https://dbc.example.com/api/2.1/unity-catalog/iceberg-rest"
+        warehouse: "main"
+        secret: "databricks_pat"
+        attach_as: "uc"
+        default_schema: "analytics"
+        authorization_type: "OAUTH2"
+        access_delegation_mode: "VENDED_CREDENTIALS"
+"#;
+        parse_and_validate(yaml).expect("unity + duckdb should validate");
     }
 
     // -----------------------------------------------------------------------
@@ -2423,10 +2469,10 @@ catalogs:
         authorization_type: OAUTH2
         access_delegation_mode: VENDED_CREDENTIALS
         support_nested_namespaces: true
-        support_stage_create: false
-        use_transaction_commit: false
+        stage_create_tables: false
+        disable_multi_table_commit: true
         skip_create_table_metadata_updates: true
-        allow_deletes: false
+        remove_files_on_delete: false
         purge_requested: true
         encode_entire_prefix: true
 "#;
@@ -2463,12 +2509,12 @@ catalogs:
     config:
       duckdb:
         endpoint: "https://example.com"
-        support_stage_create: "yes"
+        stage_create_tables: "yes"
 "#;
         let res = parse_and_validate(yaml);
         assert!(res.is_err(), "expected error for non-boolean attach option");
         assert!(
-            format!("{res:?}").contains("support_stage_create"),
+            format!("{res:?}").contains("stage_create_tables"),
             "unexpected: {res:?}"
         );
     }

--- a/crates/dbt-schemas/src/schemas/dbt_catalogs_v2.rs
+++ b/crates/dbt-schemas/src/schemas/dbt_catalogs_v2.rs
@@ -712,7 +712,7 @@ const DUCKDB_KEYS: &[&str] = &[
 
 fn validate_platform_support(catalog: &CatalogSpecV2View<'_>) -> FsResult<()> {
     let catalog_platforms = match catalog.catalog_type {
-        V2CatalogType::Horizon => &["snowflake"][..],
+        V2CatalogType::Horizon => &["snowflake", "duckdb"][..],
         V2CatalogType::Glue => &["snowflake", "duckdb"],
         V2CatalogType::IcebergRest => &["snowflake", "duckdb"],
         V2CatalogType::Unity => &["snowflake", "databricks"],
@@ -761,67 +761,100 @@ fn parse_horizon_catalog(catalog: &CatalogSpecV2View<'_>) -> FsResult<()> {
             catalog.name
         );
     }
-    let Some(snowflake) = catalog.config_block("snowflake") else {
+    let snowflake = catalog.config_block("snowflake");
+    let duckdb = catalog.config_block("duckdb");
+    if snowflake.is_none() && duckdb.is_none() {
         return err!(
             code => ErrorCode::InvalidConfig,
             hacky_yml_loc => catalog.field_span("type").cloned(),
-            "Catalog '{}' type 'horizon' requires config.snowflake",
+            "Catalog '{}' type 'horizon' requires at least one config block: snowflake or duckdb",
             catalog.name
         );
     };
-    if field_span(snowflake, "base_location_subpath").is_some() {
-        return err!(
-            code => ErrorCode::InvalidConfig,
-            hacky_yml_loc => field_span(snowflake, "base_location_subpath").cloned(),
-            "Catalog '{}' horizon/snowflake base_location_subpath is model-config only and may not be specified in catalogs.yml",
-            catalog.name
-        );
-    }
-    check_unknown_keys(
-        snowflake,
-        SNOWFLAKE_MANAGED_SNOWFLAKE_KEYS,
-        "catalogs[].config.snowflake (horizon)",
-    )?;
 
-    let Some(external_volume) = get_str(snowflake, "external_volume")? else {
-        return err!(
-            code => ErrorCode::InvalidConfig,
-            hacky_yml_loc => catalog.field_span("type").cloned(),
-            "Catalog '{}' horizon/snowflake config requires 'external_volume'",
-            catalog.name
-        );
-    };
-    if external_volume.is_empty_or_whitespace() {
-        return err!(
-            code => ErrorCode::InvalidConfig,
-            hacky_yml_loc => field_span(snowflake, "external_volume").cloned(),
-            "Catalog '{}' horizon/snowflake 'external_volume' must be non-empty",
-            catalog.name
-        );
+    if let Some(snowflake) = snowflake {
+        if field_span(snowflake, "base_location_subpath").is_some() {
+            return err!(
+                code => ErrorCode::InvalidConfig,
+                hacky_yml_loc => field_span(snowflake, "base_location_subpath").cloned(),
+                "Catalog '{}' horizon/snowflake base_location_subpath is model-config only and may not be specified in catalogs.yml",
+                catalog.name
+            );
+        }
+        check_unknown_keys(
+            snowflake,
+            SNOWFLAKE_MANAGED_SNOWFLAKE_KEYS,
+            "catalogs[].config.snowflake (horizon)",
+        )?;
+
+        let Some(external_volume) = get_str(snowflake, "external_volume")? else {
+            return err!(
+                code => ErrorCode::InvalidConfig,
+                hacky_yml_loc => catalog.field_span("type").cloned(),
+                "Catalog '{}' horizon/snowflake config requires 'external_volume'",
+                catalog.name
+            );
+        };
+        if external_volume.is_empty_or_whitespace() {
+            return err!(
+                code => ErrorCode::InvalidConfig,
+                hacky_yml_loc => field_span(snowflake, "external_volume").cloned(),
+                "Catalog '{}' horizon/snowflake 'external_volume' must be non-empty",
+                catalog.name
+            );
+        }
+        if let Some(base_location_root) = get_str(snowflake, "base_location_root")?
+            && base_location_root.is_empty_or_whitespace()
+        {
+            return err!(
+                code => ErrorCode::InvalidConfig,
+                hacky_yml_loc => field_span(snowflake, "base_location_root").cloned(),
+                "Catalog '{}' horizon/snowflake base_location_root cannot be blank",
+                catalog.name
+            );
+        }
+        if let Some(policy) = get_str(snowflake, "storage_serialization_policy")?
+            && !is_valid_storage_serialization_policy(policy)
+        {
+            return err!(
+                code => ErrorCode::InvalidConfig,
+                hacky_yml_loc => field_span(snowflake, "storage_serialization_policy").cloned(),
+                "storage_serialization_policy '{}' invalid (COMPATIBLE|OPTIMIZED)",
+                policy
+            );
+        }
+        validate_u32_range(snowflake, "data_retention_time_in_days", 90)?;
+        validate_u32_range(snowflake, "max_data_extension_time_in_days", 90)?;
+        validate_optional_bool(snowflake, "change_tracking")?;
     }
-    if let Some(base_location_root) = get_str(snowflake, "base_location_root")?
-        && base_location_root.is_empty_or_whitespace()
-    {
-        return err!(
-            code => ErrorCode::InvalidConfig,
-            hacky_yml_loc => field_span(snowflake, "base_location_root").cloned(),
-            "Catalog '{}' horizon/snowflake base_location_root cannot be blank",
-            catalog.name
-        );
+
+    if let Some(duckdb) = duckdb {
+        validate_duckdb_config(duckdb, catalog, "horizon")?;
+        if get_str(duckdb, "endpoint_type")?.is_some() {
+            return err!(
+                code => ErrorCode::InvalidConfig,
+                hacky_yml_loc => field_span(duckdb, "endpoint_type").cloned(),
+                "Catalog '{}' horizon/duckdb config requires 'endpoint', not 'endpoint_type'",
+                catalog.name
+            );
+        }
+        let Some(warehouse) = get_str(duckdb, "warehouse")? else {
+            return err!(
+                code => ErrorCode::InvalidConfig,
+                hacky_yml_loc => catalog.field_span("type").cloned(),
+                "Catalog '{}' horizon/duckdb config requires 'warehouse'",
+                catalog.name
+            );
+        };
+        if warehouse.is_empty_or_whitespace() {
+            return err!(
+                code => ErrorCode::InvalidConfig,
+                hacky_yml_loc => field_span(duckdb, "warehouse").cloned(),
+                "Catalog '{}' horizon/duckdb 'warehouse' must be non-empty",
+                catalog.name
+            );
+        }
     }
-    if let Some(policy) = get_str(snowflake, "storage_serialization_policy")?
-        && !is_valid_storage_serialization_policy(policy)
-    {
-        return err!(
-            code => ErrorCode::InvalidConfig,
-            hacky_yml_loc => field_span(snowflake, "storage_serialization_policy").cloned(),
-            "storage_serialization_policy '{}' invalid (COMPATIBLE|OPTIMIZED)",
-            policy
-        );
-    }
-    validate_u32_range(snowflake, "data_retention_time_in_days", 90)?;
-    validate_u32_range(snowflake, "max_data_extension_time_in_days", 90)?;
-    validate_optional_bool(snowflake, "change_tracking")?;
 
     Ok(())
 }
@@ -1587,6 +1620,44 @@ catalogs:
         change_tracking: false
 "#;
         parse_and_validate(yaml).expect("v2 horizon should validate");
+    }
+
+    #[test]
+    fn horizon_duckdb_v2_valid() {
+        let yaml = r#"
+catalogs:
+  - name: horizon_duck
+    type: horizon
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint: "https://snowflake.example.com/polaris/api/catalog"
+        warehouse: "HORIZON_CATALOG"
+        secret: "horizon_secret"
+        attach_as: "horizon_db"
+        default_schema: "demo"
+"#;
+        parse_and_validate(yaml).expect("horizon + duckdb should validate");
+    }
+
+    #[test]
+    fn horizon_duckdb_rejects_endpoint_type() {
+        let yaml = r#"
+catalogs:
+  - name: horizon_duck
+    type: horizon
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint_type: GLUE
+        warehouse: "HORIZON_CATALOG"
+"#;
+        let res = parse_and_validate(yaml);
+        assert!(res.is_err(), "expected endpoint_type rejection");
+        assert!(
+            format!("{res:?}").contains("requires 'endpoint', not 'endpoint_type'"),
+            "unexpected: {res:?}"
+        );
     }
 
     #[test]

--- a/crates/dbt-schemas/src/schemas/dbt_catalogs_v2.rs
+++ b/crates/dbt-schemas/src/schemas/dbt_catalogs_v2.rs
@@ -48,6 +48,9 @@
 //!         access_delegation_mode: VENDED_CREDENTIALS|NONE         # optional
 //!         support_nested_namespaces: <boolean>                    # optional
 //!         support_stage_create: <boolean>                         # optional
+//!         use_transaction_commit: <boolean>                        # optional
+//!         skip_create_table_metadata_updates: <boolean>            # optional
+//!         allow_deletes: <boolean>                                 # optional
 //!         purge_requested: <boolean>                              # optional
 //!         encode_entire_prefix: <boolean>                         # optional
 //!
@@ -116,6 +119,9 @@
 //!         access_delegation_mode: VENDED_CREDENTIALS|NONE         # optional
 //!         support_nested_namespaces: <boolean>                    # optional
 //!         support_stage_create: <boolean>                         # optional
+//!         use_transaction_commit: <boolean>                        # optional
+//!         skip_create_table_metadata_updates: <boolean>            # optional
+//!         allow_deletes: <boolean>                                 # optional
 //!         purge_requested: <boolean>                              # optional
 //!         encode_entire_prefix: <boolean>                         # optional
 //!
@@ -697,6 +703,9 @@ const DUCKDB_KEYS: &[&str] = &[
     "access_delegation_mode",
     "support_nested_namespaces",
     "support_stage_create",
+    "use_transaction_commit",
+    "skip_create_table_metadata_updates",
+    "allow_deletes",
     "purge_requested",
     "encode_entire_prefix",
 ];
@@ -961,6 +970,9 @@ fn validate_duckdb_config(
     for key in [
         "support_nested_namespaces",
         "support_stage_create",
+        "use_transaction_commit",
+        "skip_create_table_metadata_updates",
+        "allow_deletes",
         "purge_requested",
         "encode_entire_prefix",
     ] {
@@ -2341,6 +2353,9 @@ catalogs:
         access_delegation_mode: VENDED_CREDENTIALS
         support_nested_namespaces: true
         support_stage_create: false
+        use_transaction_commit: false
+        skip_create_table_metadata_updates: true
+        allow_deletes: false
         purge_requested: true
         encode_entire_prefix: true
 "#;

--- a/crates/xdbc-record-replay/src/replay.rs
+++ b/crates/xdbc-record-replay/src/replay.rs
@@ -56,11 +56,15 @@ impl Connection for ReplayConnection {
     }
 
     fn commit(&mut self) -> AdbcResult<()> {
-        unimplemented!("ADBC connection commit in replay engine")
+        // Replay connections do not maintain transaction state, but the adapter
+        // can still call commit while exercising DuckDB materialization macros.
+        Ok(())
     }
 
     fn rollback(&mut self) -> AdbcResult<()> {
-        unimplemented!("ADBC connection rollback in replay engine")
+        // See commit(): replay is deterministic trace playback, not a live
+        // transactional backend.
+        Ok(())
     }
 
     #[allow(deprecated)]
@@ -341,4 +345,25 @@ fn replay_file_execute<'a>(
         .read_batches(&data_path)
         .map_err(|e| to_adbc_error(e, Some(&data_path)))?;
     Ok(reader)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use dbt_xdbc::Connection;
+
+    use crate::Config;
+
+    use super::ReplayConnection;
+
+    #[test]
+    fn transaction_methods_are_noops() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut conn =
+            ReplayConnection::new(dir.path().to_path_buf(), Arc::new(Config::default()), 0);
+
+        conn.commit().expect("commit should be a replay no-op");
+        conn.rollback().expect("rollback should be a replay no-op");
+    }
 }


### PR DESCRIPTION
## What

Adds `catalogs.yml` v2 support for the dbt duckdb adapter, enabling catalog-backed table formats:

- **Iceberg** table materializations + REST catalog attach options
- **Unity Catalog** attachments
- **Horizon** catalog support
- catalog-aware runtime paths; routes duckdb sources through `catalogs.yml` v2
- gated `allow_unsigned_extensions` duckdb startup option
- catalog-routed demo writes

## Companion PR

Mirrors the Fusion-side stack in `dbt-labs/fs#10484` (internal). Opened as a draft to track parity while that PR lands.

## Notes

- Internal-only test crates (`dbt-adapter-tests`, `sdf-adapter`) are not part of this public mirror, so their replay recordings are not included here.
- Verified locally: `cargo check --tests` is green across the changed crates (dbt-adapter, dbt-schemas, dbt-auth, dbt-loader, dbt-parser, xdbc-record-replay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
