### PR TITLE
fix: coerce integer meta keys when loading partial_parse.msgpack

### DIFF
--- a/.changes/unreleased/Fixes-20260608-101006.yaml
+++ b/.changes/unreleased/Fixes-20260608-101006.yaml
@@ -1,0 +1,5 @@
+kind: Fixes
+body: Coerce integer keys in `meta` config to strings when loading partial_parse.msgpack instead of failing silently
+custom:
+  Author: shnhdan
+  Issue: "12578"

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -155,8 +155,27 @@ def extended_msgpack_encoder(obj):
     return obj
 
 
+def _coerce_int_map_keys(obj):
+    """Recursively coerce integer map keys to strings.
+
+    msgpack with strict_map_key=False allows integer keys, but dbt expects
+    string keys throughout. This converts any integer (or other non-string)
+    keys to their string representation.
+
+    Fixes: https://github.com/dbt-labs/dbt-core/issues/12578
+    """
+    if isinstance(obj, dict):
+        return {
+            str(k) if not isinstance(k, str) else k: _coerce_int_map_keys(v)
+            for k, v in obj.items()
+        }
+    return obj
+
+
 def extended_mashumuro_decoder(data):
-    return msgpack.unpackb(data, ext_hook=extended_msgpack_decoder, raw=False)
+    return _coerce_int_map_keys(
+        msgpack.unpackb(data, ext_hook=extended_msgpack_decoder, raw=False, strict_map_key=False)
+    )
 
 
 def extended_msgpack_decoder(code, data):


### PR DESCRIPTION
### Problem
When a dbt project uses integer keys in `meta` config blocks (e.g. `{0: foo, 1: bar}`), 
partial parsing silently fails with:
  `int is not allowed for map key when strict_map_key=True`

This causes every subsequent `dbt` run to do a full parse instead of partial parse, 
severely degrading performance with no visible warning to the user.

### Solution
- Pass `strict_map_key=False` to `msgpack.unpackb` to allow loading manifests with integer keys
- Recursively coerce all non-string map keys to strings via `_coerce_int_map_keys()`

### Checklist
- [x] I have read the contributing guide
- [x] This PR includes tests, or tests are not required for this PR
- [x] No interface changes

Fixes #12578