### PR TITLE
ci(copybara): skip dispatch when PR has no syncable changes

### DIFF
--- a/.github/workflows/auto-public-pr-copybara.yml
+++ b/.github/workflows/auto-public-pr-copybara.yml
@@ -66,11 +66,27 @@ jobs:
           echo "::error::$msg"
           exit 1
 
-  copybara:
+  dispatch:
     needs: check_run_approval
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
+      - name: Check for syncable changes
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          excluded=(".github/" ".changes/")
+          files=$(gh pr diff ${{ github.event.number }} --name-only --repo ${{ github.repository }})
+          for prefix in "${excluded[@]}"; do
+            files=$(echo "$files" | grep -v "^$prefix" || true)
+          done
+          echo "should_dispatch=$([ -n "$files" ] && echo true || echo false)" >> $GITHUB_OUTPUT
+
       - name: Trigger dbt-core PR Copybara sync in fs
+        if: steps.check.outputs.should_dispatch == 'true'
         run: |
           curl -L \
             -X POST \


### PR DESCRIPTION
Skip the `repository_dispatch` to fs when a dbt-core PR only touches `.github/` and/or `.changes/` files — nothing that copybara would sync into fs anyway.

**What changed:** The `copybara` job is renamed to `dispatch` and gains a preflight step that lists all files changed in the PR and filters out excluded prefixes (`.github/`, `.changes/`). If nothing remains, the dispatch is skipped. Adding a new exclusion in the future means editing one env var: `EXCLUDED_PREFIXES`.

**Why:** PRs that only modify workflows or add a changelog entry were triggering a reverse sync and creating a changelog-only PR in fs (e.g. dbt-labs/fs#10836).