### PR TITLE
Flip default of legacy behavior-change flags to true

### DIFF
--- a/.changes/unreleased/Breaking Changes-20260709-120000.yaml
+++ b/.changes/unreleased/Breaking Changes-20260709-120000.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Flags introduced in 1.9 and 1.10 defaults to true
+time: 2026-07-09T12:00:00.000000+00:00
+custom:
+    Author: itsnamangoyal
+    Issue: "12713"

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -369,18 +369,18 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     write_json: Optional[bool] = None
 
     # legacy behaviors - https://github.com/dbt-labs/dbt-core/blob/main/docs/guides/behavior-change-flags.md
-    require_batched_execution_for_custom_microbatch_strategy: bool = False
+    require_batched_execution_for_custom_microbatch_strategy: bool = True
     require_event_names_in_deprecations: bool = False
     require_explicit_package_overrides_for_builtin_materializations: bool = True
     require_resource_names_without_spaces: bool = True
     source_freshness_run_project_hooks: bool = True
-    skip_nodes_if_on_run_start_fails: bool = False
-    state_modified_compare_more_unrendered_values: bool = False
+    skip_nodes_if_on_run_start_fails: bool = True
+    state_modified_compare_more_unrendered_values: bool = True
     state_modified_compare_vars: bool = False
-    require_yaml_configuration_for_mf_time_spines: bool = False
-    require_nested_cumulative_type_params: bool = False
-    validate_macro_args: bool = False
-    require_all_warnings_handled_by_warn_error: bool = False
+    require_yaml_configuration_for_mf_time_spines: bool = True
+    require_nested_cumulative_type_params: bool = True
+    validate_macro_args: bool = True
+    require_all_warnings_handled_by_warn_error: bool = True
     require_generic_test_arguments_property: bool = True
     require_unique_project_resource_names: bool = False
     require_ref_searches_node_package_before_root: bool = False

--- a/core/dbt/parser/macros.py
+++ b/core/dbt/parser/macros.py
@@ -103,7 +103,7 @@ class MacroParser(BaseParser[Macro]):
             name: str = macro.name.replace(MACRO_PREFIX, "")
             node = self.parse_macro(block, base_node, name)
 
-            if getattr(get_flags(), "validate_macro_args", False):
+            if getattr(get_flags(), "validate_macro_args", True):
                 node.arguments = self._extract_args(macro)
 
             # get supported_languages for materialization macro

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -683,10 +683,12 @@ class PatchParser(YamlReader, Generic[NonSourceTarget, Parsed]):
     def normalize_attribute(self, data, path, attribute) -> None:
         if attribute in data:
             if "config" in data and attribute in data["config"]:
-                raise ParsingError(f"""
+                raise ParsingError(
+                    f"""
                     In {path}: found {attribute} dictionary in 'config' dictionary and as top-level key.
                     Remove the top-level key and define it under 'config' dictionary only.
-                """.strip())
+                """.strip()
+                )
             else:
                 if "config" not in data:
                     data["config"] = {}

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -683,12 +683,10 @@ class PatchParser(YamlReader, Generic[NonSourceTarget, Parsed]):
     def normalize_attribute(self, data, path, attribute) -> None:
         if attribute in data:
             if "config" in data and attribute in data["config"]:
-                raise ParsingError(
-                    f"""
+                raise ParsingError(f"""
                     In {path}: found {attribute} dictionary in 'config' dictionary and as top-level key.
                     Remove the top-level key and define it under 'config' dictionary only.
-                """.strip()
-                )
+                """.strip())
             else:
                 if "config" not in data:
                     data["config"] = {}
@@ -1505,7 +1503,7 @@ class MacroPatchParser(PatchParser[UnparsedMacroUpdate, ParsedMacroPatch]):
         macro.config.meta = meta
         macro.config.docs = docs
 
-        if getattr(get_flags(), "validate_macro_args", False):
+        if getattr(get_flags(), "validate_macro_args", True):
             self._check_patch_arguments(macro, patch)
             macro.arguments = patch.arguments if patch.arguments else macro.arguments
         else:

--- a/tests/functional/artifacts/expected_manifest.py
+++ b/tests/functional/artifacts/expected_manifest.py
@@ -149,7 +149,12 @@ def get_rendered_snapshot_config(**updates):
 
 
 def get_unrendered_snapshot_config(**updates):
-    result = {"check_cols": "all", "strategy": "check", "target_schema": None, "unique_key": "id"}
+    result = {
+        "check_cols": "all",
+        "strategy": "check",
+        "target_schema": "var('alternate_schema')",
+        "unique_key": "id",
+    }
     result.update(updates)
     return result
 
@@ -279,7 +284,7 @@ def expected_seeded_manifest(project, model_database=None, quote_model=False):
     unrendered_test_config = get_unrendered_tst_config()
 
     snapshot_config = get_rendered_snapshot_config(target_schema=alternate_schema)
-    unrendered_snapshot_config = get_unrendered_snapshot_config(target_schema=alternate_schema)
+    unrendered_snapshot_config = get_unrendered_snapshot_config()
 
     quote_database = quote_schema = True
     relation_name_node_format = relation_name_format(quote_database, quote_schema, quote_model)
@@ -1435,9 +1440,7 @@ def expected_references_manifest(project):
                 "sources": [],
                 "tags": [],
                 "unique_id": "snapshot.test.snapshot_seed",
-                "unrendered_config": get_unrendered_snapshot_config(
-                    target_schema=alternate_schema
-                ),
+                "unrendered_config": get_unrendered_snapshot_config(),
                 "doc_blocks": [],
             },
         },

--- a/tests/functional/configs/test_configs_in_schema_files.py
+++ b/tests/functional/configs/test_configs_in_schema_files.py
@@ -273,11 +273,9 @@ class TestLegacySchemaFileConfigs(TestSchemaFileConfigs):
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
-            # The uncommented below lines can be removed once the default behaviour is flipped.
-            # state_modified_compare_more_unrendered_values defaults to false currently
-            # "flags": {
-            #     "state_modified_compare_more_unrendered_values": False,
-            # },
+            "flags": {
+                "state_modified_compare_more_unrendered_values": False,
+            },
             "models": {
                 "+meta": {
                     "company": "NuMade",

--- a/tests/functional/macros/test_macro_annotations.py
+++ b/tests/functional/macros/test_macro_annotations.py
@@ -124,6 +124,10 @@ class TestMacroNonEnforcement:
     def macros(self):
         return {"macros.yml": bad_everything_types_macros_yml, "macros.sql": macros_sql}
 
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"validate_macro_args": False}}
+
     def test_macro_non_enforcement(self, project) -> None:
         event_catcher = EventCatcher(event_to_catch=InvalidMacroAnnotation)
         run_dbt(["parse"], callbacks=[event_catcher.catch])

--- a/tests/functional/metrics/fixtures.py
+++ b/tests/functional/metrics/fixtures.py
@@ -102,6 +102,18 @@ metricflow_time_spine_sql = """
 SELECT to_date('02/20/2023, 'mm/dd/yyyy') as date_day
 """
 
+metricflow_time_spine_yml = """
+version: 2
+
+models:
+  - name: metricflow_time_spine
+    time_spine:
+      standard_granularity_column: date_day
+    columns:
+      - name: date_day
+        granularity: day
+"""
+
 models_people_metrics_yml = """
 version: 2
 
@@ -128,16 +140,6 @@ metrics:
         filter: "{{ Dimension('id__loves_dbt') }} is true"
         join_to_timespine: true
         fill_nulls_with: 0
-
-  - name: collective_window
-    label: "Collective window"
-    description: Testing window
-    type: simple
-    type_params:
-      measure:
-        name: years_tenure
-        filter: "{{ Dimension('id__loves_dbt') }} is true"
-      window: 14 days
 
   - name: average_tenure
     label: Average Tenure
@@ -183,16 +185,6 @@ metrics:
         filter: "{{ Dimension('id__loves_dbt') }} is true"
         join_to_timespine: true
         fill_nulls_with: 0
-
-  - name: collective_window
-    label: "Collective window"
-    description: Testing window
-    type: simple
-    type_params:
-      measure:
-        name: years_tenure
-        filter: "{{ Dimension('id__loves_dbt') }} is true"
-      window: 14 days
 
   - name: average_tenure
     label: Average Tenure
@@ -790,26 +782,32 @@ metrics:
       type: cumulative
       type_params:
         measure: num_orders
-        window: 1 month
         cumulative_type_params:
+          window: 1 month
           period_agg: average
     - name: yearly_orders
       label: Orders in the past year
       type: cumulative
       type_params:
         measure: num_orders
-        window: 1 year
+        cumulative_type_params:
+          window: 1 year
+          period_agg: first
     - name: visits_mtd
       label: Visits since start of month
       type: cumulative
       type_params:
         measure: num_visits
-        grain_to_date: month
+        cumulative_type_params:
+          grain_to_date: month
+          period_agg: first
     - name: cumulative_visits
       label: Rolling total of visits (all time)
       type: cumulative
       type_params:
         measure: num_visits
+        cumulative_type_params:
+          period_agg: first
     # TODO: Re-enable this when custom grain is supported for this type
     # - name: visits_martian_day
     #   label: Visits since start of martian_day

--- a/tests/functional/metrics/test_metric_configs.py
+++ b/tests/functional/metrics/test_metric_configs.py
@@ -9,6 +9,7 @@ from tests.functional.metrics.fixtures import (
     enabled_metric_level_schema_yml,
     invalid_config_metric_yml,
     metricflow_time_spine_sql,
+    metricflow_time_spine_yml,
     models_people_metrics_meta_top_yml,
     models_people_metrics_sql,
     models_people_metrics_yml,
@@ -32,6 +33,7 @@ class TestMetricEnabledConfigProjectLevel(MetricConfigTests):
         return {
             "people.sql": models_people_sql,
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "time_spine.yml": metricflow_time_spine_yml,
             "semantic_model_people.yml": semantic_model_people_yml,
             "schema.yml": models_people_metrics_yml,
         }
@@ -76,6 +78,7 @@ class TestConfigYamlMetricLevel(MetricConfigTests):
         return {
             "people.sql": models_people_sql,
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "time_spine.yml": metricflow_time_spine_yml,
             "semantic_model_people.yml": semantic_model_people_yml,
             "schema.yml": disabled_metric_level_schema_yml,
         }
@@ -94,6 +97,7 @@ class TestMetricConfigsInheritence(MetricConfigTests):
         return {
             "people.sql": models_people_sql,
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "time_spine.yml": metricflow_time_spine_yml,
             "semantic_model_people.yml": semantic_model_people_yml,
             "schema.yml": enabled_metric_level_schema_yml,
         }
@@ -123,6 +127,7 @@ class TestDisabledMetricRef(MetricConfigTests):
         return {
             "people.sql": models_people_sql,
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "time_spine.yml": metricflow_time_spine_yml,
             "semantic_model_people.yml": semantic_model_people_yml,
             "people_metrics.sql": models_people_metrics_sql,
             "schema.yml": models_people_metrics_yml,
@@ -165,6 +170,7 @@ class TestInvalidMetric(MetricConfigTests):
         return {
             "people.sql": models_people_sql,
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "time_spine.yml": metricflow_time_spine_yml,
             "semantic_model_people.yml": semantic_model_people_yml,
             "schema.yml": invalid_config_metric_yml,
         }
@@ -182,6 +188,7 @@ class TestDisabledMetric(MetricConfigTests):
         return {
             "people.sql": models_people_sql,
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "time_spine.yml": metricflow_time_spine_yml,
             "semantic_model_people.yml": semantic_model_people_yml,
             "schema.yml": models_people_metrics_yml,
         }
@@ -215,6 +222,7 @@ class TestMetricMetaConfigProjectLevel(MetricConfigTests):
         return {
             "people.sql": models_people_sql,
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "time_spine.yml": metricflow_time_spine_yml,
             "semantic_model_people.yml": semantic_model_people_yml,
             "schema.yml": models_people_metrics_yml,
         }
@@ -251,6 +259,7 @@ class TestMetricMetaConfigLevel(MetricConfigTests):
         return {
             "people.sql": models_people_sql,
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "time_spine.yml": metricflow_time_spine_yml,
             "semantic_model_people.yml": semantic_model_people_yml,
             "schema.yml": models_people_metrics_yml,
         }
@@ -274,6 +283,7 @@ class TestMetricMetaTopLevel(MetricConfigTests):
         return {
             "people.sql": models_people_sql,
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "time_spine.yml": metricflow_time_spine_yml,
             "semantic_model_people.yml": semantic_model_people_yml,
             "schema.yml": models_people_metrics_meta_top_yml,
         }

--- a/tests/functional/metrics/test_metrics.py
+++ b/tests/functional/metrics/test_metrics.py
@@ -24,6 +24,7 @@ from tests.functional.metrics.fixtures import (
     invalid_models_people_metrics_yml,
     long_name_metrics_yml,
     metricflow_time_spine_sql,
+    metricflow_time_spine_yml,
     mock_purchase_data_csv,
     models_people_metrics_yml,
     models_people_sql,
@@ -43,6 +44,7 @@ class TestSimpleMetrics:
         return {
             "people_metrics.yml": models_people_metrics_yml,
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "time_spine.yml": metricflow_time_spine_yml,
             "semantic_model_people.yml": semantic_model_people_yml,
             "people.sql": models_people_sql,
         }
@@ -60,7 +62,6 @@ class TestSimpleMetrics:
         expected_metric_ids = [
             "metric.test.number_of_people",
             "metric.test.collective_tenure",
-            "metric.test.collective_window",
             "metric.test.average_tenure",
             "metric.test.average_tenure_minus_people",
         ]
@@ -71,9 +72,6 @@ class TestSimpleMetrics:
         )
         assert (
             len(manifest.metrics["metric.test.collective_tenure"].type_params.input_measures) == 1
-        )
-        assert (
-            len(manifest.metrics["metric.test.collective_window"].type_params.input_measures) == 1
         )
         assert len(manifest.metrics["metric.test.average_tenure"].type_params.input_measures) == 2
         assert (
@@ -222,6 +220,7 @@ class TestMetricDependsOn:
         return {
             "people.sql": models_people_sql,
             "metricflow_time_spine.sql": metricflow_time_spine_sql,
+            "time_spine.yml": metricflow_time_spine_yml,
             "semantic_models.yml": semantic_model_people_yml,
             "people_metrics.yml": models_people_metrics_yml,
         }

--- a/tests/unit/parser/test_parser.py
+++ b/tests/unit/parser/test_parser.py
@@ -1802,7 +1802,9 @@ class SnapshotParserTest(BaseParserTest):
             select 1 as id, now() as last_update"""
         full_file = """
         {{% snapshot foo %}}{}{{% endsnapshot %}}
-        """.format(raw_code)
+        """.format(
+            raw_code
+        )
         block = self.file_block_for(full_file, "nested/snap_1.sql")
         self.parser.manifest.files[block.file.file_id] = block.file
         self.parser.parse_file(block)
@@ -1872,7 +1874,9 @@ class SnapshotParserTest(BaseParserTest):
         full_file = """
         {{% snapshot foo %}}{}{{% endsnapshot %}}
         {{% snapshot bar %}}{}{{% endsnapshot %}}
-        """.format(raw_1, raw_2)
+        """.format(
+            raw_1, raw_2
+        )
         block = self.file_block_for(full_file, "nested/snap_1.sql")
         self.parser.manifest.files[block.file.file_id] = block.file
         self.parser.parse_file(block)

--- a/tests/unit/parser/test_parser.py
+++ b/tests/unit/parser/test_parser.py
@@ -9,6 +9,7 @@ import yaml
 import dbt_common.events.functions
 from dbt import tracking
 from dbt.artifacts.resources import ModelConfig, RefArgs
+from dbt.artifacts.resources.v1.macro import MacroArgument
 from dbt.artifacts.resources.v1.model import (
     ModelBuildAfter,
     ModelFreshnessUpdatesOnOptions,
@@ -1801,9 +1802,7 @@ class SnapshotParserTest(BaseParserTest):
             select 1 as id, now() as last_update"""
         full_file = """
         {{% snapshot foo %}}{}{{% endsnapshot %}}
-        """.format(
-            raw_code
-        )
+        """.format(raw_code)
         block = self.file_block_for(full_file, "nested/snap_1.sql")
         self.parser.manifest.files[block.file.file_id] = block.file
         self.parser.parse_file(block)
@@ -1873,9 +1872,7 @@ class SnapshotParserTest(BaseParserTest):
         full_file = """
         {{% snapshot foo %}}{}{{% endsnapshot %}}
         {{% snapshot bar %}}{}{{% endsnapshot %}}
-        """.format(
-            raw_1, raw_2
-        )
+        """.format(raw_1, raw_2)
         block = self.file_block_for(full_file, "nested/snap_1.sql")
         self.parser.manifest.files[block.file.file_id] = block.file
         self.parser.parse_file(block)
@@ -1992,6 +1989,7 @@ class MacroParserTest(BaseParserTest):
             original_file_path=normalize("macros/macro.sql"),
             path=normalize("macros/macro.sql"),
             macro_sql=raw_code,
+            arguments=[MacroArgument(name="a"), MacroArgument(name="b")],
         )
         assertEqualNodes(macro, expected)
         file_id = "snowplow://" + normalize("macros/macro.sql")
@@ -2015,6 +2013,7 @@ class MacroParserTest(BaseParserTest):
             original_file_path=normalize("macros/macro.sql"),
             path=normalize("macros/macro.sql"),
             macro_sql="{% macro bar(c, d) %}c + d{% endmacro %}",
+            arguments=[MacroArgument(name="c"), MacroArgument(name="d")],
         )
         expected_foo = Macro(
             name="foo",
@@ -2024,6 +2023,7 @@ class MacroParserTest(BaseParserTest):
             original_file_path=normalize("macros/macro.sql"),
             path=normalize("macros/macro.sql"),
             macro_sql="{% macro foo(a, b) %}a ~ b{% endmacro %}",
+            arguments=[MacroArgument(name="a"), MacroArgument(name="b")],
         )
         assertEqualNodes(macros[0], expected_bar)
         assertEqualNodes(macros[1], expected_foo)


### PR DESCRIPTION
Recreates #12848 against current `1.latest`.

Flips the following flags from `False` to `True`:
- `require_batched_execution_for_custom_microbatch_strategy`
- `skip_nodes_if_on_run_start_fails`
- `state_modified_compare_more_unrendered_values`
- `require_yaml_configuration_for_mf_time_spines`
- `require_nested_cumulative_type_params`
- `validate_macro_args`
- `require_all_warnings_handled_by_warn_error`

Note: two test expectations in `tests/functional/artifacts/expected_manifest.py` and `tests/functional/defer_state/test_modified_state.py` diverge from the original PR's diff, because #15336 (merged after #12848) changed how static-parsed unrendered config values are rendered (readable expressions instead of raw AST reprs). Adjusted expectations to match current behavior; all affected suites pass locally.