### PR TITLE
feat(snowflake): add cortex_agent materialization

### DIFF
--- a/.changes/unreleased/Features-20260627-211751.yaml
+++ b/.changes/unreleased/Features-20260627-211751.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add cortex_agent materialization for Snowflake Cortex Agents
+time: 2026-06-27T21:17:51-04:00
+custom:
+    author: poojacrahen
+    issue: ""
+    project: dbt-core

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-snowflake/macros/materializations/cortex_agent.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-snowflake/macros/materializations/cortex_agent.sql
@@ -1,0 +1,43 @@
+{% materialization cortex_agent, adapter='snowflake' %}
+
+  {% set original_query_tag = set_query_tag() %}
+
+  {%- set comment = config.meta_get('comment') -%}
+  {%- if comment is none -%}
+    {%- set comment = config.get('comment', default='') -%}
+  {%- endif -%}
+
+  {%- set profile = config.meta_get('profile') -%}
+  {%- if profile is none -%}
+    {%- set profile = config.get('profile', default=none) -%}
+  {%- endif -%}
+
+  {%- set specification = compiled_code -%}
+
+  {%- if specification is none or specification | trim == '' -%}
+    {{ exceptions.raise_compiler_error(
+        "cortex_agent materialization requires a non-empty model body "
+        ~ "(the FROM SPECIFICATION YAML). Model: " ~ model['unique_id']
+    ) }}
+  {%- endif -%}
+
+  {{ run_hooks(pre_hooks) }}
+
+  {% call statement('main') -%}
+    {{ get_create_cortex_agent_sql(
+        relation=this,
+        specification=specification,
+        comment=comment,
+        profile=profile
+    ) }}
+  {%- endcall %}
+
+  {#-- AGENT objects have no documented standard grant model, so apply_grants
+       is intentionally not wired here; grants (if any) go via post_hooks. --#}
+  {{ run_hooks(post_hooks) }}
+
+  {% do unset_query_tag(original_query_tag) %}
+
+  {%- do return({'relations': [this]}) -%}
+
+{% endmaterialization %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-snowflake/macros/relations/cortex_agent/create.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-snowflake/macros/relations/cortex_agent/create.sql
@@ -1,0 +1,41 @@
+{# -----------------------------------------------------------------------
+   CREATE OR REPLACE AGENT DDL builder.
+
+   Dispatched so a project may override it, and so non-Snowflake adapters
+   fail with a clear "not implemented" message rather than emitting bad DDL.
+   Snowflake DDL reference:
+     https://docs.snowflake.com/en/sql-reference/sql/create-agent
+   ----------------------------------------------------------------------- #}
+
+{% macro get_create_cortex_agent_sql(relation, specification, comment='', profile=none) -%}
+  {{ return(adapter.dispatch('get_create_cortex_agent_sql', 'dbt')(relation, specification, comment, profile)) }}
+{%- endmacro %}
+
+
+{% macro default__get_create_cortex_agent_sql(relation, specification, comment='', profile=none) -%}
+  {{ exceptions.raise_compiler_error(
+      'get_create_cortex_agent_sql is not implemented for adapter type: ' ~ adapter.type()
+  ) }}
+{%- endmacro %}
+
+
+{% macro snowflake__get_create_cortex_agent_sql(relation, specification, comment='', profile=none) -%}
+
+  {%- set profile_json = none -%}
+  {%- if profile is not none and profile | length > 0 -%}
+    {#-- tojson produces compact JSON; single-quote-escape for SQL embedding --#}
+    {%- set profile_json = profile | tojson -%}
+  {%- endif -%}
+
+  CREATE OR REPLACE AGENT {{ relation }}
+  {%- if comment | trim != '' %}
+  COMMENT = {{ "'" ~ comment | replace("'", "''") ~ "'" }}
+  {%- endif %}
+  {%- if profile_json is not none %}
+  PROFILE = '{{ profile_json | replace("'", "''") }}'
+  {%- endif %}
+  FROM SPECIFICATION $$
+{{ specification }}
+  $$
+
+{%- endmacro %}

--- a/crates/dbt-loader/tests/materializations/cortex_agent.rs
+++ b/crates/dbt-loader/tests/materializations/cortex_agent.rs
@@ -1,0 +1,123 @@
+use std::collections::BTreeMap;
+
+use dbt_adapter_core::AdapterType;
+use minijinja::Value;
+
+use crate::macro_test_harness::{
+    MacroTestHarness, assert_executed_contains, default_mock_config, executed_sql,
+};
+
+const ADAPTER: AdapterType = AdapterType::Snowflake;
+const MACRO: &str = "materialization_cortex_agent_snowflake";
+const SPEC: &str = "models:\n  orchestration: claude-4-sonnet\n";
+
+fn build_harness() -> MacroTestHarness {
+    MacroTestHarness::for_adapter(ADAPTER)
+        .load_all_macros()
+        .with_stub_functions()
+        .build()
+        .expect("harness should build")
+}
+
+/// A `config` mock that answers `config.meta_get('comment'|'profile')`.
+///
+/// `None` is returned as Jinja `none` (`Value::from(())`) so the
+/// materialization's `is none` fallback to `config.get(...)` is exercised.
+/// `config.get` itself comes from [`default_mock_config`] (returns the
+/// caller-supplied default).
+fn agent_config(comment: Option<Value>, profile: Option<Value>) -> Value {
+    let mock = default_mock_config();
+    mock.on("meta_get", move |args| {
+        let key = args.first().and_then(|v| v.as_str());
+        match key {
+            Some("comment") => Ok(comment.clone().unwrap_or(Value::from(()))),
+            Some("profile") => Ok(profile.clone().unwrap_or(Value::from(()))),
+            _ => Ok(Value::from(())),
+        }
+    });
+    Value::from_dyn_object(mock)
+}
+
+fn render(harness: &MacroTestHarness, ctx: BTreeMap<String, Value>) -> dbt_common::FsResult<String> {
+    harness.render(&format!("{{{{ {MACRO}() }}}}"), ctx)
+}
+
+/// With meta.comment and meta.profile set, the emitted DDL carries both
+/// optional clauses plus the FROM SPECIFICATION body.
+#[test]
+fn create_agent_with_comment_and_profile() {
+    let harness = build_harness();
+    let profile = Value::from_serialize(BTreeMap::from([
+        ("display_name".to_string(), Value::from("Analyst")),
+        ("color".to_string(), Value::from("blue")),
+    ]));
+    let ctx = harness
+        .materialization_context("my_agent", SPEC)
+        .config(agent_config(Some(Value::from("Domain analyst")), Some(profile)))
+        .build();
+
+    render(&harness, ctx).expect("cortex_agent materialization should render");
+
+    let mock = harness.mock();
+    assert_executed_contains(mock, "create or replace agent");
+    assert_executed_contains(mock, "comment = 'domain analyst'");
+    assert_executed_contains(mock, "profile = '");
+    assert_executed_contains(mock, "display_name");
+    assert_executed_contains(mock, "from specification $$");
+}
+
+/// Single quotes in the comment are doubled so the SQL string literal is valid.
+#[test]
+fn comment_single_quotes_are_escaped() {
+    let harness = build_harness();
+    let ctx = harness
+        .materialization_context("my_agent", SPEC)
+        .config(agent_config(Some(Value::from("dbt's agent")), None))
+        .build();
+
+    render(&harness, ctx).expect("cortex_agent materialization should render");
+
+    assert_executed_contains(harness.mock(), "comment = 'dbt''s agent'");
+}
+
+/// Without meta, the optional COMMENT / PROFILE clauses are omitted entirely.
+#[test]
+fn create_agent_without_meta_omits_optional_clauses() {
+    let harness = build_harness();
+    let ctx = harness
+        .materialization_context("my_agent", SPEC)
+        .config(agent_config(None, None))
+        .build();
+
+    render(&harness, ctx).expect("cortex_agent materialization should render");
+
+    let sqls = executed_sql(harness.mock()).join("\n").to_lowercase();
+    assert!(
+        sqls.contains("create or replace agent"),
+        "expected CREATE OR REPLACE AGENT, got: {sqls}"
+    );
+    assert!(
+        !sqls.contains("comment ="),
+        "COMMENT clause should be omitted when no comment is set, got: {sqls}"
+    );
+    assert!(
+        !sqls.contains("profile ="),
+        "PROFILE clause should be omitted when no profile is set, got: {sqls}"
+    );
+}
+
+/// An empty model body is a hard compiler error (no agent has an empty spec).
+#[test]
+fn empty_specification_raises() {
+    let harness = build_harness();
+    let ctx = harness
+        .materialization_context("my_agent", "   ")
+        .config(agent_config(None, None))
+        .build();
+
+    let result = render(&harness, ctx);
+    assert!(
+        result.is_err(),
+        "empty specification should raise a compiler error, got: {result:?}"
+    );
+}

--- a/crates/dbt-loader/tests/materializations/mod.rs
+++ b/crates/dbt-loader/tests/materializations/mod.rs
@@ -1,3 +1,4 @@
+mod cortex_agent;
 mod incremental;
 mod materialized_view;
 mod view;


### PR DESCRIPTION
## What

Adds a `cortex_agent` materialization for Snowflake that manages a [Cortex Agent](https://docs.snowflake.com/en/sql-reference/sql/create-agent) object as a dbt model.

The model body is the YAML specification handed to `CREATE OR REPLACE AGENT ... FROM SPECIFICATION $$ ... $$`. Because `ref()`/`source()` calls inside the spec are resolved by dbt before the DDL is emitted, agents get full DAG lineage to their upstream models (e.g. semantic views).

### Config (via `meta`)
- `meta.comment` → `COMMENT = '...'`
- `meta.profile` → `PROFILE = '<json>'` (serialized via `tojson`; display_name/avatar/color)

### Design
- Each run issues `CREATE OR REPLACE AGENT` atomically — the dbt project is the source of truth.
- The DDL builder is **dispatched** (`get_create_cortex_agent_sql` → `default__`/`snowflake__`), so a project can override it and non-Snowflake adapters fail with a clear "not implemented" message instead of emitting bad DDL.
- `apply_grants` is intentionally **not** wired: AGENT objects have no documented standard grant model. Grants (if any) go through `post_hooks`.

## Files
- `dbt-snowflake/macros/materializations/cortex_agent.sql` — the materialization
- `dbt-snowflake/macros/relations/cortex_agent/create.sql` — dispatched DDL builder
- `dbt-loader/tests/materializations/cortex_agent.rs` — harness tests

## Tests
4 harness tests (all passing): full DDL output with COMMENT + PROFILE + `FROM SPECIFICATION`, single-quote escaping, optional-clause omission when no meta, and the empty-spec compiler error.

## Out of scope (follow-up)
These pair with adding a `RelationType::Agent`:
- `on_configuration_change: apply` drift detection (ALTER / DESCRIBE AGENT)
- auto-drop of removed agent models
- standardized grants for AGENT objects (pending Snowflake support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)