### PR TITLE
added direct_parents property to every node for lineage

### DIFF
--- a/.changes/unreleased/Fixes-20260604-120000.yaml
+++ b/.changes/unreleased/Fixes-20260604-120000.yaml
@@ -1,0 +1,13 @@
+kind: Fixes
+body: >-
+    Add a `direct_parents` attribute to model nodes carrying the nearest public
+    ancestors only, and emit it in `dbt ls --output=json` for models. Lineage
+    consumers can now render DAG edges from `direct_parents` instead of
+    `depends_on.nodes`, which carries the full transitive closure across plugin
+    boundaries (still required for node selection and cycle detection). The new
+    attribute is runtime-only and is stripped during manifest serialization, so
+    the manifest.json contract is unchanged.
+time: 2026-06-04T12:00:00.000000000Z
+custom:
+    Author: sriramr98
+    Issue: ""

--- a/core/dbt/contracts/graph/node_args.py
+++ b/core/dbt/contracts/graph/node_args.py
@@ -22,6 +22,7 @@ class ModelNodeArgs:
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None)
     )
     depends_on_nodes: List[str] = field(default_factory=list)
+    direct_parents: List[str] = field(default_factory=list)
     enabled: bool = True
 
     @property

--- a/core/dbt/contracts/graph/nodes.py
+++ b/core/dbt/contracts/graph/nodes.py
@@ -505,6 +505,7 @@ class BatchContext(dbtClassMixin):
 class ModelNode(ModelResource, CompiledNode):
     previous_batch_results: Optional[BatchResults] = None
     batch: Optional[BatchContext] = None
+    direct_parents: List[str] = field(default_factory=list)
     _has_this: Optional[bool] = None
 
     def __post_serialize__(
@@ -515,6 +516,11 @@ class ModelNode(ModelResource, CompiledNode):
             del dct["_has_this"]
         if "previous_batch_results" in dct:
             del dct["previous_batch_results"]
+        # direct_parents is a runtime-only lineage attribute. Emit it via
+        # `dbt ls --output=json` only (see ListTask.generate_json); do not
+        # write it into manifest.json so the manifest contract is unchanged.
+        if "direct_parents" in dct:
+            del dct["direct_parents"]
         return dct
 
     @classmethod
@@ -551,6 +557,7 @@ class ModelNode(ModelResource, CompiledNode):
             path="",
             unrendered_config=unrendered_config,
             depends_on=DependsOn(nodes=args.depends_on_nodes),
+            direct_parents=args.direct_parents,
             config=ModelConfig(enabled=args.enabled),
         )
 

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -549,7 +549,41 @@ class ManifestLoader:
         self.check_microbatch_model_has_a_filtered_input()
         self.check_function_default_arguments_ordering()
 
+        self._backfill_direct_parents()
+
         return self.manifest
+
+    def _backfill_direct_parents(self) -> None:
+        """Ensure every in-project model has its `direct_parents` populated.
+
+        Why this exists
+        ---------------
+        `direct_parents` is the lineage field that DAG-drawing consumers
+        (the dbt IDE, anything parsing `dbt ls --output=json`) read. We
+        want one authoritative field per model so consumers don't have to
+        branch on "is this an external node? use direct_parents. is it
+        in-project? fall back to depends_on.nodes."
+
+        For external nodes (nodes supplied by plugins via `ModelNodeArgs`,
+        e.g. from publication artifacts) the plugin already sets
+        `direct_parents` at construction time to the *nearest public
+        ancestors* — a proper subset of `depends_on.nodes`, which for these
+        nodes carries the full transitive public-ancestor closure so cycle
+        detection still works across plugin boundaries.
+
+        For in-project models, nothing populates `direct_parents` during
+        parsing — the parser only sets `depends_on.nodes` from the
+        `{{ ref(...) }}` calls it sees in the SQL. Note that
+        `depends_on.nodes` on an in-project node is ALREADY just the
+        direct refs — parsing is not transitive. Transitive closure across
+        in-project models only emerges when the graph is walked at compile
+        time (in the Linker). So for in-project models the two fields hold
+        the same set; this method copies one into the other so consumers
+        have a single field to read.
+        """
+        for node in self.manifest.nodes.values():
+            if isinstance(node, ModelNode) and not node.direct_parents:
+                node.direct_parents = list(node.depends_on.nodes)
 
     def safe_update_project_parser_files_partially(self, project_parser_files: Dict) -> Dict:
         if self.saved_manifest is None:

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -8,6 +8,7 @@ from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.nodes import (
     Exposure,
     Metric,
+    ModelNode,
     SavedQuery,
     SemanticModel,
     SourceDefinition,
@@ -48,6 +49,7 @@ class ListTask(GraphRunnableTask):
             "name",
             "package_name",
             "depends_on",
+            "direct_parents",
             "tags",
             "config",
             "resource_type",
@@ -156,6 +158,13 @@ class ListTask(GraphRunnableTask):
     def generate_json(self):
         for node in self._iterate_selected_nodes():
             node_dict = node.to_dict(omit_none=False)
+
+            # direct_parents is stripped from ModelNode serialization (see
+            # ModelNode.__post_serialize__) so it doesn't leak into
+            # manifest.json. Reinstate it here so lineage consumers can read
+            # nearest-public-ancestor edges from `dbt ls --output=json`.
+            if isinstance(node, ModelNode):
+                node_dict["direct_parents"] = list(node.direct_parents)
 
             if self.args.output_keys:
                 # Handle both nested and regular keys

--- a/tests/functional/list/test_list.py
+++ b/tests/functional/list/test_list.py
@@ -196,6 +196,7 @@ class TestList:
                         "nodes": [],
                         "macros": ["macro.dbt.current_timestamp", "macro.dbt.date_trunc"],
                     },
+                    "direct_parents": [],
                     "tags": [],
                     "config": {
                         "enabled": True,
@@ -243,6 +244,7 @@ class TestList:
                         "nodes": ["seed.test.seed"],
                         "macros": ["macro.dbt.is_incremental"],
                     },
+                    "direct_parents": ["seed.test.seed"],
                     "tags": [],
                     "config": {
                         "enabled": True,
@@ -290,6 +292,7 @@ class TestList:
                         "nodes": ["model.test.outer"],
                         "macros": [],
                     },
+                    "direct_parents": ["model.test.outer"],
                     "tags": [],
                     "config": {
                         "enabled": True,
@@ -337,6 +340,7 @@ class TestList:
                         "nodes": [],
                         "macros": ["macro.dbt.current_timestamp", "macro.dbt.date_trunc"],
                     },
+                    "direct_parents": [],
                     "config": {
                         "enabled": True,
                         "group": "finance",
@@ -396,6 +400,7 @@ class TestList:
                         "nodes": [],
                         "macros": ["macro.dbt.current_timestamp", "macro.dbt.date_trunc"],
                     },
+                    "direct_parents": [],
                     "tags": [],
                     "config": {
                         "enabled": True,
@@ -473,6 +478,7 @@ class TestList:
                         "static_analysis": None,
                     },
                     "depends_on": {"macros": [], "nodes": ["seed.test.seed"]},
+                    "direct_parents": ["seed.test.seed"],
                     "name": "model_to_unit_test",
                     "original_file_path": normalize("models/model_to_unit_test.sql"),
                     "package_name": "test",
@@ -540,6 +546,10 @@ class TestList:
                         "macros": [],
                         "nodes": ["source.test.my_source.my_table", "model.test.ephemeral"],
                     },
+                    "direct_parents": [
+                        "source.test.my_source.my_table",
+                        "model.test.ephemeral",
+                    ],
                     "tags": ["string_tag"],
                 },
                 {
@@ -549,6 +559,7 @@ class TestList:
                         "nodes": ["model.test.ephemeral"],
                         "macros": [],
                     },
+                    "direct_parents": ["model.test.ephemeral"],
                     "tags": [],
                     "config": {
                         "enabled": True,
@@ -616,6 +627,7 @@ class TestList:
                     "name": "outer",
                     "package_name": "test",
                     "depends_on": {"nodes": [], "macros": []},
+                    "direct_parents": [],
                     "tags": [],
                     "config": {
                         "enabled": True,

--- a/tests/unit/parser/test_manifest.py
+++ b/tests/unit/parser/test_manifest.py
@@ -28,7 +28,7 @@ from dbt.parser.read_files import FileDiff
 from dbt.tracking import User
 from dbt_common.events.event_catcher import EventCatcher
 from dbt_common.events.event_manager_client import add_callback_to_manager
-from tests.unit.fixtures import model_node
+from tests.unit.fixtures import generic_test_node, model_node
 
 
 class TestPartialParse:
@@ -497,6 +497,62 @@ class TestCheckFunctionLanguageSupport:
         }
         config = self._make_config("snowflake")
         _check_function_language_support(manifest, config)
+
+
+class TestBackfillDirectParents:
+    @pytest.fixture
+    @patch("dbt.parser.manifest.ManifestLoader.build_manifest_state_check")
+    @patch("dbt.parser.manifest.os.path.exists")
+    @patch("dbt.parser.manifest.open")
+    def loader(self, patched_open, patched_os_exist, patched_state_check) -> ManifestLoader:
+        mock_project = MagicMock(RuntimeConfig)
+        mock_project.project_target_path = "mock_target_path"
+        mock_project.project_name = "mock_project_name"
+        return ManifestLoader(mock_project, {})
+
+    def test_in_project_model_gets_direct_parents_from_depends_on(
+        self, loader: ManifestLoader
+    ) -> None:
+        model = model_node()
+        model.depends_on.nodes = ["model.test.upstream", "seed.test.seed"]
+        model.direct_parents = []
+        loader.manifest.add_node_nofile(model)
+
+        loader._backfill_direct_parents()
+
+        assert model.direct_parents == ["model.test.upstream", "seed.test.seed"]
+
+    def test_external_model_direct_parents_not_overwritten(self, loader: ManifestLoader) -> None:
+        # External nodes (from publications) carry the full transitive closure in
+        # depends_on.nodes but already have the narrower nearest-public-ancestor
+        # set in direct_parents. The backfill must not widen it back.
+        model = model_node()
+        model.depends_on.nodes = ["model.upstream.nearest", "model.upstream.further"]
+        model.direct_parents = ["model.upstream.nearest"]
+        loader.manifest.add_node_nofile(model)
+
+        loader._backfill_direct_parents()
+
+        assert model.direct_parents == ["model.upstream.nearest"]
+
+    def test_non_model_nodes_skipped(self, loader: ManifestLoader) -> None:
+        test = generic_test_node()
+        test.depends_on.nodes = ["model.test.upstream"]
+        loader.manifest.add_node_nofile(test)
+
+        loader._backfill_direct_parents()
+
+        assert not hasattr(test, "direct_parents")
+
+    def test_backfill_copies_list(self, loader: ManifestLoader) -> None:
+        model = model_node()
+        model.depends_on.nodes = ["model.test.upstream"]
+        loader.manifest.add_node_nofile(model)
+        loader._backfill_direct_parents()
+
+        model.direct_parents.append("model.test.injected")
+
+        assert model.depends_on.nodes == ["model.test.upstream"]
 
 
 class TestVersionToStr:

--- a/tests/unit/task/test_list.py
+++ b/tests/unit/task/test_list.py
@@ -1,9 +1,11 @@
+import json
 from argparse import Namespace
 from unittest.mock import patch
 
 from dbt.flags import get_flags, set_from_args
 from dbt.task.list import ListTask
 from dbt_common.events.types import PrintEvent
+from tests.unit.fixtures import generic_test_node, model_node
 
 
 def test_list_output_results():
@@ -239,3 +241,57 @@ class TestGenerateJson:
 
                 result_data = json.loads(results[0])
                 assert result_data["config.meta.contact.email"] == "team@company.com"
+
+
+class TestDirectParentsInLsOutput:
+    def setup_method(self):
+        set_from_args(Namespace(models=None, output_keys=None), {})
+        self.task = ListTask(get_flags(), None, None)
+
+    def _ls_json(self, node) -> dict:
+        with patch.object(self.task, "args") as args:
+            args.output_keys = None
+            with patch.object(self.task, "_iterate_selected_nodes", return_value=[node]):
+                [raw] = list(self.task.generate_json())
+        return json.loads(raw)
+
+    def test_model_emits_direct_parents(self):
+        model = model_node()
+        model.direct_parents = ["model.test.upstream", "seed.test.seed"]
+
+        assert self._ls_json(model)["direct_parents"] == [
+            "model.test.upstream",
+            "seed.test.seed",
+        ]
+
+    def test_empty_direct_parents_is_emitted_not_omitted(self):
+        # Empty is authoritative ("no parents"), not "field missing".
+        model = model_node()
+        model.direct_parents = []
+
+        emitted = self._ls_json(model)
+
+        assert emitted["direct_parents"] == []
+
+    def test_non_model_has_no_direct_parents_field(self):
+        emitted = self._ls_json(generic_test_node())
+
+        assert "direct_parents" not in emitted
+
+    def test_emitted_list_is_a_copy(self):
+        model = model_node()
+        model.direct_parents = ["model.test.upstream"]
+
+        emitted = self._ls_json(model)
+        emitted["direct_parents"].append("tampered")
+
+        assert model.direct_parents == ["model.test.upstream"]
+
+    def test_serialization_strips_direct_parents(self):
+        # Pins the contract that motivates the re-injection in generate_json.
+        # If __post_serialize__ ever stops stripping, the re-injection becomes
+        # a duplicate write.
+        model = model_node()
+        model.direct_parents = ["model.test.upstream"]
+
+        assert "direct_parents" not in model.to_dict(omit_none=False)


### PR DESCRIPTION
### Problem

When a project consumes models from another project via plugin-supplied publication artifacts (e.g. dbt Mesh cross-project refs), `depends_on.nodes` on external `ModelNode`s carries the full transitive public-ancestor closure across plugin boundaries — that's load-bearing for node selection and cycle detection between projects, so it can't be narrowed.

Lineage consumers that drive their rendering off `depends_on.nodes` therefore draw phantom edges: ancestors several hops upstream appear as direct parents of the referencing model. This surfaces in any tool that parses `dbt ls --output=json` to render a DAG — notably the lineage view in the dbt platform, which today shows edges that don't exist in the model definition.

Concrete repro: project_1 has `foo` (public) and `foobarfoo` (public, refs `project_2.foobar`); project_2 has `foobar` (public, refs `project_1.foo`). After resolving the publication into project_1's manifest, `foobarfoo.depends_on.nodes == [model.project_2.foobar, model.project_1.foo]`, and `project_1.foo` is rendered as a direct lineage parent of `foobarfoo` even though the model only references `foobar` directly.

### Solution

Add a new runtime-only `direct_parents: List[str]` attribute on `ModelNode` (and `ModelNodeArgs`) that carries only the **nearest public ancestors** — the right set for drawing DAG edges:

- **External nodes** built via `ModelNodeArgs.from_args` arrive with `direct_parents` populated by the supplying plugin. The plugin computes the nearest-public-ancestor set from its own graph and passes it through; `depends_on.nodes` continues to carry the transitive closure for selection/cycle detection.
- **In-project nodes** get `direct_parents` backfilled from `depends_on.nodes` in `ManifestLoader._backfill_direct_parents`. For these nodes the two are equivalent — parsing only records the `{{ ref(...) }}` calls literally present in the SQL; transitive closure emerges later in the Linker, not on the node itself.
- **Emitted** in `dbt ls --output=json` for `resource_type: "model"` (`ListTask.generate_json`). Lineage consumers switch from `depends_on.nodes` to `direct_parents` and the phantom edges go away.
- **Stripped** from `ModelNode.__post_serialize__`, so `manifest.json`'s contract is unchanged. The dedicated emission path in `dbt ls` is the single delivery channel for lineage consumers.

`depends_on.nodes` is intentionally unchanged — selectors, cycle detection, and graph build ordering keep reading it.

For plugins that supply external nodes via `ModelNodeArgs` but haven't populated `direct_parents` yet, the in-project backfill applies (copies `depends_on.nodes` over), which preserves today's behavior rather than introducing a regression. Updating the plugin to compute the narrower set is what actually closes the phantom-edge bug for cross-project lineage.

#### Tests

- `tests/unit/parser/test_manifest.py::TestBackfillDirectParents` — in-project backfill, external-node preservation, non-model skip, list-copy independence.
- `tests/unit/task/test_list.py::TestDirectParentsInLsOutput` — `dbt ls` emits `direct_parents` for models, empty list is authoritative (not omitted), non-models don't get the field, serialization strip is preserved.
- `tests/functional/list/test_list.py::TestList::test_ls` — updated to expect `direct_parents` in the model JSON output.



### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
