### PR TITLE
ci(winget): publish dbt-core manifests on stable releases

### DIFF
--- a/.changes/unreleased/Under the Hood-20260612-175918.yaml
+++ b/.changes/unreleased/Under the Hood-20260612-175918.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: 'ci: publish dbt-core winget manifests to microsoft/winget-pkgs via wingetcreate update on stable releases'
+time: 2026-06-12T17:59:18.518479+05:30
+custom:
+    author: itsnamangoyal
+    issue: ""
+    project: dbt-fusion

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,0 +1,119 @@
+# **what?**
+# Bump the published `dbtLabs.dbt-core` winget manifest to a new version
+# and submit a PR to `microsoft/winget-pkgs`.
+#
+# **why?**
+# Distribute dbt-core via winget so users can `winget install dbt-core`.
+#
+# **when?**
+# - workflow_call: invoked by release-v2.yml after `github-release` for
+#   non-prerelease versions. The GitHub Release must already host the
+#   Windows `.zip`.
+# - workflow_dispatch: ad-hoc manual run against an existing release.
+#
+# **how?**
+# `wingetcreate update <id> --version V --urls URL` updates the latest
+# published manifest from `microsoft/winget-pkgs`, rewriting the version +
+# installer URL and re-hashing the zip. With `--submit`, wingetcreate
+# pushes a branch to the **PAT user's personal fork** of
+# `microsoft/winget-pkgs` (auto-created if absent) and opens a PR upstream.
+#
+# Description / publisher / license / tags / moniker / binary_name all
+# carry over from the seed manifest already on upstream — they're
+# inherited, not threaded through CLI flags.
+#
+# Dry-run path uses `--out` instead of `--submit`, so manifests land in a
+# local dir and are uploaded as a workflow artifact.
+#
+# wingetcreate is Windows-only (ships as `WingetCreateCLI.exe` from
+# `microsoft/winget-create` releases), so this workflow runs on
+# `windows-latest` even though every other release publisher runs on
+# Ubuntu.
+#
+# Submit requires `secrets.FISHTOWN_BOT_PAT` — the same PAT the homebrew
+# tap flow uses; needs `public_repo` scope. wingetcreate submits from
+# `<pat-owner>/winget-pkgs`.
+
+name: Publish winget manifests
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version string (e.g. 2.0.0)"
+        type: string
+        required: true
+      dry_run:
+        description: "If true, render manifests locally without submitting upstream."
+        type: boolean
+        required: false
+        default: false
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "SemVer to publish (e.g. 2.0.0). Do NOT include the leading `v`."
+        required: true
+        type: string
+      dry_run:
+        description: "If true, render manifests locally but do NOT submit upstream."
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish-winget:
+    name: wingetcreate update + submit
+    runs-on: windows-latest
+    timeout-minutes: 15
+    env:
+      PACKAGE_IDENTIFIER: dbtLabs.dbt-core
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Compute installer URL
+        shell: bash
+        run: echo "INSTALLER_URL=https://github.com/dbt-labs/dbt-core/releases/download/v${VERSION}/dbt-core-${VERSION}-x86_64-pc-windows-msvc.zip" >> "$GITHUB_ENV"
+
+      - name: Install wingetcreate
+        shell: pwsh
+        run: |
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+
+      - name: Render manifests (dry-run)
+        if: ${{ inputs.dry_run }}
+        shell: pwsh
+        run: |
+          Write-Host "→ $env:INSTALLER_URL"
+          .\wingetcreate.exe update $env:PACKAGE_IDENTIFIER `
+            --version $env:VERSION `
+            --urls $env:INSTALLER_URL `
+            --out manifests-out
+          Write-Host "---rendered manifests---"
+          Get-ChildItem -Recurse manifests-out
+
+      - name: Upload rendered manifests
+        if: ${{ inputs.dry_run }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: winget-manifests-${{ inputs.version }}
+          path: manifests-out/
+
+      - name: Submit to microsoft/winget-pkgs
+        if: ${{ !inputs.dry_run }}
+        shell: pwsh
+        env:
+          FISHTOWN_BOT_PAT: ${{ secrets.FISHTOWN_BOT_PAT }}
+        run: |
+          if (-not $env:FISHTOWN_BOT_PAT) {
+            Write-Error "FISHTOWN_BOT_PAT secret not set — cannot submit. Either dry-run or add the secret."
+            exit 1
+          }
+          Write-Host "→ $env:INSTALLER_URL"
+          .\wingetcreate.exe update $env:PACKAGE_IDENTIFIER `
+            --version $env:VERSION `
+            --urls $env:INSTALLER_URL `
+            --submit `
+            --token $env:FISHTOWN_BOT_PAT

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -107,10 +107,6 @@ jobs:
         env:
           FISHTOWN_BOT_PAT: ${{ secrets.FISHTOWN_BOT_PAT }}
         run: |
-          if (-not $env:FISHTOWN_BOT_PAT) {
-            Write-Error "FISHTOWN_BOT_PAT secret not set — cannot submit. Either dry-run or add the secret."
-            exit 1
-          }
           Write-Host "→ $env:INSTALLER_URL"
           .\wingetcreate.exe update $env:PACKAGE_IDENTIFIER `
             --version $env:VERSION `

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -100,8 +100,30 @@ jobs:
           name: winget-manifests-${{ inputs.version }}
           path: manifests-out/
 
-      - name: Submit to microsoft/winget-pkgs
+      # wingetcreate has no "nothing changed" detection — it opens a PR (or
+      # errors) on every submit. This workflow only ever changes the version
+      # + installer URL/hash, all deterministic from VERSION, so if the
+      # version dir already exists upstream there is nothing for us to submit.
+      # Skip it to avoid a redundant PR on re-runs.
+      - name: Check if version already published
         if: ${{ !inputs.dry_run }}
+        id: published
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          url="https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/d/dbtLabs/dbt-core/${VERSION}"
+          code=$(curl -sS -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" "$url")
+          case "$code" in
+            200) echo "Version ${VERSION} already published — skipping submit."; echo "exists=true" >> "$GITHUB_OUTPUT" ;;
+            404) echo "Version ${VERSION} not yet published — will submit."; echo "exists=false" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::Unexpected HTTP $code checking winget-pkgs for ${VERSION}"; exit 1 ;;
+          esac
+
+      - name: Submit to microsoft/winget-pkgs
+        if: ${{ !inputs.dry_run && steps.published.outputs.exists != 'true' }}
         shell: pwsh
         env:
           WINGET_PUBLISH_PAT: ${{ secrets.WINGET_PUBLISH_PAT }}

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -30,9 +30,8 @@
 # `windows-latest` even though every other release publisher runs on
 # Ubuntu.
 #
-# Submit requires `secrets.FISHTOWN_BOT_PAT` — the same PAT the homebrew
-# tap flow uses; needs `public_repo` scope. wingetcreate submits from
-# `<pat-owner>/winget-pkgs`.
+# Submit requires `secrets.WINGET_PUBLISH_PAT`; needs `public_repo` scope.
+# wingetcreate submits from `<pat-owner>/winget-pkgs`.
 
 name: Publish winget manifests
 
@@ -105,11 +104,11 @@ jobs:
         if: ${{ !inputs.dry_run }}
         shell: pwsh
         env:
-          FISHTOWN_BOT_PAT: ${{ secrets.FISHTOWN_BOT_PAT }}
+          WINGET_PUBLISH_PAT: ${{ secrets.WINGET_PUBLISH_PAT }}
         run: |
           Write-Host "→ $env:INSTALLER_URL"
           .\wingetcreate.exe update $env:PACKAGE_IDENTIFIER `
             --version $env:VERSION `
             --urls $env:INSTALLER_URL `
             --submit `
-            --token $env:FISHTOWN_BOT_PAT
+            --token $env:WINGET_PUBLISH_PAT

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -842,3 +842,19 @@ jobs:
           Release workflow: ${RUN_URL}
           EOF
           )"
+
+  # Submits an updated dbtLabs.dbt-core manifest to microsoft/winget-pkgs
+  # via `wingetcreate update` using the Windows installer archive from the
+  # `github-release` job. Skipped for pre-release versions (anything with
+  # a `-` in the SemVer) — winget users only get stable releases. Runs in
+  # parallel with `publish-homebrew`; both fan out from `github-release`.
+  publish-winget:
+    needs: [github-release]
+    if: ${{ !contains(needs.prepare-release.outputs.version, '-') }}
+    uses: ./.github/workflows/publish-winget.yml
+    with:
+      version: ${{ needs.prepare-release.outputs.version }}
+      dry_run: ${{ inputs.dry_run }}
+    permissions:
+      contents: read
+    secrets: inherit


### PR DESCRIPTION
## Summary

Publishes dbt-core winget manifests to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) automatically on every non-prerelease tag, mirroring the homebrew flow.

- New `publish-winget.yml` reusable workflow runs on `windows-latest` and uses [`wingetcreate update`](https://github.com/microsoft/winget-create) to bump the existing `dbtLabs.dbt-core` manifest with the new version + installer URL, then opens a PR to `microsoft/winget-pkgs`.
- Wired into `release-v2.yml` as a new `publish-winget` job that fans out from `github-release` in parallel with `publish-homebrew`, gated on non-prerelease versions (no `-` in SemVer).
- Honors the parent workflow's `dry_run` input — passes it through so dry runs upload the rendered manifests as a workflow artifact instead of submitting.
- Skips submission when the target version already exists on `microsoft/winget-pkgs`. `wingetcreate` has no "nothing changed" detection, and this workflow only ever changes the version + installer URL/hash (all deterministic from the version), so an existing version dir means there is nothing to submit — this avoids a redundant PR on re-runs / rollbacks.
- Submits using \`secrets.WINGET_PUBLISH_PAT\` (needs \`public_repo\` scope) — must be added to the repo before the submit path can run.

## Test plan

- [ ] Dispatch \`release-v2.yml\` with \`dry_run: true\` and confirm \`publish-winget\` uploads a \`winget-manifests-<version>\` artifact with the rendered YAML.
- [ ] On next non-prerelease tag, confirm \`publish-winget\` opens a PR against \`microsoft/winget-pkgs\` updating the \`dbtLabs.dbt-core\` manifest.
- [ ] Re-run for an already-published version and confirm the submit step is skipped (no duplicate PR).