### PR TITLE
ci: dispatch fs dbt-core version bump after release

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -866,6 +866,32 @@ jobs:
           EOF
           )"
 
+  # Tell dbt-labs/fs to bump its `# COPYBARA-DBTCORE-VERSION` marker to the
+  # released version via the `bump-dbt-core-version` repository_dispatch fs
+  # listens for. Fire-and-forget: fs opens its own PR (no-op if unchanged).
+  bump-fs-dbt-core-version:
+    name: Bump dbt-core version in fs
+    needs: [prepare-release, publish-pypi, github-release]
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      VERSION: ${{ needs.prepare-release.outputs.version }}
+    steps:
+      - name: Trigger dbt-core version bump in fs
+        run: |
+          # jq-build the body so the version can't break out of the JSON.
+          payload="$(jq -n --arg version "$VERSION" \
+            '{event_type: "bump-dbt-core-version", client_payload: {version: $version}}')"
+          curl -sS --fail-with-body -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.FS_SERVICE_PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/dbt-labs/fs/dispatches \
+            -d "$payload"
+
   # Submits an updated dbtLabs.dbt-core manifest to microsoft/winget-pkgs
   # via `wingetcreate update` using the Windows installer archive from the
   # `github-release` job. Runs in parallel with `publish-homebrew`; both

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -866,13 +866,13 @@ jobs:
           EOF
           )"
 
-  # Tell dbt-labs/fs to bump its `# COPYBARA-DBTCORE-VERSION` marker to the
-  # released version via the `bump-dbt-core-version` repository_dispatch fs
-  # listens for. On success fs opens its own PR; a failed dispatch (API blip,
-  # expired PAT) fails the job so slack-failure-notification pages oncall to
-  # raise the bump PR by hand.
-  bump-fs-dbt-core-version:
-    name: Bump dbt-core version in fs
+  # Tell the internal mirror repo to bump its dbt-core version marker to the
+  # released version via the `bump-dbt-core-version` repository_dispatch it
+  # listens for. On success the mirror opens its own PR; a failed dispatch
+  # (API blip, expired PAT) fails the job so slack-failure-notification pages
+  # oncall to raise the bump PR by hand.
+  bump-mirror-dbt-core-version:
+    name: Bump dbt-core version in mirror
     needs: [prepare-release, publish-pypi, github-release]
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
@@ -881,7 +881,7 @@ jobs:
     env:
       VERSION: ${{ needs.prepare-release.outputs.version }}
     steps:
-      - name: Trigger dbt-core version bump in fs
+      - name: Trigger dbt-core version bump in mirror
         run: |
           # jq-build the body so the version can't break out of the JSON.
           payload="$(jq -n --arg version "$VERSION" \
@@ -972,7 +972,7 @@ jobs:
         publish-homebrew,
         publish-winget,
         changelog-backport,
-        bump-fs-dbt-core-version,
+        bump-mirror-dbt-core-version,
       ]
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -868,7 +868,9 @@ jobs:
 
   # Tell dbt-labs/fs to bump its `# COPYBARA-DBTCORE-VERSION` marker to the
   # released version via the `bump-dbt-core-version` repository_dispatch fs
-  # listens for. Fire-and-forget: fs opens its own PR (no-op if unchanged).
+  # listens for. On success fs opens its own PR; a failed dispatch (API blip,
+  # expired PAT) fails the job so slack-failure-notification pages oncall to
+  # raise the bump PR by hand.
   bump-fs-dbt-core-version:
     name: Bump dbt-core version in fs
     needs: [prepare-release, publish-pypi, github-release]
@@ -970,6 +972,7 @@ jobs:
         publish-homebrew,
         publish-winget,
         changelog-backport,
+        bump-fs-dbt-core-version,
       ]
     uses: dbt-labs/dbt-release/.github/workflows/slack-post-notification.yml@main
     with:


### PR DESCRIPTION
## What

Adds a `bump-fs-dbt-core-version` job to `release-v2.yml` that, once a release publishes, fires a `repository_dispatch` to trigger the downstream dbt-core version-marker bump.

## Details

- Reuses the same trigger conditions as `changelog-backport`: `needs: [prepare-release, publish-pypi, github-release]`, `if: ${{ !inputs.dry_run }}`.
- Mirrors the existing cross-repo dispatch pattern in `auto-public-pr-copybara.yml`.
- Payload is built with `jq`; `curl --fail-with-body` surfaces a bad dispatch as a failed step.
- A failed dispatch (API blip, expired PAT) fails the job and is wired into `slack-failure-notification`, so oncall is alerted and can raise the bump PR by hand.

No changelog needed (CI-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)