### PR TITLE
ci(homebrew): publish dbt-core formula to homebrew-dbt tap

### DIFF
--- a/.changes/unreleased/Under the Hood-20260604-160919.yaml
+++ b/.changes/unreleased/Under the Hood-20260604-160919.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Publish a dbt-core Homebrew formula to dbt-labs/homebrew-dbt as part of release-v2.
+time: 2026-06-04T16:09:19.780163+05:30
+custom:
+    author: itsnamangoyal
+    issue: ""
+    project: dbt-fusion

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -1,0 +1,236 @@
+# **what?**
+# Render Formula/dbt-core.rb from the SHA256SUMS manifest attached to a
+# GitHub Release and push it to the shared dbt-labs/homebrew-dbt tap.
+#
+# **why?**
+# Distribute dbt-core via Homebrew so users can `brew install dbt-core`.
+#
+# **when?**
+# - workflow_call: invoked by release-v2.yml after `github-release`
+#   uploads the SHA256SUMS manifest + per-target tarballs to the release.
+# - workflow_dispatch: ad-hoc manual run against an existing release.
+#
+# **how?**
+# `gh release download <tag> --pattern SHA256SUMS` pulls the manifest,
+# `cargo ci homebrew render --sha256sums` picks the 4 brew-supported
+# tarballs out of it (wheels/zips/windows are silently skipped), and
+# `cargo ci homebrew publish` clones the tap, copies the rendered
+# formula, signs the commit with the build-bot GPG key, and pushes.
+#
+# Tarballs are served straight from GitHub Releases — no CDN involved.
+# The formula and the fs `dbt` formula share the dbt-labs/homebrew-dbt
+# tap; both install `bin/dbt`, so each declares `conflicts_with` on the
+# other.
+
+name: Publish Homebrew formula
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version string (e.g. 2.0.0)"
+        type: string
+        required: true
+      tag:
+        description: "Release tag (e.g. v2.0.0)"
+        type: string
+        required: true
+      dry_run:
+        description: "If true, render but pass --dry-run to publish (no push)."
+        type: boolean
+        required: false
+        default: false
+      url_template:
+        description: |
+          URL template; must contain `{filename}`. Used as the per-tarball
+          download URL in the rendered formula. Defaults to the GitHub
+          Release download URL for `inputs.tag` on dbt-labs/dbt-core.
+        type: string
+        required: false
+        default: "https://github.com/dbt-labs/dbt-core/releases/download/v{version}/{filename}"
+      tap_repo:
+        description: "Tap repo to push the formula to."
+        type: string
+        required: false
+        default: "https://github.com/dbt-labs/homebrew-dbt.git"
+      tap_branch:
+        description: "Branch on the tap repo."
+        type: string
+        required: false
+        default: "main"
+      binary_name:
+        description: |
+          Name of the binary inside each tarball. Must match
+          `release-v2.yml`'s `BINARY_NAME` env (the file staged into the
+          tarball by the build job).
+        type: string
+        required: false
+        default: "dbt-sa-cli"
+      tarball_prefix:
+        description: |
+          Tarball filename prefix. Filenames are
+          `{tarball_prefix}{version}-{target}.tar.gz`. Must match
+          `release-v2.yml`'s `${PACKAGE_NAME}-` (the `ARCHIVE_BASE`
+          template the build job uses).
+        type: string
+        required: false
+        default: "dbt-core-"
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "SemVer to render (e.g. 2.0.0). Do NOT include the leading `v`."
+        required: true
+        type: string
+      tag:
+        description: "Release tag to download SHA256SUMS from (defaults to `v<version>`)."
+        required: false
+        type: string
+      url_template:
+        description: "URL template; must contain `{filename}`."
+        required: false
+        type: string
+        default: "https://github.com/dbt-labs/dbt-core/releases/download/v{version}/{filename}"
+      tap_repo:
+        description: "Tap repo to push the formula to."
+        required: false
+        type: string
+        default: "https://github.com/dbt-labs/homebrew-dbt.git"
+      tap_branch:
+        description: "Branch on the tap repo."
+        required: false
+        type: string
+        default: "main"
+      dry_run:
+        description: "If true, render + show diff but do NOT push."
+        required: false
+        type: boolean
+        default: true
+      binary_name:
+        description: "Name of the binary inside each tarball (default: dbt-sa-cli)."
+        required: false
+        type: string
+        default: "dbt-sa-cli"
+      tarball_prefix:
+        description: "Tarball filename prefix (default: dbt-core-)."
+        required: false
+        type: string
+        default: "dbt-core-"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+jobs:
+  # Guard: only publish the formula when this tag is GitHub's "latest"
+  # release. Protects against:
+  #   - Re-running an older release pipeline (re-uploads assets but
+  #     "latest" stays on the newer tag — formula isn't downgraded).
+  #   - Hotfix on an older minor after a newer minor has shipped.
+  #   - Manual workflow_dispatch against an older version.
+  # GitHub auto-marks the highest-semver non-prerelease release as latest;
+  # an ops user can also flip it manually as a kill switch.
+  preflight:
+    name: Check this tag is the latest release
+    runs-on: ubuntu-latest
+    outputs:
+      is_latest: ${{ steps.check.outputs.is_latest }}
+    steps:
+      - name: Resolve latest release tag
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag || format('v{0}', inputs.version) }}
+        run: |
+          LATEST_TAG=$(gh release view \
+            --repo "${{ github.repository }}" \
+            --json tagName --jq .tagName)
+          if [ "$TAG" = "$LATEST_TAG" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+            echo "✓ $TAG is the latest release; proceeding."
+          else
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping brew publish: $TAG is not the latest release ($LATEST_TAG)."
+          fi
+
+  publish-homebrew:
+    name: Render + publish formula
+    needs: preflight
+    if: needs.preflight.outputs.is_latest == 'true'
+    runs-on: ${{ vars.UBUNTU_RUNNER_32 }}
+    env:
+      TAP_REPO: ${{ inputs.tap_repo }}
+      TAP_BRANCH: ${{ inputs.tap_branch }}
+      URL_TEMPLATE: ${{ inputs.url_template }}
+      TAG: ${{ inputs.tag || format('v{0}', inputs.version) }}
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+
+      - name: Download SHA256SUMS from GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and dbt-ci build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # Swatinem/rust-cache@v2.9.1
+        with:
+          shared-key: cargo-ci-tool
+          cache-targets: "true"
+
+      # Imports the build-bot GPG key and pins git identity to match its UID
+      # so the tap commit is signed and shows as Verified on GitHub. Reuses
+      # the same secrets + identity as update-test-durations.yml.
+      - name: Import build bot GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.FISHTOWN_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.FISHTOWN_BOT_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_committer_name: "Github Build Bot"
+          git_committer_email: "buildbot@dbtlabs.com"
+
+      - name: Render Homebrew formula
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          cargo ci homebrew render \
+            --sha256sums SHA256SUMS \
+            --version "$VERSION" \
+            --url-template "$URL_TEMPLATE" \
+            --formula-name dbt-core \
+            --install-as dbt \
+            --binary-name "${{ inputs.binary_name }}" \
+            --conflicts-with dbt \
+            --tarball-prefix "${{ inputs.tarball_prefix }}" \
+            --out dbt-core.rb
+          echo "---rendered Formula/dbt-core.rb---"
+          cat dbt-core.rb
+
+      - name: Publish formula to tap
+        env:
+          HOMEBREW_TAP_REPO_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
+          VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          DRY_RUN_FLAG=""
+          if [ "$DRY_RUN" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          cargo ci homebrew publish \
+            --formula dbt-core.rb \
+            --tap-repo "$TAP_REPO" \
+            --tap-branch "$TAP_BRANCH" \
+            --version "$VERSION" \
+            $DRY_RUN_FLAG

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -1,25 +1,32 @@
 # **what?**
 # Cut a `dbt-sa-cli` release: bump version on a release branch, build the
 # binary matrix via `cargo build`, pack each binary into a wheel via
-# `cargo ci pypi pack`, tag the build commit, publish to PyPI.
+# `cargo ci pypi pack`, tag the build commit, publish to PyPI, create a
+# GitHub Release with the platform tarballs, and push a Homebrew formula
+# to the dbt-labs/homebrew-dbt tap.
 #
 # **why?**
 # OSS release path for the standalone analyzer CLI. The build (`cargo build`)
 # is decoupled from the wheel writer (`cargo ci pypi pack`) — same pattern
 # the internal fs side will use to consume its CDN-built signed binaries.
 # `dbt-ci` writes wheels in pure Rust (zip + metadata) and uploads via the
-# PyPI HTTP API; no maturin, no twine.
+# PyPI HTTP API; no maturin, no twine. Homebrew distribution reuses the
+# same `dbt-ci` tooling (`homebrew render`/`publish`) and serves tarballs
+# straight from the GitHub Release.
 #
 # **when?**
 # Manual `workflow_dispatch` only — every release goes through
 # `cargo ci bump-cargo-version` for the workspace version bump.
 #
 # Flow: prepare-release → { build (matrix), test } → pack → tag →
-# { publish-pypi, github-release }. build and test fan out from
-# prepare-release in parallel and both gate pack — a failing test
-# aborts the release before any wheels are written. tag is a small
+# { publish-pypi, github-release → publish-homebrew }. build and test
+# fan out from prepare-release in parallel and both gate pack — a failing
+# test aborts the release before any wheels are written. tag is a small
 # gate that everything downstream depends on; publish-pypi and
 # github-release run in parallel and are each independently retriable.
+# publish-homebrew runs after github-release (it needs the uploaded
+# SHA256SUMS) and is gated to non-pre-release versions that GitHub
+# marked as "Latest".
 #
 # Repo setup (required `vars.*` runner labels, branch protection, secret
 # provisioning) is documented in `crates/dbt-ci/README.md`.
@@ -30,16 +37,26 @@
 # `PYPI_API_TOKEN` secret (passed to the tool as `DBT_PYPI_PROD_TOKEN`).
 # Two distributions are published — `dbt-core` and
 # `dbt-core-experimental-parser` — selected by the `release_target` input.
-# Dry-run (`inputs.dry_run = true`) skips tag push, publish, and the
-# GitHub Release — build + pack still run so artifacts are inspectable.
-# The release branch is still pushed under `release/dry-run/v…-<run_id>`
-# so the matrix has something to check out; clean these up periodically.
+#
+# **Homebrew publishing**
+# `publish-homebrew` renders `Formula/dbt-core.rb` from the SHA256SUMS the
+# `github-release` job just uploaded and pushes it to the shared
+# dbt-labs/homebrew-dbt tap. Tap commits are GPG-signed by the build bot
+# (via FISHTOWN_BOT_GPG_*). Skipped for SemVer pre-releases and any tag
+# that isn't GitHub's current "Latest" release — protects against
+# downgrades from re-runs or hotfixes on older minors.
+#
+# Dry-run (`inputs.dry_run = true`) skips tag push, PyPI publish, the
+# GitHub Release, and the Homebrew publish — build + pack still run so
+# artifacts are inspectable. The release branch is still pushed under
+# `release/dry-run/v…-<run_id>` so the matrix has something to check
+# out; clean these up periodically.
 
 name: Release dbt Core V2
 run-name: >-
   ${{
-    inputs.dry_run && format('Publish PyPI v{0} (dry run — build only)', inputs.version)
-    || format('Publish PyPI v{0}', inputs.version)
+    inputs.dry_run && format('Release v{0} (dry run — build only)', inputs.version)
+    || format('Release v{0}', inputs.version)
   }}
 
 on:
@@ -50,7 +67,7 @@ on:
         required: true
         type: string
       dry_run:
-        description: "Build and pack only — skip tag push, PyPI publish, and GitHub Release."
+        description: "Build and pack only — skip tag push, PyPI publish, GitHub Release, and Homebrew publish."
         required: false
         type: boolean
         default: false
@@ -60,7 +77,7 @@ on:
         type: string
         default: "main"
       release_target:
-        description: "Which package(s) to publish to PyPI. Pack always builds both; no effect on dry runs."
+        description: "Which package(s) to publish to PyPI. Pack always builds both; no effect on dry runs or Homebrew publish."
         required: false
         type: choice
         options:
@@ -70,7 +87,7 @@ on:
         default: both
 
 concurrency:
-  group: ${{ inputs.dry_run && format('publish-pypi-dry-{0}', github.run_id) || 'publish-pypi-prod' }}
+  group: ${{ inputs.dry_run && format('publish-release-dry-{0}', github.run_id) || 'publish-release-prod' }}
   cancel-in-progress: false
 
 permissions:
@@ -760,3 +777,25 @@ jobs:
           fi
 
           gh release upload "$TAG" --clobber "${ASSETS[@]}"
+
+  # Renders Formula/dbt-core.rb from the SHA256SUMS just uploaded by the
+  # `github-release` job and pushes it to dbt-labs/homebrew-dbt. Skipped
+  # for pre-release versions (anything with a `-` in the SemVer) — brew
+  # users only get stable releases.
+  publish-homebrew:
+    needs: [prepare-release, github-release]
+    if: ${{ !inputs.dry_run && !contains(needs.prepare-release.outputs.version, '-') }}
+    uses: ./.github/workflows/publish-homebrew.yml
+    with:
+      version: ${{ needs.prepare-release.outputs.version }}
+      tag: ${{ needs.prepare-release.outputs.tag }}
+      dry_run: false
+      # Must match the `build` job's `BINARY_NAME` env and the
+      # `ARCHIVE_BASE` template's `${PACKAGE_NAME}-` prefix. Hardcoded
+      # because reusable-workflow `with:` blocks don't accept the `env`
+      # context — keep these in lockstep with the build job manually.
+      binary_name: dbt-sa-cli
+      tarball_prefix: dbt-core-
+    permissions:
+      contents: read
+    secrets: inherit

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -783,7 +783,7 @@ jobs:
   # for pre-release versions (anything with a `-` in the SemVer) — brew
   # users only get stable releases.
   publish-homebrew:
-    needs: [prepare-release, github-release]
+    needs: [github-release]
     if: ${{ !inputs.dry_run && !contains(needs.prepare-release.outputs.version, '-') }}
     uses: ./.github/workflows/publish-homebrew.yml
     with:


### PR DESCRIPTION
## Summary

- New reusable workflow `.github/workflows/publish-homebrew.yml`: downloads `SHA256SUMS` from the GitHub Release, renders `Formula/dbt-core.rb` via `cargo ci homebrew render`, and pushes it to `dbt-labs/homebrew-dbt` via `cargo ci homebrew publish`. Tap commits are GPG-signed by the build bot (Verified).
- Wired into `release-v2.yml` as a new `publish-homebrew` job after `github-release`. Gated to non-dry-run, non-pre-release tags, and only when GitHub marks the tag as "Latest" — protects against downgrades from re-runs or older-minor hotfixes.
- Formula shares the dbt-labs/homebrew-dbt tap with the fs `dbt` formula; both install `bin/dbt`, so each declares the other in `conflicts_with`.

## Test plan

- [x] Confirm `FISHTOWN_BOT_PAT` is granted write access to `dbt-labs/homebrew-dbt`.
- [x] Local render dry-run produces a valid formula (`cargo ci homebrew render … && cat dbt-core.rb`).
- [ ] After merge, dispatch `publish-homebrew.yml` against a known-latest stable tag and verify (a) preflight passes, (b) tap commit is signed/Verified, (c) `brew install dbt-labs/dbt/dbt-core` succeeds.
- [ ] Next real release run: verify the brew job runs at the end of `release-v2.yml` and the formula on the tap points to that version.