### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260803-224024.yaml
+++ b/.changes/unreleased/Under the Hood-20260803-224024.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-08-03T22:40:24.728490954Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -8526,6 +8526,7 @@
       "type": "object",
       "properties": {
         "meta": {
+          "default": {},
           "type": [
             "object",
             "null"


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`aac9141d7a4d55205d5c8b3a23cbf905416b251e`](https://github.com/dbt-labs/fs/commit/aac9141d7a4d55205d5c8b3a23cbf905416b251e)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/30857602351)