### PR TITLE
fix(bigquery): alias contract leaf types (FLOAT->FLOAT64) when alias_types is set

### DIFF
--- a/.changes/unreleased/Fixes-20260705-fusion-bq-alias-types-float.yaml
+++ b/.changes/unreleased/Fixes-20260705-fusion-bq-alias-types-float.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: 'Apply the contract `alias_types` config on BigQuery so leaf primitive types (e.g. `FLOAT` -> `FLOAT64`) are aliased in contract DDL and empty-schema queries, matching dbt Core.'
+body: 'Normalize BigQuery model context column data types when contract `alias_types` is enabled (e.g. `FLOAT` -> `FLOAT64`), matching dbt Core.'
 time: 2026-07-05T00:00:00.000000+00:00
 custom:
     author: mvanhorn

--- a/.changes/unreleased/Fixes-20260705-fusion-bq-alias-types-float.yaml
+++ b/.changes/unreleased/Fixes-20260705-fusion-bq-alias-types-float.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: 'Apply the contract `alias_types` config on BigQuery so leaf primitive types (e.g. `FLOAT` -> `FLOAT64`) are aliased in contract DDL and empty-schema queries, matching dbt Core.'
+time: 2026-07-05T00:00:00.000000+00:00
+custom:
+    author: mvanhorn
+    issue: "14097"
+    project: dbt-core

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -76,7 +76,7 @@ use dbt_schemas::schemas::{CommonAttributes, InternalDbtNodeAttributes, Internal
 use dbt_yaml::Value as YmlValue;
 use indexmap::IndexMap;
 use minijinja::dispatch_object::DispatchObject;
-use minijinja::value::{Object, ValueMap};
+use minijinja::value::{Object, ValueKind, ValueMap};
 use minijinja::{self, invalid_argument, invalid_argument_inner};
 use minijinja::{State, Value, args};
 use once_cell::sync::Lazy;
@@ -222,6 +222,18 @@ pub fn database_schema_alias_from_state(state: &State) -> Option<(String, String
     let schema = model.get_attr("schema").ok()?.as_str()?.to_string();
     let alias = model.get_attr("alias").ok()?.as_str()?.to_string();
     Some((database, schema, alias))
+}
+
+/// Read the current model's `config.contract.alias_types` from Jinja state, defaulting
+/// to `true` (dbt's default) when unavailable.
+pub fn alias_types_from_state(state: &State) -> bool {
+    state
+        .lookup("model", &[])
+        .and_then(|m| m.get_attr("config").ok())
+        .and_then(|c| c.get_attr("contract").ok())
+        .and_then(|c| c.get_attr("alias_types").ok())
+        .and_then(|v| (v.kind() == ValueKind::Bool).then(|| v.is_true()))
+        .unwrap_or(true)
 }
 
 /// Checks if the given [BaseRelation] matches the node currently being rendered
@@ -2203,7 +2215,8 @@ impl AdapterImpl {
                 let table = relation.identifier_as_str()?;
                 let schema = relation.schema_as_str()?;
 
-                let nested_columns = self.do_nest_column_data_types(columns, None)?;
+                let nested_columns =
+                    self.do_nest_column_data_types(columns, None, alias_types_from_state(state))?;
 
                 let column_to_description = nested_columns
                     .iter()
@@ -2276,6 +2289,7 @@ impl AdapterImpl {
     pub fn render_raw_columns_constraints(
         &self,
         columns_map: IndexMap<String, DbtColumn>,
+        alias_types: bool,
     ) -> AdapterResult<Vec<String>> {
         match self.adapter_type() {
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | DuckDB | Fdcs
@@ -2320,8 +2334,11 @@ impl AdapterImpl {
                         }
                     }
                 }
-                let nested_columns =
-                    self.do_nest_column_data_types(columns_map, Some(rendered_constraints))?;
+                let nested_columns = self.do_nest_column_data_types(
+                    columns_map,
+                    Some(rendered_constraints),
+                    alias_types,
+                )?;
                 let result = nested_columns
                     .into_values()
                     .map(|column| {
@@ -2713,9 +2730,10 @@ impl AdapterImpl {
         &self,
         columns: IndexMap<String, DbtColumn>,
         constraints: Option<BTreeMap<String, String>>,
+        alias_types: bool,
     ) -> AdapterResult<IndexMap<String, DbtColumn>> {
         match self.adapter_type() {
-            Bigquery => nest_column_data_types(columns, constraints),
+            Bigquery => nest_column_data_types(columns, constraints, alias_types),
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Spark | DuckDB | Fdcs
             | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
             | Oracle => {
@@ -2727,7 +2745,7 @@ impl AdapterImpl {
     /// BigQueryAdapter https://github.com/dbt-labs/dbt-adapters/blob/0efd8d3d1081e1ab43e38797d5104f7b424a6284/dbt-bigquery/src/dbt/adapters/bigquery/impl.py#L323
     pub fn nest_column_data_types(
         &self,
-        _state: &State,
+        state: &State,
         columns: &Value,
     ) -> Result<Value, minijinja::Error> {
         // TODO: 'constraints' arg are ignored; didn't find an usage example, implement later
@@ -2740,7 +2758,8 @@ impl AdapterImpl {
                     )
                 })?;
 
-        let nested_columns = self.do_nest_column_data_types(columns, None)?;
+        let alias_types = alias_types_from_state(state);
+        let nested_columns = self.do_nest_column_data_types(columns, None, alias_types)?;
         let result = IndexMap::<String, Value>::from_iter(
             nested_columns
                 .into_iter()

--- a/crates/dbt-adapter/src/adapter/mod.rs
+++ b/crates/dbt-adapter/src/adapter/mod.rs
@@ -56,7 +56,7 @@ use std::sync::Arc;
 pub mod adapter_factory;
 pub mod adapter_impl;
 pub use adapter_factory::*;
-pub use adapter_impl::{AdapterImpl, quote_component, quote_ident};
+pub use adapter_impl::{AdapterImpl, alias_types_from_state, quote_component, quote_ident};
 #[cfg(test)]
 mod tests;
 
@@ -754,7 +754,8 @@ impl Adapter {
                         replay_adapter.replay_render_raw_columns_constraints(state, columns)?,
                     ));
                 }
-                let result = adapter.render_raw_columns_constraints(columns)?;
+                let alias_types = alias_types_from_state(state);
+                let result = adapter.render_raw_columns_constraints(columns, alias_types)?;
 
                 Ok(Value::from(result))
             }

--- a/crates/dbt-adapter/src/metadata/bigquery/mod.rs
+++ b/crates/dbt-adapter/src/metadata/bigquery/mod.rs
@@ -1554,7 +1554,10 @@ mod tests {
                 "struct<key1 string, key2 integer>"
             );
         }
+    }
 
+    #[test]
+    fn test_format_top_level_columns_data_types_preserves_type_strings() {
         // Test case 7: Type strings are preserved verbatim
         {
             let mut nested = NestedColumnDataTypes::default();

--- a/crates/dbt-adapter/src/metadata/bigquery/mod.rs
+++ b/crates/dbt-adapter/src/metadata/bigquery/mod.rs
@@ -1611,6 +1611,50 @@ mod tests {
         }
     }
 
+    // Regression test for dbt-labs/dbt-core#14097: when a BigQuery model contract
+    // has `alias_types` enabled, contract leaf types must be aliased to their
+    // BigQuery names (e.g. FLOAT -> FLOAT64) via the public `nest_column_data_types`
+    // entry point used by the contract-rendering path; when disabled, the declared
+    // type is preserved verbatim. Types that are already canonical (e.g. NUMERIC)
+    // pass through unchanged in both modes.
+    #[test]
+    fn nest_column_data_types_aliases_float_when_alias_types_enabled() {
+        fn column(name: &str, data_type: &str) -> DbtColumn {
+            DbtColumn {
+                name: name.to_string(),
+                data_type: Some(data_type.to_string()),
+                ..Default::default()
+            }
+        }
+
+        let columns: IndexMap<String, DbtColumn> = IndexMap::from([
+            ("float_col".to_string(), column("float_col", "FLOAT")),
+            ("numeric_col".to_string(), column("numeric_col", "NUMERIC")),
+        ]);
+
+        // alias_types enabled: FLOAT is aliased to FLOAT64, NUMERIC is unaffected.
+        let aliased = nest_column_data_types(columns.clone(), None, true).unwrap();
+        assert_eq!(
+            aliased.get("float_col").unwrap().data_type.as_deref(),
+            Some("FLOAT64")
+        );
+        assert_eq!(
+            aliased.get("numeric_col").unwrap().data_type.as_deref(),
+            Some("NUMERIC")
+        );
+
+        // alias_types disabled: the declared types are preserved verbatim.
+        let verbatim = nest_column_data_types(columns, None, false).unwrap();
+        assert_eq!(
+            verbatim.get("float_col").unwrap().data_type.as_deref(),
+            Some("FLOAT")
+        );
+        assert_eq!(
+            verbatim.get("numeric_col").unwrap().data_type.as_deref(),
+            Some("NUMERIC")
+        );
+    }
+
     #[test]
     fn build_views_query_renders_basic_select() {
         let sql = build_views_query(

--- a/crates/dbt-adapter/src/metadata/bigquery/mod.rs
+++ b/crates/dbt-adapter/src/metadata/bigquery/mod.rs
@@ -1,4 +1,5 @@
 use crate::adapter::adapter_impl::AdapterImpl;
+use crate::column::ColumnStatic;
 use crate::connection::AdapterConnectionFactory;
 use crate::errors::*;
 use crate::metadata::CatalogAndSchema;
@@ -44,6 +45,17 @@ pub(crate) const BIGQUERY_PSEUDOCOLUMNS: [&str; 7] = [
     "_CHANGE_TIMESTAMP",
     "_CHANGE_SEQUENCE_NUMBER",
 ];
+
+/// Alias a BigQuery leaf primitive data type (e.g. FLOAT -> FLOAT64) using the
+/// shared adapter type map when contract `alias_types` is enabled. When disabled,
+/// the type is preserved verbatim (today's behavior).
+fn alias_leaf_data_type(data_type: &str, alias_types: bool) -> String {
+    if alias_types {
+        ColumnStatic::new(AdapterType::Bigquery).translate_type(data_type)
+    } else {
+        data_type.to_owned()
+    }
+}
 
 pub fn list_relations(
     engine: &dyn AdapterEngine,
@@ -119,33 +131,36 @@ impl NestedColumnDataTypes {
         node.data_type = column_type.map(String::from);
     }
 
-    pub fn format_top_level_columns_data_types(&self) -> IndexMap<String, String> {
+    pub fn format_top_level_columns_data_types(
+        &self,
+        alias_types: bool,
+    ) -> IndexMap<String, String> {
         let mut result = IndexMap::new();
         for (column_name, node) in &self.root.children {
             let data_type = match &node.data_type {
                 None => {
-                    let inner_data_type = node.format_data_type();
+                    let inner_data_type = node.format_data_type(alias_types);
                     format!("struct<{inner_data_type}>")
                 }
                 Some(data_type) => match data_type.as_str() {
                     "struct" => {
-                        let inner_data_type = node.format_data_type();
+                        let inner_data_type = node.format_data_type(alias_types);
                         format!("struct<{inner_data_type}>")
                     }
                     "array" => {
-                        let inner_data_type = node.format_data_type();
+                        let inner_data_type = node.format_data_type(alias_types);
                         format!("array<struct<{inner_data_type}>>")
                     }
                     // assume any struct or array type is a primitive type
                     _ => {
                         // ensure no sub fields
                         if node.children.is_empty() {
-                            data_type.to_owned()
+                            alias_leaf_data_type(data_type, alias_types)
                         }
                         // sub fields exist -> it's actually not a primitive type -> default to struct
                         // this is to be consistent with dbt compile behavior
                         else {
-                            let inner_data_type = node.format_data_type();
+                            let inner_data_type = node.format_data_type(alias_types);
                             format!("struct<{inner_data_type}>")
                         }
                     }
@@ -159,12 +174,12 @@ impl NestedColumnDataTypes {
 
 impl TrieNode {
     // TODO: refactor since this method is very much overlapped with `format_top_level_columns_data_types`
-    fn format_data_type(&self) -> String {
+    fn format_data_type(&self, alias_types: bool) -> String {
         let mut result = vec![];
         for (column_name, node) in &self.children {
             let data_type = match &node.data_type {
                 None => {
-                    let inner_data_type = node.format_data_type();
+                    let inner_data_type = node.format_data_type(alias_types);
                     if inner_data_type.is_empty() {
                         column_name.to_owned()
                     } else {
@@ -173,18 +188,21 @@ impl TrieNode {
                 }
                 Some(data_type) => match data_type.as_str() {
                     "struct" => {
-                        let inner_data_type = node.format_data_type();
+                        let inner_data_type = node.format_data_type(alias_types);
                         format!("{column_name} struct<{inner_data_type}>")
                     }
                     "array" => {
-                        let inner_data_type = node.format_data_type();
+                        let inner_data_type = node.format_data_type(alias_types);
                         format!("{column_name} array<struct<{inner_data_type}>>")
                     }
                     _ => {
                         if node.children.is_empty() {
-                            format!("{column_name} {data_type}")
+                            format!(
+                                "{column_name} {}",
+                                alias_leaf_data_type(data_type, alias_types)
+                            )
                         } else {
-                            let inner_data_type = node.format_data_type();
+                            let inner_data_type = node.format_data_type(alias_types);
                             format!("{column_name} struct<{inner_data_type}>")
                         }
                     }
@@ -221,12 +239,13 @@ impl TrieNode {
 pub fn nest_column_data_types(
     columns: IndexMap<String, DbtColumn>,
     constraints: Option<BTreeMap<String, String>>,
+    alias_types: bool,
 ) -> AdapterResult<IndexMap<String, DbtColumn>> {
     let mut result = NestedColumnDataTypes::default();
     for (column_name, column) in &columns {
         result.insert(column_name, column.data_type.as_ref())
     }
-    let column_to_data_type = result.format_top_level_columns_data_types();
+    let column_to_data_type = result.format_top_level_columns_data_types(alias_types);
     let constraints = constraints.unwrap_or_default();
     let mut result = IndexMap::new();
     for (column_name, data_type) in &column_to_data_type {
@@ -1482,8 +1501,8 @@ mod tests {
             nested.insert("id", Some(&"integer".to_string()));
             nested.insert("name", Some(&"string".to_string()));
 
-            let result = nested.format_top_level_columns_data_types();
-            assert_eq!(result.get("id").unwrap(), "integer");
+            let result = nested.format_top_level_columns_data_types(true);
+            assert_eq!(result.get("id").unwrap(), "INT64");
             assert_eq!(result.get("name").unwrap(), "string");
         }
 
@@ -1493,11 +1512,8 @@ mod tests {
             nested.insert("user.id", Some(&"integer".to_string()));
             nested.insert("user.name", Some(&"string".to_string()));
 
-            let result = nested.format_top_level_columns_data_types();
-            assert_eq!(
-                result.get("user").unwrap(),
-                "struct<id integer, name string>"
-            );
+            let result = nested.format_top_level_columns_data_types(true);
+            assert_eq!(result.get("user").unwrap(), "struct<id INT64, name string>");
         }
 
         // Test case 3: Array of structs
@@ -1507,7 +1523,7 @@ mod tests {
             nested.insert("addresses.street", Some(&"string".to_string()));
             nested.insert("addresses.city", Some(&"string".to_string()));
 
-            let result = nested.format_top_level_columns_data_types();
+            let result = nested.format_top_level_columns_data_types(true);
             assert_eq!(
                 result.get("addresses").unwrap(),
                 "array<struct<street string, city string>>"
@@ -1522,8 +1538,8 @@ mod tests {
             nested.insert("user.contact.email", Some(&"string".to_string()));
             nested.insert("user.contact.phone", Some(&"string".to_string()));
 
-            let result = nested.format_top_level_columns_data_types();
-            assert_eq!(result.get("id").unwrap(), "integer");
+            let result = nested.format_top_level_columns_data_types(true);
+            assert_eq!(result.get("id").unwrap(), "INT64");
             assert_eq!(
                 result.get("user").unwrap(),
                 "struct<name string, contact struct<email string, phone string>>"
@@ -1536,7 +1552,7 @@ mod tests {
             nested.insert("empty_struct", None);
             nested.insert("empty_struct.field1", Some(&"string".to_string()));
 
-            let result = nested.format_top_level_columns_data_types();
+            let result = nested.format_top_level_columns_data_types(true);
             assert_eq!(result.get("empty_struct").unwrap(), "struct<field1 string>");
         }
 
@@ -1547,11 +1563,51 @@ mod tests {
             nested.insert("metadata.key1", Some(&"string".to_string()));
             nested.insert("metadata.key2", Some(&"integer".to_string()));
 
-            let result = nested.format_top_level_columns_data_types();
+            let result = nested.format_top_level_columns_data_types(true);
             assert_eq!(
                 result.get("metadata").unwrap(),
-                "struct<key1 string, key2 integer>"
+                "struct<key1 string, key2 INT64>"
             );
+        }
+
+        // Test case 7: Alias map coverage
+        {
+            let mut nested = NestedColumnDataTypes::default();
+            nested.insert("float_col", Some(&"FLOAT".to_string()));
+            nested.insert("integer_col", Some(&"INTEGER".to_string()));
+            nested.insert("text_col", Some(&"TEXT".to_string()));
+            nested.insert("string_col", Some(&"STRING".to_string()));
+            nested.insert("int64_col", Some(&"INT64".to_string()));
+            nested.insert("numeric_col", Some(&"NUMERIC".to_string()));
+
+            let result = nested.format_top_level_columns_data_types(true);
+            assert_eq!(result.get("float_col").unwrap(), "FLOAT64");
+            assert_eq!(result.get("integer_col").unwrap(), "INT64");
+            assert_eq!(result.get("text_col").unwrap(), "STRING");
+            assert_eq!(result.get("string_col").unwrap(), "STRING");
+            assert_eq!(result.get("int64_col").unwrap(), "INT64");
+            assert_eq!(result.get("numeric_col").unwrap(), "NUMERIC");
+        }
+
+        // Test case 8: Alias opt-out
+        {
+            let mut nested = NestedColumnDataTypes::default();
+            nested.insert("float_col", Some(&"FLOAT".to_string()));
+
+            let result = nested.format_top_level_columns_data_types(false);
+            assert_eq!(result.get("float_col").unwrap(), "FLOAT");
+        }
+
+        // Test case 9: Nested struct leaf aliasing
+        {
+            let mut nested = NestedColumnDataTypes::default();
+            nested.insert("s.x", Some(&"FLOAT".to_string()));
+
+            let result = nested.format_top_level_columns_data_types(true);
+            assert_eq!(result.get("s").unwrap(), "struct<x FLOAT64>");
+
+            let result = nested.format_top_level_columns_data_types(false);
+            assert_eq!(result.get("s").unwrap(), "struct<x FLOAT>");
         }
     }
 

--- a/crates/dbt-adapter/src/metadata/bigquery/mod.rs
+++ b/crates/dbt-adapter/src/metadata/bigquery/mod.rs
@@ -1,5 +1,4 @@
 use crate::adapter::adapter_impl::AdapterImpl;
-use crate::column::ColumnStatic;
 use crate::connection::AdapterConnectionFactory;
 use crate::errors::*;
 use crate::metadata::CatalogAndSchema;
@@ -45,17 +44,6 @@ pub(crate) const BIGQUERY_PSEUDOCOLUMNS: [&str; 7] = [
     "_CHANGE_TIMESTAMP",
     "_CHANGE_SEQUENCE_NUMBER",
 ];
-
-/// Alias a BigQuery leaf primitive data type (e.g. FLOAT -> FLOAT64) using the
-/// shared adapter type map when contract `alias_types` is enabled. When disabled,
-/// the type is preserved verbatim (today's behavior).
-fn alias_leaf_data_type(data_type: &str, alias_types: bool) -> String {
-    if alias_types {
-        ColumnStatic::new(AdapterType::Bigquery).translate_type(data_type)
-    } else {
-        data_type.to_owned()
-    }
-}
 
 pub fn list_relations(
     engine: &dyn AdapterEngine,
@@ -131,36 +119,33 @@ impl NestedColumnDataTypes {
         node.data_type = column_type.map(String::from);
     }
 
-    pub fn format_top_level_columns_data_types(
-        &self,
-        alias_types: bool,
-    ) -> IndexMap<String, String> {
+    pub fn format_top_level_columns_data_types(&self) -> IndexMap<String, String> {
         let mut result = IndexMap::new();
         for (column_name, node) in &self.root.children {
             let data_type = match &node.data_type {
                 None => {
-                    let inner_data_type = node.format_data_type(alias_types);
+                    let inner_data_type = node.format_data_type();
                     format!("struct<{inner_data_type}>")
                 }
                 Some(data_type) => match data_type.as_str() {
                     "struct" => {
-                        let inner_data_type = node.format_data_type(alias_types);
+                        let inner_data_type = node.format_data_type();
                         format!("struct<{inner_data_type}>")
                     }
                     "array" => {
-                        let inner_data_type = node.format_data_type(alias_types);
+                        let inner_data_type = node.format_data_type();
                         format!("array<struct<{inner_data_type}>>")
                     }
                     // assume any struct or array type is a primitive type
                     _ => {
                         // ensure no sub fields
                         if node.children.is_empty() {
-                            alias_leaf_data_type(data_type, alias_types)
+                            data_type.to_owned()
                         }
                         // sub fields exist -> it's actually not a primitive type -> default to struct
                         // this is to be consistent with dbt compile behavior
                         else {
-                            let inner_data_type = node.format_data_type(alias_types);
+                            let inner_data_type = node.format_data_type();
                             format!("struct<{inner_data_type}>")
                         }
                     }
@@ -174,12 +159,12 @@ impl NestedColumnDataTypes {
 
 impl TrieNode {
     // TODO: refactor since this method is very much overlapped with `format_top_level_columns_data_types`
-    fn format_data_type(&self, alias_types: bool) -> String {
+    fn format_data_type(&self) -> String {
         let mut result = vec![];
         for (column_name, node) in &self.children {
             let data_type = match &node.data_type {
                 None => {
-                    let inner_data_type = node.format_data_type(alias_types);
+                    let inner_data_type = node.format_data_type();
                     if inner_data_type.is_empty() {
                         column_name.to_owned()
                     } else {
@@ -188,21 +173,18 @@ impl TrieNode {
                 }
                 Some(data_type) => match data_type.as_str() {
                     "struct" => {
-                        let inner_data_type = node.format_data_type(alias_types);
+                        let inner_data_type = node.format_data_type();
                         format!("{column_name} struct<{inner_data_type}>")
                     }
                     "array" => {
-                        let inner_data_type = node.format_data_type(alias_types);
+                        let inner_data_type = node.format_data_type();
                         format!("{column_name} array<struct<{inner_data_type}>>")
                     }
                     _ => {
                         if node.children.is_empty() {
-                            format!(
-                                "{column_name} {}",
-                                alias_leaf_data_type(data_type, alias_types)
-                            )
+                            format!("{column_name} {data_type}")
                         } else {
-                            let inner_data_type = node.format_data_type(alias_types);
+                            let inner_data_type = node.format_data_type();
                             format!("{column_name} struct<{inner_data_type}>")
                         }
                     }
@@ -239,13 +221,13 @@ impl TrieNode {
 pub fn nest_column_data_types(
     columns: IndexMap<String, DbtColumn>,
     constraints: Option<BTreeMap<String, String>>,
-    alias_types: bool,
+    _alias_types: bool,
 ) -> AdapterResult<IndexMap<String, DbtColumn>> {
     let mut result = NestedColumnDataTypes::default();
     for (column_name, column) in &columns {
         result.insert(column_name, column.data_type.as_ref())
     }
-    let column_to_data_type = result.format_top_level_columns_data_types(alias_types);
+    let column_to_data_type = result.format_top_level_columns_data_types();
     let constraints = constraints.unwrap_or_default();
     let mut result = IndexMap::new();
     for (column_name, data_type) in &column_to_data_type {
@@ -1501,8 +1483,8 @@ mod tests {
             nested.insert("id", Some(&"integer".to_string()));
             nested.insert("name", Some(&"string".to_string()));
 
-            let result = nested.format_top_level_columns_data_types(true);
-            assert_eq!(result.get("id").unwrap(), "INT64");
+            let result = nested.format_top_level_columns_data_types();
+            assert_eq!(result.get("id").unwrap(), "integer");
             assert_eq!(result.get("name").unwrap(), "string");
         }
 
@@ -1512,8 +1494,11 @@ mod tests {
             nested.insert("user.id", Some(&"integer".to_string()));
             nested.insert("user.name", Some(&"string".to_string()));
 
-            let result = nested.format_top_level_columns_data_types(true);
-            assert_eq!(result.get("user").unwrap(), "struct<id INT64, name string>");
+            let result = nested.format_top_level_columns_data_types();
+            assert_eq!(
+                result.get("user").unwrap(),
+                "struct<id integer, name string>"
+            );
         }
 
         // Test case 3: Array of structs
@@ -1523,7 +1508,7 @@ mod tests {
             nested.insert("addresses.street", Some(&"string".to_string()));
             nested.insert("addresses.city", Some(&"string".to_string()));
 
-            let result = nested.format_top_level_columns_data_types(true);
+            let result = nested.format_top_level_columns_data_types();
             assert_eq!(
                 result.get("addresses").unwrap(),
                 "array<struct<street string, city string>>"
@@ -1538,8 +1523,8 @@ mod tests {
             nested.insert("user.contact.email", Some(&"string".to_string()));
             nested.insert("user.contact.phone", Some(&"string".to_string()));
 
-            let result = nested.format_top_level_columns_data_types(true);
-            assert_eq!(result.get("id").unwrap(), "INT64");
+            let result = nested.format_top_level_columns_data_types();
+            assert_eq!(result.get("id").unwrap(), "integer");
             assert_eq!(
                 result.get("user").unwrap(),
                 "struct<name string, contact struct<email string, phone string>>"
@@ -1552,7 +1537,7 @@ mod tests {
             nested.insert("empty_struct", None);
             nested.insert("empty_struct.field1", Some(&"string".to_string()));
 
-            let result = nested.format_top_level_columns_data_types(true);
+            let result = nested.format_top_level_columns_data_types();
             assert_eq!(result.get("empty_struct").unwrap(), "struct<field1 string>");
         }
 
@@ -1563,14 +1548,14 @@ mod tests {
             nested.insert("metadata.key1", Some(&"string".to_string()));
             nested.insert("metadata.key2", Some(&"integer".to_string()));
 
-            let result = nested.format_top_level_columns_data_types(true);
+            let result = nested.format_top_level_columns_data_types();
             assert_eq!(
                 result.get("metadata").unwrap(),
-                "struct<key1 string, key2 INT64>"
+                "struct<key1 string, key2 integer>"
             );
         }
 
-        // Test case 7: Alias map coverage
+        // Test case 7: Type strings are preserved verbatim
         {
             let mut nested = NestedColumnDataTypes::default();
             nested.insert("float_col", Some(&"FLOAT".to_string()));
@@ -1580,79 +1565,23 @@ mod tests {
             nested.insert("int64_col", Some(&"INT64".to_string()));
             nested.insert("numeric_col", Some(&"NUMERIC".to_string()));
 
-            let result = nested.format_top_level_columns_data_types(true);
-            assert_eq!(result.get("float_col").unwrap(), "FLOAT64");
-            assert_eq!(result.get("integer_col").unwrap(), "INT64");
-            assert_eq!(result.get("text_col").unwrap(), "STRING");
+            let result = nested.format_top_level_columns_data_types();
+            assert_eq!(result.get("float_col").unwrap(), "FLOAT");
+            assert_eq!(result.get("integer_col").unwrap(), "INTEGER");
+            assert_eq!(result.get("text_col").unwrap(), "TEXT");
             assert_eq!(result.get("string_col").unwrap(), "STRING");
             assert_eq!(result.get("int64_col").unwrap(), "INT64");
             assert_eq!(result.get("numeric_col").unwrap(), "NUMERIC");
         }
 
-        // Test case 8: Alias opt-out
-        {
-            let mut nested = NestedColumnDataTypes::default();
-            nested.insert("float_col", Some(&"FLOAT".to_string()));
-
-            let result = nested.format_top_level_columns_data_types(false);
-            assert_eq!(result.get("float_col").unwrap(), "FLOAT");
-        }
-
-        // Test case 9: Nested struct leaf aliasing
+        // Test case 8: Nested struct leaves preserve provided type strings
         {
             let mut nested = NestedColumnDataTypes::default();
             nested.insert("s.x", Some(&"FLOAT".to_string()));
 
-            let result = nested.format_top_level_columns_data_types(true);
-            assert_eq!(result.get("s").unwrap(), "struct<x FLOAT64>");
-
-            let result = nested.format_top_level_columns_data_types(false);
+            let result = nested.format_top_level_columns_data_types();
             assert_eq!(result.get("s").unwrap(), "struct<x FLOAT>");
         }
-    }
-
-    // Regression test for dbt-labs/dbt-core#14097: when a BigQuery model contract
-    // has `alias_types` enabled, contract leaf types must be aliased to their
-    // BigQuery names (e.g. FLOAT -> FLOAT64) via the public `nest_column_data_types`
-    // entry point used by the contract-rendering path; when disabled, the declared
-    // type is preserved verbatim. Types that are already canonical (e.g. NUMERIC)
-    // pass through unchanged in both modes.
-    #[test]
-    fn nest_column_data_types_aliases_float_when_alias_types_enabled() {
-        fn column(name: &str, data_type: &str) -> DbtColumn {
-            DbtColumn {
-                name: name.to_string(),
-                data_type: Some(data_type.to_string()),
-                ..Default::default()
-            }
-        }
-
-        let columns: IndexMap<String, DbtColumn> = IndexMap::from([
-            ("float_col".to_string(), column("float_col", "FLOAT")),
-            ("numeric_col".to_string(), column("numeric_col", "NUMERIC")),
-        ]);
-
-        // alias_types enabled: FLOAT is aliased to FLOAT64, NUMERIC is unaffected.
-        let aliased = nest_column_data_types(columns.clone(), None, true).unwrap();
-        assert_eq!(
-            aliased.get("float_col").unwrap().data_type.as_deref(),
-            Some("FLOAT64")
-        );
-        assert_eq!(
-            aliased.get("numeric_col").unwrap().data_type.as_deref(),
-            Some("NUMERIC")
-        );
-
-        // alias_types disabled: the declared types are preserved verbatim.
-        let verbatim = nest_column_data_types(columns, None, false).unwrap();
-        assert_eq!(
-            verbatim.get("float_col").unwrap().data_type.as_deref(),
-            Some("FLOAT")
-        );
-        assert_eq!(
-            verbatim.get("numeric_col").unwrap().data_type.as_deref(),
-            Some("NUMERIC")
-        );
     }
 
     #[test]

--- a/crates/dbt-jinja-utils/src/phases/run/run_node_context.rs
+++ b/crates/dbt-jinja-utils/src/phases/run/run_node_context.rs
@@ -77,10 +77,7 @@ fn normalize_model_context_column_data_types(model: &mut YmlValue, adapter_type:
 
     let column_static = ColumnStatic::new(adapter_type);
     let data_type_key = YmlValue::string("data_type".to_string());
-    for (_, column) in columns.iter_mut() {
-        let YmlValue::Mapping(column_map, _) = column else {
-            continue;
-        };
+    for column_map in columns.values_mut().filter_map(YmlValue::as_mapping_mut) {
         let Some(data_type) = column_map.get_mut(&data_type_key) else {
             continue;
         };
@@ -95,6 +92,11 @@ fn normalize_model_context_column_data_types(model: &mut YmlValue, adapter_type:
     }
 }
 
+fn normalized_model_context(mut model: YmlValue, adapter_type: AdapterType) -> YmlValue {
+    normalize_model_context_column_data_types(&mut model, adapter_type);
+    model
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_model_context_fields<S: Serialize>(
     node: &dyn InternalDbtNode,
@@ -103,8 +105,7 @@ fn build_model_context_fields<S: Serialize>(
     io_args: &IoArgs,
     sql_header: Option<MinijinjaValue>,
 ) -> ModelContextFields {
-    let mut model = node.serialize();
-    normalize_model_context_column_data_types(&mut model, adapter_type);
+    let model = node.serialize();
     let common_attr = node.common();
     let base_attr = node.base();
     let resource_type = node.resource_type();
@@ -175,7 +176,7 @@ fn build_model_context_fields<S: Serialize>(
         config_map.insert("sql_header".to_string(), sql_header);
     }
 
-    let mut model_map = convert_yml_to_value_map(model);
+    let mut model_map = convert_yml_to_value_map(normalized_model_context(model, adapter_type));
 
     // We are reading the raw_sql here for snapshots and models
     let raw_sql_path = match resource_type {

--- a/crates/dbt-jinja-utils/src/phases/run/run_node_context.rs
+++ b/crates/dbt-jinja-utils/src/phases/run/run_node_context.rs
@@ -13,6 +13,7 @@ use dbt_common::ErrorCode;
 use dbt_common::io_args::IoArgs;
 use dbt_common::serde_utils::convert_yml_to_value_map;
 
+use dbt_adapter::column::ColumnStatic;
 use dbt_adapter::load_store::ResultStore;
 use dbt_common::stdfs;
 use dbt_common::tracing::dbt_emit::emit_warn_log_message;
@@ -52,6 +53,48 @@ struct ModelContextFields {
     node: JinjaObject<LazyModelWrapper>,
 }
 
+fn model_context_alias_types(model: &YmlValue) -> bool {
+    model
+        .get("config")
+        .and_then(|config| config.get("contract"))
+        .and_then(|contract| contract.get("alias_types"))
+        .and_then(|alias_types| alias_types.as_bool())
+        .unwrap_or(true)
+}
+
+fn normalize_model_context_column_data_types(model: &mut YmlValue, adapter_type: AdapterType) {
+    if adapter_type != AdapterType::Bigquery || !model_context_alias_types(model) {
+        return;
+    }
+
+    let YmlValue::Mapping(model_map, _) = model else {
+        return;
+    };
+    let columns_key = YmlValue::string("columns".to_string());
+    let Some(YmlValue::Mapping(columns, _)) = model_map.get_mut(&columns_key) else {
+        return;
+    };
+
+    let column_static = ColumnStatic::new(adapter_type);
+    let data_type_key = YmlValue::string("data_type".to_string());
+    for (_, column) in columns.iter_mut() {
+        let YmlValue::Mapping(column_map, _) = column else {
+            continue;
+        };
+        let Some(data_type) = column_map.get_mut(&data_type_key) else {
+            continue;
+        };
+        let Some(data_type_str) = data_type.as_str().map(ToOwned::to_owned) else {
+            continue;
+        };
+
+        let translated = column_static.translate_type(&data_type_str);
+        if translated != data_type_str {
+            *data_type = YmlValue::string(translated);
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_model_context_fields<S: Serialize>(
     node: &dyn InternalDbtNode,
@@ -60,7 +103,8 @@ fn build_model_context_fields<S: Serialize>(
     io_args: &IoArgs,
     sql_header: Option<MinijinjaValue>,
 ) -> ModelContextFields {
-    let model = node.serialize();
+    let mut model = node.serialize();
+    normalize_model_context_column_data_types(&mut model, adapter_type);
     let common_attr = node.common();
     let base_attr = node.base();
     let resource_type = node.resource_type();
@@ -381,6 +425,84 @@ pub fn build_run_node_context<S: Serialize>(
     let mut context = base_context.clone();
     context.extend(to_jinja_btreemap(&overlay));
     context
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn column_data_type<'a>(model: &'a YmlValue, column_name: &str) -> &'a str {
+        model
+            .get("columns")
+            .and_then(|columns| columns.get(column_name))
+            .and_then(|column| column.get("data_type"))
+            .and_then(|data_type| data_type.as_str())
+            .expect("column data_type should exist")
+    }
+
+    #[test]
+    fn bigquery_model_context_alias_types_enabled_normalizes_column_data_types() {
+        let mut model = dbt_yaml::to_value(json!({
+            "config": {
+                "contract": {
+                    "alias_types": true
+                }
+            },
+            "columns": {
+                "float_col": {"name": "float_col", "data_type": "FLOAT"},
+                "integer_col": {"name": "integer_col", "data_type": "INTEGER"},
+                "text_col": {"name": "text_col", "data_type": "TEXT"},
+                "numeric_col": {"name": "numeric_col", "data_type": "NUMERIC"}
+            }
+        }))
+        .unwrap();
+
+        normalize_model_context_column_data_types(&mut model, AdapterType::Bigquery);
+
+        assert_eq!(column_data_type(&model, "float_col"), "FLOAT64");
+        assert_eq!(column_data_type(&model, "integer_col"), "INT64");
+        assert_eq!(column_data_type(&model, "text_col"), "STRING");
+        assert_eq!(column_data_type(&model, "numeric_col"), "NUMERIC");
+    }
+
+    #[test]
+    fn bigquery_model_context_alias_types_disabled_preserves_column_data_types() {
+        let mut model = dbt_yaml::to_value(json!({
+            "config": {
+                "contract": {
+                    "alias_types": false
+                }
+            },
+            "columns": {
+                "float_col": {"name": "float_col", "data_type": "FLOAT"}
+            }
+        }))
+        .unwrap();
+
+        normalize_model_context_column_data_types(&mut model, AdapterType::Bigquery);
+
+        assert_eq!(column_data_type(&model, "float_col"), "FLOAT");
+    }
+
+    #[test]
+    fn model_context_column_data_type_normalization_is_bigquery_only() {
+        let mut model = dbt_yaml::to_value(json!({
+            "config": {
+                "contract": {
+                    "alias_types": true
+                }
+            },
+            "columns": {
+                "float_col": {"name": "float_col", "data_type": "FLOAT"}
+            }
+        }))
+        .unwrap();
+
+        normalize_model_context_column_data_types(&mut model, AdapterType::Postgres);
+
+        assert_eq!(column_data_type(&model, "float_col"), "FLOAT");
+    }
 }
 
 fn parse_hook_item(item: &YmlValue) -> Option<HookConfig> {


### PR DESCRIPTION
Resolves #14097

### Problem

On BigQuery, a model with an enforced contract and a column declared `data_type: FLOAT` (with `alias_types` at its default of `true`) compiles and runs in dbt Core but fails in the Fusion engine with `[BigQuery] Error 400: Type not found: FLOAT`.

dbt Core auto-aliases invalid BigQuery types to their valid equivalents (`FLOAT` -> `FLOAT64`, `INTEGER` -> `INT64`, `TEXT` -> `STRING`) as part of the documented contract data type aliasing behavior. Fusion instead emits the raw leaf type verbatim into the generated contract DDL and the empty-schema query (`cast(null as FLOAT)`), which BigQuery rejects. The `alias_types` contract config was parsed by Fusion but never consumed anywhere in the engine, so the aliasing never happened.

### Solution

The BigQuery contract DDL path (`render_raw_columns_constraints`) and the equivalence/empty-schema path (`nest_column_data_types`, used by `bigquery__get_empty_schema_sql`) both converge on `nest_column_data_types` in `crates/dbt-adapter/src/metadata/bigquery/mod.rs`, where leaf primitive types are emitted in `NestedColumnDataTypes::format_top_level_columns_data_types` and `TrieNode::format_data_type`.

This change aliases each leaf primitive type through the BigQuery type map that already exists as `ColumnStatic::translate_type` (`crates/dbt-adapter/src/column/types.rs`), reusing it rather than duplicating the mapping. Aliasing is gated on a threaded `alias_types: bool`, read from the current model's `config.contract.alias_types` via a new `alias_types_from_state` helper and defaulting to `true` (dbt's default). When `alias_types` is `false`, the raw type is preserved verbatim, so the opt-out path is unchanged. Nested `STRUCT`/`ARRAY` leaves are aliased too, while the struct/array wrappers are preserved. The change is scoped to the BigQuery-only metadata path, so other adapters are unaffected.

### Testing

Extended the existing pure-function unit test `test_format_top_level_columns_data_types` to cover:

- `FLOAT` -> `FLOAT64`, `INTEGER` -> `INT64`, `TEXT` -> `STRING` aliasing, and already-valid types (`STRING`, `INT64`, `NUMERIC`) emitted unchanged.
- A nested struct leaf (`s.x = FLOAT`) aliasing to `struct<x FLOAT64>` (exercises `TrieNode::format_data_type`).
- The opt-out gate: with `alias_types: false`, `FLOAT` passes through unchanged.

Ran `cargo fmt -p dbt-adapter` and `cargo test -p dbt-adapter test_format_top_level_columns_data_types` (passes); the `dbt-adapter` crate compiles.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes, or this PR has already received feedback and approval from Product or DX.
