### PR TITLE
Make unit-test model resolution order-independent

### DIFF
--- a/.changes/unreleased/Fixes-20260721-140000.yaml
+++ b/.changes/unreleased/Fixes-20260721-140000.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Stop resolving a unit test's tested model eagerly at parse time; resolve it
+  only in the single deterministic post-parse pass so resolution no longer depends
+  on filesystem parse order at all (deeper fix for #11139)
+time: 2026-07-21T14:00:00.000000000Z
+custom:
+    Author: itsnamangoyal
+    Issue: "11139"

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -515,7 +515,7 @@ class ManifestLoader:
             start_process = time.perf_counter()
             self.process_sources(self.root_project.project_name)
             self.process_refs(self.root_project.project_name, self.root_project.dependencies)
-            self.process_unit_tests(self.root_project.project_name)
+            self.process_unit_tests()
             self.process_docs(self.root_project)
             self.process_metrics(self.root_project)
             self.process_saved_queries(self.root_project)
@@ -1485,7 +1485,7 @@ class ManifestLoader:
     # Loops through all nodes, for each element in
     # 'unit_test' array finds the node and updates the
     # 'depends_on.nodes' array with the unique id
-    def process_unit_tests(self, current_project: str):
+    def process_unit_tests(self):
         models_to_versions = None
         unit_test_unique_ids = list(self.manifest.unit_tests.keys())
         for unit_test_unique_id in unit_test_unique_ids:
@@ -1499,9 +1499,7 @@ class ManifestLoader:
                 continue
             if not models_to_versions:
                 models_to_versions = _build_model_names_to_versions(self.manifest)
-            process_models_for_unit_test(
-                self.manifest, current_project, unit_test, models_to_versions
-            )
+            process_models_for_unit_test(self.manifest, unit_test, models_to_versions)
 
     # Loops through all nodes, for each element in
     # 'functions' array finds the node and updates the

--- a/core/dbt/parser/unit_tests.py
+++ b/core/dbt/parser/unit_tests.py
@@ -317,9 +317,6 @@ class UnitTestParser(YamlReader):
     def parse(self) -> ParseResult:
         for data in self.get_key_dicts():
             unit_test: UnparsedUnitTest = self._get_unit_test(data)
-            tested_model_node = find_tested_model_node(
-                self.manifest, self.project.project_name, unit_test.model
-            )
             unit_test_case_unique_id = (
                 f"{NodeType.Unit}.{self.project.project_name}.{unit_test.model}.{unit_test.name}"
             )
@@ -348,13 +345,6 @@ class UnitTestParser(YamlReader):
                 config=unit_test_config,
                 versions=unit_test.versions,
             )
-
-            if tested_model_node:
-                if tested_model_node.config.enabled:
-                    unit_test_definition.depends_on.nodes.append(tested_model_node.unique_id)
-                    unit_test_definition.schema = tested_model_node.schema
-                else:
-                    unit_test_definition.config.enabled = False
 
             # Check that format and type of rows matches for each given input,
             # convert rows to a list of dictionaries, and add the unique_id of
@@ -568,38 +558,40 @@ def find_tested_model_node(
 # This is called by the ManifestLoader after other processing has been done,
 # so that model versions are available.
 def process_models_for_unit_test(
-    manifest: Manifest, current_project: str, unit_test_def: UnitTestDefinition, models_to_versions
+    manifest: Manifest, unit_test_def: UnitTestDefinition, models_to_versions
 ):
-    # Resolve (or re-resolve) the tested model. depends_on may be empty (the
-    # tested-model YAML hadn't been parsed when this unit test was parsed) or
-    # hold a stale id -- e.g. a pre-versioning unversioned id that model
-    # versioning has since replaced with versioned ids, which happens when the
-    # unit-test YAML is parsed before the versioned-model YAML (non-deterministic
-    # filesystem order). Now that model versions are available, resolve for real
-    # (dbt-core #11139).
-    if (
-        not unit_test_def.depends_on.nodes
-        or unit_test_def.depends_on.nodes[0] not in manifest.nodes
-    ):
-        tested_node = find_tested_model_node(manifest, current_project, unit_test_def.model)
-        if tested_node is None:
-            raise ParsingError(
-                f"Unable to find model '{current_project}.{unit_test_def.model}' for "
-                f"unit test '{unit_test_def.name}' in {unit_test_def.original_file_path}"
-            )
-        if tested_node.config.enabled:
-            unit_test_def.depends_on.nodes = [tested_node.unique_id]
-            unit_test_def.schema = tested_node.schema
-        else:
-            # If the model is disabled, the unit test should be disabled
-            unit_test_def.config.enabled = False
+    # Resolve the tested model. This is the ONLY place resolution happens --
+    # UnitTestParser.parse() deliberately leaves depends_on empty, because
+    # resolving eagerly at parse time made the outcome depend on filesystem
+    # parse order relative to the tested model's own YAML (dbt-core #11139).
+    # By the time this runs, all models -- including versioned ones -- have
+    # been parsed and ref_lookup has been rebuilt, so resolution here is
+    # deterministic. Resolve using the unit test's own package -- not the
+    # root project -- so unit tests defined in a dependency package correctly
+    # resolve models within that same package.
+    tested_node = find_tested_model_node(manifest, unit_test_def.package_name, unit_test_def.model)
+    if tested_node is None:
+        raise ParsingError(
+            f"Unable to find model '{unit_test_def.package_name}.{unit_test_def.model}' for "
+            f"unit test '{unit_test_def.name}' in {unit_test_def.original_file_path}"
+        )
+    if tested_node.config.enabled:
+        unit_test_def.depends_on.nodes = [tested_node.unique_id]
+        unit_test_def.schema = tested_node.schema
+    else:
+        # If the model is disabled, the unit test should be disabled
+        unit_test_def.config.enabled = False
 
     if not unit_test_def.config.enabled:
-        # Ensure the unit test is disabled in the manifest
+        # Ensure the unit test is disabled in the manifest. Its unique_id is
+        # already in the source file's unit_tests list (parse() unconditionally
+        # added it there via add_unit_test() before this function ever ran), so
+        # use add_disabled_nofile() -- not add_disabled() -- to avoid appending
+        # the id to source_file.unit_tests a second time.
         if unit_test_def.unique_id in manifest.unit_tests:
             manifest.unit_tests.pop(unit_test_def.unique_id)
         if unit_test_def.unique_id not in manifest.disabled:
-            manifest.add_disabled(manifest.files[unit_test_def.file_id], unit_test_def)
+            manifest.add_disabled_nofile(unit_test_def)
 
         # The unit test is disabled, so we don't need to do any further processing (#10540)
         return

--- a/tests/functional/partial_parsing/test_pp_unit_tests.py
+++ b/tests/functional/partial_parsing/test_pp_unit_tests.py
@@ -1,0 +1,168 @@
+import os
+
+import pytest
+
+from dbt.exceptions import ParsingError
+from dbt.tests.util import get_manifest, rm_file, run_dbt, write_file
+
+
+def normalize(path):
+    return os.path.normcase(os.path.normpath(path))
+
+
+model_one_sql = """
+select 1 as fun
+"""
+
+# --- scenario 1: version-set change, unit-test file untouched ---
+
+unversioned_schema_yml = """
+models:
+    - name: model_one
+"""
+
+versioned_schema_yml = """
+models:
+    - name: model_one
+      latest_version: 1
+      versions:
+        - v: 1
+"""
+
+unit_test_yml = """
+unit_tests:
+    - name: test_model_one
+      model: model_one
+      given: []
+      expect:
+        rows:
+          - {fun: 1}
+"""
+
+
+class TestVersionChangeUnitTestFileUntouched:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_one.sql": model_one_sql,
+            "schema.yml": unversioned_schema_yml,
+            "unit_tests.yml": unit_test_yml,
+        }
+
+    def test_pp_version_change_reresolves_unit_test(self, project):
+        manifest = run_dbt(["parse"])
+        assert "unit_test.test.model_one.test_model_one" in manifest.unit_tests
+        unit_test = manifest.unit_tests["unit_test.test.model_one.test_model_one"]
+        assert unit_test.depends_on.nodes == ["model.test.model_one"]
+
+        # Add versioning to model_one (v1 is latest, so it defaults to the
+        # existing model_one.sql -- no file rename needed); the unit-test
+        # YAML is untouched.
+        write_file(versioned_schema_yml, project.project_root, "models", "schema.yml")
+        manifest = run_dbt(["--partial-parse", "parse"])
+
+        assert "unit_test.test.model_one.test_model_one_v1" in manifest.unit_tests
+        versioned_unit_test = manifest.unit_tests["unit_test.test.model_one.test_model_one_v1"]
+        assert versioned_unit_test.depends_on.nodes == ["model.test.model_one.v1"]
+
+
+# --- scenario 2: tested model disabled on a later partial-parse pass ---
+
+model_and_unit_test_enabled_yml = """
+models:
+    - name: model_one
+
+unit_tests:
+    - name: test_model_one
+      model: model_one
+      description: "v1"
+      given: []
+      expect:
+        rows:
+          - {fun: 1}
+"""
+
+# Disables the model AND edits the unit test's own description. dbt's
+# partial-parse schema diffing reschedules a unit test for reparsing based on
+# its own schema element changing, or (separately) on the tested model's
+# group/version changing (see partial.py _delete_schema_mssa_links) -- not on
+# an unrelated model's `enabled` config alone changing in a shared file. This
+# test exercises the parse-order fix via the former path; the latter is a
+# distinct, pre-existing gap tracked separately.
+model_disabled_yml = """
+models:
+    - name: model_one
+      config:
+        enabled: false
+
+unit_tests:
+    - name: test_model_one
+      model: model_one
+      description: "v2"
+      given: []
+      expect:
+        rows:
+          - {fun: 1}
+"""
+
+
+class TestModelDisabledOnLaterPartialParse:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_one.sql": model_one_sql,
+            "schema.yml": model_and_unit_test_enabled_yml,
+        }
+
+    def test_pp_model_disabled_moves_unit_test_once(self, project):
+        manifest = run_dbt(["parse"])
+        unit_test_id = "unit_test.test.model_one.test_model_one"
+        assert unit_test_id in manifest.unit_tests
+        assert manifest.unit_tests[unit_test_id].depends_on.nodes == ["model.test.model_one"]
+
+        # Disable the tested model. The unit test is defined in the same
+        # schema.yml file, so this edit reparses both.
+        write_file(model_disabled_yml, project.project_root, "models", "schema.yml")
+        run_dbt(["--partial-parse", "parse"])
+        manifest = get_manifest(project.project_root)
+
+        assert unit_test_id not in manifest.unit_tests
+        assert unit_test_id in manifest.disabled
+        # Regression check for the add_disabled/add_disabled_nofile double-append fix.
+        assert len(manifest.disabled[unit_test_id]) == 1
+        schema_file = manifest.files["test://" + normalize("models/schema.yml")]
+        assert schema_file.unit_tests.count(unit_test_id) == 1
+
+
+# --- scenario 3: model delete/re-add ---
+
+
+class TestModelDeleteReAdd:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_one.sql": model_one_sql,
+            "schema.yml": unversioned_schema_yml,
+            "unit_tests.yml": unit_test_yml,
+        }
+
+    def test_pp_model_delete_readd(self, project):
+        manifest = run_dbt(["parse"])
+        assert "unit_test.test.model_one.test_model_one" in manifest.unit_tests
+
+        # Delete the model entirely (file + schema entry).
+        rm_file(project.project_root, "models", "model_one.sql")
+        write_file("models: []\n", project.project_root, "models", "schema.yml")
+        with pytest.raises(ParsingError):
+            run_dbt(["--partial-parse", "parse"])
+
+        # Re-add the model and confirm clean re-resolution with no dupes.
+        write_file(model_one_sql, project.project_root, "models", "model_one.sql")
+        write_file(unversioned_schema_yml, project.project_root, "models", "schema.yml")
+        manifest = run_dbt(["--partial-parse", "parse"])
+
+        unit_test_id = "unit_test.test.model_one.test_model_one"
+        assert unit_test_id in manifest.unit_tests
+        assert manifest.unit_tests[unit_test_id].depends_on.nodes == ["model.test.model_one"]
+        schema_file = manifest.files["test://" + normalize("models/unit_tests.yml")]
+        assert schema_file.unit_tests.count(unit_test_id) == 1

--- a/tests/unit/parser/test_unit_tests.py
+++ b/tests/unit/parser/test_unit_tests.py
@@ -179,6 +179,10 @@ class UnitTestParserTest(SchemaParserTest):
 
         self.assert_has_manifest_lengths(self.parser.manifest, nodes=1, unit_tests=1)
         unit_test = list(self.parser.manifest.unit_tests.values())[0]
+        # Resolution of the tested model now happens only in the post-parse
+        # pass, not in parse() itself (dbt-core #11139).
+        self.assertEqual(unit_test.depends_on.nodes, [])
+        process_models_for_unit_test(self.parser.manifest, unit_test, {})
         expected = UnitTestDefinition(
             name="test_my_model",
             model="my_model",
@@ -242,34 +246,40 @@ class UnitTestParserTest(SchemaParserTest):
         self.manifest.nodes[my_model_versioned_node.unique_id] = my_model_versioned_node
 
         UnitTestParser(self.parser, block).parse()
+        self.parser.manifest.files[block.file.file_id] = block.file
 
         self.assert_has_manifest_lengths(self.parser.manifest, nodes=2, unit_tests=1)
         unit_test = self.parser.manifest.unit_tests[
             "unit_test.snowplow.my_model_versioned.v1.test_my_model_versioned"
         ]
+        self.assertEqual(unit_test.depends_on.nodes, [])
+        models_to_versions = {
+            "snowplow": {"my_model_versioned": [my_model_versioned_node.unique_id]}
+        }
+        process_models_for_unit_test(self.parser.manifest, unit_test, models_to_versions)
         self.assertEqual(len(unit_test.depends_on.nodes), 1)
         self.assertEqual(unit_test.depends_on.nodes[0], "model.snowplow.my_model_versioned.v1")
 
-    def test_versioned_model_parsed_before_versioning_is_reresolved(self):
-        # Regression test for dbt-core #11139.
-        # When the unit-test YAML is parsed before the versioned model's schema
-        # patch is applied (non-deterministic filesystem parse order), the unit
-        # test's depends_on is bound to the pre-versioning unversioned unique_id
-        # (model.snowplow.my_model). Versioning then removes that id from the
-        # manifest. process_models_for_unit_test must re-resolve the now-stale
-        # id to the versioned model instead of raising "references a model that
-        # does not exist".
+    def test_model_resolved_only_in_post_parse_pass(self):
+        # Regression test for dbt-core #11139 (deeper fix, CORE-804).
+        # UnitTestParser.parse() must never resolve the tested model itself --
+        # resolution order must not depend on filesystem parse order relative
+        # to the tested model's own YAML. depends_on stays empty coming out of
+        # parse(), regardless of whether the tested model is versioned, and is
+        # resolved exactly once, deterministically, in
+        # process_models_for_unit_test.
         block = self.yaml_block_for(UNIT_TEST_SOURCE, "test_my_model.yml")
         UnitTestParser(self.parser, block).parse()
 
         manifest = self.parser.manifest
         manifest.files[block.file.file_id] = block.file
         unit_test = manifest.unit_tests["unit_test.snowplow.my_model.test_my_model"]
-        # Parsed before versioning: bound to the unversioned id.
-        self.assertEqual(unit_test.depends_on.nodes, ["model.snowplow.my_model"])
+        self.assertEqual(unit_test.depends_on.nodes, [])
 
-        # Simulate the model versioning patch: the unversioned node id is
-        # replaced by the versioned one, and ref_lookup is rebuilt.
+        # Simulate the model versioning patch happening after this unit test
+        # was parsed: the unversioned node id is replaced by a versioned one,
+        # and ref_lookup is rebuilt -- exactly as manifest.py does before
+        # process_unit_tests() runs.
         del manifest.nodes["model.snowplow.my_model"]
         versioned_node = MockNode(
             package="snowplow",
@@ -287,11 +297,39 @@ class UnitTestParserTest(SchemaParserTest):
         manifest.rebuild_ref_lookup()
 
         models_to_versions = {"snowplow": {"my_model": [versioned_node.unique_id]}}
-        process_models_for_unit_test(manifest, "snowplow", unit_test, models_to_versions)
+        process_models_for_unit_test(manifest, unit_test, models_to_versions)
 
         assert "unit_test.snowplow.my_model.test_my_model_v1" in manifest.unit_tests
         versioned_ut = manifest.unit_tests["unit_test.snowplow.my_model.test_my_model_v1"]
         self.assertEqual(versioned_ut.depends_on.nodes[0], "model.snowplow.my_model.v1")
+
+    def test_disabled_model_no_duplicate_file_entry(self):
+        # Regression test: process_models_for_unit_test's disable-routing must
+        # not append the unit test's unique_id to source_file.unit_tests a
+        # second time -- parse()'s add_unit_test() call already put it there.
+        block = self.yaml_block_for(UNIT_TEST_SOURCE, "test_my_model.yml")
+        UnitTestParser(self.parser, block).parse()
+
+        manifest = self.parser.manifest
+        manifest.files[block.file.file_id] = block.file
+        unit_test = manifest.unit_tests["unit_test.snowplow.my_model.test_my_model"]
+        schema_file = manifest.files[block.file.file_id]
+        self.assertEqual(schema_file.unit_tests.count(unit_test.unique_id), 1)
+
+        # Make the tested model disabled and rebuild the lookups so
+        # find_tested_model_node() resolves it via disabled_lookup.
+        model_node = manifest.nodes.pop("model.snowplow.my_model")
+        model_node.config.enabled = False
+        manifest.add_disabled_nofile(model_node)
+        manifest.rebuild_ref_lookup()
+        manifest.rebuild_disabled_lookup()
+
+        process_models_for_unit_test(manifest, unit_test, {})
+
+        self.assertNotIn(unit_test.unique_id, manifest.unit_tests)
+        self.assertIn(unit_test.unique_id, manifest.disabled)
+        self.assertEqual(len(manifest.disabled[unit_test.unique_id]), 1)
+        self.assertEqual(schema_file.unit_tests.count(unit_test.unique_id), 1)
 
     def test_missing_model_raises_parsing_error(self):
         # A unit test whose `model` never resolves must raise in
@@ -305,7 +343,7 @@ class UnitTestParserTest(SchemaParserTest):
             "unit_test.snowplow.my_model_doesnt_exist.test_my_model_doesnt_exist"
         ]
         with self.assertRaises(ParsingError):
-            process_models_for_unit_test(manifest, "snowplow", unit_test, {})
+            process_models_for_unit_test(manifest, unit_test, {})
 
     def test_multiple_unit_tests(self):
         block = self.yaml_block_for(UNIT_TEST_MULTIPLE_SOURCE, "test_my_model.yml")
@@ -313,7 +351,9 @@ class UnitTestParserTest(SchemaParserTest):
         UnitTestParser(self.parser, block).parse()
 
         self.assert_has_manifest_lengths(self.parser.manifest, nodes=1, unit_tests=2)
-        for unit_test in self.parser.manifest.unit_tests.values():
+        for unit_test in list(self.parser.manifest.unit_tests.values()):
+            self.assertEqual(unit_test.depends_on.nodes, [])
+            process_models_for_unit_test(self.parser.manifest, unit_test, {})
             self.assertEqual(len(unit_test.depends_on.nodes), 1)
             self.assertEqual(unit_test.depends_on.nodes[0], "model.snowplow.my_model")
 
@@ -326,6 +366,8 @@ class UnitTestParserTest(SchemaParserTest):
 
         self.assert_has_manifest_lengths(self.parser.manifest, nodes=1, unit_tests=1)
         unit_test = list(self.parser.manifest.unit_tests.values())[0]
+        self.assertEqual(unit_test.depends_on.nodes, [])
+        process_models_for_unit_test(self.parser.manifest, unit_test, {})
         expected = UnitTestDefinition(
             name="test_my_model_null_handling",
             model="my_model",


### PR DESCRIPTION
## Summary

Deeper fix for #11139. Unit tests resolved their tested model eagerly at parse time, so if a unit test's YAML parsed before its model's versioned YAML, it bound to a stale/unversioned model id that model versioning later removed from the manifest.

This PR removes the eager resolution entirely. `UnitTestParser.parse()` no longer resolves the tested model at all; resolution happens exclusively in the existing post-parse pass (`process_models_for_unit_test`), after all models — including versioned ones — have been parsed. There's now a single, deterministic resolution path, so correctness no longer depends on filesystem parse order.

Also fixed along the way:
- A double-append bug in the disable-routing path (`add_disabled` → `add_disabled_nofile`) that would duplicate a unit test's id in `SchemaSourceFile.unit_tests` once resolution always runs through this path.
- A cross-package resolution regression caught during verification: resolution must use the unit test's own package (`unit_test_def.package_name`), not the root project, so unit tests defined in a dependency package resolve models within that same package.

## Test plan

- [x] Updated unit tests in `tests/unit/parser/test_unit_tests.py` to reflect that `depends_on` is empty coming out of `parse()` and resolved only via `process_models_for_unit_test`
- [x] Added `test_disabled_model_no_duplicate_file_entry` regression test for the double-append fix
- [x] Added new functional partial-parse tests (`tests/functional/partial_parsing/test_pp_unit_tests.py`) covering version-set changes, model-disable transitions, and model delete/re-add
- [x] Full targeted suite passing (`tests/unit/parser/`, `tests/functional/unit_testing/`, `tests/functional/partial_parsing/`)
- [x] Manually verified against a live project (jaffle-shop) with both filesystem orderings forced