### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260805-070217.yaml
+++ b/.changes/unreleased/Under the Hood-20260805-070217.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-08-05T07:02:17.905718634Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -8526,6 +8526,7 @@
       "type": "object",
       "properties": {
         "meta": {
+          "default": {},
           "type": [
             "object",
             "null"


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`bc3e6d512cc023125ef0bdbb64ef44e08a052ea9`](https://github.com/dbt-labs/fs/commit/bc3e6d512cc023125ef0bdbb64ef44e08a052ea9)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/30981454628)