### PR TITLE
Parsing Performance Improvements

### DIFF
--- a/.changes/unreleased/Under the Hood-20260713-205628.yaml
+++ b/.changes/unreleased/Under the Hood-20260713-205628.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Reduce parse-time memory and macro-generation overhead by virtualizing macros and switching flat_graph/WritableManifest to lazy no-copy views
+time: 2026-07-13T20:56:28.287883+05:30
+custom:
+    Author: peterallenwebb ash2shukla
+    Issue: ' '

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -149,12 +149,12 @@ class Var:
 
     def __init__(
         self,
-        context: Mapping[str, Any],
+        context: BaseContext,
         cli_vars: Mapping[str, Any],
         node: Optional[Resource] = None,
         require_vars: bool = True,
     ) -> None:
-        self._context: Mapping[str, Any] = context
+        self._context: BaseContext = context
         self._cli_vars: Mapping[str, Any] = cli_vars
         self._node: Optional[Resource] = node
         self._require_vars: bool = require_vars
@@ -185,7 +185,7 @@ class Var:
         if not isinstance(raw, str):
             return raw
 
-        return get_rendered(raw, dict(self._context))
+        return get_rendered(raw, self._context._ctx)
 
     def __call__(self, var_name: str, default: Any = _VAR_NOTSET) -> Any:
         if self.has_var(var_name):
@@ -330,7 +330,7 @@ class BaseContext(metaclass=ContextMeta):
             from events
             where event_type = '{{ var("event_type", "activation") }}'
         """
-        return Var(self._ctx, self.cli_vars, require_vars=self.require_vars)
+        return Var(self, self.cli_vars, require_vars=self.require_vars)
 
     @contextmember()
     def env_var(self, var: str, default: Optional[str] = None) -> str:

--- a/core/dbt/context/configured.py
+++ b/core/dbt/context/configured.py
@@ -2,7 +2,13 @@ from typing import Any, Dict, Optional
 
 from dbt.adapters.contracts.connection import AdapterRequiredConfig
 from dbt.constants import DEFAULT_ENV_PLACEHOLDER
-from dbt.context.base import Var, _get_env_var, contextmember, contextproperty
+from dbt.context.base import (
+    BaseContext,
+    Var,
+    _get_env_var,
+    contextmember,
+    contextproperty,
+)
 from dbt.context.target import TargetContext
 from dbt.exceptions import EnvVarMissingError, SecretEnvVarLocationError
 from dbt.node_types import NodeType
@@ -34,10 +40,10 @@ class FQNLookup:
 class ConfiguredVar(Var):
     def __init__(
         self,
-        context: Dict[str, Any],
+        context: BaseContext,
         config: AdapterRequiredConfig,
         project_name: str,
-    ):
+    ) -> None:
         super().__init__(context, config.cli_vars)
         self._config = config
         self._project_name = project_name
@@ -82,7 +88,7 @@ class SchemaYamlContext(ConfiguredContext):
 
     @contextproperty()
     def var(self) -> ConfiguredVar:
-        return ConfiguredVar(self._ctx, self.config, self._project_name)
+        return ConfiguredVar(self, self.config, self._project_name)
 
     @contextmember()
     def env_var(self, var: str, default: Optional[str] = None) -> str:
@@ -115,7 +121,7 @@ class MacroResolvingContext(ConfiguredContext):
 
     @contextproperty()
     def var(self) -> ConfiguredVar:
-        return ConfiguredVar(self._ctx, self.config, self.config.project_name)
+        return ConfiguredVar(self, self.config, self.config.project_name)
 
 
 def generate_schema_yml_context(

--- a/core/dbt/context/macros.py
+++ b/core/dbt/context/macros.py
@@ -1,83 +1,49 @@
-from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Set, Union
+from collections import ChainMap
+from typing import Any, Dict, List, MutableMapping, Optional
 
 from dbt.clients.jinja import MacroGenerator, MacroStack
 from dbt.contracts.graph.nodes import Macro
-from dbt.exceptions import DuplicateMacroNameError, PackageNotFoundForMacroError
+from dbt.exceptions import PackageNotFoundForMacroError
 from dbt.include.global_project import PROJECT_NAME as GLOBAL_PROJECT_NAME
 
-FlatNamespace = Dict[str, MacroGenerator]
-NamespaceMember = Union[FlatNamespace, MacroGenerator]
-FullNamespace = Dict[str, NamespaceMember]
 
+class MacroNamespace(ChainMap):
+    """A "virtual" namespace of macros. Rather than eagerly wrapping every macro
+    in a MacroGenerator up front, this resolves names lazily: a MacroGenerator is
+    only created when a macro is actually looked up (and therefore about to be
+    called). Sub-namespaces (keyed by package name) are resolved the same way."""
 
-# The point of this class is to collect the various macros
-# and provide the ability to flatten them into the ManifestContexts
-# that are created for jinja, so that macro calls can be resolved.
-# Creates special iterators and _keys methods to flatten the lists.
-# When this class is created it has a static 'local_namespace' which
-# depends on the package of the node, so it only works for one
-# particular local package at a time for "flattening" into a context.
-# 'get_by_package' should work for any macro.
-class MacroNamespace(Mapping):
     def __init__(
         self,
-        global_namespace: FlatNamespace,  # root package macros
-        local_namespace: FlatNamespace,  # packages for *this* node
-        global_project_namespace: FlatNamespace,  # internal packages
-        packages: Dict[str, FlatNamespace],  # non-internal packages
-    ):
-        self.global_namespace: FlatNamespace = global_namespace
-        self.local_namespace: FlatNamespace = local_namespace
-        self.packages: Dict[str, FlatNamespace] = packages
-        self.global_project_namespace: FlatNamespace = global_project_namespace
+        ctx: Dict[str, Any],
+        node,
+        thread_ctx: MacroStack,
+        search_dicts: List[MutableMapping[str, Any]],
+    ) -> None:
+        self.ctx = ctx
+        self.node = node
+        self.thread_ctx = thread_ctx
+        super().__init__(*search_dicts)
 
-    def _search_order(self) -> Iterable[Union[FullNamespace, FlatNamespace]]:
-        yield self.local_namespace  # local package
-        yield self.global_namespace  # root package
-        # TODO CT-211
-        yield self.packages  # type: ignore[misc] # non-internal packages
-        yield {
-            # TODO CT-211
-            GLOBAL_PROJECT_NAME: self.global_project_namespace,  # type: ignore[misc] # dbt
-        }
-        yield self.global_project_namespace  # other internal project besides dbt
-
-    # provides special keys method for MacroNamespace iterator
-    # returns keys from local_namespace, global_namespace, packages,
-    # global_project_namespace
-    def _keys(self) -> Set[str]:
-        keys: Set[str] = set()
-        for search in self._search_order():
-            keys.update(search)
-        return keys
-
-    # special iterator using special keys
-    def __iter__(self) -> Iterator[str]:
-        for key in self._keys():
-            yield key
-
-    def __len__(self):
-        return len(self._keys())
-
-    def __getitem__(self, key: str) -> NamespaceMember:
-        for dct in self._search_order():
-            if key in dct:
-                return dct[key]
-        raise KeyError(key)
+    def __getitem__(self, key: str):
+        value = super().__getitem__(key)
+        if isinstance(value, Macro):
+            return MacroGenerator(value, self.ctx, self.node, self.thread_ctx)
+        elif isinstance(value, MutableMapping):
+            return MacroNamespace(self.ctx, self.node, self.thread_ctx, [value])
+        return value
 
     def get_from_package(self, package_name: Optional[str], name: str) -> Optional[MacroGenerator]:
         if package_name is None:
             return self.get(name)
-        elif package_name == GLOBAL_PROJECT_NAME:
-            return self.global_project_namespace.get(name)
-        elif package_name in self.packages:
-            return self.packages[package_name].get(name)
-        else:
-            raise PackageNotFoundForMacroError(package_name)
+        elif package_name in self:
+            return self[package_name].get(name)
+
+        raise PackageNotFoundForMacroError(package_name)
 
 
-# This class builds the MacroNamespace by adding macros to
-# internal_packages or packages, and locals/globals.
+# This class builds the MacroNamespace by assembling the ordered list of
+# dictionaries the "virtual" MacroNamespace searches through.
 # Call 'build_namespace' to return a MacroNamespace.
 # This is used by ManifestContext (and subclasses)
 class MacroNamespaceBuilder:
@@ -89,83 +55,41 @@ class MacroNamespaceBuilder:
         internal_packages: List[str],
         node: Optional[Any] = None,
     ) -> None:
-        self.root_package = root_package
-        self.search_package = search_package
-        # internal packages comes from get_adapter_package_names
-        self.internal_package_names = set(internal_packages)
-        self.internal_package_names_order = internal_packages
-        # macro_func is added here if in root package, since
-        # the root package acts as a "global" namespace, overriding
-        # everything else except local external package macro calls
-        self.globals: FlatNamespace = {}
-        # macro_func is added here if it's the package for this node
-        self.locals: FlatNamespace = {}
-        # Create a dictionary of [package name][macro name] =
-        #     MacroGenerator object which acts like a function
-        self.internal_packages: Dict[str, FlatNamespace] = {}
-        self.packages: Dict[str, FlatNamespace] = {}
-        self.thread_ctx = thread_ctx
+        self.root_package: str = root_package
+        self.search_package: str = search_package
+        self.thread_ctx: MacroStack = thread_ctx
+        self.internal_packages: List[str] = internal_packages  # order significant
         self.node = node
 
-    def _add_macro_to(
-        self,
-        hierarchy: Dict[str, FlatNamespace],
-        macro: Macro,
-        macro_func: MacroGenerator,
-    ):
-        if macro.package_name in hierarchy:
-            namespace = hierarchy[macro.package_name]
-        else:
-            namespace = {}
-            hierarchy[macro.package_name] = namespace
-
-        if macro.name in namespace:
-            raise DuplicateMacroNameError(macro_func.macro, macro, macro.package_name)
-        hierarchy[macro.package_name][macro.name] = macro_func
-
-    def add_macro(self, macro: Macro, ctx: Dict[str, Any]) -> None:
-        macro_name: str = macro.name
-
-        # MacroGenerator is in clients/jinja.py
-        # a MacroGenerator object is a callable object that will
-        # execute the MacroGenerator.__call__ function
-        macro_func: MacroGenerator = MacroGenerator(macro, ctx, self.node, self.thread_ctx)
-
-        # internal macros (from plugins) will be processed separately from
-        # project macros, so store them in a different place
-        if macro.package_name in self.internal_package_names:
-            self._add_macro_to(self.internal_packages, macro, macro_func)
-        else:
-            # if it's not an internal package
-            self._add_macro_to(self.packages, macro, macro_func)
-            # add to locals if it's the package this node is in
-            if macro.package_name == self.search_package:
-                self.locals[macro_name] = macro_func
-            # add to globals if it's in the root package
-            elif macro.package_name == self.root_package:
-                self.globals[macro_name] = macro_func
-
-    def add_macros(self, macros: Iterable[Macro], ctx: Dict[str, Any]) -> None:
-        for macro in macros:
-            self.add_macro(macro, ctx)
-
     def build_namespace(
-        self, macros_by_package: Dict[str, Dict[str, Macro]], ctx: Dict[str, Any]
+        self,
+        macros_by_package: MutableMapping[str, MutableMapping[str, Macro]],
+        ctx: Dict[str, Any],
     ) -> MacroNamespace:
-        for package in macros_by_package.values():
-            self.add_macros(package.values(), ctx)
 
-        # Iterate in reverse-order and overwrite: the packages that are first
-        # in the list are the ones we want to "win".
-        global_project_namespace: FlatNamespace = {}
-        for pkg in reversed(self.internal_package_names_order):
-            if pkg in self.internal_packages:
-                # add the macros pointed to by this package name
-                global_project_namespace.update(self.internal_packages[pkg])
-
-        return MacroNamespace(
-            global_namespace=self.globals,  # root package macros
-            local_namespace=self.locals,  # packages for *this* node
-            global_project_namespace=global_project_namespace,  # internal packages
-            packages=self.packages,  # non internal_packages
+        internals: ChainMap = ChainMap(
+            *[
+                macros_by_package[package_name]
+                for package_name in self.internal_packages
+                if package_name in macros_by_package
+            ]
         )
+
+        # The virtual namespace will attempt to resolve names into either macros
+        # or sub-namespaces by checking the dictionaries in the following list
+        # in order.
+        search_dicts: List[MutableMapping] = [
+            (
+                macros_by_package[self.search_package]
+                if self.search_package in macros_by_package
+                else {}
+            ),
+            macros_by_package[self.root_package] if self.root_package in macros_by_package else {},
+            {k: v for k, v in macros_by_package.items() if k not in self.internal_packages},
+            {
+                GLOBAL_PROJECT_NAME: internals
+            },  # Macros from internal packages are available within the 'dbt' namespace.
+            internals,
+        ]
+
+        return MacroNamespace(ctx, self.node, self.thread_ctx, search_dicts)

--- a/core/dbt/context/manifest.py
+++ b/core/dbt/context/manifest.py
@@ -1,3 +1,4 @@
+from collections import ChainMap
 from typing import List
 
 from dbt.adapters.contracts.connection import AdapterRequiredConfig
@@ -39,7 +40,7 @@ class ManifestContext(ConfiguredContext):
         # this takes all the macros in the manifest and adds them
         # to the MacroNamespaceBuilder stored in self.namespace
         builder = self._get_namespace_builder()
-        return builder.build_namespace(self.manifest.get_macros_by_package(), self._ctx)
+        return builder.build_namespace(self.manifest.get_macros_by_package(), self._ctx)  # type: ignore
 
     def _get_namespace_builder(self) -> MacroNamespaceBuilder:
         # avoid an import loop
@@ -62,10 +63,26 @@ class ManifestContext(ConfiguredContext):
         if isinstance(self.namespace, TestMacroNamespace):
             dct.update(self.namespace.local_namespace)
             dct.update(self.namespace.project_namespace)
+            return dct
         else:
-            dct.update(self.namespace)
+            # The following is a performance optimization which creates a "virtual"
+            # copy of dct, updated with the values in namespace. The result is
+            # called cm and by using a ChainMap it avoids the very large cost of
+            # iterating every value of namespace.
+            cm = ChainMap(self.namespace, dct)
 
-        return dct
+            # These next lines repair certain assumptions which were important
+            # before the performance optimization:
+            # 1. The context has a key called 'context' whose value is a reference
+            #    to the full context.
+            # 2. That self.namespace has the updated version of dct as its context,
+            #    which is used for macro context later.
+            # 3. That self._ctx is the updated version of dct rather than just dct
+            cm.maps.insert(0, {"context": cm})
+            self.namespace.ctx = cm
+            self._ctx = cm
+
+            return cm
 
     @contextproperty()
     def context_macro_stack(self):

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -46,7 +46,13 @@ from dbt.clients.jinja import (
 from dbt.clients.jinja_static import statically_parse_unrendered_config
 from dbt.config import IsFQNResource, Project, RuntimeConfig
 from dbt.constants import DEFAULT_ENV_PLACEHOLDER
-from dbt.context.base import Var, _get_env_var, contextmember, contextproperty
+from dbt.context.base import (
+    BaseContext,
+    Var,
+    _get_env_var,
+    contextmember,
+    contextproperty,
+)
 from dbt.context.configured import FQNLookup
 from dbt.context.context_config import ContextConfig
 from dbt.context.exceptions_jinja import wrapped_exports
@@ -929,7 +935,7 @@ class RuntimeMetricResolver(BaseMetricResolver):
 class ModelConfiguredVar(Var):
     def __init__(
         self,
-        context: Dict[str, Any],
+        context: BaseContext,
         config: RuntimeConfig,
         node: Resource,
     ) -> None:
@@ -975,7 +981,7 @@ class RuntimeVar(ModelConfiguredVar):
 class UnitTestVar(RuntimeVar):
     def __init__(
         self,
-        context: Dict[str, Any],
+        context: BaseContext,
         config: RuntimeConfig,
         node: Resource,
     ) -> None:
@@ -1554,7 +1560,7 @@ class ProviderContext(ManifestContext):
     @contextproperty()
     def var(self) -> ModelConfiguredVar:
         return self.provider.Var(
-            context=self._ctx,
+            context=self,
             config=self.config,
             node=self.model,
         )

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -11,6 +11,7 @@ from typing import (
     Dict,
     FrozenSet,
     Generic,
+    Iterator,
     List,
     Mapping,
     MutableMapping,
@@ -938,6 +939,42 @@ NodeClassT = TypeVar("NodeClassT", bound="BaseNode")
 ResourceClassT = TypeVar("ResourceClassT", bound="BaseResource")
 
 
+class FlatGraphMapping(Mapping[str, Dict]):
+    """Provides a no-copy view of one of the node dictionaries that make up the
+    'flat_graph' data structure, with values converted to dictionaries on demand."""
+
+    def __init__(self, inner_dict: Mapping[str, BaseNode]) -> None:
+        self.inner_dict = inner_dict
+
+    def __getitem__(self, key: str) -> Dict:
+        return self.inner_dict.__getitem__(key).to_dict(omit_none=False)
+
+    def __len__(self) -> int:
+        return len(self.inner_dict)
+
+    def __iter__(self) -> Iterator[str]:
+        return self.inner_dict.__iter__()
+
+
+class ResourceMapping(Mapping[str, ResourceClassT]):
+    """Provides a no-copy view over a node dictionary, converting each node to
+    its resource representation on demand."""
+
+    def __init__(self, node_mapping: Mapping[str, BaseNode]) -> None:
+        self.node_mapping = node_mapping
+
+    def __getitem__(self, node_id: str) -> ResourceClassT:
+        # to_resource() is typed as returning the base resource; each node
+        # returns its own concrete resource type at runtime.
+        return self.node_mapping[node_id].to_resource()  # type: ignore[return-value]
+
+    def __len__(self) -> int:
+        return self.node_mapping.__len__()
+
+    def __iter__(self) -> Iterator[str]:
+        return self.node_mapping.__iter__()
+
+
 @dataclass
 class Manifest(MacroMethods, dbtClassMixin):
     """The manifest for the full graph, after parsing and during compilation."""
@@ -956,7 +993,9 @@ class Manifest(MacroMethods, dbtClassMixin):
     selectors: MutableMapping[str, Any] = field(default_factory=dict)
     files: MutableMapping[str, AnySourceFile] = field(default_factory=dict)
     metadata: ManifestMetadata = field(default_factory=ManifestMetadata)
-    flat_graph: Dict[str, Any] = field(default_factory=dict)
+    flat_graph: Dict[str, Any] = field(
+        default_factory=dict, metadata={"serialize": lambda x: None, "deserialize": lambda x: {}}
+    )
     state_check: ManifestStateCheck = field(default_factory=ManifestStateCheck)
     source_patches: MutableMapping[SourceKey, SourcePatch] = field(default_factory=dict)
     disabled: MutableMapping[str, List[GraphMemberNode]] = field(default_factory=dict)
@@ -1025,6 +1064,9 @@ class Manifest(MacroMethods, dbtClassMixin):
     @classmethod
     def __post_deserialize__(cls, obj: "Manifest") -> "Manifest":
         obj._lock = get_mp_context().Lock()
+        # flat_graph is not serialized (see the field metadata above), so rebuild
+        # its no-copy views here after deserialization.
+        obj.build_flat_graph()
         return obj
 
     def build_flat_graph(self) -> None:
@@ -1034,19 +1076,15 @@ class Manifest(MacroMethods, dbtClassMixin):
         manifest!
         """
         self.flat_graph = {
-            "exposures": {k: v.to_dict(omit_none=False) for k, v in self.exposures.items()},
-            "functions": {k: v.to_dict(omit_none=False) for k, v in self.functions.items()},
-            "groups": {k: v.to_dict(omit_none=False) for k, v in self.groups.items()},
-            "metrics": {k: v.to_dict(omit_none=False) for k, v in self.metrics.items()},
-            "nodes": {k: v.to_dict(omit_none=False) for k, v in self.nodes.items()},
-            "sources": {k: v.to_dict(omit_none=False) for k, v in self.sources.items()},
-            "semantic_models": {
-                k: v.to_dict(omit_none=False) for k, v in self.semantic_models.items()
-            },
-            "saved_queries": {
-                k: v.to_dict(omit_none=False) for k, v in self.saved_queries.items()
-            },
-            "unit_tests": {k: v.to_dict(omit_none=False) for k, v in self.unit_tests.items()},
+            "exposures": FlatGraphMapping(self.exposures),
+            "functions": FlatGraphMapping(self.functions),
+            "groups": FlatGraphMapping(self.groups),
+            "metrics": FlatGraphMapping(self.metrics),
+            "nodes": FlatGraphMapping(self.nodes),
+            "sources": FlatGraphMapping(self.sources),
+            "semantic_models": FlatGraphMapping(self.semantic_models),
+            "saved_queries": FlatGraphMapping(self.saved_queries),
+            "unit_tests": FlatGraphMapping(self.unit_tests),
         }
 
     def build_disabled_by_file_id(self) -> Dict[str, GraphMemberNode]:
@@ -1302,23 +1340,23 @@ class Manifest(MacroMethods, dbtClassMixin):
         self.fill_tracking_metadata()
 
         return WritableManifest(
-            nodes=self._map_nodes_to_map_resources(self.nodes),
-            sources=self._map_nodes_to_map_resources(self.sources),
-            macros=self._map_nodes_to_map_resources(self.macros),
-            docs=self._map_nodes_to_map_resources(self.docs),
-            exposures=self._map_nodes_to_map_resources(self.exposures),
-            functions=self._map_nodes_to_map_resources(self.functions),
-            metrics=self._map_nodes_to_map_resources(self.metrics),
-            groups=self._map_nodes_to_map_resources(self.groups),
+            nodes=ResourceMapping(self.nodes),
+            sources=ResourceMapping(self.sources),
+            macros=ResourceMapping(self.macros),
+            docs=ResourceMapping(self.docs),
+            exposures=ResourceMapping(self.exposures),
+            functions=ResourceMapping(self.functions),
+            metrics=ResourceMapping(self.metrics),
+            groups=ResourceMapping(self.groups),
             selectors=self.selectors,
             metadata=self.metadata,
             disabled=self._map_list_nodes_to_map_list_resources(self.disabled),
             child_map=self.child_map,
             parent_map=self.parent_map,
             group_map=self.group_map,
-            semantic_models=self._map_nodes_to_map_resources(self.semantic_models),
-            unit_tests=self._map_nodes_to_map_resources(self.unit_tests),
-            saved_queries=self._map_nodes_to_map_resources(self.saved_queries),
+            semantic_models=ResourceMapping(self.semantic_models),
+            unit_tests=ResourceMapping(self.unit_tests),
+            saved_queries=ResourceMapping(self.saved_queries),
         )
 
     def write(self, path: str) -> None:

--- a/tests/functional/macros/test_macros.py
+++ b/tests/functional/macros/test_macros.py
@@ -5,7 +5,13 @@ import pytest
 
 import dbt_common.exceptions
 from dbt.tests.fixtures.project import write_project_files
-from dbt.tests.util import check_relations_equal, get_manifest, run_dbt
+from dbt.tests.util import (
+    check_relations_equal,
+    get_manifest,
+    get_project_config,
+    run_dbt,
+    set_project_config,
+)
 from tests.functional.macros.fixtures import (
     dbt_project__incorrect_dispatch,
     macros__config_sql,
@@ -347,3 +353,17 @@ class TestMacroMetaDocsMerge:
         assert macro.docs.node_color == expected_docs_node_color
         assert macro.config.docs.show == expected_docs_show
         assert macro.config.docs.node_color == expected_docs_node_color
+
+
+class TestVarUsingProjectVarValue:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model.sql": "select * from pg_type where {{ var('truncate_timestamp_to') }} <= {{ var('truncate_timestamp_to') }} limit 1"
+        }
+
+    def test_var_using_project_var_value(self, project):
+        config = get_project_config(project)
+        config["vars"] = {"truncate_timestamp_to": "{{ current_timestamp() }}"}
+        set_project_config(project, config)
+        run_dbt(["parse"])

--- a/tests/unit/context/test_context.py
+++ b/tests/unit/context/test_context.py
@@ -497,18 +497,6 @@ def test_docs_runtime_context(config_postgres):
     assert_has_keys(REQUIRED_DOCS_KEYS, MAYBE_KEYS, ctx)
 
 
-def test_macro_namespace_duplicates(config_postgres, manifest_fx):
-    mn = macros.MacroNamespaceBuilder("root", "search", MacroStack(), ["dbt_postgres", "dbt"])
-    mn.add_macros(manifest_fx.macros.values(), {})
-
-    # same pkg, same name: error
-    with pytest.raises(dbt_common.exceptions.CompilationError):
-        mn.add_macro(mock_macro("macro_a", "root"), {})
-
-    # different pkg, same name: no error
-    mn.add_macros(mock_macro("macro_a", "dbt"), {})
-
-
 def test_macro_namespace(config_postgres, manifest_fx):
     mn = macros.MacroNamespaceBuilder("root", "search", MacroStack(), ["dbt_postgres", "dbt"])
 

--- a/tests/unit/contracts/graph/test_manifest.py
+++ b/tests/unit/contracts/graph/test_manifest.py
@@ -1110,6 +1110,38 @@ class MixedManifestTest(unittest.TestCase):
                 self.assertEqual(frozenset(node), REQUIRED_PARSED_NODE_KEYS)
         self.assertEqual(compiled_count, 2)
 
+    def test_flat_graph_msgpack(self):
+        """Ensure the manifest still serializes to msgpack after flat_graph has
+        been populated with the lazy FlatGraphMapping views (flat_graph itself is
+        not serialized and is rebuilt on deserialization)."""
+        from dbt.parser.manifest import (
+            extended_mashumaro_encoder,
+            extended_mashumuro_decoder,
+        )
+
+        nodes = deepcopy(self.nested_nodes)
+        manifest = Manifest(
+            nodes=nodes,
+            sources={},
+            functions={},
+            macros={},
+            docs={},
+            disabled={},
+            selectors={},
+            files={},
+            exposures={},
+            semantic_models={},
+            saved_queries={},
+        )
+        manifest.build_flat_graph()
+
+        manifest_mp = manifest.to_msgpack(encoder=extended_mashumaro_encoder)
+        roundtripped = Manifest.from_msgpack(manifest_mp, decoder=extended_mashumuro_decoder)
+
+        # flat_graph is not serialized, but __post_deserialize__ rebuilds it.
+        assert set(roundtripped.flat_graph) == set(manifest.flat_graph)
+        assert set(roundtripped.flat_graph["nodes"]) == set(manifest.flat_graph["nodes"])
+
     def test_merge_from_artifact(self):
         original_nodes = deepcopy(self.nested_nodes)
         other_nodes = deepcopy(self.nested_nodes)


### PR DESCRIPTION
Resolves #15524

### Problem

Parsing large projects uses more time and memory than necessary in a few places:

- **Macro generation is eager.** Building a macro namespace wraps *every* macro in the manifest in a `MacroGenerator` up front, and `ManifestContext.to_dict()` copies the entire namespace into the context dict on every invocation — even though only a small fraction of macros are ever called.
- **`flat_graph` is a full second copy of the graph.** `build_flat_graph()` calls `to_dict()` on every node, source, exposure, etc. and stores the resulting dictionaries in memory.
- **`writable_manifest()` materializes every resource** by converting each node to its resource object up front.

### Solution

**1. Virtualize macros** (`context/macros.py`, `context/manifest.py`, `context/base.py`, `context/configured.py`, `context/providers.py`)

`MacroNamespace` is now a `ChainMap` that resolves names lazily — a `MacroGenerator` is created only when a macro is actually looked up (i.e. about to be called), and sub-namespaces are resolved the same way. `ManifestContext.to_dict()` layers the namespace over the base context via a `ChainMap` instead of iterating and copying every macro. `Var` now takes the context object and reads its `_ctx` at render time rather than materializing a dict up front.

**2. No-copy views for `flat_graph` and `WritableManifest`** (`contracts/graph/manifest.py`)

`build_flat_graph()` now stores lightweight `FlatGraphMapping` views that convert each node to a dict on demand instead of eagerly building dictionaries. `writable_manifest()` wraps node dictionaries in `ResourceMapping` views that convert to resource objects lazily.

**3. Fix manifest msgpack serialization when `flat_graph` is populated**

Because `flat_graph` now holds view objects rather than plain dicts, it is excluded from serialization and rebuilt in `__post_deserialize__` (the views are cheap to reconstruct), keeping partial-parse msgpack round-trips working.

These changes have no public API or behavior impact — `flat_graph`, the macro namespace, and `WritableManifest` present the same interfaces; only their internal representation and evaluation timing changed.

**Testing**

- Added `test_flat_graph_msgpack` covering the msgpack round-trip with a populated `flat_graph`.
- Added a regression test for `var()` resolving a project var whose value references another context function.
- Removed the obsolete macro-namespace duplicate-detection test (the eager duplicate check no longer exists in the virtualized namespace).
- Verified against the context unit tests, manifest contract tests, functional macro tests, var/context-method functional tests, and partial-parsing tests. `mypy`, `flake8`, and `black` are clean on the touched files.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
