### PR TITLE
fix: preserve parent-then-child tag inheritance order

### DIFF
--- a/.changes/unreleased/Fixes-20260718-111500.yaml
+++ b/.changes/unreleased/Fixes-20260718-111500.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Align inherited +tags order with dbt-core (parent then child, no alphabetical sort)
+time: 2026-07-18T11:15:00.000000+05:30
+custom:
+    author: benhurstephen
+    issue: "15590"
+    project: dbt-core

--- a/crates/dbt-schemas/src/schemas/common.rs
+++ b/crates/dbt-schemas/src/schemas/common.rs
@@ -1581,7 +1581,10 @@ pub fn merge_meta(
     }
 }
 
-/// Merge two tag lists, deduplicating and sorting the result.
+/// Merge two string lists, deduplicating and sorting the result.
+///
+/// Prefer this for unordered set-like configs (e.g. classifiers). For tags,
+/// use [`merge_tags`] so inheritance order matches dbt-core.
 pub fn merge_vec(
     base_vec: Option<Vec<String>>,
     update_vec: Option<Vec<String>>,
@@ -1600,6 +1603,38 @@ pub fn merge_vec(
         (Some(base), None) => Some(base),
         (None, Some(update)) => Some(update),
     }
+}
+
+/// Merge inherited tags in dbt-core order: parent (less specific) first, then
+/// child (more specific), with first-seen deduplication and no alphabetical sort.
+///
+/// dbt-core concatenates additive tags along the config hierarchy. Callers that
+/// depend on list position (e.g. custom schema naming from `tags[0]`) require
+/// this order for Core/Fusion parity. See dbt-labs/dbt-core#15590.
+pub fn merge_tags(
+    parent_tags: Option<Vec<String>>,
+    child_tags: Option<Vec<String>>,
+) -> Option<Vec<String>> {
+    match (parent_tags, child_tags) {
+        (None, None) => None,
+        (Some(mut parent), Some(child)) => {
+            parent.extend(child);
+            dedup_preserve_order(parent)
+        }
+        (Some(parent), None) => dedup_preserve_order(parent),
+        (None, Some(child)) => dedup_preserve_order(child),
+    }
+}
+
+fn dedup_preserve_order(tags: Vec<String>) -> Option<Vec<String>> {
+    let mut seen = std::collections::HashSet::with_capacity(tags.len());
+    let mut out = Vec::with_capacity(tags.len());
+    for tag in tags {
+        if seen.insert(tag.clone()) {
+            out.push(tag);
+        }
+    }
+    Some(out)
 }
 
 pub fn conform_normalized_snapshot_raw_code_to_mantle_format(normalized_full: &str) -> String {
@@ -2596,6 +2631,47 @@ period: hour
     #[test]
     fn test_merge_classifiers_both_none_is_none() {
         assert_eq!(merge_vec(None, None), None);
+    }
+
+    #[test]
+    fn test_merge_tags_parent_first_preserves_inheritance_order() {
+        // Regression for dbt-labs/dbt-core#15590: nested +tags must keep
+        // parent-then-child order (not alphabetical). Alphabetical would put
+        // DAILY before INTERMEDIATE.
+        let parent = Some(vec!["INTERMEDIATE".to_string()]);
+        let child = Some(vec!["DAILY".to_string()]);
+        assert_eq!(
+            merge_tags(parent, child),
+            Some(vec!["INTERMEDIATE".to_string(), "DAILY".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_merge_tags_dedupes_preserving_first_seen() {
+        let parent = Some(vec!["a".to_string(), "b".to_string()]);
+        let child = Some(vec!["b".to_string(), "c".to_string()]);
+        assert_eq!(
+            merge_tags(parent, child),
+            Some(vec!["a".to_string(), "b".to_string(), "c".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_merge_tags_matches_docs_additive_hierarchy() {
+        // Docs example: contains_pii (project) + hourly (folder) + finance (model)
+        // must stay inheritance order, not alpha (contains_pii, finance, hourly).
+        let project = Some(vec!["contains_pii".to_string()]);
+        let folder = Some(vec!["hourly".to_string()]);
+        let model = Some(vec!["finance".to_string()]);
+        let after_folder = merge_tags(project, folder);
+        assert_eq!(
+            merge_tags(after_folder, model),
+            Some(vec![
+                "contains_pii".to_string(),
+                "hourly".to_string(),
+                "finance".to_string(),
+            ])
+        );
     }
 
     #[test]

--- a/crates/dbt-schemas/src/schemas/project/configs/common.rs
+++ b/crates/dbt-schemas/src/schemas/project/configs/common.rs
@@ -15,6 +15,7 @@ use crate::default_to;
 use crate::schemas::common::Hooks;
 use crate::schemas::common::PartitionConfig;
 use crate::schemas::common::merge_meta;
+use crate::schemas::common::merge_tags;
 use crate::schemas::common::merge_vec;
 use crate::schemas::common::{ClusterConfig, DbtQuoting, DocsConfig, Schedule};
 use crate::schemas::manifest::GrantAccessToTarget;
@@ -103,11 +104,12 @@ pub fn default_meta_and_tags(
     // Handle meta using existing merge function
     *child_meta = merge_meta(parent_meta.clone(), child_meta.take());
 
-    // Handle tags using existing merge function
+    // Parent (less specific) tags first, then child — matches dbt-core additive
+    // inheritance order. Do not alphabetically sort (dbt-labs/dbt-core#15590).
     let child_tags_vec = child_tags.take().map(|tags| tags.into());
     let parent_tags_vec = parent_tags.clone().map(|tags| tags.into());
     *child_tags =
-        merge_vec(child_tags_vec, parent_tags_vec).map(StringOrArrayOfStrings::ArrayOfStrings);
+        merge_tags(parent_tags_vec, child_tags_vec).map(StringOrArrayOfStrings::ArrayOfStrings);
 }
 
 /// Helper function to handle default_to logic for classifiers.
@@ -124,7 +126,8 @@ pub fn default_classifiers(
 
 /// Helper function to handle default_to logic for packages
 /// Packages should append parent values to child values (parent first, then child)
-/// Note: Unlike tags, packages are NOT deduplicated or sorted, matching dbt-core behavior
+/// Note: Unlike tags (which order-preserving-dedupe), packages are NOT deduplicated,
+/// matching dbt-core behavior
 pub fn default_packages(
     child_packages: &mut Option<StringOrArrayOfStrings>,
     parent_packages: &Option<StringOrArrayOfStrings>,
@@ -1627,6 +1630,28 @@ mod tests {
             child,
             Some(StringOrArrayOfStrings::ArrayOfStrings(vec![
                 "pii".to_string(),
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_default_meta_and_tags_parent_first_order() {
+        // Nested dbt_project.yml +tags: parent folder INTERMEDIATE, child DAILY
+        // must resolve to [INTERMEDIATE, DAILY] like dbt-core (issue #15590).
+        let mut child_meta = None;
+        let parent_meta = None;
+        let mut child_tags = Some(StringOrArrayOfStrings::ArrayOfStrings(vec![
+            "DAILY".to_string(),
+        ]));
+        let parent_tags = Some(StringOrArrayOfStrings::ArrayOfStrings(vec![
+            "INTERMEDIATE".to_string(),
+        ]));
+        default_meta_and_tags(&mut child_meta, &parent_meta, &mut child_tags, &parent_tags);
+        assert_eq!(
+            child_tags,
+            Some(StringOrArrayOfStrings::ArrayOfStrings(vec![
+                "INTERMEDIATE".to_string(),
+                "DAILY".to_string(),
             ]))
         );
     }


### PR DESCRIPTION
## Summary
- Nested `+tags` in `dbt_project.yml` were merged and alphabetically sorted in Fusion, so parent/child tags could land in a different order than dbt-core (e.g. `DAILY` before `INTERMEDIATE`).
- That broke projects/macros that depend on tag position, such as schema naming from `tags[0]`.
- This change merges tags parent-then-child with order-preserving dedupe (no sort), matching dbt-core inheritance order. Sorted `merge_vec` is unchanged for classifiers.

Fixes #15590

## Test plan
- [x] `cargo test -p dbt-schemas --lib merge_tags`
- [x] `cargo test -p dbt-schemas --lib default_meta_and_tags`
- [ ] Optional: parse a project with nested `+tags: ['INTERMEDIATE']` / `+tags: ['DAILY']` and confirm manifest tag order matches Core