### PR TITLE
fix 1.13 changelog missing 1.11 and 1.12 changelog references

### DIFF
--- a/.changes/0.0.0.md
+++ b/.changes/0.0.0.md
@@ -3,6 +3,8 @@
 For information on prior major and minor releases, see their changelogs:
 
 
+* [1.12](https://github.com/dbt-labs/dbt-core/blob/1.12.latest/CHANGELOG.md)
+* [1.11](https://github.com/dbt-labs/dbt-core/blob/1.11.latest/CHANGELOG.md)
 * [1.10](https://github.com/dbt-labs/dbt-core/blob/1.10.latest/CHANGELOG.md)
 * [1.9](https://github.com/dbt-labs/dbt-core/blob/1.9.latest/CHANGELOG.md)
 * [1.8](https://github.com/dbt-labs/dbt-core/blob/1.8.latest/CHANGELOG.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 For information on prior major and minor releases, see their changelogs:
 
+
+* [1.12](https://github.com/dbt-labs/dbt-core/blob/1.12.latest/CHANGELOG.md)
 * [1.11](https://github.com/dbt-labs/dbt-core/blob/1.11.latest/CHANGELOG.md)
 * [1.10](https://github.com/dbt-labs/dbt-core/blob/1.10.latest/CHANGELOG.md)
 * [1.9](https://github.com/dbt-labs/dbt-core/blob/1.9.latest/CHANGELOG.md)


### PR DESCRIPTION
Resolves #

<!---
  Include the number of the issue addressed by this PR above, if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Add the `user docs` label to this PR if it will need docs changes.  An 
  issue will get opened in docs.getdbt.com upon successful merge of this PR.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
1.13 CHANGELOG.md file is missing references to the previous 1.11 and 1.12 releases

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
1. Updated 0.0.0.md file to add references to the previous 1.11 and 1.12 release CHANGELOG.md
2. Generated CHANGELOG using `changie merge`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
