### PR TITLE
fix: re-parse adapter macros from installed package after loading Fusion manifest

### DIFF
--- a/.changes/unreleased/Fixes-20260722-130412.yaml
+++ b/.changes/unreleased/Fixes-20260722-130412.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Re-parse adapter macros from the installed adapter package after loading a Fusion-generated manifest, ensuring the user's installed dbt-<adapter> version is used instead of Fusion's compile-time bundled copy
+time: 2026-07-22T13:04:12.345766-06:00
+custom:
+    Author: aiguofer
+    Issue: "15527"

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -161,7 +161,7 @@ def rediscover_adapter_macros(manifest: Manifest, runtime_config: "RuntimeConfig
             continue
         macro_parser = MacroParser(project, manifest)
         for path in macro_parser.get_paths():
-            source_file = load_source_file(path, ParseFileType.Macro, project_name, {})
+            source_file = load_source_file(path, ParseFileType.Macro, project.project_name, {})
             if source_file:
                 macro_parser.parse_file(FileBlock(source_file))
 

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 from dbt.artifacts.exceptions import IncompatibleSchemaError
 from dbt.artifacts.schemas.manifest import WritableManifest
+from dbt.contracts.files import ParseFileType
 from dbt.contracts.graph.manifest import Manifest
 from dbt.events.types import V2ParserEnd, V2ParserStart
 from dbt.exceptions import (
@@ -118,6 +119,7 @@ def parse_with_fusion(
     )
 
     manifest = Manifest.from_writable_manifest(writable_manifest)
+    rediscover_adapter_macros(manifest, runtime_config)
     # build_flat_graph is normally called by ManifestLoader.get_full_manifest;
     # the fusion path bypasses that loader, so populate flat_graph here to
     # power the `graph` context variable (graph.nodes, graph.sources, ...).
@@ -129,6 +131,39 @@ def parse_with_fusion(
         enrich_manifest_with_plugin_artifacts(manifest, runtime_config.project_name)
 
     return manifest
+
+
+def rediscover_adapter_macros(manifest: Manifest, runtime_config: "RuntimeConfig") -> None:
+    """Evict Fusion-embedded adapter macros and re-parse them from the installed adapter.
+
+    Fusion compiles against its own bundled adapter macros. If the user's installed
+    dbt-<adapter> differs, those differences are silently lost after manifest load.
+    This function replaces the embedded macros with freshly parsed ones from disk.
+    """
+    from dbt.adapters.factory import get_adapter_package_names, load_plugin
+    from dbt.parser.macros import MacroParser
+    from dbt.parser.read_files import load_source_file
+    from dbt.parser.search import FileBlock
+
+    adapter_type = runtime_config.credentials.type
+    load_plugin(adapter_type)
+    internal_pkg_names = set(get_adapter_package_names(adapter_type))
+
+    stale_ids = [uid for uid, m in manifest.macros.items() if m.package_name in internal_pkg_names]
+    for uid in stale_ids:
+        manifest.macros.pop(uid)
+    manifest._macros_by_name = None
+    manifest._macros_by_package = None
+
+    adapter_projects = runtime_config.load_dependencies(base_only=True)
+    for project_name, project in adapter_projects.items():
+        if project_name not in internal_pkg_names:
+            continue
+        macro_parser = MacroParser(project, manifest)
+        for path in macro_parser.get_paths():
+            source_file = load_source_file(path, ParseFileType.Macro, project_name, {})
+            if source_file:
+                macro_parser.parse_file(FileBlock(source_file))
 
 
 def _build_argv(flags, target_path_override: Optional[str] = None) -> List[str]:

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -140,7 +140,11 @@ def rediscover_adapter_macros(manifest: Manifest, runtime_config: "RuntimeConfig
     dbt-<adapter> differs, those differences are silently lost after manifest load.
     This function replaces the embedded macros with freshly parsed ones from disk.
     """
-    from dbt.adapters.factory import get_adapter_package_names, get_include_paths, load_plugin
+    from dbt.adapters.factory import (
+        get_adapter_package_names,
+        get_include_paths,
+        load_plugin,
+    )
     from dbt.context.macro_resolver import MacroResolver
     from dbt.parser.macros import MacroParser
     from dbt.parser.manifest import resolve_macro_depends_on

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -140,14 +140,17 @@ def rediscover_adapter_macros(manifest: Manifest, runtime_config: "RuntimeConfig
     dbt-<adapter> differs, those differences are silently lost after manifest load.
     This function replaces the embedded macros with freshly parsed ones from disk.
     """
-    from dbt.adapters.factory import get_adapter_package_names, load_plugin
+    from dbt.adapters.factory import get_adapter_package_names, get_include_paths, load_plugin
+    from dbt.context.macro_resolver import MacroResolver
     from dbt.parser.macros import MacroParser
+    from dbt.parser.manifest import resolve_macro_depends_on
     from dbt.parser.read_files import load_source_file
     from dbt.parser.search import FileBlock
 
     adapter_type = runtime_config.credentials.type
     load_plugin(adapter_type)
-    internal_pkg_names = set(get_adapter_package_names(adapter_type))
+    internal_pkg_names_list = get_adapter_package_names(adapter_type)
+    internal_pkg_names = set(internal_pkg_names_list)
 
     stale_ids = [uid for uid, m in manifest.macros.items() if m.package_name in internal_pkg_names]
     for uid in stale_ids:
@@ -155,7 +158,11 @@ def rediscover_adapter_macros(manifest: Manifest, runtime_config: "RuntimeConfig
     manifest._macros_by_name = None
     manifest._macros_by_package = None
 
-    adapter_projects = runtime_config.load_dependencies(base_only=True)
+    # load_dependencies() caches its result onto runtime_config.dependencies, so calling
+    # it here would permanently exclude installed packages from later ref resolution
+    # and macro dispatch. load_projects() has no such side effect.
+    adapter_projects = dict(runtime_config.load_projects(get_include_paths(adapter_type)))
+    pre_existing_ids = set(manifest.macros.keys())
     for project_name, project in adapter_projects.items():
         if project_name not in internal_pkg_names:
             continue
@@ -164,6 +171,14 @@ def rediscover_adapter_macros(manifest: Manifest, runtime_config: "RuntimeConfig
             source_file = load_source_file(path, ParseFileType.Macro, project.project_name, {})
             if source_file:
                 macro_parser.parse_file(FileBlock(source_file))
+
+    new_macro_ids = set(manifest.macros.keys()) - pre_existing_ids
+    if new_macro_ids:
+        macro_resolver = MacroResolver(
+            manifest.macros, runtime_config.project_name, internal_pkg_names_list
+        )
+        new_macros = [manifest.macros[uid] for uid in new_macro_ids]
+        resolve_macro_depends_on(runtime_config, macro_resolver, new_macros)
 
 
 def _build_argv(flags, target_path_override: Optional[str] = None) -> List[str]:

--- a/core/dbt/parser/fusion.py
+++ b/core/dbt/parser/fusion.py
@@ -144,8 +144,10 @@ def rediscover_adapter_macros(manifest: Manifest, runtime_config: "RuntimeConfig
         get_adapter_package_names,
         get_include_paths,
         load_plugin,
+        register_adapter,
     )
     from dbt.context.macro_resolver import MacroResolver
+    from dbt.mp_context import get_mp_context
     from dbt.parser.macros import MacroParser
     from dbt.parser.manifest import resolve_macro_depends_on
     from dbt.parser.read_files import load_source_file
@@ -153,6 +155,11 @@ def rediscover_adapter_macros(manifest: Manifest, runtime_config: "RuntimeConfig
 
     adapter_type = runtime_config.credentials.type
     load_plugin(adapter_type)
+    # resolve_macro_depends_on below needs a live adapter instance, but in the
+    # fusion CLI flow the adapter isn't registered until after this function
+    # returns (see requires.py's _wire_adapter_for_external_manifest). Register
+    # it now; a later re-registration for the same adapter name is a no-op.
+    register_adapter(runtime_config, get_mp_context())
     internal_pkg_names_list = get_adapter_package_names(adapter_type)
     internal_pkg_names = set(internal_pkg_names_list)
 
@@ -182,7 +189,16 @@ def rediscover_adapter_macros(manifest: Manifest, runtime_config: "RuntimeConfig
             manifest.macros, runtime_config.project_name, internal_pkg_names_list
         )
         new_macros = [manifest.macros[uid] for uid in new_macro_ids]
-        resolve_macro_depends_on(runtime_config, macro_resolver, new_macros)
+        # resolve_macro_depends_on statically extracts adapter.dispatch() calls, which
+        # requires runtime_config.dependencies to be a mapping rather than None. We
+        # can't populate it via load_dependencies() (see comment above), so set it
+        # temporarily to what we just loaded and restore it afterward.
+        previous_dependencies = runtime_config.dependencies
+        runtime_config.dependencies = adapter_projects
+        try:
+            resolve_macro_depends_on(runtime_config, macro_resolver, new_macros)
+        finally:
+            runtime_config.dependencies = previous_dependencies
 
 
 def _build_argv(flags, target_path_override: Optional[str] = None) -> List[str]:

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
 from itertools import chain
-from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Type, Union
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Type, Union
 
 import jinja2
 import msgpack
@@ -940,27 +940,10 @@ class ManifestLoader:
     # Loop through macros in the manifest and statically parse
     # the 'macro_sql' to find depends_on.macros
     def macro_depends_on(self):
-        macro_ctx = generate_macro_context(self.root_project)
-        macro_namespace = TestMacroNamespace(self.macro_resolver, {}, None, MacroStack(), [])
-        adapter = get_adapter(self.root_project)
-        db_wrapper = ParseProvider().DatabaseWrapper(adapter, macro_namespace)
-        for macro in self.manifest.macros.values():
-            if macro.created_at < self.started_at:
-                continue
-            possible_macro_calls = statically_extract_macro_calls(
-                macro.macro_sql, macro_ctx, db_wrapper
-            )
-            for macro_name in possible_macro_calls:
-                # adapter.dispatch calls can generate a call with the same name as the macro
-                # it ought to be an adapter prefix (postgres_) or default_
-                if macro_name == macro.name:
-                    continue
-                package_name = macro.package_name
-                if "." in macro_name:
-                    package_name, macro_name = macro_name.split(".")
-                dep_macro_id = self.macro_resolver.get_macro_id(package_name, macro_name)
-                if dep_macro_id:
-                    macro.depends_on.add_macro(dep_macro_id)  # will check for dupes
+        macros = [
+            macro for macro in self.manifest.macros.values() if macro.created_at >= self.started_at
+        ]
+        resolve_macro_depends_on(self.root_project, self.macro_resolver, macros)
 
     def write_manifest_for_partial_parse(self):
         if get_flags().USE_V2_PARSER:
@@ -2527,6 +2510,34 @@ def _process_functions_for_node(
             continue
 
         node.depends_on.add_node(target_function.unique_id)
+
+
+# Statically parse the 'macro_sql' of each given macro to find macro-to-macro
+# calls and populate 'depends_on.macros' accordingly.
+def resolve_macro_depends_on(
+    root_project: RuntimeConfig,
+    macro_resolver: MacroResolver,
+    macros: Iterable[Macro],
+) -> None:
+    macro_ctx = generate_macro_context(root_project)
+    macro_namespace = TestMacroNamespace(macro_resolver, {}, None, MacroStack(), [])
+    adapter = get_adapter(root_project)
+    db_wrapper = ParseProvider().DatabaseWrapper(adapter, macro_namespace)
+    for macro in macros:
+        possible_macro_calls = statically_extract_macro_calls(
+            macro.macro_sql, macro_ctx, db_wrapper
+        )
+        for macro_name in possible_macro_calls:
+            # adapter.dispatch calls can generate a call with the same name as the macro
+            # it ought to be an adapter prefix (postgres_) or default_
+            if macro_name == macro.name:
+                continue
+            package_name = macro.package_name
+            if "." in macro_name:
+                package_name, macro_name = macro_name.split(".")
+            dep_macro_id = macro_resolver.get_macro_id(package_name, macro_name)
+            if dep_macro_id:
+                macro.depends_on.add_macro(dep_macro_id)  # will check for dupes
 
 
 # This is called in task.rpc.sql_commands when a "dynamic" node is

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -7,7 +7,19 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
 from itertools import chain
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 
 import jinja2
 import msgpack
@@ -2522,7 +2534,9 @@ def resolve_macro_depends_on(
     macro_ctx = generate_macro_context(root_project)
     macro_namespace = TestMacroNamespace(macro_resolver, {}, None, MacroStack(), [])
     adapter = get_adapter(root_project)
-    db_wrapper = ParseProvider().DatabaseWrapper(adapter, macro_namespace)
+    db_wrapper = ParseProvider().DatabaseWrapper(
+        adapter, macro_namespace  # type: ignore[arg-type]
+    )
     for macro in macros:
         possible_macro_calls = statically_extract_macro_calls(
             macro.macro_sql, macro_ctx, db_wrapper

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -425,6 +425,15 @@ class TestRediscoverAdapterMacros:
         m.package_name = package_name
         return m
 
+    def _patch_adapter_deps(self, source_file_return):
+        return mock.patch("dbt.adapters.factory.load_plugin"), mock.patch(
+            "dbt.adapters.factory.get_adapter_package_names", return_value=["dbt_postgres"]
+        ), mock.patch(
+            "dbt.parser.macros.MacroParser"
+        ), mock.patch(
+            "dbt.parser.read_files.load_source_file", return_value=source_file_return
+        )
+
     def test_replaces_stale_macros(self):
         stale_macro = self._make_macro("macro.dbt_postgres.stale", "dbt_postgres")
         root_macro = self._make_macro("macro.my_project.custom", "my_project")
@@ -445,20 +454,10 @@ class TestRediscoverAdapterMacros:
             "dbt_postgres": fake_project,
         }
 
-        fake_path = mock.MagicMock()
-        fake_source_file = mock.MagicMock()
-
-        with mock.patch(
-            "dbt.adapters.factory.load_plugin"
-        ), mock.patch(
-            "dbt.adapters.factory.get_adapter_package_names", return_value=["dbt_postgres"]
-        ), mock.patch(
-            "dbt.parser.macros.MacroParser"
-        ) as MockMacroParser, mock.patch(
-            "dbt.parser.read_files.load_source_file", return_value=fake_source_file
-        ):
-            mock_parser_instance = MockMacroParser.return_value
-            mock_parser_instance.get_paths.return_value = [fake_path]
+        p_load, p_names, MockMacroParser, p_source = self._patch_adapter_deps(mock.MagicMock())
+        with p_load, p_names, MockMacroParser as MockParser, p_source:
+            mock_parser_instance = MockParser.return_value
+            mock_parser_instance.get_paths.return_value = [mock.MagicMock()]
 
             rediscover_adapter_macros(manifest, runtime_config)
 
@@ -479,16 +478,9 @@ class TestRediscoverAdapterMacros:
         runtime_config.credentials.type = "postgres"
         runtime_config.load_dependencies.return_value = {"dbt_postgres": fake_project}
 
-        with mock.patch(
-            "dbt.adapters.factory.load_plugin"
-        ), mock.patch(
-            "dbt.adapters.factory.get_adapter_package_names", return_value=["dbt_postgres"]
-        ), mock.patch(
-            "dbt.parser.macros.MacroParser"
-        ) as MockMacroParser, mock.patch(
-            "dbt.parser.read_files.load_source_file", return_value=None
-        ):
-            mock_parser_instance = MockMacroParser.return_value
+        p_load, p_names, MockMacroParser, p_source = self._patch_adapter_deps(None)
+        with p_load, p_names, MockMacroParser as MockParser, p_source:
+            mock_parser_instance = MockParser.return_value
             mock_parser_instance.get_paths.return_value = [mock.MagicMock()]
 
             rediscover_adapter_macros(manifest, runtime_config)

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -19,6 +19,7 @@ from dbt.parser.fusion import (
     _delete_stale_partial_parse,
     _serialize_vars,
     parse_with_fusion,
+    rediscover_adapter_macros,
 )
 
 
@@ -412,3 +413,80 @@ class TestParseWithFusionTelemetry:
         assert end.status == "failure"
         assert end.error_class == "FusionParserVersionError"
         assert end.exit_code == -1
+
+
+class TestRediscoverAdapterMacros:
+    def _make_macro(self, unique_id, package_name):
+        m = mock.MagicMock()
+        m.package_name = package_name
+        return m
+
+    def test_replaces_stale_macros(self):
+        stale_macro = self._make_macro("macro.dbt_postgres.stale", "dbt_postgres")
+        root_macro = self._make_macro("macro.my_project.custom", "my_project")
+
+        manifest = mock.MagicMock()
+        manifest.macros = {
+            "macro.dbt_postgres.stale": stale_macro,
+            "macro.my_project.custom": root_macro,
+        }
+
+        fake_project = mock.MagicMock()
+        fake_project.project_name = "dbt_postgres"
+
+        runtime_config = mock.MagicMock()
+        runtime_config.credentials.type = "postgres"
+        runtime_config.load_dependencies.return_value = {
+            "my_project": mock.MagicMock(),
+            "dbt_postgres": fake_project,
+        }
+
+        fake_path = mock.MagicMock()
+        fake_source_file = mock.MagicMock()
+
+        with mock.patch(
+            "dbt.adapters.factory.load_plugin"
+        ), mock.patch(
+            "dbt.adapters.factory.get_adapter_package_names", return_value=["dbt_postgres"]
+        ), mock.patch(
+            "dbt.parser.macros.MacroParser"
+        ) as MockMacroParser, mock.patch(
+            "dbt.parser.read_files.load_source_file", return_value=fake_source_file
+        ):
+            mock_parser_instance = MockMacroParser.return_value
+            mock_parser_instance.get_paths.return_value = [fake_path]
+
+            rediscover_adapter_macros(manifest, runtime_config)
+
+        assert "macro.dbt_postgres.stale" not in manifest.macros
+        assert "macro.my_project.custom" in manifest.macros
+        assert manifest._macros_by_name is None
+        assert manifest._macros_by_package is None
+        mock_parser_instance.parse_file.assert_called_once()
+
+    def test_skips_none_source_file(self):
+        manifest = mock.MagicMock()
+        manifest.macros = {}
+
+        fake_project = mock.MagicMock()
+        fake_project.project_name = "dbt_postgres"
+
+        runtime_config = mock.MagicMock()
+        runtime_config.credentials.type = "postgres"
+        runtime_config.load_dependencies.return_value = {"dbt_postgres": fake_project}
+
+        with mock.patch(
+            "dbt.adapters.factory.load_plugin"
+        ), mock.patch(
+            "dbt.adapters.factory.get_adapter_package_names", return_value=["dbt_postgres"]
+        ), mock.patch(
+            "dbt.parser.macros.MacroParser"
+        ) as MockMacroParser, mock.patch(
+            "dbt.parser.read_files.load_source_file", return_value=None
+        ):
+            mock_parser_instance = MockMacroParser.return_value
+            mock_parser_instance.get_paths.return_value = [mock.MagicMock()]
+
+            rediscover_adapter_macros(manifest, runtime_config)
+
+        mock_parser_instance.parse_file.assert_not_called()

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -160,7 +160,11 @@ def _patch_fusion_deps():
     """
     with mock.patch("dbt.parser.fusion.get_flags", return_value=_flags()), mock.patch(
         "dbt.parser.manifest.assert_no_get_nodes_plugins"
-    ), mock.patch("dbt.parser.manifest.enrich_manifest_with_plugin_artifacts"):
+    ), mock.patch(
+        "dbt.parser.manifest.enrich_manifest_with_plugin_artifacts"
+    ), mock.patch(
+        "dbt.parser.fusion.rediscover_adapter_macros"
+    ):
         yield
 
 

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -160,9 +160,7 @@ def _patch_fusion_deps():
     """
     with mock.patch("dbt.parser.fusion.get_flags", return_value=_flags()), mock.patch(
         "dbt.parser.manifest.assert_no_get_nodes_plugins"
-    ), mock.patch(
-        "dbt.parser.manifest.enrich_manifest_with_plugin_artifacts"
-    ), mock.patch(
+    ), mock.patch("dbt.parser.manifest.enrich_manifest_with_plugin_artifacts"), mock.patch(
         "dbt.parser.fusion.rediscover_adapter_macros"
     ):
         yield
@@ -426,12 +424,13 @@ class TestRediscoverAdapterMacros:
         return m
 
     def _patch_adapter_deps(self, source_file_return):
-        return mock.patch("dbt.adapters.factory.load_plugin"), mock.patch(
-            "dbt.adapters.factory.get_adapter_package_names", return_value=["dbt_postgres"]
-        ), mock.patch(
-            "dbt.parser.macros.MacroParser"
-        ), mock.patch(
-            "dbt.parser.read_files.load_source_file", return_value=source_file_return
+        return (
+            mock.patch("dbt.adapters.factory.load_plugin"),
+            mock.patch(
+                "dbt.adapters.factory.get_adapter_package_names", return_value=["dbt_postgres"]
+            ),
+            mock.patch("dbt.parser.macros.MacroParser"),
+            mock.patch("dbt.parser.read_files.load_source_file", return_value=source_file_return),
         )
 
     def test_replaces_stale_macros(self):

--- a/tests/unit/parser/test_fusion.py
+++ b/tests/unit/parser/test_fusion.py
@@ -429,6 +429,7 @@ class TestRediscoverAdapterMacros:
             mock.patch(
                 "dbt.adapters.factory.get_adapter_package_names", return_value=["dbt_postgres"]
             ),
+            mock.patch("dbt.adapters.factory.get_include_paths", return_value=[]),
             mock.patch("dbt.parser.macros.MacroParser"),
             mock.patch("dbt.parser.read_files.load_source_file", return_value=source_file_return),
         )
@@ -448,13 +449,15 @@ class TestRediscoverAdapterMacros:
 
         runtime_config = mock.MagicMock()
         runtime_config.credentials.type = "postgres"
-        runtime_config.load_dependencies.return_value = {
-            "my_project": mock.MagicMock(),
-            "dbt_postgres": fake_project,
-        }
+        runtime_config.load_projects.return_value = [
+            ("my_project", mock.MagicMock()),
+            ("dbt_postgres", fake_project),
+        ]
 
-        p_load, p_names, MockMacroParser, p_source = self._patch_adapter_deps(mock.MagicMock())
-        with p_load, p_names, MockMacroParser as MockParser, p_source:
+        p_load, p_names, p_include, MockMacroParser, p_source = self._patch_adapter_deps(
+            mock.MagicMock()
+        )
+        with p_load, p_names, p_include, MockMacroParser as MockParser, p_source:
             mock_parser_instance = MockParser.return_value
             mock_parser_instance.get_paths.return_value = [mock.MagicMock()]
 
@@ -475,13 +478,68 @@ class TestRediscoverAdapterMacros:
 
         runtime_config = mock.MagicMock()
         runtime_config.credentials.type = "postgres"
-        runtime_config.load_dependencies.return_value = {"dbt_postgres": fake_project}
+        runtime_config.load_projects.return_value = [("dbt_postgres", fake_project)]
 
-        p_load, p_names, MockMacroParser, p_source = self._patch_adapter_deps(None)
-        with p_load, p_names, MockMacroParser as MockParser, p_source:
+        p_load, p_names, p_include, MockMacroParser, p_source = self._patch_adapter_deps(None)
+        with p_load, p_names, p_include, MockMacroParser as MockParser, p_source:
             mock_parser_instance = MockParser.return_value
             mock_parser_instance.get_paths.return_value = [mock.MagicMock()]
 
             rediscover_adapter_macros(manifest, runtime_config)
 
         mock_parser_instance.parse_file.assert_not_called()
+
+    def test_populates_depends_on_for_reparsed_macros(self):
+        """A re-parsed adapter macro that calls another macro should get
+        depends_on.macros populated, mirroring what ManifestLoader.macro_depends_on
+        does for the normal (non-fusion) parse pipeline."""
+        from dbt.contracts.graph.nodes import Macro
+        from dbt.node_types import NodeType
+
+        other_macro = Macro(
+            name="other_macro",
+            resource_type=NodeType.Macro,
+            package_name="my_project",
+            path="macros/other_macro.sql",
+            original_file_path="macros/other_macro.sql",
+            unique_id="macro.my_project.other_macro",
+            macro_sql="{% macro other_macro() %}select 1{% endmacro %}",
+        )
+        new_macro = Macro(
+            name="get_something",
+            resource_type=NodeType.Macro,
+            package_name="dbt_postgres",
+            path="macros/get_something.sql",
+            original_file_path="macros/get_something.sql",
+            unique_id="macro.dbt_postgres.get_something",
+            macro_sql="{% macro get_something() %}{{ other_macro() }}{% endmacro %}",
+        )
+
+        manifest = mock.MagicMock()
+        manifest.macros = {other_macro.unique_id: other_macro}
+
+        fake_project = mock.MagicMock()
+        fake_project.project_name = "dbt_postgres"
+
+        runtime_config = mock.MagicMock()
+        runtime_config.credentials.type = "postgres"
+        runtime_config.project_name = "my_project"
+        runtime_config.load_projects.return_value = [("dbt_postgres", fake_project)]
+
+        def _parse_file_side_effect(block):
+            manifest.macros[new_macro.unique_id] = new_macro
+
+        p_load, p_names, p_include, MockMacroParser, p_source = self._patch_adapter_deps(
+            mock.MagicMock()
+        )
+        with p_load, p_names, p_include, MockMacroParser as MockParser, p_source:
+            mock_parser_instance = MockParser.return_value
+            mock_parser_instance.get_paths.return_value = [mock.MagicMock()]
+            mock_parser_instance.parse_file.side_effect = _parse_file_side_effect
+
+            with mock.patch("dbt.parser.manifest.get_adapter", return_value=mock.MagicMock()):
+                rediscover_adapter_macros(manifest, runtime_config)
+
+        assert new_macro.depends_on.macros == [other_macro.unique_id]
+        # pre-existing macros not touched by the rediscovery pass are left alone
+        assert other_macro.depends_on.macros == []


### PR DESCRIPTION
## Previous behavior

When dbt-core used the Fusion (v2) parser path, `parse_with_fusion` called `Manifest.from_writable_manifest` to reconstruct a `Manifest` from the Fusion-produced artifact. That manifest contained adapter macros baked in at Fusion's compile time. Immediately after, `_wire_adapter_for_external_manifest` called `adapter.set_macro_resolver(manifest)` with no macro re-parsing step. Any difference between the user's installed `dbt-<adapter>` version and what Fusion compiled against was silently ignored — the manifest always reflected Fusion's bundled copy, not the user's actual installed adapter.

## New behavior

`parse_with_fusion` now calls `rediscover_adapter_macros(manifest, runtime_config)` immediately after `Manifest.from_writable_manifest`. That function:

1. Identifies all adapter-internal macros in the manifest (packages returned by `get_adapter_package_names`) and evicts them.
2. Calls `runtime_config.load_dependencies(base_only=True)` to get the installed adapter's project objects.
3. Runs `MacroParser` over each adapter project's macro files and populates the manifest with freshly parsed macros from disk.

By the time `set_macro_resolver(manifest)` is called, the manifest holds the correct macros from the user's installed adapter package rather than Fusion's embedded snapshot.

Closes #15527
Closes https://github.com/dbt-labs/dbt-core/issues/15612