### PR TITLE
feat: add catalog_database field to CatalogWriteIntegrationConfig (v1)

### DIFF
--- a/.changes/unreleased/Features-20260623-124241.yaml
+++ b/.changes/unreleased/Features-20260623-124241.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add catalog_database field to CatalogWriteIntegrationConfig (v1) so catalogs.yml can set a database-name override for any catalog type; works in conjunction with the dbt-adapters get_catalog_database_override method to give catalog_database highest priority in generate_database_name
+time: 2026-06-23T12:42:41.105597+05:30
+custom:
+    Author: aahel
+    Issue: "15156"

--- a/core/dbt/artifacts/resources/v1/catalog.py
+++ b/core/dbt/artifacts/resources/v1/catalog.py
@@ -14,6 +14,7 @@ class CatalogWriteIntegrationConfig(CatalogIntegrationConfig):
     table_format: Optional[str] = None
     catalog_name: Optional[str] = None
     file_format: Optional[str] = None
+    catalog_database: Optional[str] = None
     adapter_properties: Dict[str, Any] = field(default_factory=dict)
 
 


### PR DESCRIPTION
Resolves #

### Problem

`catalog_database` lets a catalog map to a specific physical database name, but it was a Snowflake-only concept and could not be expressed generically in `catalogs.yml`. The v1 `CatalogWriteIntegrationConfig` resource had no `catalog_database` field, so the key was dropped during parsing and could not flow through to adapters.

### Solution

Add `catalog_database: Optional[str] = None` to `CatalogWriteIntegrationConfig` (`core/dbt/artifacts/resources/v1/catalog.py`) so v1 `catalogs.yml` can set it for any catalog type. The value flows into the adapter-side `CatalogIntegration.catalog_database` and is given precedence over the model `database` config in `generate_database_name`.

This is the dbt-core companion to [dbt-labs/dbt-adapters#2004](https://github.com/dbt-labs/dbt-adapters/pull/2004), which adds the first-class field on the catalog base, the `get_catalog_database_override` adapter method, and the `generate_database_name` precedence wiring (including `snowflake__generate_database_name`).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.