### PR TITLE
[ClickHouse] Add common settings used for the Table materialization

### DIFF
--- a/.changes/unreleased/Features-20260710-163343.yaml
+++ b/.changes/unreleased/Features-20260710-163343.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: 'Clickhouse: Add missing configurations for ClickHouse table materialization'
+time: 2026-07-10T16:33:43.19249+02:00
+custom:
+    author: koletzilla
+    issue: "14585"
+    project: dbt-core

--- a/crates/dbt-schemas/src/schemas/project/configs/common.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/common.rs
@@ -245,6 +245,14 @@ pub struct WarehouseSpecificNodeConfig {
     #[serde(default)]
     pub primary_key: PrimaryKeyConfig,
     pub category: Option<DataLakeObjectCategory>,
+
+    // ClickHouse
+    // table materialization
+    pub engine: Option<String>,
+    pub order_by: Option<StringOrArrayOfStrings>,
+    pub ttl: Option<String>,
+    pub settings: Option<BTreeMap<String, YmlValue>>,
+    pub query_settings: Option<BTreeMap<String, YmlValue>>,
 }
 
 impl ResolvedConfig for WarehouseSpecificNodeConfig {
@@ -447,6 +455,11 @@ pub fn same_warehouse_config(
     let indexes_eq = self_wh.indexes == other_wh.indexes;
     let primary_key_eq = self_wh.primary_key == other_wh.primary_key;
     let category_eq = self_wh.category == other_wh.category;
+    let engine_eq = self_wh.engine == other_wh.engine;
+    let order_by_eq = self_wh.order_by == other_wh.order_by;
+    let ttl_eq = self_wh.ttl == other_wh.ttl;
+    let settings_eq = self_wh.settings == other_wh.settings;
+    let query_settings_eq = self_wh.query_settings == other_wh.query_settings;
 
     let result = partition_by_eq
         && cluster_by_eq
@@ -517,7 +530,12 @@ pub fn same_warehouse_config(
         && table_type_eq
         && indexes_eq
         && primary_key_eq
-        && category_eq;
+        && category_eq
+        && engine_eq
+        && order_by_eq
+        && ttl_eq
+        && settings_eq
+        && query_settings_eq;
 
     if !result {
         log_state_mod_diff(
@@ -1082,6 +1100,46 @@ pub fn same_warehouse_config(
                     Some((
                         format!("{:?}", &self_wh.category),
                         format!("{:?}", &other_wh.category),
+                    )),
+                ),
+                (
+                    "engine",
+                    engine_eq,
+                    Some((
+                        format!("{:?}", &self_wh.engine),
+                        format!("{:?}", &other_wh.engine),
+                    )),
+                ),
+                (
+                    "order_by",
+                    order_by_eq,
+                    Some((
+                        format!("{:?}", &self_wh.order_by),
+                        format!("{:?}", &other_wh.order_by),
+                    )),
+                ),
+                (
+                    "ttl",
+                    ttl_eq,
+                    Some((
+                        format!("{:?}", &self_wh.ttl),
+                        format!("{:?}", &other_wh.ttl),
+                    )),
+                ),
+                (
+                    "settings",
+                    settings_eq,
+                    Some((
+                        format!("{:?}", &self_wh.settings),
+                        format!("{:?}", &other_wh.settings),
+                    )),
+                ),
+                (
+                    "query_settings",
+                    query_settings_eq,
+                    Some((
+                        format!("{:?}", &self_wh.query_settings),
+                        format!("{:?}", &other_wh.query_settings),
                     )),
                 ),
             ],

--- a/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/data_test_config.rs
@@ -508,6 +508,12 @@ impl From<ProjectDataTestConfig> for DataTestConfig {
                 // data test is unsupported for Salesforce yet
                 primary_key: PrimaryKeyConfig::default(),
                 category: None,
+
+                engine: None,
+                order_by: None,
+                ttl: None,
+                settings: None,
+                query_settings: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/model_config.rs
@@ -516,6 +516,19 @@ pub struct ProjectModelConfig {
     #[serde(rename = "+sync")]
     pub sync: Option<SyncConfig>,
 
+    // ClickHouse
+    // table materialization
+    #[serde(rename = "+engine")]
+    pub engine: Option<String>,
+    #[serde(rename = "+order_by")]
+    pub order_by: Option<StringOrArrayOfStrings>,
+    #[serde(rename = "+ttl")]
+    pub ttl: Option<String>,
+    #[serde(rename = "+settings")]
+    pub settings: Option<BTreeMap<String, YmlValue>>,
+    #[serde(rename = "+query_settings")]
+    pub query_settings: Option<BTreeMap<String, YmlValue>>,
+
     // Flattened field:
     pub __additional_properties__: BTreeMap<String, ShouldBe<ProjectModelConfig>>,
 }
@@ -821,6 +834,12 @@ impl From<ProjectModelConfig> for ModelConfig {
 
                 primary_key: config.primary_key,
                 category: config.category,
+
+                engine: config.engine,
+                order_by: config.order_by,
+                ttl: config.ttl,
+                settings: config.settings,
+                query_settings: config.query_settings,
             },
             // Python-specific fields - initialized to None here, set during Python AST analysis
             config_keys_used: None,
@@ -1012,6 +1031,11 @@ impl From<ModelConfig> for ProjectModelConfig {
             primary_key: config.__warehouse_specific_config__.primary_key,
             category: config.__warehouse_specific_config__.category,
             sync: config.sync,
+            engine: config.__warehouse_specific_config__.engine,
+            order_by: config.__warehouse_specific_config__.order_by,
+            ttl: config.__warehouse_specific_config__.ttl,
+            settings: config.__warehouse_specific_config__.settings,
+            query_settings: config.__warehouse_specific_config__.query_settings,
             __additional_properties__: BTreeMap::new(),
         }
     }
@@ -2008,5 +2032,88 @@ __additional_properties__: {}
                 "matplotlib".to_string(),
             ])))
         );
+    }
+
+    #[test]
+    fn test_clickhouse_project_config_keys_parse_with_plus_prefix() {
+        use crate::schemas::serde::StringOrArrayOfStrings;
+
+        let config: ProjectModelConfig = dbt_yaml::from_str(
+            r#"
++engine: ReplacingMergeTree()
++order_by:
+  - id
+  - ts
++ttl: ts + INTERVAL 30 DAY
++settings:
+  index_granularity: 4096
++query_settings:
+  join_use_nulls: 1
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.engine.as_deref(), Some("ReplacingMergeTree()"));
+        assert_eq!(
+            config.order_by,
+            Some(StringOrArrayOfStrings::ArrayOfStrings(vec![
+                "id".to_string(),
+                "ts".to_string(),
+            ]))
+        );
+        assert_eq!(config.ttl.as_deref(), Some("ts + INTERVAL 30 DAY"));
+        let settings = config.settings.as_ref().expect("+settings should parse");
+        assert_eq!(
+            settings.get("index_granularity").and_then(|v| v.as_i64()),
+            Some(4096)
+        );
+        let query_settings = config
+            .query_settings
+            .as_ref()
+            .expect("+query_settings should parse");
+        assert_eq!(
+            query_settings.get("join_use_nulls").and_then(|v| v.as_i64()),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn test_clickhouse_config_keys_roundtrip_through_model_config() {
+        use crate::schemas::serde::StringOrArrayOfStrings;
+
+        let project_config: ProjectModelConfig = dbt_yaml::from_str(
+            r#"
++engine: MergeTree()
++order_by: id
++ttl: ts + INTERVAL 1 DAY
++settings:
+  allow_nullable_key: 1
++query_settings:
+  max_threads: 4
+__additional_properties__: {}
+"#,
+        )
+        .unwrap();
+
+        // ProjectModelConfig -> ModelConfig lands the keys in the warehouse config
+        let model_config: ModelConfig = project_config.clone().into();
+        let wh = &model_config.__warehouse_specific_config__;
+        assert_eq!(wh.engine, project_config.engine);
+        assert_eq!(
+            wh.order_by,
+            Some(StringOrArrayOfStrings::String("id".to_string()))
+        );
+        assert_eq!(wh.ttl, project_config.ttl);
+        assert_eq!(wh.settings, project_config.settings);
+        assert_eq!(wh.query_settings, project_config.query_settings);
+
+        // ModelConfig -> ProjectModelConfig restores them
+        let roundtripped: ProjectModelConfig = model_config.into();
+        assert_eq!(roundtripped.engine, project_config.engine);
+        assert_eq!(roundtripped.order_by, project_config.order_by);
+        assert_eq!(roundtripped.ttl, project_config.ttl);
+        assert_eq!(roundtripped.settings, project_config.settings);
+        assert_eq!(roundtripped.query_settings, project_config.query_settings);
     }
 }

--- a/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/seed_config.rs
@@ -471,6 +471,12 @@ impl From<ProjectSeedConfig> for SeedConfig {
                 // seed is unsupported for Salesforce yet
                 primary_key: PrimaryKeyConfig::default(),
                 category: None,
+
+                engine: None,
+                order_by: None,
+                ttl: None,
+                settings: None,
+                query_settings: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/snapshot_config.rs
@@ -679,6 +679,12 @@ impl From<ProjectSnapshotConfig> for SnapshotConfig {
                 // snapshot is unsupported for Salesforce yet
                 primary_key: PrimaryKeyConfig::default(),
                 category: None,
+
+                engine: None,
+                order_by: None,
+                ttl: None,
+                settings: None,
+                query_settings: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/source_config.rs
@@ -388,6 +388,12 @@ impl From<ProjectSourceConfig> for SourceConfig {
                 // sources doesn't need this field
                 primary_key: PrimaryKeyConfig::default(),
                 category: None,
+
+                engine: None,
+                order_by: None,
+                ttl: None,
+                settings: None,
+                query_settings: None,
             },
         }
     }

--- a/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/unit_test_config.rs
@@ -409,6 +409,12 @@ impl From<ProjectUnitTestConfig> for UnitTestConfig {
                 // unit test is unsupported for Salesforce yet
                 primary_key: PrimaryKeyConfig::default(),
                 category: None,
+
+                engine: None,
+                order_by: None,
+                ttl: None,
+                settings: None,
+                query_settings: None,
             },
         }
     }


### PR DESCRIPTION
Related to https://github.com/dbt-labs/dbt-core/issues/14583

This PR registers `engine`, `order_by`, `ttl`, `settings`, and `query_settings` for the ClickHouse adapter table materialization.

Notes:
- `settings` and `query_settings` are accepted without errors and reach the macro layer, but render as no-ops for now. The local `clickhouse_model_settings``clickhouse_model_query_settings` stubs return '' until the `get_model_settings`/`get_model_query_settings` adapter methods and the upstream macro sync land in follow-up PRs.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [X] I have run this code in development, and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required or relevant for this PR.
- [X] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [ ] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
