### PR TITLE
Add ClickHouse as non experimental

### DIFF
--- a/.changes/unreleased/Under the Hood-20260701-173038.yaml
+++ b/.changes/unreleased/Under the Hood-20260701-173038.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Add ClickHouse to the list of non experimental adapters.
+time: 2026-07-01T17:30:38.566801+02:00
+custom:
+    author: '@koletzilla'
+    issue: ""
+    project: dbt-core

--- a/crates/dbt-adapter-core/src/lib.rs
+++ b/crates/dbt-adapter-core/src/lib.rs
@@ -8,6 +8,7 @@ pub const NON_EXPERIMENTAL_ADAPTERS: &[AdapterType] = &[
     AdapterType::Redshift,
     AdapterType::DuckDB,
     AdapterType::Salesforce,
+    AdapterType::ClickHouse,
 ];
 
 pub const STATIC_ANALYSIS_SUPPORTED_ADAPTERS: &[AdapterType] = &[


### PR DESCRIPTION
Related to https://github.com/dbt-labs/dbt-core/issues/14585

Adds ClickHouse to the list of Non Experimental adapters