### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260804-032104.yaml
+++ b/.changes/unreleased/Under the Hood-20260804-032104.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-08-04T03:21:04.787118146Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -8526,6 +8526,7 @@
       "type": "object",
       "properties": {
         "meta": {
+          "default": {},
           "type": [
             "object",
             "null"


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`0fcf88c4461784af67fa21c3af883cdbaced7bbc`](https://github.com/dbt-labs/fs/commit/0fcf88c4461784af67fa21c3af883cdbaced7bbc)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/30873028506)