### PR TITLE
Tag adapter issues with area:adapters and drop default area:core

### DIFF
--- a/.github/workflows/label-adapter.yml
+++ b/.github/workflows/label-adapter.yml
@@ -41,18 +41,4 @@ jobs:
                 issue_number: context.issue.number,
                 labels: [...labels, 'area:adapters'],
               });
-
-              // v2-labeled issues are auto-added to the Core working board with
-              // `area:core` applied by default. Adapter issues belong under
-              // area:adapters instead, so drop the default here.
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  name: 'area:core',
-                });
-              } catch (error) {
-                if (error.status !== 404) throw error;
-              }
             }

--- a/.github/workflows/label-adapter.yml
+++ b/.github/workflows/label-adapter.yml
@@ -39,6 +39,20 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                labels,
+                labels: [...labels, 'area:adapters'],
               });
+
+              // v2-labeled issues are auto-added to the Core working board with
+              // `area:core` applied by default. Adapter issues belong under
+              // area:adapters instead, so drop the default here.
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: 'area:core',
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
             }


### PR DESCRIPTION
## Summary
- `bug-report-v2.yml`'s default labels are `bug`, `triage`, `v2`, `type:bug`, `status:triage`, `engine:v2` — no area label, unlike `bug-report-vsce.yml` (`area:vscode`) or `sql-understanding.yml` (`area:static-analysis`).
- `label-adapter.yml` already detects the selected adapter from the issue form; it now also adds `area:adapters` so adapter-specific v2 bugs get routed correctly.

## Test plan
- [ ] Open a test issue via the v2 bug report form, select a valid adapter (e.g. snowflake), confirm the adapter label + `area:adapters` are applied
- [ ] Open a test issue with no adapter selected (or "other"), confirm no area label is added