### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260709-182053.yaml
+++ b/.changes/unreleased/Under the Hood-20260709-182053.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-07-09T18:20:53.214022685Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -4750,6 +4750,15 @@
             "null"
           ]
         },
+        "+resource_tags": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "+row_access_policy": {
           "type": [
             "string",
@@ -5681,6 +5690,15 @@
             "string",
             "null"
           ]
+        },
+        "+resource_tags": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "+row_access_policy": {
           "type": [


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`26d9cc9036997f57ca50a3dd56fd114e1060a77a`](https://github.com/dbt-labs/fs/commit/26d9cc9036997f57ca50a3dd56fd114e1060a77a)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/29038323175)