### PR TITLE
fix: prevent duplicate CTE names in unit tests when upstream models share the same alias

### DIFF
--- a/.changes/unreleased/Fixes-20260621-160710.yaml
+++ b/.changes/unreleased/Fixes-20260621-160710.yaml
@@ -1,0 +1,8 @@
+﻿kind: Fixes
+body: >-
+  Fix duplicate CTE name error in unit tests when two upstream models share the
+  same alias config but have different model names or schemas
+time: 2026-06-21T16:07:10.000000+00:00
+custom:
+    Author: kalluripradeep
+    Issue: "10740"

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -133,7 +133,7 @@ class UnitTestManifestLoader:
                 "original_file_path": unit_test_node.original_file_path,
                 "config": ModelConfig(materialized="ephemeral"),
                 "database": original_input_node.database,
-                "alias": original_input_node.identifier,
+                "alias": original_input_node.name,  # use model name not alias to prevent duplicate CTEs when two upstream models share the same alias (fixes #10740)
                 "schema": original_input_node.schema,
                 "fqn": original_input_node.fqn,
                 "checksum": FileHash.empty(),

--- a/tests/functional/unit_testing/test_ut_aliases.py
+++ b/tests/functional/unit_testing/test_ut_aliases.py
@@ -50,3 +50,78 @@ class TestUnitTestInputWithAlias:
 
         results = run_dbt(["test"])
         assert len(results) == 1
+
+
+model_with_alias_a_sql = """
+{{
+    config(
+        alias='shared_alias',
+        schema='schema_a',
+        materialized='view'
+    )
+}}
+select 1 as id_a
+"""
+
+model_with_alias_b_sql = """
+{{
+    config(
+        alias='shared_alias',
+        schema='schema_b',
+        materialized='view'
+    )
+}}
+select 2 as id_b
+"""
+
+model_tested_duplicate_alias_sql = """
+select id_a from {{ ref('model_with_alias_a') }}
+union all
+select id_b from {{ ref('model_with_alias_b') }}
+"""
+
+unit_test_duplicate_alias_yml = """
+unit_tests:
+  - name: test_duplicate_alias_inputs
+    model: model_tested_duplicate_alias
+    given:
+      - input: ref('model_with_alias_a')
+        rows:
+          - {id_a: 10}
+      - input: ref('model_with_alias_b')
+        rows:
+          - {id_b: 20}
+    expect:
+      rows:
+        - {id_a: 10}
+        - {id_a: 20}
+"""
+
+
+class TestUnitTestDuplicateAliasInputs:
+    """Regression test for https://github.com/dbt-labs/dbt-core/issues/10740.
+
+    When two upstream models share the same alias (but have different model
+    names/schemas), the unit test compiler previously generated duplicate CTE
+    names (__dbt__cte__<alias>) for both input nodes, causing:
+
+        Parser Error: Duplicate CTE name "__dbt__cte__<alias>"
+
+    The fix is to use the model's *name* (always unique within a project) as
+    the alias for ephemeral unit-test input nodes, not its *identifier*
+    (which reflects the configured alias and can collide across models).
+    """
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_with_alias_a.sql": model_with_alias_a_sql,
+            "model_with_alias_b.sql": model_with_alias_b_sql,
+            "model_tested_duplicate_alias.sql": model_tested_duplicate_alias_sql,
+            "unit_test.yml": unit_test_duplicate_alias_yml,
+        }
+
+    def test_duplicate_alias_inputs(self, project):
+        run_dbt(["run"])
+        results = run_dbt(["test"])
+        assert len(results) == 1


### PR DESCRIPTION
Resolves #10740

### Problem

When two upstream models are configured with the same `alias` (via `config(alias='...')`) but have different model names or schemas, running a unit test against a model that refs both causes a SQL parse error:

```
Runtime Error in unit_test ...
  Parser Error: Duplicate CTE name "__dbt__cte__<alias>"
```

The root cause is in `parse_unit_test_case()` in `core/dbt/parser/unit_tests.py`. Each `given` input creates an ephemeral `ModelNode` with:

```python
"alias": original_input_node.identifier,
```

`identifier` returns the model's configured alias (e.g. `"my_upstream_model"`). When two different upstream models share the same alias, both get the same `identifier` → same CTE name (`__dbt__cte__my_upstream_model`) → duplicate CTE error.

### Solution

Use `original_input_node.name` instead of `original_input_node.identifier` as the alias for ephemeral unit-test input nodes.

A model's `name` is its filename without extension, which is always unique within a project. For models *without* a custom alias, `name == identifier`, so this change is a no-op for all existing cases.

The CTE name used in the tested model's compiled SQL (`create_ephemeral_from(input_node)`) and the CTE name injected during compilation (`add_ephemeral_prefix(cte_model.identifier)`) both derive from `input_node.identifier`. Since we change the alias on the input node, both sides update consistently — no mismatch.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.