### PR TITLE
ci(winget): Slack alert with PR link when publishing PR opens

### DIFF
--- a/.changes/unreleased/Features-20260703-133618.yaml
+++ b/.changes/unreleased/Features-20260703-133618.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Post a Slack alert with the microsoft/winget-pkgs PR link when a winget publishing PR opens
+time: 2026-07-03T13:36:18.028467+05:30
+custom:
+    author: itsnamangoyal
+    issue: ""
+    project: dbt-core

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -63,13 +63,19 @@ on:
 permissions:
   contents: read
 
+# Workflow-level so both publish-winget (windows) and notify-winget-pr (ubuntu) see it.
+env:
+  PACKAGE_IDENTIFIER: dbtLabs.dbt-core
+
 jobs:
   publish-winget:
     name: wingetcreate update + submit
     runs-on: windows-latest
     timeout-minutes: 15
+    outputs:
+      pr_url: ${{ steps.submit.outputs.pr_url }}
+      pr_number: ${{ steps.submit.outputs.pr_number }}
     env:
-      PACKAGE_IDENTIFIER: dbtLabs.dbt-core
       VERSION: ${{ inputs.version }}
     steps:
       - name: Compute installer URL and release date
@@ -131,14 +137,60 @@ jobs:
 
       - name: Submit to microsoft/winget-pkgs
         if: ${{ !inputs.dry_run && steps.published.outputs.exists != 'true' }}
+        id: submit
         shell: pwsh
         env:
           WINGET_PUBLISH_PAT: ${{ secrets.WINGET_PUBLISH_PAT }}
         run: |
           Write-Host "→ $env:INSTALLER_URL"
+          # Tee keeps the live log; $LASTEXITCODE still reflects the native exe
+          # (Tee-Object is a cmdlet and does not overwrite it).
           .\wingetcreate.exe update $env:PACKAGE_IDENTIFIER `
             --version $env:VERSION `
             --urls $env:INSTALLER_URL `
             --release-date $env:RELEASE_DATE `
             --submit `
-            --token $env:WINGET_PUBLISH_PAT
+            --token $env:WINGET_PUBLISH_PAT 2>&1 | Tee-Object -Variable out
+          $code = $LASTEXITCODE
+          if ($code -ne 0) { Write-Error "wingetcreate submit failed (exit $code)"; exit $code }
+          # Anchor on the PR URL shape, not the localizable log prose.
+          $joined = $out | Out-String
+          $matched = [regex]::Matches($joined, 'https://github\.com/microsoft/winget-pkgs/pull/(\d+)')
+          if ($matched.Count -eq 0) {
+            Write-Error "Submit succeeded but no winget-pkgs PR URL found in output"; exit 1
+          }
+          $last = $matched[$matched.Count - 1]
+          "pr_url=$($last.Value)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "pr_number=$($last.Groups[1].Value)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "Captured winget PR: $($last.Value)"
+
+  notify-winget-pr:
+    name: Notify Slack (winget PR opened)
+    needs: [publish-winget]
+    if: ${{ !inputs.dry_run && needs.publish-winget.outputs.pr_url != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      # Post the winget-pkgs PR link to Slack so on-call can review it. Slack
+      # returns HTTP 200 even on failure, so assert on the `ok` field in the body.
+      - name: Post Slack message
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_WINGET_BOT_TOKEN }}
+          SLACK_CHANNEL: ${{ vars.WINGET_SLACK_CHANNEL }}
+          VERSION: ${{ inputs.version }}
+          PR_URL: ${{ needs.publish-winget.outputs.pr_url }}
+        run: |
+          text=":package: New winget PR opened for \`${PACKAGE_IDENTIFIER}\` \`${VERSION}\`: ${PR_URL}"
+          resp=$(jq -n --arg c "$SLACK_CHANNEL" --arg t "$text" \
+            '{channel: $c, text: $t, unfurl_links: false}' | \
+            curl -sS -X POST https://slack.com/api/chat.postMessage \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-type: application/json; charset=utf-8" \
+              --data @-)
+          if [ "$(echo "$resp" | jq -r '.ok')" != "true" ]; then
+            echo "::error::Slack chat.postMessage failed: $resp"
+            exit 1
+          fi
+          echo "Posted winget PR alert: $PR_URL"


### PR DESCRIPTION
Adds a Slack alert with the microsoft/winget-pkgs PR link when a dbt-core winget publishing PR opens, mirroring the fs approach.

- Captures the winget-pkgs PR URL from the submit step (Tee + regex, fail-fast).
- Posts `:package: New winget PR opened for \`dbtLabs.dbt-core\` ...` via `chat.postMessage` to `WINGET_SLACK_CHANNEL`, asserting on the `ok` field.
- Notify job is pure curl (no checkout/actions), so no SHA-pinned actions added.

**Requires** the `SLACK_WINGET_BOT_TOKEN` secret and `WINGET_SLACK_CHANNEL` variable in dbt-labs/dbt-core (same values as fs) before the notify job can post.