### PR TITLE
fix: propagate v2 metric fill_nulls_with into type_params

### DIFF
--- a/.changes/unreleased/Fixes-20260805-000000.yaml
+++ b/.changes/unreleased/Fixes-20260805-000000.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Propagate a v2 semantic YAML metric's `fill_nulls_with` into `type_params.fill_nulls_with`
+  so it is no longer silently dropped from the manifest and semantic manifest
+time: 2026-08-05T00:00:00.000000+00:00
+custom:
+    Author: charlie-liner
+    Issue: "13037"

--- a/core/dbt/parser/schema_yaml_readers.py
+++ b/core/dbt/parser/schema_yaml_readers.py
@@ -513,6 +513,7 @@ class MetricParser(YamlReader):
                     unparsed_metric=unparsed_metric,
                 ),
                 metric_aggregation_params=metric_aggregation_params,
+                fill_nulls_with=unparsed_metric.fill_nulls_with,
                 join_to_timespine=unparsed_metric.join_to_timespine or False,
                 is_private=unparsed_metric.hidden,
             )

--- a/tests/functional/semantic_models/fixtures.py
+++ b/tests/functional/semantic_models/fixtures.py
@@ -896,6 +896,31 @@ schema_yml_v2_metrics_with_hidden = """
         hidden: true
 """
 
+schema_yml_v2_metrics_with_fill_nulls_with = """
+    metrics:
+      - name: metric_filling_nulls
+        description: A metric that fills nulls with zero.
+        label: Metric Filling Nulls
+        type: simple
+        agg: count
+        expr: id
+        fill_nulls_with: 0
+        join_to_timespine: true
+      - name: metric_filling_nulls_negative
+        description: A metric that fills nulls with a negative value.
+        label: Metric Filling Nulls Negative
+        type: simple
+        agg: count
+        expr: id
+        fill_nulls_with: -1
+      - name: metric_not_filling_nulls
+        description: A metric that does not fill nulls.
+        label: Metric Not Filling Nulls
+        type: simple
+        agg: count
+        expr: id
+"""
+
 schema_yml_v2_metric_with_doc_jinja = """
       - name: simple_metric_with_doc_jinja
         description: "{{ doc('simple_metric_description') }}"

--- a/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
+++ b/tests/functional/semantic_models/test_semantic_model_v2_parsing.py
@@ -24,6 +24,7 @@ from tests.functional.semantic_models.fixtures import (
     schema_yml_v2_metric_with_filter_dimension_jinja,
     schema_yml_v2_metric_with_input_metrics_filter_dimension_jinja,
     schema_yml_v2_metric_with_numerator_filter_dimension_jinja,
+    schema_yml_v2_metrics_with_fill_nulls_with,
     schema_yml_v2_metrics_with_hidden,
     schema_yml_v2_simple_metric_on_model_1,
     schema_yml_v2_standalone_metrics,
@@ -501,6 +502,52 @@ class TestMetricHiddenMapsToIsPrivate:
 
         private_metric = metrics["metric.test.private_metric"]
         assert private_metric.type_params.is_private is True
+
+
+class TestMetricFillNullsWith:
+    """Test that a metric's 'fill_nulls_with' field in YAML reaches the semantic manifest."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": base_schema_yml_v2 + schema_yml_v2_metrics_with_fill_nulls_with,
+            "fct_revenue.sql": fct_revenue_sql,
+            "metricflow_time_spine.sql": metricflow_time_spine_sql,
+        }
+
+    def test_metric_fill_nulls_with(self, project):
+        runner = dbtTestRunner()
+        result = runner.invoke(["parse"])
+        assert result.success
+        manifest = result.result
+        metrics = manifest.metrics
+        assert len(metrics) == 3
+
+        semantic_manifest = SemanticManifest(manifest)
+        semantic_manifest_metrics = {
+            metric.name: metric
+            for metric in semantic_manifest._get_pydantic_semantic_manifest().metrics
+        }
+
+        filling_nulls = metrics["metric.test.metric_filling_nulls"]
+        assert filling_nulls.type_params.fill_nulls_with == 0
+        assert filling_nulls.type_params.join_to_timespine is True
+        assert semantic_manifest_metrics["metric_filling_nulls"].type_params.fill_nulls_with == 0
+
+        # A negative fill value must survive too; 0 alone would pass on a falsy-check bug.
+        filling_nulls_negative = metrics["metric.test.metric_filling_nulls_negative"]
+        assert filling_nulls_negative.type_params.fill_nulls_with == -1
+        assert (
+            semantic_manifest_metrics["metric_filling_nulls_negative"].type_params.fill_nulls_with
+            == -1
+        )
+
+        not_filling_nulls = metrics["metric.test.metric_not_filling_nulls"]
+        assert not_filling_nulls.type_params.fill_nulls_with is None
+        assert (
+            semantic_manifest_metrics["metric_not_filling_nulls"].type_params.fill_nulls_with
+            is None
+        )
 
 
 class TestStandaloneMetricParsingSimpleMetricFails:


### PR DESCRIPTION
Resolves #13037

### Problem

A metric's `fill_nulls_with` is silently dropped when it is set at the metric level in v2 semantic YAML:

```yaml
models:
  - name: fct_revenue
    metrics:
      - name: orders_filled
        type: simple
        agg: sum
        expr: amount
        fill_nulls_with: 0
        join_to_timespine: true
```

After `dbt parse`, `type_params.fill_nulls_with` is `null` in both `manifest.json` and `semantic_manifest.json`, while the sibling `join_to_timespine` on the same metric is preserved.

The field is not rejected anywhere along the way, which is what makes this hard to spot — it is declared on `UnparsedMetricV2`, and the JSON schema accepts it. It is read off the YAML correctly and then discarded when the parser builds `MetricTypeParams`:

```
unparsed.fill_nulls_with      = 0     # read from YAML
type_params.fill_nulls_with   = None  # lost here
type_params.join_to_timespine = True  # survives
```

The cause is in `MetricParser._get_metric_type_params`. In the `UnparsedMetricV2` branch, `join_to_timespine` and `is_private` are passed through to `MetricTypeParams` but `fill_nulls_with` is not:

```python
metric_aggregation_params=metric_aggregation_params,
                                                    # fill_nulls_with never passed
join_to_timespine=unparsed_metric.join_to_timespine or False,
is_private=unparsed_metric.hidden,
```

The v1 branch is unaffected: `fill_nulls_with` nested under `type_params.measure` is propagated to `type_params.measure.fill_nulls_with` as before.

### Solution

Pass `fill_nulls_with` through alongside `join_to_timespine`, mirroring how the adjacent v2-only fields are already handled.

Two notes for reviewers:

**Scope relative to #13037.** The issue reports `type_params.fill_nulls_with` being null for the metric-level field and for `type_params.measure`. This PR fixes the metric-level (v2 YAML) case, which is a plain omission. The v1 `type_params.measure.fill_nulls_with` case looks intentional rather than broken: the value belongs on the measure input in v1, dbt-semantic-interfaces promotes it onto the metric in `flatten_simple_metrics_with_measure_inputs`, and its validator emits a warning if a simple metric carries both a measure input and `type_params.fill_nulls_with`. Happy to widen the scope if that reading is wrong.

**Behavior change on non-simple metrics.** Because the value now reaches the manifest, setting `fill_nulls_with` on a non-simple metric surfaces the existing dbt-semantic-interfaces validation error instead of being ignored. `join_to_timespine` already behaves this way and is checked by the same rule, so this makes the two consistent — but it does mean a project that had a meaningless `fill_nulls_with` on a derived or cumulative metric will now get an error telling them so.

This changes JSON artifact output: a field that was previously always `null` is now populated. Flagging it for the interface-changes checkbox below.

### Verification

- Added `TestMetricFillNullsWith`, asserting the value reaches both `manifest.metrics` and the pydantic semantic manifest. It covers `0`, `-1`, and unset — `-1` is there so a truthiness-based regression can't pass on `0` alone.
- The new test fails without the parser change (`assert None == 0`) and passes with it.
- `tests/functional/semantic_models`, `tests/functional/metrics`, `tests/unit/parser`, and `tests/unit/contracts/graph/test_semantic_manifest.py`: 341 passed, 2 skipped.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [ ] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX. — **left unchecked**: `type_params.fill_nulls_with` in `manifest.json` / `semantic_manifest.json` goes from always-null to populated. See the note above.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new and modified functions.
