### PR TITLE
fix: correct `dbt build` "X of Y" node count with unit tests

### DIFF
--- a/.changes/unreleased/Fixes-20260720-120000.yaml
+++ b/.changes/unreleased/Fixes-20260720-120000.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Fix `dbt build` node count ("X of Y") being inflated when unit tests are selected,
+  by adding the unit test count to num_nodes exactly once instead of on every dequeue
+  while run_count is still 0
+time: 2026-07-20T12:00:00.000000+00:00
+custom:
+    Author: tauhid621
+    Issue: "11185"

--- a/core/dbt/task/build.py
+++ b/core/dbt/task/build.py
@@ -61,6 +61,7 @@ class BuildTask(RunTask):
         super().__init__(args, config, manifest, catalogs=catalogs)
         self.selected_unit_tests: Set = set()
         self.model_to_unit_test_map: Dict[str, List] = {}
+        self._unit_test_count_added: bool = False
 
     def before_run(self, adapter: BaseAdapter, selected_uids: AbstractSet[str]) -> RunStatus:
         self._maybe_show_reuse_relations_hint()
@@ -135,8 +136,12 @@ class BuildTask(RunTask):
 
     # overrides handle_job_queue in runnable.py
     def handle_job_queue(self, pool, callback):
-        if self.run_count == 0:
+        # Unit tests run alongside their model, not as queue nodes, so add their
+        # count to num_nodes exactly once (run_count is an unreliable guard: the
+        # async workers may leave it at 0 across several dequeues).
+        if not self._unit_test_count_added:
             self.num_nodes = self.num_nodes + len(self.selected_unit_tests)
+            self._unit_test_count_added = True
         node = self.job_queue.get()
         if (
             node.resource_type == NodeType.Model

--- a/tests/unit/task/test_build.py
+++ b/tests/unit/task/test_build.py
@@ -53,6 +53,40 @@ class TestBuildReuseRelationsHint:
         mock_show_hint.assert_not_called()
 
 
+class TestBuildUnitTestNodeCount:
+    """Unit tests run alongside their model rather than as their own queue
+    nodes, so their count is added to num_nodes in handle_job_queue. That
+    addition must happen exactly once -- see dbt-core#11185, where gating on
+    run_count (only bumped by the async workers, so still 0 across several
+    dequeues) inflated the "X of Y" node count.
+    """
+
+    def _make_task(self, num_nodes, selected_unit_tests):
+        task = BuildTask.__new__(BuildTask)
+        task.num_nodes = num_nodes
+        task.selected_unit_tests = selected_unit_tests
+        task._unit_test_count_added = False
+        task.run_count = 0
+        task.model_to_unit_test_map = {}
+        task.job_queue = mock.Mock()
+        task.job_queue.get.return_value = _test_node()
+        # Isolate the num_nodes bookkeeping from the actual dispatch.
+        task.handle_job_queue_node = mock.Mock()
+        return task
+
+    def test_count_added_once_across_dequeues(self):
+        task = self._make_task(num_nodes=3, selected_unit_tests={"ut.1", "ut.2"})
+        # Several dequeues happen before any worker bumps run_count.
+        for _ in range(3):
+            task.handle_job_queue(pool=mock.Mock(), callback=mock.Mock())
+        assert task.num_nodes == 5
+
+    def test_no_unit_tests_is_noop(self):
+        task = self._make_task(num_nodes=4, selected_unit_tests=set())
+        task.handle_job_queue(pool=mock.Mock(), callback=mock.Mock())
+        assert task.num_nodes == 4
+
+
 def test_saved_query_runner_on_skip(saved_query: SavedQuery):
     runner = SavedQueryRunner(
         config=None,


### PR DESCRIPTION
### What
`dbt build` reported an inflated "X of Y" node count when unit tests were selected — the displayed total didn't match what actually ran. Fixes #11185.

### Why
Unit tests run alongside their model rather than as queue nodes, so their count is added back to `num_nodes` in `handle_job_queue`. That add was gated on `run_count == 0`, but `run_count` is only bumped by the async workers — it can stay `0` across several dequeues, so the count got added repeatedly and inflated the total.

### How
Gate the add on a dedicated `_unit_test_count_added` flag set synchronously in the same method, guaranteeing it happens exactly once. Added unit tests covering the once-across-dequeues and no-unit-tests cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)