### PR TITLE
Fix partial parse dropping YAML snapshot changes when coupled with its upstream source changes

### DIFF
--- a/.changes/unreleased/Fixes-20260803-140857.yaml
+++ b/.changes/unreleased/Fixes-20260803-140857.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix partial parsing dropping YAML snapshot changes when the snapshot's upstream
+  source changes in the same run
+time: 2026-08-03T14:08:57.208068+01:00
+custom:
+    Author: antoniabadarau
+    Issue: "15785"

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -14,6 +14,7 @@ from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.nodes import (
     AnalysisNode,
     GenericTestNode,
+    ManifestNode,
     ModelNode,
     SeedNode,
     SnapshotNode,
@@ -491,29 +492,32 @@ class PartialParsing:
         if unique_id in self.saved_manifest.child_map:
             self.schedule_nodes_for_parsing(self.saved_manifest.child_map[unique_id])
 
+    def _reschedule_saved_node(self, node: ManifestNode) -> None:
+        # Generic test nodes are handled separately (removed from the schema file).
+        if node.resource_type == NodeType.Test and node.test_node_type == "generic":
+            return
+        file_id = node.file_id
+        if file_id not in self.saved_files or file_id in self.file_diff["deleted"]:
+            return
+        source_file = self.saved_files[file_id]
+        if isinstance(source_file, SchemaSourceFile):
+            # YAML-defined nodes live in a schema file, not a SQL SourceFile.
+            # remove_mssat_file is a no-op for these and overwriting saved_files with
+            # the new content here would leave the stale node in the manifest. Route
+            # through the schema-file change path so the stale node is removed and
+            # the new one is scheduled.
+            if file_id in self.new_files:
+                self.change_schema_file(file_id)
+        else:
+            self.remove_mssat_file(source_file)
+            # content of non-schema files is only in new files
+            self.saved_files[file_id] = deepcopy(self.new_files[file_id])
+            self.add_to_pp_files(self.saved_files[file_id])
+
     def schedule_nodes_for_parsing(self, unique_ids):
         for unique_id in unique_ids:
             if unique_id in self.saved_manifest.nodes:
-                node = self.saved_manifest.nodes[unique_id]
-                if node.resource_type == NodeType.Test and node.test_node_type == "generic":
-                    # test nodes are handled separately. Must be removed from schema file
-                    continue
-                file_id = node.file_id
-                if file_id in self.saved_files and file_id not in self.file_diff["deleted"]:
-                    source_file = self.saved_files[file_id]
-                    if isinstance(source_file, SchemaSourceFile):
-                        # YAML-defined nodes live in a schema file, not a SQL SourceFile.
-                        # remove_mssat_file is a no-op for these and overwriting saved_files with
-                        # the new content here would leave the stale node in the manifest. Route
-                        # through the schema-file change path so the stale node is removed and
-                        # the new one is scheduled.
-                        if file_id in self.new_files:
-                            self.change_schema_file(file_id)
-                    else:
-                        self.remove_mssat_file(source_file)
-                        # content of non-schema files is only in new files
-                        self.saved_files[file_id] = deepcopy(self.new_files[file_id])
-                        self.add_to_pp_files(self.saved_files[file_id])
+                self._reschedule_saved_node(self.saved_manifest.nodes[unique_id])
             elif unique_id in self.saved_manifest.sources:
                 source = self.saved_manifest.sources[unique_id]
                 self._schedule_for_parsing(

--- a/core/dbt/parser/partial.py
+++ b/core/dbt/parser/partial.py
@@ -501,10 +501,19 @@ class PartialParsing:
                 file_id = node.file_id
                 if file_id in self.saved_files and file_id not in self.file_diff["deleted"]:
                     source_file = self.saved_files[file_id]
-                    self.remove_mssat_file(source_file)
-                    # content of non-schema files is only in new files
-                    self.saved_files[file_id] = deepcopy(self.new_files[file_id])
-                    self.add_to_pp_files(self.saved_files[file_id])
+                    if isinstance(source_file, SchemaSourceFile):
+                        # YAML-defined nodes live in a schema file, not a SQL SourceFile.
+                        # remove_mssat_file is a no-op for these and overwriting saved_files with
+                        # the new content here would leave the stale node in the manifest. Route
+                        # through the schema-file change path so the stale node is removed and
+                        # the new one is scheduled.
+                        if file_id in self.new_files:
+                            self.change_schema_file(file_id)
+                    else:
+                        self.remove_mssat_file(source_file)
+                        # content of non-schema files is only in new files
+                        self.saved_files[file_id] = deepcopy(self.new_files[file_id])
+                        self.add_to_pp_files(self.saved_files[file_id])
             elif unique_id in self.saved_manifest.sources:
                 source = self.saved_manifest.sources[unique_id]
                 self._schedule_for_parsing(

--- a/tests/functional/partial_parsing/test_pp_snapshot_upstream_change.py
+++ b/tests/functional/partial_parsing/test_pp_snapshot_upstream_change.py
@@ -64,8 +64,9 @@ class TestSnapshotChangeWithUpstreamSourceCoChange:
         write_file(sources_yml_changed, project.project_root, "models", "sources.yml")
         write_file(snapshot_yml_changed, project.project_root, "models", "a_snap.yml")
 
-        # partial parse (reuses the msgpack from the baseline run)
-        run_dbt(["parse"])
+        # partial parse (reuses the msgpack from the baseline run); pass --partial-parse
+        # explicitly so the test can't silently pass via a full-parse fallback
+        run_dbt(["--partial-parse", "parse"])
         manifest = get_manifest(project.project_root)
         # FAILS on 1.latest (stays "team_a" - stale node); PASSES after the fix
         assert manifest.nodes[SNAP_ID].config.meta["owner"] == "team_b"
@@ -81,6 +82,7 @@ class TestSnapshotChangeInIsolationStillDetected:
     def test_isolated_snapshot_change_detected(self, project):
         run_dbt(["parse"])
         write_file(snapshot_yml_changed, project.project_root, "models", "a_snap.yml")
-        run_dbt(["parse"])
+        # explicit --partial-parse so a full-parse fallback can't mask a regression
+        run_dbt(["--partial-parse", "parse"])
         manifest = get_manifest(project.project_root)
         assert manifest.nodes[SNAP_ID].config.meta["owner"] == "team_b"

--- a/tests/functional/partial_parsing/test_pp_snapshot_upstream_change.py
+++ b/tests/functional/partial_parsing/test_pp_snapshot_upstream_change.py
@@ -1,0 +1,86 @@
+import os
+
+import pytest
+
+from dbt.tests.util import get_manifest, run_dbt, write_file
+
+os.environ["DBT_PP_TEST"] = "true"
+
+# ORDERING MATTERS: this bug only triggers when the *source* schema file is processed
+# before the snapshot in reverse-sorted file-id order. Both files therefore live under
+# models/, and "models/sources.yml" reverse-sorts ahead of "models/a_snap.yml" (s > a),
+# so the source is processed first and pre-empts the snapshot's own change detection.
+# Defining the snapshot under snapshots/ would reverse-sort it first (the safe order) and
+# the test would pass trivially without exercising the bug.
+
+sources_yml = """
+version: 2
+sources:
+  - name: my_source
+    schema: my_schema
+    tables:
+      - name: my_table
+"""
+
+sources_yml_changed = """
+version: 2
+sources:
+  - name: my_source
+    description: changed
+    schema: my_schema
+    tables:
+      - name: my_table
+"""
+
+snapshot_yml = """
+snapshots:
+  - name: my_snapshot
+    relation: "source('my_source', 'my_table')"
+    config:
+      strategy: check
+      unique_key: id
+      check_cols: all
+      meta:
+        owner: team_a
+"""
+
+snapshot_yml_changed = snapshot_yml.replace("team_a", "team_b")
+
+SNAP_ID = "snapshot.test.my_snapshot"
+
+
+class TestSnapshotChangeWithUpstreamSourceCoChange:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"sources.yml": sources_yml, "a_snap.yml": snapshot_yml}
+
+    def test_snapshot_change_survives_upstream_source_cochange(self, project):
+        # baseline full parse
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        assert manifest.nodes[SNAP_ID].config.meta["owner"] == "team_a"
+
+        # co-change BOTH the snapshot and its upstream source in one partial parse
+        write_file(sources_yml_changed, project.project_root, "models", "sources.yml")
+        write_file(snapshot_yml_changed, project.project_root, "models", "a_snap.yml")
+
+        # partial parse (reuses the msgpack from the baseline run)
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        # FAILS on 1.latest (stays "team_a" - stale node); PASSES after the fix
+        assert manifest.nodes[SNAP_ID].config.meta["owner"] == "team_b"
+
+
+class TestSnapshotChangeInIsolationStillDetected:
+    """Regression guard: the direct snapshot-edit path (dbt-core #10907) must keep working."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"sources.yml": sources_yml, "a_snap.yml": snapshot_yml}
+
+    def test_isolated_snapshot_change_detected(self, project):
+        run_dbt(["parse"])
+        write_file(snapshot_yml_changed, project.project_root, "models", "a_snap.yml")
+        run_dbt(["parse"])
+        manifest = get_manifest(project.project_root)
+        assert manifest.nodes[SNAP_ID].config.meta["owner"] == "team_b"


### PR DESCRIPTION
Fix partial parsing dropped YAML snapshot changes when its upstream source changes in the same run

Resolves https://github.com/dbt-labs/dbt-core/issues/15785

### Problem

When a YAML-based snapshot and its upstream dependency change in the same partial parse, the snapshot's own changes are silently dropped - the manifest keeps the pre-change snapshot node. A full parse always works correctly and produces the expected outcome.

This behaviour appears to be order-dependent: it only triggers when the source's schema file is processed before the snapshot's in reverse-sorted file-id order — e.g. both under `models/`, with `models/sources.yml` sorting ahead of the snapshot's file.

Root cause is in `schedule_nodes_for_parsing` (`core/dbt/parser/partial.py`). A YAML snapshot is a manifest node, so it takes the SQL-file branch:
- `remove_mssat_file` returns early on `not isinstance(source_file, SourceFile)`, so it **no-ops** on a snapshot's `SchemaSourceFile` (YAML-snapshot ids live in `SchemaSourceFile.snapshots`, not `SourceFile.nodes`).
- when the source change schedules the snapshot for re-parse, `schedule_nodes_for_parsing` overwrites `saved_files[file_id] = deepcopy(new_files[file_id])`.
  - the snapshot's own `change_schema_file` then diffs **new-vs-new**, so `get_diff_for("snapshots")` is empty and `delete_yaml_snapshot` never fires → the stale node maintained

**Related but distinct issues**
- #10907 added YAML-snapshot partial-parse handling (`delete_yaml_snapshot`) for a change to the snapshot — this path still works and is unaffected; the linked issue does not cover the upstream-co-change trigger.
- #11444 is the same family (stale YAML-snapshot node under partial parse) but a different trigger

### Solution

In `schedule_nodes_for_parsing`, when the scheduled node lives in a `SchemaSourceFile`, route it through `change_schema_file` instead of the SQL-file overwrite path. `change_schema_file` diffs the intact saved content against the new content, so `handle_schema_file_changes` removes the stale snapshot node (`delete_yaml_snapshot`) and schedules the new one (`merge_patch`)

Added a new functional test (`tests/functional/partial_parsing/test_pp_snapshot_upstream_change.py`):
- co-change of a source + a snapshot downstream of it — fails before this change and passes as expected after
- a regression guard that an isolated snapshot edit is still detected (#10907)

**Notes**
- the scope is source (schema-file) upstreams, matching the issue.
- a model (`ref`) upstream lives in the SQL-file pass and was verified not to reproduce this so it is intentionally not covered in this PR

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
