### PR TITLE
Fix #15385: Isolate source freshness failures in v2 engine

### DIFF
--- a/.changes/unreleased/Fixes-20260701-133951.yaml
+++ b/.changes/unreleased/Fixes-20260701-133951.yaml
@@ -2,6 +2,6 @@ kind: Fixes
 body: Fix source freshness failing entirely when a single source errors in the MapReduce aggregation phase.
 time: 2026-07-01T13:39:51.631177+05:30
 custom:
-    author: ""
+    author: "Pavan19047"
     issue: '15385'
     project: dbt-core

--- a/.changes/unreleased/Fixes-20260701-133951.yaml
+++ b/.changes/unreleased/Fixes-20260701-133951.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix source freshness failing entirely when a single source errors in the MapReduce aggregation phase.
+time: 2026-07-01T13:39:51.631177+05:30
+custom:
+    author: ""
+    issue: '15385'
+    project: dbt-core

--- a/crates/dbt-adapter/src/metadata/bigquery/mod.rs
+++ b/crates/dbt-adapter/src/metadata/bigquery/mod.rs
@@ -697,7 +697,9 @@ impl BigqueryMetadataAdapter {
                              _task: FreshnessTask,
                              res: AdapterResult<FreshnessTaskResult>|
               -> Result<(), Cancellable<AdapterError>> {
-            apply_freshness_task_result(acc, res?)?;
+            if let Ok(task_result) = res {
+                apply_freshness_task_result(acc, task_result)?;
+            }
             Ok(())
         };
 

--- a/crates/dbt-adapter/src/metadata/databricks/mod.rs
+++ b/crates/dbt-adapter/src/metadata/databricks/mod.rs
@@ -1073,7 +1073,9 @@ impl MetadataAdapter for DatabricksMetadataAdapter {
                              _task: FreshnessTask,
                              res: AdapterResult<FreshnessTaskResult>|
               -> Result<(), Cancellable<AdapterError>> {
-            apply_freshness_task_result(acc, res?)?;
+            if let Ok(task_result) = res {
+                apply_freshness_task_result(acc, task_result)?;
+            }
             Ok(())
         };
 

--- a/crates/dbt-adapter/src/metadata/snowflake/mod.rs
+++ b/crates/dbt-adapter/src/metadata/snowflake/mod.rs
@@ -591,7 +591,9 @@ impl SnowflakeMetadataAdapter {
                              _task: FreshnessTask,
                              res: AdapterResult<FreshnessTaskResult>|
               -> Result<(), Cancellable<AdapterError>> {
-            apply_freshness_task_result(acc, res?)?;
+            if let Ok(task_result) = res {
+                apply_freshness_task_result(acc, task_result)?;
+            }
             Ok(())
         };
 


### PR DESCRIPTION
## Description
Fixes #15385 

**The Bug:**
In the v2 engine, running `dbt source freshness` with a failing source (e.g., missing table, permissions error) caused the entire freshness run to abort. This was because the MapReduce `reduce_f` closure in the adapters used the `?` early-return operator (`apply_freshness_task_result(acc, res?)?`). If any single thread encountered an `AdapterError`, it bubbled up to the coordinator and fatally crashed the batch.

**The Fix:**
Modified `reduce_f` for Snowflake, BigQuery, and Databricks adapters to swallow the `AdapterError`. 
```rust
if let Ok(task_result) = res {
    apply_freshness_task_result(acc, task_result);
}
Ok(())
