### PR TITLE
Fix overloaded UDF overload-body dependencies being dropped from the DAG

### DIFF
--- a/.changes/unreleased/Fixes-20260710-121800.yaml
+++ b/.changes/unreleased/Fixes-20260710-121800.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Carry ref/source/function dependencies declared inside an overloaded UDF's
+  overload body onto the root function node, so they are not dropped from the DAG
+  when the overload SQL file is absorbed
+time: 2026-07-10T12:18:00.000000000Z
+custom:
+    Author: aahel
+    Issue: "15501"

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -1399,6 +1399,23 @@ class FunctionPatchParser(NodePatchParser[UnparsedFunctionUpdate]):
                 )
             )
 
+            # An overload SQL body can contain its own ref()/source()/function()
+            # calls. The overload node is about to be deleted, so carry those
+            # dependencies onto the root — otherwise the DAG edges would be
+            # silently lost, since the root's own body never mentions them.
+            # process_refs/process_sources/process_functions run later over the
+            # root and resolve these into depends_on. Dedup against the root's
+            # own dependencies so a shared reference doesn't get duplicated.
+            for ref in overload_node.refs:
+                if ref not in root_node.refs:
+                    root_node.refs.append(ref)
+            for source in overload_node.sources:
+                if source not in root_node.sources:
+                    root_node.sources.append(source)
+            for function in overload_node.functions:
+                if function not in root_node.functions:
+                    root_node.functions.append(function)
+
             # Track the overload→root relationship for partial parsing
             self.manifest.function_overload_owners[overload_node.file_id] = root_node.unique_id
 

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -1399,22 +1399,7 @@ class FunctionPatchParser(NodePatchParser[UnparsedFunctionUpdate]):
                 )
             )
 
-            # An overload SQL body can contain its own ref()/source()/function()
-            # calls. The overload node is about to be deleted, so carry those
-            # dependencies onto the root — otherwise the DAG edges would be
-            # silently lost, since the root's own body never mentions them.
-            # process_refs/process_sources/process_functions run later over the
-            # root and resolve these into depends_on. Dedup against the root's
-            # own dependencies so a shared reference doesn't get duplicated.
-            for ref in overload_node.refs:
-                if ref not in root_node.refs:
-                    root_node.refs.append(ref)
-            for source in overload_node.sources:
-                if source not in root_node.sources:
-                    root_node.sources.append(source)
-            for function in overload_node.functions:
-                if function not in root_node.functions:
-                    root_node.functions.append(function)
+            self._merge_overload_dependencies(root_node, overload_node)
 
             # Track the overload→root relationship for partial parsing
             self.manifest.function_overload_owners[overload_node.file_id] = root_node.unique_id
@@ -1429,6 +1414,30 @@ class FunctionPatchParser(NodePatchParser[UnparsedFunctionUpdate]):
             del self.manifest.functions[overload_unique_id]
 
         root_node.overloads = absorbed
+
+    @staticmethod
+    def _merge_overload_dependencies(
+        root_node: "FunctionNode", overload_node: "FunctionNode"
+    ) -> None:
+        """Carry an overload body's ref()/source()/function() dependencies onto
+        the root.
+
+        An overload SQL body can reference other nodes, but the overload node is
+        deleted during absorption, so those edges would be silently lost — the
+        root's own body never mentions them. process_refs/process_sources/
+        process_functions run later over the root and resolve these into
+        depends_on. Dedup against the root's own dependencies so a shared
+        reference doesn't get duplicated.
+        """
+        for ref in overload_node.refs:
+            if ref not in root_node.refs:
+                root_node.refs.append(ref)
+        for source in overload_node.sources:
+            if source not in root_node.sources:
+                root_node.sources.append(source)
+        for function in overload_node.functions:
+            if function not in root_node.functions:
+                root_node.functions.append(function)
 
     def _get_node_patch(self, block: TargetBlock[NodeTarget], refs: ParserRef) -> ParsedNodePatch:
         target = block.target

--- a/tests/functional/functions/test_overloaded_udfs.py
+++ b/tests/functional/functions/test_overloaded_udfs.py
@@ -44,6 +44,44 @@ model_using_overloaded_function_sql = """
 SELECT {{ function('double_int') }}(5) as result
 """
 
+# -- Fixtures: an overload body that references another function ----------------
+
+helper_sql = """
+SELECT val + 1
+"""
+
+wrapper_root_sql = """
+SELECT val
+"""
+
+# The overload body — and only the overload body — calls another function.
+wrapper_overload_sql = """
+SELECT {{ function('helper') }}(val)
+"""
+
+wrapper_with_overload_ref_yml = """
+functions:
+  - name: helper
+    arguments:
+      - name: val
+        data_type: integer
+    returns:
+      data_type: integer
+  - name: wrapper
+    arguments:
+      - name: val
+        data_type: integer
+    returns:
+      data_type: integer
+    overloads:
+      - defined_in: wrapper_overload
+        arguments:
+          - name: val
+            data_type: float
+        returns:
+          data_type: float
+"""
+
 
 class TestOverloadedUDFParsing:
     """Parsing a root function with overloads."""
@@ -102,6 +140,35 @@ class TestOverloadedUDFDependency:
         model = manifest.nodes["model.test.my_model"]
         fn_deps = [d for d in model.depends_on.nodes if d.startswith("function.")]
         assert fn_deps == ["function.test.double_int"]
+
+
+class TestOverloadedUDFOverloadBodyDependencies:
+    """An overload body's ref()/source()/function() calls must land on the root.
+
+    The overload SQL file is absorbed into the root and never becomes its own
+    node, so a dependency that appears only inside an overload body would be lost
+    from the DAG unless it is carried onto the root during absorption.
+    """
+
+    @pytest.fixture(scope="class")
+    def functions(self) -> Dict[str, str]:
+        return {
+            "helper.sql": helper_sql,
+            "wrapper.sql": wrapper_root_sql,
+            "wrapper_overload.sql": wrapper_overload_sql,
+            "schema.yml": wrapper_with_overload_ref_yml,
+        }
+
+    def test_root_depends_on_function_referenced_only_in_overload(self, project):
+        manifest = run_dbt(["parse"])
+
+        # The overload file is absorbed, not a standalone node.
+        assert "function.test.wrapper_overload" not in manifest.functions
+
+        wrapper = manifest.functions["function.test.wrapper"]
+        # `helper` is referenced only in the overload body, yet the root must
+        # carry the dependency so build order and lineage stay correct.
+        assert "function.test.helper" in wrapper.depends_on.nodes
 
 
 class TestOverloadedUDFBuild:


### PR DESCRIPTION
Resolves #15501

### Problem

When an overloaded UDF's overload body (the `defined_in` SQL file) contains a `ref()`, `source()`, or `function()` call, that dependency is silently dropped from the DAG.

`FunctionPatchParser._absorb_overloads` copies only the overload's `raw_code` onto the root node and then deletes the overload node from the manifest:

```python
absorbed.append(FunctionOverload(..., raw_body=overload_node.raw_code))
...
del self.manifest.functions[overload_unique_id]
```

The overload node's `refs` / `sources` / `functions` are never merged onto the root, so `process_refs`/`process_sources`/`process_functions` never see them. The overload file is absorbed (never a standalone node), so the edge has nowhere else to live. Result: missing `depends_on` edges → wrong build order, incomplete lineage, and `CREATE FUNCTION` failures when an overload body references a not-yet-created object.

### Solution

In `_absorb_overloads`, merge the overload node's `refs`/`sources`/`functions` onto the root before deleting the overload node (deduped against the root's own). The later `process_*` passes then resolve them into the root's `depends_on`.

Verified end-to-end on Snowflake with a `wrapper` function whose overload body calls `{{ function('helper') }}`: `helper` is now correctly built before `wrapper`, and the overload's `CREATE FUNCTION` succeeds (`PASS=2`). Before the fix the root's `depends_on.nodes` was empty.

Added `TestOverloadedUDFOverloadBodyDependencies` covering the parse-time edge.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes type annotations for new and modified functions.