### PR TITLE
Add `dbt agent` CLI for authoring Fivetran MCP contextsets from YAML

### DIFF
--- a/.changes/unreleased/Features-20260701-000000.yaml
+++ b/.changes/unreleased/Features-20260701-000000.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add `dbt agent {list,show,deploy}` CLI for authoring Fivetran MCP contextsets from YAML.
+time: 2026-07-01T00:00:00.000000-07:00
+custom:
+    author: ""
+    issue: ""
+    project: dbt-core

--- a/crates/dbt-features/Cargo.toml
+++ b/crates/dbt-features/Cargo.toml
@@ -49,6 +49,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 vortex-events = { workspace = true }
+walkdir = { workspace = true }
 
 [lib]
 name = "dbt_features"

--- a/crates/dbt-features/src/agents.rs
+++ b/crates/dbt-features/src/agents.rs
@@ -1,0 +1,598 @@
+//! Author-side agent specs and the v0 "manifest-adjacent" plumbing.
+//!
+//! Agents are declared in `<project>/agents/**/*.yml` and pushed to a Fivetran AI
+//! MCP contextset by the `dbt agent deploy` command. In v0 they are not first-class
+//! nodes in the manifest — the parser here reads the YAML, resolves selectors
+//! against an already-produced `target/manifest.json`, and emits a companion
+//! `target/agents.json` artifact.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::path::{Path, PathBuf};
+
+use dbt_common::{ErrorCode, FsResult, fs_err};
+use serde::{Deserialize, Serialize};
+use walkdir::WalkDir;
+
+/// Top-level container matching the `agents:` list in a YAML file.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentsFile {
+    #[serde(default)]
+    pub agents: Vec<AgentSpec>,
+}
+
+/// One agent as authored in YAML.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AgentSpec {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// `public` | `protected` | `private`. Metadata only in v0.
+    #[serde(default)]
+    pub access: Option<String>,
+    pub scope: AgentScope,
+    #[serde(default)]
+    pub tools: Option<AgentTools>,
+    /// Name of an mcp-server entry. Metadata only in v0 — the deploy command
+    /// receives its URL/token/group_id from CLI flags or environment variables.
+    #[serde(default)]
+    pub mcp_server: Option<String>,
+}
+
+/// Node-selector expressions defining the agent's reachable scope.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AgentScope {
+    /// Union of dbt selector expressions (e.g. `group:sales,tag:certified`, `dim_customers+`).
+    pub select: Vec<String>,
+    #[serde(default)]
+    pub exclude: Option<Vec<String>>,
+}
+
+/// Tool allowlist / denylist. Accepted in v0 but not enforced server-side.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AgentTools {
+    #[serde(default)]
+    pub include: Option<Vec<String>>,
+    #[serde(default)]
+    pub exclude: Option<Vec<String>>,
+}
+
+/// An agent plus its resolved warehouse scope, ready for deploy.
+#[derive(Debug, Clone, Serialize)]
+pub struct ResolvedAgent {
+    #[serde(flatten)]
+    pub spec: AgentSpec,
+    pub resolved_scope: ResolvedScope,
+}
+
+/// The concrete warehouse targets the agent is allowed to touch.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ResolvedScope {
+    pub schema_fqns: Vec<String>,
+    pub table_fqns: Vec<String>,
+    pub model_unique_ids: Vec<String>,
+}
+
+/// Walk `<project>/agents/` recursively and load every `*.yml` / `*.yaml` file.
+///
+/// Returns the discovered specs in the order encountered. Fails if two specs share
+/// a `name`.
+pub fn discover_agent_specs(project_dir: &Path) -> FsResult<Vec<AgentSpec>> {
+    let agents_dir = project_dir.join("agents");
+    if !agents_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut specs: Vec<AgentSpec> = Vec::new();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+
+    for entry in WalkDir::new(&agents_dir).into_iter().filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if !matches!(ext, "yml" | "yaml") {
+            continue;
+        }
+        let file = load_agents_file(path)?;
+        for spec in file.agents {
+            validate_spec(&spec, path)?;
+            if !seen.insert(spec.name.clone()) {
+                return Err(fs_err!(
+                    ErrorCode::Generic,
+                    "Duplicate agent name '{}' (found again in {})",
+                    spec.name,
+                    path.display()
+                ));
+            }
+            specs.push(spec);
+        }
+    }
+
+    Ok(specs)
+}
+
+fn load_agents_file(path: &Path) -> FsResult<AgentsFile> {
+    let content = std::fs::read_to_string(path).map_err(|err| {
+        fs_err!(
+            ErrorCode::Generic,
+            "Failed to read agent file {}: {}",
+            path.display(),
+            err
+        )
+    })?;
+    dbt_yaml::from_str::<AgentsFile>(&content).map_err(|err| {
+        fs_err!(
+            ErrorCode::Generic,
+            "Failed to parse agent file {}: {}",
+            path.display(),
+            err
+        )
+    })
+}
+
+fn validate_spec(spec: &AgentSpec, path: &Path) -> FsResult<()> {
+    if spec.name.trim().is_empty() {
+        return Err(fs_err!(
+            ErrorCode::Generic,
+            "Agent in {} is missing a name",
+            path.display()
+        ));
+    }
+    if spec.scope.select.is_empty() {
+        return Err(fs_err!(
+            ErrorCode::Generic,
+            "Agent '{}' in {} has an empty scope.select — at least one selector is required",
+            spec.name,
+            path.display()
+        ));
+    }
+    if let Some(access) = &spec.access
+        && !matches!(access.as_str(), "public" | "protected" | "private")
+    {
+        return Err(fs_err!(
+            ErrorCode::Generic,
+            "Agent '{}' has invalid access '{}' (expected public|protected|private)",
+            spec.name,
+            access
+        ));
+    }
+    Ok(())
+}
+
+/// Convenience: the default artifact path for `target/agents.json`.
+pub fn agents_json_path(target_dir: &Path) -> PathBuf {
+    target_dir.join("agents.json")
+}
+
+// ------------------------------------------------------------------------------------------------
+// Selector resolution
+//
+// v0 supports a pragmatic subset of dbt selector syntax against a deserialized manifest.json:
+//
+//   - bare name          `dim_customers`
+//   - resource type      `resource_type:model`
+//   - tag / group        `tag:certified`, `group:sales`
+//   - graph ops          `+name`, `name+`, `+N+name`, `name+N`, `+N+name+M` (numeric depths)
+//   - `,` inside a single expression is intersection (AND)
+//   - each entry in `scope.select` (or `scope.exclude`) is a separate expression (OR / subtract)
+//
+// v0 explicitly does *not* implement: `state:`, `source:`, `test:`, `path:`, wildcard globbing,
+// version modifiers, or the full parenthesized boolean grammar. The demo project stays inside
+// the supported subset.
+
+/// A lean, forgiving projection of `manifest.json` — just the fields the agent
+/// resolver needs. Deliberately does not use `DbtManifestV11` from `dbt-schemas`,
+/// because that shape requires internal fields (e.g. `__other__`) that don't
+/// appear in the serialized artifact.
+#[derive(Debug, Deserialize)]
+pub struct ManifestView {
+    #[serde(default)]
+    pub nodes: BTreeMap<String, ManifestNode>,
+    #[serde(default)]
+    pub parent_map: BTreeMap<String, Vec<String>>,
+    #[serde(default)]
+    pub child_map: BTreeMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ManifestNode {
+    /// dbt writes `resource_type` on every node. We only care about `"model"` for v0.
+    #[serde(default)]
+    pub resource_type: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub database: String,
+    #[serde(default)]
+    pub schema: String,
+    #[serde(default)]
+    pub relation_name: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub group: Option<String>,
+    #[serde(default)]
+    pub config: Option<ManifestNodeConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ManifestNodeConfig {
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub tags: Option<serde_json::Value>,
+    #[serde(default)]
+    pub group: Option<String>,
+}
+
+impl ManifestNode {
+    fn is_model(&self) -> bool {
+        self.resource_type == "model"
+    }
+
+    fn effective_group(&self) -> Option<&str> {
+        self.group
+            .as_deref()
+            .or_else(|| self.config.as_ref().and_then(|c| c.group.as_deref()))
+    }
+
+    fn has_tag(&self, tag: &str) -> bool {
+        if self.tags.iter().any(|t| t == tag) {
+            return true;
+        }
+        match self.config.as_ref().and_then(|c| c.tags.as_ref()) {
+            Some(serde_json::Value::Array(arr)) => arr
+                .iter()
+                .filter_map(|v| v.as_str())
+                .any(|t| t == tag),
+            Some(serde_json::Value::String(s)) => s == tag,
+            _ => false,
+        }
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.config
+            .as_ref()
+            .and_then(|c| c.enabled)
+            .unwrap_or(true)
+    }
+}
+
+/// Load and deserialize `target/manifest.json` into the lean view.
+pub fn load_manifest(manifest_path: &Path) -> FsResult<ManifestView> {
+    let content = std::fs::read_to_string(manifest_path).map_err(|err| {
+        fs_err!(
+            ErrorCode::Generic,
+            "Failed to read manifest at {}: {} (run `dbt parse` or `dbt compile` first)",
+            manifest_path.display(),
+            err
+        )
+    })?;
+    serde_json::from_str::<ManifestView>(&content).map_err(|err| {
+        fs_err!(
+            ErrorCode::Generic,
+            "Failed to parse manifest at {}: {}",
+            manifest_path.display(),
+            err
+        )
+    })
+}
+
+/// Resolve every agent spec against a loaded manifest, producing warehouse-level scope.
+pub fn resolve_all(
+    specs: Vec<AgentSpec>,
+    manifest: &ManifestView,
+) -> FsResult<Vec<ResolvedAgent>> {
+    specs
+        .into_iter()
+        .map(|spec| {
+            let resolved_scope = resolve_scope(&spec, manifest)?;
+            Ok(ResolvedAgent {
+                spec,
+                resolved_scope,
+            })
+        })
+        .collect()
+}
+
+fn resolve_scope(spec: &AgentSpec, manifest: &ManifestView) -> FsResult<ResolvedScope> {
+    let mut included: BTreeSet<String> = BTreeSet::new();
+    for expr in &spec.scope.select {
+        let matched = evaluate_expression(expr, manifest).map_err(|err| {
+            fs_err!(
+                ErrorCode::Generic,
+                "Agent '{}': failed to resolve select expression `{}`: {}",
+                spec.name,
+                expr,
+                err
+            )
+        })?;
+        included.extend(matched);
+    }
+
+    if let Some(exclude_exprs) = &spec.scope.exclude {
+        for expr in exclude_exprs {
+            let matched = evaluate_expression(expr, manifest).map_err(|err| {
+                fs_err!(
+                    ErrorCode::Generic,
+                    "Agent '{}': failed to resolve exclude expression `{}`: {}",
+                    spec.name,
+                    expr,
+                    err
+                )
+            })?;
+            for id in matched {
+                included.remove(&id);
+            }
+        }
+    }
+
+    let mut table_fqns: BTreeSet<String> = BTreeSet::new();
+    let mut schema_fqns: BTreeSet<String> = BTreeSet::new();
+    let mut model_unique_ids: Vec<String> = Vec::new();
+
+    for unique_id in &included {
+        let Some(node) = manifest.nodes.get(unique_id) else {
+            continue;
+        };
+        if !node.is_model() || !node.is_enabled() {
+            continue;
+        }
+        let database = node.database.trim();
+        let schema = node.schema.trim();
+        let name = node.name.trim();
+        let relation = node
+            .relation_name
+            .as_deref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty());
+        let has_relation = relation.is_some()
+            || (!database.is_empty() && !schema.is_empty() && !name.is_empty());
+        if !has_relation {
+            // ephemeral / not-materialized-to-a-relation nodes are skipped.
+            continue;
+        }
+        model_unique_ids.push(unique_id.clone());
+        if let Some(r) = relation {
+            table_fqns.insert(strip_quotes(r));
+        } else {
+            table_fqns.insert(format!("{}.{}.{}", database, schema, name));
+        }
+        if !database.is_empty() && !schema.is_empty() {
+            schema_fqns.insert(format!("{}.{}", database, schema));
+        }
+    }
+
+    if table_fqns.is_empty() {
+        return Err(fs_err!(
+            ErrorCode::Generic,
+            "Agent '{}': scope resolved to zero deployable models",
+            spec.name
+        ));
+    }
+
+    Ok(ResolvedScope {
+        schema_fqns: schema_fqns.into_iter().collect(),
+        table_fqns: table_fqns.into_iter().collect(),
+        model_unique_ids,
+    })
+}
+
+/// Evaluate a single dbt-style selector expression (with optional `,`-intersect and graph ops).
+fn evaluate_expression(expr: &str, manifest: &ManifestView) -> FsResult<BTreeSet<String>> {
+    let mut term_results: Vec<BTreeSet<String>> = Vec::new();
+    for term in expr.split(',') {
+        let term = term.trim();
+        if term.is_empty() {
+            continue;
+        }
+        term_results.push(evaluate_term(term, manifest)?);
+    }
+    if term_results.is_empty() {
+        return Ok(BTreeSet::new());
+    }
+    let mut iter = term_results.into_iter();
+    let mut acc = iter.next().unwrap();
+    for next in iter {
+        acc = acc.intersection(&next).cloned().collect();
+    }
+    Ok(acc)
+}
+
+fn evaluate_term(term: &str, manifest: &ManifestView) -> FsResult<BTreeSet<String>> {
+    let (leading_parents, core, trailing_children) = strip_graph_ops(term);
+
+    let base_ids = if let Some((method, value)) = core.split_once(':') {
+        match method {
+            "resource_type" => match_by_resource_type(value, manifest),
+            "tag" => match_by_tag(value, manifest),
+            "group" => match_by_group(value, manifest),
+            "name" => match_by_name(value, manifest),
+            other => {
+                return Err(fs_err!(
+                    ErrorCode::Generic,
+                    "Selector method `{}:` is not supported in v0",
+                    other
+                ));
+            }
+        }
+    } else {
+        match_by_name(core, manifest)
+    };
+
+    let mut result = base_ids.clone();
+    if let Some(depth) = leading_parents {
+        for id in &base_ids {
+            expand_ancestors(id, depth, &manifest.parent_map, &mut result);
+        }
+    }
+    if let Some(depth) = trailing_children {
+        for id in &base_ids {
+            expand_descendants(id, depth, &manifest.child_map, &mut result);
+        }
+    }
+    Ok(result)
+}
+
+/// Parse dbt-style graph ops from a selector term.
+///
+/// Returns `(leading_parents, core, trailing_children)` where:
+/// - `Some(None)` = unbounded (`+name` or `name+`)
+/// - `Some(Some(n))` = bounded depth (`N+name` or `name+N`)
+/// - `None` = no graph op on that side
+#[allow(clippy::type_complexity)]
+fn strip_graph_ops(term: &str) -> (Option<Option<usize>>, &str, Option<Option<usize>>) {
+    let mut s = term;
+    let mut leading: Option<Option<usize>> = None;
+    let mut trailing: Option<Option<usize>> = None;
+
+    // Leading: `<digits>+` (bounded) or plain `+` (unbounded)
+    let (n_leading, after_digits) = leading_number(s);
+    if let Some(rest) = after_digits.strip_prefix('+') {
+        leading = Some(n_leading);
+        s = rest;
+    } else if let Some(rest) = s.strip_prefix('+') {
+        leading = Some(None);
+        s = rest;
+    }
+
+    // Trailing: `+<digits>` (bounded) or trailing `+` (unbounded)
+    let bytes = s.as_bytes();
+    let mut end = bytes.len();
+    while end > 0 && bytes[end - 1].is_ascii_digit() {
+        end -= 1;
+    }
+    if end < bytes.len() && end > 0 && bytes[end - 1] == b'+' {
+        let depth: usize = s[end..].parse().unwrap_or(0);
+        trailing = Some(Some(depth));
+        s = &s[..end - 1];
+    } else if let Some(rest) = s.strip_suffix('+') {
+        trailing = Some(None);
+        s = rest;
+    }
+
+    (leading, s, trailing)
+}
+
+fn leading_number(s: &str) -> (Option<usize>, &str) {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i == 0 {
+        (None, s)
+    } else {
+        let n: usize = s[..i].parse().unwrap_or(0);
+        (Some(n), &s[i..])
+    }
+}
+
+fn match_by_name(name: &str, manifest: &ManifestView) -> BTreeSet<String> {
+    manifest
+        .nodes
+        .iter()
+        .filter_map(|(uid, node)| {
+            if node.is_model() && node.name == name {
+                Some(uid.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn match_by_resource_type(value: &str, manifest: &ManifestView) -> BTreeSet<String> {
+    manifest
+        .nodes
+        .iter()
+        .filter_map(|(uid, node)| {
+            if node.resource_type == value {
+                Some(uid.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn match_by_tag(tag: &str, manifest: &ManifestView) -> BTreeSet<String> {
+    manifest
+        .nodes
+        .iter()
+        .filter_map(|(uid, node)| {
+            if node.is_model() && node.has_tag(tag) {
+                Some(uid.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn match_by_group(group: &str, manifest: &ManifestView) -> BTreeSet<String> {
+    manifest
+        .nodes
+        .iter()
+        .filter_map(|(uid, node)| {
+            if node.is_model() && node.effective_group() == Some(group) {
+                Some(uid.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn expand_ancestors(
+    start: &str,
+    depth: Option<usize>,
+    parent_map: &BTreeMap<String, Vec<String>>,
+    out: &mut BTreeSet<String>,
+) {
+    let mut queue: VecDeque<(String, usize)> = VecDeque::new();
+    queue.push_back((start.to_string(), 0));
+    while let Some((id, d)) = queue.pop_front() {
+        if let Some(limit) = depth
+            && d >= limit
+        {
+            continue;
+        }
+        if let Some(parents) = parent_map.get(&id) {
+            for p in parents {
+                if out.insert(p.clone()) {
+                    queue.push_back((p.clone(), d + 1));
+                }
+            }
+        }
+    }
+}
+
+fn expand_descendants(
+    start: &str,
+    depth: Option<usize>,
+    child_map: &BTreeMap<String, Vec<String>>,
+    out: &mut BTreeSet<String>,
+) {
+    let mut queue: VecDeque<(String, usize)> = VecDeque::new();
+    queue.push_back((start.to_string(), 0));
+    while let Some((id, d)) = queue.pop_front() {
+        if let Some(limit) = depth
+            && d >= limit
+        {
+            continue;
+        }
+        if let Some(children) = child_map.get(&id) {
+            for c in children {
+                if out.insert(c.clone()) {
+                    queue.push_back((c.clone(), d + 1));
+                }
+            }
+        }
+    }
+}
+
+fn strip_quotes(fqn: &str) -> String {
+    fqn.replace(['"', '`'], "")
+}

--- a/crates/dbt-features/src/cli.rs
+++ b/crates/dbt-features/src/cli.rs
@@ -126,8 +126,10 @@ impl SystemMgmtArgs {
 pub enum OSSExtensionCommand {
     /// dbt Core 2.x system subcommand
     System(SystemMgmtArgs),
-    /// Manage Fivetran AI catalog contextsets
+    /// Manage Fivetran AI catalog contextsets (low-level admin)
     Contextset(ContextsetArgs),
+    /// Author and deploy dbt agents (v0: pushes resolved scope to a Fivetran MCP contextset)
+    Agent(AgentArgs),
 }
 
 #[derive(Parser, Debug, Clone, Serialize, Deserialize)]
@@ -209,11 +211,74 @@ impl ContextsetArgs {
     }
 }
 
+// ---------- dbt agent -------------------------------------------------------------------------
+
+#[derive(Parser, Debug, Clone, Serialize, Deserialize)]
+pub struct AgentArgs {
+    #[command(subcommand)]
+    pub command: AgentCommand,
+    #[clap(flatten)]
+    pub common_args: CommonArgs,
+}
+
+#[derive(clap::Subcommand, Debug, Clone, Serialize, Deserialize)]
+pub enum AgentCommand {
+    /// List all agents discovered under `<project>/agents/*.yml`.
+    List(AgentListArgs),
+    /// Show the resolved scope for one or all agents (dry-run, no network calls).
+    Show(AgentShowArgs),
+    /// Push each agent's resolved scope to the configured Fivetran MCP contextset endpoint.
+    Deploy(AgentDeployArgs),
+}
+
+#[derive(clap::Args, Debug, Clone, Serialize, Deserialize)]
+pub struct AgentListArgs {
+    /// Project directory (defaults to CWD).
+    #[arg(long, default_value = ".")]
+    pub project_dir: PathBuf,
+}
+
+#[derive(clap::Args, Debug, Clone, Serialize, Deserialize)]
+pub struct AgentShowArgs {
+    /// Optional agent name; shows all agents when omitted.
+    pub name: Option<String>,
+    #[arg(long, default_value = ".")]
+    pub project_dir: PathBuf,
+    /// Override the manifest location; defaults to `<project_dir>/target/manifest.json`.
+    #[arg(long)]
+    pub manifest_path: Option<PathBuf>,
+}
+
+#[derive(clap::Args, Debug, Clone, Serialize, Deserialize)]
+pub struct AgentDeployArgs {
+    /// Optional agent name; deploys all agents when omitted.
+    pub name: Option<String>,
+    #[arg(long, default_value = ".")]
+    pub project_dir: PathBuf,
+    /// Override the manifest location; defaults to `<project_dir>/target/manifest.json`.
+    #[arg(long)]
+    pub manifest_path: Option<PathBuf>,
+    /// Show the payload but do not call the MCP endpoint.
+    #[arg(long)]
+    pub dry_run: bool,
+    #[clap(flatten)]
+    pub client: ContextsetClientArgs,
+}
+
+impl AgentArgs {
+    pub fn to_eval_args(&self, arg: SystemArgs, in_dir: &Path, out_dir: &Path) -> EvalArgs {
+        let mut eval_args = self.common_args.to_eval_args(arg, in_dir, out_dir);
+        eval_args.phase = Phases::Deps;
+        eval_args
+    }
+}
+
 impl AbstractExtensionCommand for OSSExtensionCommand {
     fn name(&self) -> &'static str {
         match self {
             OSSExtensionCommand::System(_) => "system",
             OSSExtensionCommand::Contextset(_) => "contextset",
+            OSSExtensionCommand::Agent(_) => "agent",
         }
     }
 
@@ -237,7 +302,7 @@ impl AbstractExtensionCommand for OSSExtensionCommand {
 
     fn is_project_command(&self) -> bool {
         use OSSExtensionCommand::*;
-        !matches!(self, System(_) | Contextset(_))
+        !matches!(self, System(_) | Contextset(_) | Agent(_))
     }
 
     fn to_eval_args(&self, common_args: &CommonArgs, system_arg: SystemArgs) -> FsResult<EvalArgs> {
@@ -254,6 +319,7 @@ impl AbstractExtensionCommand for OSSExtensionCommand {
         let mut arg = match self {
             System(args) => args.to_eval_args(system_arg, &in_dir, &out_dir),
             Contextset(args) => args.to_eval_args(system_arg, &in_dir, &out_dir),
+            Agent(args) => args.to_eval_args(system_arg, &in_dir, &out_dir),
         };
         arg.from_main = from_main;
 
@@ -265,6 +331,7 @@ impl AbstractExtensionCommand for OSSExtensionCommand {
         match self {
             System(args) => args.common_args.clone(),
             Contextset(args) => args.common_args.clone(),
+            Agent(args) => args.common_args.clone(),
         }
     }
 
@@ -273,6 +340,7 @@ impl AbstractExtensionCommand for OSSExtensionCommand {
         match self {
             System(_) => unreachable!("System command does not need a phase"),
             Contextset(_) => unreachable!("Contextset command does not need a phase"),
+            Agent(_) => unreachable!("Agent command does not need a phase"),
         }
     }
 
@@ -280,6 +348,7 @@ impl AbstractExtensionCommand for OSSExtensionCommand {
         match self {
             OSSExtensionCommand::System(_) => FsCommand::System,
             OSSExtensionCommand::Contextset(_) => FsCommand::Extension("contextset"),
+            OSSExtensionCommand::Agent(_) => FsCommand::Extension("agent"),
         }
     }
 
@@ -328,6 +397,133 @@ impl ExtensionCommandParser for OSSExtensionCommandParser {
 struct ContextsetPayload<'a> {
     schema_fqns: &'a [String],
     table_fqns: &'a [String],
+}
+
+async fn execute_agent_command(command: &AgentCommand) -> FsResult<()> {
+    use crate::agents;
+
+    match command {
+        AgentCommand::List(args) => {
+            let specs = agents::discover_agent_specs(&args.project_dir)?;
+            if specs.is_empty() {
+                emit_stdout_line(format!(
+                    "No agents found under {}/agents/",
+                    args.project_dir.display()
+                ));
+                return Ok(());
+            }
+            for spec in &specs {
+                emit_stdout_line(format!(
+                    "{}  {}",
+                    spec.name,
+                    spec.description.as_deref().unwrap_or("")
+                ));
+            }
+        }
+
+        AgentCommand::Show(args) => {
+            let specs = agents::discover_agent_specs(&args.project_dir)?;
+            let filtered = filter_specs(specs, args.name.as_deref())?;
+            let manifest_path = manifest_path_for(&args.project_dir, args.manifest_path.as_ref());
+            let manifest = agents::load_manifest(&manifest_path)?;
+            let resolved = agents::resolve_all(filtered, &manifest)?;
+            write_agents_json(&args.project_dir, &resolved)?;
+            emit_stdout_line(
+                serde_json::to_string_pretty(&resolved).unwrap_or_else(|_| "[]".to_string()),
+            );
+        }
+
+        AgentCommand::Deploy(args) => {
+            let specs = agents::discover_agent_specs(&args.project_dir)?;
+            let filtered = filter_specs(specs, args.name.as_deref())?;
+            let manifest_path = manifest_path_for(&args.project_dir, args.manifest_path.as_ref());
+            let manifest = agents::load_manifest(&manifest_path)?;
+            let resolved = agents::resolve_all(filtered, &manifest)?;
+            write_agents_json(&args.project_dir, &resolved)?;
+
+            for agent in &resolved {
+                let payload = ContextsetPayload {
+                    schema_fqns: &agent.resolved_scope.schema_fqns,
+                    table_fqns: &agent.resolved_scope.table_fqns,
+                };
+                emit_stdout_line(format!(
+                    "{}: {} tables across {} schemas",
+                    agent.spec.name,
+                    agent.resolved_scope.table_fqns.len(),
+                    agent.resolved_scope.schema_fqns.len()
+                ));
+                if args.dry_run {
+                    let body = serde_json::to_string_pretty(&payload)
+                        .unwrap_or_else(|_| "{}".to_string());
+                    emit_stdout_line(format!("  dry-run payload:\n{}", body));
+                    continue;
+                }
+                let body = send_contextset_request(
+                    reqwest::Method::PUT,
+                    &args.client,
+                    &agent.spec.name,
+                    Some(&payload),
+                )
+                .await?;
+                emit_response_body(body, &format!("  {} deployed.", agent.spec.name));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn filter_specs(
+    specs: Vec<crate::agents::AgentSpec>,
+    name: Option<&str>,
+) -> FsResult<Vec<crate::agents::AgentSpec>> {
+    let Some(name) = name else {
+        return Ok(specs);
+    };
+    let filtered: Vec<_> = specs.into_iter().filter(|s| s.name == name).collect();
+    if filtered.is_empty() {
+        return Err(fs_err!(
+            ErrorCode::Generic,
+            "No agent named `{}` found under agents/",
+            name
+        ));
+    }
+    Ok(filtered)
+}
+
+fn manifest_path_for(project_dir: &Path, override_path: Option<&PathBuf>) -> PathBuf {
+    if let Some(p) = override_path {
+        return p.clone();
+    }
+    project_dir.join("target").join("manifest.json")
+}
+
+fn write_agents_json(project_dir: &Path, resolved: &[crate::agents::ResolvedAgent]) -> FsResult<()> {
+    let target_dir = project_dir.join("target");
+    if let Err(err) = std::fs::create_dir_all(&target_dir) {
+        return Err(fs_err!(
+            ErrorCode::Generic,
+            "Failed to create {}: {}",
+            target_dir.display(),
+            err
+        ));
+    }
+    let path = crate::agents::agents_json_path(&target_dir);
+    let content = serde_json::to_string_pretty(resolved).map_err(|err| {
+        fs_err!(
+            ErrorCode::Generic,
+            "Failed to serialize agents.json: {}",
+            err
+        )
+    })?;
+    std::fs::write(&path, content).map_err(|err| {
+        fs_err!(
+            ErrorCode::Generic,
+            "Failed to write {}: {}",
+            path.display(),
+            err
+        )
+    })?;
+    Ok(())
 }
 
 async fn execute_contextset_command(command: &ContextsetCommand) -> FsResult<()> {
@@ -663,6 +859,16 @@ impl CliExtensionHooks for DefaultCliExtensionHooks {
             }
             Some(Contextset(args)) => {
                 if let Err(err) = execute_contextset_command(&args.command).await {
+                    emit_error_log_from_fs_error(
+                        err.as_ref(),
+                        eval_arg.io.status_reporter.as_ref(),
+                    );
+                    return Err(FsError::exit_with_status(1));
+                }
+                Err(FsError::exit_with_status(0))
+            }
+            Some(Agent(args)) => {
+                if let Err(err) = execute_agent_command(&args.command).await {
                     emit_error_log_from_fs_error(
                         err.as_ref(),
                         eval_arg.io.status_reporter.as_ref(),

--- a/crates/dbt-features/src/mod.rs
+++ b/crates/dbt-features/src/mod.rs
@@ -7,6 +7,7 @@ pub mod feature_stack_builder;
 
 // All features:
 pub mod adapter;
+pub mod agents;
 pub mod antlr_parser;
 pub mod cli;
 pub mod index;

--- a/examples/agents-demo/README.md
+++ b/examples/agents-demo/README.md
@@ -1,0 +1,164 @@
+# agents-demo
+
+A minimal dbt project that demonstrates the v0 **`dbt agent`** workflow: author
+governed agents as YAML in the project, resolve their scope against the manifest,
+and push each one to a Fivetran AI MCP contextset.
+
+## Layout
+
+```
+agents-demo/
+├── dbt_project.yml         project + groups + access defaults
+├── profiles.yml            zero-setup DuckDB target
+├── models/
+│   ├── _models.yml         model metadata (groups, tags, access)
+│   ├── sales/              group:sales — dim_customers, fct_orders, fct_orders_pii
+│   ├── support/            group:support — tickets
+│   └── finance/            group:finance, access:private — revenue
+└── agents/
+    ├── sales_analyst.yml   group:sales,tag:certified minus tag:pii
+    ├── support_triage.yml  group:support + tickets lineage
+    └── finance_read.yml    group:finance (private scope)
+```
+
+## Prerequisites
+
+- A `dbt` binary built from this branch (`agents/v0-node-type`):
+  ```
+  cargo build --release --package dbt-features
+  ```
+  The binary lands at `target/release/dbt` (from the repo root).
+- For deploy: a reachable Fivetran AI MCP endpoint with a valid bearer token.
+
+## Runbook
+
+### 1. Parse the project
+
+Produce `target/manifest.json`. The agent tool reads it — no warehouse connection
+needed for scope resolution.
+
+```bash
+cd examples/agents-demo
+dbt parse --profiles-dir .
+```
+
+### 2. Enumerate agents
+
+```bash
+dbt agent list --project-dir .
+```
+
+Expected:
+
+```
+finance_read    Read-only access to recognized-revenue rollups.
+sales_analyst   Answers questions about the sales pipeline. Excludes PII columns.
+support_triage  Routes incoming tickets. Scope: the support group and its lineage.
+```
+
+### 3. Show resolved scope (dry-run, no network)
+
+```bash
+dbt agent show sales_analyst --project-dir .
+```
+
+Expected shape (abridged):
+
+```json
+[
+  {
+    "name": "sales_analyst",
+    "scope": { ... },
+    "resolved_scope": {
+      "schema_fqns": ["dev.main"],
+      "table_fqns": [
+        "dev.main.dim_customers",
+        "dev.main.fct_orders"
+      ],
+      "model_unique_ids": [
+        "model.agents_demo.dim_customers",
+        "model.agents_demo.fct_orders"
+      ]
+    }
+  }
+]
+```
+
+Note that `fct_orders_pii` was pulled in by `group:sales` but subtracted by
+`exclude: tag:pii` — a subtractive selector, not a filter.
+
+The command also writes `target/agents.json` for inspection.
+
+### 4. Dry-run the deploy
+
+```bash
+dbt agent deploy sales_analyst \
+  --project-dir . \
+  --dry-run \
+  --url https://mcp.fivetran.example.com \
+  --token dummy \
+  --group-id demo-group
+```
+
+Prints the PUT payload without hitting the network. Use this in reviews to show
+exactly what will be sent.
+
+### 5. Live deploy
+
+Set your credentials once:
+
+```bash
+export DBT_FIVETRAN_MCP_URL=https://mcp.fivetran.example.com
+export DBT_FIVETRAN_MCP_TOKEN=<bearer>
+export DBT_FIVETRAN_GROUP_ID=<group id>
+```
+
+Deploy all agents:
+
+```bash
+dbt agent deploy --project-dir .
+```
+
+Each agent PUTs to `PUT /contextsets/<name>?group_id=<group>` with a body of
+`{schema_fqns, table_fqns}`.
+
+### 6. Verify
+
+Confirm the contextset landed in Fivetran using the low-level admin command:
+
+```bash
+dbt contextset get sales_analyst
+```
+
+Or exercise the enforcement path — call the Fivetran MCP `execute_aisql` tool
+with `contextset=sales_analyst` for an in-scope table (succeeds) and again for
+`fct_orders_pii` (blocked).
+
+## What each agent demonstrates
+
+| Agent            | Selector shape                                | Point of the demo                                     |
+| ---------------- | --------------------------------------------- | ----------------------------------------------------- |
+| `sales_analyst`  | `group:sales,tag:certified` + `dim_customers+` minus `tag:pii` | Union of selectors, graph op, subtractive exclude     |
+| `support_triage` | `group:support` + `+tickets`                  | Ancestor graph op — pulls in upstream models          |
+| `finance_read`   | `group:finance`                               | Access modifier on a private surface                  |
+
+## Editing loop
+
+1. Edit any `agents/*.yml`.
+2. `dbt agent show <name>` to see the new resolved scope.
+3. `dbt agent deploy <name>` to push. The Fivetran server treats each PUT as a
+   full replacement of the contextset by that name.
+
+## Known v0 caveats
+
+- `tools.include` is stored on the agent but **not** server-enforced yet — the
+  Fivetran MCP still exposes every tool it has. Enforcement is a v0.5 add.
+- `mcp_server: fivetran_primary` in the YAML is metadata only. In v0 the actual
+  URL/token/group_id come from CLI flags or environment variables. A first-class
+  `mcp-servers:` block in `dbt_project.yml` is deferred to v0.5.
+- Only models with a resolved `relation_name` land in the contextset. Ephemerals,
+  disabled models, and sources are excluded by design.
+- Supported selector syntax subset: bare name, `resource_type:`, `tag:`, `group:`,
+  and `+`/`N+`/`+N`/`N+…+N` graph ops. `,` inside one expression is intersect;
+  list entries are union. Not supported in v0: `state:`, `source:`, `test:`,
+  `path:`, wildcards, or parenthesized boolean expressions.

--- a/examples/agents-demo/agents/finance_read.yml
+++ b/examples/agents-demo/agents/finance_read.yml
@@ -1,0 +1,10 @@
+agents:
+  - name: finance_read
+    description: "Read-only access to recognized-revenue rollups."
+    access: private
+    scope:
+      select:
+        - "group:finance"
+    tools:
+      include: [search_tables, execute_aisql]
+    mcp_server: fivetran_primary

--- a/examples/agents-demo/agents/sales_analyst.yml
+++ b/examples/agents-demo/agents/sales_analyst.yml
@@ -1,0 +1,17 @@
+agents:
+  - name: sales_analyst
+    description: "Answers questions about the sales pipeline. Excludes PII columns."
+    access: protected
+    scope:
+      select:
+        - "group:sales,tag:certified"
+        - "dim_customers+"
+      exclude:
+        - "tag:pii"
+    tools:
+      include:
+        - search_tables
+        - list_tables
+        - table_deep_dive
+        - execute_aisql
+    mcp_server: fivetran_primary

--- a/examples/agents-demo/agents/support_triage.yml
+++ b/examples/agents-demo/agents/support_triage.yml
@@ -1,0 +1,11 @@
+agents:
+  - name: support_triage
+    description: "Routes incoming tickets. Scope: the support group and its lineage."
+    access: protected
+    scope:
+      select:
+        - "group:support"
+        - "+tickets"
+    tools:
+      include: [search_tables, list_tables, table_deep_dive]
+    mcp_server: fivetran_primary

--- a/examples/agents-demo/dbt_project.yml
+++ b/examples/agents-demo/dbt_project.yml
@@ -1,0 +1,18 @@
+name: agents_demo
+version: "1.0.0"
+config-version: 2
+
+profile: agents_demo
+
+model-paths: ["models"]
+
+models:
+  agents_demo:
+    +materialized: table
+    sales:
+      +group: sales
+    support:
+      +group: support
+    finance:
+      +group: finance
+      +access: private

--- a/examples/agents-demo/models/_models.yml
+++ b/examples/agents-demo/models/_models.yml
@@ -1,0 +1,46 @@
+version: 2
+
+groups:
+  - name: sales
+    owner:
+      name: Sales team
+  - name: support
+    owner:
+      name: Support team
+  - name: finance
+    owner:
+      name: Finance team
+
+models:
+  - name: dim_customers
+    description: "One row per customer, joined against subscription history."
+    config:
+      group: sales
+      access: protected
+      tags: [certified]
+
+  - name: fct_orders
+    description: "Order fact table with revenue and status."
+    config:
+      group: sales
+      access: protected
+      tags: [certified]
+
+  - name: fct_orders_pii
+    description: "Order line items with PII columns retained for compliance."
+    config:
+      group: sales
+      access: private
+      tags: [pii]
+
+  - name: tickets
+    description: "Support tickets with routing metadata."
+    config:
+      group: support
+      tags: [certified]
+
+  - name: revenue
+    description: "Monthly recognized revenue."
+    config:
+      group: finance
+      access: private

--- a/examples/agents-demo/models/finance/revenue.sql
+++ b/examples/agents-demo/models/finance/revenue.sql
@@ -1,0 +1,3 @@
+select
+    '2026-01'::varchar as month,
+    12345.67 as recognized_revenue

--- a/examples/agents-demo/models/sales/dim_customers.sql
+++ b/examples/agents-demo/models/sales/dim_customers.sql
@@ -1,0 +1,4 @@
+select
+    1 as customer_id,
+    'Acme Co' as name,
+    '2026-01-01'::date as first_seen_at

--- a/examples/agents-demo/models/sales/fct_orders.sql
+++ b/examples/agents-demo/models/sales/fct_orders.sql
@@ -1,0 +1,5 @@
+select
+    1 as order_id,
+    1 as customer_id,
+    100.00 as amount,
+    'completed' as status

--- a/examples/agents-demo/models/sales/fct_orders_pii.sql
+++ b/examples/agents-demo/models/sales/fct_orders_pii.sql
@@ -1,0 +1,4 @@
+select
+    1 as order_id,
+    'ssn-123-45-6789' as customer_ssn,
+    'card-4111111111111111' as customer_card

--- a/examples/agents-demo/models/support/tickets.sql
+++ b/examples/agents-demo/models/support/tickets.sql
@@ -1,0 +1,5 @@
+select
+    1 as ticket_id,
+    1 as customer_id,
+    'open' as status,
+    'billing' as category

--- a/examples/agents-demo/profiles.yml
+++ b/examples/agents-demo/profiles.yml
@@ -1,0 +1,10 @@
+# Zero-setup DuckDB profile. `dbt parse` uses this only to know the database name
+# — no data is written; the demo needs a manifest.json, not a materialized warehouse.
+
+agents_demo:
+  target: dev
+  outputs:
+    dev:
+      type: duckdb
+      path: dev.duckdb
+      schema: main


### PR DESCRIPTION
Stacked on #15365 — please review that PR first.

## Summary

- **New `dbt agent {list,show,deploy}` subcommand** on top of Lev's low-level `dbt contextset`. Authors declare agents as YAML in `<project>/agents/`, and `dbt agent deploy` resolves the scope against `target/manifest.json` and PUTs the resolved schema/table FQNs to the Fivetran AI MCP contextset endpoint keyed by agent name.
- **Runnable example project** under `examples/agents-demo/` with three agents demonstrating union, `+` graph ops, subtractive `exclude`, and `access` modifiers. README doubles as the demo runbook.
- Verified end-to-end against a local `dbt parse` — `list` / `show` / `deploy --dry-run` all produce the expected resolved scopes.

## Design notes

**v0 is "manifest-adjacent," not a first-class Fusion node type.** The alternative — adding `agent` as a real resource type across parser, node schemas, selector, and manifest — is 2–3 weeks of plumbing and mostly boilerplate. Sequencing that after the demo lands is intentional. YAML shape and CLI surface are forward-compatible with the eventual node-type upgrade.

**Selector subset supported:** bare name, `resource_type:`, `tag:`, `group:`, and `N+`/`+N`/`+`/`N+…+N` graph ops. `,` inside one expression is intersect; list entries are union. Not implemented: `state:`, `source:`, `test:`, `path:`, wildcards, or full boolean grammar. The demo project stays inside the supported subset.

**Lean manifest deserialization.** Uses a local `ManifestView` struct instead of `DbtManifestV11` — the schemas crate's internal shape has required fields (e.g. `__other__`) that don't survive round-tripping through `manifest.json`. `ManifestView` only reads the fields the resolver needs, is forgiving on missing keys, and insulates us from downstream churn in `dbt-schemas`.

## Deliberate v0 punts

- **`tools.include` accepted but not server-enforced.** Stored on the agent so a v0.5 Fivetran-side change can flip the switch without breaking existing YAML.
- **`mcp_server:` in YAML is metadata only.** URL / token / group_id come from CLI flags or env vars (reuses Lev's `ContextsetClientArgs`). First-class `mcp-servers:` block in `dbt_project.yml` is deferred.
- **No sources, ephemerals, or semantic-layer objects in scope.** Only models with a resolved `relation_name` land in the contextset. The demo covers the wedge without them.

## Test plan

- [x] `cargo check --package dbt-features` clean
- [x] `cargo clippy --package dbt-features` clean
- [x] `cargo build --release --package dbt-sa-cli` produces a working binary
- [x] `dbt agent list --project-dir examples/agents-demo` — three agents enumerated
- [x] `dbt parse` on the demo project produces `target/manifest.json`
- [x] `dbt agent show sales_analyst` resolves to `{dim_customers, fct_orders}` — `fct_orders_pii` correctly excluded by `tag:pii`
- [x] `dbt agent deploy --dry-run` prints correct payloads for all three agents
- [x] `target/agents.json` artifact written on `show` and `deploy`
- [ ] Live deploy against a running Fivetran MCP endpoint (blocked on staging deployment of #15365's server-side counterpart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)