### PR TITLE
chore(changie): drop project prefix from rendered changelog

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -21,9 +21,9 @@ custom:
     type: string
     required: false
 
-# Change format: project prefix + optional issue links. Issue links are only
-# rendered for dbt-core changes (resolving to the dbt-core repo) and only when
-# an issue number is present.
+# Change format: optional issue links only. The project field is retained in the
+# change files (for the internal changelog) but not rendered here. Issue links
+# are only rendered for dbt-core changes and only when an issue number is present.
 changeFormat: |-
   {{- $IssueList := list }}
   {{- if eq $.Custom.project "dbt-core" }}
@@ -34,7 +34,7 @@ changeFormat: |-
     {{- end -}}
   {{- end -}}
   {{- end -}}
-  - [{{.Custom.project}}] {{.Body}}{{if $IssueList}} ({{ range $index, $element := $IssueList }}{{if $index}}, {{end}}{{$element}}{{end}}){{end}}
+  - {{.Body}}{{if $IssueList}} ({{ range $index, $element := $IssueList }}{{if $index}}, {{end}}{{$element}}{{end}}){{end}}
 
 kinds:
   - label: Breaking Changes


### PR DESCRIPTION
## What

Removes the `[{{.Custom.project}}]` prefix from the rendered changelog entries in `.changie.yaml`.

Previously every entry rendered with a `[dbt-core]` prefix — and entries without a `project` set rendered an empty `[]`, which looked broken. Since this is a single-project repo, the prefix was pure noise in the final `CHANGELOG.md`.

## Details

- Dropped the `[...]` prefix from the `changeFormat` output line.
- **Kept** the `project` field plumbing (the `post:` block still stamps `project: dbt-core` on change files) so the internal changelog can continue to use it.
- Issue-link rendering is unchanged (still gated on `project == dbt-core`, still resolves to dbt-core issues).

Verified with `changie batch patch --dry-run`: entries now render as plain `- <body>` with issue links intact and no `[]` prefixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)