### PR TITLE
notify in slack for community pr

### DIFF
--- a/.github/workflows/community-pr-notify.yml
+++ b/.github/workflows/community-pr-notify.yml
@@ -3,7 +3,8 @@
 
 # **why?**
 # Give the internal team real-time visibility into new community contributions
-# so they can be triaged and assigned promptly
+# so they can be triaged and assigned promptly. PRs that close a heavily
+# upvoted issue are flagged high-priority in the Slack message.
 
 # **when?**
 # When the `community` label is applied to a pull request
@@ -22,6 +23,9 @@ defaults:
 
 permissions:
   contents: read
+  # needed to read the linked issue's upvote (reaction) count via the API
+  issues: read
+  pull-requests: read
 
 jobs:
   notify-community-pr:
@@ -37,31 +41,64 @@ jobs:
       - name: Post Slack message
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CORE_PR_CHANNEL_URL }}
+          GH_TOKEN: ${{ github.token }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
           REPO: ${{ github.repository }}
+          # PRs whose linked issue has >= this many upvotes are flagged high-priority
+          UPVOTE_THRESHOLD: "10"
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
             echo "::error::SLACK_CORE_PR_CHANNEL_URL secret is not set"
             exit 1
           fi
 
+          # Highest \ud83d\udc4d (THUMBS_UP) count across all issues this PR closes; 0 if none linked
+          upvotes=$(gh api graphql \
+            -F owner="$OWNER" -F repo="$REPO_NAME" -F pr="$PR_NUMBER" \
+            -f query='
+              query($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pr) {
+                    closingIssuesReferences(first: 20) {
+                      nodes { reactions(content: THUMBS_UP) { totalCount } }
+                    }
+                  }
+                }
+              }' \
+            --jq '[.data.repository.pullRequest.closingIssuesReferences.nodes[].reactions.totalCount] | max // 0')
+
+          if [ "$upvotes" -ge "$UPVOTE_THRESHOLD" ]; then
+            high_priority=true
+          else
+            high_priority=false
+          fi
+          echo "Linked-issue upvotes: ${upvotes} (threshold ${UPVOTE_THRESHOLD}, high_priority=${high_priority})"
+
           resp=$(jq -n \
-            --arg repo   "$REPO" \
-            --arg title  "$PR_TITLE" \
-            --arg url    "$PR_URL" \
-            --arg author "$PR_AUTHOR" \
-            --arg number "$PR_NUMBER" \
+            --arg repo    "$REPO" \
+            --arg title   "$PR_TITLE" \
+            --arg url     "$PR_URL" \
+            --arg author  "$PR_AUTHOR" \
+            --arg number  "$PR_NUMBER" \
+            --arg upvotes "$upvotes" \
+            --argjson hp  "$high_priority" \
             '{
-              text: ("New community PR on " + $repo),
+              text: ((if $hp then ":rotating_light: High-priority community PR on " else "New community PR on " end) + $repo),
               blocks: [
                 {
                   type: "section",
                   text: {
                     type: "mrkdwn",
-                    text: (":earth_asia: *New community PR* \u2014 `" + $repo + "`\n*<" + $url + "|#" + $number + " " + $title + ">*\nOpened by: *" + $author + "*")
+                    text: (
+                      (if $hp then ":rotating_light: *High-priority community PR* \u2014 `" else ":earth_asia: *New community PR* \u2014 `" end)
+                      + $repo + "`\n*<" + $url + "|#" + $number + " " + $title + ">*\nOpened by: *" + $author + "*"
+                      + (if $hp then "\n:fire: Linked issue has *" + $upvotes + "* \ud83d\udc4d upvotes" else "" end)
+                    )
                   }
                 }
               ]

--- a/.github/workflows/community-pr-notify.yml
+++ b/.github/workflows/community-pr-notify.yml
@@ -1,0 +1,78 @@
+# **what?**
+# Post a Slack notification when a PR is labeled `community`
+
+# **why?**
+# Give the internal team real-time visibility into new community contributions
+# so they can be triaged and assigned promptly
+
+# **when?**
+# When the `community` label is applied to a pull request
+# (label is applied automatically by community-label.yml for PRs from outside core-group)
+
+name: Notify Slack on community PR
+
+on:
+  # pull_request_target required since community PRs come from forks
+  pull_request_target:
+    types: [labeled]
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  notify-community-pr:
+    name: Post to Slack
+    # Only fire when the label being applied is `community`
+    # Skip bots
+    if: |
+      github.event.label.name == 'community'
+      && github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Post Slack message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CORE_PR_CHANNEL_URL }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "::error::SLACK_CORE_PR_CHANNEL_URL secret is not set"
+            exit 1
+          fi
+
+          resp=$(jq -n \
+            --arg repo   "$REPO" \
+            --arg title  "$PR_TITLE" \
+            --arg url    "$PR_URL" \
+            --arg author "$PR_AUTHOR" \
+            --arg number "$PR_NUMBER" \
+            '{
+              text: ("New community PR on " + $repo),
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: (":earth_asia: *New community PR* \u2014 `" + $repo + "`\n*<" + $url + "|#" + $number + " " + $title + ">*\nOpened by: *" + $author + "*")
+                  }
+                }
+              ]
+            }' | \
+            curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+              -H "Content-type: application/json" \
+              --data @-)
+
+          # Incoming webhooks return "ok" as plain text on success
+          if [ "$resp" != "ok" ]; then
+            echo "::error::Slack webhook failed: $resp"
+            exit 1
+          fi
+          echo "Posted community PR alert for #${PR_NUMBER}"


### PR DESCRIPTION
Internal tooling change — no associated issue (not a product code change).

### Problem

Contributions from outside the core group could sit unnoticed until someone happened to scan the PR list, delaying triage and assignment. There was also no signal for which community PRs matter most to users.

### Solution

Adds a `pull_request_target` workflow (`.github/workflows/community-pr-notify.yml`) that posts to Slack (`#core-prs`, via the `SLACK_CORE_PR_CHANNEL_URL` webhook secret) whenever the `community` label is applied to a PR.

- Fires only on the `community` label; skips bots.
- Message links the PR and names the author.
- **High-priority flagging:** queries the PR's `closingIssuesReferences` (issues linked via `closes/fixes #N` or the sidebar) and, if any linked issue has **≥ 10 👍 reactions**, switches the notification to a high-priority variant (🚨 header + upvote count) so heavily-demanded contributions stand out. Threshold is a documented env var.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
