### PR TITLE
Show resource type env vars in CLI help

### DIFF
--- a/.changes/unreleased/Fixes-20260625-185134.yaml
+++ b/.changes/unreleased/Fixes-20260625-185134.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Show DBT_RESOURCE_TYPES and DBT_EXCLUDE_RESOURCE_TYPES in CLI help for resource type filters
+time: 2026-06-25T18:51:34Z
+custom:
+    author: AMBRA7592
+    issue: "15341"
+    project: dbt-core

--- a/crates/dbt-clap-core/src/lib.rs
+++ b/crates/dbt-clap-core/src/lib.rs
@@ -73,6 +73,8 @@ pub mod help_headings {
     pub const ADVANCED: &str = "Advanced";
 }
 const MANAGE_STATE_ENV: &str = "DBT_ENGINE_MANAGE_STATE";
+const RESOURCE_TYPES_ENV: &str = "DBT_RESOURCE_TYPES";
+const EXCLUDE_RESOURCE_TYPES_ENV: &str = "DBT_EXCLUDE_RESOURCE_TYPES";
 const USER_SETTINGS_YML: &str = ".dbt/user_settings.yml";
 
 // defined in pretty string, but copied here to avoid cycle...
@@ -563,11 +565,23 @@ pub struct CompileArgs {
     pub inline: Option<String>,
 
     /// Select nodes of a specific type;
-    #[arg(long, num_args(1..), value_delimiter = ' ', aliases = ["resource-types"])]
+    #[arg(
+        long,
+        num_args(1..),
+        value_delimiter = ' ',
+        aliases = ["resource-types"],
+        env = RESOURCE_TYPES_ENV
+    )]
     pub resource_type: Option<Vec<ClapResourceType>>,
 
     /// Exclude nodes of a specific type;
-    #[arg(long, num_args(1..), value_delimiter = ' ', aliases = ["exclude-resource-types"])]
+    #[arg(
+        long,
+        num_args(1..),
+        value_delimiter = ' ',
+        aliases = ["exclude-resource-types"],
+        env = EXCLUDE_RESOURCE_TYPES_ENV
+    )]
     pub exclude_resource_type: Option<Vec<ClapResourceType>>,
 
     /// Limiting number of shown rows. Run with --limit -1 to remove limit [default: 10]
@@ -728,11 +742,23 @@ pub struct ShowArgs {
     pub inline: Option<String>,
 
     /// Select nodes of a specific type;
-    #[arg(long, num_args(1..), value_delimiter = ' ', aliases = ["resource-types"])]
+    #[arg(
+        long,
+        num_args(1..),
+        value_delimiter = ' ',
+        aliases = ["resource-types"],
+        env = RESOURCE_TYPES_ENV
+    )]
     pub resource_type: Option<Vec<ClapResourceType>>,
 
     /// Exclude nodes of a specific type;
-    #[arg(long, num_args(1..), value_delimiter = ' ', aliases = ["exclude-resource-types"])]
+    #[arg(
+        long,
+        num_args(1..),
+        value_delimiter = ' ',
+        aliases = ["exclude-resource-types"],
+        env = EXCLUDE_RESOURCE_TYPES_ENV
+    )]
     pub exclude_resource_type: Option<Vec<ClapResourceType>>,
 
     /// Limiting number of shown rows. Run with --limit -1 to remove limit [default: 10]
@@ -916,11 +942,23 @@ pub struct BuildArgs {
     pub common_args: CommonArgs,
 
     /// Select nodes of a specific type;
-    #[arg(long, num_args(1..), value_delimiter = ' ', aliases = ["resource-types"])]
+    #[arg(
+        long,
+        num_args(1..),
+        value_delimiter = ' ',
+        aliases = ["resource-types"],
+        env = RESOURCE_TYPES_ENV
+    )]
     pub resource_type: Option<Vec<ClapResourceType>>,
 
     /// Exclude nodes of a specific type;
-    #[arg(long, num_args(1..), value_delimiter = ' ', aliases = ["exclude-resource-types"])]
+    #[arg(
+        long,
+        num_args(1..),
+        value_delimiter = ' ',
+        aliases = ["exclude-resource-types"],
+        env = EXCLUDE_RESOURCE_TYPES_ENV
+    )]
     pub exclude_resource_type: Option<Vec<ClapResourceType>>,
 
     /// Enable optimizations (testaggregation, testreuse)
@@ -1032,11 +1070,23 @@ pub struct ListArgs {
     pub output_keys: Vec<String>,
 
     /// Select nodes of a specific type;
-    #[arg(long, num_args(1..), value_delimiter = ' ', aliases = ["resource-types"])]
+    #[arg(
+        long,
+        num_args(1..),
+        value_delimiter = ' ',
+        aliases = ["resource-types"],
+        env = RESOURCE_TYPES_ENV
+    )]
     pub resource_type: Option<Vec<ClapResourceType>>,
 
     /// Exclude nodes of a specific type;
-    #[arg(long, num_args(1..), value_delimiter = ' ', aliases = ["exclude-resource-types"])]
+    #[arg(
+        long,
+        num_args(1..),
+        value_delimiter = ' ',
+        aliases = ["exclude-resource-types"],
+        env = EXCLUDE_RESOURCE_TYPES_ENV
+    )]
     pub exclude_resource_type: Option<Vec<ClapResourceType>>,
 }
 
@@ -2679,6 +2729,18 @@ pub fn from_lib(cli: &Cli) -> SystemArgs {
 mod tests {
     use super::*;
 
+    struct NoExtensionCommandParser;
+
+    impl ExtensionCommandParser for NoExtensionCommandParser {
+        fn has_subcommand(&self, _name: &str) -> bool {
+            false
+        }
+    }
+
+    fn test_parser() -> CliParser {
+        CliParser::new("dbt", "test", Box::new(NoExtensionCommandParser))
+    }
+
     fn get_manage_state_with_env(
         common_args: &CommonArgs,
         project_dir: &Path,
@@ -2690,6 +2752,55 @@ mod tests {
             env_value.map(OsString::from),
             user_settings_path,
         )
+    }
+
+    #[test]
+    fn build_resource_type_help_shows_env_vars() {
+        let err = test_parser()
+            .try_parse_from(["dbt", "build", "--help"])
+            .unwrap_err();
+        let help = err.to_string();
+
+        assert!(help.contains("[env: DBT_RESOURCE_TYPES=]"), "{help}");
+        assert!(
+            help.contains("[env: DBT_EXCLUDE_RESOURCE_TYPES=]"),
+            "{help}"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    fn build_resource_type_filters_read_env_vars() {
+        static RESOURCE_TYPES_ENV_LOCK: std::sync::Mutex<()> =
+            std::sync::Mutex::new(());
+
+        let _guard = RESOURCE_TYPES_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            env::set_var(RESOURCE_TYPES_ENV, "model seed");
+            env::set_var(EXCLUDE_RESOURCE_TYPES_ENV, "test");
+        }
+
+        let cli = test_parser().try_parse_from(["dbt", "build"]).unwrap();
+
+        unsafe {
+            env::remove_var(RESOURCE_TYPES_ENV);
+            env::remove_var(EXCLUDE_RESOURCE_TYPES_ENV);
+        }
+
+        let Command::Core(CoreCommand::Build(build_args)) = &cli.command else {
+            panic!("expected build command");
+        };
+
+        assert_eq!(
+            build_args.resource_type,
+            Some(vec![ClapResourceType::Model, ClapResourceType::Seed])
+        );
+        assert_eq!(
+            build_args.exclude_resource_type,
+            Some(vec![ClapResourceType::Test])
+        );
     }
 
     #[test]

--- a/crates/dbt-main/src/vars.rs
+++ b/crates/dbt-main/src/vars.rs
@@ -19,6 +19,7 @@ const ALIASABLE_ENV_VARS: &[&str] = &[
     "DBT_DISABLE_VERSION_CHECK",
     "DBT_EVENT_TIME_END",
     "DBT_EVENT_TIME_START",
+    "DBT_EXCLUDE_RESOURCE_TYPES",
     "DBT_EXPORT_SAVED_QUERIES",
     "DBT_EXPORT_TO_OTLP",
     "DBT_FAIL_FAST",
@@ -56,6 +57,7 @@ const ALIASABLE_ENV_VARS: &[&str] = &[
     "DBT_PROFILES_DIR",
     "DBT_PROJECT_DIR",
     "DBT_QUIET",
+    "DBT_RESOURCE_TYPES",
     "DBT_SAMPLE",
     "DBT_SEND_ANONYMOUS_USAGE_STATS",
     "DBT_SHOW_ALL_DEPRECATIONS",
@@ -89,7 +91,6 @@ const KNOWN_UNUSED_ENGINE_ENV_VARS: &[&str] = &[
     "DBT_ENGINE_DEFER_TO_STATE",
     "DBT_ENGINE_DOWNLOAD_DIR",
     "DBT_ENGINE_EMPTY",
-    "DBT_ENGINE_EXCLUDE_RESOURCE_TYPES",
     "DBT_ENGINE_FAVOR_STATE_MODE",
     "DBT_ENGINE_HOST",
     "DBT_ENGINE_INCLUDE_SAVED_QUERY",
@@ -99,7 +100,6 @@ const KNOWN_UNUSED_ENGINE_ENV_VARS: &[&str] = &[
     "DBT_ENGINE_PP_FILE_DIFF_TEST",
     "DBT_ENGINE_PP_TEST",
     "DBT_ENGINE_RECORDED_FILE_PATH",
-    "DBT_ENGINE_RESOURCE_TYPES",
     "DBT_ENGINE_SHOW_RESOURCE_REPORT",
     "DBT_ENGINE_SQLPARSE",
     "DBT_ENGINE_TEST_STATE_MODIFIED",
@@ -421,6 +421,57 @@ mod tests {
         unsafe {
             #[allow(clippy::disallowed_methods)]
             std::env::remove_var("DBT_ENGINE_FAIL_FAST");
+        }
+    }
+
+    #[test]
+    fn resource_type_engine_env_vars_are_supported_aliases() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+
+        unsafe {
+            #[allow(clippy::disallowed_methods)]
+            std::env::remove_var("DBT_RESOURCE_TYPES");
+            #[allow(clippy::disallowed_methods)]
+            std::env::remove_var("DBT_ENGINE_RESOURCE_TYPES");
+            #[allow(clippy::disallowed_methods)]
+            std::env::remove_var("DBT_EXCLUDE_RESOURCE_TYPES");
+            #[allow(clippy::disallowed_methods)]
+            std::env::remove_var("DBT_ENGINE_EXCLUDE_RESOURCE_TYPES");
+            #[allow(clippy::disallowed_methods)]
+            std::env::set_var("DBT_ENGINE_RESOURCE_TYPES", "model seed");
+            #[allow(clippy::disallowed_methods)]
+            std::env::set_var("DBT_ENGINE_EXCLUDE_RESOURCE_TYPES", "test");
+        }
+
+        apply_engine_env_var_aliases();
+        let unused = warn_unused_engine_env_vars();
+
+        assert_eq!(
+            std::env::var("DBT_RESOURCE_TYPES").ok(),
+            Some("model seed".to_string())
+        );
+        assert_eq!(
+            std::env::var("DBT_EXCLUDE_RESOURCE_TYPES").ok(),
+            Some("test".to_string())
+        );
+        assert!(
+            !unused.contains(&"DBT_ENGINE_RESOURCE_TYPES".to_string()),
+            "should not report DBT_ENGINE_RESOURCE_TYPES as unused"
+        );
+        assert!(
+            !unused.contains(&"DBT_ENGINE_EXCLUDE_RESOURCE_TYPES".to_string()),
+            "should not report DBT_ENGINE_EXCLUDE_RESOURCE_TYPES as unused"
+        );
+
+        unsafe {
+            #[allow(clippy::disallowed_methods)]
+            std::env::remove_var("DBT_RESOURCE_TYPES");
+            #[allow(clippy::disallowed_methods)]
+            std::env::remove_var("DBT_ENGINE_RESOURCE_TYPES");
+            #[allow(clippy::disallowed_methods)]
+            std::env::remove_var("DBT_EXCLUDE_RESOURCE_TYPES");
+            #[allow(clippy::disallowed_methods)]
+            std::env::remove_var("DBT_ENGINE_EXCLUDE_RESOURCE_TYPES");
         }
     }
 }


### PR DESCRIPTION
Resolves #15341

### Problem

The CLI help for resource type filters does not show the documented `DBT_RESOURCE_TYPES` and `DBT_EXCLUDE_RESOURCE_TYPES` environment variables. The engine-prefixed variants are also currently treated as unsupported instead of being aliased to the classic `DBT_*` names.

### Solution

- Add `env` metadata for `--resource-type` / `--exclude-resource-type` on `compile`, `show`, `build`, and `list`.
- Add `DBT_RESOURCE_TYPES` and `DBT_EXCLUDE_RESOURCE_TYPES` to the engine env-var alias list.
- Stop reporting `DBT_ENGINE_RESOURCE_TYPES` and `DBT_ENGINE_EXCLUDE_RESOURCE_TYPES` as unused engine env vars.
- Add regression coverage for help output, env parsing, and alias handling.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue. `cargo`/`rustc` are not installed in this local environment.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

Validation run locally:

- `git diff --check`

Not run locally:

- `cargo fmt --check`
- `cargo test`

This machine does not currently have a Rust toolchain installed.
