### PR TITLE
fix: update the version for libpq-dev,ca-certificates and openssh-client

### DIFF
--- a/.changes/unreleased/Dependencies-20260701-120000.yaml
+++ b/.changes/unreleased/Dependencies-20260701-120000.yaml
@@ -1,0 +1,8 @@
+kind: Dependencies
+body: Bump ca-certificates, libpq-dev, and openssh-client in Docker image to current
+  bullseye versions to fix Docker release build failure caused by superseded package
+  versions
+time: 2026-07-01T12:00:00.000000-04:00
+custom:
+  Author: ajnovice
+  Issue: NA

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
   # Install version-pinned packages for reproducible builds
   && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
-    ca-certificates=20210119 \
-    libpq-dev=13.23-0+deb11u3 \
+    ca-certificates=20230311+deb12u1~deb11u1 \
+    libpq-dev=13.23-0+deb11u4 \
     make=4.3-4.1 \
-    openssh-client=1:8.4p1-5+deb11u3 \
+    openssh-client=1:8.4p1-5+deb11u7 \
     software-properties-common=0.96.20.2-2.1 \
   # Prevent dist-upgrade from changing pinned package versions
   && apt-mark hold \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
   # Install version-pinned packages for reproducible builds
   && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
-    ca-certificates=20230311+deb12u1~deb11u1 \
+    ca-certificates=20230311 \
     libpq-dev=13.23-0+deb11u4 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u7 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
   # Install version-pinned packages for reproducible builds
   && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
-    ca-certificates=20230311 \
+    ca-certificates=20230311+deb12u1~deb11u1 \
     libpq-dev=13.23-0+deb11u4 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u7 \


### PR DESCRIPTION
## Summary
- Bump `ca-certificates` in Docker image from `20210119` to `20230311+deb12u1~deb11u1`
- Bump `libpq-dev` in Docker image from `13.23-0+deb11u3` to `13.23-0+deb11u4`
- Bump `openssh-client` in Docker image from `1:8.4p1-5+deb11u3` to `1:8.4p1-5+deb11u7`
- The previous versions were superseded by Debian bullseye security updates and are no longer available in the apt repos, causing Docker builds to fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)