### PR TITLE
bump dbt-adapters

### DIFF
--- a/.changes/unreleased/Dependencies-20260715-211254.yaml
+++ b/.changes/unreleased/Dependencies-20260715-211254.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump dbt-adapters to 1.24.5 lowerbound
+time: 2026-07-15T21:12:54.678168+05:30
+custom:
+    Author: ash2shukla
+    Issue: ' '

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "metricflow>=0.211.0,<1.0",
     # Minor versions for these are expected to be backwards-compatible
     "dbt-common>=1.37.5,<2.0",
-    "dbt-adapters>=1.24.1,<2.0",
+    "dbt-adapters>=1.24.5,<2.0",
     "dbt-protos>=1.0.514,<2.0",
     "dbt-core-experimental-parser>=2.0.0a4,<3",
     # Bundled plugin: installed by default but opt-in. PluginManager skips loading


### PR DESCRIPTION
Resolves #

### Problem
catalogs support bugfixes went in 1.24.5 and it will break in lower base adapters versions

### Solution
Bump dbt adapters to 1.24.5 lowerbound

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
