### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260805-113956.yaml
+++ b/.changes/unreleased/Under the Hood-20260805-113956.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-08-05T11:39:56.359237639Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -8526,6 +8526,7 @@
       "type": "object",
       "properties": {
         "meta": {
+          "default": {},
           "type": [
             "object",
             "null"


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`2c3202ab0fe89b56e5c5d40dd8c3f1558ceebcc9`](https://github.com/dbt-labs/fs/commit/2c3202ab0fe89b56e5c5d40dd8c3f1558ceebcc9)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/31000266166)