### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/.changes/unreleased/Under the Hood-20260805-195412.yaml
+++ b/.changes/unreleased/Under the Hood-20260805-195412.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: sync JSON schemas from dbt-fusion
+time: 2026-08-05T19:54:12.455480846Z
+custom:
+    Author: fa-assistant
+    Issue: N/A

--- a/core/dbt/jsonschemas/resources/latest.json
+++ b/core/dbt/jsonschemas/resources/latest.json
@@ -8526,6 +8526,7 @@
       "type": "object",
       "properties": {
         "meta": {
+          "default": {},
           "type": [
             "object",
             "null"


### PR DESCRIPTION
## Summary

This PR syncs the JSON schemas from the dbt-fusion repository.

### Files Updated
- `core/dbt/jsonschemas/project/latest.json`
- `core/dbt/jsonschemas/resources/latest.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Commit**: [`7b4aaaf9902daf0970e2b0f500a4d52bc7f31836`](https://github.com/dbt-labs/fs/commit/7b4aaaf9902daf0970e2b0f500a4d52bc7f31836)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/31039020894)