### PR TITLE
persist hint_ts at dbt home and gate on bare except clause

### DIFF
--- a/.changes/unreleased/Fixes-20260716-005624.yaml
+++ b/.changes/unreleased/Fixes-20260716-005624.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Persist hint_ts in dbt_home and gate rw on bare Except clause to be more defensive
+time: 2026-07-16T00:56:24.648557+05:30
+custom:
+    Author: ash2shukla
+    Issue: "15510"

--- a/core/dbt/cli/requires.py
+++ b/core/dbt/cli/requires.py
@@ -36,7 +36,6 @@ from dbt.events.types import (
 )
 from dbt.exceptions import DbtProjectError, FailFastError
 from dbt.flags import get_flag_dict, get_flags, set_flags
-from dbt.hints import load_hint_ts
 from dbt.mp_context import get_mp_context
 from dbt.parser.manifest import parse_manifest
 from dbt.plugins import set_up_plugin_manager
@@ -370,10 +369,6 @@ def runtime_config(func):
         )
 
         ctx.obj["runtime_config"] = config
-
-        # Prime the hint cooldown cache now that we know this project's target
-        # dir, so any hint surfaced later in the invocation honors the limit.
-        load_hint_ts(config.project_target_path)
 
         if dbt.tracking.active_user is not None:
             adapter_type = (

--- a/core/dbt/hints.py
+++ b/core/dbt/hints.py
@@ -1,10 +1,9 @@
 import json
 import time
-from contextvars import ContextVar
 from functools import lru_cache
 from pathlib import Path
-from typing import Optional, Union
 
+from dbt.constants import DBT_HOME_DIR_NAME
 from dbt.flags import get_flags
 from dbt.tracking import track_hint_view
 from dbt_common.dataclass_schema import StrEnum
@@ -17,7 +16,9 @@ HINT_PREFIX = "[HINT] "
 # Don't show the same hint more than once a week.
 HINT_COOLDOWN_SECONDS = 7 * 24 * 60 * 60
 
-# File (under the project's target dir) tracking when each hint was last shown.
+# File (under the dbt home dir, ~/.dbt) tracking when each hint was last shown.
+# Living in the home dir means the cooldown is shared across every project, so a
+# hint doesn't reappear just because you ran dbt in a different project.
 HINT_TS_FILENAME = "hint_ts.json"
 
 # Hint message text shown to the user. Keep these actionable and point at docs.
@@ -42,66 +43,49 @@ hint_to_msg_map: dict[HintType, str] = {
     HintType.LONG_PARSING_WITHOUT_V2_PARSER: LONG_PARSING_WITHOUT_V2_PARSER,
 }
 
-# Path to the current invocation's hint file, set by load_hint_ts(). Held in a
-# ContextVar so it's isolated per invocation and follows dbt's threaded execution
-# the same way the invocation context does. None until load_hint_ts() runs.
-_hint_ts_path: ContextVar[Optional[Path]] = ContextVar("hint_ts_path", default=None)
+
+def _hint_ts_file() -> Path:
+    # A single, fixed location (~/.dbt/hint_ts.json). Because it's shared across
+    # every project, the once-a-week cooldown follows the user, not the project.
+    return Path.home() / DBT_HOME_DIR_NAME / HINT_TS_FILENAME
 
 
-@lru_cache(None)
+@lru_cache(maxsize=None)
 def _read_hint_ts(path_str: str) -> dict:
-    """Read and cache one hint file's contents, keyed by path. The returned dict
-    is mutated in place by record_hint_shown(), so the cache stays current within
-    this process; a new invocation is a new process and re-reads from disk."""
+    """Read the hint file (hint_type -> last-shown epoch seconds), cached by path
+    so repeated cooldown checks don't re-touch disk. The returned dict is mutated
+    in place by record_hint_shown(), keeping the cache current within a run;
+    keying by path also isolates different homes (e.g. across tests). A missing or
+    partially-written file just means "never shown"."""
     try:
         return json.loads(Path(path_str).read_text())
-    except (FileNotFoundError, ValueError):
-        # No file yet, or a partially-written one — treat as "never shown".
+    except Exception:
+        # Missing, unreadable (permissions), or partially-written file — none of
+        # it should break a run, so treat any read failure as "never shown".
         return {}
-
-
-def load_hint_ts(target_path: Optional[Union[str, Path]] = None) -> dict:
-    """Point the hint machinery at a project's target dir and load its hint file.
-    Call this early (from requires.runtime_config); later reads reuse the cached
-    copy so we don't touch disk on every hint."""
-    if target_path is None:
-        return {}
-    path = Path(target_path) / HINT_TS_FILENAME
-    _hint_ts_path.set(path)
-    return _read_hint_ts(str(path))
-
-
-def reset_hint_ts() -> None:
-    """Forget the current path and clear cached hint files. Primarily for tests,
-    where the process (and this cache) is reused across invocations."""
-    _hint_ts_path.set(None)
-    _read_hint_ts.cache_clear()
 
 
 def has_hint_cooldown(hint_type: HintType) -> bool:
     """True if this hint was shown recently enough that we should stay quiet."""
-    path = _hint_ts_path.get()
-    if path is None:
-        return False
-    last_shown = _read_hint_ts(str(path)).get(hint_type, 0)
+    last_shown = _read_hint_ts(str(_hint_ts_file())).get(hint_type, 0)
     return (time.time() - last_shown) < HINT_COOLDOWN_SECONDS
 
 
 def record_hint_shown(hint_type: HintType) -> None:
     """Stamp the current time for this hint and persist it, so future runs honor
-    the cooldown. No-op if we never loaded a target path (nowhere to write)."""
-    path = _hint_ts_path.get()
-    if path is None:
-        return
+    the cooldown."""
+    path = _hint_ts_file()
     hint_ts = _read_hint_ts(str(path))
     # Store epoch seconds as an int so the file interops cleanly with the Rust
-    # engine (which reads/writes integer timestamps).
+    # engine (which reads/writes integer timestamps). Mutating the cached dict in
+    # place keeps a subsequent cooldown check consistent without a re-read.
     hint_ts[hint_type] = int(time.time())
     try:
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(hint_ts))
-    except OSError:
-        # A read-only/full/unwritable target must never break the run just
-        # because we couldn't persist a hint timestamp.
+    except Exception:
+        # A read-only/full/permission-denied home dir must never break the run
+        # just because we couldn't persist a hint timestamp.
         pass
 
 

--- a/tests/functional/hints/test_hints.py
+++ b/tests/functional/hints/test_hints.py
@@ -8,7 +8,6 @@ from dbt.hints import (
     HINT_PREFIX,
     LONG_PARSING_WITHOUT_V2_PARSER,
     REUSE_RELATIONS_ON_TOO_MANY_MODELS,
-    reset_hint_ts,
 )
 from dbt.tests.util import run_dbt
 from dbt_common.events.event_catcher import EventCatcher
@@ -23,12 +22,13 @@ def no_snowplow(mocker: MockerFixture):
 
 
 @pytest.fixture(autouse=True)
-def fresh_hint_ts():
-    # The cooldown cache is a module global that survives across invocations in
-    # the same process, so drop it before and after each test to avoid leakage.
-    reset_hint_ts()
-    yield
-    reset_hint_ts()
+def isolated_home(monkeypatch, tmp_path):
+    # hint_ts.json lives in the dbt home dir (~/.dbt). Point HOME at a temp dir
+    # per test so runs don't touch (or leak the cooldown through) the real ~/.dbt.
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
 
 
 def hint_events(catcher: EventCatcher, hint_msg: str):
@@ -115,8 +115,6 @@ class TestHintsDisabledViaProjectFlag:
 
 
 class TestHintCooldownAcrossRuns:
-    # Its own class so it gets a fresh (class-scoped) target dir, i.e. a clean
-    # hint_ts.json that isn't pre-populated by the other tests above.
     @pytest.fixture(scope="class")
     def models(self):
         return {"model_a.sql": model_sql, "model_b.sql": model_sql}
@@ -124,13 +122,12 @@ class TestHintCooldownAcrossRuns:
     def test_second_run_is_silent_within_cooldown(self, project, mocker):
         mocker.patch("dbt.task.build.BuildTask.REUSE_RELATIONS_HINT_MODEL_THRESHOLD", 0)
 
-        # First run shows the hint and writes hint_ts.json to the target dir.
+        # First run shows the hint and writes hint_ts.json to the dbt home dir.
         first = EventCatcher(event_to_catch=Note)
         run_dbt(["build"], callbacks=[first.catch])
         assert len(hint_events(first, REUSE_RELATIONS_ON_TOO_MANY_MODELS)) == 1
 
-        # A fresh invocation re-reads that file and stays quiet during cooldown.
-        reset_hint_ts()
+        # A second invocation re-reads that file and stays quiet during cooldown.
         second = EventCatcher(event_to_catch=Note)
         run_dbt(["build"], callbacks=[second.catch])
         assert hint_events(second, REUSE_RELATIONS_ON_TOO_MANY_MODELS) == []

--- a/tests/unit/test_hints.py
+++ b/tests/unit/test_hints.py
@@ -11,19 +11,20 @@ from dbt.hints import (
     HintType,
     has_hint_cooldown,
     hint_to_msg_map,
-    load_hint_ts,
     record_hint_shown,
-    reset_hint_ts,
     show_hint,
 )
 
 
 @pytest.fixture(autouse=True)
-def fresh_hint_ts():
-    # The cooldown state is module-global; keep tests isolated from each other.
-    reset_hint_ts()
-    yield
-    reset_hint_ts()
+def dbt_home(monkeypatch, tmp_path):
+    # The hint file lives in the dbt home dir (~/.dbt); point HOME at a temp dir
+    # so tests read/write there instead of the real home. Returns the ~/.dbt dir.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    dbt_dir = tmp_path / ".dbt"
+    dbt_dir.mkdir()
+    return dbt_dir
 
 
 def test_hint_to_msg_map_covers_every_hint_type():
@@ -32,69 +33,48 @@ def test_hint_to_msg_map_covers_every_hint_type():
 
 
 class TestHintCooldown:
-    def test_load_is_empty_when_file_missing(self, tmp_path):
-        assert load_hint_ts(tmp_path) == {}
-
-    def test_load_reads_existing_file(self, tmp_path):
-        (tmp_path / HINT_TS_FILENAME).write_text(json.dumps({"some_hint": 123.0}))
-        assert load_hint_ts(tmp_path) == {"some_hint": 123.0}
-
-    def test_same_path_is_cached_not_reread(self, tmp_path):
-        hint_file = tmp_path / HINT_TS_FILENAME
-        hint_file.write_text(json.dumps({"some_hint": 1.0}))
-        assert load_hint_ts(tmp_path) == {"some_hint": 1.0}
-
-        # Overwrite on disk; a re-load of the same path returns the cached copy.
-        hint_file.write_text(json.dumps({"some_hint": 999.0}))
-        assert load_hint_ts(tmp_path) == {"some_hint": 1.0}
-
-    def test_different_paths_are_cached_separately(self, tmp_path):
-        (tmp_path / HINT_TS_FILENAME).write_text(json.dumps({"a": 1.0}))
-        other = tmp_path / "other"
-        other.mkdir()
-        (other / HINT_TS_FILENAME).write_text(json.dumps({"b": 2.0}))
-
-        assert load_hint_ts(tmp_path) == {"a": 1.0}
-        assert load_hint_ts(other) == {"b": 2.0}
-
-    def test_load_tolerates_corrupt_file(self, tmp_path):
-        (tmp_path / HINT_TS_FILENAME).write_text("{not valid json")
-        assert load_hint_ts(tmp_path) == {}
-
-    def test_no_cooldown_before_load(self):
-        # Never loaded -> nothing is on cooldown, so hints are free to show.
+    def test_no_cooldown_when_file_missing(self):
         assert has_hint_cooldown(HintType.LONG_PARSING_WITHOUT_V2_PARSER) is False
 
-    def test_recent_hint_is_on_cooldown(self, tmp_path):
-        load_hint_ts(tmp_path)
+    def test_recent_hint_is_on_cooldown(self):
         record_hint_shown(HintType.LONG_PARSING_WITHOUT_V2_PARSER)
         assert has_hint_cooldown(HintType.LONG_PARSING_WITHOUT_V2_PARSER) is True
 
-    def test_expired_hint_is_not_on_cooldown(self, tmp_path):
-        stale = {HintType.LONG_PARSING_WITHOUT_V2_PARSER: 0.0}  # epoch => long ago
-        (tmp_path / HINT_TS_FILENAME).write_text(json.dumps(stale))
-        load_hint_ts(tmp_path)
+    def test_expired_hint_is_not_on_cooldown(self, dbt_home):
+        stale = {HintType.LONG_PARSING_WITHOUT_V2_PARSER: 0}  # epoch => long ago
+        (dbt_home / HINT_TS_FILENAME).write_text(json.dumps(stale))
         assert has_hint_cooldown(HintType.LONG_PARSING_WITHOUT_V2_PARSER) is False
 
-    def test_record_persists_to_disk(self, tmp_path):
-        load_hint_ts(tmp_path)
+    def test_cooldown_tolerates_corrupt_file(self, dbt_home):
+        (dbt_home / HINT_TS_FILENAME).write_text("{not valid json")
+        assert has_hint_cooldown(HintType.LONG_PARSING_WITHOUT_V2_PARSER) is False
+
+    def test_cooldown_tolerates_unreadable_file(self, mocker):
+        # A read failure (e.g. permission denied) must not raise, just show hints.
+        mocker.patch.object(Path, "read_text", side_effect=PermissionError("denied"))
+        assert has_hint_cooldown(HintType.LONG_PARSING_WITHOUT_V2_PARSER) is False
+
+    def test_record_persists_to_disk(self, dbt_home):
         record_hint_shown(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
 
-        on_disk = json.loads((tmp_path / HINT_TS_FILENAME).read_text())
+        on_disk = json.loads((dbt_home / HINT_TS_FILENAME).read_text())
         assert HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS in on_disk
         stored = on_disk[HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS]
         # Persisted as an int (epoch seconds) for cross-compat with the Rust engine.
         assert isinstance(stored, int)
         assert stored > 0
 
-    def test_record_is_noop_without_target(self):
-        # Nothing loaded -> nowhere to write, and it must not raise.
-        record_hint_shown(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
-        assert has_hint_cooldown(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS) is False
+    def test_record_creates_home_dir_if_missing(self, tmp_path, monkeypatch):
+        # ~/.dbt may not exist yet; record_hint_shown should create it.
+        home = tmp_path / "fresh"
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
 
-    def test_record_swallows_write_errors(self, tmp_path, mocker):
+        record_hint_shown(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
+        assert (home / ".dbt" / HINT_TS_FILENAME).exists()
+
+    def test_record_swallows_write_errors(self, mocker):
         # A failed write (read-only dir, disk full, ...) must not raise.
-        load_hint_ts(tmp_path)
         mocker.patch.object(Path, "write_text", side_effect=OSError("read-only"))
         record_hint_shown(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
 
@@ -140,8 +120,7 @@ class TestShowHint:
         mock_fire_event.assert_called_once()
         mock_track_hint_view.assert_called_once()
 
-    def test_skips_when_within_cooldown(self, tmp_path, mock_fire_event, mock_track_hint_view):
-        load_hint_ts(tmp_path)
+    def test_skips_when_within_cooldown(self, mock_fire_event, mock_track_hint_view):
         record_hint_shown(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
         with self._mock_flags(hints_enabled=True):
             show_hint(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)
@@ -150,12 +129,11 @@ class TestShowHint:
         mock_track_hint_view.assert_not_called()
 
     def test_shows_and_records_when_cooldown_expired(
-        self, tmp_path, mock_fire_event, mock_track_hint_view
+        self, dbt_home, mock_fire_event, mock_track_hint_view
     ):
-        # Load a stale timestamp so the hint is eligible again.
-        stale = {HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS: 0.0}
-        (tmp_path / HINT_TS_FILENAME).write_text(json.dumps(stale))
-        load_hint_ts(tmp_path)
+        # A stale timestamp so the hint is eligible again.
+        stale = {HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS: 0}
+        (dbt_home / HINT_TS_FILENAME).write_text(json.dumps(stale))
 
         with self._mock_flags(hints_enabled=True):
             show_hint(HintType.REUSE_RELATIONS_ON_TOO_MANY_MODELS)


### PR DESCRIPTION
Resolves #15510 

### Problem
- At present we persist hint_ts in project target which can get cleaned up and cause repetitive hints to show up.
- The OSError gate does not cover all possible exceptions ( eg. ValueError on bad parsing )

### Solution
- Persist it at ~/.dbt
- gate rw behind bare Exception clause to be more defensive

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
