### PR TITLE
remove ddtrace from integration test workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,7 +227,7 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           shell: bash
-          command: cd core && hatch -v run ci:integration-tests -- ${{ secrets.DATADOG_API_KEY != '' && '--ddtrace' || '' }} --splits ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }} --group ${{ matrix.split-group }}
+          command: cd core && hatch -v run ci:integration-tests -- --splits ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }} --group ${{ matrix.split-group }}
 
       - name: Get current date
         if: always()
@@ -305,7 +305,7 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           shell: bash
-          command: cd core && hatch -v run ci:integration-tests -- ${{ secrets.DATADOG_API_KEY != '' && '--ddtrace' || '' }} --splits ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }} --group ${{ matrix.split-group }}
+          command: cd core && hatch -v run ci:integration-tests -- --splits ${{ env.PYTHON_INTEGRATION_TEST_WORKERS }} --group ${{ matrix.split-group }}
 
       - name: Get current date
         if: always()

--- a/.github/workflows/test-repeater.yml
+++ b/.github/workflows/test-repeater.yml
@@ -130,7 +130,7 @@ jobs:
           for ((i=1; i<=${{ inputs.num_runs_per_batch }}; i++))
           do
             echo "Running pytest iteration $i..."
-            python -m pytest --ddtrace ${{ inputs.test_path }}
+            python -m pytest ${{ inputs.test_path }}
             exit_code=$?
 
             if [[ $exit_code -eq 0 ]]; then


### PR DESCRIPTION
Resolves #

### Problem
We push test CI logs to dd but upstream its not utilized anywhere, this also causes issues with oss fork PRs. we save costs and avoid the OSS fork PR issues by getting rid of the flag entirely.

### Solution
Removes --ddtrace from integration tests CI


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
