### PR TITLE
Use DBT_MANAGE_STATE for manage-state help

### DIFF
--- a/.changes/unreleased/Fixes-20260627-214500.yaml
+++ b/.changes/unreleased/Fixes-20260627-214500.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Show `DBT_MANAGE_STATE` for the `--manage-state` CLI help environment variable while continuing to accept `DBT_ENGINE_MANAGE_STATE` as an alias.
+time: 2026-06-27T21:45:00+02:00
+custom:
+    author: AMBRA7592
+    issue: "15343"
+    project: dbt-fusion

--- a/crates/dbt-clap-core/src/lib.rs
+++ b/crates/dbt-clap-core/src/lib.rs
@@ -72,7 +72,8 @@ pub mod help_headings {
     pub const SAMPLE: &str = "Sample";
     pub const ADVANCED: &str = "Advanced";
 }
-const MANAGE_STATE_ENV: &str = "DBT_ENGINE_MANAGE_STATE";
+const MANAGE_STATE_ENV: &str = "DBT_MANAGE_STATE";
+const LEGACY_ENGINE_MANAGE_STATE_ENV: &str = "DBT_ENGINE_MANAGE_STATE";
 const USER_SETTINGS_YML: &str = ".dbt/user_settings.yml";
 
 // defined in pretty string, but copied here to avoid cycle...
@@ -2189,7 +2190,8 @@ impl CommonArgs {
     pub fn get_manage_state(&self, project_dir: &Path) -> bool {
         self.get_manage_state_with(
             project_dir,
-            env::var_os(MANAGE_STATE_ENV),
+            env::var_os(MANAGE_STATE_ENV)
+                .or_else(|| env::var_os(LEGACY_ENGINE_MANAGE_STATE_ENV)),
             user_settings_path(),
         )
     }

--- a/crates/dbt-common/src/io_args.rs
+++ b/crates/dbt-common/src/io_args.rs
@@ -491,7 +491,7 @@ pub struct EvalArgs {
     pub export_saved_queries: bool,
     pub task_cache_url: String,
     /// Whether dbt State management (auto-deferral) is enabled, resolved from
-    /// `--manage-state`, `DBT_ENGINE_MANAGE_STATE`, or `flags.manage_state` in
+    /// `--manage-state`, `DBT_MANAGE_STATE`, or `flags.manage_state` in
     /// dbt_project.yml / user settings. Also surfaced on the invocation telemetry
     /// span as `manage_state`.
     pub run_cache_service: bool,

--- a/crates/dbt-common/src/tracing/invocation.rs
+++ b/crates/dbt-common/src/tracing/invocation.rs
@@ -53,7 +53,7 @@ fn create_invocation_eval_args(eval_arg: &EvalArgs) -> InvocationEvalArgs {
         write_json: Some(eval_arg.write_json),
         write_catalog: Some(eval_arg.write_catalog),
         // `run_cache_service` holds the resolved dbt State management flag
-        // (--manage-state / DBT_ENGINE_MANAGE_STATE / flags.manage_state).
+        // (--manage-state / DBT_MANAGE_STATE / flags.manage_state).
         manage_state: Some(eval_arg.run_cache_service),
     }
 }

--- a/crates/dbt-login/src/state_guidance.rs
+++ b/crates/dbt-login/src/state_guidance.rs
@@ -4,7 +4,8 @@ use dbt_common::{ErrorCode, FsResult, fs_err};
 use dbt_platform_auth::Credential;
 use dbt_schemas::schemas::UserSettings;
 
-const MANAGE_STATE_ENV: &str = "DBT_ENGINE_MANAGE_STATE";
+const MANAGE_STATE_ENV: &str = "DBT_MANAGE_STATE";
+const LEGACY_ENGINE_MANAGE_STATE_ENV: &str = "DBT_ENGINE_MANAGE_STATE";
 
 // ── State config detection ────────────────────────────────────────────────────
 
@@ -19,7 +20,7 @@ pub enum StateConfigSource {
 impl StateConfigSource {
     fn inline_description(self) -> &'static str {
         match self {
-            Self::EnvVar => "set via `DBT_ENGINE_MANAGE_STATE`",
+            Self::EnvVar => "set via `DBT_MANAGE_STATE`",
             Self::DbtProjectYml => "set in `./dbt_project.yml`",
             Self::UserSettingsYml => "set in `~/.dbt/user_settings.yml`",
         }
@@ -30,6 +31,7 @@ impl StateConfigSource {
 /// Returns the first matching source (env > project > user settings), or `None`.
 pub fn check_state_configured() -> Option<StateConfigSource> {
     if std::env::var(MANAGE_STATE_ENV)
+        .or_else(|_| std::env::var(LEGACY_ENGINE_MANAGE_STATE_ENV))
         .map(|v| v.eq_ignore_ascii_case("true"))
         .unwrap_or(false)
     {
@@ -142,7 +144,7 @@ async fn prompt_to_set_state() -> FsResult<()> {
         println!(
             "If you want to enable dbt State in the future, you can add the following to \
             ~/.dbt/user_settings.yml\n  flags:\n    manage_state: true\n\
-            Or set the environment variable: DBT_ENGINE_MANAGE_STATE=true"
+            Or set the environment variable: DBT_MANAGE_STATE=true"
         );
     }
 

--- a/crates/dbt-main/src/vars.rs
+++ b/crates/dbt-main/src/vars.rs
@@ -37,6 +37,7 @@ const ALIASABLE_ENV_VARS: &[&str] = &[
     "DBT_LOG_LEVEL_FILE",
     "DBT_LOG_PATH",
     "DBT_MACRO_DEBUGGING",
+    "DBT_MANAGE_STATE",
     "DBT_MAXIMUM_SEED_SIZE_MIB",
     "DBT_NO_FAIL_FAST",
     "DBT_NO_FAVOR_STATE",
@@ -117,7 +118,6 @@ const USED_ENGINE_ENV_VARS: &[&str] = &[
     "DBT_ENGINE_BETA_PARSING",
     "DBT_ENGINE_EXPERIMENTAL_LIST_UDFS",
     "DBT_ENGINE_EXPERIMENTAL_SNAPSHOT_COLUMNS",
-    "DBT_ENGINE_MANAGE_STATE",
     "DBT_ENGINE_NO_WARN_SEMANTIC_MANIFEST_VALIDATION",
     "DBT_ENGINE_RECORDER_FILE_PATH",
     "DBT_ENGINE_RECORDER_MODE",
@@ -363,6 +363,31 @@ mod tests {
             std::env::remove_var("DBT_QUIET");
             #[allow(clippy::disallowed_methods)]
             std::env::remove_var("DBT_ENGINE_QUIET");
+        }
+    }
+
+    #[test]
+    fn apply_engine_env_var_aliases_supports_manage_state() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        unsafe {
+            #[allow(clippy::disallowed_methods)]
+            std::env::remove_var("DBT_MANAGE_STATE");
+            #[allow(clippy::disallowed_methods)]
+            std::env::remove_var("DBT_ENGINE_MANAGE_STATE");
+            #[allow(clippy::disallowed_methods)]
+            std::env::set_var("DBT_ENGINE_MANAGE_STATE", "true");
+        }
+
+        apply_engine_env_var_aliases();
+
+        let result = std::env::var("DBT_MANAGE_STATE");
+        assert_eq!(result.ok(), Some("true".to_string()));
+
+        unsafe {
+            #[allow(clippy::disallowed_methods)]
+            std::env::remove_var("DBT_MANAGE_STATE");
+            #[allow(clippy::disallowed_methods)]
+            std::env::remove_var("DBT_ENGINE_MANAGE_STATE");
         }
     }
 

--- a/crates/dbt-state/src/service_config.rs
+++ b/crates/dbt-state/src/service_config.rs
@@ -13,7 +13,8 @@ pub const DEFAULT_DEFER_LOG_LEVEL: &str = "off";
 pub const DEFAULT_LOG_FILE_LIMIT: i64 = 20;
 pub const DEFAULT_LOG_PREFIX: &str = "responses_";
 pub const DEFAULT_METADATA_CACHE_TTL_SECONDS: i64 = 0;
-const STATE_MANAGE_ENV: &str = "DBT_ENGINE_MANAGE_STATE";
+const STATE_MANAGE_ENV: &str = "DBT_MANAGE_STATE";
+const LEGACY_STATE_MANAGE_ENV: &str = "DBT_ENGINE_MANAGE_STATE";
 const STATE_OAUTH_CLIENT_ID_ENV: &str = "DBT_ENGINE_STATE_OAUTH_CLIENT_ID";
 const STATE_OAUTH_CLIENT_SECRET_ENV: &str = "DBT_ENV_SECRET_STATE_OAUTH_CLIENT_SECRET";
 
@@ -80,9 +81,8 @@ impl RunCacheServiceConfig {
     where
         F: FnMut(&str) -> Option<String>,
     {
-        get_env(STATE_MANAGE_ENV)
-            .filter(|value| !value.trim().is_empty())
-            .map(|value| parse_bool(STATE_MANAGE_ENV, &value).unwrap_or(true))
+        manage_state_value(&mut get_env)
+            .map(|(name, value)| parse_bool(name, &value).unwrap_or(true))
             .unwrap_or(false)
     }
 
@@ -90,8 +90,8 @@ impl RunCacheServiceConfig {
     where
         F: FnMut(&str) -> Option<String>,
     {
-        match get_env(STATE_MANAGE_ENV).filter(|value| !value.trim().is_empty()) {
-            Some(value) => parse_bool(STATE_MANAGE_ENV, &value)
+        match manage_state_value(&mut get_env) {
+            Some((name, value)) => parse_bool(name, &value)
                 .map(|enabled| !enabled)
                 .unwrap_or(false),
             None => config_value(&mut get_env, "ENABLED")
@@ -108,9 +108,9 @@ impl RunCacheServiceConfig {
     where
         F: FnMut(&str) -> Option<String>,
     {
-        let enabled = match get_env(STATE_MANAGE_ENV).filter(|value| !value.trim().is_empty()) {
-            Some(value) => {
-                let manage_state_enabled = parse_bool(STATE_MANAGE_ENV, &value)?;
+        let enabled = match manage_state_value(&mut get_env) {
+            Some((name, value)) => {
+                let manage_state_enabled = parse_bool(name, &value)?;
                 if manage_state_enabled {
                     config_enabled(&mut get_env)?.unwrap_or(true)
                 } else {
@@ -321,6 +321,20 @@ where
         .transpose()
 }
 
+fn manage_state_value<F>(get_env: &mut F) -> Option<(&'static str, String)>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    get_env(STATE_MANAGE_ENV)
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| (STATE_MANAGE_ENV, value))
+        .or_else(|| {
+            get_env(LEGACY_STATE_MANAGE_ENV)
+                .filter(|value| !value.trim().is_empty())
+                .map(|value| (LEGACY_STATE_MANAGE_ENV, value))
+        })
+}
+
 fn state_config_value<F>(
     get_env: &mut F,
     state_name: &'static str,
@@ -468,13 +482,13 @@ mod tests {
 
     #[test]
     fn manage_state_can_be_disabled_from_config() {
-        let config = config_from_pairs(&[("DBT_ENGINE_MANAGE_STATE", "false")]).unwrap();
+        let config = config_from_pairs(&[("DBT_MANAGE_STATE", "false")]).unwrap();
 
         assert!(!config.enabled);
         assert!(!RunCacheServiceConfig::disabled().enabled);
         assert!(
             !RunCacheServiceConfig::is_explicitly_requested_from_env_getter(|name| {
-                (name == "DBT_ENGINE_MANAGE_STATE").then(|| "false".to_string())
+                (name == "DBT_MANAGE_STATE").then(|| "false".to_string())
             })
         );
         assert!(
@@ -501,7 +515,7 @@ mod tests {
     fn explicit_enabled_env_requests_service_without_api_url() {
         assert!(
             RunCacheServiceConfig::is_explicitly_requested_from_env_getter(|name| {
-                (name == "DBT_ENGINE_MANAGE_STATE").then(|| "true".to_string())
+                (name == "DBT_MANAGE_STATE").then(|| "true".to_string())
             })
         );
         assert!(
@@ -512,7 +526,7 @@ mod tests {
 
         assert!(
             RunCacheServiceConfig::is_explicitly_requested_from_env_getter(|name| {
-                (name == "DBT_ENGINE_MANAGE_STATE").then(|| "not-a-bool".to_string())
+                (name == "DBT_MANAGE_STATE").then(|| "not-a-bool".to_string())
             })
         );
         assert!(
@@ -546,18 +560,18 @@ mod tests {
 
     #[test]
     fn dbt_state_manage_env_controls_enabled() {
-        let config = config_from_pairs(&[("DBT_ENGINE_MANAGE_STATE", "false")]).unwrap();
+        let config = config_from_pairs(&[("DBT_MANAGE_STATE", "false")]).unwrap();
 
         assert!(!config.enabled);
         assert!(
             !RunCacheServiceConfig::is_explicitly_requested_from_env_getter(|name| {
-                (name == "DBT_ENGINE_MANAGE_STATE").then(|| "false".to_string())
+                (name == "DBT_MANAGE_STATE").then(|| "false".to_string())
             })
         );
 
         assert!(
             RunCacheServiceConfig::is_explicitly_requested_from_env_getter(|name| {
-                (name == "DBT_ENGINE_MANAGE_STATE").then(|| "true".to_string())
+                (name == "DBT_MANAGE_STATE").then(|| "true".to_string())
             })
         );
     }
@@ -565,7 +579,7 @@ mod tests {
     #[test]
     fn dbt_state_manage_env_controls_enabled_without_service_config() {
         let config = config_from_pairs(&[
-            ("DBT_ENGINE_MANAGE_STATE", "false"),
+            ("DBT_MANAGE_STATE", "false"),
             ("RUN_CACHE_API_URL", "localhost:50051"),
         ])
         .unwrap();
@@ -576,7 +590,7 @@ mod tests {
     #[test]
     fn legacy_enabled_false_can_disable_managed_state() {
         let config = config_from_pairs(&[
-            ("DBT_ENGINE_MANAGE_STATE", "true"),
+            ("DBT_MANAGE_STATE", "true"),
             ("RUN_CACHE_ENABLED", "false"),
         ])
         .unwrap();
@@ -587,7 +601,7 @@ mod tests {
     #[test]
     fn manage_state_false_overrides_legacy_enabled_true() {
         let config = config_from_pairs(&[
-            ("DBT_ENGINE_MANAGE_STATE", "false"),
+            ("DBT_MANAGE_STATE", "false"),
             ("RUN_CACHE_ENABLED", "true"),
         ])
         .unwrap();
@@ -597,9 +611,21 @@ mod tests {
 
     #[test]
     fn invalid_manage_state_env_reports_manage_state_name() {
-        let err = config_from_pairs(&[("DBT_ENGINE_MANAGE_STATE", "invalid")]).unwrap_err();
+        let err = config_from_pairs(&[("DBT_MANAGE_STATE", "invalid")]).unwrap_err();
 
-        assert!(err.to_string().contains("DBT_ENGINE_MANAGE_STATE"));
+        assert!(err.to_string().contains("DBT_MANAGE_STATE"));
+    }
+
+    #[test]
+    fn legacy_engine_manage_state_env_is_still_accepted() {
+        let config = config_from_pairs(&[("DBT_ENGINE_MANAGE_STATE", "false")]).unwrap();
+
+        assert!(!config.enabled);
+        assert!(
+            !RunCacheServiceConfig::is_explicitly_requested_from_env_getter(|name| {
+                (name == "DBT_ENGINE_MANAGE_STATE").then(|| "false".to_string())
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
Resolves #15343

### Problem

`dbt build --help` shows `DBT_ENGINE_MANAGE_STATE` for `--manage-state`, while the other public CLI flags show `DBT_*` environment variables. That makes `--manage-state` look inconsistent with the rest of the CLI surface.

### Solution

This changes the public CLI env var for `--manage-state` to `DBT_MANAGE_STATE`.

To preserve compatibility, `DBT_ENGINE_MANAGE_STATE` remains accepted:

- `dbt-main` aliases `DBT_ENGINE_MANAGE_STATE` to `DBT_MANAGE_STATE` before CLI parsing.
- `dbt-clap-core` falls back to `DBT_ENGINE_MANAGE_STATE` when resolving `manage_state`.
- `dbt-state` accepts both names when reading service config.
- `dbt-login` user-facing guidance now points at `DBT_MANAGE_STATE`.

I also added a changelog entry and focused coverage for the alias/service-config behavior.

Validation:

- `git diff --check`

I could not run `cargo fmt` or Rust tests locally because this environment does not have the Rust toolchain installed (`cargo` is not on PATH).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [ ] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
