### PR TITLE
Fix macro dispatch crash when a project name collides with a macro name

### DIFF
--- a/.changes/unreleased/Fixes-20260715-113746.yaml
+++ b/.changes/unreleased/Fixes-20260715-113746.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix macro namespace resolution so a dbt project named after a macro no longer crashes with 'MacroGenerator' during dispatch
+time: 2026-07-15T11:37:46.319428+05:30
+custom:
+    Author: ash2shukla
+    Issue: "15556"

--- a/core/dbt/context/macros.py
+++ b/core/dbt/context/macros.py
@@ -36,8 +36,17 @@ class MacroNamespace(ChainMap):
     def get_from_package(self, package_name: Optional[str], name: str) -> Optional[MacroGenerator]:
         if package_name is None:
             return self.get(name)
-        elif package_name in self:
-            return self[package_name].get(name)
+
+        # A package name can collide with a macro name (e.g. a project named
+        # after a macro). Resolve the package to its sub-namespace directly,
+        # skipping any flat macro of the same name, rather than relying on
+        # __getitem__ resolution order (which would return a MacroGenerator for
+        # the colliding macro and blow up on `.get`).
+        for mapping in self.maps:
+            member = mapping.get(package_name)
+            if isinstance(member, MutableMapping):
+                sub_namespace = MacroNamespace(self.ctx, self.node, self.thread_ctx, [member])
+                return sub_namespace.get(name)
 
         raise PackageNotFoundForMacroError(package_name)
 

--- a/tests/unit/context/test_context.py
+++ b/tests/unit/context/test_context.py
@@ -18,6 +18,7 @@ from dbt.contracts.graph.nodes import (
     UnitTestNode,
     UnitTestOverrides,
 )
+from dbt.exceptions import PackageNotFoundForMacroError
 from dbt.node_types import NodeType
 from dbt_common.events.functions import reset_metadata_vars
 from tests.unit.mock_adapter import adapter_factory
@@ -529,6 +530,39 @@ def test_macro_namespace(config_postgres, manifest_fx):
         assert result["dbt"]["some_macro"].macro is pg_macro
         assert result["root"]["some_macro"].macro is package_macro
         assert result["some_macro"].macro is package_macro
+
+
+def test_macro_namespace_package_name_collides_with_macro(config_postgres, manifest_fx):
+    # A dbt project can legitimately share its name with a macro. Package
+    # resolution must not return the colliding macro (a MacroGenerator), which
+    # would raise `AttributeError: 'MacroGenerator' object has no attribute 'get'`.
+    # Regression test for the macro-namespace collision surfaced by the
+    # get_catalog_for_single_relation test (project named after the macro).
+    mn = macros.MacroNamespaceBuilder("shared_name", "dbt", MacroStack(), ["dbt_postgres", "dbt"])
+
+    mbp = manifest_fx.get_macros_by_package()
+    # a global macro whose name collides with a project (package) name, plus a
+    # macro that is *only* a macro (no package of the same name)
+    mbp["dbt"] = {
+        "shared_name": mock_macro("shared_name", "dbt"),
+        "only_a_macro": mock_macro("only_a_macro", "dbt"),
+    }
+    # a project named "shared_name" that provides a macro
+    project_macro = mock_macro("some_macro", "shared_name")
+    mbp["shared_name"] = {"some_macro": project_macro}
+
+    namespace = mn.build_namespace(mbp, {})
+
+    # resolving the package must return the project's macro, not blow up on the
+    # colliding global macro of the same name
+    resolved = namespace.get_from_package("shared_name", "some_macro")
+    assert resolved is not None
+    assert resolved.macro is project_macro
+
+    # a name that is only a macro (no such package) raises cleanly rather than
+    # dereferencing a MacroGenerator
+    with pytest.raises(PackageNotFoundForMacroError):
+        namespace.get_from_package("only_a_macro", "some_macro")
 
 
 def test_dbt_metadata_envs(


### PR DESCRIPTION
Resolves #15556

### Problem

`MacroNamespace.get_from_package` raises `AttributeError: 'MacroGenerator' object has no attribute 'get'` during `adapter.dispatch` whenever a dbt project's name is identical to a macro name.

This is a regression from #15526 (Parsing Performance Improvements), which changed package resolution to:

```python
elif package_name in self:
    return self[package_name].get(name)
```

`self[package_name]` walks the entire namespace search order, which includes the flat `macro name -> Macro` maps. When a package name collides with a macro name, `__getitem__` returns a `MacroGenerator` (the macro) instead of a package sub-namespace, so the subsequent `.get(name)` blows up.

This surfaced in dbt-adapters CI: the `get_catalog_for_single_relation` functional test names its project `get_catalog_for_single_relation`, which is also the name of a global macro. During setup (`create_schema` dispatch), resolution collides and the test errors out.

### Solution

Resolve `package_name` only to package **sub-namespaces**, restoring the pre-#15526 `self.packages` / `GLOBAL_PROJECT_NAME` semantics without giving up the lazy-resolution performance work. We iterate the underlying search maps and only match an entry whose value is a `MutableMapping` (a package namespace); a bare `Macro` of the same name is skipped:

```python
for mapping in self.maps:
    member = mapping.get(package_name)
    if isinstance(member, MutableMapping):
        sub_namespace = MacroNamespace(self.ctx, self.node, self.thread_ctx, [member])
        return sub_namespace.get(name)

raise PackageNotFoundForMacroError(package_name)
```

Since a `Macro` node is not a `MutableMapping`, a colliding macro can no longer be mistaken for a package. When no matching package exists, `PackageNotFoundForMacroError` (a `CompilationError`) is raised, which `dispatch` already catches and treats as "not found" — so dispatch continues to the next candidate package exactly as before.

Added `test_macro_namespace_package_name_collides_with_macro`, which reproduces the exact `AttributeError` on the pre-fix code and passes with the fix. It also asserts that a name matching only a macro (no package) raises `PackageNotFoundForMacroError` cleanly.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
