### PR TITLE
chore: replace `user docs` label with `action:needs-docs`

### DIFF
--- a/.github/ISSUE_TEMPLATE/implementation-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/implementation-ticket.yml
@@ -1,7 +1,7 @@
 name: 🛠️ Implementation
 description: This is an implementation ticket intended for use by the maintainers of dbt-core
 title: "[<project>] <title>"
-labels: ["user docs"]
+labels: ["action:needs-docs"]
 body:
   - type: markdown
     attributes:
@@ -11,7 +11,7 @@ body:
       label: Housekeeping
       description: >
         A couple friendly reminders:
-          1. Remove the `user docs` label if the scope of this work does not require changes to https://docs.getdbt.com/docs: no end-user interface (e.g. yml spec, CLI, error messages, etc) or functional changes
+          1. Remove the `action:needs-docs` label if the scope of this work does not require changes to https://docs.getdbt.com/docs: no end-user interface (e.g. yml spec, CLI, error messages, etc) or functional changes
           2. Link any blocking issues in the "Blocked on" field under the "Core devs & maintainers" project.
       options:
         - label: I am a maintainer of dbt-core

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ Resolves #
   PRs for code changes without an associated issue *will not be merged*.
   See CONTRIBUTING.md for more information.
 
-  Add the `user docs` label to this PR if it will need docs changes.  An 
+  Add the `action:needs-docs` label to this PR if it will need docs changes.  An 
   issue will get opened in docs.getdbt.com upon successful merge of this PR.
 -->
 

--- a/.github/workflows/docs-issue.yml
+++ b/.github/workflows/docs-issue.yml
@@ -1,11 +1,11 @@
 # **what?**
-# Open an issue in docs.getdbt.com when an issue is labeled `user docs` and closed as completed
+# Open an issue in docs.getdbt.com when an issue is labeled `action:needs-docs` and closed as completed
 
 # **why?**
 # To reduce barriers for keeping docs up to date
 
 # **when?**
-# When an issue is labeled `user docs` and is closed as completed.  Can be labeled before or after the issue is closed.
+# When an issue is labeled `action:needs-docs` and is closed as completed.  Can be labeled before or after the issue is closed.
 
 
 name: Open issues in docs.getdbt.com repo when an issue is labeled
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   get_pr_info:
-    # we only want to run this when the issue is closed as completed and the label `user docs` has been assigned.
+    # we only want to run this when the issue is closed as completed and the label `action:needs-docs` has been assigned.
     # If this logic does not exist in this workflow, it runs the
     # risk of duplicaton of issues being created due to merge and label both triggering this workflow to run and neither having
     # generating the comment before the other runs.  This lives here instead of the shared workflow because this is where we
@@ -32,7 +32,7 @@ jobs:
     if: |
       (github.event.issue.state == 'closed' &&
        github.event.issue.state_reason == 'completed' &&
-       contains( github.event.issue.labels.*.name, 'user docs'))
+       contains( github.event.issue.labels.*.name, 'action:needs-docs'))
     runs-on: ubuntu-latest
     outputs:
       pr_url: ${{ steps.find_pr.outputs.pr_url }}


### PR DESCRIPTION
### Problem

The `user docs` label no longer exists in this repo — it has been replaced by `action:needs-docs` ("Use for PRs that require public docs or release notes. Opens an issue for the docs team."), but nothing in `.github/` was updated to match.

This is silently broken in two ways:

1. **`docs-issue.yml` can never fire.** Its `if:` condition gates on `contains(github.event.issue.labels.*.name, 'user docs')`, a label that can no longer be applied. No docs issue is ever opened in `docs.getdbt.com`.
2. **New implementation tickets get no label at all.** `implementation-ticket.yml` declares `labels: ["user docs"]`, and GitHub silently skips labels that don't exist — so the template's own housekeeping reminder ("remove the label if...") refers to a label that was never added.

### Solution

Replace every reference to `user docs` with `action:needs-docs`:

- **`.github/workflows/docs-issue.yml`** — the `if:` gating condition, plus the three header/inline comments that document it
- **`.github/ISSUE_TEMPLATE/implementation-ticket.yml`** — the default `labels:` entry and the housekeeping reminder
- **`.github/pull_request_template.md`** — the contributor instruction

Verified `action:needs-docs` exists via `gh label list` and that `grep -rn "user docs" .github/` now returns nothing.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated problem.
- [ ] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g. macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.

_No changelog entry: `changelog-existence.yml` has `paths-ignore: ['.changes/**', '.github/**', ...]`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)