### PR TITLE
Trigger backport when a labeled PR is merged

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -30,14 +30,8 @@ jobs:
   backport:
     name: Backport
     runs-on: ${{ vars.UBUNTU_LATEST }}
-    # Only react to merged PRs for security reasons: the `pull_request` event
-    # runs in the context of the base branch, and gating on `merged` ensures we
-    # never act on unmerged or fork PRs.
-    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request.
-    # Handle both flows: labeling an already-merged PR, and merging a PR that
-    # already carries a backport label. The `backport ` prefix (with trailing
-    # space) matches the "backport <branch>" convention and avoids triggering on
-    # labels like `no-backport`.
+    # Only react to merged PRs for security reasons (never unmerged/fork PRs).
+    # Handles both flows: labeling a merged PR, and merging an already-labeled PR.
     if: >
       github.event.pull_request.merged
       && (

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -20,6 +20,7 @@ on:
   pull_request:
     types:
       - labeled
+      - closed
 
 permissions:
   contents: write
@@ -31,9 +32,14 @@ jobs:
     runs-on: ${{ vars.UBUNTU_LATEST }}
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    # Handle both flows: labeling an already-merged PR, and merging a PR that
+    # already carries a backport label.
     if: >
       github.event.pull_request.merged
-      && contains(github.event.label.name, 'backport')
+      && (
+        (github.event.action == 'labeled' && contains(github.event.label.name, 'backport'))
+        || (github.event.action == 'closed' && contains(join(github.event.pull_request.labels.*.name, ' '), 'backport'))
+      )
     steps:
       - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # tibdex/backport@v2.0.4
         with:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -30,15 +30,19 @@ jobs:
   backport:
     name: Backport
     runs-on: ${{ vars.UBUNTU_LATEST }}
-    # Only react to merged PRs for security reasons.
-    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    # Only react to merged PRs for security reasons: the `pull_request` event
+    # runs in the context of the base branch, and gating on `merged` ensures we
+    # never act on unmerged or fork PRs.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request.
     # Handle both flows: labeling an already-merged PR, and merging a PR that
-    # already carries a backport label.
+    # already carries a backport label. The `backport ` prefix (with trailing
+    # space) matches the "backport <branch>" convention and avoids triggering on
+    # labels like `no-backport`.
     if: >
       github.event.pull_request.merged
       && (
-        (github.event.action == 'labeled' && contains(github.event.label.name, 'backport'))
-        || (github.event.action == 'closed' && contains(join(github.event.pull_request.labels.*.name, ' '), 'backport'))
+        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'backport '))
+        || (github.event.action == 'closed' && contains(format(' {0}', join(github.event.pull_request.labels.*.name, ' ')), ' backport '))
       )
     steps:
       - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # tibdex/backport@v2.0.4


### PR DESCRIPTION
The backport workflow only triggered on the `labeled` event with an already-merged PR, so the common "add backport label, then merge" order silently did nothing. This also triggers on `closed` and checks the merged PR's full label set, keeping the existing merge-then-label path working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)