### PR TITLE
fix: quote VSCE bug template description so the issue form parses

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-vsce.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-vsce.yml
@@ -39,7 +39,7 @@ body:
   - type: textarea
     attributes:
       label: Troubleshooting
-      description: Does the bug consistently occur? Does it go away after running `Developer: Reload Window`?
+      description: "Does the bug consistently occur? Does it go away after running `Developer: Reload Window`?"
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
## What

Fixes the `bug-report-vsce.yml` issue form added in #13089. The file merged and is on `main`, but the **VSCE bug template never appeared in the new-issue chooser** because the YAML failed to parse — GitHub silently drops malformed issue forms.

The `description` on the "Troubleshooting" block was an **unquoted scalar containing a colon-space**:

```yaml
description: Does the bug consistently occur? Does it go away after running `Developer: Reload Window`?
```

In YAML, `: ` (colon-space) is the mapping-value indicator, so the parser errors with `mapping values are not allowed here` (line 42, col 93 — the colon in `Developer: Reload Window`). This fix quotes the string.

## Verification

```
$ python -c "import yaml; yaml.safe_load(open('bug-report-vsce.yml'))"   # now parses clean
YAML NOW VALID; name= 🐞📟 VS Code Extension Bug ; body blocks= 10
```

The other two templates from #13089 (`bug-report-v2.yml`, `sql-understanding.yml`) parse fine and were unaffected — this was VSCE-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
