### PR TITLE
Fix range() off-by-one with negative step values

### DIFF
--- a/.changes/unreleased/Fixes-20260717-023000.yaml
+++ b/.changes/unreleased/Fixes-20260717-023000.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix range() returning incorrect values when using negative steps.
+time: 2026-07-17T02:30:00.000000+05:30
+custom:
+    author: "arijitroy003"
+    issue: '15585'
+    project: dbt-core

--- a/crates/dbt-jinja/minijinja/src/functions.rs
+++ b/crates/dbt-jinja/minijinja/src/functions.rs
@@ -325,11 +325,11 @@ mod builtins {
                 "cannot create range with step of 0",
             )),
             positive if positive > 0 => to_result((lower..upper).step_by(positive as usize)),
-            negative => to_result(
-                (upper + 1..lower + 1)
-                    .step_by(negative.unsigned_abs() as usize)
-                    .rev(),
-            ),
+            negative => {
+                let abs_step = negative.unsigned_abs() as i32;
+                let start = upper + 1 + (lower - upper - 1) % abs_step;
+                to_result((start..lower + 1).step_by(abs_step as usize).rev())
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #15585

The `range()` function produces incorrect values when called with a negative step. For example, `range(10, 0, -2)` returns `[9, 7, 5, 3, 1]` instead of the correct `[10, 8, 6, 4, 2]`.

## Root cause

The negative-step branch uses a reverse-iteration approach: it builds an ascending range and calls `.rev()`. The ascending range was `(upper + 1..lower + 1).step_by(abs_step)`, which starts stepping from `upper + 1`. When `upper + 1` is not congruent to `lower` modulo `abs_step`, the reversed sequence misses `lower` entirely and is offset by 1.

For `range(10, 0, -2)`:
- Old: `(1..11).step_by(2)` = `[1, 3, 5, 7, 9]`, reversed = `[9, 7, 5, 3, 1]`
- Correct forward range should be `(2..11).step_by(2)` = `[2, 4, 6, 8, 10]`, reversed = `[10, 8, 6, 4, 2]`

## Fix

Compute a correctly aligned start for the forward range:

```rust
let start = upper + 1 + (lower - upper - 1) % abs_step;
```

This ensures `lower` is always reachable by stepping from `start`, so the reversed iterator begins at `lower` as expected — matching Python/Jinja2 semantics.

## Before / After

| Call | Before | After (matches Python) |
|------|--------|----------------------|
| `range(10, 0, -2)` | `[9, 7, 5, 3, 1]` | `[10, 8, 6, 4, 2]` |
| `range(10, 0, -3)` | `[10, 7, 4, 1]` | `[10, 7, 4, 1]` |
| `range(5, 0, -1)` | `[5, 4, 3, 2, 1]` | `[5, 4, 3, 2, 1]` |
| `range(10, 4, -3)` | `[10, 7]` | `[10, 7]` |

Note: cases where `(lower - upper) % abs_step == 0` (like step=-1, or step=-3 with 10→0) were already correct since the alignment happened to match. The bug only manifests when there's a remainder.