### PR TITLE
Fix/bigquery timestamp precision

### DIFF
--- a/.changes/unreleased/Fixes-20260615-121500.yaml
+++ b/.changes/unreleased/Fixes-20260615-121500.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix BigQuery TIMESTAMP type precision issue when using --sample with microbatch event-time filtering. BigQuery only supports 6-digit (microsecond) precision, but dbt was generating 9-digit (nanosecond) precision literals.
+time: 2026-06-15T12:15:00.000000-00:00
+custom:
+    author: stva01
+    issue: "15242"
+    project: dbt-fusion

--- a/crates/dbt-schemas/src/schemas/relations/base.rs
+++ b/crates/dbt-schemas/src/schemas/relations/base.rs
@@ -852,3 +852,27 @@ pub trait BaseRelation: BaseRelationProperties + Any + Send + Sync + fmt::Debug 
         unimplemented!("Available only for BigQuery and Redshift")
     }
 }
+#[cfg(test)]
+mod tests {
+
+    use chrono::{DateTime, Utc};
+
+    #[test]
+    fn test_bigquery_timestamp_precision() {
+        let dt = DateTime::parse_from_rfc3339("2026-06-05T03:50:56.538507786+00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let formatted = dt.format("%Y-%m-%dT%H:%M:%S%.6f%:z").to_string();
+
+        assert!(
+            formatted.contains("538507"),
+            "Expected 6-digit precision in: {}",
+            formatted
+        );
+        assert!(
+            !formatted.contains("538507786"),
+            "Should not contain 9-digit precision"
+        );
+    }
+}

--- a/crates/dbt-schemas/src/schemas/relations/base.rs
+++ b/crates/dbt-schemas/src/schemas/relations/base.rs
@@ -533,11 +533,11 @@ pub trait BaseRelation: BaseRelationProperties + Any + Send + Sync + fmt::Debug 
         // get start/end times
         let (start, end) = run_filter.sample_times();
 
-        // Render with explicit UTC offset so non-UTC sessions (e.g. Snowflake
-        // with a session TIMEZONE other than UTC) interpret the literal as UTC,
-        // matching the microbatch DELETE predicate which also uses `to_rfc3339`.
-        let start = start.map(|t| t.to_rfc3339());
-        let end = end.map(|t| t.to_rfc3339());
+        // Render with explicit UTC offset so non-UTC sessions interpret the
+        // literal as UTC. Use microsecond precision (6 fractional digits) which
+        // is the maximum supported by BigQuery's TIMESTAMP type.
+        let start = start.map(|t| t.format("%Y-%m-%dT%H:%M:%S%.6f%:z").to_string());
+        let end = end.map(|t| t.format("%Y-%m-%dT%H:%M:%S%.6f%:z").to_string());
 
         // render the filter conditions
         let (start, end) = match self.adapter_type() {


### PR DESCRIPTION
Resolves #15242

## Problem

BigQuery's TIMESTAMP type only supports 6 fractional second digits (microsecond precision).

When using `--sample` with microbatch event-time filtering, dbt was generating timestamp literals with full nanosecond precision (9 digits) via `to_rfc3339()`. This caused implicit string-to-timestamp coercion to fail in BigQuery.

## Solution

Changed timestamp formatting from `to_rfc3339()` to chrono's format string with `%.6f` to ensure 6-digit microsecond precision for all adapters, while preserving explicit UTF offset.

- Modified `render_with_run_filter()` in `crates/dbt-schemas/src/schemas/relations/base.rs` to format timestamps with microsecond precision
- Added test case `test_bigquery_timestamp_precision` to verify truncation works correctly

## Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.