### PR TITLE
fix: name where an env var was required in EnvVarMissingError (#10803)

### DIFF
--- a/.changes/unreleased/Fixes-20260627-165705-10803.yaml
+++ b/.changes/unreleased/Fixes-20260627-165705-10803.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Include the location (model file, or profiles.yml/dbt_project.yml) in the "Env
+  var required but not provided" error so it says where the env var was required
+time: 2026-06-27T16:57:05.000000000Z
+custom:
+    Author: nikolauspschuetz
+    Issue: "10803"

--- a/core/dbt/context/configured.py
+++ b/core/dbt/context/configured.py
@@ -106,7 +106,7 @@ class SchemaYamlContext(ConfiguredContext):
 
             return return_value
         else:
-            raise EnvVarMissingError(var)
+            raise EnvVarMissingError(var, source=f"project '{self._project_name}'")
 
 
 class MacroResolvingContext(ConfiguredContext):

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1782,7 +1782,7 @@ class ProviderContext(ManifestContext):
                         source_file.env_vars.append(var)  # type: ignore[union-attr]
             return return_value
         else:
-            raise EnvVarMissingError(var)
+            raise EnvVarMissingError(var, node=self.model)
 
     @contextproperty()
     def selected_resources(self) -> List[str]:
@@ -2300,7 +2300,7 @@ class TestContext(ProviderContext):
                     source_file.add_env_var(var, yaml_key, name)  # type: ignore[union-attr]
             return return_value
         else:
-            raise EnvVarMissingError(var)
+            raise EnvVarMissingError(var, node=self.model)
 
 
 def generate_test_context(

--- a/core/dbt/context/secret.py
+++ b/core/dbt/context/secret.py
@@ -50,7 +50,7 @@ class SecretContext(BaseContext):
                 self.env_vars[var] = return_value if found_in_env else DEFAULT_ENV_PLACEHOLDER
             return return_value
         else:
-            raise EnvVarMissingError(var)
+            raise EnvVarMissingError(var, source="profiles.yml or packages.yml")
 
 
 def generate_secret_context(cli_vars: Dict[str, Any]) -> Dict[str, Any]:

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -856,12 +856,19 @@ class TestTypeError(ParsingError):
 
 # This is triggered across multiple files
 class EnvVarMissingError(ParsingError):
-    def __init__(self, var: str):
+    def __init__(self, var: str, node=None, source: Optional[str] = None):
+        # `node` lets the base error append the file location (e.g. the model
+        # that called env_var). For node-less contexts (profiles.yml,
+        # dbt_project.yml/schema.yml) there is no node, so `source` names where
+        # the env var was required instead.
         self.var = var
-        super().__init__(msg=self.get_message())
+        self.source = source
+        super().__init__(msg=self.get_message(), node=node)
 
     def get_message(self) -> str:
         msg = f"Env var required but not provided: '{self.var}'"
+        if self.source is not None:
+            msg += f" (required in {self.source})"
         return msg
 
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+from dbt.exceptions import EnvVarMissingError
+from dbt.tests.util import safe_set_invocation_context
+
+
+class TestEnvVarMissingError:
+    """Regression tests for #10803: a missing env var error should say *where*
+    the env var was required."""
+
+    def test_message_without_context_is_unchanged(self):
+        # Node-less call with no source keeps the original, backwards-compatible message.
+        exc = EnvVarMissingError("DBT_MISSING")
+        assert exc.get_message() == "Env var required but not provided: 'DBT_MISSING'"
+
+    def test_source_is_included_for_node_less_contexts(self):
+        # profiles.yml / dbt_project.yml contexts have no node, so they pass `source`.
+        exc = EnvVarMissingError("DBT_DATABASE", source="profiles.yml or packages.yml")
+        message = exc.get_message()
+        assert "Env var required but not provided: 'DBT_DATABASE'" in message
+        assert "(required in profiles.yml or packages.yml)" in message
+
+    def test_node_location_is_included_for_model_contexts(self):
+        # Model contexts pass `node`; the base error appends the file location.
+        safe_set_invocation_context()
+        node = SimpleNamespace(
+            resource_type="model",
+            name="my_model",
+            original_file_path="models/my_model.sql",
+        )
+        exc = EnvVarMissingError("DBT_MISSING", node=node)
+        rendered = str(exc)
+        assert "DBT_MISSING" in rendered
+        assert "models/my_model.sql" in rendered


### PR DESCRIPTION
### Resolves #10803

#### Problem
When `env_var('FOO')` is called and `FOO` is unset, dbt raises:

```
Env var required but not provided: 'FOO'
```

The message gives no indication of **where** the env var was required. In a large project with many models/profiles, this is hard to track down. (Reported case: `DBT_DATABASE` set via `profiles.yml`.)

#### Fix
`EnvVarMissingError` now accepts optional `node` and `source`:

- **Model / test contexts** (`context/providers.py`) pass `node=self.model`, so the base error appends the model's file location:
  ```
  Env var required but not provided: 'FOO' in model my_model (models/my_model.sql)
  ```
- **Node-less contexts** pass `source` to name the origin directly in the message:
  - `context/secret.py` (profiles.yml / packages.yml — the reporter's path): `(required in profiles.yml or packages.yml)`
  - `context/configured.py` (schema.yml / dbt_project.yml): `(required in project '<name>')`

Both parameters default to `None`, so the message is **unchanged** where no location is reachable (the generic `context/base.py` context is intentionally left as-is).

#### Tests
Adds `tests/unit/test_exceptions.py` covering:
- the unchanged baseline message (backwards compatibility),
- the `source`-enriched message for node-less contexts,
- the node file-path rendering for model contexts.

Local run (Python 3.11): `tests/unit/test_exceptions.py` 3 passed; `tests/unit/context` + `tests/unit/test_env_vars.py` 85 passed (no regression).

#### Notes
- Builds on the approach in #12732 (voluntarily closed), extending it to the node-less profile/project sites that the original case actually hit, and adding tests.
- Changelog entry added via changie (`Fixes`, issue 10803).