### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260721-203325.yaml
+++ b/.changes/unreleased/Under the Hood-20260721-203325.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-07-21T20:33:25.738991694Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -10787,7 +10787,8 @@
       "enum": [
         "configuredoff",
         "unabletofetchschema",
-        "nodownstream"
+        "nodownstream",
+        "custommaterialization"
       ]
     },
     "StoreFailuresAs": {


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`6a1cb5e7fba242a36f06fb69e053a428075b5988`](https://github.com/dbt-labs/fs/commit/6a1cb5e7fba242a36f06fb69e053a428075b5988)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/29864105523)