### PR TITLE
Fix mypy failure caused by Click 8.4.2 ClassVar annotation changes

### DIFF
--- a/core/dbt/cli/exceptions.py
+++ b/core/dbt/cli/exceptions.py
@@ -21,10 +21,8 @@ class CliException(ClickException):
     The exit_code attribute is used by click to determine which exit code to produce
     after an invocation."""
 
-    exit_code: int  # Overrides ClickException's class variable to permit instance-level assignment
-
     def __init__(self, exit_code: ExitCodes) -> None:
-        self.exit_code = exit_code.value
+        self.exit_code = exit_code.value  # type: ignore[misc]
 
     # the typing of _file is to satisfy the signature of ClickException.show
     # overriding this method prevents click from printing any exceptions to stdout

--- a/core/dbt/cli/exceptions.py
+++ b/core/dbt/cli/exceptions.py
@@ -21,6 +21,8 @@ class CliException(ClickException):
     The exit_code attribute is used by click to determine which exit code to produce
     after an invocation."""
 
+    exit_code: int  # Overrides ClickException's class variable to permit instance-level assignment
+
     def __init__(self, exit_code: ExitCodes) -> None:
         self.exit_code = exit_code.value
 


### PR DESCRIPTION
# Summary of Changes

## 1. What Changed

Removed a bare instance-variable annotation (exit_code: int) from CliException and replaced it with a scoped # type: ignore[misc] on the assignment:

  ```python
  # Before 
self.exit_code = exit_code.value

# After
self.exit_code = exit_code.value  # type: ignore[misc]  
  ```

## 2. Why Changed
* CI failure on `1.latest`, `1.11.latest`, `1.12.latest` — the `code-quality` job (pre-commit mypy hook) began failing ~June 24.

* Root cause: Click released `8.4.2`, which added an explicit `ClassVar[int]` annotation to `ClickException.exit_code`. `CliException` subclasses ClickException and assigns `self.exit_code` per-instance in `__init__`, which mypy 1.4.1 now correctly rejects.

* Since `click>=8.3.0,<9.0` has no tight upper bound and there is no lockfile, pip silently resolved `8.4.1` → `8.4.2` on fresh CI runners between runs on the same commit.