### PR TITLE
Sync dbt-redshift bundled macros with upstream dbt-adapters

### DIFF
--- a/.changes/unreleased/Under the Hood-20260711-093000.yaml
+++ b/.changes/unreleased/Under the Hood-20260711-093000.yaml
@@ -2,6 +2,6 @@ kind: Under the Hood
 body: Sync dbt-redshift bundled macros with upstream dbt-adapters, including extended grants support, alter_column_type, and catalog metadata helpers.
 time: 2026-07-11T09:30:00.000000+05:30
 custom:
-    author: kpandey
+    author: kunalpandey1
     issue: "15467"
     project: dbt-fusion

--- a/.changes/unreleased/Under the Hood-20260711-093000.yaml
+++ b/.changes/unreleased/Under the Hood-20260711-093000.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Sync dbt-redshift bundled macros with upstream dbt-adapters, including extended grants support, alter_column_type, and catalog metadata helpers.
+time: 2026-07-11T09:30:00.000000+05:30
+custom:
+    author: kpandey
+    issue: "15467"
+    project: dbt-fusion

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -217,6 +217,53 @@ pub(crate) fn redshift_has_feature(
     }
 }
 
+fn warn_unrecognized_has_feature(adapter_type: AdapterType, name: &str) {
+    emit_warn_log_message(
+        ErrorCode::InvalidArgument,
+        format!(
+            "Unrecognized feature: {name} for {adapter_type} adapter"
+        ),
+        None,
+    );
+}
+
+fn resolve_has_feature(
+    adapter: &AdapterImpl,
+    state: &State,
+    name: &str,
+    token: CancellationToken,
+) -> AdapterResult<Option<bool>> {
+    let is_motherduck = |engine: &dyn AdapterEngine| {
+        engine
+            .config("path")
+            .map(|p| dbt_auth::is_motherduck_path(&p))
+            .unwrap_or(false)
+    };
+
+    match (adapter.adapter_type(), name) {
+        (DuckDB, "motherduck") => Ok(Some(is_motherduck(adapter.engine().as_ref()))),
+        (DuckDB, "transactions") => Ok(Some(!is_motherduck(adapter.engine().as_ref()))),
+        // Assume that all other adapters support transactions for now.
+        (_, "transactions") => Ok(Some(true)),
+        (Redshift, name) => match redshift_has_feature(adapter.engine().as_ref(), name)? {
+            Some(value) => Ok(Some(value)),
+            None => {
+                warn_unrecognized_has_feature(adapter.adapter_type(), name);
+                Ok(None)
+            }
+        },
+        (Databricks, _) => {
+            let mut conn = adapter.borrow_tlocal_connection(Some(state), node_id_from_state(state))?;
+            let has_capability = adapter.has_dbr_capability(state, conn.as_mut(), name, token)?;
+            Ok(Some(has_capability))
+        }
+        _ => {
+            warn_unrecognized_has_feature(adapter.adapter_type(), name);
+            Ok(None)
+        }
+    }
+}
+
 pub fn quote_ident(adapter_type: AdapterType, identifier: &str) -> String {
     let q = dbt_adapter_core::quote_char(adapter_type);
     format!("{q}{identifier}{q}")
@@ -1557,58 +1604,7 @@ impl AdapterImpl {
         name: &str,
         token: CancellationToken,
     ) -> AdapterResult<Option<bool>> {
-        // PRE-CONDITION: adapter_type is DuckDB
-        let is_motherduck = |engine: &dyn AdapterEngine| {
-            engine
-                .config("path")
-                .map(|p| dbt_auth::is_motherduck_path(&p))
-                .unwrap_or(false)
-        };
-
-        match (self.adapter_type(), name) {
-            (DuckDB, "motherduck") => Ok(Some(is_motherduck(self.engine().as_ref()))),
-            (DuckDB, "transactions") => {
-                // MotherDuck does not support explicit transactions
-                Ok(Some(!is_motherduck(self.engine().as_ref())))
-            }
-            // Assume that all other adapters support transactions for now.
-            (_, "transactions") => Ok(Some(true)),
-            (Redshift, name) => match redshift_has_feature(self.engine().as_ref(), name)? {
-                Some(value) => Ok(Some(value)),
-                None => {
-                    emit_warn_log_message(
-                        ErrorCode::InvalidArgument,
-                        format!(
-                            "Unrecognized feature: {} for {} adapter",
-                            name,
-                            self.adapter_type()
-                        ),
-                        None,
-                    );
-                    Ok(None)
-                }
-            },
-            (Databricks, _) => {
-                let mut conn =
-                    self.borrow_tlocal_connection(Some(state), node_id_from_state(state))?;
-                let has_capability = self.has_dbr_capability(state, conn.as_mut(), name, token)?;
-                Ok(Some(has_capability))
-            }
-            _ => {
-                emit_warn_log_message(
-                    ErrorCode::InvalidArgument,
-                    format!(
-                        "Unrecognized feature: {} for {} adapter",
-                        name,
-                        self.adapter_type()
-                    ),
-                    None,
-                );
-                // None is falsy, so features should be named in such a way that
-                // `false` is the most reasonable assumption.
-                Ok(None)
-            }
-        }
+        resolve_has_feature(self, state, name, token)
     }
 
     /// Returns a dict with database/schema/identifier for temp tables on MotherDuck.

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -1561,6 +1561,13 @@ impl AdapterImpl {
                 self.engine().as_ref(),
                 "drop_without_cascade",
             )?)),
+            (Redshift, "grants_extended") => Ok(Some(
+                self.engine()
+                    .behavior_flag_overrides()
+                    .get("redshift_grants_extended")
+                    .copied()
+                    .unwrap_or(false),
+            )),
             (Databricks, _) => {
                 let mut conn =
                     self.borrow_tlocal_connection(Some(state), node_id_from_state(state))?;
@@ -4714,7 +4721,24 @@ pub(crate) fn adapter_specific_behavior_flags(adapter_type: AdapterType) -> Vec<
             vec![flag]
         }
         Postgres | Redshift | Salesforce | Spark | DuckDB | Fdcs | ClickHouse | Exasol
-        | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => vec![],
+        | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
+            if adapter_type == Redshift {
+                let redshift_grants_extended = BehaviorFlag::new(
+                    "redshift_grants_extended",
+                    false,
+                    Some(
+                        "Enable groups and roles support in dbt grants config. \
+                         When enabled, grantee names must use 'user:', 'group:', or 'role:' prefixes. \
+                         Unprefixed entries are treated as users for backward compatibility.",
+                    ),
+                    None,
+                    None,
+                );
+                vec![redshift_grants_extended]
+            } else {
+                vec![]
+            }
+        }
     }
 }
 
@@ -5621,6 +5645,21 @@ mod tests {
             .has_feature(&state, "datasharing", CancellationToken::never_cancels())
             .unwrap();
         assert_eq!(result, Some(true));
+    }
+
+    #[test]
+    fn test_has_feature_grants_extended_false_by_default() {
+        let env = Environment::new();
+        let state = State::new_for_env(&env);
+        let adapter = AdapterImpl::new(engine(Redshift), None);
+        let result = adapter
+            .has_feature(
+                &state,
+                "grants_extended",
+                CancellationToken::never_cancels(),
+            )
+            .unwrap();
+        assert_eq!(result, Some(false));
     }
 
     #[test]

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -197,6 +197,26 @@ pub(crate) fn get_bool_config(engine: &dyn AdapterEngine, key: &str) -> AdapterR
         .map_err(|e| AdapterError::new(AdapterErrorKind::Configuration, e.to_string()))
 }
 
+/// Redshift-specific features exposed to macros via `adapter.has_feature()`.
+/// Returns `None` when `name` is not a recognized Redshift feature.
+pub(crate) fn redshift_has_feature(
+    engine: &dyn AdapterEngine,
+    name: &str,
+) -> AdapterResult<Option<bool>> {
+    match name {
+        "datasharing" => Ok(Some(get_bool_config(engine, "datasharing")?)),
+        "drop_without_cascade" => Ok(Some(get_bool_config(engine, "drop_without_cascade")?)),
+        "grants_extended" => Ok(Some(
+            engine
+                .behavior_flag_overrides()
+                .get("redshift_grants_extended")
+                .copied()
+                .unwrap_or(false),
+        )),
+        _ => Ok(None),
+    }
+}
+
 pub fn quote_ident(adapter_type: AdapterType, identifier: &str) -> String {
     let q = dbt_adapter_core::quote_char(adapter_type);
     format!("{q}{identifier}{q}")
@@ -1553,21 +1573,21 @@ impl AdapterImpl {
             }
             // Assume that all other adapters support transactions for now.
             (_, "transactions") => Ok(Some(true)),
-            (Redshift, "datasharing") => Ok(Some(get_bool_config(
-                self.engine().as_ref(),
-                "datasharing",
-            )?)),
-            (Redshift, "drop_without_cascade") => Ok(Some(get_bool_config(
-                self.engine().as_ref(),
-                "drop_without_cascade",
-            )?)),
-            (Redshift, "grants_extended") => Ok(Some(
-                self.engine()
-                    .behavior_flag_overrides()
-                    .get("redshift_grants_extended")
-                    .copied()
-                    .unwrap_or(false),
-            )),
+            (Redshift, name) => match redshift_has_feature(self.engine().as_ref(), name)? {
+                Some(value) => Ok(Some(value)),
+                None => {
+                    emit_warn_log_message(
+                        ErrorCode::InvalidArgument,
+                        format!(
+                            "Unrecognized feature: {} for {} adapter",
+                            name,
+                            self.adapter_type()
+                        ),
+                        None,
+                    );
+                    Ok(None)
+                }
+            },
             (Databricks, _) => {
                 let mut conn =
                     self.borrow_tlocal_connection(Some(state), node_id_from_state(state))?;

--- a/crates/dbt-loader/src/dbt_macro_assets/README.md
+++ b/crates/dbt-loader/src/dbt_macro_assets/README.md
@@ -5,6 +5,9 @@ All adapter macros are currently maintained in:
 
 ## Changelog
 
+### [2026-07-11]
+  - dbt-redshift: sync macros from dbt-labs/dbt-adapters (commit a045dfae0185796010bea1a97092cbe6a5f4128b)
+
 ### [2026-03-04]
   - dbt-databricks: v1.11.5 (commit 24325a3195171d36972804e545b2ccf967ab575d)
 

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-redshift/macros/adapters.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-redshift/macros/adapters.sql
@@ -1,6 +1,9 @@
 
 {% macro dist(dist) %}
   {%- if dist is not none -%}
+      {%- if dist is not string -%}
+        {% do exceptions.raise_compiler_error("The 'dist' config must be a single value (e.g. dist: primary_key), not a list or other type. Redshift distribution key accepts only one column or one of: all, even, auto.") %}
+      {%- endif -%}
       {%- set dist = dist.strip().lower() -%}
 
       {%- if dist in ['all', 'even'] -%}
@@ -283,30 +286,71 @@
 {% endmacro %}
 
 {% macro redshift__list_relations_without_caching(schema_relation) %}
-
-  {% call statement('list_relations_without_caching', fetch_result=True) -%}
-    select
+  {#- DIVERGENCE: v2 routes list_relations_without_caching through native Rust when
+      datasharing is enabled. Preserve the v1 SHOW path for 1.x handoff only. -#}
+  {%- if not dbt_version.startswith('2.') and redshift__use_show_apis() -%}
+    {% call statement('show_tables', fetch_result=True) -%}
+      SHOW TABLES FROM SCHEMA {{ adapter.quote(schema_relation.database) }}.{{ adapter.quote(schema_relation.schema) }}
+    {% endcall %}
+    {% set show_result = load_result('show_tables').table %}
+    {% set table_and_view_relations = adapter.transform_show_tables_for_list_relations(show_result) %}
+    {% set function_relations = redshift__list_function_relations_without_caching(schema_relation) %}
+    {{ return(adapter.combine_show_tables_and_function_relations(table_and_view_relations, function_relations)) }}
+  {%- else -%}
+    {% call statement('list_relations_without_caching', fetch_result=True) -%}
+      select
         table_catalog as database,
         table_name as name,
         table_schema as schema,
         'table' as type
-    from information_schema.tables
-    where table_schema ilike '{{ schema_relation.schema }}'
-    and table_type = 'BASE TABLE'
-    union all
-    select
-      table_catalog as database,
-      table_name as name,
-      table_schema as schema,
-      case
-        when view_definition ilike '%create materialized view%'
-          then 'materialized_view'
-        else 'view'
-      end as type
-    from information_schema.views
-    where table_schema ilike '{{ schema_relation.schema }}'
+      from information_schema.tables
+      where table_schema ilike '{{ schema_relation.schema }}'
+      and table_type = 'BASE TABLE'
+      union all
+      select
+        table_catalog as database,
+        table_name as name,
+        table_schema as schema,
+        case
+          when view_definition ilike '%create materialized view%'
+            then 'materialized_view'
+          else 'view'
+        end as type
+      from information_schema.views
+      where table_schema ilike '{{ schema_relation.schema }}'
+      union all
+      select distinct
+        '{{ schema_relation.database }}' as database,
+        proname as name,
+        ns.nspname as schema,
+        'function' as type
+      from pg_proc
+      join pg_namespace as ns on pronamespace = ns.oid
+      where ns.nspname ilike '{{ schema_relation.schema }}'
+    {% endcall %}
+    {{ return(load_result('list_relations_without_caching').table) }}
+  {%- endif -%}
+{% endmacro %}
+
+
+{% macro redshift__list_function_relations_without_caching(schema_relation) %}
+  {#
+    There is no SHOW API equivalent for functions in Redshift (unlike `SHOW TABLES FROM SCHEMA`),
+    so we always use pg_proc regardless of the `use_show_apis` flag. This is safe because
+    Redshift datasharing does not support sharing UDFs or stored procedures across databases,
+    meaning functions are always local to the current database.
+  #}
+  {% call statement('list_function_relations_without_caching', fetch_result=True) -%}
+    select distinct
+      '{{ schema_relation.database }}' as database,
+      proname::varchar as name,
+      ns.nspname::varchar as schema,
+      'function' as type
+    from pg_proc
+    join pg_namespace as ns on pronamespace = ns.oid
+    where ns.nspname ilike '{{ schema_relation.schema }}'
   {% endcall %}
-  {{ return(load_result('list_relations_without_caching').table) }}
+  {{ return(load_result('list_function_relations_without_caching').table) }}
 {% endmacro %}
 
 {% macro redshift__information_schema_name(database) -%}
@@ -338,9 +382,20 @@
   {% endif %}
 {% endmacro %}
 
-{% macro redshift__check_schema_exists(information_schema, schema) -%}
-  {{ return(postgres__check_schema_exists(information_schema, schema)) }}
-{%- endmacro %}
+{% macro redshift__check_schema_exists(information_schema, schema) %}
+  {% if redshift__use_show_apis() %}
+    {% call statement('check_schema_exists', fetch_result=True) -%}
+      SHOW SCHEMAS FROM DATABASE {{ adapter.quote(information_schema.database) }}
+      LIKE '{{ schema }}'
+    {% endcall %}
+    {%- set table = load_result('check_schema_exists').table -%}
+
+    {# We return list of list because the base adapter expects column count #}
+    {{ return([[table.rows | length]]) }}
+  {% else %}
+    {{ return(postgres__check_schema_exists(information_schema, schema)) }}
+  {% endif %}
+{% endmacro %}
 
 
 {% macro redshift__persist_docs(relation, model, for_relation, for_columns) -%}
@@ -386,13 +441,41 @@
 {% endmacro %}
 
 
+{% macro redshift__alter_column_type(relation, column_name, new_column_type) -%}
+  {#
+    Redshift ALTER COLUMN TYPE only supports VARCHAR and VARBYTE (size changes).
+    For those, use native ALTER; for any other type change, fall back to
+    default add/copy/drop/rename.
+
+    The native ALTER TABLE ALTER COLUMN cannot run inside a transaction block.
+    It is only safe to use when `redshift_skip_autocommit_transaction_statements`
+    is enabled (i.e. we are not wrapping statements in BEGIN/COMMIT).
+    When the flag is off, always use the default migration path.
+  #}
+  {% set type_lower = (new_column_type | lower) | trim %}
+  {#- DIVERGENCE: Fusion always skips autocommit transaction wrapping for Redshift. -#}
+  {% if dbt_version.startswith('2.') %}
+    {% set skip_txn = true %}
+  {% else %}
+    {% set skip_txn = adapter.behavior.redshift_skip_autocommit_transaction_statements.no_warn %}
+  {% endif %}
+  {% if skip_txn and (type_lower[:7] == 'varchar' or type_lower[:17] == 'character varying' or type_lower[:7] == 'varbyte') %}
+    {% call statement('alter_column_type') %}
+      alter table {{ relation.render() }} alter column {{ adapter.quote(column_name) }} type {{ new_column_type }}
+    {% endcall %}
+  {% else %}
+    {{ default__alter_column_type(relation, column_name, new_column_type) }}
+  {% endif %}
+{% endmacro %}
+
+
 {% macro redshift__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}
 
   {% if add_columns %}
 
     {% for column in add_columns %}
       {% set sql -%}
-          alter {{ relation.type }} {{ relation }} add column {{ column.name }} {{ column.data_type }}
+          alter {{ relation.type }} {{ relation }} add column {{ column.quoted }} {{ column.data_type }}
       {% endset %}
       {% do run_query(sql) %}
     {% endfor %}
@@ -403,11 +486,19 @@
 
     {% for column in remove_columns %}
       {% set sql -%}
-          alter {{ relation.type }} {{ relation }} drop column {{ column.name }}
+          alter {{ relation.type }} {{ relation }} drop column {{ column.quoted }}
       {% endset %}
       {% do run_query(sql) %}
     {% endfor %}
 
   {% endif %}
 
+{% endmacro %}
+
+
+{% macro redshift__show_tables_from_schema(database, schema) %}
+    {%- call statement('show_tables', fetch_result=True) -%}
+        SHOW TABLES FROM SCHEMA {{ adapter.quote(database) }}.{{ adapter.quote(schema) }}
+    {%- endcall -%}
+    {{ return(load_result('show_tables')) }}
 {% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-redshift/macros/adapters/apply_grants.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-redshift/macros/adapters/apply_grants.sql
@@ -1,12 +1,67 @@
-{% macro redshift__get_show_grant_sql(relation) %}
-  {#- DIVERGENCE BEGIN: upstream uses redshift__use_show_apis(); Fusion uses adapter.has_feature("datasharing") -#}
-  {% if adapter.has_feature("datasharing") %}
-  {#- DIVERGENCE END -#}
-    SHOW GRANTS ON TABLE {{ adapter.quote(relation.database) }}.{{ adapter.quote(relation.schema) }}.{{ adapter.quote(relation.identifier) }}
-  {% else %}
-    with privileges as (
+{#-- Normalize a grants config dict by adding 'user:' prefix to unprefixed entries --#}
+{% macro redshift__normalize_grants_dict(grants_dict) %}
+    {%- set normalized = {} -%}
+    {%- for privilege, grantees in grants_dict.items() -%}
+        {%- set normalized_grantees = [] -%}
+        {%- for grantee in grantees -%}
+            {%- if grantee.startswith('group:') or grantee.startswith('role:') or grantee.startswith('user:') -%}
+                {%- do normalized_grantees.append(grantee) -%}
+            {%- else -%}
+                {#-- Unprefixed = user, add prefix for consistent comparison --#}
+                {%- do normalized_grantees.append('user:' ~ grantee) -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {%- do normalized.update({privilege: normalized_grantees}) -%}
+    {%- endfor -%}
+    {{ return(normalized) }}
+{% endmacro %}
 
-        -- valid options per https://docs.aws.amazon.com/redshift/latest/dg/r_HAS_TABLE_PRIVILEGE.html
+
+{#-- Override apply_grants to normalize config before delegating to default --#}
+{% macro redshift__apply_grants(relation, grant_config, should_revoke=True) %}
+    {% if grant_config %}
+        {% if redshift__use_grants_extended() %}
+            {% set normalized_grant_config = redshift__normalize_grants_dict(grant_config) %}
+            {{ default__apply_grants(relation, normalized_grant_config, should_revoke) }}
+        {% else %}
+            {{ default__apply_grants(relation, grant_config, should_revoke) }}
+        {% endif %}
+    {% endif %}
+{% endmacro %}
+
+
+{% macro redshift__get_show_grant_sql(relation) %}
+  {% if redshift__use_show_apis() %}
+{#-
+    Use SHOW GRANTS for cross-database support (required for RA3/datasharing).
+    Note: SHOW GRANTS conflates groups and roles — groups appear with a '/'
+    prefix on identity_name and identity_type='role'. The standardize_grants_dict
+    method in RedshiftAdapter handles this translation.
+-#}
+    SHOW GRANTS ON TABLE {{ adapter.quote(relation.database) }}.{{ adapter.quote(relation.schema) }}.{{ adapter.quote(relation.identifier) }}
+  {% elif redshift__use_grants_extended() %}
+{#-
+    Use svv_relation_privileges for same-database grants. This view correctly
+    distinguishes users, groups, and roles via the identity_type column.
+    Requires superuser or SYSLOG ACCESS UNRESTRICTED for full visibility.
+    Does NOT support cross-database references.
+-#}
+    select
+        identity_name,
+        identity_type,
+        privilege_type
+    from svv_relation_privileges
+    where namespace_name = '{{ relation.schema }}'
+      and relation_name = '{{ relation.identifier }}'
+      and not (identity_type = 'user' and identity_name = current_user)
+  {% else %}
+{#-
+    Legacy path: query pg_user with has_table_privilege(). Only detects user
+    grants; groups and roles are not visible. Returns a 'grantee' column
+    compatible with the base standardize_grants_dict implementation.
+-#}
+    with privileges as (
+         -- valid options per https://docs.aws.amazon.com/redshift/latest/dg/r_HAS_TABLE_PRIVILEGE.html
         select 'select' as privilege_type
         union all
         select 'insert' as privilege_type
@@ -16,9 +71,7 @@
         select 'delete' as privilege_type
         union all
         select 'references' as privilege_type
-
     )
-
     select
         u.usename as grantee,
         p.privilege_type
@@ -28,4 +81,41 @@
         and u.usename != current_user
         and not u.usesuper
   {% endif %}
+{% endmacro %}
+
+
+{#-- Format prefixed grantees into Redshift SQL syntax --#}
+{% macro redshift__format_grantees(grantees) %}
+    {%- set formatted = [] -%}
+    {%- for grantee in grantees -%}
+        {%- if grantee.startswith('group:') -%}
+            {%- do formatted.append('GROUP ' ~ grantee[6:]) -%}
+        {%- elif grantee.startswith('role:') -%}
+            {%- do formatted.append('ROLE ' ~ grantee[5:]) -%}
+        {%- elif grantee.startswith('user:') -%}
+            {%- do formatted.append(grantee[5:]) -%}
+        {%- else -%}
+            {%- do formatted.append(grantee) -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{ return(formatted) }}
+{% endmacro %}
+
+
+{% macro redshift__get_grant_sql(relation, privilege, grantees) %}
+    {% if redshift__use_grants_extended() %}
+        {%- set formatted_grantees = redshift__format_grantees(grantees) -%}
+        grant {{ privilege }} on {{ relation.render() }} to {{ formatted_grantees | join(', ') }}
+    {% else %}
+        {{ default__get_grant_sql(relation, privilege, grantees) }}
+    {% endif %}
+{% endmacro %}
+
+{% macro redshift__get_revoke_sql(relation, privilege, grantees) %}
+    {% if redshift__use_grants_extended() %}
+        {%- set formatted_grantees = redshift__format_grantees(grantees) -%}
+        revoke {{ privilege }} on {{ relation.render() }} from {{ formatted_grantees | join(', ') }}
+    {% else %}
+        {{ default__get_revoke_sql(relation, privilege, grantees) }}
+    {% endif %}
 {% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-redshift/macros/catalog/by_relation.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-redshift/macros/catalog/by_relation.sql
@@ -17,13 +17,13 @@
         {% set catalog = _redshift__get_base_catalog_by_relation(dbschema.database, relations) %}
     {% endif %}
 
-    {#% set select_extended = redshift__can_select_from('svv_table_info') %#}
-    {#% if select_extended %#}
-        {#% set extended_catalog = _redshift__get_extended_catalog_by_relation(relations) %#}
-        {#% set catalog = catalog.join(extended_catalog, ['table_schema', 'table_name']) %#}
-    {#% else %#}
-        {#{ redshift__no_svv_table_info_warning() }#}
-    {#% endif %#}
+    {% set select_extended = redshift__can_select_from('svv_table_info') %}
+    {% if select_extended %}
+        {% set extended_catalog = _redshift__get_extended_catalog_by_relation(relations) %}
+        {% set catalog = catalog.join(extended_catalog, ['table_schema', 'table_name']) %}
+    {% else %}
+        {{ redshift__no_svv_table_info_warning() }}
+    {% endif %}
 
     {{ return(catalog) }}
 

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-redshift/macros/catalog/by_schema.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-redshift/macros/catalog/by_schema.sql
@@ -17,13 +17,13 @@
     {% endif %}
 
 
-    {#% set select_extended = redshift__can_select_from('svv_table_info') %#}
-    {#% if select_extended %#}
-        {#% set extended_catalog = _redshift__get_extended_catalog_by_schema(schemas) %#}
-        {#% set catalog = catalog.join(extended_catalog, ['table_schema', 'table_name']) %#}
-    {#% else %#}
-        {#{ redshift__no_svv_table_info_warning() }#}
-    {#% endif %#}
+    {% set select_extended = redshift__can_select_from('svv_table_info') %}
+    {% if select_extended %}
+        {% set extended_catalog = _redshift__get_extended_catalog_by_schema(schemas) %}
+        {% set catalog = catalog.join(extended_catalog, ['table_schema', 'table_name']) %}
+    {% else %}
+        {{ redshift__no_svv_table_info_warning() }}
+    {% endif %}
 
     {{ return(catalog) }}
 

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-redshift/macros/materializations/incremental_merge.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-redshift/macros/materializations/incremental_merge.sql
@@ -1,18 +1,5 @@
 {% macro redshift__get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) -%}
-    {%- set predicates = [] -%}
-    {% if incremental_predicates is not none %}
-        {%- set incremental_predicates_list = [] + incremental_predicates -%}
-        {%- for pred in incremental_predicates_list -%}
-            {% if "DBT_INTERNAL_DEST." in pred %}
-                {%- set pred =  pred | replace("DBT_INTERNAL_DEST.", target ~ "." ) -%}
-            {% endif %}
-            {% if "dbt_internal_dest." in pred %}
-                {%- set pred =  pred | replace("dbt_internal_dest.", target ~ "." ) -%}
-            {% endif %}
-            {% do predicates.append(pred) %}
-        {% endfor %}
-    {% endif %}
-
+    {%- set predicates = _update_predicates(target, incremental_predicates) -%}
     {%- set merge_update_columns = config.get('merge_update_columns') -%}
     {%- set merge_exclude_columns = config.get('merge_exclude_columns') -%}
     {%- set update_columns = get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) -%}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-redshift/macros/metadata/helpers.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-redshift/macros/metadata/helpers.sql
@@ -1,0 +1,24 @@
+{#- Feature helpers bridging v1 adapter methods and v2 Fusion has_feature API. -#}
+{% macro redshift__use_show_apis() %}
+  {%- if dbt_version.startswith('2.') -%}
+    {{ return(adapter.has_feature("datasharing")) }}
+  {%- else -%}
+    {{ return(adapter.use_show_apis()) }}
+  {%- endif -%}
+{% endmacro %}
+
+{% macro redshift__use_grants_extended() %}
+  {%- if dbt_version.startswith('2.') -%}
+    {{ return(adapter.has_feature("grants_extended")) }}
+  {%- else -%}
+    {{ return(adapter.use_grants_extended()) }}
+  {%- endif -%}
+{% endmacro %}
+
+{% macro redshift__drop_without_cascade() %}
+  {%- if dbt_version.startswith('2.') -%}
+    {{ return(adapter.has_feature("drop_without_cascade")) }}
+  {%- else -%}
+    {{ return(adapter.drop_without_cascade()) }}
+  {%- endif -%}
+{% endmacro %}

--- a/crates/dbt-loader/src/dbt_macro_assets/dbt-redshift/macros/relations/materialized_view/describe.sql
+++ b/crates/dbt-loader/src/dbt_macro_assets/dbt-redshift/macros/relations/materialized_view/describe.sql
@@ -24,6 +24,11 @@
     {%- endset %}
     {% set _materialized_view = run_query(_materialized_view_sql) %}
 
+    {#-
+        Query the internal MV storage table (mv_tbl__<name>__*) for distkey/sortkey info.
+        Redshift stores MV data in this internal table, so we need to query pg_attribute
+        on this table to get the distribution and sort key configuration.
+    -#}
     {%- set _column_descriptor_sql -%}
         SELECT
             a.attname as column,


### PR DESCRIPTION
Closes #15467

### Problem

Bundled Redshift macros in dbt-core v2 (`crates/dbt-loader/src/dbt_macro_assets/dbt-redshift/`) have drifted from upstream v1 macros in `dbt-labs/dbt-adapters` (`dbt-redshift/src/dbt/include/redshift/macros/`). Both runtimes need to behave consistently on Redshift, but the two copies evolve independently:

- v1 receives adapter fixes (extended grants, catalog metadata, schema checks, column alter paths, etc.)
- v2 adds Fusion-specific behavior (`adapter.has_feature`, native Rust listing, intentional view/MV divergences)

Without periodic catch-up, v2 users miss v1 parity fixes or hit subtle behavioral differences on Redshift.

**Upstream baseline:** `dbt-labs/dbt-adapters` @ `a045dfae0185796010bea1a97092cbe6a5f4128b`

### Solution

Sync v2 bundled Redshift macros with upstream v1, preserving documented v2 divergences.

#### New: `metadata/helpers.sql`

Bridge macros so the same templates work under v1 (Python adapter methods) and v2 (Rust `has_feature`):

- `redshift__use_show_apis()` → v1: `adapter.use_show_apis()` / v2: `adapter.has_feature("datasharing")`
- `redshift__use_grants_extended()` → v1: `adapter.use_grants_extended()` / v2: `adapter.has_feature("grants_extended")`
- `redshift__drop_without_cascade()` → v1: `adapter.drop_without_cascade()` / v2: `adapter.has_feature("drop_without_cascade")`

#### `adapters/apply_grants.sql` (major sync)

Port full upstream extended grants support:

- `redshift__normalize_grants_dict` — prefix unprefixed grantees with `user:`
- `redshift__apply_grants` — normalize config when extended grants enabled
- Three-tier `redshift__get_show_grant_sql`: SHOW GRANTS (datasharing) → `svv_relation_privileges` (extended) → legacy `pg_user` path
- `redshift__format_grantees`, `redshift__get_grant_sql`, `redshift__get_revoke_sql` — GROUP/ROLE/user SQL formatting

#### `adapters.sql`

- **`dist` validation** — compiler error if `dist` is not a string (Redshift accepts only one dist key)
- **`redshift__list_relations_without_caching`** — include UDF/function relations via `pg_proc`; preserve v1 SHOW TABLES path for 1.x handoff only
- **`redshift__list_function_relations_without_caching`** — new helper macro (upstream parity)
- **`redshift__check_schema_exists`** — SHOW SCHEMAS path when datasharing enabled (was always postgres fallback)
- **`redshift__alter_column_type`** — native VARCHAR/VARBYTE alter when safe; v2 always skips autocommit txn wrapping
- **`redshift__alter_relation_add_remove_columns`** — use `column.quoted` instead of `column.name` (upstream parity)
- **`redshift__show_tables_from_schema`** — new helper for catalog SHOW TABLES path

#### Catalog macros

- **`catalog/by_relation.sql`** and **`catalog/by_schema.sql`** — re-enable `svv_table_info` extended catalog join (was commented out in v2)

#### Other macro sync

- **`materializations/incremental_merge.sql`** — use shared `_update_predicates` helper (upstream refactor)
- **`relations/materialized_view/describe.sql`** — restore upstream comment explaining internal MV storage table query

#### Rust adapter (`adapter_impl.rs`)

- Register `redshift_grants_extended` behavior flag (default `false`)
- Add `has_feature("grants_extended")` for Redshift so macros can gate extended grants in v2
- Add unit test `test_has_feature_grants_extended_false_by_default`

#### Documentation / changelog

- Update `dbt_macro_assets/README.md` with sync commit SHA
- Add changie entry: `.changes/unreleased/Under the Hood-20260711-093000.yaml`

### Intentional v2 divergences preserved (not reverted)

| Area | v1 (upstream) | v2 (kept) |
|------|---------------|-----------|
| View materialization | Safe-swap rename + drop | `CREATE OR REPLACE VIEW` |
| MV create | `materialized_view.query` | `sql` (Fusion renders SQL directly) |
| MV alter | `autorefresh.context` | bool `autorefresh` |
| Drop CASCADE | `redshift__drop_without_cascade()` | `dbt_version` + `has_feature('drop_without_cascade')` |
| `list_relations_without_caching` | SHOW path when datasharing | SHOW path only for 1.x handoff; v2 uses native Rust listing |
| `list_schemas` return format | Transformed list-of-lists | Raw SHOW batch (Rust parses `schema_name`) |
| Catalog macro signature | `information_schema` param | `dbschema` param |
| Feature gating in schema/column macros | `redshift__use_show_apis()` via helpers | Existing `DIVERGENCE` blocks with `has_feature` + `dbt_version` guards retained |

### Test plan

- [x] `cargo test -p dbt-adapter test_has_feature`
- [x] `cargo test -p dbt-adapter redshift` (29 tests)
- [x] `cargo test -p dbt-loader` (78 tests, includes Redshift view materialization macros)
- [ ] CI green on PR

No live Redshift cluster required for these tests (unit/macro harness).

Per #15467, additional macro tests deferred to adapter maintainers unless CI/request changes.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR. _(Existing adapter/loader tests; no new macro test files per issue scope.)_
- [ ] This PR has no interface changes … _(N/A — this PR updates bundled adapter macros and `has_feature` surface.)_
- [ ] This PR includes type annotations for new and modified functions. _(N/A — Rust + Jinja macros.)_