### PR TITLE
Reuse serialized node for component name macros

### DIFF
--- a/.changes/unreleased/Under the Hood-20260701-201156.yaml
+++ b/.changes/unreleased/Under the Hood-20260701-201156.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Reuse a pre-serialized node when generating database and schema component names to avoid serializing the same node twice
+time: 2026-07-01T20:11:56.000000+02:00
+custom:
+    author: mattfaltyn
+    issue: "15413"
+    project: dbt-core

--- a/crates/dbt-jinja-utils/src/utils.rs
+++ b/crates/dbt-jinja-utils/src/utils.rs
@@ -488,32 +488,35 @@ pub fn find_macro_template(
 /// Serialize a node once for use as the `node` argument to component-name macros.
 pub fn serialize_node_for_component_name(node: &dyn InternalDbtNode) -> YmlValue {
     let mut serialized = node.serialize_keep_none();
-    // Strip resource-type prefix from path so node.path inside macros like
-    // generate_schema_name matches dbt-core convention ("staging/model.sql"
-    // not "models/staging/model.sql"). build_flat_graph does the same for
-    // graph.nodes.
-    let prefix = match node.resource_type() {
+    strip_resource_prefix_from_serialized_path(node.resource_type(), &mut serialized);
+    serialized
+}
+
+/// Strip resource-type prefix from path so node.path inside macros like
+/// generate_schema_name matches dbt-core convention ("staging/model.sql"
+/// not "models/staging/model.sql"). build_flat_graph does the same for
+/// graph.nodes.
+fn strip_resource_prefix_from_serialized_path(resource_type: NodeType, serialized: &mut YmlValue) {
+    let prefix = match resource_type {
         NodeType::Model => "models",
         NodeType::Snapshot => "snapshots",
         NodeType::Seed => "seeds",
         NodeType::Analysis => "analyses",
-        _ => "",
+        _ => return,
     };
-    if !prefix.is_empty() {
-        if let YmlValue::Mapping(ref mut map, _) = serialized {
-            let path_key = YmlValue::string("path".to_string());
-            if let Some(path_value) = map.get(&path_key) {
-                if let Some(path_str) = path_value.as_str() {
-                    let stripped = Path::new(path_str)
-                        .strip_prefix(prefix)
-                        .map(|p| p.to_string_lossy().into_owned())
-                        .unwrap_or_else(|_| path_str.to_string());
-                    map.insert(path_key, YmlValue::string(stripped));
-                }
-            }
-        }
-    }
-    serialized
+
+    let YmlValue::Mapping(map, _) = serialized else {
+        return;
+    };
+    let path_key = YmlValue::string("path".to_string());
+    let Some(path_str) = map.get(&path_key).and_then(|v| v.as_str()) else {
+        return;
+    };
+    let stripped = Path::new(path_str)
+        .strip_prefix(prefix)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| path_str.to_string());
+    map.insert(path_key, YmlValue::string(stripped));
 }
 
 /// Generate a component name using an already serialized node argument.

--- a/crates/dbt-jinja-utils/src/utils.rs
+++ b/crates/dbt-jinja-utils/src/utils.rs
@@ -485,15 +485,46 @@ pub fn find_macro_template(
     ))
 }
 
-/// Generate a component name using the specified macro
-pub fn generate_component_name(
+/// Serialize a node once for use as the `node` argument to component-name macros.
+pub fn serialize_node_for_component_name(node: &dyn InternalDbtNode) -> YmlValue {
+    let mut serialized = node.serialize_keep_none();
+    // Strip resource-type prefix from path so node.path inside macros like
+    // generate_schema_name matches dbt-core convention ("staging/model.sql"
+    // not "models/staging/model.sql"). build_flat_graph does the same for
+    // graph.nodes.
+    let prefix = match node.resource_type() {
+        NodeType::Model => "models",
+        NodeType::Snapshot => "snapshots",
+        NodeType::Seed => "seeds",
+        NodeType::Analysis => "analyses",
+        _ => "",
+    };
+    if !prefix.is_empty() {
+        if let YmlValue::Mapping(ref mut map, _) = serialized {
+            let path_key = YmlValue::string("path".to_string());
+            if let Some(path_value) = map.get(&path_key) {
+                if let Some(path_str) = path_value.as_str() {
+                    let stripped = Path::new(path_str)
+                        .strip_prefix(prefix)
+                        .map(|p| p.to_string_lossy().into_owned())
+                        .unwrap_or_else(|_| path_str.to_string());
+                    map.insert(path_key, YmlValue::string(stripped));
+                }
+            }
+        }
+    }
+    serialized
+}
+
+/// Generate a component name using an already serialized node argument.
+pub fn generate_component_name_with_serialized_node(
     env: &JinjaEnv,
     component: &str,
     root_project_name: &str,
     current_project_name: &str,
     base_ctx: &BTreeMap<String, Value>,
     custom_name: Option<String>,
-    node: Option<&dyn InternalDbtNode>,
+    serialized_node: Option<&YmlValue>,
 ) -> FsResult<String> {
     let macro_name = format!("generate_{component}_name");
     // find the macro template - this is now cached for performance
@@ -510,34 +541,8 @@ pub fn generate_component_name(
     let mut args = custom_name
         .map(|name| vec![Value::from(name)])
         .unwrap_or_else(|| vec![Value::from(())]); // If no custom name, pass in none so the macro reads from the target context
-    if let Some(node) = node {
-        let mut serialized = node.serialize_keep_none();
-        // Strip resource-type prefix from path so node.path inside macros like
-        // generate_schema_name matches dbt-core convention ("staging/model.sql"
-        // not "models/staging/model.sql"). build_flat_graph does the same for
-        // graph.nodes.
-        let prefix = match node.resource_type() {
-            NodeType::Model => "models",
-            NodeType::Snapshot => "snapshots",
-            NodeType::Seed => "seeds",
-            NodeType::Analysis => "analyses",
-            _ => "",
-        };
-        if !prefix.is_empty() {
-            if let YmlValue::Mapping(ref mut map, _) = serialized {
-                let path_key = YmlValue::string("path".to_string());
-                if let Some(path_value) = map.get(&path_key) {
-                    if let Some(path_str) = path_value.as_str() {
-                        let stripped = Path::new(path_str)
-                            .strip_prefix(prefix)
-                            .map(|p| p.to_string_lossy().into_owned())
-                            .unwrap_or_else(|_| path_str.to_string());
-                        map.insert(path_key, YmlValue::string(stripped));
-                    }
-                }
-            }
-        }
-        args.push(Value::from_serialize(serialized));
+    if let Some(serialized_node) = serialized_node {
+        args.push(Value::from_serialize(serialized_node));
     }
 
     // Call the macro
@@ -555,6 +560,28 @@ pub fn generate_component_name(
         })?;
     // Return the result
     Ok(result)
+}
+
+/// Generate a component name using the specified macro.
+pub fn generate_component_name(
+    env: &JinjaEnv,
+    component: &str,
+    root_project_name: &str,
+    current_project_name: &str,
+    base_ctx: &BTreeMap<String, Value>,
+    custom_name: Option<String>,
+    node: Option<&dyn InternalDbtNode>,
+) -> FsResult<String> {
+    let serialized_node = node.map(serialize_node_for_component_name);
+    generate_component_name_with_serialized_node(
+        env,
+        component,
+        root_project_name,
+        current_project_name,
+        base_ctx,
+        custom_name,
+        serialized_node.as_ref(),
+    )
 }
 
 /// Clear template cache (primarily for testing purposes)
@@ -719,13 +746,84 @@ pub(crate) fn get_status_reporter<'a>(env: &'a Environment) -> Option<&'a Arc<dy
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
     use std::rc::Rc;
 
+    use dbt_schemas::schemas::common::DbtMaterialization;
+    use dbt_schemas::schemas::project::DataTestConfig;
+    use dbt_schemas::schemas::{
+        AdapterAttr, CommonAttributes, DbtTest, DbtTestAttr, NodeBaseAttributes,
+    };
     use minijinja::{Environment, context, listener::RenderingEventListener};
 
+    use crate::jinja_environment::JinjaEnv;
     use crate::listener::DefaultRenderingEventListener;
 
-    use super::raw_source_spans_to_macro_span_vec;
+    use super::{
+        generate_component_name, generate_component_name_with_serialized_node,
+        raw_source_spans_to_macro_span_vec, serialize_node_for_component_name,
+    };
+
+    #[test]
+    fn generate_component_name_accepts_pre_serialized_node() {
+        let mut env = Environment::new();
+        env.add_template(
+            "pkg.generate_schema_name",
+            "{% macro generate_schema_name(custom_schema_name=none, node=none) -%}{{ custom_schema_name }}__{{ node.name }}__{{ node.resource_type }}{%- endmacro %}",
+        )
+        .unwrap();
+        let jinja_env = JinjaEnv::new(env);
+        let base_ctx = BTreeMap::new();
+        let node = DbtTest {
+            __common_attr__: CommonAttributes {
+                unique_id: "test.pkg.my_test".to_string(),
+                name: "my_test".to_string(),
+                package_name: "pkg".to_string(),
+                fqn: vec!["pkg".to_string(), "my_test".to_string()],
+                ..Default::default()
+            },
+            __base_attr__: NodeBaseAttributes {
+                database: "db".to_string(),
+                schema: "schema".to_string(),
+                alias: "my_test".to_string(),
+                materialized: DbtMaterialization::Test,
+                enabled: true,
+                ..Default::default()
+            },
+            __test_attr__: DbtTestAttr::default(),
+            __adapter_attr__: AdapterAttr::default(),
+            defined_at: None,
+            manifest_original_file_path: PathBuf::new(),
+            deprecated_config: DataTestConfig::default(),
+            __other__: BTreeMap::new(),
+        };
+
+        let expected = generate_component_name(
+            &jinja_env,
+            "schema",
+            "pkg",
+            "pkg",
+            &base_ctx,
+            Some("custom".to_string()),
+            Some(&node),
+        )
+        .unwrap();
+        let serialized_node = serialize_node_for_component_name(&node);
+        let actual = generate_component_name_with_serialized_node(
+            &jinja_env,
+            "schema",
+            "pkg",
+            "pkg",
+            &base_ctx,
+            Some("custom".to_string()),
+            Some(&serialized_node),
+        )
+        .unwrap();
+
+        assert_eq!(actual, expected);
+        assert_eq!(actual, "custom__my_test__test");
+    }
 
     #[test]
     fn raw_source_spans_track_rendered_loop_lines() {

--- a/crates/dbt-parser/src/utils.rs
+++ b/crates/dbt-parser/src/utils.rs
@@ -8,7 +8,10 @@ use dbt_common::tracing::dbt_emit::emit_error_log_from_fs_error;
 use dbt_common::{ErrorCode, FsError, FsResult, fs_err, stdfs};
 use dbt_jinja_utils::jinja_environment::JinjaEnv;
 use dbt_jinja_utils::phases::parse::sql_resource::SqlResource;
-use dbt_jinja_utils::utils::{generate_component_name, generate_relation_name};
+use dbt_jinja_utils::utils::{
+    generate_component_name, generate_component_name_with_serialized_node, generate_relation_name,
+    serialize_node_for_component_name,
+};
 use dbt_schemas::schemas::InternalDbtNodeAttributes;
 use dbt_schemas::schemas::common::{DbtMaterialization, ResolvedQuoting, normalize_quoting};
 use dbt_schemas::schemas::project::{ResolvableConfig, ResolvedConfig};
@@ -392,19 +395,22 @@ fn generate_database_and_schema(
     adapter_type: AdapterType,
 ) -> FsResult<(String, String, ResolvedQuoting)> {
     let (default_database, default_schema) = (node.database(), node.schema());
+    let serialized_node = (!node.skip_generate_database_name_macro()
+        || !node.skip_generate_schema_name_macro())
+    .then(|| serialize_node_for_component_name(node));
 
     // Generate database name
     let database = if node.skip_generate_database_name_macro() {
         components.database.clone().unwrap_or(default_database)
     } else {
-        generate_component_name(
+        generate_component_name_with_serialized_node(
             env,
             "database",
             root_project_name,
             current_project_name,
             base_ctx,
             components.database.clone(),
-            Some(node),
+            serialized_node.as_ref(),
         )
         .unwrap_or_else(|_| default_database.to_owned())
     };
@@ -413,14 +419,14 @@ fn generate_database_and_schema(
     let schema = if node.skip_generate_schema_name_macro() {
         components.schema.clone().unwrap_or(default_schema)
     } else {
-        generate_component_name(
+        generate_component_name_with_serialized_node(
             env,
             "schema",
             root_project_name,
             current_project_name,
             base_ctx,
             components.schema.clone(),
-            Some(node),
+            serialized_node.as_ref(),
         )
         .unwrap_or_else(|_| default_schema.to_owned())
     };


### PR DESCRIPTION
Resolves #15413

### Problem

During `dbt parse`, `generate_database_and_schema` calls `generate_component_name` separately for the database and schema macros. Each call serializes the same node via `node.serialize_keep_none()` and applies the same path-prefix stripping logic, even though both macros receive the same node snapshot.

This duplicate serialization shows up on parse hot paths, especially when generating relation components for data tests.

### Solution

Extract node serialization into a shared helper (`serialize_node_for_component_name`) and add a companion entry point (`generate_component_name_with_serialized_node`) that accepts a pre-serialized node. Keep the existing `generate_component_name` API unchanged by delegating to the new helper after serializing once.

In `generate_database_and_schema`, serialize the node once and reuse that value for both database and schema macro calls before the node is mutated for alias generation.

### Measurement

Workload: `moms_flower_shop` with DuckDB profile, `dbt parse --no-version-check --no-partial-parse`.

Hotpath showed data-test relation component generation as the best small target.

Before/after:
- `dbt.relation.generate_database_and_schema`: `20.04ms` -> `18.20ms` across 50 calls
- `dbt.data_tests.update_relation_components`: `15.18ms` -> `13.98ms`

### Why behavior is unchanged

The existing `generate_component_name` path now delegates to the same helper after serializing the node. Parser code only reuses that serialized value for the database/schema pair before the node is mutated for alias generation.

### Tests

- `cargo fmt -p dbt-jinja-utils -p dbt-parser`
- `cargo test -p dbt-jinja-utils generate_component_name_accepts_pre_serialized_node --lib`
- `git diff --check`
- Hotpath parse on `moms_flower_shop`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] N/A — this is a Rust PR; the type annotations checklist item applies to Python changes.

Made with [Cursor](https://cursor.com)