### PR TITLE
Fix typo in `try_or_compiler_error` type-check warning message

### DIFF
--- a/.changes/unreleased/Fixes-20260622-154408.yaml
+++ b/.changes/unreleased/Fixes-20260622-154408.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix typo in the `try_or_compiler_error` type-check warning message ("a optional argument argument" -> "an optional argument")
+time: 2026-06-22T15:44:08.000000-00:00
+custom:
+    author: zozo123
+    issue: "15323"
+    project: dbt-core

--- a/crates/dbt-jinja/minijinja/src/types/function.rs
+++ b/crates/dbt-jinja/minijinja/src/types/function.rs
@@ -466,7 +466,7 @@ impl FunctionType for TryOrCompilerErrorFunctionType {
             // It is not possible to resolve the module here.
         } else if !&args[1].is_none() {
             listener.warn(&format!(
-                "Expected a optional argument argument for try_or_compiler_error function, got {:?}",
+                "Expected an optional argument for try_or_compiler_error function, got {:?}",
                 args[1]
             ));
             return Ok(Type::Any { hard: false });


### PR DESCRIPTION
### Description

Corrects a user-facing type-check warning string in `TryOrCompilerErrorFunctionType::_resolve_arguments` that had a wrong article and an accidentally doubled word:

```diff
- "Expected a optional argument argument for try_or_compiler_error function, got {:?}"
+ "Expected an optional argument for try_or_compiler_error function, got {:?}"
```

`crates/dbt-jinja/minijinja/src/types/function.rs:469`. The sibling warnings in the same function ("Expected a string argument for try_or_compiler_error function") confirm the singular wording is intended. Cosmetic only — no behavior change.

Resolves #15323.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] This change is covered by an associated issue (#15323).
- [x] I have added a changelog entry (`.changes/unreleased/Fixes-*.yaml`).
- [x] CLA — I (the author) will sign the Contributor License Agreement via cla-bot.

> Note: string-literal change only; `cargo build`/tests not run locally as there is no behavioral change.