### PR TITLE
Add v1/v2 version labels and dropdowns to issue templates

### DIFF
--- a/.changes/unreleased/Under the Hood-20260609-000000.yaml
+++ b/.changes/unreleased/Under the Hood-20260609-000000.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Add v1/v2 version labels and version dropdowns to issue templates
+time: 2026-06-09T00:00:00.000000+00:00
+custom:
+    author: tauhid621
+    issue: ""
+    project: dbt-fusion

--- a/.github/ISSUE_TEMPLATE/bug-report-v2.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-v2.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug (dbt v2.x)
 description: Report a bug or issue you've found in dbt v2.x (Core or Fusion distributions)
 title: "[v2 Bug] <title>"
-labels: ["bug", "triage"]
+labels: ["bug", "triage", "v2"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report-vsce.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-vsce.yml
@@ -1,7 +1,7 @@
 name: 🐞📟 VS Code Extension Bug
 description: Report a bug with the dbt VS Code extension
 title: "[VSCE] [Bug] <title>"
-labels: ["bug", "triage", "vsce"]
+labels: ["bug", "triage", "vsce", "v2"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug
 description: Report a bug or an issue you've found with dbt
 title: "[Bug] <title>"
-labels: ["bug", "triage"]
+labels: ["bug", "triage", "v1"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,12 +1,14 @@
-name: 🐞 Bug
-description: Report a bug or an issue you've found with dbt
-title: "[Bug] <title>"
+name: 🐞 Bug (dbt 1.x)
+description: Report a bug or issue you've found in dbt Core 1.x
+title: "[1.x Bug] <title>"
 labels: ["bug", "triage", "v1"]
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for taking the time to fill out this bug report!
+
+        This template is for bugs in dbt Core 1.x. For bugs in dbt v2.x (the Core or Fusion distributions), use the "🐞 Bug (dbt v2.x)" template instead.
   - type: checkboxes
     attributes:
       label: Is this a new bug in dbt-core?

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -24,6 +24,19 @@ body:
           required: true
         - label: I am requesting a straightforward extension of existing dbt functionality, rather than a Big Idea better suited to a discussion
           required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Which version of dbt is this feature for?
+      description: >
+        This helps us route the request. dbt v2.x covers the Core and Fusion distributions.
+        A maintainer will apply the corresponding label after triage.
+      options:
+        - dbt v2.x (Core or Fusion)
+        - dbt 1.x
+        - Not sure / both
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Describe the feature

--- a/.github/ISSUE_TEMPLATE/regression-report.yml
+++ b/.github/ISSUE_TEMPLATE/regression-report.yml
@@ -18,6 +18,20 @@ body:
           required: true
         - label: I have searched the existing issues, and I could not find an existing issue for this regression
           required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Which versions does this regression span?
+      description: >
+        Where did the behavior break? dbt v2.x covers the Core and Fusion distributions.
+        A maintainer will apply the corresponding label after triage.
+      options:
+        - Within dbt 1.x (worked in an older 1.x, broke in a newer 1.x)
+        - dbt 1.x → dbt v2.x (worked in 1.x, broke after upgrading to v2.x)
+        - Within dbt v2.x (worked in an older v2.x, broke in a newer v2.x)
+        - Not sure
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Current Behavior

--- a/.github/ISSUE_TEMPLATE/sql-understanding.yml
+++ b/.github/ISSUE_TEMPLATE/sql-understanding.yml
@@ -1,7 +1,7 @@
 name: 🧠 SQL understanding issue
 description: dbt Fusion doesn't recognize a function, flags valid SQL as an error, infers the wrong column type, or produces incorrect lineage
 title: "[SQL] <title>"
-labels: ["bug", "triage", "SQL_understanding"]
+labels: ["bug", "triage", "SQL_understanding", "v2"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Adds version labels (`v1`/`v2`) to the bug templates and version dropdowns to the feature-request and regression templates, so issues route to the right line during triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)