### PR TITLE
ci(winget): authenticate wingetcreate reads in dry-run

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -84,11 +84,15 @@ jobs:
       - name: Render manifests (dry-run)
         if: ${{ inputs.dry_run }}
         shell: pwsh
+        env:
+          # Authenticates wingetcreate's API reads to avoid the anonymous rate limit.
+          WINGET_PUBLISH_PAT: ${{ secrets.WINGET_PUBLISH_PAT }}
         run: |
           Write-Host "→ $env:INSTALLER_URL"
           .\wingetcreate.exe update $env:PACKAGE_IDENTIFIER `
             --version $env:VERSION `
             --urls $env:INSTALLER_URL `
+            --token $env:WINGET_PUBLISH_PAT `
             --out manifests-out
           Write-Host "---rendered manifests---"
           Get-ChildItem -Recurse manifests-out


### PR DESCRIPTION
## Summary

Follow-up to #15244. The dry-run render step (`wingetcreate update --out`) hit GitHub's anonymous API rate limit (60/hr per shared runner IP) while fetching the upstream manifest and downloading the zip to hash, because it ran without a token.

- Pass `--token` to the dry-run `wingetcreate update` call so its API reads are authenticated (5,000/hr). `--out` (no `--submit`) still renders locally without pushing anything.

## Test plan

- [ ] Dispatch `release-v2.yml` with `dry_run: true` and confirm `publish-winget` renders + uploads the manifest artifact without a rate-limit error.