### PR TITLE
ci(release-v2): publish pre-release versions to Homebrew + winget

### DIFF
--- a/.changes/unreleased/Under the Hood-20260702-000000.yaml
+++ b/.changes/unreleased/Under the Hood-20260702-000000.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Publish pre-release versions to Homebrew and winget during the pre-stable window, and fix the empty-version bug in the release-v2 publish jobs.
+time: 2026-07-02T00:00:00.000000+05:30
+custom:
+    author: itsnamangoyal
+    issue: ""
+    project: dbt-fusion

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -125,6 +125,14 @@ defaults:
     shell: bash --noprofile --norc -euo pipefail {0}
 
 jobs:
+  # ── DISABLED DURING PRE-STABLE PREVIEW WINDOW ────────────────────────
+  # The preflight "is this the latest release" guard is turned off so every
+  # release (including pre-releases) publishes to the tap. RESTORE AT FIRST
+  # 2.x STABLE: uncomment this job AND the `needs: preflight` + `if:` lines
+  # on publish-homebrew below (all together, or the workflow is invalid).
+  # Repo-wide "latest" is correct again once a 2.x stable ships — it
+  # outranks the Python 1.x line by semver.
+  #
   # Guard: only publish the formula when this tag is GitHub's "latest"
   # release. Protects against:
   #   - Re-running an older release pipeline (re-uploads assets but
@@ -133,33 +141,33 @@ jobs:
   #   - Manual workflow_dispatch against an older version.
   # GitHub auto-marks the highest-semver non-prerelease release as latest;
   # an ops user can also flip it manually as a kill switch.
-  preflight:
-    name: Check this tag is the latest release
-    runs-on: ubuntu-latest
-    outputs:
-      is_latest: ${{ steps.check.outputs.is_latest }}
-    steps:
-      - name: Resolve latest release tag
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ inputs.tag || format('v{0}', inputs.version) }}
-        run: |
-          LATEST_TAG=$(gh release view \
-            --repo "${{ github.repository }}" \
-            --json tagName --jq .tagName)
-          if [ "$TAG" = "$LATEST_TAG" ]; then
-            echo "is_latest=true" >> "$GITHUB_OUTPUT"
-            echo "✓ $TAG is the latest release; proceeding."
-          else
-            echo "is_latest=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping brew publish: $TAG is not the latest release ($LATEST_TAG)."
-          fi
+  # preflight:
+  #   name: Check this tag is the latest release
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     is_latest: ${{ steps.check.outputs.is_latest }}
+  #   steps:
+  #     - name: Resolve latest release tag
+  #       id: check
+  #       env:
+  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         TAG: ${{ inputs.tag || format('v{0}', inputs.version) }}
+  #       run: |
+  #         LATEST_TAG=$(gh release view \
+  #           --repo "${{ github.repository }}" \
+  #           --json tagName --jq .tagName)
+  #         if [ "$TAG" = "$LATEST_TAG" ]; then
+  #           echo "is_latest=true" >> "$GITHUB_OUTPUT"
+  #           echo "✓ $TAG is the latest release; proceeding."
+  #         else
+  #           echo "is_latest=false" >> "$GITHUB_OUTPUT"
+  #           echo "::notice::Skipping brew publish: $TAG is not the latest release ($LATEST_TAG)."
+  #         fi
 
   publish-homebrew:
     name: Render + publish formula
-    needs: preflight
-    if: needs.preflight.outputs.is_latest == 'true'
+    # needs: preflight
+    # if: needs.preflight.outputs.is_latest == 'true'
     runs-on: ${{ vars.UBUNTU_RUNNER_32 }}
     env:
       TAP_REPO: ${{ inputs.tap_repo }}

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -706,12 +706,18 @@ jobs:
           gh release upload "$TAG" --clobber "${ASSETS[@]}"
 
   # Renders Formula/dbt-core.rb from the SHA256SUMS just uploaded by the
-  # `github-release` job and pushes it to dbt-labs/homebrew-dbt. Skipped
-  # for pre-release versions (anything with a `-` in the SemVer) — brew
-  # users only get stable releases.
+  # `github-release` job and pushes it to dbt-labs/homebrew-dbt.
+  #
+  # PRE-STABLE PREVIEW WINDOW: we publish every version, including
+  # pre-releases (anything with a `-` in the SemVer), so brew users can
+  # install previews before the first 2.x stable ships. Restore the
+  # pre-release guard at first stable by swapping the `if` below back to
+  # the commented line AND re-enabling the preflight job in
+  # publish-homebrew.yml.
   publish-homebrew:
-    needs: [github-release]
-    if: ${{ !inputs.dry_run && !contains(needs.prepare-release.outputs.version, '-') }}
+    needs: [prepare-release, github-release]
+    # if: ${{ !inputs.dry_run && !contains(needs.prepare-release.outputs.version, '-') }}
+    if: ${{ !inputs.dry_run }}
     uses: ./.github/workflows/publish-homebrew.yml
     with:
       version: ${{ needs.prepare-release.outputs.version }}
@@ -845,12 +851,16 @@ jobs:
 
   # Submits an updated dbtLabs.dbt-core manifest to microsoft/winget-pkgs
   # via `wingetcreate update` using the Windows installer archive from the
-  # `github-release` job. Skipped for pre-release versions (anything with
-  # a `-` in the SemVer) — winget users only get stable releases. Runs in
-  # parallel with `publish-homebrew`; both fan out from `github-release`.
+  # `github-release` job. Runs in parallel with `publish-homebrew`; both
+  # fan out from `github-release`.
+  #
+  # PRE-STABLE PREVIEW WINDOW: pre-release versions are published too. Note
+  # each preview opens a new upstream winget-pkgs PR and a permanent
+  # published version (winget accumulates versions; it does not overwrite).
+  # Restore the pre-release guard at first stable by uncommenting the `if`.
   publish-winget:
-    needs: [github-release]
-    if: ${{ !contains(needs.prepare-release.outputs.version, '-') }}
+    needs: [prepare-release, github-release]
+    # if: ${{ !contains(needs.prepare-release.outputs.version, '-') }}
     uses: ./.github/workflows/publish-winget.yml
     with:
       version: ${{ needs.prepare-release.outputs.version }}


### PR DESCRIPTION
Enables preview publishing to the brew tap + winget during the pre-stable window, and fixes a latent bug that meant nothing was actually publishing.

## Changes
- **Bug fix (permanent):** `publish-homebrew` and `publish-winget` now use `needs: [prepare-release, github-release]`. Both referenced `needs.prepare-release.outputs.version` / `.tag` but only declared `needs: [github-release]`, so — since GitHub's `needs` context only exposes *direct* dependencies — those resolved to empty strings. Result: `version`/`tag` passed through empty and the reusable homebrew workflow always skipped at its preflight (tag resolved to bare `v`). Nothing published, for previews **or** stable.
- **Preview window (revert at first 2.x stable):**
  - `release-v2.yml` `publish-homebrew`: commented the `!contains(version, '-')` guard; `if` is now `!inputs.dry_run`.
  - `release-v2.yml` `publish-winget`: commented the `!contains(version, '-')` guard (job runs on `needs` success).
  - `publish-homebrew.yml`: commented out the `preflight` latest-gate job plus the `needs:`/`if:` lines on the publish job (all together, so the workflow stays valid).

## Restore at first 2.x stable
1. `release-v2.yml` `publish-homebrew`: swap `if` back to the commented `!contains(..., '-')` line.
2. `release-v2.yml` `publish-winget`: uncomment the `if`.
3. `publish-homebrew.yml`: uncomment the `preflight` job + the `needs:`/`if:` lines on `publish-homebrew`.

## Heads-ups
- **No downgrade protection during the preview window** (preflight disabled): re-running an old preview run would overwrite the tap formula with an older build.
- **winget accumulates, homebrew overwrites:** each preview opens a new upstream `microsoft/winget-pkgs` PR and a permanent published winget version (confirmed `-` versions are accepted — `dbtLabs.dbt` is already live at `2.0.0-preview.184`). Homebrew just overwrites the single `dbt-core.rb`.
- **First 2.x stable flips repo "Latest":** it will be marked non-prerelease and `2.x > 1.11.x`, so it becomes the repo's GitHub "Latest" / `/releases/latest`, displacing the Python 1.x line. Flag to whoever owns Python 1.x distribution.