### PR TITLE
ci(copybara): skip dispatch for draft PRs

### DIFF
--- a/.github/workflows/auto-public-pr-copybara.yml
+++ b/.github/workflows/auto-public-pr-copybara.yml
@@ -10,15 +10,17 @@ name: Copybara - Auto Public PR Migration
 # land here need to flow back into fs so the two stay in sync.
 #
 # **when?**
-# On PRs targeting `main` (open/reopen/synchronize). Legacy branches like
-# `1.latest` have no copybara baseline, so the `branches` filter below skips
-# them. PRs from public forks must carry the `ci:approve-public-fork-ci`
+# On PRs targeting `main` (open/reopen/synchronize/ready_for_review). Legacy
+# branches like `1.latest` have no copybara baseline, so the `branches` filter
+# below skips them. Draft PRs are skipped to avoid syncing work-in-progress;
+# the `ready_for_review` event re-triggers dispatch when a draft is marked
+# ready. PRs from public forks must carry the `ci:approve-public-fork-ci`
 # label before the secret-bearing dispatch runs; it's stripped on each push
 # so updates require re-approval.
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
     branches:
       - main
     paths-ignore:
@@ -68,6 +70,7 @@ jobs:
 
   dispatch:
     needs: check_run_approval
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Skip the reverse copybara dispatch when a dbt-core PR is in draft, to avoid creating noisy fs PRs for work-in-progress.
- Add `ready_for_review` to the trigger types so dispatch fires when a draft is marked ready.

## Behavior
- Draft PR opened → no dispatch.
- Draft → ready (`ready_for_review`) → dispatch runs.
- Push to draft PR → `check_run_approval` still runs (preserves fork-label stripping); dispatch skipped.
- Push to ready PR → dispatch runs as before.

## Test plan
- [ ] Open a draft PR with syncable changes; confirm no fs PR is created.
- [ ] Mark the draft as ready; confirm dispatch fires and the fs PR is created.
- [ ] Push to a ready non-draft PR; confirm dispatch still runs.