### PR TITLE
Fix mypy failure caused by Click 8.4.2 ClassVar annotation changes

### DIFF
--- a/core/dbt/cli/exceptions.py
+++ b/core/dbt/cli/exceptions.py
@@ -21,6 +21,8 @@ class CliException(ClickException):
     The exit_code attribute is used by click to determine which exit code to produce
     after an invocation."""
 
+    exit_code: int  # Overrides ClickException's class variable to permit instance-level assignment
+
     def __init__(self, exit_code: ExitCodes) -> None:
         self.exit_code = exit_code.value
 


### PR DESCRIPTION
# Summary of Changes

## 1. What Changed

* Added an explicit instance attribute declaration:

  ```python
  exit_code: int
  ```
* This shadows the inherited `ClickException.exit_code` class variable, allowing `exit_code` to be assigned on individual exception instances.

## 2. Why Changed
* CI failure on `1.latest`, `1.11.latest`, `1.12.latest` — mypy breaking due to Click 8.4.2
* What's failing: The `code-quality` job (pre-commit mypy hook) has been failing since ~June 24 19:00 UTC.
* Root cause: Click released `8.4.2`, which added an explicit `ClassVar[int]` annotation to `ClickException.exit_code`. Our `core/dbt/cli/exceptions.py` subclasses `ClickException` and assigns to `self.exit_code` in __init__, which mypy 1.4.1 now correctly rejects as a class variable assignment.
Since click>=8.3.0,<9.0 has no tight upper bound and there's no lockfile, pip silently upgraded from `8.4.1` → `8.4.2` on fresh CI runners.

