### PR TITLE
Fix package analyses inheriting models enabled config

### DIFF
--- a/.changes/unreleased/Fixes-20260719-15415.yaml
+++ b/.changes/unreleased/Fixes-20260719-15415.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Report disabled refs from package analyses instead of inheriting models enabled config
+time: 2026-07-19T17:30:00.000000+05:30
+custom:
+    Author: Aastha204
+    Issue: "15415"

--- a/core/dbt/context/context_config.py
+++ b/core/dbt/context/context_config.py
@@ -59,9 +59,8 @@ class UnrenderedConfig(ConfigSource):
             model_configs = unrendered.get("exposures")
         elif resource_type == NodeType.Unit:
             model_configs = unrendered.get("unit_tests")
-        elif resource_type == NodeType.Analysis and getattr(
-            get_flags(), "require_corrected_analysis_fqns", False
-        ):
+        elif resource_type == NodeType.Analysis:
+            # Always use analyses: — reading models: wrongly disables package analyses (#15415).
             model_configs = unrendered.get("analyses")
         else:
             model_configs = unrendered.get("models")
@@ -94,9 +93,8 @@ class RenderedConfig(ConfigSource):
             model_configs = self.project.exposures
         elif resource_type == NodeType.Unit:
             model_configs = self.project.unit_tests
-        elif resource_type == NodeType.Analysis and getattr(
-            get_flags(), "require_corrected_analysis_fqns", False
-        ):
+        elif resource_type == NodeType.Analysis:
+            # Same as UnrenderedConfig: analyses read from analyses:, not models:.
             model_configs = self.project.analyses
         elif resource_type == NodeType.Function:
             model_configs = self.project.functions

--- a/tests/functional/analysis/test_package_analysis_disabled_ref.py
+++ b/tests/functional/analysis/test_package_analysis_disabled_ref.py
@@ -1,0 +1,64 @@
+"""
+Regression test for https://github.com/dbt-labs/dbt-core/issues/15415
+
+Package analyses that ref a disabled model must raise during parse. They must
+not inherit `models: <package>: +enabled: false` and silently skip ref checks.
+"""
+
+import pytest
+
+from dbt.exceptions import CompilationError
+from dbt.tests.fixtures.project import write_project_files
+from dbt.tests.util import run_dbt
+
+# Minimal package project: one model + one analysis that refs it.
+my_package_dbt_project_yml = """
+name: 'my_package'
+version: '1.0'
+config-version: 2
+
+profile: 'default'
+
+model-paths: ["models"]
+analysis-paths: ["analyses"]
+"""
+
+my_package_model_a_sql = """
+select 1 as x
+"""
+
+my_package_analysis_sql = """
+select x + 1 as y from {{ ref('A') }}
+"""
+
+
+class TestPackageAnalysisRefsDisabledModel:
+    @pytest.fixture(scope="class", autouse=True)
+    def setUp(self, project_root):
+        # Write a local package beside the root test project (same pattern as
+        # other package functional tests, e.g. test_duplicate_model.py).
+        local_package_files = {
+            "dbt_project.yml": my_package_dbt_project_yml,
+            "models": {"A.sql": my_package_model_a_sql},
+            "analyses": {"my_analysis.sql": my_package_analysis_sql},
+        }
+        write_project_files(project_root, "my_package", local_package_files)
+
+    @pytest.fixture(scope="class")
+    def packages(self):
+        # Root project depends on the local package; `dbt deps` installs it.
+        return {"packages": [{"local": "my_package"}]}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        # Disable only package *models*. Package analyses should stay enabled
+        # so parse can report the disabled ref.
+        return {"models": {"my_package": {"+enabled": False}}}
+
+    def test_package_analysis_reports_disabled_ref(self, project):
+        run_dbt(["deps"])
+
+        with pytest.raises(CompilationError) as exc:
+            run_dbt(["parse"])
+
+        assert "which is disabled" in str(exc.value)


### PR DESCRIPTION
Resolves #15415

### Problem

When a root project disables models from a package with:

```yaml
models:
  my_package:
    +enabled: false
```

and that package contains an analysis that `ref()`s a now-disabled model, `dbt parse` should fail with a disabled-ref error.

Before this PR, package analyses incorrectly inherited config from the `models:` tree (unless `require_corrected_analysis_fqns` was enabled). That wrongly disabled the analysis, skipped ref validation, and parse succeeded with no error — even though the analysis still depended on a disabled model.

### Solution

Always resolve analysis config from the `analyses:` section of `dbt_project.yml` in both `UnrenderedConfig` and `RenderedConfig` (`core/dbt/context/context_config.py`), matching other resource types (seeds → `seeds:`, etc.).

With that change:

- `models: <package>: +enabled: false` disables only package models
- package analyses stay enabled by default
- ref processing runs and reports the disabled dependency

Added a functional regression test that reproduces the package scenario from #15415.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.

