### PR TITLE
Add CLI hints

### DIFF
--- a/.changes/unreleased/Features-20260711-014336.yaml
+++ b/.changes/unreleased/Features-20260711-014336.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add hints for cli users based on dbt usage
+time: 2026-07-11T01:43:36.525076+05:30
+custom:
+    Author: ash2shukla
+    Issue: "15510"

--- a/core/dbt/cli/main.py
+++ b/core/dbt/cli/main.py
@@ -118,6 +118,7 @@ def global_flags(func):
     @p.deprecated_state
     @p.fail_fast
     @p.favor_state
+    @p.hints_enabled
     @p.indirect_selection
     @p.log_cache_events
     @p.log_file_max_bytes

--- a/core/dbt/cli/params.py
+++ b/core/dbt/cli/params.py
@@ -306,6 +306,13 @@ full_refresh = _create_option_and_track_env_var(
     is_flag=True,
 )
 
+hints_enabled = _create_option_and_track_env_var(
+    "--hints-enabled/--no-hints-enabled",
+    envvar="DBT_ENGINE_HINTS_ENABLED",
+    help="If set, dbt will surface occasional hints suggesting ways to speed up or improve your project.",
+    default=True,
+)
+
 host = _create_option_and_track_env_var(
     "--host",
     envvar="DBT_HOST",

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -36,6 +36,7 @@ from dbt.events.types import (
 )
 from dbt.exceptions import DbtProjectError, FailFastError
 from dbt.flags import get_flag_dict, get_flags, set_flags
+from dbt.hints import load_hint_ts
 from dbt.mp_context import get_mp_context
 from dbt.parser.manifest import parse_manifest
 from dbt.plugins import set_up_plugin_manager
@@ -369,6 +370,10 @@ def runtime_config(func):
         )
 
         ctx.obj["runtime_config"] = config
+
+        # Prime the hint cooldown cache now that we know this project's target
+        # dir, so any hint surfaced later in the invocation honors the limit.
+        load_hint_ts(config.project_target_path)
 
         if dbt.tracking.active_user is not None:
             adapter_type = (

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -342,6 +342,7 @@ class ProjectFlags(ExtensibleDbtClassMixin):
     cache_selected_only: Optional[bool] = None
     debug: Optional[bool] = None
     fail_fast: Optional[bool] = None
+    hints_enabled: Optional[bool] = None
     indirect_selection: Optional[str] = None
     log_format: Optional[str] = None
     log_format_file: Optional[str] = None

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -70,6 +70,7 @@ def get_flag_dict():
         "invocation_command",
         "empty",
         "maximum_seed_size_mib",
+        "hints_enabled",
     }
     return {key: getattr(GLOBAL_FLAGS, key.upper(), None) for key in flag_attr}
 

--- a/core/dbt/hints.py
+++ b/core/dbt/hints.py
@@ -22,13 +22,12 @@ HINT_TS_FILENAME = "hint_ts.json"
 
 # Hint message text shown to the user. Keep these actionable and point at docs.
 REUSE_RELATIONS_ON_TOO_MANY_MODELS = (
-    "You're building a lot from scratch. Did you know you can speed up your "
-    "builds by reusing relations from other schemas: check out "
-    "https://docs.getdbt.com/docs/optimizing-builds?utm_source=dbt-cli"
+    "You're rebuilding a lot from scratch. You can use state to save time and money by reusing or skipping existing objects: "
+    "https://docs.getdbt.com/docs/optimize-builds?utm_source=dbt-cli"
 )
+
 LONG_PARSING_WITHOUT_V2_PARSER = (
-    "Your parse is taking a long time. Did you know you can speed up your "
-    "parsing with the new rust parser: check out "
+    "Your parse is taking a long time. You can speed up your parsing with the new rust parser: "
     "https://docs.getdbt.com/reference/global-configs/parsing?utm_source=dbt-cli#opt-in-v2-parser"
 )
 

--- a/core/dbt/hints.py
+++ b/core/dbt/hints.py
@@ -4,14 +4,17 @@ from dbt_common.dataclass_schema import StrEnum
 from dbt_common.events.functions import fire_event
 from dbt_common.events.types import Note
 
+# Prefix prepended to every hint when surfaced to the user.
+HINT_PREFIX = "[HINT] "
+
 # Hint message text shown to the user. Keep these actionable and point at docs.
 REUSE_RELATIONS_ON_TOO_MANY_MODELS = (
-    "[HINT] You're building a lot from scratch. Did you know you can speed up your "
+    "You're building a lot from scratch. Did you know you can speed up your "
     "builds by reusing relations from other schemas: check out "
     "https://docs.getdbt.com/docs/optimizing-builds?utm_source=dbt-cli"
 )
 LONG_PARSING_WITHOUT_V2_PARSER = (
-    "[HINT] Your parse is taking a long time. Did you know you can speed up your "
+    "Your parse is taking a long time. Did you know you can speed up your "
     "parsing with the new rust parser: check out "
     "https://docs.getdbt.com/reference/global-configs/parsing?utm_source=dbt-cli#opt-in-v2-parser"
 )
@@ -36,5 +39,5 @@ def show_hint(hint_type: HintType) -> None:
         return
 
     msg = hint_to_msg_map[hint_type]
-    fire_event(Note(msg=msg))
+    fire_event(Note(msg=f"{HINT_PREFIX}{msg}"))
     track_hint_view(hint_type)

--- a/core/dbt/hints.py
+++ b/core/dbt/hints.py
@@ -1,3 +1,10 @@
+import json
+import time
+from contextvars import ContextVar
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional, Union
+
 from dbt.flags import get_flags
 from dbt.tracking import track_hint_view
 from dbt_common.dataclass_schema import StrEnum
@@ -6,6 +13,12 @@ from dbt_common.events.types import Note
 
 # Prefix prepended to every hint when surfaced to the user.
 HINT_PREFIX = "[HINT] "
+
+# Don't show the same hint more than once a week.
+HINT_COOLDOWN_SECONDS = 7 * 24 * 60 * 60
+
+# File (under the project's target dir) tracking when each hint was last shown.
+HINT_TS_FILENAME = "hint_ts.json"
 
 # Hint message text shown to the user. Keep these actionable and point at docs.
 REUSE_RELATIONS_ON_TOO_MANY_MODELS = (
@@ -30,14 +43,79 @@ hint_to_msg_map: dict[HintType, str] = {
     HintType.LONG_PARSING_WITHOUT_V2_PARSER: LONG_PARSING_WITHOUT_V2_PARSER,
 }
 
+# Path to the current invocation's hint file, set by load_hint_ts(). Held in a
+# ContextVar so it's isolated per invocation and follows dbt's threaded execution
+# the same way the invocation context does. None until load_hint_ts() runs.
+_hint_ts_path: ContextVar[Optional[Path]] = ContextVar("hint_ts_path", default=None)
+
+
+@lru_cache(None)
+def _read_hint_ts(path_str: str) -> dict:
+    """Read and cache one hint file's contents, keyed by path. The returned dict
+    is mutated in place by record_hint_shown(), so the cache stays current within
+    this process; a new invocation is a new process and re-reads from disk."""
+    try:
+        return json.loads(Path(path_str).read_text())
+    except (FileNotFoundError, ValueError):
+        # No file yet, or a partially-written one — treat as "never shown".
+        return {}
+
+
+def load_hint_ts(target_path: Optional[Union[str, Path]] = None) -> dict:
+    """Point the hint machinery at a project's target dir and load its hint file.
+    Call this early (from requires.runtime_config); later reads reuse the cached
+    copy so we don't touch disk on every hint."""
+    if target_path is None:
+        return {}
+    path = Path(target_path) / HINT_TS_FILENAME
+    _hint_ts_path.set(path)
+    return _read_hint_ts(str(path))
+
+
+def reset_hint_ts() -> None:
+    """Forget the current path and clear cached hint files. Primarily for tests,
+    where the process (and this cache) is reused across invocations."""
+    _hint_ts_path.set(None)
+    _read_hint_ts.cache_clear()
+
+
+def has_hint_cooldown(hint_type: HintType) -> bool:
+    """True if this hint was shown recently enough that we should stay quiet."""
+    path = _hint_ts_path.get()
+    if path is None:
+        return False
+    last_shown = _read_hint_ts(str(path)).get(hint_type, 0)
+    return (time.time() - last_shown) < HINT_COOLDOWN_SECONDS
+
+
+def record_hint_shown(hint_type: HintType) -> None:
+    """Stamp the current time for this hint and persist it, so future runs honor
+    the cooldown. No-op if we never loaded a target path (nowhere to write)."""
+    path = _hint_ts_path.get()
+    if path is None:
+        return
+    hint_ts = _read_hint_ts(str(path))
+    # Store epoch seconds as an int so the file interops cleanly with the Rust
+    # engine (which reads/writes integer timestamps).
+    hint_ts[hint_type] = int(time.time())
+    try:
+        path.write_text(json.dumps(hint_ts))
+    except OSError:
+        # A read-only/full/unwritable target must never break the run just
+        # because we couldn't persist a hint timestamp.
+        pass
+
 
 def show_hint(hint_type: HintType) -> None:
     """Surface a hint to the user, unless hints have been disabled via the
-    hints_enabled flag. Also records a telemetry event so we can tell which
-    hints are actually being seen."""
+    hints_enabled flag or the hint is still within its cooldown window. Also
+    records a telemetry event so we can tell which hints are actually being seen."""
     if not getattr(get_flags(), "HINTS_ENABLED", True):
+        return
+    if has_hint_cooldown(hint_type):
         return
 
     msg = hint_to_msg_map[hint_type]
     fire_event(Note(msg=f"{HINT_PREFIX}{msg}"))
     track_hint_view(hint_type)
+    record_hint_shown(hint_type)

--- a/core/dbt/hints.py
+++ b/core/dbt/hints.py
@@ -1,9 +1,8 @@
+from dbt.flags import get_flags
+from dbt.tracking import track_hint_view
 from dbt_common.dataclass_schema import StrEnum
 from dbt_common.events.functions import fire_event
 from dbt_common.events.types import Note
-
-from dbt.flags import get_flags
-from dbt.tracking import track_hint_view
 
 # Hint message text shown to the user. Keep these actionable and point at docs.
 REUSE_RELATIONS_ON_TOO_MANY_MODELS = (
@@ -29,7 +28,7 @@ hint_to_msg_map: dict[HintType, str] = {
 }
 
 
-def show_hint(hint_type: str) -> None:
+def show_hint(hint_type: HintType) -> None:
     """Surface a hint to the user, unless hints have been disabled via the
     hints_enabled flag. Also records a telemetry event so we can tell which
     hints are actually being seen."""

--- a/core/dbt/hints.py
+++ b/core/dbt/hints.py
@@ -1,0 +1,41 @@
+from dbt_common.dataclass_schema import StrEnum
+from dbt_common.events.functions import fire_event
+from dbt_common.events.types import Note
+
+from dbt.flags import get_flags
+from dbt.tracking import track_hint_view
+
+# Hint message text shown to the user. Keep these actionable and point at docs.
+REUSE_RELATIONS_ON_TOO_MANY_MODELS = (
+    "[HINT] You're building a lot from scratch. Did you know you can speed up your "
+    "builds by reusing relations from other schemas: check out "
+    "https://docs.getdbt.com/docs/optimizing-builds?utm_source=dbt-cli"
+)
+LONG_PARSING_WITHOUT_V2_PARSER = (
+    "[HINT] Your parse is taking a long time. Did you know you can speed up your "
+    "parsing with the new rust parser: check out "
+    "https://docs.getdbt.com/reference/global-configs/parsing?utm_source=dbt-cli#opt-in-v2-parser"
+)
+
+
+class HintType(StrEnum):
+    REUSE_RELATIONS_ON_TOO_MANY_MODELS = "reuse_relations_on_too_many_models"
+    LONG_PARSING_WITHOUT_V2_PARSER = "long_parsing_without_v2_parser"
+
+
+hint_to_msg_map: dict[HintType, str] = {
+    HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS: REUSE_RELATIONS_ON_TOO_MANY_MODELS,
+    HintType.LONG_PARSING_WITHOUT_V2_PARSER: LONG_PARSING_WITHOUT_V2_PARSER,
+}
+
+
+def show_hint(hint_type: str) -> None:
+    """Surface a hint to the user, unless hints have been disabled via the
+    hints_enabled flag. Also records a telemetry event so we can tell which
+    hints are actually being seen."""
+    if not getattr(get_flags(), "HINTS_ENABLED", True):
+        return
+
+    msg = hint_to_msg_map[hint_type]
+    fire_event(Note(msg=msg))
+    track_hint_view(hint_type)

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -104,6 +104,7 @@ from dbt.exceptions import (
     scrub_secrets,
 )
 from dbt.flags import get_flags
+from dbt.hints import HintType, show_hint
 from dbt.mp_context import get_mp_context
 from dbt.node_types import AccessType, NodeType
 from dbt.parser.analysis import AnalysisParser
@@ -149,6 +150,18 @@ from dbt_common.helper_types import PathSet
 from dbt_common.ui import error_tag
 
 PERF_INFO_FILE_NAME = "perf_info.json"
+
+# Parses slower than this (in seconds) are slow enough to suggest the v2 parser.
+LONG_PARSING_THRESHOLD_SECONDS = 5 * 60
+
+
+def _maybe_show_long_parsing_hint(load_all_elapsed: Optional[float]) -> None:
+    if (
+        load_all_elapsed is not None
+        and load_all_elapsed > LONG_PARSING_THRESHOLD_SECONDS
+        and not get_flags().USE_V2_PARSER
+    ):
+        show_hint(HintType.LONG_PARSING_WITHOUT_V2_PARSER)
 
 
 def extended_mashumaro_encoder(data):
@@ -344,6 +357,10 @@ class ManifestLoader:
         # Save performance info
         loader._perf_info.load_all_elapsed = time.perf_counter() - start_load_all
         loader.track_project_load()
+
+        # If parsing was slow and we're still on the legacy parser, nudge the user
+        # toward the v2 parser.
+        _maybe_show_long_parsing_hint(loader._perf_info.load_all_elapsed)
 
         if write_perf_info:
             loader.write_perf_info(config.project_target_path)

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -152,7 +152,7 @@ from dbt_common.ui import error_tag
 PERF_INFO_FILE_NAME = "perf_info.json"
 
 # Parses slower than this (in seconds) are slow enough to suggest the v2 parser.
-LONG_PARSING_THRESHOLD_SECONDS = 5 * 60
+LONG_PARSING_THRESHOLD_SECONDS = 30
 
 
 def _maybe_show_long_parsing_hint(load_all_elapsed: Optional[float]) -> None:

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -63,13 +63,21 @@ class BuildTask(RunTask):
         self.model_to_unit_test_map: Dict[str, List] = {}
 
     def before_run(self, adapter: BaseAdapter, selected_uids: AbstractSet[str]) -> RunStatus:
+        self._maybe_show_reuse_relations_hint()
+        return super().before_run(adapter, selected_uids)
+
+    def _maybe_show_reuse_relations_hint(self) -> None:
+        # This hint nudges users building a lot *from scratch*. If they've already
+        # opted into state/deferral (--state / --defer / --defer-state), they're
+        # not building from scratch, so stay quiet.
+        if self.args.state or self.args.defer or self.args.defer_state:
+            return
+
         model_count = sum(
             1 for node in (self._flattened_nodes or []) if node.resource_type == NodeType.Model
         )
         if model_count > self.REUSE_RELATIONS_HINT_MODEL_THRESHOLD:
             show_hint(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
-
-        return super().before_run(adapter, selected_uids)
 
     def resource_types(self, no_unit_tests: bool = False) -> List[NodeType]:
         resource_types = resource_types_from_args(

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -1,8 +1,9 @@
-from typing import Dict, Iterable, List, Optional, Set, Type
+from typing import AbstractSet, Dict, Iterable, List, Optional, Set, Type
 
-from dbt.adapters.base import BaseRelation
+from dbt.adapters.base import BaseAdapter, BaseRelation
 from dbt.artifacts.resources import Catalog
-from dbt.artifacts.schemas.results import NodeResult, NodeStatus
+from dbt.artifacts.schemas.results import NodeResult, NodeStatus, RunStatus
+from dbt.hints import HintType, show_hint
 from dbt.cli.flags import Flags
 from dbt.config.runtime import RuntimeConfig
 from dbt.contracts.graph.manifest import Manifest
@@ -48,6 +49,7 @@ class BuildTask(RunTask):
         NodeType.Function: function_runner,
     }
     ALL_RESOURCE_VALUES = frozenset({x for x in RUNNER_MAP.keys()})
+    REUSE_RELATIONS_HINT_MODEL_THRESHOLD = 100
 
     def __init__(
         self,
@@ -59,6 +61,15 @@ class BuildTask(RunTask):
         super().__init__(args, config, manifest, catalogs=catalogs)
         self.selected_unit_tests: Set = set()
         self.model_to_unit_test_map: Dict[str, List] = {}
+
+    def before_run(self, adapter: BaseAdapter, selected_uids: AbstractSet[str]) -> RunStatus:
+        model_count = sum(
+            1 for node in (self._flattened_nodes or []) if node.resource_type == NodeType.Model
+        )
+        if model_count > self.REUSE_RELATIONS_HINT_MODEL_THRESHOLD:
+            show_hint(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
+
+        return super().before_run(adapter, selected_uids)
 
     def resource_types(self, no_unit_tests: bool = False) -> List[NodeType]:
         resource_types = resource_types_from_args(

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -3,12 +3,12 @@ from typing import AbstractSet, Dict, Iterable, List, Optional, Set, Type
 from dbt.adapters.base import BaseAdapter, BaseRelation
 from dbt.artifacts.resources import Catalog
 from dbt.artifacts.schemas.results import NodeResult, NodeStatus, RunStatus
-from dbt.hints import HintType, show_hint
 from dbt.cli.flags import Flags
 from dbt.config.runtime import RuntimeConfig
 from dbt.contracts.graph.manifest import Manifest
 from dbt.exceptions import DbtInternalError
 from dbt.graph import Graph, GraphQueue, ResourceTypeSelector
+from dbt.hints import HintType, show_hint
 from dbt.node_types import NodeType
 from dbt.runners import ExposureRunner as exposure_runner
 from dbt.runners import SavedQueryRunner as saved_query_runner

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -54,6 +54,7 @@ RUN_MODEL_SPEC = "iglu:com.dbt/run_model/jsonschema/1-1-1"
 PLUGIN_GET_NODES = "iglu:com.dbt/plugin_get_nodes/jsonschema/1-0-0"
 ARTIFACT_UPLOAD = "iglu:com.dbt/artifact_upload/jsonschema/1-0-0"
 MANAGE_STATE_SPEC = "iglu:com.dbt/manage_state/jsonschema/1-0-0"
+HINT_VIEW_SPEC = "iglu:com.dbt/hint_view/jsonschema/1-0-0"
 
 SNOWPLOW_TRACKER_VERSION = Version(snowplow_version)
 
@@ -365,6 +366,22 @@ def track_deprecation_warn(options):
         action="deprecation",
         label=get_invocation_id(),
         property_="warn",
+        context=context,
+    )
+
+
+def track_hint_view(hint_type: str) -> None:
+    if active_user is None:
+        return
+
+    context = [SelfDescribingJson(HINT_VIEW_SPEC, {"hint_type": hint_type})]
+
+    track(
+        active_user,
+        category="dbt",
+        action="hint",
+        label=get_invocation_id(),
+        property_="view",
         context=context,
     )
 

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -379,9 +379,8 @@ def track_hint_view(hint_type: str) -> None:
     track(
         active_user,
         category="dbt",
-        action="hint",
+        action="hint_view",
         label=get_invocation_id(),
-        property_="view",
         context=context,
     )
 

--- a/tests/functional/cli/test_requires.py
+++ b/tests/functional/cli/test_requires.py
@@ -146,6 +146,7 @@ class TestKnownEngineEnvVarsExplicit:
             "DBT_ENGINE_STATE_API_URL",
             "DBT_ENGINE_MANAGE_STATE",
             "DBT_ENGINE_SKIP_BROWSER_AUTH",
+            "DBT_ENGINE_HINTS_ENABLED",
         }
         from dbt.env_vars import _ALLOWED_ENV_VARS
 

--- a/tests/functional/hints/test_hints.py
+++ b/tests/functional/hints/test_hints.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -55,6 +58,59 @@ class TestReuseRelationsHint:
     def test_silent_when_hints_disabled(self, project, mocker, catcher):
         mocker.patch("dbt.task.build.BuildTask.REUSE_RELATIONS_HINT_MODEL_THRESHOLD", 0)
         run_dbt(["build", "--no-hints-enabled"], callbacks=[catcher.catch])
+        assert hint_events(catcher, REUSE_RELATIONS_ON_TOO_MANY_MODELS) == []
+
+
+class TestReuseRelationsHintSkippedWithState:
+    # Users on state/deferral aren't building from scratch, so the reuse hint
+    # should stay silent even when the model count is over the threshold.
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_a.sql": model_sql, "model_b.sql": model_sql}
+
+    def _make_state(self, project) -> str:
+        # `parse` produces a manifest without triggering the reuse hint, so no
+        # hint_ts.json is written and the cooldown can't mask the state guard.
+        run_dbt(["parse"])
+        state = os.path.join(project.project_root, "state")
+        os.makedirs(state, exist_ok=True)
+        shutil.copyfile(
+            os.path.join(project.project_root, "target", "manifest.json"),
+            os.path.join(state, "manifest.json"),
+        )
+        return "state"
+
+    @pytest.mark.parametrize(
+        "extra_args",
+        [
+            ["--state", "state"],
+            ["--defer", "--state", "state"],
+            ["--defer-state", "state"],
+        ],
+    )
+    def test_silent_when_state_or_defer_in_use(self, project, mocker, extra_args):
+        mocker.patch("dbt.task.build.BuildTask.REUSE_RELATIONS_HINT_MODEL_THRESHOLD", 0)
+        self._make_state(project)
+
+        catcher = EventCatcher(event_to_catch=Note)
+        run_dbt(["build"] + extra_args, callbacks=[catcher.catch])
+        assert hint_events(catcher, REUSE_RELATIONS_ON_TOO_MANY_MODELS) == []
+
+
+class TestHintsDisabledViaProjectFlag:
+    # `hints_enabled: false` under `flags:` in dbt_project.yml must suppress hints.
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_a.sql": model_sql, "model_b.sql": model_sql}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"hints_enabled": False}}
+
+    def test_project_flag_disables_hint(self, project, mocker):
+        mocker.patch("dbt.task.build.BuildTask.REUSE_RELATIONS_HINT_MODEL_THRESHOLD", 0)
+        catcher = EventCatcher(event_to_catch=Note)
+        run_dbt(["build"], callbacks=[catcher.catch])
         assert hint_events(catcher, REUSE_RELATIONS_ON_TOO_MANY_MODELS) == []
 
 

--- a/tests/functional/hints/test_hints.py
+++ b/tests/functional/hints/test_hints.py
@@ -5,6 +5,7 @@ from dbt.hints import (
     HINT_PREFIX,
     LONG_PARSING_WITHOUT_V2_PARSER,
     REUSE_RELATIONS_ON_TOO_MANY_MODELS,
+    reset_hint_ts,
 )
 from dbt.tests.util import run_dbt
 from dbt_common.events.event_catcher import EventCatcher
@@ -16,6 +17,15 @@ model_sql = "select 1 as id"
 @pytest.fixture(autouse=True)
 def no_snowplow(mocker: MockerFixture):
     mocker.patch("dbt.hints.track_hint_view")
+
+
+@pytest.fixture(autouse=True)
+def fresh_hint_ts():
+    # The cooldown cache is a module global that survives across invocations in
+    # the same process, so drop it before and after each test to avoid leakage.
+    reset_hint_ts()
+    yield
+    reset_hint_ts()
 
 
 def hint_events(catcher: EventCatcher, hint_msg: str):
@@ -46,6 +56,28 @@ class TestReuseRelationsHint:
         mocker.patch("dbt.task.build.BuildTask.REUSE_RELATIONS_HINT_MODEL_THRESHOLD", 0)
         run_dbt(["build", "--no-hints-enabled"], callbacks=[catcher.catch])
         assert hint_events(catcher, REUSE_RELATIONS_ON_TOO_MANY_MODELS) == []
+
+
+class TestHintCooldownAcrossRuns:
+    # Its own class so it gets a fresh (class-scoped) target dir, i.e. a clean
+    # hint_ts.json that isn't pre-populated by the other tests above.
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_a.sql": model_sql, "model_b.sql": model_sql}
+
+    def test_second_run_is_silent_within_cooldown(self, project, mocker):
+        mocker.patch("dbt.task.build.BuildTask.REUSE_RELATIONS_HINT_MODEL_THRESHOLD", 0)
+
+        # First run shows the hint and writes hint_ts.json to the target dir.
+        first = EventCatcher(event_to_catch=Note)
+        run_dbt(["build"], callbacks=[first.catch])
+        assert len(hint_events(first, REUSE_RELATIONS_ON_TOO_MANY_MODELS)) == 1
+
+        # A fresh invocation re-reads that file and stays quiet during cooldown.
+        reset_hint_ts()
+        second = EventCatcher(event_to_catch=Note)
+        run_dbt(["build"], callbacks=[second.catch])
+        assert hint_events(second, REUSE_RELATIONS_ON_TOO_MANY_MODELS) == []
 
 
 class TestLongParsingHint:

--- a/tests/functional/hints/test_hints.py
+++ b/tests/functional/hints/test_hints.py
@@ -1,7 +1,11 @@
 import pytest
 from pytest_mock import MockerFixture
 
-from dbt.hints import LONG_PARSING_WITHOUT_V2_PARSER, REUSE_RELATIONS_ON_TOO_MANY_MODELS
+from dbt.hints import (
+    HINT_PREFIX,
+    LONG_PARSING_WITHOUT_V2_PARSER,
+    REUSE_RELATIONS_ON_TOO_MANY_MODELS,
+)
 from dbt.tests.util import run_dbt
 from dbt_common.events.event_catcher import EventCatcher
 from dbt_common.events.types import Note
@@ -16,7 +20,7 @@ def no_snowplow(mocker: MockerFixture):
 
 def hint_events(catcher: EventCatcher, hint_msg: str):
     # Note fires for lots of things; keep only the specific hint we care about.
-    return [e for e in catcher.caught_events if e.data.msg == hint_msg]
+    return [e for e in catcher.caught_events if e.data.msg == HINT_PREFIX + hint_msg]
 
 
 class TestReuseRelationsHint:

--- a/tests/functional/hints/test_hints.py
+++ b/tests/functional/hints/test_hints.py
@@ -1,0 +1,69 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from dbt.hints import LONG_PARSING_WITHOUT_V2_PARSER, REUSE_RELATIONS_ON_TOO_MANY_MODELS
+from dbt.tests.util import run_dbt
+from dbt_common.events.event_catcher import EventCatcher
+from dbt_common.events.types import Note
+
+model_sql = "select 1 as id"
+
+
+@pytest.fixture(autouse=True)
+def no_snowplow(mocker: MockerFixture):
+    mocker.patch("dbt.hints.track_hint_view")
+
+
+def hint_events(catcher: EventCatcher, hint_msg: str):
+    # Note fires for lots of things; keep only the specific hint we care about.
+    return [e for e in catcher.caught_events if e.data.msg == hint_msg]
+
+
+class TestReuseRelationsHint:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_a.sql": model_sql, "model_b.sql": model_sql}
+
+    @pytest.fixture
+    def catcher(self):
+        return EventCatcher(event_to_catch=Note)
+
+    def test_fires_when_over_threshold(self, project, mocker, catcher):
+        mocker.patch("dbt.task.build.BuildTask.REUSE_RELATIONS_HINT_MODEL_THRESHOLD", 0)
+        run_dbt(["build"], callbacks=[catcher.catch])
+        assert len(hint_events(catcher, REUSE_RELATIONS_ON_TOO_MANY_MODELS)) == 1
+
+    def test_silent_when_under_threshold(self, project, mocker, catcher):
+        mocker.patch("dbt.task.build.BuildTask.REUSE_RELATIONS_HINT_MODEL_THRESHOLD", 100)
+        run_dbt(["build"], callbacks=[catcher.catch])
+        assert hint_events(catcher, REUSE_RELATIONS_ON_TOO_MANY_MODELS) == []
+
+    def test_silent_when_hints_disabled(self, project, mocker, catcher):
+        mocker.patch("dbt.task.build.BuildTask.REUSE_RELATIONS_HINT_MODEL_THRESHOLD", 0)
+        run_dbt(["build", "--no-hints-enabled"], callbacks=[catcher.catch])
+        assert hint_events(catcher, REUSE_RELATIONS_ON_TOO_MANY_MODELS) == []
+
+
+class TestLongParsingHint:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_a.sql": model_sql}
+
+    @pytest.fixture
+    def catcher(self):
+        return EventCatcher(event_to_catch=Note)
+
+    def test_fires_when_parse_is_slow_on_legacy_parser(self, project, mocker, catcher):
+        mocker.patch("dbt.parser.manifest.LONG_PARSING_THRESHOLD_SECONDS", -1)
+        run_dbt(["parse", "--no-partial-parse"], callbacks=[catcher.catch])
+        assert len(hint_events(catcher, LONG_PARSING_WITHOUT_V2_PARSER)) == 1
+
+    def test_silent_when_parse_is_fast(self, project, mocker, catcher):
+        mocker.patch("dbt.parser.manifest.LONG_PARSING_THRESHOLD_SECONDS", 100 * 60)
+        run_dbt(["parse", "--no-partial-parse"], callbacks=[catcher.catch])
+        assert hint_events(catcher, LONG_PARSING_WITHOUT_V2_PARSER) == []
+
+    def test_silent_when_hints_disabled(self, project, mocker, catcher):
+        mocker.patch("dbt.parser.manifest.LONG_PARSING_THRESHOLD_SECONDS", -1)
+        run_dbt(["parse", "--no-partial-parse", "--no-hints-enabled"], callbacks=[catcher.catch])
+        assert hint_events(catcher, LONG_PARSING_WITHOUT_V2_PARSER) == []

--- a/tests/unit/parser/test_manifest.py
+++ b/tests/unit/parser/test_manifest.py
@@ -16,9 +16,12 @@ from dbt.contracts.graph.manifest import Manifest, ManifestStateCheck
 from dbt.events.types import InvalidConcurrentBatchesConfig, UnusedResourceConfigPath
 from dbt.exceptions import ParsingError
 from dbt.flags import set_from_args
+from dbt.hints import HintType
 from dbt.parser.manifest import (
+    LONG_PARSING_THRESHOLD_SECONDS,
     ManifestLoader,
     _check_function_language_support,
+    _maybe_show_long_parsing_hint,
     _warn_for_unused_resource_config_paths,
     extended_mashumaro_encoder,
     extended_msgpack_encoder,
@@ -574,3 +577,33 @@ class TestVersionToStr:
     )
     def test_version_to_str(self, version, expected):
         assert version_to_str(version) == expected
+
+
+class TestLongParsingHint:
+    @pytest.fixture(autouse=True)
+    def mock_hint_deps(self, mocker: MockerFixture):
+        self.mock_show_hint = mocker.patch("dbt.parser.manifest.show_hint")
+        self.mock_get_flags = mocker.patch("dbt.parser.manifest.get_flags")
+
+    def _set_v2_parser(self, enabled: bool):
+        self.mock_get_flags.return_value = MagicMock(USE_V2_PARSER=enabled)
+
+    def test_fires_when_slow_and_legacy_parser(self):
+        self._set_v2_parser(False)
+        _maybe_show_long_parsing_hint(LONG_PARSING_THRESHOLD_SECONDS + 1)
+        self.mock_show_hint.assert_called_once_with(HintType.LONG_PARSING_WITHOUT_V2_PARSER)
+
+    def test_silent_when_fast(self):
+        self._set_v2_parser(False)
+        _maybe_show_long_parsing_hint(LONG_PARSING_THRESHOLD_SECONDS)
+        self.mock_show_hint.assert_not_called()
+
+    def test_silent_when_using_v2_parser(self):
+        self._set_v2_parser(True)
+        _maybe_show_long_parsing_hint(LONG_PARSING_THRESHOLD_SECONDS + 100)
+        self.mock_show_hint.assert_not_called()
+
+    def test_silent_when_elapsed_is_none(self):
+        self._set_v2_parser(False)
+        _maybe_show_long_parsing_hint(None)
+        self.mock_show_hint.assert_not_called()

--- a/tests/unit/task/test_build.py
+++ b/tests/unit/task/test_build.py
@@ -1,5 +1,54 @@
+from unittest import mock
+
+from dbt.artifacts.schemas.results import RunStatus
 from dbt.contracts.graph.nodes import SavedQuery
+from dbt.hints import HintType
+from dbt.node_types import NodeType
 from dbt.runners import SavedQueryRunner
+from dbt.task.build import BuildTask
+
+
+def _model_node():
+    return mock.Mock(resource_type=NodeType.Model)
+
+
+def _test_node():
+    return mock.Mock(resource_type=NodeType.Test)
+
+
+class TestBuildReuseRelationsHint:
+    def _run_before_run(self, flattened_nodes):
+        task = BuildTask.__new__(BuildTask)
+        task._flattened_nodes = flattened_nodes
+        with mock.patch("dbt.task.build.show_hint") as mock_show_hint:
+            # Skip the real (adapter-driven) before_run body.
+            with mock.patch(
+                "dbt.task.run.RunTask.before_run", return_value=RunStatus.Success
+            ) as mock_super:
+                result = task.before_run(adapter=mock.Mock(), selected_uids=set())
+        assert result == RunStatus.Success
+        mock_super.assert_called_once()
+        return mock_show_hint
+
+    def test_hint_fires_above_threshold(self):
+        nodes = [_model_node() for _ in range(101)]
+        mock_show_hint = self._run_before_run(nodes)
+        mock_show_hint.assert_called_once_with(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
+
+    def test_hint_not_fired_at_threshold(self):
+        nodes = [_model_node() for _ in range(100)]
+        mock_show_hint = self._run_before_run(nodes)
+        mock_show_hint.assert_not_called()
+
+    def test_only_models_counted(self):
+        # 100 models + many tests: still at (not above) the model threshold.
+        nodes = [_model_node() for _ in range(100)] + [_test_node() for _ in range(50)]
+        mock_show_hint = self._run_before_run(nodes)
+        mock_show_hint.assert_not_called()
+
+    def test_no_nodes(self):
+        mock_show_hint = self._run_before_run(None)
+        mock_show_hint.assert_not_called()
 
 
 def test_saved_query_runner_on_skip(saved_query: SavedQuery):

--- a/tests/unit/task/test_build.py
+++ b/tests/unit/task/test_build.py
@@ -20,6 +20,8 @@ class TestBuildReuseRelationsHint:
     def _run_before_run(self, flattened_nodes):
         task = BuildTask.__new__(BuildTask)
         task._flattened_nodes = flattened_nodes
+        # No state/deferral in play, so the hint is eligible on count alone.
+        task.args = mock.Mock(state=None, defer=False, defer_state=None)
         with mock.patch("dbt.task.build.show_hint") as mock_show_hint:
             # Skip the real (adapter-driven) before_run body.
             with mock.patch(

--- a/tests/unit/test_hints.py
+++ b/tests/unit/test_hints.py
@@ -11,11 +11,6 @@ def test_hint_to_msg_map_covers_every_hint_type():
     assert set(hint_to_msg_map) == set(HintType)
 
 
-def test_hint_type_members_are_strings():
-    assert HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS == "reuse_relations_on_too_many_models"
-    assert HintType.LONG_PARSING_WITHOUT_V2_PARSER == "long_parsing_without_v2_parser"
-
-
 class TestShowHint:
     @pytest.fixture
     def mock_fire_event(self):

--- a/tests/unit/test_hints.py
+++ b/tests/unit/test_hints.py
@@ -1,14 +1,106 @@
+import json
+from pathlib import Path
 from unittest import mock
 
 import pytest
 
 from dbt import hints
-from dbt.hints import HINT_PREFIX, HintType, hint_to_msg_map, show_hint
+from dbt.hints import (
+    HINT_COOLDOWN_SECONDS,
+    HINT_PREFIX,
+    HINT_TS_FILENAME,
+    HintType,
+    has_hint_cooldown,
+    hint_to_msg_map,
+    load_hint_ts,
+    record_hint_shown,
+    reset_hint_ts,
+    show_hint,
+)
+
+
+@pytest.fixture(autouse=True)
+def fresh_hint_ts():
+    # The cooldown state is module-global; keep tests isolated from each other.
+    reset_hint_ts()
+    yield
+    reset_hint_ts()
 
 
 def test_hint_to_msg_map_covers_every_hint_type():
-    # Every HintType member must have a message, otherwise show_hint would KeyError.
+    # Every HintType must have a message, otherwise show_hint would KeyError.
     assert set(hint_to_msg_map) == set(HintType)
+
+
+class TestHintCooldown:
+    def test_load_is_empty_when_file_missing(self, tmp_path):
+        assert load_hint_ts(tmp_path) == {}
+
+    def test_load_reads_existing_file(self, tmp_path):
+        (tmp_path / HINT_TS_FILENAME).write_text(json.dumps({"some_hint": 123.0}))
+        assert load_hint_ts(tmp_path) == {"some_hint": 123.0}
+
+    def test_same_path_is_cached_not_reread(self, tmp_path):
+        hint_file = tmp_path / HINT_TS_FILENAME
+        hint_file.write_text(json.dumps({"some_hint": 1.0}))
+        assert load_hint_ts(tmp_path) == {"some_hint": 1.0}
+
+        # Overwrite on disk; a re-load of the same path returns the cached copy.
+        hint_file.write_text(json.dumps({"some_hint": 999.0}))
+        assert load_hint_ts(tmp_path) == {"some_hint": 1.0}
+
+    def test_different_paths_are_cached_separately(self, tmp_path):
+        (tmp_path / HINT_TS_FILENAME).write_text(json.dumps({"a": 1.0}))
+        other = tmp_path / "other"
+        other.mkdir()
+        (other / HINT_TS_FILENAME).write_text(json.dumps({"b": 2.0}))
+
+        assert load_hint_ts(tmp_path) == {"a": 1.0}
+        assert load_hint_ts(other) == {"b": 2.0}
+
+    def test_load_tolerates_corrupt_file(self, tmp_path):
+        (tmp_path / HINT_TS_FILENAME).write_text("{not valid json")
+        assert load_hint_ts(tmp_path) == {}
+
+    def test_no_cooldown_before_load(self):
+        # Never loaded -> nothing is on cooldown, so hints are free to show.
+        assert has_hint_cooldown(HintType.LONG_PARSING_WITHOUT_V2_PARSER) is False
+
+    def test_recent_hint_is_on_cooldown(self, tmp_path):
+        load_hint_ts(tmp_path)
+        record_hint_shown(HintType.LONG_PARSING_WITHOUT_V2_PARSER)
+        assert has_hint_cooldown(HintType.LONG_PARSING_WITHOUT_V2_PARSER) is True
+
+    def test_expired_hint_is_not_on_cooldown(self, tmp_path):
+        stale = {HintType.LONG_PARSING_WITHOUT_V2_PARSER: 0.0}  # epoch => long ago
+        (tmp_path / HINT_TS_FILENAME).write_text(json.dumps(stale))
+        load_hint_ts(tmp_path)
+        assert has_hint_cooldown(HintType.LONG_PARSING_WITHOUT_V2_PARSER) is False
+
+    def test_record_persists_to_disk(self, tmp_path):
+        load_hint_ts(tmp_path)
+        record_hint_shown(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
+
+        on_disk = json.loads((tmp_path / HINT_TS_FILENAME).read_text())
+        assert HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS in on_disk
+        stored = on_disk[HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS]
+        # Persisted as an int (epoch seconds) for cross-compat with the Rust engine.
+        assert isinstance(stored, int)
+        assert stored > 0
+
+    def test_record_is_noop_without_target(self):
+        # Nothing loaded -> nowhere to write, and it must not raise.
+        record_hint_shown(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
+        assert has_hint_cooldown(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS) is False
+
+    def test_record_swallows_write_errors(self, tmp_path, mocker):
+        # A failed write (read-only dir, disk full, ...) must not raise.
+        load_hint_ts(tmp_path)
+        mocker.patch.object(Path, "write_text", side_effect=OSError("read-only"))
+        record_hint_shown(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
+
+    def test_cooldown_window_is_one_week(self):
+        assert HINT_COOLDOWN_SECONDS == 7 * 24 * 60 * 60
 
 
 class TestShowHint:
@@ -51,3 +143,28 @@ class TestShowHint:
 
         mock_fire_event.assert_called_once()
         mock_track_hint_view.assert_called_once()
+
+    def test_skips_when_within_cooldown(self, tmp_path, mock_fire_event, mock_track_hint_view):
+        load_hint_ts(tmp_path)
+        record_hint_shown(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
+        with self._mock_flags(hints_enabled=True):
+            show_hint(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
+
+        mock_fire_event.assert_not_called()
+        mock_track_hint_view.assert_not_called()
+
+    def test_shows_and_records_when_cooldown_expired(
+        self, tmp_path, mock_fire_event, mock_track_hint_view
+    ):
+        # Load a stale timestamp so the hint is eligible again.
+        stale = {HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS: 0.0}
+        (tmp_path / HINT_TS_FILENAME).write_text(json.dumps(stale))
+        load_hint_ts(tmp_path)
+
+        with self._mock_flags(hints_enabled=True):
+            show_hint(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
+
+        mock_fire_event.assert_called_once()
+        mock_track_hint_view.assert_called_once()
+        # The shown hint is now on cooldown again.
+        assert has_hint_cooldown(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS) is True

--- a/tests/unit/test_hints.py
+++ b/tests/unit/test_hints.py
@@ -6,7 +6,6 @@ import pytest
 
 from dbt import hints
 from dbt.hints import (
-    HINT_COOLDOWN_SECONDS,
     HINT_PREFIX,
     HINT_TS_FILENAME,
     HintType,
@@ -98,9 +97,6 @@ class TestHintCooldown:
         load_hint_ts(tmp_path)
         mocker.patch.object(Path, "write_text", side_effect=OSError("read-only"))
         record_hint_shown(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
-
-    def test_cooldown_window_is_one_week(self):
-        assert HINT_COOLDOWN_SECONDS == 7 * 24 * 60 * 60
 
 
 class TestShowHint:

--- a/tests/unit/test_hints.py
+++ b/tests/unit/test_hints.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from dbt import hints
-from dbt.hints import HintType, hint_to_msg_map, show_hint
+from dbt.hints import HINT_PREFIX, HintType, hint_to_msg_map, show_hint
 
 
 def test_hint_to_msg_map_covers_every_hint_type():
@@ -33,7 +33,7 @@ class TestShowHint:
 
         mock_fire_event.assert_called_once()
         note = mock_fire_event.call_args.args[0]
-        assert note.msg == hint_to_msg_map[HintType.LONG_PARSING_WITHOUT_V2_PARSER]
+        assert note.msg == HINT_PREFIX + hint_to_msg_map[HintType.LONG_PARSING_WITHOUT_V2_PARSER]
         mock_track_hint_view.assert_called_once_with(HintType.LONG_PARSING_WITHOUT_V2_PARSER)
 
     def test_does_nothing_when_disabled(self, mock_fire_event, mock_track_hint_view):

--- a/tests/unit/test_hints.py
+++ b/tests/unit/test_hints.py
@@ -1,0 +1,58 @@
+from unittest import mock
+
+import pytest
+
+from dbt import hints
+from dbt.hints import HintType, hint_to_msg_map, show_hint
+
+
+def test_hint_to_msg_map_covers_every_hint_type():
+    # Every HintType member must have a message, otherwise show_hint would KeyError.
+    assert set(hint_to_msg_map) == set(HintType)
+
+
+def test_hint_type_members_are_strings():
+    assert HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS == "reuse_relations_on_too_many_models"
+    assert HintType.LONG_PARSING_WITHOUT_V2_PARSER == "long_parsing_without_v2_parser"
+
+
+class TestShowHint:
+    @pytest.fixture
+    def mock_fire_event(self):
+        with mock.patch.object(hints, "fire_event") as m:
+            yield m
+
+    @pytest.fixture
+    def mock_track_hint_view(self):
+        with mock.patch.object(hints, "track_hint_view") as m:
+            yield m
+
+    def _mock_flags(self, hints_enabled: bool):
+        return mock.patch.object(
+            hints, "get_flags", return_value=mock.Mock(HINTS_ENABLED=hints_enabled)
+        )
+
+    def test_fires_event_and_telemetry_when_enabled(self, mock_fire_event, mock_track_hint_view):
+        with self._mock_flags(hints_enabled=True):
+            show_hint(HintType.LONG_PARSING_WITHOUT_V2_PARSER)
+
+        mock_fire_event.assert_called_once()
+        note = mock_fire_event.call_args.args[0]
+        assert note.msg == hint_to_msg_map[HintType.LONG_PARSING_WITHOUT_V2_PARSER]
+        mock_track_hint_view.assert_called_once_with(HintType.LONG_PARSING_WITHOUT_V2_PARSER)
+
+    def test_does_nothing_when_disabled(self, mock_fire_event, mock_track_hint_view):
+        with self._mock_flags(hints_enabled=False):
+            show_hint(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
+
+        mock_fire_event.assert_not_called()
+        mock_track_hint_view.assert_not_called()
+
+    def test_defaults_to_enabled_when_flag_missing(self, mock_fire_event, mock_track_hint_view):
+        # If HINTS_ENABLED isn't set on the flags object at all, hints still show.
+        flags = mock.Mock(spec=[])  # no HINTS_ENABLED attribute
+        with mock.patch.object(hints, "get_flags", return_value=flags):
+            show_hint(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
+
+        mock_fire_event.assert_called_once()
+        mock_track_hint_view.assert_called_once()

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -103,6 +103,7 @@ class TestTrackHintView:
                 dbt.tracking.track_hint_view("some_hint")
 
         mock_track.assert_called_once()
+        assert mock_track.call_args.kwargs["action"] == "hint_view"
         context = mock_track.call_args.kwargs["context"]
         assert len(context) == 1
         self_describing = context[0].to_json()

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -89,6 +89,27 @@ class TestTracking:
         assert dbt.tracking.active_user.do_not_track != send_anonymous_usage_stats
 
 
+class TestTrackHintView:
+    def test_track_hint_view_no_active_user(self, active_user_none):
+        # Should be a no-op (and not raise) when there is no active user.
+        with mock.patch("dbt.tracking.track") as mock_track:
+            dbt.tracking.track_hint_view("some_hint")
+        mock_track.assert_not_called()
+
+    def test_track_hint_view_sends_event(self):
+        mock_user = mock.Mock(do_not_track=False)
+        with mock.patch("dbt.tracking.active_user", mock_user):
+            with mock.patch("dbt.tracking.track") as mock_track:
+                dbt.tracking.track_hint_view("some_hint")
+
+        mock_track.assert_called_once()
+        context = mock_track.call_args.kwargs["context"]
+        assert len(context) == 1
+        self_describing = context[0].to_json()
+        assert self_describing["schema"] == dbt.tracking.HINT_VIEW_SPEC
+        assert self_describing["data"] == {"hint_type": "some_hint"}
+
+
 class TestCompileStatsTracking:
     def test_generate_stats_includes_catalog_count(self) -> None:
         mock_manifest = mock.MagicMock()


### PR DESCRIPTION
Resolves #15510

### Problem

We want to surface occasional, non-blocking **hints** that point users toward ways to optimize their dbt projects (with links to the relevant docs). Users also need a way to opt out.

### Solution

Adds a lightweight hints system to dbt-core.

**New `hints_enabled` flag (default `true`)**
- CLI: `--hints-enabled/--no-hints-enabled`, env var `DBT_ENGINE_HINTS_ENABLED`.
- Configurable via `flags:` in `dbt_project.yml`:
  ```yaml
  flags:
    hints_enabled: true  # default true; set false to silence hints
  ```
- Added to `get_flag_dict()` so it shows up in `MainReportArgs` telemetry.

**New `dbt/hints.py`**
- `HintType` (a `StrEnum`) enumerates the hint identifiers.
- `hint_to_msg_map` maps each `HintType` to its user-facing message.
- `show_hint(hint_type)` is the single entry point: it no-ops when `hints_enabled` is off, otherwise emits the message as a `Note` event (INFO level, not a warning) and records a telemetry event.

**Hints implemented**
- `reuse_relations_on_too_many_models` — fired from `BuildTask.before_run` when a `dbt build` selects more than 100 models. Points at `docs.getdbt.com/docs/optimizing-builds`.
- `long_parsing_without_v2_parser` — fired after manifest load when parsing takes ≥ 5 minutes and `--use-v2-parser` is off. Points at the v2 (rust) parser docs.

**Telemetry**
- New `HintView { hint_type }` Snowplow event via `track_hint_view` in `core/dbt/tracking.py` (schema `iglu:com.dbt/hint_view/jsonschema/1-0-0`), so we can measure how many users see each hint.

### Notes for reviewers
- Docs links / final copy still to be confirmed by @reubenmc per the issue.
- Backports required: `1.12.latest`, `1.13.latest`
- First merge: https://github.com/dbt-labs/iglu.sinter-collect.com/pull/103

<img width="1704" height="193" alt="image" src="https://github.com/user-attachments/assets/5fb5a985-c22e-492d-9c41-879672b06aa9" />


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
