### PR TITLE
fix(scheduler): return leaf node and ancestors for @ operator (#15280)

### DIFF
--- a/.changes/unreleased/Fixes-20260628-155340.yaml
+++ b/.changes/unreleased/Fixes-20260628-155340.yaml
@@ -1,0 +1,9 @@
+kind: Fixes
+body: Fix the `@` graph operator (and the equivalent `childrens_parents` YAML selector)
+    returning an empty set when applied to a leaf node. It now correctly returns the
+    node together with its ancestors.
+time: 2026-06-28T15:53:40.000000-00:00
+custom:
+    author: AndreaBozzo
+    issue: "15280"
+    project: dbt-core

--- a/crates/dbt-scheduler/src/schedule.rs
+++ b/crates/dbt-scheduler/src/schedule.rs
@@ -1025,7 +1025,7 @@ fn collect_childrens_parents(
     // A node is its own descendant, so the selected nodes are themselves leaf
     // candidates: when a selected node has no children it produces no descendant
     // edges in `desc` and would otherwise be dropped entirely (see #15280).
-    let leaf_nodes: Vec<String> = desc
+    let leaf_nodes: BTreeSet<String> = desc
         .keys()
         .chain(desc.values().flatten())
         .chain(selected_nodes)
@@ -1039,8 +1039,8 @@ fn collect_childrens_parents(
     // because `upstream` only returns edges, which omit a leaf that has no
     // ancestors (e.g. an isolated node).
     for leaf in leaf_nodes {
-        selected.insert(leaf.clone());
         add_nodes(upstream(deps, &leaf, u32::MAX), &mut selected);
+        selected.insert(leaf);
     }
     selected
 }

--- a/crates/dbt-scheduler/src/schedule.rs
+++ b/crates/dbt-scheduler/src/schedule.rs
@@ -1021,18 +1021,25 @@ fn collect_childrens_parents(
         let descendants = downstream(deps, node, u32::MAX);
         desc.extend(descendants);
     }
-    // 2. find leaf nodes (nodes with no children) and get all their ancestors
+    // 2. find leaf nodes (nodes with no children) and get all their ancestors.
+    // A node is its own descendant, so the selected nodes are themselves leaf
+    // candidates: when a selected node has no children it produces no descendant
+    // edges in `desc` and would otherwise be dropped entirely (see #15280).
     let leaf_nodes: Vec<String> = desc
         .keys()
         .chain(desc.values().flatten())
+        .chain(selected_nodes)
         .filter(|node| {
             // A node is a leaf if it has no outgoing dependencies in the descendant graph
             !desc.contains_key(*node) || desc.get(*node).is_none_or(|children| children.is_empty())
         })
         .cloned()
         .collect();
-    // Get upstream of all leaf nodes
+    // Get each leaf plus all of its ancestors. The leaf is inserted explicitly
+    // because `upstream` only returns edges, which omit a leaf that has no
+    // ancestors (e.g. an isolated node).
     for leaf in leaf_nodes {
+        selected.insert(leaf.clone());
         add_nodes(upstream(deps, &leaf, u32::MAX), &mut selected);
     }
     selected
@@ -1550,6 +1557,55 @@ mod tests {
         let select = create_select_expression("@b");
         let result = schedule_test_graph(&graph, &select);
         assert_eq!(result, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_schedule_graph_at_operator_on_leaf() {
+        // Regression test for https://github.com/dbt-labs/dbt-core/issues/15280
+        // `@` on a leaf node (one with no children) should return the node plus
+        // its ancestors. A node is its own descendant, so for a leaf the
+        // descendant set is just the node itself.
+        let builder = TestGraphBuilder::new()
+            .add_edge("a", "b")
+            .add_edge("b", "c");
+        let graph = builder.build_graph();
+
+        // `c` is the leaf of the chain a -> b -> c.
+        let select = create_select_expression("@c");
+        let result = schedule_test_graph(&graph, &select);
+        assert_eq!(result, vec!["a", "b", "c"]);
+
+        // A leaf with a single ancestor.
+        let builder = TestGraphBuilder::new().add_edge("a", "b");
+        let graph = builder.build_graph();
+        let select = create_select_expression("@b");
+        let result = schedule_test_graph(&graph, &select);
+        assert_eq!(result, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_collect_childrens_parents_leaf_and_isolated() {
+        // `deps` maps each node to its parents (upstream dependencies).
+        // Chain a -> b -> c.
+        let deps = BTreeMap::from([
+            ("a".to_string(), BTreeSet::new()),
+            ("b".to_string(), BTreeSet::from(["a".to_string()])),
+            ("c".to_string(), BTreeSet::from(["b".to_string()])),
+        ]);
+
+        // `@c` on the leaf `c` -> the leaf plus all of its ancestors.
+        let selected = BTreeSet::from(["c".to_string()]);
+        let result = collect_childrens_parents(&deps, &selected);
+        assert_eq!(
+            result,
+            BTreeSet::from(["a".to_string(), "b".to_string(), "c".to_string()])
+        );
+
+        // An isolated node (leaf with no ancestors) -> just itself.
+        let deps = BTreeMap::from([("a".to_string(), BTreeSet::new())]);
+        let selected = BTreeSet::from(["a".to_string()]);
+        let result = collect_childrens_parents(&deps, &selected);
+        assert_eq!(result, BTreeSet::from(["a".to_string()]));
     }
 
     #[test]


### PR DESCRIPTION
Resolves #15280

### Problem

The `@` graph operator returned an empty set when applied to a node with no children (a leaf). `+`, `state:`, and `@` on non-leaf nodes all worked, but `@<leaf>` dropped the node entirely. The same bug affected the equivalent `childrens_parents: true` YAML selector.

```
# graph: a -> b -> c
$ dbt ls --select @c   → (empty)     # ❌ expected: a, b, c
$ dbt ls --select @b   → a, b, c     # ✅ b is not a leaf
$ dbt ls --select +c   → a, b, c     # ✅ + works on the same leaf
```

Documented `@` semantics are "the model, its descendants, and the ancestors of its descendants". A node is its own descendant, so for a leaf the descendant set is just the node itself, and the result should be the node plus its ancestors. This matches dbt-core 1.x.

### Solution

The bug is in `collect_childrens_parents` (`crates/dbt-scheduler/src/schedule.rs`). It built the descendant set via `downstream()`, which returns only descendant *edges*. For a leaf node that map is empty, so no leaf was found and the subsequent ancestor walk produced nothing.

The fix:

- Seed the leaf candidates with the selected nodes themselves, since a node is its own descendant. A selected leaf then correctly enters the leaf set instead of being dropped.
- Insert each leaf explicitly before walking its ancestors, because `upstream()` also returns only edges — this keeps a leaf that has no ancestors (e.g. an isolated node) in the result.

Existing non-leaf behavior is unchanged (the selected nodes are added as candidates but filtered out when they have descendant edges).

Added regression tests covering `@` on a chain leaf, `@` on a leaf with a single ancestor, and a direct `collect_childrens_parents` test for the leaf and isolated-node cases. The full `dbt-scheduler` suite passes (101 tests).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
