### PR TITLE
ci(winget): set ReleaseDate metadata on manifests

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -72,9 +72,11 @@ jobs:
       PACKAGE_IDENTIFIER: dbtLabs.dbt-core
       VERSION: ${{ inputs.version }}
     steps:
-      - name: Compute installer URL
+      - name: Compute installer URL and release date
         shell: bash
-        run: echo "INSTALLER_URL=https://github.com/dbt-labs/dbt-core/releases/download/v${VERSION}/dbt-core-${VERSION}-x86_64-pc-windows-msvc.zip" >> "$GITHUB_ENV"
+        run: |
+          echo "INSTALLER_URL=https://github.com/dbt-labs/dbt-core/releases/download/v${VERSION}/dbt-core-${VERSION}-x86_64-pc-windows-msvc.zip" >> "$GITHUB_ENV"
+          echo "RELEASE_DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
 
       - name: Install wingetcreate
         shell: pwsh
@@ -92,6 +94,7 @@ jobs:
           .\wingetcreate.exe update $env:PACKAGE_IDENTIFIER `
             --version $env:VERSION `
             --urls $env:INSTALLER_URL `
+            --release-date $env:RELEASE_DATE `
             --token $env:WINGET_PUBLISH_PAT `
             --out manifests-out
           Write-Host "---rendered manifests---"
@@ -136,5 +139,6 @@ jobs:
           .\wingetcreate.exe update $env:PACKAGE_IDENTIFIER `
             --version $env:VERSION `
             --urls $env:INSTALLER_URL `
+            --release-date $env:RELEASE_DATE `
             --submit `
             --token $env:WINGET_PUBLISH_PAT


### PR DESCRIPTION
## Summary

Adds the installer `ReleaseDate` metadata to the dbt-core winget manifest.

- New `Compute installer URL and release date` step exports `RELEASE_DATE` (current UTC date, `YYYY-MM-DD`).
- Passes `--release-date $RELEASE_DATE` to both the dry-run render and submit `wingetcreate update` calls.

The workflow runs at release time, so the run date is the effective release date.

## Test plan

- [ ] Dispatch `release-v2.yml` with `dry_run: true` and confirm the rendered installer manifest includes a `ReleaseDate` field.