### PR TITLE
test: copybara reverse-sync end-to-end (DO NOT MERGE)

### DIFF
--- a/crates/dbt-sa-cli/src/main.rs
+++ b/crates/dbt-sa-cli/src/main.rs
@@ -8,6 +8,7 @@ use dbt_lib::print_trimmed_error;
 use std::process::ExitCode;
 use std::sync::Arc;
 
+// test: copybara reverse-sync end-to-end probe — remove before merge
 fn main() -> ExitCode {
     let cli_parser = DefaultCliParserFactory.create("dbt-core");
     let cli = dbt_lib::prepare_cli_or_exit(&cli_parser);


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

Test PR used to exercise the copybara reverse-sync chain end-to-end.

## What it tests
- **Draft skip** ([#15220](https://github.com/dbt-labs/dbt-core/pull/15220)): opened as draft → confirm no fs PR is created.
- **Label on create** ([fs#10932](https://github.com/dbt-labs/fs/pull/10932)): mark as ready → confirm fs PR gets the `public-pr` label.
- **Manual workflow_dispatch** (cherry-picked into fs#10932): trigger the fs workflow from the GitHub UI with this PR's number → confirm sync + label.
- **Syncable-changes gate** ([#15178](https://github.com/dbt-labs/dbt-core/pull/15178)): push a `.changes/`-only commit later → confirm no extra dispatch.
- **Flow 1 close-sync** (upcoming): closing this PR will eventually trigger close of the fs counterpart.

## Cleanup
Close this PR (do not merge) when testing wraps. The fs counterpart will need a manual close until Flow 1 close-sync ships.

## Diff
A single-line comment in `crates/dbt-sa-cli/src/main.rs` to give copybara something syncable.