### PR TITLE
Fix latest_version_pointer collision check to be quoting/case aware

### DIFF
--- a/.changes/unreleased/Fixes-20260608-170907.yaml
+++ b/.changes/unreleased/Fixes-20260608-170907.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Make the latest_version_pointer collision check quoting/case aware so an unquoted latest-version alias differing from the pointer name only by case is correctly detected on case-insensitive warehouses
+time: 2026-06-08T17:09:07.712495+05:30
+custom:
+    Author: aahel
+    Issue: "15210"

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -254,8 +254,6 @@ class ModelRunner(CompileRunner[ModelNode]):
         identifier_quoted = bool(getattr(quote_policy, "identifier", True))
         if identifier_quoted:
             return source_identifier == pointer_identifier
-        # Match dbt's identifier folding convention (`.lower()`, as in
-        # BaseRelation.get_lowered_part / _is_exactish_match).
         return source_identifier.lower() == pointer_identifier.lower()
 
     def _latest_version_pointer_identifier(

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -254,7 +254,9 @@ class ModelRunner(CompileRunner[ModelNode]):
         identifier_quoted = bool(getattr(quote_policy, "identifier", True))
         if identifier_quoted:
             return source_identifier == pointer_identifier
-        return source_identifier.casefold() == pointer_identifier.casefold()
+        # Match dbt's identifier folding convention (`.lower()`, as in
+        # BaseRelation.get_lowered_part / _is_exactish_match).
+        return source_identifier.lower() == pointer_identifier.lower()
 
     def _latest_version_pointer_identifier(
         self,

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -238,6 +238,24 @@ class ModelRunner(CompileRunner[ModelNode]):
             return identifier
         return relation.name or ""
 
+    def _pointer_collides_with_source(
+        self, source_relation: BaseRelation, pointer_identifier: str
+    ) -> bool:
+        """Whether the pointer identifier resolves to the same relation as the latest
+        version's identifier.
+
+        When the identifier component is unquoted, the warehouse resolves identifiers
+        case-insensitively (e.g. Snowflake folds ``DIM_CUSTOMERS`` and ``dim_customers``
+        to the same object), so compare case-insensitively. When quoted, identifiers are
+        case-sensitive, so compare exactly.
+        """
+        source_identifier = self._relation_identifier(source_relation)
+        quote_policy = getattr(source_relation, "quote_policy", None)
+        identifier_quoted = bool(getattr(quote_policy, "identifier", True))
+        if identifier_quoted:
+            return source_identifier == pointer_identifier
+        return source_identifier.casefold() == pointer_identifier.casefold()
+
     def _latest_version_pointer_identifier(
         self,
         model: ModelNode,
@@ -285,7 +303,7 @@ class ModelRunner(CompileRunner[ModelNode]):
         source_relation = relations[0]
         pointer_identifier = self._latest_version_pointer_identifier(model, manifest, context)
 
-        if self._relation_identifier(source_relation) == pointer_identifier:
+        if self._pointer_collides_with_source(source_relation, pointer_identifier):
             raise DbtRuntimeError(
                 f"Cannot create latest version pointer: the latest version of '{model.name}' "
                 f"is already aliased to '{pointer_identifier}'. "

--- a/tests/unit/task/test_run.py
+++ b/tests/unit/task/test_run.py
@@ -448,6 +448,92 @@ class TestModelRunner:
                 relations=[source_relation],
             )
 
+    def test_materialize_latest_version_pointer_collision_is_case_insensitive_when_unquoted(
+        self, mocker: MockerFixture, model_runner: ModelRunner
+    ) -> None:
+        # When the identifier is unquoted, the warehouse resolves it case-insensitively
+        # (e.g. Snowflake folds DIM_CUSTOMERS and dim_customers to the same object), so a
+        # latest-version alias differing from the pointer name only by case must still be
+        # detected as a collision.
+        @dataclass
+        class FakePolicy:
+            identifier: bool
+
+        @dataclass
+        class FakeRelation:
+            database: str
+            schema: str
+            identifier: str
+            type: str
+            quote_policy: FakePolicy
+
+            @property
+            def name(self) -> str:
+                return self.identifier
+
+        model = model_runner.node
+        model.name = "versioned_model"
+        model.version = 2
+        model.latest_version = 2
+        model.config = ModelConfig(
+            materialized="table",
+            # pointer resolves to "versioned_model_v2"; alias differs only by case
+            latest_version_pointer=LatestVersionPointer(enabled=True, alias="versioned_model_v2"),
+        )
+
+        source_relation = FakeRelation(
+            database="dbt",
+            schema="dbt_schema",
+            identifier="VERSIONED_MODEL_V2",
+            type="table",
+            quote_policy=FakePolicy(identifier=False),
+        )
+
+        model_runner.adapter = mocker.Mock()
+        manifest = mocker.Mock(spec=Manifest)
+        manifest.find_macro_by_name.return_value = None
+
+        with pytest.raises(DbtRuntimeError, match="already aliased"):
+            model_runner._materialize_latest_version_pointer(
+                manifest=manifest,
+                model=model,
+                context={"context_macro_stack": []},
+                relations=[source_relation],
+            )
+
+    def test_materialize_latest_version_pointer_no_collision_when_quoted_case_differs(
+        self, model_runner: ModelRunner
+    ) -> None:
+        # When the identifier is quoted it is case-sensitive, so names differing only by
+        # case are distinct relations and must NOT be treated as a collision.
+        @dataclass
+        class FakePolicy:
+            identifier: bool
+
+        @dataclass
+        class FakeRelation:
+            database: str
+            schema: str
+            identifier: str
+            type: str
+            quote_policy: FakePolicy
+
+            @property
+            def name(self) -> str:
+                return self.identifier
+
+        runner = model_runner
+        assert not runner._pointer_collides_with_source(
+            FakeRelation(
+                database="dbt",
+                schema="dbt_schema",
+                identifier="VERSIONED_MODEL_V2",
+                type="table",
+                quote_policy=FakePolicy(identifier=True),
+            ),
+            "versioned_model_v2",
+        )
+
 
 class TestMicrobatchModelRunner:
     @pytest.fixture


### PR DESCRIPTION
Resolves N/A (no pre-existing issue; see context below)

### Problem

`ModelRunner._materialize_latest_version_pointer` guards against the latest version's alias colliding with the pointer name by comparing **raw identifier strings**:

```python
if self._relation_identifier(source_relation) == pointer_identifier:
    raise DbtRuntimeError(... "already aliased" ...)
```

When the identifier is **unquoted**, warehouses resolve identifiers case-insensitively (e.g. Snowflake folds `DIM_CUSTOMERS` and `dim_customers` to the same object; Postgres folds to lowercase). A raw `==` compare therefore misses the collision when the latest version's alias differs from the pointer name only by case, and dbt proceeds to `CREATE OR REPLACE VIEW <pointer> AS SELECT * FROM <source>` where target and source are the **same physical relation** — clobbering the table with a self-referencing view instead of raising the intended config error.

**This is reachable in default configs on Snowflake.** Per the [quoting docs](https://docs.getdbt.com/reference/project-configs/quoting), Snowflake defaults `quoting` to `false` for all components (most other adapters default to `true`). So no opt-in is required on Snowflake — only a versioned model whose latest version is aliased to a case-variant of the pointer name.

Repro (Postgres, which also folds unquoted identifiers — verified live on both branches):

```yaml
# dbt_project.yml
quoting:
  identifier: false        # implicit default on Snowflake; explicit here for Postgres

# models/schema.yml
models:
  - name: dim_customers          # pointer resolves to "dim_customers"
    latest_version: 2
    config:
      latest_version_pointer:
        enabled: true
    versions:
      - v: 1
      - v: 2
        config:
          alias: DIM_CUSTOMERS   # folds to the same object as the pointer
```

- **Before this PR:** cryptic error — Postgres: *"dbt found an approximate match … please delete or rename DIM_CUSTOMERS"*; Snowflake: `[002003] Object '…DIM_CUSTOMERS' does not exist` after the pointer clobbers the table.
- **After this PR:** `Cannot create latest version pointer: the latest version of 'dim_customers' is already aliased to 'dim_customers'. …`

### Solution

Compare as the warehouse would resolve, via a new `_pointer_collides_with_source` helper:
- identifier **unquoted** → case-insensitive compare (`casefold()`), matching warehouse folding;
- identifier **quoted** → exact compare (case-sensitive), unchanged.

When a relation exposes no `quote_policy` the helper defaults to the exact (quoted) comparison, so existing behavior is preserved for adapters/relations where quoting is on.

Caveat: `casefold()` is a cross-adapter approximation. Adapters that are case-sensitive even when unquoted (e.g. BigQuery) would treat a case-only difference as a collision under this helper; that combination (versioned model with a latest-version alias differing only by case) is pathological, and the outcome is a clear config error rather than data loss. A fully adapter-aware normalization could be layered on later if needed.

Found while implementing the equivalent feature in dbt-fusion ([dbt-labs/fs#10475](https://github.com/dbt-labs/fs/pull/10475)); the same fix has been applied there.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me.
- [x] I have run this code in development (verified live on Postgres: bug present on `1.latest`, resolved on this branch), and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (only tightens an existing error condition for a previously-missed collision).
- [x] This PR includes type annotations for new and modified functions.