### PR TITLE
Allow database-less OSI dataset sources to bind by schema + alias

### DIFF
--- a/.changes/unreleased/Features-20260723-160000.yaml
+++ b/.changes/unreleased/Features-20260723-160000.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Allow database-less OSI dataset sources (`schema.table`) to bind to models
+  by schema and alias, so one OSI document works across environments whose only
+  difference is the database
+time: 2026-07-23T16:00:00.000000+09:00
+custom:
+    Author: ota2000
+    Issue: "15649"

--- a/core/dbt/parser/osi.py
+++ b/core/dbt/parser/osi.py
@@ -57,9 +57,7 @@ def _build_model_lookup(manifest: Manifest) -> Dict[Tuple[str, str, str], ModelN
 
 
 def _match_database_less(
-    ctx: _OsiFileContext,
-    dataset_name: str,
-    table_ref: str,
+    error_prefix: str,
     key: Tuple[str, str, str],
     model_lookup: Dict[Tuple[str, str, str], ModelNode],
 ) -> Optional[ModelNode]:
@@ -72,8 +70,7 @@ def _match_database_less(
     if len(candidates) > 1:
         databases = sorted({node.database or "<no database>" for node in candidates})
         raise ParsingError(
-            f"OSI file '{ctx.path}' contains dataset '{dataset_name}' "
-            f"({table_ref}) that matches models in multiple "
+            f"{error_prefix} matches models in multiple "
             f"databases: {', '.join(databases)}. Qualify the source with a "
             f"database to disambiguate."
         )
@@ -94,14 +91,14 @@ def _match_model_for_dataset(
     table_ref = ".".join(
         filter(None, [node_relation.database, node_relation.schema_name, node_relation.alias])
     )
+    error_prefix = f"OSI file '{ctx.path}' contains dataset '{dataset_name}' ({table_ref}) that"
 
     matched = model_lookup.get(key)
     if matched is None and not key[2]:
-        matched = _match_database_less(ctx, dataset_name, table_ref, key, model_lookup)
+        matched = _match_database_less(error_prefix, key, model_lookup)
     if matched is None:
         raise ParsingError(
-            f"OSI file '{ctx.path}' contains dataset '{dataset_name}' "
-            f"({table_ref}) that does not match any dbt model in this project. "
+            f"{error_prefix} does not match any dbt model in this project. "
             f"Each OSI dataset must reference a table managed by a dbt model."
         )
     return matched

--- a/core/dbt/parser/osi.py
+++ b/core/dbt/parser/osi.py
@@ -2,7 +2,7 @@ import dataclasses
 import os
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from metricflow.converters.osi_to_msi import OSIToMSIConverter
 
@@ -56,6 +56,30 @@ def _build_model_lookup(manifest: Manifest) -> Dict[Tuple[str, str, str], ModelN
     }
 
 
+def _match_database_less(
+    ctx: _OsiFileContext,
+    dataset_name: str,
+    table_ref: str,
+    key: Tuple[str, str, str],
+    model_lookup: Dict[Tuple[str, str, str], ModelNode],
+) -> Optional[ModelNode]:
+    # Database-less sources (`schema.table`) bind on schema + alias alone, so a
+    # single OSI document can be shared across environments whose only
+    # difference is the database (e.g. per-environment BigQuery projects).
+    candidates = [
+        node for (alias, schema, _), node in model_lookup.items() if (alias, schema) == key[:2]
+    ]
+    if len(candidates) > 1:
+        databases = sorted({node.database or "<no database>" for node in candidates})
+        raise ParsingError(
+            f"OSI file '{ctx.path}' contains dataset '{dataset_name}' "
+            f"({table_ref}) that matches models in multiple "
+            f"databases: {', '.join(databases)}. Qualify the source with a "
+            f"database to disambiguate."
+        )
+    return candidates[0] if candidates else None
+
+
 def _match_model_for_dataset(
     ctx: _OsiFileContext,
     dataset_name: str,
@@ -73,24 +97,7 @@ def _match_model_for_dataset(
 
     matched = model_lookup.get(key)
     if matched is None and not key[2]:
-        # Database-less sources (`schema.table`) bind on schema + alias alone, so a
-        # single OSI document can be shared across environments whose only
-        # difference is the database (e.g. per-environment BigQuery projects).
-        candidates = [
-            node
-            for (alias, schema, _), node in model_lookup.items()
-            if (alias, schema) == key[:2]
-        ]
-        if len(candidates) == 1:
-            matched = candidates[0]
-        elif len(candidates) > 1:
-            databases = sorted((node.database or "") for node in candidates)
-            raise ParsingError(
-                f"OSI file '{ctx.path}' contains dataset '{dataset_name}' "
-                f"({table_ref}) that matches models in multiple "
-                f"databases: {', '.join(databases)}. Qualify the source with a "
-                f"database to disambiguate."
-            )
+        matched = _match_database_less(ctx, dataset_name, table_ref, key, model_lookup)
     if matched is None:
         raise ParsingError(
             f"OSI file '{ctx.path}' contains dataset '{dataset_name}' "

--- a/core/dbt/parser/osi.py
+++ b/core/dbt/parser/osi.py
@@ -56,18 +56,21 @@ def _build_model_lookup(manifest: Manifest) -> Dict[Tuple[str, str, str], ModelN
     }
 
 
-def _inject_one_semantic_model(
-    manifest: Manifest,
+def _match_model_for_dataset(
     ctx: _OsiFileContext,
+    dataset_name: str,
+    node_relation: Any,
     model_lookup: Dict[Tuple[str, str, str], ModelNode],
-    pydantic_sm: Any,
-) -> str:
-    nr = pydantic_sm.node_relation
+) -> ModelNode:
     key = (
-        (nr.alias or "").lower(),
-        (nr.schema_name or "").lower(),
-        (nr.database or "").lower(),
+        (node_relation.alias or "").lower(),
+        (node_relation.schema_name or "").lower(),
+        (node_relation.database or "").lower(),
     )
+    table_ref = ".".join(
+        filter(None, [node_relation.database, node_relation.schema_name, node_relation.alias])
+    )
+
     matched = model_lookup.get(key)
     if matched is None and not key[2]:
         # Database-less sources (`schema.table`) bind on schema + alias alone, so a
@@ -83,18 +86,28 @@ def _inject_one_semantic_model(
         elif len(candidates) > 1:
             databases = sorted((node.database or "") for node in candidates)
             raise ParsingError(
-                f"OSI file '{ctx.path}' contains dataset '{pydantic_sm.name}' "
-                f"({nr.schema_name}.{nr.alias}) that matches models in multiple "
+                f"OSI file '{ctx.path}' contains dataset '{dataset_name}' "
+                f"({table_ref}) that matches models in multiple "
                 f"databases: {', '.join(databases)}. Qualify the source with a "
                 f"database to disambiguate."
             )
     if matched is None:
-        table_ref = ".".join(filter(None, [nr.database, nr.schema_name, nr.alias]))
         raise ParsingError(
-            f"OSI file '{ctx.path}' contains dataset '{pydantic_sm.name}' "
+            f"OSI file '{ctx.path}' contains dataset '{dataset_name}' "
             f"({table_ref}) that does not match any dbt model in this project. "
             f"Each OSI dataset must reference a table managed by a dbt model."
         )
+    return matched
+
+
+def _inject_one_semantic_model(
+    manifest: Manifest,
+    ctx: _OsiFileContext,
+    model_lookup: Dict[Tuple[str, str, str], ModelNode],
+    pydantic_sm: Any,
+) -> str:
+    nr = pydantic_sm.node_relation
+    matched = _match_model_for_dataset(ctx, pydantic_sm.name, nr, model_lookup)
 
     unique_id = f"semantic_model.{ctx.package_name}.{pydantic_sm.name}"
     if unique_id in manifest.semantic_models:

--- a/core/dbt/parser/osi.py
+++ b/core/dbt/parser/osi.py
@@ -69,6 +69,25 @@ def _inject_one_semantic_model(
         (nr.database or "").lower(),
     )
     matched = model_lookup.get(key)
+    if matched is None and not key[2]:
+        # Database-less sources (`schema.table`) bind on schema + alias alone, so a
+        # single OSI document can be shared across environments whose only
+        # difference is the database (e.g. per-environment BigQuery projects).
+        candidates = [
+            node
+            for (alias, schema, _), node in model_lookup.items()
+            if (alias, schema) == key[:2]
+        ]
+        if len(candidates) == 1:
+            matched = candidates[0]
+        elif len(candidates) > 1:
+            databases = sorted((node.database or "") for node in candidates)
+            raise ParsingError(
+                f"OSI file '{ctx.path}' contains dataset '{pydantic_sm.name}' "
+                f"({nr.schema_name}.{nr.alias}) that matches models in multiple "
+                f"databases: {', '.join(databases)}. Qualify the source with a "
+                f"database to disambiguate."
+            )
     if matched is None:
         table_ref = ".".join(filter(None, [nr.database, nr.schema_name, nr.alias]))
         raise ParsingError(

--- a/tests/unit/parser/test_osi.py
+++ b/tests/unit/parser/test_osi.py
@@ -236,6 +236,25 @@ class TestLoadOsiIntoManifest:
         with pytest.raises(ParsingError, match="unsupported version"):
             load_osi_into_manifest(str(tmp_path), PKG, manifest, OSI_PATHS)
 
+    def test_database_less_source_binds_by_schema_and_alias(self, tmp_path):
+        (tmp_path / "OSI").mkdir()
+        (tmp_path / "OSI" / "orders.json").write_text(_osi_json("orders", "dbt_schema.orders"))
+        manifest = make_manifest(nodes=[_orders_model()])
+        load_osi_into_manifest(str(tmp_path), PKG, manifest, OSI_PATHS)
+        sm = manifest.semantic_models[f"semantic_model.{PKG}.orders"]
+        assert sm.model == "ref('orders')"
+
+    def test_database_less_source_ambiguous_across_databases_raises(self, tmp_path):
+        (tmp_path / "OSI").mkdir()
+        (tmp_path / "OSI" / "orders.json").write_text(_osi_json("orders", "dbt_schema.orders"))
+        model_a = _orders_model()
+        model_b = make_model(PKG, "orders_other_db", "select 1", alias=model_a.alias)
+        model_b.schema = model_a.schema
+        model_b.database = "another_db"
+        manifest = make_manifest(nodes=[model_a, model_b])
+        with pytest.raises(ParsingError, match="matches models in multiple databases"):
+            load_osi_into_manifest(str(tmp_path), PKG, manifest, OSI_PATHS)
+
     def test_no_matching_model_raises_parsing_error(self, tmp_path):
         (tmp_path / "OSI").mkdir()
         # Source references a table that has no corresponding model node


### PR DESCRIPTION
Resolves #15649. Supersedes #15650 (same story as #15654: the head stopped tracking the branch after the base retarget to `1.latest` and the PR could not be reopened — apologies for the noise).

## Problem

OSI documents pin their dataset binding to a static `database.schema.table` string, but the database is environment-dependent in many projects (`+database: "{{ env_var(...) }}"`). OSI JSON is not rendered, so a fully-qualified source parses in exactly one environment and hard-fails everywhere else, and a database-less `schema.table` source (a shape `OSIToMSIConverter._parse_source` already emits with `database=None`) never matches because the lookup compares the full `(alias, schema, database)` key. The only workaround is duplicating OSI documents per environment.

## Solution

When the source omits the database, fall back to matching on schema + alias. If that matches models in more than one database, raise a `ParsingError` listing the candidate databases. Fully-qualified sources behave exactly as before.

## Verification

- `tests/unit/parser/test_osi.py`: 35 passed (2 new: database-less binding, ambiguous-across-databases error) — re-run on the `1.latest` base
- End-to-end on a real BigQuery project with per-environment projects: the same OSI document binds to `<project>-dev` and `<project>-prod` models depending on `DBT_GOOGLE_PROJECT_ID`

Review history on #15650: CodeScene's complexity/argument advisories and Copilot's three comments (shared `table_ref`, deduped database list, and the deliberately-declined secondary-index micro-optimization) are already addressed in these commits; the final pre-retarget head passed `CodeScene Code Health Review (1.12.latest)`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX