### PR TITLE
Fix parse-order race for unit tests on versioned models (#11139)

### DIFF
--- a/.changes/unreleased/Fixes-20260703-120000.yaml
+++ b/.changes/unreleased/Fixes-20260703-120000.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix intermittent "references a model that does not exist" parsing error when
+  unit testing versioned models, caused by non-deterministic filesystem parse order
+time: 2026-07-03T12:00:00.000000000Z
+custom:
+    Author: itsnamangoyal
+    Issue: "11139"

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -594,10 +594,25 @@ def process_models_for_unit_test(
             # If the model is disabled, the unit test should be disabled
             unit_test_def.config.enabled = False
         else:
-            # If we've reached here and the model is not disabled, throw an error
-            raise ParsingError(
-                f"Unit test '{unit_test_def.name}' references a model that does not exist: {target_model_id}"
-            )
+            # The stored model id may be stale: during parsing the tested model
+            # was resolved to its pre-versioning unversioned id, which model
+            # versioning has since replaced with versioned ids. This happens
+            # when the unit-test YAML is parsed before the versioned-model YAML
+            # (non-deterministic filesystem order). Re-resolve now that model
+            # versions are available (dbt-core #11139).
+            tested_node = find_tested_model_node(manifest, current_project, unit_test_def.model)
+            if tested_node is None:
+                # If we've reached here and the model is not disabled, throw an error
+                raise ParsingError(
+                    f"Unit test '{unit_test_def.name}' references a model that does not exist: {target_model_id}"
+                )
+            elif tested_node.config.enabled:
+                target_model_id = tested_node.unique_id
+                unit_test_def.depends_on.nodes[0] = target_model_id
+                unit_test_def.schema = tested_node.schema
+            else:
+                # If the model is disabled, the unit test should be disabled
+                unit_test_def.config.enabled = False
 
     if not unit_test_def.config.enabled:
         # Ensure the unit test is disabled in the manifest

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -570,49 +570,29 @@ def find_tested_model_node(
 def process_models_for_unit_test(
     manifest: Manifest, current_project: str, unit_test_def: UnitTestDefinition, models_to_versions
 ):
-    # If the unit tests doesn't have a depends_on.nodes[0] then we weren't able to resolve
-    # the model, either because versions hadn't been processed yet, or it's not a valid model name
-    if not unit_test_def.depends_on.nodes:
+    # Resolve (or re-resolve) the tested model. depends_on may be empty (the
+    # tested-model YAML hadn't been parsed when this unit test was parsed) or
+    # hold a stale id -- e.g. a pre-versioning unversioned id that model
+    # versioning has since replaced with versioned ids, which happens when the
+    # unit-test YAML is parsed before the versioned-model YAML (non-deterministic
+    # filesystem order). Now that model versions are available, resolve for real
+    # (dbt-core #11139).
+    if (
+        not unit_test_def.depends_on.nodes
+        or unit_test_def.depends_on.nodes[0] not in manifest.nodes
+    ):
         tested_node = find_tested_model_node(manifest, current_project, unit_test_def.model)
-        if not tested_node:
+        if tested_node is None:
             raise ParsingError(
                 f"Unable to find model '{current_project}.{unit_test_def.model}' for "
                 f"unit test '{unit_test_def.name}' in {unit_test_def.original_file_path}"
             )
         if tested_node.config.enabled:
-            unit_test_def.depends_on.nodes.append(tested_node.unique_id)
+            unit_test_def.depends_on.nodes = [tested_node.unique_id]
             unit_test_def.schema = tested_node.schema
         else:
             # If the model is disabled, the unit test should be disabled
             unit_test_def.config.enabled = False
-
-    # The UnitTestDefinition should only have one "depends_on" at this point,
-    # the one that's found by the "model" field.
-    target_model_id = unit_test_def.depends_on.nodes[0]
-    if target_model_id not in manifest.nodes:
-        if target_model_id in manifest.disabled:
-            # If the model is disabled, the unit test should be disabled
-            unit_test_def.config.enabled = False
-        else:
-            # The stored model id may be stale: during parsing the tested model
-            # was resolved to its pre-versioning unversioned id, which model
-            # versioning has since replaced with versioned ids. This happens
-            # when the unit-test YAML is parsed before the versioned-model YAML
-            # (non-deterministic filesystem order). Re-resolve now that model
-            # versions are available (dbt-core #11139).
-            tested_node = find_tested_model_node(manifest, current_project, unit_test_def.model)
-            if tested_node is None:
-                # If we've reached here and the model is not disabled, throw an error
-                raise ParsingError(
-                    f"Unit test '{unit_test_def.name}' references a model that does not exist: {target_model_id}"
-                )
-            elif tested_node.config.enabled:
-                target_model_id = tested_node.unique_id
-                unit_test_def.depends_on.nodes[0] = target_model_id
-                unit_test_def.schema = tested_node.schema
-            else:
-                # If the model is disabled, the unit test should be disabled
-                unit_test_def.config.enabled = False
 
     if not unit_test_def.config.enabled:
         # Ensure the unit test is disabled in the manifest
@@ -624,6 +604,9 @@ def process_models_for_unit_test(
         # The unit test is disabled, so we don't need to do any further processing (#10540)
         return
 
+    # The UnitTestDefinition should only have one "depends_on" at this point,
+    # the one that's found by the "model" field.
+    target_model_id = unit_test_def.depends_on.nodes[0]
     target_model = manifest.nodes[target_model_id]
     assert isinstance(target_model, ModelNode)
 

--- a/tests/functional/unit_testing/test_ut_versioned_parse_order.py
+++ b/tests/functional/unit_testing/test_ut_versioned_parse_order.py
@@ -1,0 +1,79 @@
+from unittest import mock
+
+import pytest
+
+import dbt.parser.read_files as read_files_module
+from dbt.tests.util import run_dbt
+
+my_model_sql = "select 1 as id\n"
+my_model_v2_sql = "select 1 as id\n"
+
+# Model-versions definition and unit test live in separate YAML files, as they
+# commonly do (models/ vs tests/ separation). File names are chosen so that,
+# once parse order is made deterministic, the unit-test file is parsed BEFORE
+# the model-versions file -- the order that triggers dbt-core #11139.
+model_versions_yml = """
+models:
+  - name: my_model
+    latest_version: 1
+    versions:
+      - v: 2
+        defined_in: my_model_v2
+      - v: 1
+        defined_in: my_model
+        config:
+          alias: my_model
+"""
+
+unit_test_yml = """
+unit_tests:
+  - name: test_my_model
+    model: my_model
+    versions:
+      include:
+        - 2
+    given: []
+    expect:
+      rows:
+        - {id: 1}
+"""
+
+
+def _ordered_filesystem_search(original, reverse):
+    """Make filesystem parse order deterministic so both orderings of the
+    unit-test YAML and model-versions YAML are exercised on every run."""
+
+    def wrapper(*args, **kwargs):
+        return sorted(original(*args, **kwargs), key=lambda fp: fp.relative_path, reverse=reverse)
+
+    return wrapper
+
+
+class TestUnitTestVersionedModelParseOrder:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "my_model_v2.sql": my_model_v2_sql,
+            # "a_..." sorts before "z_..." so ascending order parses the unit
+            # test first, descending order parses the model versions first.
+            "a_unit_test.yml": unit_test_yml,
+            "z_model_versions.yml": model_versions_yml,
+        }
+
+    @pytest.mark.parametrize("reverse", [False, True])
+    def test_parse_succeeds_regardless_of_file_order(self, project, reverse):
+        # dbt-core #11139: parsing must succeed no matter which of the two
+        # schema files is read first. Before the fix, `reverse=False` (unit
+        # test parsed before model versions) raises:
+        #   Parsing Error - Unit test 'test_my_model' references a model
+        #   that does not exist: model.test.my_model
+        original = read_files_module.filesystem_search
+        with mock.patch.object(
+            read_files_module,
+            "filesystem_search",
+            _ordered_filesystem_search(original, reverse),
+        ):
+            manifest = run_dbt(["parse"])
+
+        assert "unit_test.test.my_model.test_my_model_v2" in manifest.unit_tests

--- a/tests/unit/parser/test_unit_tests.py
+++ b/tests/unit/parser/test_unit_tests.py
@@ -3,6 +3,7 @@ from unittest import mock
 from dbt.artifacts.resources import DependsOn, UnitTestConfig, UnitTestFormat
 from dbt.contracts.graph.nodes import NodeType, UnitTestDefinition
 from dbt.contracts.graph.unparsed import UnitTestOutputFixture
+from dbt.exceptions import ParsingError
 from dbt.parser import SchemaParser
 from dbt.parser.unit_tests import UnitTestParser, process_models_for_unit_test
 from dbt_common.events.event_catcher import EventCatcher
@@ -291,6 +292,20 @@ class UnitTestParserTest(SchemaParserTest):
         assert "unit_test.snowplow.my_model.test_my_model_v1" in manifest.unit_tests
         versioned_ut = manifest.unit_tests["unit_test.snowplow.my_model.test_my_model_v1"]
         self.assertEqual(versioned_ut.depends_on.nodes[0], "model.snowplow.my_model.v1")
+
+    def test_missing_model_raises_parsing_error(self):
+        # A unit test whose `model` never resolves must raise in
+        # process_models_for_unit_test (covers the not-found path of the
+        # re-resolution added for dbt-core #11139).
+        block = self.yaml_block_for(UNIT_TEST_MODEL_NOT_FOUND_SOURCE, "test_missing.yml")
+        UnitTestParser(self.parser, block).parse()
+
+        manifest = self.parser.manifest
+        unit_test = manifest.unit_tests[
+            "unit_test.snowplow.my_model_doesnt_exist.test_my_model_doesnt_exist"
+        ]
+        with self.assertRaises(ParsingError):
+            process_models_for_unit_test(manifest, "snowplow", unit_test, {})
 
     def test_multiple_unit_tests(self):
         block = self.yaml_block_for(UNIT_TEST_MULTIPLE_SOURCE, "test_my_model.yml")

--- a/tests/unit/parser/test_unit_tests.py
+++ b/tests/unit/parser/test_unit_tests.py
@@ -4,7 +4,7 @@ from dbt.artifacts.resources import DependsOn, UnitTestConfig, UnitTestFormat
 from dbt.contracts.graph.nodes import NodeType, UnitTestDefinition
 from dbt.contracts.graph.unparsed import UnitTestOutputFixture
 from dbt.parser import SchemaParser
-from dbt.parser.unit_tests import UnitTestParser
+from dbt.parser.unit_tests import UnitTestParser, process_models_for_unit_test
 from dbt_common.events.event_catcher import EventCatcher
 from dbt_common.events.event_manager_client import add_callback_to_manager
 from dbt_common.events.types import SystemStdErr
@@ -248,6 +248,49 @@ class UnitTestParserTest(SchemaParserTest):
         ]
         self.assertEqual(len(unit_test.depends_on.nodes), 1)
         self.assertEqual(unit_test.depends_on.nodes[0], "model.snowplow.my_model_versioned.v1")
+
+    def test_versioned_model_parsed_before_versioning_is_reresolved(self):
+        # Regression test for dbt-core #11139.
+        # When the unit-test YAML is parsed before the versioned model's schema
+        # patch is applied (non-deterministic filesystem parse order), the unit
+        # test's depends_on is bound to the pre-versioning unversioned unique_id
+        # (model.snowplow.my_model). Versioning then removes that id from the
+        # manifest. process_models_for_unit_test must re-resolve the now-stale
+        # id to the versioned model instead of raising "references a model that
+        # does not exist".
+        block = self.yaml_block_for(UNIT_TEST_SOURCE, "test_my_model.yml")
+        UnitTestParser(self.parser, block).parse()
+
+        manifest = self.parser.manifest
+        manifest.files[block.file.file_id] = block.file
+        unit_test = manifest.unit_tests["unit_test.snowplow.my_model.test_my_model"]
+        # Parsed before versioning: bound to the unversioned id.
+        self.assertEqual(unit_test.depends_on.nodes, ["model.snowplow.my_model"])
+
+        # Simulate the model versioning patch: the unversioned node id is
+        # replaced by the versioned one, and ref_lookup is rebuilt.
+        del manifest.nodes["model.snowplow.my_model"]
+        versioned_node = MockNode(
+            package="snowplow",
+            name="my_model",
+            config=mock.MagicMock(enabled=True),
+            schema="test_schema",
+            refs=[],
+            sources=[],
+            patch_path=None,
+            version=1,
+            latest_version=1,
+            is_latest_version=True,
+        )
+        manifest.nodes[versioned_node.unique_id] = versioned_node
+        manifest.rebuild_ref_lookup()
+
+        models_to_versions = {"snowplow": {"my_model": [versioned_node.unique_id]}}
+        process_models_for_unit_test(manifest, "snowplow", unit_test, models_to_versions)
+
+        assert "unit_test.snowplow.my_model.test_my_model_v1" in manifest.unit_tests
+        versioned_ut = manifest.unit_tests["unit_test.snowplow.my_model.test_my_model_v1"]
+        self.assertEqual(versioned_ut.depends_on.nodes[0], "model.snowplow.my_model.v1")
 
     def test_multiple_unit_tests(self):
         block = self.yaml_block_for(UNIT_TEST_MULTIPLE_SOURCE, "test_my_model.yml")


### PR DESCRIPTION
Resolves #11139.

## Problem
Unit tests on versioned models intermittently fail during parsing with `Unit test '<name>' references a model that does not exist`. Root cause is non-deterministic filesystem parse order: when the unit-test YAML is parsed before the versioned-model YAML, the tested model is resolved to its pre-versioning unversioned unique_id (e.g. `model.pkg.model`), which model versioning then removes from the manifest (replacing it with `model.pkg.model.v1`/`.v2`). `process_models_for_unit_test` only re-resolved when `depends_on.nodes` was empty, so the stale id slipped through and raised.

## Fix
In `process_models_for_unit_test`, when the stored tested-model id is not in `manifest.nodes` (and not disabled), re-resolve it via `find_tested_model_node` — which runs after model versions are finalized — instead of raising. Preserves the existing disabled-model handling (#10540).

## Tests
- Deterministic unit regression test in `test_unit_tests.py` reproducing the stale-id state.
- Functional test covering both file orderings (`test_ut_versioned_parse_order.py`).
- Verified end-to-end against a real project (jaffle-shop): the failing order errors before the fix and parses cleanly after.

Tracking: CORE-726.