### PR TITLE
Add telemetry for state management opt-ins

### DIFF
--- a/.changes/unreleased/Features-20260609-000000.yaml
+++ b/.changes/unreleased/Features-20260609-000000.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Emit anonymous usage telemetry when state management is enabled via the --manage-state
+  flag, DBT_ENGINE_MANAGE_STATE env var, or manage_state project config, including
+  which surface supplied the opt-in
+time: 2026-06-09T00:00:00.000000-07:00
+custom:
+  Author: colinrogers
+  Issue: "0000"

--- a/.changes/unreleased/Features-20260609-000000.yaml
+++ b/.changes/unreleased/Features-20260609-000000.yaml
@@ -5,4 +5,4 @@ body: Emit anonymous usage telemetry when state management is enabled via the --
 time: 2026-06-09T00:00:00.000000-07:00
 custom:
   Author: colinrogers
-  Issue: "0000"
+  Issue: "15222"

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -395,8 +395,22 @@ class Flags:
         if not getattr(self, "MANAGE_STATE", False):
             return None
 
-        # `manage_state` is a global option, so it may be parsed in the top-level
-        # context, any parent context, or the invoked subcommand's context.
+        click_source = self._manage_state_click_source(ctx, invoked_subcommand_ctx)
+        if click_source is not None:
+            return click_source
+        if project_flags is not None and getattr(project_flags, "manage_state", None) is not None:
+            return "project_config"
+        if user_flags.get("manage_state") is not None:
+            return "user_settings"
+        return None
+
+    def _manage_state_click_source(
+        self, ctx: Context, invoked_subcommand_ctx: Optional[Context]
+    ) -> Optional[str]:
+        """Return "cli_flag"/"env_var" if Click parsed manage_state from the command
+        line or an env var, else None. `manage_state` is a global option, so it may
+        be parsed in the top-level context, any parent context, or the invoked
+        subcommand's context."""
         contexts: List[Context] = []
         cur: Optional[Context] = ctx
         while cur is not None:
@@ -416,10 +430,6 @@ class Flags:
             return "cli_flag"
         if ParameterSource.ENVIRONMENT in click_sources:
             return "env_var"
-        if project_flags is not None and getattr(project_flags, "manage_state", None) is not None:
-            return "project_config"
-        if user_flags.get("manage_state") is not None:
-            return "user_settings"
         return None
 
     def _override_if_set(self, lead: str, follow: str, defaulted: Set[str]) -> None:

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -390,8 +390,8 @@ class Flags:
         """Attribute the resolved MANAGE_STATE value to the surface that supplied it.
 
         Returns None when state management is not enabled. Otherwise returns one of
-        "cli_flag", "env_var", "project_config", or "user_settings", following the
-        same precedence dbt uses when resolving the flag."""
+        "cli_flag", "env_var", "programmatic", "project_config", or "user_settings",
+        following the same precedence dbt uses when resolving the flag."""
         if not getattr(self, "MANAGE_STATE", False):
             return None
 
@@ -407,10 +407,12 @@ class Flags:
     def _manage_state_click_source(
         self, ctx: Context, invoked_subcommand_ctx: Optional[Context]
     ) -> Optional[str]:
-        """Return "cli_flag"/"env_var" if Click parsed manage_state from the command
-        line or an env var, else None. `manage_state` is a global option, so it may
-        be parsed in the top-level context, any parent context, or the invoked
-        subcommand's context."""
+        """Return "cli_flag"/"env_var"/"programmatic" if Click parsed manage_state
+        from the command line, an env var, or a dbtRunner.invoke() kwarg, else None.
+        `manage_state` is a global option, so it may be parsed in the top-level
+        context, any parent context, or the invoked subcommand's context.
+        dbtRunner.invoke() tags kwarg-supplied params with the string source
+        "kwargs" (see dbt.cli.main), which we surface as "programmatic"."""
         contexts: List[Context] = []
         cur: Optional[Context] = ctx
         while cur is not None:
@@ -430,6 +432,8 @@ class Flags:
             return "cli_flag"
         if ParameterSource.ENVIRONMENT in click_sources:
             return "env_var"
+        if "kwargs" in click_sources:
+            return "programmatic"
         return None
 
     def _override_if_set(self, lead: str, follow: str, defaulted: Set[str]) -> None:

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -421,12 +421,9 @@ class Flags:
         if invoked_subcommand_ctx is not None:
             contexts.append(invoked_subcommand_ctx)
 
-        click_sources = set()
-        for context in contexts:
-            try:
-                click_sources.add(context.get_parameter_source("manage_state"))
-            except Exception:
-                continue
+        # Context.get_parameter_source returns None (it does not raise) when the
+        # parameter was not supplied in that context; None entries are ignored below.
+        click_sources = {context.get_parameter_source("manage_state") for context in contexts}
 
         if ParameterSource.COMMANDLINE in click_sources:
             return "cli_flag"

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -260,6 +260,7 @@ class Flags:
         )
 
         # Get the invoked command flags.
+        invoked_subcommand_ctx: Optional[Context] = None
         invoked_subcommand_name = (
             ctx.invoked_subcommand if hasattr(ctx, "invoked_subcommand") else None
         )
@@ -267,9 +268,10 @@ class Flags:
             invoked_subcommand = getattr(import_module("dbt.cli.main"), invoked_subcommand_name)
             invoked_subcommand.allow_extra_args = True
             invoked_subcommand.ignore_unknown_options = True
-            invoked_subcommand_ctx = invoked_subcommand.make_context(None, sys.argv)
+            subcommand_ctx = invoked_subcommand.make_context(None, sys.argv)
+            invoked_subcommand_ctx = subcommand_ctx
             _assign_params(
-                invoked_subcommand_ctx,
+                subcommand_ctx,
                 params_assigned_from_default,
                 params_assigned_from_user,
                 deprecated_env_vars,
@@ -321,6 +323,17 @@ class Flags:
                 )
                 params_assigned_from_default.remove(param_name)
 
+        # Record which surface supplied MANAGE_STATE so telemetry can attribute
+        # opt-ins to a CLI flag, env var, project config, or user settings. The
+        # ordering mirrors the resolution precedence applied above.
+        object.__setattr__(
+            self,
+            "MANAGE_STATE_SOURCE",
+            self._resolve_manage_state_source(
+                ctx, invoked_subcommand_ctx, project_flags, user_flags
+            ),
+        )
+
         # Set hard coded flags.
         object.__setattr__(self, "WHICH", invoked_subcommand_name or ctx.info_name)
 
@@ -366,6 +379,48 @@ class Flags:
 
     def __str__(self) -> str:
         return str(pf(self.__dict__))
+
+    def _resolve_manage_state_source(
+        self,
+        ctx: Context,
+        invoked_subcommand_ctx: Optional[Context],
+        project_flags: Optional[ProjectFlags],
+        user_flags: Dict[str, Any],
+    ) -> Optional[str]:
+        """Attribute the resolved MANAGE_STATE value to the surface that supplied it.
+
+        Returns None when state management is not enabled. Otherwise returns one of
+        "cli_flag", "env_var", "project_config", or "user_settings", following the
+        same precedence dbt uses when resolving the flag."""
+        if not getattr(self, "MANAGE_STATE", False):
+            return None
+
+        # `manage_state` is a global option, so it may be parsed in the top-level
+        # context, any parent context, or the invoked subcommand's context.
+        contexts: List[Context] = []
+        cur: Optional[Context] = ctx
+        while cur is not None:
+            contexts.append(cur)
+            cur = cur.parent
+        if invoked_subcommand_ctx is not None:
+            contexts.append(invoked_subcommand_ctx)
+
+        click_sources = set()
+        for context in contexts:
+            try:
+                click_sources.add(context.get_parameter_source("manage_state"))
+            except Exception:
+                continue
+
+        if ParameterSource.COMMANDLINE in click_sources:
+            return "cli_flag"
+        if ParameterSource.ENVIRONMENT in click_sources:
+            return "env_var"
+        if project_flags is not None and getattr(project_flags, "manage_state", None) is not None:
+            return "project_config"
+        if user_flags.get("manage_state") is not None:
+            return "user_settings"
+        return None
 
     def _override_if_set(self, lead: str, follow: str, defaulted: Set[str]) -> None:
         """If the value of the lead parameter was set explicitly, apply the value to follow, unless follow was also set explicitly."""

--- a/core/dbt/cli/flags.py
+++ b/core/dbt/cli/flags.py
@@ -268,10 +268,10 @@ class Flags:
             invoked_subcommand = getattr(import_module("dbt.cli.main"), invoked_subcommand_name)
             invoked_subcommand.allow_extra_args = True
             invoked_subcommand.ignore_unknown_options = True
-            subcommand_ctx = invoked_subcommand.make_context(None, sys.argv)
-            invoked_subcommand_ctx = subcommand_ctx
+            invoked_subcommand_ctx = invoked_subcommand.make_context(None, sys.argv)
+            assert invoked_subcommand_ctx is not None  # make_context never returns None
             _assign_params(
-                subcommand_ctx,
+                invoked_subcommand_ctx,
                 params_assigned_from_default,
                 params_assigned_from_user,
                 deprecated_env_vars,

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -40,7 +40,12 @@ from dbt.mp_context import get_mp_context
 from dbt.parser.manifest import parse_manifest
 from dbt.plugins import set_up_plugin_manager
 from dbt.profiler import profiler
-from dbt.tracking import active_user, initialize_from_flags, track_run
+from dbt.tracking import (
+    active_user,
+    initialize_from_flags,
+    track_manage_state,
+    track_run,
+)
 from dbt.utils import try_get_max_rss_kb
 from dbt.utils.artifact_upload import upload_artifacts
 from dbt.version import installed as installed_version
@@ -111,6 +116,16 @@ def preflight(func):
         # Tracking
         initialize_from_flags(flags.SEND_ANONYMOUS_USAGE_STATS, flags.PROFILES_DIR)
         ctx.with_resource(track_run(run_command=flags.WHICH))
+
+        # Telemetry for opt-in state management (--manage-state /
+        # DBT_ENGINE_MANAGE_STATE / manage_state: true).
+        if getattr(flags, "MANAGE_STATE", False) and dbt.tracking.active_user is not None:
+            track_manage_state(
+                {
+                    "manage_state": True,
+                    "source": getattr(flags, "MANAGE_STATE_SOURCE", None),
+                }
+            )
 
         # Now that we have our logger, fire away!
         fire_event(MainReportVersion(version=str(installed_version), log_version=LOG_VERSION))

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -112,8 +112,11 @@ def preflight(func):
         initialize_from_flags(flags.SEND_ANONYMOUS_USAGE_STATS, flags.PROFILES_DIR)
         ctx.with_resource(track_run(run_command=flags.WHICH))
 
-        # Telemetry for opt-in state management (--manage-state /
-        # DBT_ENGINE_MANAGE_STATE / manage_state: true).
+        # Telemetry for opt-in state management. Source is attributed to whichever
+        # surface enabled it: --manage-state (cli_flag), DBT_ENGINE_MANAGE_STATE
+        # (env_var), dbtRunner.invoke(manage_state=...) (programmatic),
+        # manage_state: true in dbt_project.yml (project_config), or
+        # user_settings.yml (user_settings).
         if getattr(flags, "MANAGE_STATE", False) and dbt.tracking.active_user is not None:
             track_manage_state(
                 {

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -40,12 +40,7 @@ from dbt.mp_context import get_mp_context
 from dbt.parser.manifest import parse_manifest
 from dbt.plugins import set_up_plugin_manager
 from dbt.profiler import profiler
-from dbt.tracking import (
-    active_user,
-    initialize_from_flags,
-    track_manage_state,
-    track_run,
-)
+from dbt.tracking import initialize_from_flags, track_manage_state, track_run
 from dbt.utils import try_get_max_rss_kb
 from dbt.utils.artifact_upload import upload_artifacts
 from dbt.version import installed as installed_version
@@ -135,8 +130,8 @@ def preflight(func):
         # Deprecation warnings
         flags.fire_deprecations(ctx)
 
-        if active_user is not None:  # mypy appeasement, always true
-            fire_event(MainTrackingUserState(user_state=active_user.state()))
+        if dbt.tracking.active_user is not None:  # mypy appeasement, always true
+            fire_event(MainTrackingUserState(user_state=dbt.tracking.active_user.state()))
 
         # Profiling
         if flags.RECORD_TIMING_INFO:

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -453,6 +453,12 @@ def track_plugin_get_nodes(options):
 
 
 def _track_context_event(spec: str, action: str, options, error_msg: str) -> None:
+    """Emit a single-context structured tracking event.
+
+    Most track_* helpers in this module inline this same assert-then-track
+    pattern; this is the canonical form that the rest are intended to adopt.
+    For now only track_manage_state uses it (a full migration is deferred to a
+    follow-up to keep this change scoped)."""
     assert active_user is not None, error_msg
     track(
         active_user,

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -452,16 +452,23 @@ def track_plugin_get_nodes(options):
     )
 
 
-def track_manage_state(options):
-    context = [SelfDescribingJson(MANAGE_STATE_SPEC, options)]
-    assert active_user is not None, "Cannot track manage_state when active user is None"
-
+def _track_context_event(spec: str, action: str, options, error_msg: str) -> None:
+    assert active_user is not None, error_msg
     track(
         active_user,
         category="dbt",
-        action="manage_state",
+        action=action,
         label=get_invocation_id(),
-        context=context,
+        context=[SelfDescribingJson(spec, options)],
+    )
+
+
+def track_manage_state(options):
+    _track_context_event(
+        MANAGE_STATE_SPEC,
+        "manage_state",
+        options,
+        "Cannot track manage_state when active user is None",
     )
 
 

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -53,6 +53,7 @@ RUNNABLE_TIMING = "iglu:com.dbt/runnable/jsonschema/1-0-0"
 RUN_MODEL_SPEC = "iglu:com.dbt/run_model/jsonschema/1-1-1"
 PLUGIN_GET_NODES = "iglu:com.dbt/plugin_get_nodes/jsonschema/1-0-0"
 ARTIFACT_UPLOAD = "iglu:com.dbt/artifact_upload/jsonschema/1-0-0"
+MANAGE_STATE_SPEC = "iglu:com.dbt/manage_state/jsonschema/1-0-0"
 
 SNOWPLOW_TRACKER_VERSION = Version(snowplow_version)
 
@@ -446,6 +447,19 @@ def track_plugin_get_nodes(options):
         active_user,
         category="dbt",
         action="plugin_get_nodes",
+        label=get_invocation_id(),
+        context=context,
+    )
+
+
+def track_manage_state(options):
+    context = [SelfDescribingJson(MANAGE_STATE_SPEC, options)]
+    assert active_user is not None, "Cannot track manage_state when active user is None"
+
+    track(
+        active_user,
+        category="dbt",
+        action="manage_state",
         label=get_invocation_id(),
         context=context,
     )

--- a/tests/unit/cli/test_flags.py
+++ b/tests/unit/cli/test_flags.py
@@ -180,60 +180,49 @@ class TestFlags:
         flags = Flags(context)
         assert flags.USE_COLORS is True
 
-    def test_manage_state_source_unset(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "argv,manage_state_project,user_flags,env_value,expected_state,expected_source",
+        [
+            (["run"], None, {}, None, False, None),
+            (["--manage-state", "run"], None, {}, None, True, "cli_flag"),
+            (["run"], None, {}, "True", True, "env_var"),
+            (["run"], True, {}, None, True, "project_config"),
+            (["run"], None, {"manage_state": True}, None, True, "user_settings"),
+            (["--manage-state", "run"], False, {}, None, True, "cli_flag"),
+        ],
+        ids=[
+            "unset",
+            "cli_flag",
+            "env_var",
+            "project_config",
+            "user_settings",
+            "cli_overrides_project",
+        ],
+    )
+    def test_manage_state_source(
+        self,
+        monkeypatch,
+        argv,
+        manage_state_project,
+        user_flags,
+        env_value,
+        expected_state,
+        expected_source,
+    ):
         # PluginManager may leak DBT_ENGINE_MANAGE_STATE=true into os.environ in a
-        # shared test process; clear it so this case exercises the true default.
-        monkeypatch.delenv("DBT_ENGINE_MANAGE_STATE", raising=False)
-        monkeypatch.setattr("dbt.cli.flags.get_user_setting_flags", lambda: {})
-        context = self.make_dbt_context("run", ["run"])
-        flags = Flags(context)
-        assert flags.MANAGE_STATE is False
-        assert flags.MANAGE_STATE_SOURCE is None
-
-    def test_manage_state_source_cli_flag(self, monkeypatch):
-        monkeypatch.delenv("DBT_ENGINE_MANAGE_STATE", raising=False)
-        monkeypatch.setattr("dbt.cli.flags.get_user_setting_flags", lambda: {})
-        context = self.make_dbt_context("run", ["--manage-state", "run"])
-        flags = Flags(context)
-        assert flags.MANAGE_STATE is True
-        assert flags.MANAGE_STATE_SOURCE == "cli_flag"
-
-    def test_manage_state_source_env_var(self, monkeypatch):
-        monkeypatch.setattr("dbt.cli.flags.get_user_setting_flags", lambda: {})
-        monkeypatch.setenv("DBT_ENGINE_MANAGE_STATE", "True")
-        context = self.make_dbt_context("run", ["run"])
-        flags = Flags(context)
-        assert flags.MANAGE_STATE is True
-        assert flags.MANAGE_STATE_SOURCE == "env_var"
-
-    def test_manage_state_source_project_config(self, monkeypatch):
-        monkeypatch.delenv("DBT_ENGINE_MANAGE_STATE", raising=False)
-        monkeypatch.setattr("dbt.cli.flags.get_user_setting_flags", lambda: {})
-        project_flags = ProjectFlags(manage_state=True)
-        context = self.make_dbt_context("run", ["run"])
-        flags = Flags(context, project_flags)
-        assert flags.MANAGE_STATE is True
-        assert flags.MANAGE_STATE_SOURCE == "project_config"
-
-    def test_manage_state_source_user_settings(self, monkeypatch):
-        monkeypatch.delenv("DBT_ENGINE_MANAGE_STATE", raising=False)
-        monkeypatch.setattr(
-            "dbt.cli.flags.get_user_setting_flags",
-            lambda: {"manage_state": True},
-        )
-        context = self.make_dbt_context("run", ["run"])
-        flags = Flags(context)
-        assert flags.MANAGE_STATE is True
-        assert flags.MANAGE_STATE_SOURCE == "user_settings"
-
-    def test_manage_state_source_cli_overrides_project(self, monkeypatch):
-        monkeypatch.delenv("DBT_ENGINE_MANAGE_STATE", raising=False)
-        monkeypatch.setattr("dbt.cli.flags.get_user_setting_flags", lambda: {})
-        project_flags = ProjectFlags(manage_state=False)
-        context = self.make_dbt_context("run", ["--manage-state", "run"])
-        flags = Flags(context, project_flags)
-        assert flags.MANAGE_STATE is True
-        assert flags.MANAGE_STATE_SOURCE == "cli_flag"
+        # shared test process; control it explicitly per case.
+        if env_value is None:
+            monkeypatch.delenv("DBT_ENGINE_MANAGE_STATE", raising=False)
+        else:
+            monkeypatch.setenv("DBT_ENGINE_MANAGE_STATE", env_value)
+        monkeypatch.setattr("dbt.cli.flags.get_user_setting_flags", lambda: user_flags)
+        context = self.make_dbt_context("run", argv)
+        if manage_state_project is None:
+            flags = Flags(context)
+        else:
+            flags = Flags(context, ProjectFlags(manage_state=manage_state_project))
+        assert flags.MANAGE_STATE is expected_state
+        assert flags.MANAGE_STATE_SOURCE == expected_source
 
     def test_mutually_exclusive_options_passed_separately(self):
         """Assert options that are mutually exclusive can be passed separately without error"""

--- a/tests/unit/cli/test_flags.py
+++ b/tests/unit/cli/test_flags.py
@@ -180,6 +180,61 @@ class TestFlags:
         flags = Flags(context)
         assert flags.USE_COLORS is True
 
+    def test_manage_state_source_unset(self, monkeypatch):
+        # PluginManager may leak DBT_ENGINE_MANAGE_STATE=true into os.environ in a
+        # shared test process; clear it so this case exercises the true default.
+        monkeypatch.delenv("DBT_ENGINE_MANAGE_STATE", raising=False)
+        monkeypatch.setattr("dbt.cli.flags.get_user_setting_flags", lambda: {})
+        context = self.make_dbt_context("run", ["run"])
+        flags = Flags(context)
+        assert flags.MANAGE_STATE is False
+        assert flags.MANAGE_STATE_SOURCE is None
+
+    def test_manage_state_source_cli_flag(self, monkeypatch):
+        monkeypatch.delenv("DBT_ENGINE_MANAGE_STATE", raising=False)
+        monkeypatch.setattr("dbt.cli.flags.get_user_setting_flags", lambda: {})
+        context = self.make_dbt_context("run", ["--manage-state", "run"])
+        flags = Flags(context)
+        assert flags.MANAGE_STATE is True
+        assert flags.MANAGE_STATE_SOURCE == "cli_flag"
+
+    def test_manage_state_source_env_var(self, monkeypatch):
+        monkeypatch.setattr("dbt.cli.flags.get_user_setting_flags", lambda: {})
+        monkeypatch.setenv("DBT_ENGINE_MANAGE_STATE", "True")
+        context = self.make_dbt_context("run", ["run"])
+        flags = Flags(context)
+        assert flags.MANAGE_STATE is True
+        assert flags.MANAGE_STATE_SOURCE == "env_var"
+
+    def test_manage_state_source_project_config(self, monkeypatch):
+        monkeypatch.delenv("DBT_ENGINE_MANAGE_STATE", raising=False)
+        monkeypatch.setattr("dbt.cli.flags.get_user_setting_flags", lambda: {})
+        project_flags = ProjectFlags(manage_state=True)
+        context = self.make_dbt_context("run", ["run"])
+        flags = Flags(context, project_flags)
+        assert flags.MANAGE_STATE is True
+        assert flags.MANAGE_STATE_SOURCE == "project_config"
+
+    def test_manage_state_source_user_settings(self, monkeypatch):
+        monkeypatch.delenv("DBT_ENGINE_MANAGE_STATE", raising=False)
+        monkeypatch.setattr(
+            "dbt.cli.flags.get_user_setting_flags",
+            lambda: {"manage_state": True},
+        )
+        context = self.make_dbt_context("run", ["run"])
+        flags = Flags(context)
+        assert flags.MANAGE_STATE is True
+        assert flags.MANAGE_STATE_SOURCE == "user_settings"
+
+    def test_manage_state_source_cli_overrides_project(self, monkeypatch):
+        monkeypatch.delenv("DBT_ENGINE_MANAGE_STATE", raising=False)
+        monkeypatch.setattr("dbt.cli.flags.get_user_setting_flags", lambda: {})
+        project_flags = ProjectFlags(manage_state=False)
+        context = self.make_dbt_context("run", ["--manage-state", "run"])
+        flags = Flags(context, project_flags)
+        assert flags.MANAGE_STATE is True
+        assert flags.MANAGE_STATE_SOURCE == "cli_flag"
+
     def test_mutually_exclusive_options_passed_separately(self):
         """Assert options that are mutually exclusive can be passed separately without error"""
         warn_error_context = self.make_dbt_context("run", ["--warn-error", "run"])

--- a/tests/unit/cli/test_flags.py
+++ b/tests/unit/cli/test_flags.py
@@ -224,6 +224,18 @@ class TestFlags:
         assert flags.MANAGE_STATE is expected_state
         assert flags.MANAGE_STATE_SOURCE == expected_source
 
+    def test_manage_state_source_programmatic(self, monkeypatch):
+        # dbtRunner.invoke(manage_state=True) tags the param source with the string
+        # "kwargs"; this should be attributed to the "programmatic" surface.
+        monkeypatch.delenv("DBT_ENGINE_MANAGE_STATE", raising=False)
+        monkeypatch.setattr("dbt.cli.flags.get_user_setting_flags", lambda: {})
+        context = self.make_dbt_context("run", ["run"])
+        context.params["manage_state"] = True
+        context.set_parameter_source("manage_state", "kwargs")
+        flags = Flags(context)
+        assert flags.MANAGE_STATE is True
+        assert flags.MANAGE_STATE_SOURCE == "programmatic"
+
     def test_mutually_exclusive_options_passed_separately(self):
         """Assert options that are mutually exclusive can be passed separately without error"""
         warn_error_context = self.make_dbt_context("run", ["--warn-error", "run"])

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -111,6 +111,36 @@ class TestCompileStatsTracking:
         assert resource_counts["models"] == 1
 
 
+class TestTrackManageState:
+    def test_emits_manage_state_event(self) -> None:
+        mock_user = mock.Mock(do_not_track=False)
+        with mock.patch("dbt.tracking.active_user", mock_user):
+            with mock.patch("dbt.tracking.tracker") as mock_tracker:
+                with mock.patch("dbt.tracking.fire_event"):
+                    dbt.tracking.track_manage_state({"manage_state": True, "source": "cli_flag"})
+
+        mock_tracker.track.assert_called_once()
+        event = mock_tracker.track.call_args[0][0]
+        assert event.action == "manage_state"
+        context = event.context
+        assert len(context) == 1
+        payload = context[0].to_json()["data"]
+        assert payload == {"manage_state": True, "source": "cli_flag"}
+        assert context[0].to_json()["schema"] == dbt.tracking.MANAGE_STATE_SPEC
+
+    def test_does_not_track_when_user_opted_out(self) -> None:
+        mock_user = mock.Mock(do_not_track=True)
+        with mock.patch("dbt.tracking.active_user", mock_user):
+            with mock.patch("dbt.tracking.tracker") as mock_tracker:
+                with mock.patch("dbt.tracking.fire_event"):
+                    dbt.tracking.track_manage_state({"manage_state": True, "source": "env_var"})
+        mock_tracker.track.assert_not_called()
+
+    def test_raises_without_active_user(self, active_user_none) -> None:
+        with pytest.raises(AssertionError, match="active user is None"):
+            dbt.tracking.track_manage_state({"manage_state": True, "source": "cli_flag"})
+
+
 class TestTrackModelRun:
     def test_raises_without_active_user(self, active_user_none) -> None:
         node = mock.MagicMock(resource_type=NodeType.Model)


### PR DESCRIPTION
Resolves #

### Problem

dbt has no visibility into how often users enable the opt-in state management feature, or which surface they use to enable it. The feature can be turned on three ways — the `--manage-state` CLI flag, the `DBT_ENGINE_MANAGE_STATE` env var, or `manage_state: true` in project config (plus a `user_settings.yml` auto-enable path) — but none of these emit any usage signal.

### Solution

Emit an anonymous usage event once per invocation whenever `MANAGE_STATE` resolves to true, tagged with the surface that supplied the opt-in.

- **`core/dbt/tracking.py`** — Adds a `MANAGE_STATE_SPEC` schema constant and a `track_manage_state(options)` function following the existing `track_plugin_get_nodes` pattern (Snowplow `StructuredEvent`, action `manage_state`, respects `do_not_track`).
- **`core/dbt/cli/flags.py`** — Adds `MANAGE_STATE_SOURCE` to the resolved `Flags`, computed by `_resolve_manage_state_source(...)`. It attributes the value to `"cli_flag"`, `"env_var"`, `"project_config"`, or `"user_settings"` using Click's authoritative `ParameterSource` (checked across parent + invoked-subcommand contexts), falling back through the config layers in dbt's real precedence order. Returns `None` when not enabled.
- **`core/dbt/cli/requires.py`** — In `preflight`, immediately after tracking is initialized, fires `track_manage_state({"manage_state": True, "source": ...})` when the flag is enabled.

Payload shape: `{"manage_state": bool, "source": str | null}`.

#### Reviewer notes

- **Schema registration is a required external step.** Like every other `*_SPEC` in `tracking.py`, `iglu:com.dbt/manage_state/jsonschema/1-0-0` must be registered in the iglu schema repository before the collector will accept these events.
- The `source` attribution uses Click's `ParameterSource` for CLI-vs-env (authoritative), and only consults the project/user-settings layers when Click reports `DEFAULT` — matching the precedence applied during flag resolution.
- The fire site uses `dbt.tracking.active_user` (the live module global) rather than the stale `from dbt.tracking import active_user` name, since `initialize_from_flags` rebinds the module attribute.
- Issue number is a placeholder in the changelog (`Features-20260609`) — happy to update once an issue is filed.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)