### PR TITLE
fix: reconstruct unrendered config kwarg values as readable expressions

### DIFF
--- a/.changes/unreleased/Fixes-20260514-200000.yaml
+++ b/.changes/unreleased/Fixes-20260514-200000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Reconstruct unrendered config kwarg values as readable expressions instead of raw AST repr
+time: 2026-05-14T20:00:00.000000000Z
+custom:
+    Author: MichelleArk
+    Issue: "15336"

--- a/core/dbt/artifacts/schemas/upgrades/upgrade_manifest_dbt_version.py
+++ b/core/dbt/artifacts/schemas/upgrades/upgrade_manifest_dbt_version.py
@@ -1,2 +1,35 @@
+from dbt.clients.jinja_static import statically_parse_unrendered_config
+from dbt.flags import get_flags
+
 def upgrade_manifest_json_dbt_version(manifest: dict) -> dict:
+    upgrade_unrendered_config(manifest)
+    
     return manifest
+
+
+def upgrade_unrendered_config(manifest: dict) -> dict:
+    """Patch unrendered_config entries in a loaded manifest to include raw kwarg values extracted from raw_code.
+
+    unrendered_config from raw_code was previously set to a Python representation of the Jinja `{{ config() }}` call.
+    The latest implementation of statically_parse_unrendered_config improved on this by reconstructing the raw unrendered_config
+    call from the intermediate Python representation, behind state_modified_compare_more_unrendered_values.
+
+    Only upgrade the manifest if state_modified_compare_more_unrendered_values is set to True, as the change to statically_parse_unrendered_config
+    would only lead to false positives in that scenario as projects with state_modified_compare_more_unrendered_values set to false do not go through 
+    the statically_parse_unrendered_config call at all.
+
+    Similarly, simple built-in generic tests (not_null, unique) are skipped because they have no raw_code config block.
+    Their config is set directly on the ContextConfig without going through a Jinja config() call.
+    """
+    if get_flags().state_modified_compare_more_unrendered_values:
+        for unique_id, node in manifest.get("nodes", {}).items():
+            if _node_is_simple_builtin_generic_test(node):
+                continue
+            if node.get("raw_code") and node.get("unrendered_config"):
+                new_unrendered_config_from_code = statically_parse_unrendered_config(node.get("raw_code", "")) or {}
+                manifest["nodes"][unique_id]["unrendered_config"].update(new_unrendered_config_from_code)
+
+    return manifest
+
+def _node_is_simple_builtin_generic_test(node: dict) -> bool:
+    return node.get("resource_type") == "test" and node.get("depends_on", {}).get("macros") in (["macro.dbt.test_not_null"], ["macro.dbt.test_unique"])

--- a/core/dbt/artifacts/schemas/upgrades/upgrade_manifest_dbt_version.py
+++ b/core/dbt/artifacts/schemas/upgrades/upgrade_manifest_dbt_version.py
@@ -1,9 +1,10 @@
 from dbt.clients.jinja_static import statically_parse_unrendered_config
 from dbt.flags import get_flags
 
+
 def upgrade_manifest_json_dbt_version(manifest: dict) -> dict:
     upgrade_unrendered_config(manifest)
-    
+
     return manifest
 
 
@@ -15,7 +16,7 @@ def upgrade_unrendered_config(manifest: dict) -> dict:
     call from the intermediate Python representation, behind state_modified_compare_more_unrendered_values.
 
     Only upgrade the manifest if state_modified_compare_more_unrendered_values is set to True, as the change to statically_parse_unrendered_config
-    would only lead to false positives in that scenario as projects with state_modified_compare_more_unrendered_values set to false do not go through 
+    would only lead to false positives in that scenario as projects with state_modified_compare_more_unrendered_values set to false do not go through
     the statically_parse_unrendered_config call at all.
 
     Similarly, simple built-in generic tests (not_null, unique) are skipped because they have no raw_code config block.
@@ -26,10 +27,18 @@ def upgrade_unrendered_config(manifest: dict) -> dict:
             if _node_is_simple_builtin_generic_test(node):
                 continue
             if node.get("raw_code") and node.get("unrendered_config"):
-                new_unrendered_config_from_code = statically_parse_unrendered_config(node.get("raw_code", "")) or {}
-                manifest["nodes"][unique_id]["unrendered_config"].update(new_unrendered_config_from_code)
+                new_unrendered_config_from_code = (
+                    statically_parse_unrendered_config(node.get("raw_code", "")) or {}
+                )
+                manifest["nodes"][unique_id]["unrendered_config"].update(
+                    new_unrendered_config_from_code
+                )
 
     return manifest
 
+
 def _node_is_simple_builtin_generic_test(node: dict) -> bool:
-    return node.get("resource_type") == "test" and node.get("depends_on", {}).get("macros") in (["macro.dbt.test_not_null"], ["macro.dbt.test_unique"])
+    return node.get("resource_type") == "test" and node.get("depends_on", {}).get("macros") in (
+        ["macro.dbt.test_not_null"],
+        ["macro.dbt.test_unique"],
+    )

--- a/core/dbt/cli/exceptions.py
+++ b/core/dbt/cli/exceptions.py
@@ -21,8 +21,6 @@ class CliException(ClickException):
     The exit_code attribute is used by click to determine which exit code to produce
     after an invocation."""
 
-    exit_code: int  # shadows ClickException's class variable to allow instance assignment
-
     def __init__(self, exit_code: ExitCodes) -> None:
         self.exit_code = exit_code.value  # type: ignore[misc]
 

--- a/core/dbt/cli/exceptions.py
+++ b/core/dbt/cli/exceptions.py
@@ -21,6 +21,8 @@ class CliException(ClickException):
     The exit_code attribute is used by click to determine which exit code to produce
     after an invocation."""
 
+    exit_code: int  # shadows ClickException's class variable to allow instance assignment
+
     def __init__(self, exit_code: ExitCodes) -> None:
         self.exit_code = exit_code.value  # type: ignore[misc]
 

--- a/core/dbt/clients/jinja_static.py
+++ b/core/dbt/clients/jinja_static.py
@@ -249,8 +249,73 @@ def statically_parse_unrendered_config(string: str) -> Optional[Dict[str, Any]]:
     return unrendered_config
 
 
+_COMPARE_OPS = {
+    "eq": "==",
+    "ne": "!=",
+    "lt": "<",
+    "lteq": "<=",
+    "gt": ">",
+    "gteq": ">=",
+    "in": "in",
+    "notin": "not in",
+}
+
+
+def _reconstruct_node(node) -> str:
+    """Reconstruct a Jinja2 AST node back to a source-like expression string."""
+    if isinstance(node, jinja2.nodes.Const):
+        return repr(node.value)
+    if isinstance(node, jinja2.nodes.Name):
+        return node.name
+    if isinstance(node, jinja2.nodes.Call):
+        func = _reconstruct_node(node.node)
+        parts: List[str] = [_reconstruct_node(a) for a in node.args]
+        parts += [f"{kw.key}={_reconstruct_node(kw.value)}" for kw in node.kwargs]
+        if node.dyn_args is not None:
+            parts.append(f"*{_reconstruct_node(node.dyn_args)}")
+        if node.dyn_kwargs is not None:
+            parts.append(f"**{_reconstruct_node(node.dyn_kwargs)}")
+        return f"{func}({', '.join(parts)})"
+    if isinstance(node, jinja2.nodes.List):
+        return f"[{', '.join(_reconstruct_node(i) for i in node.items)}]"
+    if isinstance(node, jinja2.nodes.Tuple):
+        items = [_reconstruct_node(i) for i in node.items]
+        return f"({items[0]},)" if len(items) == 1 else f"({', '.join(items)})"
+    if isinstance(node, jinja2.nodes.Dict):
+        pairs = [f"{_reconstruct_node(p.key)}: {_reconstruct_node(p.value)}" for p in node.items]
+        return "{" + ", ".join(pairs) + "}"
+    if isinstance(node, jinja2.nodes.Getattr):
+        return f"{_reconstruct_node(node.node)}.{node.attr}"
+    if isinstance(node, jinja2.nodes.Getitem):
+        return f"{_reconstruct_node(node.node)}[{_reconstruct_node(node.arg)}]"
+    if isinstance(node, jinja2.nodes.Concat):
+        return " ~ ".join(_reconstruct_node(n) for n in node.nodes)
+    if isinstance(node, jinja2.nodes.Compare):
+        expr = _reconstruct_node(node.expr)
+        ops = " ".join(
+            f"{_COMPARE_OPS.get(op.op, op.op)} {_reconstruct_node(op.expr)}"
+            for op in node.ops
+        )
+        return f"{expr} {ops}"
+    if isinstance(node, jinja2.nodes.Not):
+        return f"not {_reconstruct_node(node.node)}"
+    if isinstance(node, jinja2.nodes.Neg):
+        return f"-{_reconstruct_node(node.node)}"
+    if isinstance(node, jinja2.nodes.And):
+        return f"{_reconstruct_node(node.left)} and {_reconstruct_node(node.right)}"
+    if isinstance(node, jinja2.nodes.Or):
+        return f"{_reconstruct_node(node.left)} or {_reconstruct_node(node.right)}"
+    # Fallback for any unhandled node type — preserves existing behaviour
+    return str(node)
+
+
 def construct_static_kwarg_value(kwarg) -> str:
-    # Instead of trying to re-assemble complex kwarg value, simply stringify the value.
-    # This is still useful to be able to detect changes in unrendered configs, even if it is
-    # not an exact representation of the user input.
-    return str(kwarg)
+    try:
+        # If the final value is a plain string constant, return it without quotes.
+        # Nested string args (e.g. inside env_var) keep their repr() quoting.
+        if isinstance(kwarg.value, jinja2.nodes.Const) and isinstance(kwarg.value.value, str):
+            return kwarg.value.value
+        return _reconstruct_node(kwarg.value)
+    except Exception:
+        # Sensitive codepath — fall back to the original AST repr on any error
+        return str(kwarg)

--- a/core/dbt/clients/jinja_static.py
+++ b/core/dbt/clients/jinja_static.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import jinja2
 
@@ -277,52 +277,59 @@ def construct_static_kwarg_value(kwarg) -> str:
         return str(kwarg)
 
 
+def _reconstruct_call(n: Any) -> str:
+    func = _reconstruct_node(n.node)
+    parts: List[str] = [_reconstruct_node(a) for a in n.args]
+    parts += [f"{kw.key}={_reconstruct_node(kw.value)}" for kw in n.kwargs]
+    if n.dyn_args is not None:
+        parts.append(f"*{_reconstruct_node(n.dyn_args)}")
+    if n.dyn_kwargs is not None:
+        parts.append(f"**{_reconstruct_node(n.dyn_kwargs)}")
+    return f"{func}({', '.join(parts)})"
+
+
+def _reconstruct_tuple(n: Any) -> str:
+    items = [_reconstruct_node(i) for i in n.items]
+    return f"({items[0]},)" if len(items) == 1 else f"({', '.join(items)})"
+
+
+def _reconstruct_dict(n: Any) -> str:
+    pairs = [f"{_reconstruct_node(p.key)}: {_reconstruct_node(p.value)}" for p in n.items]
+    return "{" + ", ".join(pairs) + "}"
+
+
+def _reconstruct_compare(n: Any) -> str:
+    expr = _reconstruct_node(n.expr)
+    ops = " ".join(
+        f"{_COMPARE_OPS.get(op.op, op.op)} {_reconstruct_node(op.expr)}" for op in n.ops
+    )
+    return f"{expr} {ops}"
+
+
+# Dispatch table keyed by exact node type. All keys are concrete leaf classes in
+# the jinja2 AST, so an exact `type(node)` lookup is sufficient.
+_NODE_HANDLERS: Dict[type, Callable[[Any], str]] = {
+    jinja2.nodes.Const: lambda n: repr(n.value),
+    jinja2.nodes.Name: lambda n: n.name,
+    jinja2.nodes.Call: _reconstruct_call,
+    jinja2.nodes.List: lambda n: f"[{', '.join(_reconstruct_node(i) for i in n.items)}]",
+    jinja2.nodes.Tuple: _reconstruct_tuple,
+    jinja2.nodes.Dict: _reconstruct_dict,
+    jinja2.nodes.Getattr: lambda n: f"{_reconstruct_node(n.node)}.{n.attr}",
+    jinja2.nodes.Getitem: lambda n: f"{_reconstruct_node(n.node)}[{_reconstruct_node(n.arg)}]",
+    jinja2.nodes.Concat: lambda n: " ~ ".join(_reconstruct_node(c) for c in n.nodes),
+    jinja2.nodes.Compare: _reconstruct_compare,
+    jinja2.nodes.Not: lambda n: f"not {_reconstruct_node(n.node)}",
+    jinja2.nodes.Neg: lambda n: f"-{_reconstruct_node(n.node)}",
+    jinja2.nodes.And: lambda n: f"{_reconstruct_node(n.left)} and {_reconstruct_node(n.right)}",
+    jinja2.nodes.Or: lambda n: f"{_reconstruct_node(n.left)} or {_reconstruct_node(n.right)}",
+}
+
+
 def _reconstruct_node(node) -> str:
     """Reconstruct a Jinja2 AST node back to a source-like expression string."""
-    # jinja2 nodes define their fields dynamically; mypy stubs don't include them.
-    # `n` is typed Any so attribute access below bypasses the missing-attr errors
-    # while `node` is still used for isinstance checks.
-    n: Any = node
-    if isinstance(node, jinja2.nodes.Const):
-        return repr(n.value)
-    if isinstance(node, jinja2.nodes.Name):
-        return n.name
-    if isinstance(node, jinja2.nodes.Call):
-        func = _reconstruct_node(n.node)
-        parts: List[str] = [_reconstruct_node(a) for a in n.args]
-        parts += [f"{kw.key}={_reconstruct_node(kw.value)}" for kw in n.kwargs]
-        if n.dyn_args is not None:
-            parts.append(f"*{_reconstruct_node(n.dyn_args)}")
-        if n.dyn_kwargs is not None:
-            parts.append(f"**{_reconstruct_node(n.dyn_kwargs)}")
-        return f"{func}({', '.join(parts)})"
-    if isinstance(node, jinja2.nodes.List):
-        return f"[{', '.join(_reconstruct_node(i) for i in n.items)}]"
-    if isinstance(node, jinja2.nodes.Tuple):
-        items = [_reconstruct_node(i) for i in n.items]
-        return f"({items[0]},)" if len(items) == 1 else f"({', '.join(items)})"
-    if isinstance(node, jinja2.nodes.Dict):
-        pairs = [f"{_reconstruct_node(p.key)}: {_reconstruct_node(p.value)}" for p in n.items]
-        return "{" + ", ".join(pairs) + "}"
-    if isinstance(node, jinja2.nodes.Getattr):
-        return f"{_reconstruct_node(n.node)}.{n.attr}"
-    if isinstance(node, jinja2.nodes.Getitem):
-        return f"{_reconstruct_node(n.node)}[{_reconstruct_node(n.arg)}]"
-    if isinstance(node, jinja2.nodes.Concat):
-        return " ~ ".join(_reconstruct_node(child) for child in n.nodes)
-    if isinstance(node, jinja2.nodes.Compare):
-        expr = _reconstruct_node(n.expr)
-        ops = " ".join(
-            f"{_COMPARE_OPS.get(op.op, op.op)} {_reconstruct_node(op.expr)}" for op in n.ops
-        )
-        return f"{expr} {ops}"
-    if isinstance(node, jinja2.nodes.Not):
-        return f"not {_reconstruct_node(n.node)}"
-    if isinstance(node, jinja2.nodes.Neg):
-        return f"-{_reconstruct_node(n.node)}"
-    if isinstance(node, jinja2.nodes.And):
-        return f"{_reconstruct_node(n.left)} and {_reconstruct_node(n.right)}"
-    if isinstance(node, jinja2.nodes.Or):
-        return f"{_reconstruct_node(n.left)} or {_reconstruct_node(n.right)}"
+    handler = _NODE_HANDLERS.get(type(node))
+    if handler is not None:
+        return handler(node)
     # Fallback for any unhandled node type — preserves existing behaviour
     return str(node)

--- a/core/dbt/clients/jinja_static.py
+++ b/core/dbt/clients/jinja_static.py
@@ -328,8 +328,6 @@ _NODE_HANDLERS: Dict[type, Callable[[Any], str]] = {
 
 def _reconstruct_node(node) -> str:
     """Reconstruct a Jinja2 AST node back to a source-like expression string."""
-    handler = _NODE_HANDLERS.get(type(node))
-    if handler is not None:
-        return handler(node)
-    # Fallback for any unhandled node type — preserves existing behaviour
-    return str(node)
+    # `str` is the fallback for any unhandled node type — preserves existing behaviour.
+    handler = _NODE_HANDLERS.get(type(node), str)
+    return handler(node)

--- a/core/dbt/clients/jinja_static.py
+++ b/core/dbt/clients/jinja_static.py
@@ -15,6 +15,16 @@ if typing.TYPE_CHECKING:
 
 
 _TESTING_MACRO_CACHE: Dict[str, Any] = {}
+_COMPARE_OPS = {
+    "eq": "==",
+    "ne": "!=",
+    "lt": "<",
+    "lteq": "<=",
+    "gt": ">",
+    "gteq": ">=",
+    "in": "in",
+    "notin": "not in",
+}
 
 
 def statically_check_has_jinja(source: Optional[str]) -> bool:
@@ -249,73 +259,70 @@ def statically_parse_unrendered_config(string: str) -> Optional[Dict[str, Any]]:
     return unrendered_config
 
 
-_COMPARE_OPS = {
-    "eq": "==",
-    "ne": "!=",
-    "lt": "<",
-    "lteq": "<=",
-    "gt": ">",
-    "gteq": ">=",
-    "in": "in",
-    "notin": "not in",
-}
+def construct_static_kwarg_value(kwarg) -> str:
+    try:
+        # jinja2 nodes define fields dynamically; kw typed Any to avoid attr errors.
+        kw: Any = kwarg
+        kw_val: Any = kw.value
+        # If the final value is a plain string constant, return it without quotes.
+        # Nested string args (e.g. inside env_var) keep their repr() quoting.
+        if isinstance(kw_val, jinja2.nodes.Const):
+            # Re-bind to Any after narrowing so .value access stays untyped.
+            const_val: Any = kw_val
+            if isinstance(const_val.value, str):
+                return const_val.value
+        return _reconstruct_node(kw_val)
+    except Exception:
+        # Sensitive codepath — fall back to the original AST repr on any error
+        return str(kwarg)
 
 
 def _reconstruct_node(node) -> str:
     """Reconstruct a Jinja2 AST node back to a source-like expression string."""
+    # jinja2 nodes define their fields dynamically; mypy stubs don't include them.
+    # `n` is typed Any so attribute access below bypasses the missing-attr errors
+    # while `node` is still used for isinstance checks.
+    n: Any = node
     if isinstance(node, jinja2.nodes.Const):
-        return repr(node.value)
+        return repr(n.value)
     if isinstance(node, jinja2.nodes.Name):
-        return node.name
+        return n.name
     if isinstance(node, jinja2.nodes.Call):
-        func = _reconstruct_node(node.node)
-        parts: List[str] = [_reconstruct_node(a) for a in node.args]
-        parts += [f"{kw.key}={_reconstruct_node(kw.value)}" for kw in node.kwargs]
-        if node.dyn_args is not None:
-            parts.append(f"*{_reconstruct_node(node.dyn_args)}")
-        if node.dyn_kwargs is not None:
-            parts.append(f"**{_reconstruct_node(node.dyn_kwargs)}")
+        func = _reconstruct_node(n.node)
+        parts: List[str] = [_reconstruct_node(a) for a in n.args]
+        parts += [f"{kw.key}={_reconstruct_node(kw.value)}" for kw in n.kwargs]
+        if n.dyn_args is not None:
+            parts.append(f"*{_reconstruct_node(n.dyn_args)}")
+        if n.dyn_kwargs is not None:
+            parts.append(f"**{_reconstruct_node(n.dyn_kwargs)}")
         return f"{func}({', '.join(parts)})"
     if isinstance(node, jinja2.nodes.List):
-        return f"[{', '.join(_reconstruct_node(i) for i in node.items)}]"
+        return f"[{', '.join(_reconstruct_node(i) for i in n.items)}]"
     if isinstance(node, jinja2.nodes.Tuple):
-        items = [_reconstruct_node(i) for i in node.items]
+        items = [_reconstruct_node(i) for i in n.items]
         return f"({items[0]},)" if len(items) == 1 else f"({', '.join(items)})"
     if isinstance(node, jinja2.nodes.Dict):
-        pairs = [f"{_reconstruct_node(p.key)}: {_reconstruct_node(p.value)}" for p in node.items]
+        pairs = [f"{_reconstruct_node(p.key)}: {_reconstruct_node(p.value)}" for p in n.items]
         return "{" + ", ".join(pairs) + "}"
     if isinstance(node, jinja2.nodes.Getattr):
-        return f"{_reconstruct_node(node.node)}.{node.attr}"
+        return f"{_reconstruct_node(n.node)}.{n.attr}"
     if isinstance(node, jinja2.nodes.Getitem):
-        return f"{_reconstruct_node(node.node)}[{_reconstruct_node(node.arg)}]"
+        return f"{_reconstruct_node(n.node)}[{_reconstruct_node(n.arg)}]"
     if isinstance(node, jinja2.nodes.Concat):
-        return " ~ ".join(_reconstruct_node(n) for n in node.nodes)
+        return " ~ ".join(_reconstruct_node(child) for child in n.nodes)
     if isinstance(node, jinja2.nodes.Compare):
-        expr = _reconstruct_node(node.expr)
+        expr = _reconstruct_node(n.expr)
         ops = " ".join(
-            f"{_COMPARE_OPS.get(op.op, op.op)} {_reconstruct_node(op.expr)}"
-            for op in node.ops
+            f"{_COMPARE_OPS.get(op.op, op.op)} {_reconstruct_node(op.expr)}" for op in n.ops
         )
         return f"{expr} {ops}"
     if isinstance(node, jinja2.nodes.Not):
-        return f"not {_reconstruct_node(node.node)}"
+        return f"not {_reconstruct_node(n.node)}"
     if isinstance(node, jinja2.nodes.Neg):
-        return f"-{_reconstruct_node(node.node)}"
+        return f"-{_reconstruct_node(n.node)}"
     if isinstance(node, jinja2.nodes.And):
-        return f"{_reconstruct_node(node.left)} and {_reconstruct_node(node.right)}"
+        return f"{_reconstruct_node(n.left)} and {_reconstruct_node(n.right)}"
     if isinstance(node, jinja2.nodes.Or):
-        return f"{_reconstruct_node(node.left)} or {_reconstruct_node(node.right)}"
+        return f"{_reconstruct_node(n.left)} or {_reconstruct_node(n.right)}"
     # Fallback for any unhandled node type — preserves existing behaviour
     return str(node)
-
-
-def construct_static_kwarg_value(kwarg) -> str:
-    try:
-        # If the final value is a plain string constant, return it without quotes.
-        # Nested string args (e.g. inside env_var) keep their repr() quoting.
-        if isinstance(kwarg.value, jinja2.nodes.Const) and isinstance(kwarg.value.value, str):
-            return kwarg.value.value
-        return _reconstruct_node(kwarg.value)
-    except Exception:
-        # Sensitive codepath — fall back to the original AST repr on any error
-        return str(kwarg)

--- a/tests/functional/defer_state/test_modified_state_schema_evolution.py
+++ b/tests/functional/defer_state/test_modified_state_schema_evolution.py
@@ -38,3 +38,13 @@ class TestModifiedStateSchemaEvolution:
 
         # No false positives when no project changes are made
         assert len(results) == 0
+
+
+class TestSchemaEvolutionCompareMoreUnrenderedValues(TestModifiedStateSchemaEvolution):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {
+                "state_modified_compare_more_unrendered_values": True,
+            }
+        }

--- a/tests/unit/clients/test_jinja_static.py
+++ b/tests/unit/clients/test_jinja_static.py
@@ -85,10 +85,16 @@ class TestStaticallyParseUnrenderedConfig:
     @pytest.mark.parametrize(
         "expression,expected_unrendered_config",
         [
+            # plain string — returned without quotes at the top level
             (
                 "{{ config(materialized='view') }}",
                 {"materialized": "view"},
             ),
+            (
+                '{{ config(materialized="view") }}',
+                {"materialized": "view"},
+            ),
+            # multiple kwargs
             (
                 "{{ config(materialized='view', enabled=True) }}",
                 {
@@ -96,23 +102,137 @@ class TestStaticallyParseUnrenderedConfig:
                     "enabled": "True",
                 },
             ),
+            # macro call — string args keep repr() quoting
             (
                 "{{ config(materialized=env_var('test')) }}",
                 {"materialized": "env_var('test')"},
             ),
+            # nested keyword arg in macro call
             (
                 "{{ config(materialized=env_var('test', default='default')) }}",
                 {"materialized": "env_var('test', default='default')"},
             ),
+            # doubly nested macro calls
             (
                 "{{ config(materialized=env_var('test', default=env_var('default'))) }}",
                 {"materialized": "env_var('test', default=env_var('default'))"},
+            ),
+            # var() call
+            (
+                "{{ config(enabled=var('is_enabled')) }}",
+                {"enabled": "var('is_enabled')"},
+            ),
+            # integer constant
+            (
+                "{{ config(hours_to_expiration=24) }}",
+                {"hours_to_expiration": "24"},
+            ),
+            # None / Jinja2 `none`
+            (
+                "{{ config(full_refresh=none) }}",
+                {"full_refresh": "None"},
+            ),
+            # list literal
+            (
+                "{{ config(tags=['t1', 't2']) }}",
+                {"tags": "['t1', 't2']"},
+            ),
+            # dict literal
+            (
+                "{{ config(meta={'owner': 'alice'}) }}",
+                {"meta": "{'owner': 'alice'}"},
+            ),
+            # attribute access
+            (
+                "{{ config(alias=target.name) }}",
+                {"alias": "target.name"},
+            ),
+            # comparison expression
+            (
+                "{{ config(full_refresh=target.name == 'prod') }}",
+                {"full_refresh": "target.name == 'prod'"},
+            ),
+            # ~ string concatenation
+            (
+                "{{ config(alias='prefix_' ~ target.schema) }}",
+                {"alias": "'prefix_' ~ target.schema"},
+            ),
+            # not operator
+            (
+                "{{ config(enabled=not true) }}",
+                {"enabled": "not True"},
+            ),
+            # config call with surrounding SQL
+            (
+                "{{ config(materialized='table') }}\nselect 1 as id",
+                {"materialized": "table"},
+            ),
+            # empty config call
+            (
+                "{{ config() }}",
+                {},
+            ),
+            # False boolean
+            (
+                "{{ config(enabled=false) }}",
+                {"enabled": "False"},
+            ),
+            # float constant
+            (
+                "{{ config(some_ratio=0.5) }}",
+                {"some_ratio": "0.5"},
+            ),
+            # negative number (Neg node)
+            (
+                "{{ config(hours_to_expiration=-1) }}",
+                {"hours_to_expiration": "-1"},
+            ),
+            # != comparison
+            (
+                "{{ config(full_refresh=target.name != 'prod') }}",
+                {"full_refresh": "target.name != 'prod'"},
+            ),
+            # in operator with list
+            (
+                "{{ config(enabled=target.name in ['prod', 'staging']) }}",
+                {"enabled": "target.name in ['prod', 'staging']"},
+            ),
+            # and operator
+            (
+                "{{ config(enabled=var('x') and true) }}",
+                {"enabled": "var('x') and True"},
+            ),
+            # or operator
+            (
+                "{{ config(enabled=var('x') or false) }}",
+                {"enabled": "var('x') or False"},
+            ),
+            # list of dicts (BigQuery grants pattern)
+            (
+                "{{ config(grant_access_to=[{'project': 'p', 'dataset': 'd'}]) }}",
+                {"grant_access_to": "[{'project': 'p', 'dataset': 'd'}]"},
+            ),
+            # getitem access
+            (
+                "{{ config(alias=var('aliases')['my_model']) }}",
+                {"alias": "var('aliases')['my_model']"},
             ),
         ],
     )
     def test_statically_parse_unrendered_config(self, expression, expected_unrendered_config):
         unrendered_config = statically_parse_unrendered_config(expression)
         assert unrendered_config == expected_unrendered_config
+
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "select 1 as id",
+            "{{ ref('my_model') }}",
+            "{% set x = 1 %}",
+        ],
+    )
+    def test_statically_parse_unrendered_config_no_config_call(self, expression):
+        assert statically_parse_unrendered_config(expression) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/clients/test_jinja_static.py
+++ b/tests/unit/clients/test_jinja_static.py
@@ -87,32 +87,26 @@ class TestStaticallyParseUnrenderedConfig:
         [
             (
                 "{{ config(materialized='view') }}",
-                {"materialized": "Keyword(key='materialized', value=Const(value='view'))"},
+                {"materialized": "view"},
             ),
             (
                 "{{ config(materialized='view', enabled=True) }}",
                 {
-                    "materialized": "Keyword(key='materialized', value=Const(value='view'))",
-                    "enabled": "Keyword(key='enabled', value=Const(value=True))",
+                    "materialized": "view",
+                    "enabled": "True",
                 },
             ),
             (
                 "{{ config(materialized=env_var('test')) }}",
-                {
-                    "materialized": "Keyword(key='materialized', value=Call(node=Name(name='env_var', ctx='load'), args=[Const(value='test')], kwargs=[], dyn_args=None, dyn_kwargs=None))"
-                },
+                {"materialized": "env_var('test')"},
             ),
             (
                 "{{ config(materialized=env_var('test', default='default')) }}",
-                {
-                    "materialized": "Keyword(key='materialized', value=Call(node=Name(name='env_var', ctx='load'), args=[Const(value='test')], kwargs=[Keyword(key='default', value=Const(value='default'))], dyn_args=None, dyn_kwargs=None))"
-                },
+                {"materialized": "env_var('test', default='default')"},
             ),
             (
                 "{{ config(materialized=env_var('test', default=env_var('default'))) }}",
-                {
-                    "materialized": "Keyword(key='materialized', value=Call(node=Name(name='env_var', ctx='load'), args=[Const(value='test')], kwargs=[Keyword(key='default', value=Call(node=Name(name='env_var', ctx='load'), args=[Const(value='default')], kwargs=[], dyn_args=None, dyn_kwargs=None))], dyn_args=None, dyn_kwargs=None))"
-                },
+                {"materialized": "env_var('test', default=env_var('default'))"},
             ),
         ],
     )


### PR DESCRIPTION
## Summary

- Replaces the raw Jinja2 AST repr in `construct_static_kwarg_value` with a recursive `_reconstruct_node` pretty-printer that rebuilds config kwarg values as readable source-like expressions (e.g. `env_var('DBT_TEST_STATE_MODIFIED')` instead of the full AST string)
- Top-level plain-string values (e.g. `materialized='view'`) are returned without extra quotes; nested string args inside macro calls keep their `repr()` quoting
- Falls back to the original `str(kwarg)` on any exception to protect this sensitive parse-time codepath
- Only reached when `state_modified_compare_more_unrendered_values` flag is true

## Test plan

- [x] Existing `TestStaticallyParseUnrenderedConfig` unit tests updated and passing
- [x] Manual verification of output format for common config patterns (`Const`, `Call`, `List`, `Dict`, `Getattr`, `Compare`, `Concat`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)