### PR TITLE
Fix regression: node.path for yaml based snapshots in subdirectories …

### DIFF
--- a/.changes/unreleased/Fixes-20260731-112645.yaml
+++ b/.changes/unreleased/Fixes-20260731-112645.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix regression where node.path for yaml based snapshots in subdirectories omitted the subdirectory path
+time: 2026-07-31T11:26:45.964839+01:00
+custom:
+    Author: mattogburke
+    Issue: "15753"

--- a/.changes/unreleased/Fixes-20260731-112645.yaml
+++ b/.changes/unreleased/Fixes-20260731-112645.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: Fix regression where node.path for yaml based snapshots in subdirectories omitted the subdirectory path
+body: Fix regression where node.path for YAML-based snapshots in subdirectories omitted the subdirectory path
 time: 2026-07-31T11:26:45.964839+01:00
 custom:
     Author: mattogburke

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -1,4 +1,5 @@
 import datetime
+import pathlib
 import re
 import time
 from abc import ABCMeta, abstractmethod
@@ -345,7 +346,11 @@ class SchemaParser(SimpleParser[YamlBlock, ModelNode]):
                 fqn = parser.get_fqn_prefix(block.path.relative_path)
                 fqn.append(snapshot["name"])
 
-                compiled_path = snapshot["name"] + ".sql"
+                compiled_path = str(
+                    pathlib.PurePath("").joinpath(
+                        block.path.relative_path, snapshot["name"] + ".sql"
+                    )
+                )
                 snapshot_node = parser._create_parsetime_node(
                     block,
                     compiled_path,

--- a/tests/functional/snapshots/test_basic_snapshot.py
+++ b/tests/functional/snapshots/test_basic_snapshot.py
@@ -410,7 +410,7 @@ class TestYamlSnapshotCompiledPath(BasicYaml):
         """Verify yml-based snapshots get correct compiled paths without doubling."""
         manifest = run_dbt(["parse"])
         node = manifest.nodes["snapshot.test.snapshot_actual"]
-        assert node.path == "snapshot_actual.sql"
+        assert node.path == "snapshot.yml/snapshot_actual.sql"
         assert node.original_file_path == os.path.join("snapshots", "snapshot.yml")
 
         run_dbt(["compile"])
@@ -489,6 +489,44 @@ class TestSnapshotNodePathIncludesSubdir:
             "subdir", "subdir_snap.sql"
         ), f"Expected node.path to include subdirectory, got: {node.path!r}"
         assert node.original_file_path == os.path.join("snapshots", "subdir", "subdir_snap.sql")
+
+
+subdir_model__sql = """
+select 1 as id, 'alice' as name
+"""
+
+subdir_snapshot__yml = """
+version: 2
+snapshots:
+  - name: subdir_snap
+    relation: ref('subdir_model')
+    config:
+      strategy: check
+      unique_key: id
+      check_cols: all
+      hard_deletes: new_record"""
+
+
+class TestYamlSnapshotNodePathIncludesSubdir:
+    """Regression test: node.path for a snapshot in a subdirectory must include
+    the subdirectory (e.g. 'subdir/subdir_snap.sql'), not just the filename.
+    See https://github.com/dbt-labs/dbt-core/issues/15753."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"subdir": {"subdir_model.sql": subdir_model__sql}}
+
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {"subdir": {"subdir_snap.yml": subdir_snapshot__yml}}
+
+    def test_node_path_includes_subdir(self, project):
+        manifest = run_dbt(["parse"])
+        node = manifest.nodes["snapshot.test.subdir_snap"]
+        assert node.path == os.path.join(
+            "subdir", "subdir_snap.yml", "subdir_snap.sql"
+        ), f"Expected node.path to include subdirectory, got: {node.path!r}"
+        assert node.original_file_path == os.path.join("snapshots", "subdir", "subdir_snap.yml")
 
 
 class TestYamlSnapshotPartialParsing(BasicYaml):

--- a/tests/functional/snapshots/test_basic_snapshot.py
+++ b/tests/functional/snapshots/test_basic_snapshot.py
@@ -509,7 +509,8 @@ snapshots:
 
 class TestYamlSnapshotNodePathIncludesSubdir:
     """Regression test: node.path for a snapshot in a subdirectory must include
-    the subdirectory (e.g. 'subdir/subdir_snap.sql'), not just the filename.
+    the subdirectory and original filename (e.g. 'subdir/subdir_snap.yml/subdir_snap.sql'),
+    not just the filename.
     See https://github.com/dbt-labs/dbt-core/issues/15753."""
 
     @pytest.fixture(scope="class")

--- a/tests/functional/snapshots/test_basic_snapshot.py
+++ b/tests/functional/snapshots/test_basic_snapshot.py
@@ -410,7 +410,7 @@ class TestYamlSnapshotCompiledPath(BasicYaml):
         """Verify yml-based snapshots get correct compiled paths without doubling."""
         manifest = run_dbt(["parse"])
         node = manifest.nodes["snapshot.test.snapshot_actual"]
-        assert node.path == "snapshot.yml/snapshot_actual.sql"
+        assert node.path == os.path.join("snapshot.yml", "snapshot_actual.sql")
         assert node.original_file_path == os.path.join("snapshots", "snapshot.yml")
 
         run_dbt(["compile"])


### PR DESCRIPTION
…drops the subdirectory

Resolves https://github.com/dbt-labs/dbt-core/issues/15753

### Problem

Very similar to https://github.com/dbt-labs/dbt-core/pull/12791 which resolved this for sql based snapshots - by effectively reverting part of https://github.com/dbt-labs/dbt-core/pull/12568 which was no longer need after https://github.com/dbt-labs/dbt-core/pull/12693.

### Solution

Apply the same treatment here, and add specific tests for this (and update the unit test asserting on the wrong behavior).


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
