### PR TITLE
[1.11.latest] Fix spurious deprecation warnings for state model configs

### DIFF
--- a/.changes/unreleased/Fixes-20260701-071300.yaml
+++ b/.changes/unreleased/Fixes-20260701-071300.yaml
@@ -5,4 +5,4 @@ body: Stop emitting spurious deprecation warnings for `state` model configs (`pr
 time: 2026-07-01T07:13:00.000000-00:00
 custom:
     Author: tauhid621
-    Issue: "15313"
+    Issue: "13016"

--- a/.changes/unreleased/Fixes-20260701-071300.yaml
+++ b/.changes/unreleased/Fixes-20260701-071300.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Stop emitting spurious deprecation warnings for `state` model configs (`pre_clone`,
+  `lag_tolerance`, `require_fresh_data_from`, etc.) by adding the `ModelState` schema
+  to the bundled jsonschemas
+time: 2026-07-01T07:13:00.000000-00:00
+custom:
+    Author: tauhid621
+    Issue: "15313"

--- a/core/dbt/jsonschemas/project/0.0.110.json
+++ b/core/dbt/jsonschemas/project/0.0.110.json
@@ -874,6 +874,70 @@
       },
       "additionalProperties": false
     },
+    "ModelState": {
+      "type": "object",
+      "properties": {
+        "evaluate_volatile_sql": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "execute_hooks_on_any_reuse": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "lag_tolerance": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelFreshnessRules"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pre_clone": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StatePreClone"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "require_fresh_data_from": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/UpdatesOn"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "OnConfigurationChange": {
       "type": "string",
       "enum": [
@@ -2747,6 +2811,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "+state": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelState"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "+static_analysis": {
@@ -5406,6 +5480,14 @@
             "type": "string"
           }
         }
+      ]
+    },
+    "StatePreClone": {
+      "type": "string",
+      "enum": [
+        "never",
+        "if_missing",
+        "always"
       ]
     },
     "StaticAnalysisKind": {

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -4443,6 +4443,16 @@
             "null"
           ]
         },
+        "state": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelState"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "static_analysis": {
           "anyOf": [
             {
@@ -4896,6 +4906,70 @@
         },
         "standard_granularity_column": {
           "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ModelState": {
+      "type": "object",
+      "properties": {
+        "evaluate_volatile_sql": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "execute_hooks_on_any_reuse": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "lag_tolerance": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelFreshnessRules"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pre_clone": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StatePreClone"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "require_fresh_data_from": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/UpdatesOn"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -7536,6 +7610,14 @@
         }
       },
       "additionalProperties": false
+    },
+    "StatePreClone": {
+      "type": "string",
+      "enum": [
+        "never",
+        "if_missing",
+        "always"
+      ]
     },
     "StaticAnalysisKind": {
       "type": "string",


### PR DESCRIPTION
Backports `state` model-config support to the bundled jsonschemas so 1.11.x stops emitting spurious `custom-key-in-config-deprecation` warnings for `+state` configs (`pre_clone`, `lag_tolerance`, `require_fresh_data_from`).

**Why not a full fusion re-sync:** the full `1.11.latest` → `main` schema diff is 12k+ lines and would pull in 1.12-era changes that could be breaking on a patch. This is the minimal `state`-only subset instead.

**Change:** add `ModelState` + `StatePreClone` defs; wire `+state` into `ProjectModelConfig` (project schema) and `state` into `ModelConfig` (resources schema). Additive only, 164 lines. Copied verbatim from `main`.

**Origin:** these schema entries were introduced on `main` by #13016.

**Verified:** replaying dbt's deprecation logic on a real `dbt_project.yml` → warnings before, none after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)