### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260729-182945.yaml
+++ b/.changes/unreleased/Under the Hood-20260729-182945.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-07-29T18:29:45.958173574Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/project/latest.json
+++ b/core/dbt/jsonschemas/project/latest.json
@@ -532,6 +532,37 @@
         "Other"
       ]
     },
+    "DataTestState": {
+      "description": "The dbt State configs supported on data tests: only `require_fresh_data_from` and `evaluate_volatile_sql` (snapshots reuse the full `ModelState`). Other keys are not fields here, so they are flagged as unknown keys at parse time.",
+      "type": "object",
+      "properties": {
+        "evaluate_volatile_sql": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "require_fresh_data_from": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/UpdatesOn"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "DbtBatchSize": {
       "type": "string",
       "enum": [
@@ -2134,6 +2165,16 @@
             "null"
           ]
         },
+        "+state": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DataTestState"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "+static_analysis": {
           "anyOf": [
             {
@@ -2220,6 +2261,21 @@
           ]
         },
         "+transient": {
+          "anyOf": [
+            {
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "+unlogged": {
           "anyOf": [
             {
               "default": null,
@@ -3987,6 +4043,21 @@
             }
           ]
         },
+        "+unlogged": {
+          "anyOf": [
+            {
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "+use_anonymous_sproc": {
           "anyOf": [
             {
@@ -4956,6 +5027,20 @@
               "pattern": "^\\{.*\\}$"
             }
           ]
+        },
+        "+unlogged": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
         }
       },
       "additionalProperties": {
@@ -5832,6 +5917,16 @@
             "null"
           ]
         },
+        "+state": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelState"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "+static_analysis": {
           "anyOf": [
             {
@@ -5943,6 +6038,21 @@
             },
             {
               "type": "null"
+            }
+          ]
+        },
+        "+unlogged": {
+          "anyOf": [
+            {
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
             }
           ]
         },
@@ -6545,6 +6655,21 @@
           "additionalProperties": {
             "$ref": "#/definitions/AnyValue"
           }
+        },
+        "+unlogged": {
+          "anyOf": [
+            {
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
         }
       },
       "additionalProperties": {
@@ -7251,6 +7376,21 @@
           ]
         },
         "+transient": {
+          "anyOf": [
+            {
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "+unlogged": {
           "anyOf": [
             {
               "default": null,

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -1820,6 +1820,16 @@
             "null"
           ]
         },
+        "state": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DataTestState"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "static_analysis": {
           "anyOf": [
             {
@@ -1953,6 +1963,20 @@
             }
           ]
         },
+        "unlogged": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "use_safer_relation_operations": {
           "anyOf": [
             {
@@ -2040,6 +2064,37 @@
           "anyOf": [
             {
               "$ref": "#/definitions/StaticAnalysisOffReason"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "DataTestState": {
+      "description": "The dbt State configs supported on data tests: only `require_fresh_data_from` and `evaluate_volatile_sql` (snapshots reuse the full `ModelState`). Other keys are not fields here, so they are flagged as unknown keys at parse time.",
+      "type": "object",
+      "properties": {
+        "evaluate_volatile_sql": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "require_fresh_data_from": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/UpdatesOn"
             },
             {
               "type": "null"
@@ -3968,6 +4023,20 @@
             },
             {
               "type": "null"
+            }
+          ]
+        },
+        "unlogged": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
             }
           ]
         },
@@ -6303,6 +6372,20 @@
             }
           ]
         },
+        "unlogged": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "use_anonymous_sproc": {
           "anyOf": [
             {
@@ -8303,6 +8386,20 @@
             }
           ]
         },
+        "unlogged": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
         "use_safer_relation_operations": {
           "anyOf": [
             {
@@ -9398,6 +9495,16 @@
             "null"
           ]
         },
+        "state": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelState"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "static_analysis": {
           "anyOf": [
             {
@@ -9542,6 +9649,20 @@
             },
             {
               "type": "null"
+            }
+          ]
+        },
+        "unlogged": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
             }
           ]
         },
@@ -10635,6 +10756,20 @@
           ]
         },
         "transient": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "unlogged": {
           "anyOf": [
             {
               "type": [
@@ -11966,6 +12101,20 @@
           ]
         },
         "transient": {
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^\\{.*\\}$"
+            }
+          ]
+        },
+        "unlogged": {
           "anyOf": [
             {
               "type": [


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`c4dc1cb6df42d2de94a2d089aecbc8b1464168c9`](https://github.com/dbt-labs/fs/commit/c4dc1cb6df42d2de94a2d089aecbc8b1464168c9)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/30477830532)