### PR TITLE
Add python programmtic interface support

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -49,9 +49,9 @@
 # by the `release_target` input.
 #
 # `dbt-core`'s wheels are built by `maturin build` in the `build` job
-# (abi3-py310, one cp310-abi3 wheel per platform) — not `cargo ci pypi pack`,
+# (abi3-py311, one cp311-abi3 wheel per platform) — not `cargo ci pypi pack`,
 # which only packs the standalone analyzer binary into `dbt-core-experimental-
-# parser`. `publish-pypi` passes `--python-tag cp310 --abi-tag abi3` for the
+# parser`. `publish-pypi` passes `--python-tag cp311 --abi-tag abi3` for the
 # dbt-core publish step so the sdist's manifest matches the maturin wheel
 # filenames actually sitting at the GitHub Release download URL (the default
 # `py3`/`none` tags are for the binary-CLI wheel, used for the parser publish
@@ -358,20 +358,52 @@ jobs:
           ls -la archives/
 
       # dbt-core is the maturin abi3 extension wheel (CLI + dbtRunner), not a
-      # packed binary. abi3-py310 → one cp310-abi3 wheel per platform. The
-      # manylinux containers ship the cp310 interpreter under /opt/python;
-      # the mac/windows runners use the system Python (abi3 is forward-compat).
+      # packed binary. abi3-py311 → one cp311-abi3 wheel per platform, valid
+      # on any interpreter >= 3.11 (crates/dbt-python's own requires-python
+      # floor). abi3 does NOT support older interpreters — maturin only
+      # *warns* and silently falls back to a version-specific, non-abi3
+      # cp3xx-cp3xx wheel if handed one, so `--interpreter` must resolve to
+      # an actual >=3.11 build or the release ships a wheel that's
+      # uninstallable everywhere (its own metadata says >=3.11, but the
+      # wheel tag says otherwise).
+      #
+      # The manylinux containers bundle cp311 under /opt/python; the
+      # mac/windows runner images don't reliably ship 3.11 as `python3` (this
+      # bit us once already — the containers only had cp310 available), so
+      # those two pin it explicitly via actions/setup-python.
+      - name: Setup Python 3.11 (macOS/Windows)
+        if: ${{ matrix.container == '' }}
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # A venv sidesteps the mac/windows runners' externally-managed system
+      # Python (PEP 668), which rejects a plain `pip install maturin`
+      # outright. `maturin build` only writes a wheel file (it doesn't
+      # install anything, unlike `maturin develop`), so the venv only needs
+      # to hold the `maturin` CLI itself — `--interpreter "$PY"` is what
+      # actually controls which Python's ABI the wheel targets.
       - name: Build maturin wheel (dbt-core)
         env:
           TARGET: ${{ matrix.target }}
         run: |
-          if [ -x /opt/python/cp310-cp310/bin/python ]; then
-            PY=/opt/python/cp310-cp310/bin/python
+          if [ -x /opt/python/cp311-cp311/bin/python ]; then
+            PY=/opt/python/cp311-cp311/bin/python
           else
             PY=python3
           fi
-          "$PY" -m pip install --upgrade maturin
-          "$PY" -m maturin build --release --locked \
+          # Belt-and-suspenders: fail loudly instead of letting maturin
+          # silently downgrade to a version-specific, non-abi3 wheel.
+          "$PY" -c 'import sys; assert sys.version_info[:2] >= (3, 11), f"need Python >=3.11, got {sys.version}"'
+
+          "$PY" -m venv .maturin-venv
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            VENV_BIN=".maturin-venv/Scripts"
+          else
+            VENV_BIN=".maturin-venv/bin"
+          fi
+          "$VENV_BIN/python" -m pip install --upgrade pip "maturin>=1.0,<2.0"
+          "$VENV_BIN/maturin" build --release --locked \
             --target "$TARGET" \
             --interpreter "$PY" \
             -m crates/dbt-python/Cargo.toml \
@@ -471,19 +503,25 @@ jobs:
       - name: Run tests
         run: cargo nextest run
 
-      # uv is used here purely as a fast venv/pip tool (`uv venv` + `uv pip
-      # install`), not the project-sync workflow — so this doesn't require
-      # declaring maturin/pytest in crates/dbt-python's own pyproject.toml.
-      - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # astral-sh/setup-uv@v9.0.0
+      # Pinned to 3.11 explicitly, same as the `build` job's maturin
+      # invocation — this job's whole point is gating `pack` on a build of
+      # the actual shipped artifact, so testing against anything other than
+      # the abi3 floor (crates/dbt-python's own requires-python) wouldn't
+      # actually exercise what gets published.
+      - name: Setup Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # actions/setup-python@v6
+        with:
+          python-version: "3.11"
 
       # Prepending .venv/bin to PATH lets every later step call `maturin`/
-      # `pytest` directly instead of the full .venv/bin/... path.
+      # `pytest` directly instead of the full .venv/bin/... path. This
+      # doesn't require declaring maturin/pytest in crates/dbt-python's own
+      # pyproject.toml.
       - name: Create venv and install maturin + pytest
         working-directory: crates/dbt-python
         run: |
-          uv venv .venv
-          uv pip install --python .venv "maturin>=1.0,<2.0" "pytest>=9.1"
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip "maturin>=1.0,<2.0" "pytest>=9.1"
           echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       # No --locked: this is a test job, not a reproducible release build
@@ -697,7 +735,7 @@ jobs:
       # One --target per wheel uploaded to the Release; keep in lockstep with
       # the `build` job's matrix — each target's wheel is fetched and hashed.
       #
-      # dbt-core's wheels are maturin abi3 extension wheels (cp310-abi3), not
+      # dbt-core's wheels are maturin abi3 extension wheels (cp311-abi3), not
       # the binary CLI wheel (py3-none) `cargo ci pypi pack` produces — pass
       # the matching python/abi tags so the sdist manifest's filenames match
       # what's actually sitting at BASE_URL.
@@ -710,7 +748,7 @@ jobs:
             --environment prod \
             --version "${{ needs.prepare-release.outputs.version }}" \
             --download-base-url "$BASE_URL" \
-            --python-tag cp310 \
+            --python-tag cp311 \
             --abi-tag abi3 \
             --target x86_64-unknown-linux-gnu \
             --target aarch64-unknown-linux-gnu \

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -73,14 +73,26 @@
 # out; clean these up periodically.
 #
 # **Test-PyPI-only mode** (`inputs.dry_run_with_test_pypi = true`)
-# Everything dry-run skips, this skips too — tag, GitHub Release, Homebrew,
-# winget, changelog backport, and the mirror version bump all get
-# `if: !inputs.dry_run && !inputs.dry_run_with_test_pypi` — plus it actually
-# publishes to Test PyPI on top of that (dry-run's build + pack still just
-# leave artifacts sitting in the run). Since there's no GitHub Release for
-# publish-pypi to fetch wheels from in this mode, it uploads the `pack`
-# job's `release-assets` artifact directly via `--dist` instead of the
-# usual download-at-install sdist.
+# Homebrew, winget, changelog backport, and the mirror version bump are all
+# skipped (`if: !inputs.dry_run && !inputs.dry_run_with_test_pypi`), same as
+# dry-run. Unlike dry-run, though, tag, github-release, and publish-pypi DO
+# run — under a distinct `v{version}-test-pypi` tag instead of the real
+# `v{version}` one, and publish-pypi runs `--environment test-pypi` against
+# `TEST_PYPI_API_TOKEN` instead of prod. github-release always marks this
+# release pre-release/not-Latest, regardless of the version's own SemVer.
+#
+# Publishing a real (if clearly test-only) GitHub Release here — rather
+# than skipping github-release like dry-run does, or using a draft release
+# — means publish-pypi exercises the *exact* same download-at-install sdist
+# mechanism prod uses. Draft release assets aren't downloadable without
+# authentication, which would break both the sdist-assembly fetch and, more
+# importantly, a real `pip install` from Test PyPI by anyone testing this.
+# slack-notification is skipped here too — announcing "released!" to
+# #core-releases for what's just a Test PyPI rehearsal would be misleading.
+#
+# prepare-release still gets `dry_run: true` in this mode, so it cuts a
+# throwaway `release/dry-run/v…-<run_id>` branch instead of a real
+# `release/vX.Y.Z` one — no branch to remember to clean up afterward.
 
 name: Release dbt Core V2
 run-name: >-
@@ -103,7 +115,7 @@ on:
         type: boolean
         default: false
       dry_run_with_test_pypi:
-        description: "Dry Run + Test PyPI Publish. Works like dry_run (skips tag, GitHub Release, Homebrew, winget, changelog backport, mirror version bump) but additionally publishes the built wheels to Test PyPI."
+        description: "Dry Run + Test PyPI Publish. Tags and creates a pre-release GitHub Release under a distinct v{version}-test-pypi tag, and publishes to Test PyPI instead of prod. Skips Homebrew, winget, changelog backport, and the mirror version bump."
         required: false
         type: boolean
         default: false
@@ -151,7 +163,10 @@ jobs:
     uses: ./.github/workflows/release-prep-v2.yml
     with:
       version: ${{ inputs.version }}
-      dry_run: ${{ inputs.dry_run }}
+      # dry_run_with_test_pypi still cuts a throwaway release/dry-run/...
+      # branch (not a real release/vX.Y.Z one) — it's a rehearsal, not a
+      # branch anyone should have to remember to clean up.
+      dry_run: ${{ inputs.dry_run || inputs.dry_run_with_test_pypi }}
       source_ref: ${{ inputs.source_ref }}
 
   # ------------------------------------------------------------------
@@ -672,13 +687,18 @@ jobs:
   # everything downstream hangs off. Skipped on dry-run — the throwaway
   # `release/dry-run/...` branch isn't worth tagging, and the upstream
   # `prepare-release` step already rejects pre-existing tags.
+  #
+  # dry_run_with_test_pypi DOES tag (github-release/publish-pypi need a
+  # real tag to hang a GitHub Release off of), just under a distinct
+  # `-test-pypi` suffix so it never collides with a real release tag.
+  #
   # Idempotent: re-running a successful tag job is a no-op; pointing
   # at a different SHA than the existing tag fails loudly.
   # ------------------------------------------------------------------
   tag:
     name: Tag release commit
     needs: [prepare-release, pack]
-    if: ${{ !inputs.dry_run && !inputs.dry_run_with_test_pypi }}
+    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -694,7 +714,7 @@ jobs:
 
       - name: Tag branch HEAD
         env:
-          TAG: ${{ needs.prepare-release.outputs.tag }}
+          TAG: ${{ needs.prepare-release.outputs.tag }}${{ inputs.dry_run_with_test_pypi && '-test-pypi' || '' }}
           VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |
           HEAD_SHA=$(git rev-parse HEAD)
@@ -707,40 +727,29 @@ jobs:
           git push origin "$TAG"
 
   # ------------------------------------------------------------------
-  # Publish to PyPI. Skipped on dry-run. Two modes, both gated by
-  # `inputs.dry_run_with_test_pypi`:
+  # Publish the download-at-install sdist to PyPI. Skipped on dry-run.
+  # Runs after `github-release` in both prod and `inputs.dry_run_with_test_pypi`
+  # modes — dry_run_with_test_pypi publishes a real (not draft) GitHub
+  # Release too (see github-release's comment) specifically so this job
+  # exercises the exact same sdist/download-at-install mechanism prod uses,
+  # just against a distinct `-test-pypi`-suffixed tag and Test PyPI instead
+  # of prod PyPI.
   #
-  #   prod (default): runs after `github-release` and publishes a
-  #   download-at-install sdist (not wheels). Points `cargo ci pypi publish`
-  #   at the GitHub Release download URL via `--download-base-url`, which
-  #   fetches each platform wheel (one per `--target`), hashes the live
-  #   bytes, and assembles an sdist pinning those filenames + sha256s; pip
-  #   fetches the matching wheel from the Release at install time. Runs with
-  #   `--environment prod`, authenticating with the repo-level
-  #   `PYPI_API_TOKEN` secret (passed to the tool as `DBT_PYPI_PROD_TOKEN`).
-  #
-  #   dry_run_with_test_pypi: no GitHub Release exists in this mode, so instead of
-  #   fetching wheels from a download URL, it downloads the `pack` job's
-  #   `release-assets` artifact and uploads those wheels directly via
-  #   `--dist`. Runs with `--environment test-pypi`, authenticating with
-  #   the repo-level `TEST_PYPI_API_TOKEN` secret (`DBT_PYPI_TEST_TOKEN`).
-  #
+  # Points `cargo ci pypi publish` at the GitHub Release download URL via
+  # `--download-base-url`, which fetches each platform wheel (one per
+  # `--target`), hashes the live bytes, and assembles an sdist pinning
+  # those filenames + sha256s; pip fetches the matching wheel from the
+  # Release at install time. Authenticates with the repo-level
+  # `PYPI_API_TOKEN`/`TEST_PYPI_API_TOKEN` secret depending on mode
+  # (passed to the tool as `DBT_PYPI_PROD_TOKEN`/`DBT_PYPI_TEST_TOKEN`).
   # `release_target` selects which of the two distributions (`dbt-core`,
   # `dbt-core-experimental-parser`) to publish, in both modes.
-  #
-  # `if: !failure() && !cancelled()` (instead of the usual `needs.*.result
-  # == 'success'` implied by a plain `if: !inputs.dry_run`) lets this job
-  # run when `github-release` was skipped (dry_run_with_test_pypi) as well as when
-  # it succeeded (prod) — a skipped dependency isn't a success, so the
-  # default `if` would otherwise skip this job too.
   # ------------------------------------------------------------------
   publish-pypi:
     name: Publish to PyPI
-    # pack + tag are transitive via github-release; prepare-release stays for
-    # its outputs. pack is listed explicitly too since dry_run_with_test_pypi reads
-    # its `release-assets` artifact directly, without going through github-release.
-    needs: [prepare-release, pack, github-release]
-    if: ${{ !inputs.dry_run && !failure() && !cancelled() }}
+    # pack + tag are transitive via github-release; prepare-release stays for its outputs.
+    needs: [prepare-release, github-release]
+    if: ${{ !inputs.dry_run }}
     runs-on: ${{ vars.UBUNTU_RUNNER_32 }}
     permissions:
       contents: read
@@ -748,9 +757,11 @@ jobs:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache
       # GitHub Release download URL hosting this version's wheels; the sdist
-      # backend fetches the matching wheel from here at install time. Only
-      # used in prod mode.
-      BASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ needs.prepare-release.outputs.tag }}
+      # backend fetches the matching wheel from here at install time. The
+      # `-test-pypi` suffix must match the tag job's.
+      BASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ needs.prepare-release.outputs.tag }}${{ inputs.dry_run_with_test_pypi && '-test-pypi' || '' }}
+      DBT_PYPI_PROD_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      DBT_PYPI_TEST_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
         with:
@@ -770,37 +781,23 @@ jobs:
         with:
           version: "v0.12.0"
 
-      # dry_run_with_test_pypi only: pulls the wheels `pack` already built instead of
-      # fetching them from a GitHub Release (there isn't one in this mode).
-      - name: Download release assets (test-pypi-only)
-        if: inputs.dry_run_with_test_pypi
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
-        with:
-          name: release-assets
-          path: dist
-
-      # Both modes read the distribution name from pyproject's [project].name
-      # — sdist mode to build the wheel filenames it downloads from BASE_URL,
-      # --dist mode to filter which wheels in dist/ to upload — so to publish
+      # sdist mode reads the distribution name from pyproject's [project].name
+      # to build the wheel filenames it downloads from BASE_URL, so to publish
       # both distributions we publish once, swap pyproject in place, then
       # publish again. Mirrors the pack-job pattern.
       #
       # One --target per wheel uploaded to the Release; keep in lockstep with
       # the `build` job's matrix — each target's wheel is fetched and hashed.
-      # Prod mode only (dry_run_with_test_pypi's --dist upload doesn't need --target).
       #
       # dbt-core's wheels are maturin abi3 extension wheels (cp311-abi3), not
-      # the binary CLI wheel (py3-none) `cargo ci pypi pack` produces — prod
-      # mode passes the matching python/abi tags so the sdist manifest's
-      # filenames match what's actually sitting at BASE_URL. dry_run_with_test_pypi's
-      # --dist mode uploads the actual wheel files, so it doesn't need them.
-      - name: Publish (dbt-core, prod)
-        if: ${{ inputs.release_target != 'parser' && !inputs.dry_run_with_test_pypi }}
-        env:
-          DBT_PYPI_PROD_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      # the binary CLI wheel (py3-none) `cargo ci pypi pack` produces — pass
+      # the matching python/abi tags so the sdist manifest's filenames match
+      # what's actually sitting at BASE_URL.
+      - name: Publish (dbt-core)
+        if: inputs.release_target != 'parser'
         run: |
           cargo ci pypi publish \
-            --environment prod \
+            --environment ${{ inputs.dry_run_with_test_pypi && 'test-pypi' || 'prod' }} \
             --version "${{ needs.prepare-release.outputs.version }}" \
             --download-base-url "$BASE_URL" \
             --python-tag cp311 \
@@ -811,29 +808,17 @@ jobs:
             --target aarch64-apple-darwin \
             --target x86_64-pc-windows-msvc
 
-      - name: Publish (dbt-core, test-pypi-only)
-        if: ${{ inputs.release_target != 'parser' && inputs.dry_run_with_test_pypi }}
-        env:
-          DBT_PYPI_TEST_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        run: |
-          cargo ci pypi publish \
-            --environment test-pypi \
-            --version "${{ needs.prepare-release.outputs.version }}" \
-            --dist dist
-
       - name: Rename pyproject for parser publish
         if: inputs.release_target != 'core'
         run: |
           sed -i 's/^name = "dbt-core"$/name = "dbt-core-experimental-parser"/' pyproject.toml
           grep '^name = ' pyproject.toml
 
-      - name: Publish (dbt-core-experimental-parser, prod)
-        if: ${{ inputs.release_target != 'core' && !inputs.dry_run_with_test_pypi }}
-        env:
-          DBT_PYPI_PROD_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish (dbt-core-experimental-parser)
+        if: inputs.release_target != 'core'
         run: |
           cargo ci pypi publish \
-            --environment prod \
+            --environment ${{ inputs.dry_run_with_test_pypi && 'test-pypi' || 'prod' }} \
             --version "${{ needs.prepare-release.outputs.version }}" \
             --download-base-url "$BASE_URL" \
             --target x86_64-unknown-linux-gnu \
@@ -842,16 +827,6 @@ jobs:
             --target aarch64-apple-darwin \
             --target x86_64-pc-windows-msvc
 
-      - name: Publish (dbt-core-experimental-parser, test-pypi-only)
-        if: ${{ inputs.release_target != 'core' && inputs.dry_run_with_test_pypi }}
-        env:
-          DBT_PYPI_TEST_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        run: |
-          cargo ci pypi publish \
-            --environment test-pypi \
-            --version "${{ needs.prepare-release.outputs.version }}" \
-            --dist dist
-
       - name: Restore pyproject name after parser publish
         if: ${{ always() && inputs.release_target != 'core' }}
         run: |
@@ -859,9 +834,17 @@ jobs:
           grep '^name = ' pyproject.toml
 
   # ------------------------------------------------------------------
-  # Create the GitHub Release with all assets. Skipped on dry-run and on
-  # dry_run_with_test_pypi (no GitHub Release involved in that mode — publish-pypi
-  # uploads the pack job's wheels directly instead).
+  # Create the GitHub Release with all assets. Skipped on dry-run.
+  #
+  # dry_run_with_test_pypi creates one too — under the distinct
+  # `-test-pypi`-suffixed tag, always marked pre-release — so publish-pypi
+  # can exercise the exact same download-at-install sdist mechanism prod
+  # uses. A *draft* release was considered instead of a real one, but draft
+  # release assets aren't downloadable without authentication, which would
+  # break both this job's own asset upload flow and, more importantly, a
+  # real end user's `pip install` from Test PyPI — defeating the point of
+  # testing the actual install path.
+  #
   # Idempotent: if the release already exists, re-uploads assets with
   # --clobber so a flaky asset upload can be retried without manual
   # cleanup.
@@ -869,7 +852,7 @@ jobs:
   github-release:
     name: Create GitHub Release
     needs: [prepare-release, pack, tag]
-    if: ${{ !inputs.dry_run && !inputs.dry_run_with_test_pypi }}
+    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -887,8 +870,11 @@ jobs:
       - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.prepare-release.outputs.tag }}
+          # Must match the tag job's — dry_run_with_test_pypi tags under a
+          # distinct suffix so this release never collides with a real one.
+          TAG: ${{ needs.prepare-release.outputs.tag }}${{ inputs.dry_run_with_test_pypi && '-test-pypi' || '' }}
           VERSION: ${{ needs.prepare-release.outputs.version }}
+          DRY_RUN_WITH_TEST_PYPI: ${{ inputs.dry_run_with_test_pypi }}
         run: |
           shopt -s nullglob
           ASSETS=(dist/*.whl dist/*.tar.gz dist/*.zip)
@@ -897,10 +883,14 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists; re-uploading assets."
           else
-            # Pre-release versions (SemVer with a pre-release segment) shouldn't
-            # surface as "Latest" on the Releases page.
             CREATE_ARGS=(--title "$TAG")
-            [[ "$VERSION" == *-* ]] && CREATE_ARGS+=(--prerelease)
+            # Pre-release versions (SemVer with a pre-release segment)
+            # shouldn't surface as "Latest" on the Releases page — and a
+            # dry_run_with_test_pypi release never should, regardless of
+            # its version.
+            if [[ "$VERSION" == *-* ]] || [ "$DRY_RUN_WITH_TEST_PYPI" = "true" ]; then
+              CREATE_ARGS+=(--prerelease)
+            fi
 
             NOTES=".changes/${VERSION}.md"
             if [ -f "$NOTES" ]; then
@@ -1104,6 +1094,9 @@ jobs:
   publish-winget:
     needs: [prepare-release, github-release]
     # if: ${{ !contains(needs.prepare-release.outputs.version, '-') }}
+    # dry_run cascades via github-release being skipped; dry_run_with_test_pypi
+    # needs an explicit guard since github-release now runs in that mode too.
+    if: ${{ !inputs.dry_run_with_test_pypi }}
     uses: ./.github/workflows/publish-winget.yml
     with:
       version: ${{ needs.prepare-release.outputs.version }}
@@ -1122,8 +1115,9 @@ jobs:
   # ------------------------------------------------------------------
   slack-notification:
     name: Slack Notification
-    # dry_run_with_test_pypi doesn't create a GitHub Release, so there's nothing for
-    # this announcement (and its RELEASE_URL) to correctly point at.
+    # dry_run_with_test_pypi does create a real GitHub Release now, but
+    # announcing "dbt Core vX has been released!" to #core-releases would
+    # be misleading for what's actually just a Test PyPI rehearsal.
     if: ${{ success() && !inputs.dry_run && !inputs.dry_run_with_test_pypi }}
     needs:
       [

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -10,9 +10,12 @@
 # is decoupled from the wheel writer (`cargo ci pypi pack`) — same pattern
 # the internal fs side will use to consume its CDN-built signed binaries.
 # `dbt-ci` writes wheels in pure Rust (zip + metadata) and uploads via the
-# PyPI HTTP API; no maturin, no twine. Homebrew distribution reuses the
-# same `dbt-ci` tooling (`homebrew render`/`publish`) and serves tarballs
-# straight from the GitHub Release.
+# PyPI HTTP API; no maturin, no twine, for the analyzer CLI. Homebrew
+# distribution reuses the same `dbt-ci` tooling (`homebrew render`/`publish`)
+# and serves tarballs straight from the GitHub Release.
+#
+# dbt-core itself, though, is the maturin abi3 extension wheel (CLI +
+# dbtRunner) built from `crates/dbt-python` — see **PyPI publishing** below.
 #
 # **when?**
 # Manual `workflow_dispatch` only — every release goes through
@@ -21,13 +24,14 @@
 # Flow: prepare-release → { build (matrix), test } → pack → tag →
 # github-release → { publish-pypi, publish-homebrew, publish-winget }.
 # build and test fan out from prepare-release in parallel and both gate
-# pack — a failing test aborts the release before any wheels are written.
-# tag is a small gate that everything downstream depends on. github-release
-# uploads the wheels + tarballs the downstream publishers consume, so they
-# all run after it: publish-pypi builds its download-at-install sdist from
-# the uploaded wheels, and publish-homebrew renders its formula from the
-# uploaded SHA256SUMS. publish-homebrew is gated to non-pre-release versions
-# that GitHub marked as "Latest".
+# pack — a failing test (Rust or dbt-python; `test` runs both) aborts the
+# release before any wheels are written. tag is a small gate that everything
+# downstream depends on. github-release uploads the wheels + tarballs the
+# downstream publishers
+# consume, so they all run after it: publish-pypi builds its
+# download-at-install sdist from the uploaded wheels, and publish-homebrew
+# renders its formula from the uploaded SHA256SUMS. publish-homebrew is
+# gated to non-pre-release versions that GitHub marked as "Latest".
 #
 # Repo setup (required `vars.*` runner labels, branch protection, secret
 # provisioning) is documented in `crates/dbt-ci/README.md`.
@@ -43,6 +47,15 @@
 # secret (passed to the tool as `DBT_PYPI_PROD_TOKEN`). Two distributions
 # are published — `dbt-core` and `dbt-core-experimental-parser` — selected
 # by the `release_target` input.
+#
+# `dbt-core`'s wheels are built by `maturin build` in the `build` job
+# (abi3-py310, one cp310-abi3 wheel per platform) — not `cargo ci pypi pack`,
+# which only packs the standalone analyzer binary into `dbt-core-experimental-
+# parser`. `publish-pypi` passes `--python-tag cp310 --abi-tag abi3` for the
+# dbt-core publish step so the sdist's manifest matches the maturin wheel
+# filenames actually sitting at the GitHub Release download URL (the default
+# `py3`/`none` tags are for the binary-CLI wheel, used for the parser publish
+# step instead).
 #
 # **Homebrew publishing**
 # `publish-homebrew` renders `Formula/dbt-core.rb` from the SHA256SUMS the
@@ -344,6 +357,27 @@ jobs:
           fi
           ls -la archives/
 
+      # dbt-core is the maturin abi3 extension wheel (CLI + dbtRunner), not a
+      # packed binary. abi3-py310 → one cp310-abi3 wheel per platform. The
+      # manylinux containers ship the cp310 interpreter under /opt/python;
+      # the mac/windows runners use the system Python (abi3 is forward-compat).
+      - name: Build maturin wheel (dbt-core)
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          if [ -x /opt/python/cp310-cp310/bin/python ]; then
+            PY=/opt/python/cp310-cp310/bin/python
+          else
+            PY=python3
+          fi
+          "$PY" -m pip install --upgrade maturin
+          "$PY" -m maturin build --release --locked \
+            --target "$TARGET" \
+            --interpreter "$PY" \
+            -m crates/dbt-python/Cargo.toml \
+            --out target/wheels
+          ls -la target/wheels/
+
       - name: Upload binary artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
         with:
@@ -358,11 +392,22 @@ jobs:
           path: archives/*
           if-no-files-found: error
 
+      - name: Upload wheel artifact (dbt-core)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.target }}
+          path: target/wheels/*.whl
+          if-no-files-found: error
+
   # ------------------------------------------------------------------
-  # Run the workspace test suite. Parallel to `build` (both fan out from
-  # `prepare-release`) and gates `pack` so a failing test aborts the
-  # release before any wheels are produced. Linux-only — host OS
-  # coverage lives in the regular CI workflow; this is a release gate.
+  # Run the workspace test suite, then the dbt-python crate's pytest suite
+  # (crates/dbt-python) in the same job so both reuse the Rust
+  # toolchain/sccache/protoc setup instead of paying for it twice. No
+  # lint (ruff/mypy) — that's a PR-time check, not a release gate.
+  # Parallel to `build` (both fan out from `prepare-release`) and gates
+  # `pack` so a failing test — Rust or dbt-python — aborts the release
+  # before any wheels are produced. Linux-only — host OS coverage lives
+  # in the regular CI workflow; this is a release gate.
   # ------------------------------------------------------------------
   test:
     name: Test workspace
@@ -426,6 +471,34 @@ jobs:
       - name: Run tests
         run: cargo nextest run
 
+      # uv is used here purely as a fast venv/pip tool (`uv venv` + `uv pip
+      # install`), not the project-sync workflow — so this doesn't require
+      # declaring maturin/pytest in crates/dbt-python's own pyproject.toml.
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # astral-sh/setup-uv@v9.0.0
+
+      # Prepending .venv/bin to PATH lets every later step call `maturin`/
+      # `pytest` directly instead of the full .venv/bin/... path.
+      - name: Create venv and install maturin + pytest
+        working-directory: crates/dbt-python
+        run: |
+          uv venv .venv
+          uv pip install --python .venv "maturin>=1.0,<2.0" "pytest>=9.1"
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+
+      # No --locked: this is a test job, not a reproducible release build
+      # (the `build` job's maturin invocation keeps --locked), so let cargo
+      # reconcile the lock rather than fail the run on dependency bookkeeping.
+      # maturin develop also installs [project.dependencies] (mashumaro)
+      # into .venv as part of installing the built wheel.
+      - name: Build extension (maturin develop)
+        working-directory: crates/dbt-python
+        run: maturin develop
+
+      - name: pytest (dbt-python)
+        working-directory: crates/dbt-python
+        run: pytest
+
       - name: sccache stats
         if: always()
         run: sccache --show-stats || true
@@ -472,23 +545,21 @@ jobs:
       - name: List binaries
         run: ls -la binaries/
 
-      # Two distribution names are produced from the same binaries:
-      #   - dbt-core                       (script: dbt)
-      #   - dbt-core-experimental-parser   (script: dbt-core-experimental-parser)
-      # `cargo ci pypi pack` reads the wheel/distribution name from
-      # [project].name in pyproject.toml — there's no CLI override — so we
-      # pack once, swap pyproject in place, then pack again. The edit is
-      # scoped to the runner's checkout and never committed.
-      - name: Pack wheels (dbt-core)
-        env:
-          VERSION: ${{ needs.prepare-release.outputs.version }}
-        run: |
-          cargo ci pypi pack \
-            --binaries-dir binaries \
-            --version "$VERSION" \
-            --bin-name dbt \
-            --out target/wheels
+      # Two distributions are produced by different mechanisms:
+      #   - dbt-core                     → maturin abi3 wheel, built in `build`
+      #                                    and downloaded here into target/wheels.
+      #   - dbt-core-experimental-parser → packed from the binary via
+      #                                    `cargo ci pypi pack` (unchanged).
+      - name: Download all wheels (dbt-core, maturin)
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
+        with:
+          path: target/wheels
+          pattern: wheel-*
+          merge-multiple: true
 
+      # `cargo ci pypi pack` reads the distribution name from [project].name in
+      # pyproject.toml — there's no CLI override — so swap it in place for the
+      # parser pack, then restore. The edit is scoped to the runner's checkout.
       - name: Rename pyproject for parser pack
         run: |
           sed -i 's/^name = "dbt-core"$/name = "dbt-core-experimental-parser"/' pyproject.toml
@@ -625,6 +696,11 @@ jobs:
       #
       # One --target per wheel uploaded to the Release; keep in lockstep with
       # the `build` job's matrix — each target's wheel is fetched and hashed.
+      #
+      # dbt-core's wheels are maturin abi3 extension wheels (cp310-abi3), not
+      # the binary CLI wheel (py3-none) `cargo ci pypi pack` produces — pass
+      # the matching python/abi tags so the sdist manifest's filenames match
+      # what's actually sitting at BASE_URL.
       - name: Publish (dbt-core)
         if: inputs.release_target != 'parser'
         env:
@@ -634,6 +710,8 @@ jobs:
             --environment prod \
             --version "${{ needs.prepare-release.outputs.version }}" \
             --download-base-url "$BASE_URL" \
+            --python-tag cp310 \
+            --abi-tag abi3 \
             --target x86_64-unknown-linux-gnu \
             --target aarch64-unknown-linux-gnu \
             --target x86_64-apple-darwin \

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -27,11 +27,12 @@
 # pack — a failing test (Rust or dbt-python; `test` runs both) aborts the
 # release before any wheels are written. tag is a small gate that everything
 # downstream depends on. github-release uploads the wheels + tarballs the
-# downstream publishers
-# consume, so they all run after it: publish-pypi builds its
-# download-at-install sdist from the uploaded wheels, and publish-homebrew
-# renders its formula from the uploaded SHA256SUMS. publish-homebrew is
-# gated to non-pre-release versions that GitHub marked as "Latest".
+# downstream publishers consume, so they all run after it: publish-pypi
+# builds its download-at-install sdist from the uploaded wheels, and
+# publish-homebrew renders its formula from the uploaded SHA256SUMS.
+# publish-homebrew is gated to non-pre-release versions that GitHub marked
+# as "Latest". See **Test-PyPI-only mode** below for the alternate flow
+# that skips everything past publish-pypi.
 #
 # Repo setup (required `vars.*` runner labels, branch protection, secret
 # provisioning) is documented in `crates/dbt-ci/README.md`.
@@ -70,11 +71,22 @@
 # artifacts are inspectable. The release branch is still pushed under
 # `release/dry-run/v…-<run_id>` so the matrix has something to check
 # out; clean these up periodically.
+#
+# **Test-PyPI-only mode** (`inputs.dry_run_with_test_pypi = true`)
+# Everything dry-run skips, this skips too — tag, GitHub Release, Homebrew,
+# winget, changelog backport, and the mirror version bump all get
+# `if: !inputs.dry_run && !inputs.dry_run_with_test_pypi` — plus it actually
+# publishes to Test PyPI on top of that (dry-run's build + pack still just
+# leave artifacts sitting in the run). Since there's no GitHub Release for
+# publish-pypi to fetch wheels from in this mode, it uploads the `pack`
+# job's `release-assets` artifact directly via `--dist` instead of the
+# usual download-at-install sdist.
 
 name: Release dbt Core V2
 run-name: >-
   ${{
     inputs.dry_run && format('Release v{0} (dry run — build only)', inputs.version)
+    || inputs.dry_run_with_test_pypi && format('Release v{0} (Test PyPI only)', inputs.version)
     || format('Release v{0}', inputs.version)
   }}
 
@@ -87,6 +99,11 @@ on:
         type: string
       dry_run:
         description: "Build and pack only — skip tag push, PyPI publish, GitHub Release, and Homebrew publish."
+        required: false
+        type: boolean
+        default: false
+      dry_run_with_test_pypi:
+        description: "Dry Run + Test PyPI Publish. Works like dry_run (skips tag, GitHub Release, Homebrew, winget, changelog backport, mirror version bump) but additionally publishes the built wheels to Test PyPI."
         required: false
         type: boolean
         default: false
@@ -106,7 +123,12 @@ on:
         default: both
 
 concurrency:
-  group: ${{ inputs.dry_run && format('publish-release-dry-{0}', github.run_id) || 'publish-release-prod' }}
+  group: >-
+    ${{
+      inputs.dry_run && format('publish-release-dry-{0}', github.run_id)
+      || inputs.dry_run_with_test_pypi && format('publish-release-test-pypi-{0}', github.run_id)
+      || 'publish-release-prod'
+    }}
   cancel-in-progress: false
 
 permissions:
@@ -656,7 +678,7 @@ jobs:
   tag:
     name: Tag release commit
     needs: [prepare-release, pack]
-    if: ${{ !inputs.dry_run }}
+    if: ${{ !inputs.dry_run && !inputs.dry_run_with_test_pypi }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -685,20 +707,40 @@ jobs:
           git push origin "$TAG"
 
   # ------------------------------------------------------------------
-  # Publish the download-at-install sdist to production PyPI. Skipped on
-  # dry-run. Runs after `github-release` because it fetches this release's
-  # wheels from the GitHub Release download URL (`--download-base-url`),
-  # hashes the live bytes, and publishes an sdist pinning those filenames +
-  # sha256s — no wheels are uploaded to PyPI. Authenticates with the
-  # repo-level `PYPI_API_TOKEN` secret (passed to `cargo ci pypi publish`
-  # as `DBT_PYPI_PROD_TOKEN`). `release_target` selects which of the two
-  # distributions (`dbt-core`, `dbt-core-experimental-parser`) to publish.
+  # Publish to PyPI. Skipped on dry-run. Two modes, both gated by
+  # `inputs.dry_run_with_test_pypi`:
+  #
+  #   prod (default): runs after `github-release` and publishes a
+  #   download-at-install sdist (not wheels). Points `cargo ci pypi publish`
+  #   at the GitHub Release download URL via `--download-base-url`, which
+  #   fetches each platform wheel (one per `--target`), hashes the live
+  #   bytes, and assembles an sdist pinning those filenames + sha256s; pip
+  #   fetches the matching wheel from the Release at install time. Runs with
+  #   `--environment prod`, authenticating with the repo-level
+  #   `PYPI_API_TOKEN` secret (passed to the tool as `DBT_PYPI_PROD_TOKEN`).
+  #
+  #   dry_run_with_test_pypi: no GitHub Release exists in this mode, so instead of
+  #   fetching wheels from a download URL, it downloads the `pack` job's
+  #   `release-assets` artifact and uploads those wheels directly via
+  #   `--dist`. Runs with `--environment test-pypi`, authenticating with
+  #   the repo-level `TEST_PYPI_API_TOKEN` secret (`DBT_PYPI_TEST_TOKEN`).
+  #
+  # `release_target` selects which of the two distributions (`dbt-core`,
+  # `dbt-core-experimental-parser`) to publish, in both modes.
+  #
+  # `if: !failure() && !cancelled()` (instead of the usual `needs.*.result
+  # == 'success'` implied by a plain `if: !inputs.dry_run`) lets this job
+  # run when `github-release` was skipped (dry_run_with_test_pypi) as well as when
+  # it succeeded (prod) — a skipped dependency isn't a success, so the
+  # default `if` would otherwise skip this job too.
   # ------------------------------------------------------------------
   publish-pypi:
     name: Publish to PyPI
-    # pack + tag are transitive via github-release; prepare-release stays for its outputs.
-    needs: [prepare-release, github-release]
-    if: ${{ !inputs.dry_run }}
+    # pack + tag are transitive via github-release; prepare-release stays for
+    # its outputs. pack is listed explicitly too since dry_run_with_test_pypi reads
+    # its `release-assets` artifact directly, without going through github-release.
+    needs: [prepare-release, pack, github-release]
+    if: ${{ !inputs.dry_run && !failure() && !cancelled() }}
     runs-on: ${{ vars.UBUNTU_RUNNER_32 }}
     permissions:
       contents: read
@@ -706,7 +748,8 @@ jobs:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache
       # GitHub Release download URL hosting this version's wheels; the sdist
-      # backend fetches the matching wheel from here at install time.
+      # backend fetches the matching wheel from here at install time. Only
+      # used in prod mode.
       BASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ needs.prepare-release.outputs.tag }}
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
@@ -727,20 +770,32 @@ jobs:
         with:
           version: "v0.12.0"
 
-      # sdist mode reads the distribution name from pyproject's [project].name
-      # to build the wheel filenames it downloads from BASE_URL, so to publish
+      # dry_run_with_test_pypi only: pulls the wheels `pack` already built instead of
+      # fetching them from a GitHub Release (there isn't one in this mode).
+      - name: Download release assets (test-pypi-only)
+        if: inputs.dry_run_with_test_pypi
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
+        with:
+          name: release-assets
+          path: dist
+
+      # Both modes read the distribution name from pyproject's [project].name
+      # — sdist mode to build the wheel filenames it downloads from BASE_URL,
+      # --dist mode to filter which wheels in dist/ to upload — so to publish
       # both distributions we publish once, swap pyproject in place, then
       # publish again. Mirrors the pack-job pattern.
       #
       # One --target per wheel uploaded to the Release; keep in lockstep with
       # the `build` job's matrix — each target's wheel is fetched and hashed.
+      # Prod mode only (dry_run_with_test_pypi's --dist upload doesn't need --target).
       #
       # dbt-core's wheels are maturin abi3 extension wheels (cp311-abi3), not
-      # the binary CLI wheel (py3-none) `cargo ci pypi pack` produces — pass
-      # the matching python/abi tags so the sdist manifest's filenames match
-      # what's actually sitting at BASE_URL.
-      - name: Publish (dbt-core)
-        if: inputs.release_target != 'parser'
+      # the binary CLI wheel (py3-none) `cargo ci pypi pack` produces — prod
+      # mode passes the matching python/abi tags so the sdist manifest's
+      # filenames match what's actually sitting at BASE_URL. dry_run_with_test_pypi's
+      # --dist mode uploads the actual wheel files, so it doesn't need them.
+      - name: Publish (dbt-core, prod)
+        if: ${{ inputs.release_target != 'parser' && !inputs.dry_run_with_test_pypi }}
         env:
           DBT_PYPI_PROD_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
@@ -756,14 +811,24 @@ jobs:
             --target aarch64-apple-darwin \
             --target x86_64-pc-windows-msvc
 
+      - name: Publish (dbt-core, test-pypi-only)
+        if: ${{ inputs.release_target != 'parser' && inputs.dry_run_with_test_pypi }}
+        env:
+          DBT_PYPI_TEST_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: |
+          cargo ci pypi publish \
+            --environment test-pypi \
+            --version "${{ needs.prepare-release.outputs.version }}" \
+            --dist dist
+
       - name: Rename pyproject for parser publish
         if: inputs.release_target != 'core'
         run: |
           sed -i 's/^name = "dbt-core"$/name = "dbt-core-experimental-parser"/' pyproject.toml
           grep '^name = ' pyproject.toml
 
-      - name: Publish (dbt-core-experimental-parser)
-        if: inputs.release_target != 'core'
+      - name: Publish (dbt-core-experimental-parser, prod)
+        if: ${{ inputs.release_target != 'core' && !inputs.dry_run_with_test_pypi }}
         env:
           DBT_PYPI_PROD_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
@@ -777,6 +842,16 @@ jobs:
             --target aarch64-apple-darwin \
             --target x86_64-pc-windows-msvc
 
+      - name: Publish (dbt-core-experimental-parser, test-pypi-only)
+        if: ${{ inputs.release_target != 'core' && inputs.dry_run_with_test_pypi }}
+        env:
+          DBT_PYPI_TEST_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: |
+          cargo ci pypi publish \
+            --environment test-pypi \
+            --version "${{ needs.prepare-release.outputs.version }}" \
+            --dist dist
+
       - name: Restore pyproject name after parser publish
         if: ${{ always() && inputs.release_target != 'core' }}
         run: |
@@ -784,7 +859,9 @@ jobs:
           grep '^name = ' pyproject.toml
 
   # ------------------------------------------------------------------
-  # Create the GitHub Release with all assets. Skipped on dry-run.
+  # Create the GitHub Release with all assets. Skipped on dry-run and on
+  # dry_run_with_test_pypi (no GitHub Release involved in that mode — publish-pypi
+  # uploads the pack job's wheels directly instead).
   # Idempotent: if the release already exists, re-uploads assets with
   # --clobber so a flaky asset upload can be retried without manual
   # cleanup.
@@ -792,7 +869,7 @@ jobs:
   github-release:
     name: Create GitHub Release
     needs: [prepare-release, pack, tag]
-    if: ${{ !inputs.dry_run }}
+    if: ${{ !inputs.dry_run && !inputs.dry_run_with_test_pypi }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -849,8 +926,8 @@ jobs:
   # publish-homebrew.yml.
   publish-homebrew:
     needs: [prepare-release, github-release]
-    # if: ${{ !inputs.dry_run && !contains(needs.prepare-release.outputs.version, '-') }}
-    if: ${{ !inputs.dry_run }}
+    # if: ${{ !inputs.dry_run && !inputs.dry_run_with_test_pypi && !contains(needs.prepare-release.outputs.version, '-') }}
+    if: ${{ !inputs.dry_run && !inputs.dry_run_with_test_pypi }}
     uses: ./.github/workflows/publish-homebrew.yml
     with:
       version: ${{ needs.prepare-release.outputs.version }}
@@ -872,7 +949,7 @@ jobs:
   changelog-backport:
     name: Backport changelog to main
     needs: [prepare-release, publish-pypi, github-release]
-    if: ${{ !inputs.dry_run }}
+    if: ${{ !inputs.dry_run && !inputs.dry_run_with_test_pypi }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -995,7 +1072,7 @@ jobs:
   bump-mirror-dbt-core-version:
     name: Bump dbt-core version in mirror
     needs: [prepare-release, publish-pypi, github-release]
-    if: ${{ !inputs.dry_run }}
+    if: ${{ !inputs.dry_run && !inputs.dry_run_with_test_pypi }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1045,7 +1122,9 @@ jobs:
   # ------------------------------------------------------------------
   slack-notification:
     name: Slack Notification
-    if: ${{ success() && !inputs.dry_run }}
+    # dry_run_with_test_pypi doesn't create a GitHub Release, so there's nothing for
+    # this announcement (and its RELEASE_URL) to correctly point at.
+    if: ${{ success() && !inputs.dry_run && !inputs.dry_run_with_test_pypi }}
     needs:
       [
         prepare-release,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Build analytics the way engineers build applications"
 authors = [{ name = "dbt Labs", email = "info@dbtlabs.com" }]
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
   "Programming Language :: Rust",
   "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Resolves: #

### Problem
dbt-core wheel builds with rust binary only, we need to publish the maturin built wheels instead.

### Solution
Modify CI to publish the maturin built wheels.

### Tests
- Build and publish to test pypi - https://github.com/dbt-labs/dbt-core/actions/runs/31142175582/job/92762026605
- Published dev23 - https://test.pypi.org/project/dbt_core/2.0.0.dev23/#files
- Installed locally in a new venv from test pypi and ran a test invocation successfully.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
