### PR TITLE
fix(init): clear authenticator field when switching away from SSO/MFA auth

### DIFF
--- a/.changes/unreleased/Fixes-20260702-140451.yaml
+++ b/.changes/unreleased/Fixes-20260702-140451.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: When re-running dbt init to edit an existing Snowflake profile, if the profilea
+time: 2026-07-02T14:04:51.656394+05:30
+custom:
+    author: priyankahotkar
+    issue: . 15364
+    project: dbt-core

--- a/.changes/unreleased/Fixes-20260702-140451.yaml
+++ b/.changes/unreleased/Fixes-20260702-140451.yaml
@@ -3,5 +3,5 @@ body: dbt init no longer leaves a stale authenticator field when switching from 
 time: 2026-07-02T14:04:51.656394+05:30
 custom:
     author: priyankahotkar
-    issue: 15364
+    issue: 15378
     project: dbt-core

--- a/.changes/unreleased/Fixes-20260702-140451.yaml
+++ b/.changes/unreleased/Fixes-20260702-140451.yaml
@@ -1,7 +1,7 @@
 kind: Fixes
-body: When re-running dbt init to edit an existing Snowflake profile, if the profilea
+body: dbt init no longer leaves a stale authenticator field when switching from SSO/MFA to Password or Key pair authentication for Snowflake profiles
 time: 2026-07-02T14:04:51.656394+05:30
 custom:
     author: priyankahotkar
-    issue: . 15364
+    issue: 15364
     project: dbt-core

--- a/crates/dbt-init/src/adapter_config/snowflake_config.rs
+++ b/crates/dbt-init/src/adapter_config/snowflake_config.rs
@@ -103,7 +103,7 @@ impl InteractiveSetup for SnowflakeDbConfig {
                     match auth_method {
                         2 => self.authenticator = Some("externalbrowser".to_string()),
                         3 => self.authenticator = Some("username_password_mfa".to_string()),
-                        _ => {}
+                        _ => self.authenticator = None,
                     }
                 }
             }


### PR DESCRIPTION
## Problem

When re-running `dbt init` to edit an existing Snowflake profile, if the profile
already had `authenticator: externalbrowser` (from a prior SSO setup) and the
user selects "Password" or "Key pair" auth this time, the stale `authenticator`
field was never cleared. This caused dbt to attempt SSO login instead of using
the newly configured password, resulting in confusing authentication failures.

## Fix

In `SnowflakeDbConfig::set_field`, the `auth_method` handler now explicitly
clears `authenticator` when the selected method is not SSO or MFA, instead of
silently leaving it untouched.

## Testing

Manually verified:
1. Ran `dbt init` choosing SSO → confirmed `authenticator: externalbrowser` in `profiles.yml`
2. Re-ran `dbt init` on the same profile, chose "Edit existing profile" → selected "Password" → entered a password
3. Confirmed `profiles.yml` no longer contains `authenticator`, only the new `password` field

Fixes #15378