### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260615-065436.yaml
+++ b/.changes/unreleased/Under the Hood-20260615-065436.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-06-15T06:54:36.085893025Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -884,6 +884,27 @@
         "table"
       ]
     },
+    "FunctionSnowflakeConfig": {
+      "description": "Snowflake-specific configuration for functions. Nested under the `snowflake` key inside `config:` in schema YAML (or `+snowflake:` under `functions:` in `dbt_project.yml`).",
+      "type": "object",
+      "properties": {
+        "quote_args": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "GrantAccessToTarget": {
       "type": "object",
       "properties": {
@@ -1970,6 +1991,12 @@
             }
           ]
         },
+        "+reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+row_access_policy": {
           "type": [
             "string",
@@ -2465,6 +2492,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "+snowflake": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FunctionSnowflakeConfig"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "+static_analysis": {
@@ -3621,6 +3658,12 @@
             }
           ]
         },
+        "+reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+resource_tags": {
           "type": [
             "object",
@@ -4652,6 +4695,12 @@
             }
           ]
         },
+        "+reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+row_access_policy": {
           "type": [
             "string",
@@ -5578,6 +5627,12 @@
             }
           ]
         },
+        "+reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+row_access_policy": {
           "type": [
             "string",
@@ -6283,6 +6338,12 @@
             }
           ]
         },
+        "+reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+schedule": {
           "anyOf": [
             {
@@ -6950,6 +7011,12 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "+reservation": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "+row_access_policy": {

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -1649,6 +1649,12 @@
             }
           ]
         },
+        "reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "resource_tags": {
           "type": [
             "object",
@@ -3639,6 +3645,12 @@
             }
           ]
         },
+        "reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "resource_tags": {
           "type": [
             "object",
@@ -3721,6 +3733,16 @@
             {
               "type": "string",
               "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "snowflake": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FunctionSnowflakeConfig"
+            },
+            {
+              "type": "null"
             }
           ]
         },
@@ -4061,6 +4083,27 @@
           "type": [
             "string",
             "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "FunctionSnowflakeConfig": {
+      "description": "Snowflake-specific configuration for functions. Nested under the `snowflake` key inside `config:` in schema YAML (or `+snowflake:` under `functions:` in `dbt_project.yml`).",
+      "type": "object",
+      "properties": {
+        "quote_args": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
           ]
         }
       },
@@ -5843,6 +5886,12 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "reservation": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "resource_tags": {
@@ -7861,6 +7910,12 @@
             }
           ]
         },
+        "reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "resource_tags": {
           "type": [
             "object",
@@ -9012,6 +9067,12 @@
             }
           ]
         },
+        "reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "resource_tags": {
           "type": [
             "object",
@@ -10104,6 +10165,12 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "reservation": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "resource_tags": {
@@ -11400,6 +11467,12 @@
               "type": "string",
               "pattern": "^\\{.*\\}$"
             }
+          ]
+        },
+        "reservation": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "resource_tags": {


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`e2bf43c3f53d3686e18d2bbb1a78e2a9f5b2b3f1`](https://github.com/dbt-labs/fs/commit/e2bf43c3f53d3686e18d2bbb1a78e2a9f5b2b3f1)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/27528140726)