### PR TITLE
chore: add faceted labels to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-v2.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-v2.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug (dbt v2.x)
 description: Report a bug or issue you've found in dbt v2.x (Core or Fusion distributions)
 title: "[v2 Bug] <title>"
-labels: ["bug", "triage", "v2"]
+labels: ["bug", "triage", "v2", "type:bug", "status:triage", "engine:v2"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report-vsce.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-vsce.yml
@@ -1,7 +1,7 @@
 name: 🐞📟 VS Code Extension Bug
 description: Report a bug with the dbt VS Code extension
 title: "[VSCE] [Bug] <title>"
-labels: ["bug", "triage", "vsce", "v2"]
+labels: ["bug", "triage", "vsce", "v2", "type:bug", "status:triage", "area:vscode", "engine:v2"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug (dbt 1.x)
 description: Report a bug or issue you've found in dbt Core 1.x
 title: "[1.x Bug] <title>"
-labels: ["bug", "triage", "v1"]
+labels: ["bug", "triage", "v1", "type:bug", "status:triage", "engine:v1"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/code-docs.yml
+++ b/.github/ISSUE_TEMPLATE/code-docs.yml
@@ -1,7 +1,7 @@
 name: 📄 Code docs
 description: Report an issue for markdown files within this repo, such as README, ARCHITECTURE, etc.
 title: "[Code docs] <title>"
-labels: ["triage"]
+labels: ["triage", "status:triage", "type:docs"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,7 @@
 name: ✨ Feature
 description: Propose a straightforward extension of dbt functionality
 title: "[Feature] <title>"
-labels: ["enhancement", "triage"]
+labels: ["enhancement", "triage", "type:feature", "status:triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/regression-report.yml
+++ b/.github/ISSUE_TEMPLATE/regression-report.yml
@@ -1,7 +1,7 @@
 name: ☣️ Regression
 description: Report a regression you've observed in a newer version of dbt
 title: "[Regression] <title>"
-labels: ["bug", "regression", "triage"]
+labels: ["bug", "regression", "triage", "type:bug", "status:triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/sql-understanding.yml
+++ b/.github/ISSUE_TEMPLATE/sql-understanding.yml
@@ -1,7 +1,7 @@
 name: 🧠 SQL understanding issue
 description: dbt Fusion doesn't recognize a function, flags valid SQL as an error, infers the wrong column type, or produces incorrect lineage
 title: "[SQL] <title>"
-labels: ["bug", "triage", "SQL_understanding", "v2"]
+labels: ["bug", "triage", "SQL_understanding", "v2", "type:bug", "status:triage", "area:static-analysis", "engine:v2"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## What

Adds the namespaced `facet:value` labels alongside the existing legacy labels in each issue template, matching the taxonomy synced from `dbt-labs/fs`.

## Why

The label taxonomy in `dbt-labs/fs` (`.github/labels.yml`) syncs into this repo (create-only). All 40 faceted labels already exist here, but the issue templates still apply only legacy labels (`bug`, `triage`, `v1`, `v2`, …), so newly filed issues aren't picking up the faceted taxonomy used for triage.

## Changes (additive — legacy labels kept)

| Template | Added |
| --- | --- |
| `bug-report.yml` | `type:bug`, `status:triage`, `engine:v1` |
| `bug-report-v2.yml` | `type:bug`, `status:triage`, `engine:v2` |
| `bug-report-vsce.yml` | `type:bug`, `status:triage`, `area:vscode`, `engine:v2` |
| `feature-request.yml` | `type:feature`, `status:triage` |
| `regression-report.yml` | `type:bug`, `status:triage` |
| `code-docs.yml` | `status:triage`, `type:docs` |
| `sql-understanding.yml` | `type:bug`, `status:triage`, `area:static-analysis`, `engine:v2` |

Additive only, so existing triage automation / saved searches keying off `triage`, `bug`, etc. are unaffected. All added labels are confirmed to exist in this repo. YAML validated.

## Not changed / for follow-up

- `implementation-ticket.yml` (maintainer-only, `user docs` label) left untouched — mapping unclear; flag if a faceted equivalent is wanted.
- **Brand flag:** `.github/ISSUE_TEMPLATE/config.yml` has a "Contact dbt Cloud support" contact link. Per current naming guidance the managed product is "dbt platform" — flagging for docs/PMM to confirm rather than changing here.

Companion docs PR: dbt-labs/docs.getdbt.com#9572

🤖 Generated with [Claude Code](https://claude.com/claude-code)