### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260609-162000.yaml
+++ b/.changes/unreleased/Under the Hood-20260609-162000.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-06-09T16:20:00.902477965Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -6252,16 +6252,6 @@
             }
           ]
         },
-        "+quoting": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DbtQuoting"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "+refresh_interval_minutes": {
           "anyOf": [
             {

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -10065,16 +10065,6 @@
             }
           ]
         },
-        "quoting": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DbtQuoting"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "refresh_interval_minutes": {
           "anyOf": [
             {


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`9216f805e863b0ecfe200e6bcc10bd913b0e13ec`](https://github.com/dbt-labs/fs/commit/9216f805e863b0ecfe200e6bcc10bd913b0e13ec)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/27218381256)