### PR TITLE
docs: explain the community PR flow + auto-welcome comment

### DIFF
--- a/.github/workflows/welcome-community-pr.yml
+++ b/.github/workflows/welcome-community-pr.yml
@@ -1,0 +1,82 @@
+# **what?**
+# Post a one-time welcome comment on pull requests from community contributors,
+# linking to the contributing guide's explanation of what happens after a PR is
+# opened (labels, the "dbt Labs CI" status check, fork-CI re-approval on each
+# push, and the bot that closes the PR once the change is merged upstream).
+#
+# **why?**
+# dbt Core is the public mirror of a private dbt Labs repository, and changes
+# flow between the two automatically. The resulting labels, comments, status
+# checks, and bot-close behavior are surprising to first-time contributors.
+# Surfacing the guide up front sets expectations and reduces confusion.
+#
+# **when?**
+# When a non-draft PR from an external contributor is opened, or when a draft
+# PR from an external contributor is marked ready for review. A hidden marker
+# in the comment body prevents duplicate comments on later events.
+
+name: Welcome community contributors
+
+on:
+  # pull_request_target so the job has write access to comment on fork PRs
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  pull-requests: write
+
+jobs:
+  welcome:
+    # Only external contributors (not maintainers/members) and not bots.
+    if: |
+      (
+        github.event.pull_request.author_association == 'CONTRIBUTOR'
+        || github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+        || github.event.pull_request.author_association == 'FIRST_TIMER'
+        || github.event.pull_request.author_association == 'NONE'
+      )
+      && github.event.pull_request.user.type != 'Bot'
+      && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post welcome comment (once)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- welcome-comment -->';
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            if (comments.some(c => c.body && c.body.includes(marker))) {
+              core.info('Welcome comment already present, skipping.');
+              return;
+            }
+
+            const guide = 'https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md#what-happens-after-you-open-a-pull-request';
+            const body = [
+              '👋 Thanks for contributing to dbt Core!',
+              '',
+              'A few things to expect on your PR:',
+              '- It will be labeled `community` and triaged by a maintainer.',
+              '- CI on fork PRs requires a maintainer to add the `ci:approve-public-fork-ci` label. That label is removed on every push, so it needs re-approval after each update — this is expected.',
+              '- CI results appear here as the **dbt Labs CI** status check.',
+              '- When your change is merged, a bot will comment and close this PR. Your commit lands here shortly afterward — this means your change was accepted, not rejected.',
+              '',
+              `The full flow is documented here: [What happens after you open a pull request](${guide}).`,
+              '',
+              marker,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,27 @@ Contribute by opening a pull request against the current development branch, `ma
 
 Once your PR has been approved, a maintainer will take it from there and shepherd your changes into dbt Core. And that's it! Happy developing 🎉
 
+## What happens after you open a pull request
+
+dbt Core is developed through dbt Labs' internal build and review process, and this repository is kept in sync with it automatically. You don't need to do anything special for this — but it's worth knowing, because it explains the labels, comments, and status checks you'll see on your PR.
+
+1. **Your PR is triaged.** PRs opened by community members are automatically labeled `community`, and during triage they're marked `source:community` to note the change came from an external contributor. A maintainer reviews the change and, once it's on the right track, assigns a reviewer.
+
+2. **The changelog check runs.** If your PR doesn't include a changelog entry, a bot comments to let you know. See [Adding a CHANGELOG Entry](#adding-a-changelog-entry). If a changelog isn't needed, a maintainer can add the `Skip Changelog` label.
+
+3. **CI is approved (fork PRs only).** Because PRs from forks can't safely access repository secrets, a maintainer must add the `ci:approve-public-fork-ci` label before CI runs. **This label is automatically removed every time you push new commits**, so a maintainer will re-approve after each update. This is expected — it isn't a sign that anything is wrong with your change.
+
+4. **CI results and sync status appear on your PR.** Build results surface as the **dbt Labs CI** status check. The review's progress is reflected through `review-status:` labels:
+
+   | Label | Meaning |
+   | --- | --- |
+   | `review-status: in-review` | Your change synced successfully and is under review. |
+   | `review-status: sync-failed` | The sync couldn't be applied (for example, a merge conflict). A maintainer will help resolve it — you may be asked to rebase. |
+   | `review-status: merged-upstream` | Your change has been merged and will land in this repository in the next sync. |
+   | `review-status: closed-upstream` | The change was closed without merging. |
+
+5. **Your change is merged.** When your change is merged, a bot comments to let you know and closes this PR. Your commit lands in this repository in the next sync. Closing the PR in this way is normal — your contribution has been accepted, not rejected. 🎉
+
 ## Adding a CHANGELOG Entry
 
 We use [changie](https://changie.dev) to generate `CHANGELOG` entries. **Note:** Do not edit the `CHANGELOG.md` directly. Your modifications will be lost.


### PR DESCRIPTION
Adds a CONTRIBUTING.md section explaining what community contributors see after opening a PR (labels, fork-CI re-approval on each push, sync status, and the bot that closes the PR once merged upstream), plus a workflow that posts a one-time welcome comment linking to it.

- New section: **What happens after you open a pull request**
- New workflow: `welcome-community-pr.yml` — comments once on external, non-draft PRs. Uses `pull_request_target` for write access but never checks out or runs fork code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)