### PR TITLE
ci(winget): switch Slack notification from bot token to incoming webhook

### DIFF
--- a/.changes/unreleased/Fixes-20260723-200329.yaml
+++ b/.changes/unreleased/Fixes-20260723-200329.yaml
@@ -1,7 +1,0 @@
-kind: Fixes
-body: Winget publish PR notifications now use a Slack incoming webhook instead of a bot token
-time: 2026-07-23T20:03:29.716261+05:30
-custom:
-    author: itsnamangoyal
-    issue: ""
-    project: dbt-core

--- a/.changes/unreleased/Fixes-20260723-200329.yaml
+++ b/.changes/unreleased/Fixes-20260723-200329.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Winget publish PR notifications now use a Slack incoming webhook instead of a bot token
+time: 2026-07-23T20:03:29.716261+05:30
+custom:
+    author: itsnamangoyal
+    issue: ""
+    project: dbt-core

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -174,7 +174,9 @@ jobs:
       contents: read
     steps:
       # Post the winget-pkgs PR link to Slack so on-call can review it.
+      # A Slack outage shouldn't fail the release workflow, so don't let this step fail the job.
       - name: Post Slack message
+        continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WINGET_WEBHOOK_URL }}
           VERSION: ${{ inputs.version }}

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -173,24 +173,21 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Post the winget-pkgs PR link to Slack so on-call can review it. Slack
-      # returns HTTP 200 even on failure, so assert on the `ok` field in the body.
+      # Post the winget-pkgs PR link to Slack so on-call can review it.
       - name: Post Slack message
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_WINGET_BOT_TOKEN }}
-          SLACK_CHANNEL: ${{ vars.WINGET_SLACK_CHANNEL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WINGET_WEBHOOK_URL }}
           VERSION: ${{ inputs.version }}
           PR_URL: ${{ needs.publish-winget.outputs.pr_url }}
         run: |
           text=":package: New winget PR opened for \`${PACKAGE_IDENTIFIER}\` \`${VERSION}\`: ${PR_URL}"
-          resp=$(jq -n --arg c "$SLACK_CHANNEL" --arg t "$text" \
-            '{channel: $c, text: $t, unfurl_links: false}' | \
-            curl -sS -X POST https://slack.com/api/chat.postMessage \
-              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+          resp=$(jq -n --arg t "$text" '{text: $t, unfurl_links: false}' | \
+            curl -sS -X POST "$SLACK_WEBHOOK_URL" \
               -H "Content-type: application/json; charset=utf-8" \
               --data @-)
-          if [ "$(echo "$resp" | jq -r '.ok')" != "true" ]; then
-            echo "::error::Slack chat.postMessage failed: $resp"
+          # Incoming webhooks return "ok" as plain text on success
+          if [ "$resp" != "ok" ]; then
+            echo "::error::Slack webhook failed: $resp"
             exit 1
           fi
           echo "Posted winget PR alert: $PR_URL"


### PR DESCRIPTION
## What
Switches the winget-publish Slack notification (`notify-winget-pr` job) from a bot token (`chat.postMessage`) to a Slack incoming webhook.

## Why
Simplifies credential management for this one-off notification — a scoped incoming webhook needs no bot install/channel-invite step, unlike a bot token.

## Before this fires
Repository config in `dbt-labs/dbt-core`:
- add secret `SLACK_WINGET_WEBHOOK_URL` — Slack incoming webhook URL for the target channel
- remove secret `SLACK_WINGET_BOT_TOKEN`
- remove variable `WINGET_SLACK_CHANNEL` (channel is now baked into the webhook URL)