### PR TITLE
chore: bump dbt-core-experimental-parser to 2.0.0a3

### DIFF
--- a/.changes/unreleased/Dependencies-20260630-120000.yaml
+++ b/.changes/unreleased/Dependencies-20260630-120000.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump the minimum `dbt-core-experimental-parser` to `2.0.0a3`
+time: 2026-06-30T12:00:00.000000000Z
+custom:
+    Author: tauhid621
+    Issue: "15391"

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     "dbt-common>=1.37.5,<2.0",
     "dbt-adapters>=1.24.1,<2.0",
     "dbt-protos>=1.0.514,<2.0",
-    "dbt-core-experimental-parser>=2.0.0a1,<3",
+    "dbt-core-experimental-parser>=2.0.0a3,<3",
     # Bundled plugin: installed by default but opt-in. PluginManager skips loading
     # unless the user passes `--manage-state` on the CLI, sets
     # `DBT_ENGINE_MANAGE_STATE=true`, or sets `manage_state: true` in dbt_project.yml's


### PR DESCRIPTION
Bumps the `dbt-core-experimental-parser` dependency from `2.0.0a1` to `2.0.0a3` in `core/pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)