### PR TITLE
Fix/installation failure

### DIFF
--- a/.changes/unreleased/Fixes-20260614-151218.yaml
+++ b/.changes/unreleased/Fixes-20260614-151218.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: 'fix: explicitly set default empty variable for $SHELL so that the script will not end while setting the $SHELL.'
+time: 2026-06-14T15:12:18.167108503+09:00
+custom:
+    author: yuwtennis
+    issue: "14599"
+    project: dbt-fusion

--- a/crates/dbt-common/assets/install.sh
+++ b/crates/dbt-common/assets/install.sh
@@ -338,7 +338,7 @@ setup_shell_config() {
     shell_name=""
 
     # Detect shell and config file early
-    if [ -n "$SHELL" ]; then
+    if [ -n "${SHELL:-}" ]; then
         shell_name=$(basename "$SHELL")
     else
         if [ -f "$HOME/.bashrc" ]; then


### PR DESCRIPTION
Resolves #14599 

### Problem

https://github.com/dbt-labs/dbt-core/issues/14599#issuecomment-4700873364

### Solution

By setting _empty default value_ for `$SHELL` before entering the setup of `$SHELL`, 
the script will safely proceed with the setup.

I have tested using the fixed `install.sh` and executing inside the `Dockerfile`.

```
FROM debian:trixie-slim AS build

RUN apt update && apt install -y -q curl && apt clean

WORKDIR /build
ADD crates/dbt-common/assets/install.sh .
RUN ./install.sh --update

FROM debian:trixie-slim AS app

COPY --from=build /root/.local/bin/dbt /usr/local/bin/dbt

WORKDIR /app
COPY . ./
``` 

#### Result 

<img width="564" height="362" alt="image" src="https://github.com/user-attachments/assets/069068ed-f4f0-4b15-b4db-4bb42b6e49d3" />

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
