### PR TITLE
fix: add resource_tags config support in seeds & snapshots in dbt_project.yml

### DIFF
--- a/.changes/unreleased/Fixes-20260608-112234.yaml
+++ b/.changes/unreleased/Fixes-20260608-112234.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Add +resource_tags config support for seeds and snapshots in dbt_project.yml
+time: 2026-06-08T11:22:34.488709+02:00
+custom:
+    author: Thrasi
+    issue: "15207"
+    project: dbt-fusion

--- a/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
@@ -671,4 +671,23 @@ __additional_properties__: {}
             .expect("resource_tags should propagate from ProjectSeedConfig to SeedConfig");
         assert_eq!(resource_tags["123456789012/dbt-access"], "managed");
     }
+
+    #[test]
+    fn test_seed_config_resource_tags_propagates_to_project_seed_config() {
+        let project_config: ProjectSeedConfig = dbt_yaml::from_str(
+            r#"
++resource_tags:
+  "123456789012/dbt-access": "managed"
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+
+        let seed_config: SeedConfig = project_config.into();
+        let round_tripped: ProjectSeedConfig = seed_config.into();
+        let resource_tags = round_tripped
+            .resource_tags
+            .expect("resource_tags should propagate from SeedConfig back to ProjectSeedConfig");
+        assert_eq!(resource_tags["123456789012/dbt-access"], "managed");
+    }
 }

--- a/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
@@ -147,6 +147,8 @@ pub struct ProjectSeedConfig {
         deserialize_with = "f64_or_string_f64"
     )]
     pub refresh_interval_minutes: Option<f64>,
+    #[serde(rename = "+resource_tags")]
+    pub resource_tags: Option<IndexMap<String, String>>,
     #[serde(rename = "+max_staleness")]
     pub max_staleness: Option<String>,
     #[serde(rename = "+file_format")]
@@ -370,7 +372,7 @@ impl From<ProjectSeedConfig> for SeedConfig {
                 partitions: config.partitions,
                 enable_refresh: config.enable_refresh,
                 refresh_interval_minutes: config.refresh_interval_minutes,
-                resource_tags: None,
+                resource_tags: config.resource_tags,
                 max_staleness: config.max_staleness,
                 jar_file_uri: None,
                 timeout: None,
@@ -475,6 +477,7 @@ impl From<SeedConfig> for ProjectSeedConfig {
             refresh_interval_minutes: config
                 .__warehouse_specific_config__
                 .refresh_interval_minutes,
+            resource_tags: config.__warehouse_specific_config__.resource_tags,
             max_staleness: config.__warehouse_specific_config__.max_staleness,
             // Databricks fields
             file_format: config.__warehouse_specific_config__.file_format,
@@ -624,4 +627,57 @@ impl ResolvableConfig<SeedConfig> for SeedConfig {
 impl ConfigKeys for SeedConfig {
     // The default implementation from the trait will handle
     // extracting field names via serialization automatically
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ProjectSeedConfig, SeedConfig};
+
+    #[test]
+    fn test_project_seed_config_resource_tags_parses() {
+        let config: ProjectSeedConfig = dbt_yaml::from_str(
+            r#"
++resource_tags:
+  "123456789012/dbt-access": "managed"
+  "123456789012/cost-center": "analytics"
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+
+        let resource_tags = config
+            .resource_tags
+            .expect("+resource_tags should parse on ProjectSeedConfig");
+        assert_eq!(resource_tags.len(), 2);
+        assert_eq!(
+            resource_tags.get("123456789012/dbt-access"),
+            Some(&"managed".to_string())
+        );
+        assert_eq!(
+            resource_tags.get("123456789012/cost-center"),
+            Some(&"analytics".to_string())
+        );
+    }
+
+    #[test]
+    fn test_project_seed_config_resource_tags_propagates_to_seed_config() {
+        let project_config: ProjectSeedConfig = dbt_yaml::from_str(
+            r#"
++resource_tags:
+  "123456789012/dbt-access": "managed"
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+
+        let seed_config: SeedConfig = project_config.into();
+        let resource_tags = seed_config
+            .__warehouse_specific_config__
+            .resource_tags
+            .expect("resource_tags should propagate from ProjectSeedConfig to SeedConfig");
+        assert_eq!(
+            resource_tags.get("123456789012/dbt-access"),
+            Some(&"managed".to_string())
+        );
+    }
 }

--- a/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
@@ -649,14 +649,8 @@ __additional_properties__: {}
             .resource_tags
             .expect("+resource_tags should parse on ProjectSeedConfig");
         assert_eq!(resource_tags.len(), 2);
-        assert_eq!(
-            resource_tags.get("123456789012/dbt-access"),
-            Some(&"managed".to_string())
-        );
-        assert_eq!(
-            resource_tags.get("123456789012/cost-center"),
-            Some(&"analytics".to_string())
-        );
+        assert_eq!(resource_tags["123456789012/dbt-access"], "managed");
+        assert_eq!(resource_tags["123456789012/cost-center"], "analytics");
     }
 
     #[test]
@@ -675,9 +669,6 @@ __additional_properties__: {}
             .__warehouse_specific_config__
             .resource_tags
             .expect("resource_tags should propagate from ProjectSeedConfig to SeedConfig");
-        assert_eq!(
-            resource_tags.get("123456789012/dbt-access"),
-            Some(&"managed".to_string())
-        );
+        assert_eq!(resource_tags["123456789012/dbt-access"], "managed");
     }
 }

--- a/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
@@ -946,14 +946,8 @@ __additional_properties__: {}
             .resource_tags
             .expect("+resource_tags should parse on ProjectSnapshotConfig");
         assert_eq!(resource_tags.len(), 2);
-        assert_eq!(
-            resource_tags.get("123456789012/dbt-access"),
-            Some(&"managed".to_string())
-        );
-        assert_eq!(
-            resource_tags.get("123456789012/cost-center"),
-            Some(&"analytics".to_string())
-        );
+        assert_eq!(resource_tags["123456789012/dbt-access"], "managed");
+        assert_eq!(resource_tags["123456789012/cost-center"], "analytics");
     }
 
     #[test]
@@ -972,9 +966,6 @@ __additional_properties__: {}
             .__warehouse_specific_config__
             .resource_tags
             .expect("resource_tags should propagate from ProjectSnapshotConfig to SnapshotConfig");
-        assert_eq!(
-            resource_tags.get("123456789012/dbt-access"),
-            Some(&"managed".to_string())
-        );
+        assert_eq!(resource_tags["123456789012/dbt-access"], "managed");
     }
 }

--- a/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
@@ -236,6 +236,8 @@ pub struct ProjectSnapshotConfig {
         deserialize_with = "f64_or_string_f64"
     )]
     pub refresh_interval_minutes: Option<f64>,
+    #[serde(rename = "+resource_tags")]
+    pub resource_tags: Option<IndexMap<String, String>>,
     #[serde(
         default,
         rename = "+require_partition_filter",
@@ -606,7 +608,7 @@ impl From<ProjectSnapshotConfig> for SnapshotConfig {
                 partitions: config.partitions,
                 enable_refresh: config.enable_refresh,
                 refresh_interval_minutes: config.refresh_interval_minutes,
-                resource_tags: None,
+                resource_tags: config.resource_tags,
                 max_staleness: config.max_staleness,
                 jar_file_uri: None,
                 timeout: None,
@@ -740,6 +742,7 @@ impl From<SnapshotConfig> for ProjectSnapshotConfig {
             refresh_interval_minutes: config
                 .__warehouse_specific_config__
                 .refresh_interval_minutes,
+            resource_tags: config.__warehouse_specific_config__.resource_tags,
             max_staleness: config.__warehouse_specific_config__.max_staleness,
             // Databricks fields
             file_format: config.__warehouse_specific_config__.file_format,
@@ -921,4 +924,57 @@ impl ResolvableConfig<SnapshotConfig> for SnapshotConfig {
 impl ConfigKeys for SnapshotConfig {
     // The default implementation from the trait will handle
     // extracting field names via serialization automatically
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ProjectSnapshotConfig, SnapshotConfig};
+
+    #[test]
+    fn test_project_snapshot_config_resource_tags_parses() {
+        let config: ProjectSnapshotConfig = dbt_yaml::from_str(
+            r#"
++resource_tags:
+  "123456789012/dbt-access": "managed"
+  "123456789012/cost-center": "analytics"
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+
+        let resource_tags = config
+            .resource_tags
+            .expect("+resource_tags should parse on ProjectSnapshotConfig");
+        assert_eq!(resource_tags.len(), 2);
+        assert_eq!(
+            resource_tags.get("123456789012/dbt-access"),
+            Some(&"managed".to_string())
+        );
+        assert_eq!(
+            resource_tags.get("123456789012/cost-center"),
+            Some(&"analytics".to_string())
+        );
+    }
+
+    #[test]
+    fn test_project_snapshot_config_resource_tags_propagates_to_snapshot_config() {
+        let project_config: ProjectSnapshotConfig = dbt_yaml::from_str(
+            r#"
++resource_tags:
+  "123456789012/dbt-access": "managed"
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+
+        let snapshot_config: SnapshotConfig = project_config.into();
+        let resource_tags = snapshot_config
+            .__warehouse_specific_config__
+            .resource_tags
+            .expect("resource_tags should propagate from ProjectSnapshotConfig to SnapshotConfig");
+        assert_eq!(
+            resource_tags.get("123456789012/dbt-access"),
+            Some(&"managed".to_string())
+        );
+    }
 }

--- a/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
@@ -968,4 +968,23 @@ __additional_properties__: {}
             .expect("resource_tags should propagate from ProjectSnapshotConfig to SnapshotConfig");
         assert_eq!(resource_tags["123456789012/dbt-access"], "managed");
     }
+
+    #[test]
+    fn test_snapshot_config_resource_tags_propagates_to_project_snapshot_config() {
+        let project_config: ProjectSnapshotConfig = dbt_yaml::from_str(
+            r#"
++resource_tags:
+  "123456789012/dbt-access": "managed"
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+
+        let snapshot_config: SnapshotConfig = project_config.into();
+        let round_tripped: ProjectSnapshotConfig = snapshot_config.into();
+        let resource_tags = round_tripped
+            .resource_tags
+            .expect("resource_tags should propagate from SnapshotConfig back to ProjectSnapshotConfig");
+        assert_eq!(resource_tags["123456789012/dbt-access"], "managed");
+    }
 }


### PR DESCRIPTION
Resolves #15207

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

Setting +resource_tags on seeds or snapshots in dbt_project.yml causes a SerializationError (dbt1013):
```
  [error] [SerializationError (dbt1013)]: Invalid seed definition `+resource_tags.123456789012/dbt-access`:
  seeds.+resource_tags.123456789012/dbt-access: invalid type: string "managed",
  expected struct ProjectSeedConfig
```

This config works correctly on models because ProjectModelConfig includes a +resource_tags field, but ProjectSeedConfig and ProjectSnapshotConfig are missing it. Their From impls hardcode resource_tags: None. In dbt-core 1.11.9, +resource_tags on seeds/snapshots is accepted (with a deprecation warning) and BigQuery applies the tags to the resulting tables.

### Solution

Add +resource_tags: Option<IndexMap<String, String>> to both ProjectSeedConfig and ProjectSnapshotConfig, and wire it through their From impls, matching the existing pattern in ProjectModelConfig. Includes unit tests for both parsing and propagation for each resource type.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
