### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260629-171219.yaml
+++ b/.changes/unreleased/Under the Hood-20260629-171219.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-06-29T17:12:19.617438937Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -837,6 +837,7 @@
     "FreshnessPeriod": {
       "type": "string",
       "enum": [
+        "second",
         "minute",
         "hour",
         "day"

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -2904,6 +2904,7 @@
     "FreshnessPeriod": {
       "type": "string",
       "enum": [
+        "second",
         "minute",
         "hour",
         "day"


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`cbc3c9c9a982c54e9cad73500e3ca36e73caeb8c`](https://github.com/dbt-labs/fs/commit/cbc3c9c9a982c54e9cad73500e3ca36e73caeb8c)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/28387929596)