### PR TITLE
fix(jinja): return dispatch errors for templates without macros

### DIFF
--- a/.changes/unreleased/Fixes-20260804-100244.yaml
+++ b/.changes/unreleased/Fixes-20260804-100244.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Return a catchable dispatch error when a resolved Jinja template does not export the requested macro instead of overflowing the stack
+time: 2026-08-04T10:02:44.528289-04:00
+custom:
+    author: mach-kernel
+    issue: "15700"
+    project: dbt-core

--- a/crates/dbt-jinja/minijinja/src/dispatch_object.rs
+++ b/crates/dbt-jinja/minijinja/src/dispatch_object.rs
@@ -87,14 +87,10 @@ impl Object for DispatchObject {
                 let template_name = format!("{}.{}", pkg, self.macro_name);
                 attempts.push(template_name.clone());
 
-                // Try to execute the template, but catch any errors and convert to a strict mode error
-                match self.execute_template(state, &template_name, args, listeners) {
-                    Ok(rv) => return Ok(rv),
-                    Err(err) => {
-                        // In strict mode, we want a specific error message
-                        return Err(err);
-                    }
+                if let Some(rv) = self.execute_template(state, &template_name, args, listeners)? {
+                    return Ok(rv);
                 }
+                return Err(self.macro_not_found_error(&attempts));
             }
         }
 
@@ -126,18 +122,22 @@ impl Object for DispatchObject {
                         if let Some(pkg) = dbt_and_adapters_namespace.get(&search_name_value) {
                             let template_name = format!("{pkg}.{search_name}");
                             attempts.push(template_name.clone());
-                            let rv =
-                                self.execute_template(state, &template_name, args, listeners)?;
-                            return Ok(rv);
+                            if let Some(rv) =
+                                self.execute_template(state, &template_name, args, listeners)?
+                            {
+                                return Ok(rv);
+                            }
                         }
                     } else if non_internal_namespace.contains_key(&Value::from(package_name)) {
                         // For non-internal packages
                         let template_name = format!("{package_name}.{search_name}");
                         attempts.push(template_name.clone());
                         if template_exists(state, &template_name) {
-                            let rv =
-                                self.execute_template(state, &template_name, args, listeners)?;
-                            return Ok(rv);
+                            if let Some(rv) =
+                                self.execute_template(state, &template_name, args, listeners)?
+                            {
+                                return Ok(rv);
+                            }
                         }
                     }
                 }
@@ -146,32 +146,42 @@ impl Object for DispatchObject {
                 for prefix in &adapter_prefixes {
                     let search_name = format!("{}__{}", prefix, self.macro_name);
 
-                    if let Some(template_name) =
-                        macro_namespace_template_resolver(state, &search_name, &mut attempts)
+                    for template_name in
+                        macro_namespace_template_candidates(state, &search_name, &mut attempts)
                     {
-                        let rv = self.execute_template(state, &template_name, args, listeners)?;
-                        return Ok(rv);
+                        if let Some(rv) =
+                            self.execute_template(state, &template_name, args, listeners)?
+                        {
+                            return Ok(rv);
+                        }
                     }
                 }
                 // find the macro without prefix
-                if let Some(template_name) =
-                    macro_namespace_template_resolver(state, &self.macro_name, &mut attempts)
+                for template_name in
+                    macro_namespace_template_candidates(state, &self.macro_name, &mut attempts)
                 {
-                    let rv = self.execute_template(state, &template_name, args, listeners)?;
-                    return Ok(rv);
+                    if let Some(rv) =
+                        self.execute_template(state, &template_name, args, listeners)?
+                    {
+                        return Ok(rv);
+                    }
                 }
             }
         }
 
-        // Format error message
+        Err(self.macro_not_found_error(&attempts))
+    }
+}
+
+impl DispatchObject {
+    fn macro_not_found_error(&self, attempts: &[String]) -> Error {
         let searched = attempts
             .iter()
             .map(|a| format!("'{a}'"))
             .collect::<Vec<_>>()
             .join(", ");
 
-        // Create error with the original file information preserved
-        let err = Error::new(
+        Error::new(
             ErrorKind::UnknownFunction,
             format!(
                 "In dispatch: No macro named '{}' found within namespace: '{}'\n    Searched for: {}",
@@ -179,13 +189,9 @@ impl Object for DispatchObject {
                 self.package_name.clone().unwrap_or_else(|| "None".to_string()),
                 searched
             ),
-        );
-
-        Err(err)
+        )
     }
-}
 
-impl DispatchObject {
     // Update the get_search_packages method to better match Python's logic
     fn get_search_packages(&self, state: &State<'_, '_>) -> Vec<Option<String>> {
         let root_package = state.env().get_root_package_name();
@@ -253,7 +259,7 @@ impl DispatchObject {
         template_name: &str,
         args: &[Value],
         listeners: &[Rc<dyn RenderingEventListener>],
-    ) -> Result<Value, Error> {
+    ) -> Result<Option<Value>, Error> {
         let template = match state.env().get_template(template_name) {
             Ok(template) => template,
             Err(err) => {
@@ -320,22 +326,23 @@ impl DispatchObject {
             }
         }
 
-        let func = template_state
-            .lookup(
-                template_name
-                    .split('.')
-                    .next_back()
-                    .expect("template_name should have a dot"),
-                listeners,
-            )
-            .expect("function should exist in template");
+        let macro_name = template_name
+            .split('.')
+            .next_back()
+            .expect("template_name should have a dot");
+        let Some(func) = template_state.ctx.exports().get(macro_name).cloned() else {
+            return Ok(None);
+        };
+        if func.downcast_object_ref::<Macro>().is_none() {
+            return Ok(None);
+        }
 
         // Forward the caller's pending call site (recorded by the vm before the
         // dispatch) onto the macro's template state, since `func.call` runs with
         // `template_state` rather than the original caller state.
         template_state.pending_call_site = state.pending_call_site.clone();
 
-        func.call(&template_state, &args, listeners)
+        func.call(&template_state, &args, listeners).map(Some)
     }
 }
 
@@ -403,7 +410,7 @@ fn template_exists(state: &State<'_, '_>, template_name: &str) -> bool {
 /// * `attempts` - A vector to track attempted template paths (for error reporting)
 ///
 /// # Returns
-/// * `Result<Option<String>, Error>` - The template path if found, None otherwise
+/// * `Option<String>` - The template path if found, None otherwise
 ///
 /// Logic comes from https://github.com/dbt-labs/dbt-core/blob/4aa5169212d8256002095d44dc5f2505dca1b07c/core/dbt/context/macros.py#L83
 /// and https://github.com/dbt-labs/dbt-core/blob/4aa5169212d8256002095d44dc5f2505dca1b07c/core/dbt/context/macros.py#L34
@@ -413,6 +420,16 @@ pub fn macro_namespace_template_resolver(
     search_name: &str,
     attempts: &mut Vec<String>,
 ) -> Option<String> {
+    macro_namespace_template_candidates(state, search_name, attempts)
+        .into_iter()
+        .next()
+}
+
+fn macro_namespace_template_candidates(
+    state: &State<'_, '_>,
+    search_name: &str,
+    attempts: &mut Vec<String>,
+) -> Vec<String> {
     // Get necessary values from state
     let current_package_name = state
         .ctx
@@ -421,19 +438,20 @@ pub fn macro_namespace_template_resolver(
         .unwrap_or_else(|| "dbt".to_string());
     let root_package = state.env().get_root_package_name();
     let dbt_and_adapters = state.env().get_dbt_and_adapters_namespace();
+    let mut candidates = Vec::new();
 
     // 1. Local namespace (current package)
     let template_name = format!("{current_package_name}.{search_name}");
     attempts.push(template_name.clone());
     if template_exists(state, &template_name) {
-        return Some(template_name);
+        candidates.push(template_name);
     }
 
     // 2. Root package namespace
     let template_name = format!("{root_package}.{search_name}");
     attempts.push(template_name.clone());
-    if template_exists(state, &template_name) {
-        return Some(template_name);
+    if template_exists(state, &template_name) && !candidates.contains(&template_name) {
+        candidates.push(template_name);
     }
 
     // 3. Internal packages
@@ -441,11 +459,10 @@ pub fn macro_namespace_template_resolver(
     if let Some(pkg) = dbt_and_adapters.get(&search_name_value) {
         let template_name = format!("{pkg}.{search_name}");
         attempts.push(template_name.clone());
-        if template_exists(state, &template_name) {
-            return Some(template_name);
+        if template_exists(state, &template_name) && !candidates.contains(&template_name) {
+            candidates.push(template_name);
         }
     }
 
-    // No template found
-    None
+    candidates
 }

--- a/crates/dbt-jinja/minijinja/src/vm/context.rs
+++ b/crates/dbt-jinja/minijinja/src/vm/context.rs
@@ -259,13 +259,14 @@ impl<'env> Context<'env> {
         current_path: PathBuf,
         current_span: Span,
         outer_stack_depth: usize,
-    ) -> Context<'env> {
+    ) -> Result<Context<'env>, Error> {
         let mut rv = Context::new(recursion_limit);
         rv.stack.push(frame);
         rv.current_path = current_path;
         rv.current_span = current_span;
         rv.outer_stack_depth = outer_stack_depth;
-        rv
+        ok!(rv.check_depth());
+        Ok(rv)
     }
 
     /// Stores a variable in the context.

--- a/crates/dbt-jinja/minijinja/src/vm/mod.rs
+++ b/crates/dbt-jinja/minijinja/src/vm/mod.rs
@@ -203,7 +203,7 @@ impl<'env> Vm<'env> {
     ) -> Result<(Value, State<'template, 'env>), Error> {
         let _guard = value_optimization();
 
-        let ctx = Context::new_with_frame_and_stack_depth(
+        let ctx = ok!(Context::new_with_frame_and_stack_depth(
             ok!(Frame::new_checked(root.clone())),
             self.env.recursion_limit(),
             root.get_attr_fast(CURRENT_PATH)
@@ -211,7 +211,7 @@ impl<'env> Vm<'env> {
             root.get_attr_fast(CURRENT_SPAN)
                 .map_or_else(Span::default, |value| deserialize_span(&value)),
             outer_stack_depth,
-        );
+        ));
 
         let mut state = State::new(
             self.env,

--- a/crates/dbt-jinja/minijinja/tests/test_render.rs
+++ b/crates/dbt-jinja/minijinja/tests/test_render.rs
@@ -1,11 +1,11 @@
 use insta::assert_snapshot;
 use minijinja::{
-    constants::MACRO_NAMESPACE_REGISTRY,
+    constants::{MACRO_NAMESPACE_REGISTRY, ROOT_PACKAGE_NAME},
     context,
     dispatch_object::DispatchObject,
     listener::RenderingEventListener,
     value::{mutable_vec::MutableVec, Object, ValueMap},
-    Environment, Error as MinijinjaError, State, Value,
+    Environment, Error as MinijinjaError, ErrorKind, State, Value,
 };
 use std::rc::Rc;
 use std::sync::Arc;
@@ -198,6 +198,162 @@ fn test_macro_namespace_subscript_lookup() {
         )
         .unwrap();
     assert_snapshot!(rv, @"two");
+}
+
+fn add_dispatch(env: &mut Environment<'static>) {
+    env.add_global(ROOT_PACKAGE_NAME, Value::from("myproj"));
+    env.add_global(
+        "dispatch",
+        Value::from_object(DispatchObject {
+            macro_name: "thing".to_string(),
+            package_name: None,
+            strict: false,
+            auto_execute: false,
+            context: None,
+        }),
+    );
+}
+
+#[test]
+fn test_dispatch_skips_template_without_macro() {
+    let mut env = Environment::new();
+    add_dispatch(&mut env);
+    env.add_template(
+        "myproj.default__thing",
+        "-- intentionally defines no macro\n",
+    )
+    .unwrap();
+
+    let err = env
+        .render_str("{{ dispatch() }}", Value::UNDEFINED, &[])
+        .unwrap_err();
+
+    assert_eq!(err.kind(), ErrorKind::UnknownFunction);
+    assert_eq!(
+        err.detail(),
+        Some(concat!(
+            "In dispatch: No macro named 'thing' found within namespace: 'None'\n",
+            "    Searched for: 'dbt.postgres__thing', 'myproj.postgres__thing', ",
+            "'dbt.default__thing', 'myproj.default__thing', 'dbt.thing', 'myproj.thing'"
+        ))
+    );
+}
+
+#[test]
+fn test_state_lookup_template_without_macro_returns_error() {
+    let mut env = Environment::new();
+    env.add_global(ROOT_PACKAGE_NAME, Value::from("myproj"));
+    env.add_template(
+        "myproj.default__thing",
+        "-- intentionally defines no macro\n",
+    )
+    .unwrap();
+
+    let err = env
+        .render_str("{{ default__thing() }}", Value::UNDEFINED, &[])
+        .unwrap_err();
+
+    assert_eq!(err.kind(), ErrorKind::UnknownFunction);
+    assert_eq!(
+        err.detail(),
+        Some(concat!(
+            "In dispatch: No macro named 'default__thing' found within namespace: 'myproj'\n",
+            "    Searched for: 'myproj.default__thing'"
+        ))
+    );
+}
+
+#[test]
+fn test_dispatch_skips_missing_macro_for_later_candidate() {
+    for candidate in [
+        "-- intentionally defines no macro\n",
+        "{% set postgres__thing = 'not a macro' %}",
+    ] {
+        let mut env = Environment::new();
+        add_dispatch(&mut env);
+        env.add_template("myproj.postgres__thing", candidate)
+            .unwrap();
+        env.add_template(
+            "myproj.default__thing",
+            "{% macro default__thing() %}default{% endmacro %}",
+        )
+        .unwrap();
+
+        let rv = env
+            .render_str("{{ dispatch() }}", Value::UNDEFINED, &[])
+            .unwrap();
+
+        assert_eq!(rv, "default");
+    }
+}
+
+#[test]
+fn test_dispatch_skips_missing_macro_for_same_name_later_package() {
+    let mut env = Environment::new();
+    add_dispatch(&mut env);
+    env.add_template("dbt.default__thing", "-- intentionally defines no macro\n")
+        .unwrap();
+    env.add_template(
+        "myproj.default__thing",
+        "{% macro default__thing() %}default{% endmacro %}",
+    )
+    .unwrap();
+
+    let rv = env
+        .render_str("{{ dispatch() }}", Value::UNDEFINED, &[])
+        .unwrap();
+
+    assert_eq!(rv, "default");
+}
+
+#[test]
+fn test_dispatch_preserves_candidate_errors() {
+    for candidate in [
+        "{{ fail() }}{% macro postgres__thing() %}postgres{% endmacro %}",
+        "{% macro postgres__thing() %}{{ fail() }}{% endmacro %}",
+    ] {
+        let mut env = Environment::new();
+        add_dispatch(&mut env);
+        env.add_function("fail", || -> Result<Value, MinijinjaError> {
+            Err(MinijinjaError::new(
+                ErrorKind::InvalidOperation,
+                "candidate failed",
+            ))
+        });
+        env.add_template("myproj.postgres__thing", candidate)
+            .unwrap();
+        env.add_template(
+            "myproj.default__thing",
+            "{% macro default__thing() %}default{% endmacro %}",
+        )
+        .unwrap();
+
+        let err = env
+            .render_str("{{ dispatch() }}", Value::UNDEFINED, &[])
+            .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::InvalidOperation);
+        assert_eq!(err.detail(), Some("candidate failed"));
+    }
+}
+
+#[test]
+fn test_dispatch_checks_depth_before_template_evaluation() {
+    let mut env = Environment::new();
+    env.set_recursion_limit(20);
+    add_dispatch(&mut env);
+    env.add_template(
+        "myproj.default__thing",
+        "{{ default__thing() }}{% macro default__thing() %}ok{% endmacro %}",
+    )
+    .unwrap();
+
+    let err = env
+        .render_str("{{ dispatch() }}", Value::UNDEFINED, &[])
+        .unwrap_err();
+
+    assert_eq!(err.kind(), ErrorKind::InvalidOperation);
+    assert_eq!(err.detail(), Some("recursion limit exceeded"));
 }
 
 #[test]


### PR DESCRIPTION
Resolves #15700

### Problem

Dispatch treated a matching template name as proof that the requested macro existed. If the template did not export that macro, `execute_template` performed another broad state lookup, which resolved to the same dispatch object and recursed until the process aborted with a stack overflow.

The template-execution path also carried its caller's stack depth into a fresh VM context without checking it before evaluation.

### Solution

Read the requested export directly from the evaluated template context and accept it only when it is a macro. A missing or non-macro export is now a candidate miss: non-strict dispatch continues through later packages and prefixes, while strict lookup or an exhausted search returns the existing catchable `UnknownFunction` error. Template evaluation and macro call errors still propagate unchanged.

The fresh VM context now checks the carried stack depth before evaluating the template as a defense-in-depth recursion guard.

### Coverage / needs eyes

- Reproduced the original fixture before the fix: `cargo test -p minijinja test_dispatch_skips_template_without_macro --all-features` aborted with `thread ... has overflowed its stack` and `SIGABRT`.
- `cargo test -p minijinja --lib --tests`
- `cargo test -p minijinja --test test_render --all-features`
- `cargo clippy -p minijinja --all-features --tests -- -D warnings`
- `cargo fmt -p minijinja -- --check`

Coverage includes direct state lookup, strict and exhausted-search errors, missing and non-macro exports, same-prefix fallback across packages, later-prefix fallback, propagation of evaluation and macro-call errors, and the carried-depth guard.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
