### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260713-220831.yaml
+++ b/.changes/unreleased/Under the Hood-20260713-220831.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-07-13T22:08:31.561907727Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -2327,6 +2327,16 @@
             }
           ]
         },
+        "state-org-id": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrInteger"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "tenant_hostname": {
           "type": [
             "string",


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`65fedc66482fe36044dc5b4a3ccf3c7d5872300a`](https://github.com/dbt-labs/fs/commit/65fedc66482fe36044dc5b4a3ccf3c7d5872300a)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/29286964893)